### PR TITLE
docs(cosh): add /hooks install step to post-installation guide

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -85,6 +85,30 @@ Then run the build script. By default it installs dependencies, builds, and inst
 2. os-skills are mostly static assets and do not require compilation.
 3. AgentSight is an optional component that provides audit and observability capabilities but is not required for core functionality. It is excluded from default builds; use `--component sight` to include it explicitly.
 4. AgentSight system dependencies (clang/llvm/libbpf/kernel headers) should be installed through your distro package manager.
+5. **Sandbox policy hooks are not enabled automatically.** After installation, run `/hooks install` inside Copilot Shell once to activate the built-in sandbox-guard hooks. See [3.3 Post-Installation: Enable Sandbox Hooks](#33-post-installation-enable-sandbox-hooks) below.
+
+### 3.3 Post-Installation: Enable Sandbox Hooks
+
+The build script installs the components but does not automatically activate the sandbox policy hooks. To prevent unauthorized file system access or dangerous command execution, run the following inside Copilot Shell after installation:
+
+```bash
+cosh
+```
+
+Then inside the session:
+
+```
+/hooks install
+```
+
+This command:
+- Copies the bundled `sandbox-guard.py` and `sandbox-failure-handler.py` scripts to `~/.copilot-shell/hooks/`
+- Registers them as `PreToolUse` and `PostToolUseFailure` hooks in your user settings (`~/.copilot-shell/settings.json`)
+- Activates the hooks immediately in the current session
+
+You only need to run this once — the configuration persists across sessions.
+
+> **Note:** The sandbox hooks require `agent-sec-core` (linux-sandbox) to be installed at `/usr/local/bin/linux-sandbox`. When a dangerous command is detected, `sandbox-guard.py` wraps it inside the `linux-sandbox` binary for execution. If `agent-sec-core` is not built and installed, the hook will be registered but sandboxed execution of dangerous commands will fail. Make sure `agent-sec-core` is built (it is included in the default `build-all.sh` run) before relying on sandbox enforcement.
 
 ---
 

--- a/docs/BUILDING_CN.md
+++ b/docs/BUILDING_CN.md
@@ -86,6 +86,30 @@ cd anolisa
 2. os-skills 大部分是静态资源，无需编译。
 3. AgentSight 是可选组件，提供审计和可观测性能力，但不是核心功能所必需的。默认构建不包含它，使用 `--component sight` 显式包含。
 4. AgentSight 的系统依赖（clang/llvm/libbpf/内核头文件）需通过发行版包管理器安装。
+5. **沙箱策略 Hooks 不会自动启用。** 安装完成后，需在 Copilot Shell 内执行一次 `/hooks install` 来激活内置的 sandbox-guard hooks。详见 [3.3 安装后：启用沙箱 Hooks](#33-安装后启用沙箱-hooks)。
+
+### 3.3 安装后：启用沙箱 Hooks
+
+构建脚本完成安装后，沙箱策略 hooks 不会自动激活。为防止未经授权的文件系统访问或危险命令执行，请在安装完成后执行以下操作：
+
+```bash
+cosh
+```
+
+进入 Copilot Shell 会话后，执行：
+
+```
+/hooks install
+```
+
+该命令会：
+- 将内置的 `sandbox-guard.py` 和 `sandbox-failure-handler.py` 脚本复制到 `~/.copilot-shell/hooks/`
+- 将其注册为 `PreToolUse` 和 `PostToolUseFailure` hooks，写入用户配置（`~/.copilot-shell/settings.json`）
+- 立即在当前会话中激活这些 hooks
+
+只需执行一次，配置会持久保存，后续会话自动生效。
+
+> **说明：** 沙箱 hooks 依赖 `agent-sec-core`（linux-sandbox）正确构建并安装到 `/usr/local/bin/linux-sandbox`。当 `sandbox-guard.py` 检测到危险命令时，会将其包裹为 `linux-sandbox ... bash -c '...'` 的形式执行。若 `agent-sec-core` 未构建安装，hooks 可以注册成功，但危险命令的沙箱隔离执行将会失败。请确保在依赖沙箱防护前已完成 `agent-sec-core` 的构建（默认 `build-all.sh` 已包含该步骤）。
 
 ---
 

--- a/docs/copilot-shell/users/quickstart.md
+++ b/docs/copilot-shell/users/quickstart.md
@@ -72,6 +72,26 @@ You'll see the welcome screen with your session information and recent conversat
 >
 > You can also use the aliases `co` or `copilot` instead of `cosh`.
 
+## Step 4: Enable sandbox hooks (recommended)
+
+Copilot Shell ships with built-in sandbox-guard hooks that intercept tool calls and enforce security policies — preventing unauthorized file system access or dangerous operations. These hooks are not active until you install them.
+
+Inside Copilot Shell, run:
+
+```
+/hooks install
+```
+
+This command copies the bundled `sandbox-guard.py` script to `~/.copilot-shell/hooks/` and registers it in your user settings. You only need to run this once — the configuration is saved and persists across sessions.
+
+> [!note]
+>
+> This step requires `agent-sec-core` (linux-sandbox) to be installed at `/usr/local/bin/linux-sandbox`. When a dangerous command is detected, `sandbox-guard.py` wraps it inside the `linux-sandbox` binary for execution. If you built ANOLISA using the default `./scripts/build-all.sh`, `agent-sec-core` is included and installed automatically.
+
+> [!tip]
+>
+> To verify the hooks are active, run `/hooks list` inside Copilot Shell. You should see `sandbox-guard` and `sandbox-failure-handler` listed as enabled.
+
 ## Chat with Copilot Shell
 
 ### Ask your first question
@@ -213,9 +233,11 @@ review my changes and suggest improvements
 Here are the most important commands for daily use:
 
 | Command | What it does | Example |
-|---------|--------------|---------|
+|---------|--------------|----------|
 | `cosh` | Start Copilot Shell | `cosh` |
 | `/auth` | Change authentication method | `/auth` |
+| `/hooks install` | Install sandbox-guard hooks (run once after install) | `/hooks install` |
+| `/hooks list` | Show all registered hooks and their status | `/hooks list` |
 | `/help` | Display help for available commands | `/help` or `/?` |
 | `/bash` | Drop into an interactive shell | `/bash` |
 | `/model` | Switch between configured models | `/model` |


### PR DESCRIPTION
## Description

After running `build-all.sh`, the sandbox policy hooks are not active by default,
causing commands (e.g. `ls /usr`) to bypass sandbox enforcement
(reported in issue #77).

This PR documents the required post-installation step: users must run
`/hooks install` inside Copilot Shell once after installation to register
`sandbox-guard.py` and `sandbox-failure-handler.py` into their user settings.

Also clarifies that sandbox hooks depend on `agent-sec-core` (linux-sandbox)
being installed at `/usr/local/bin/linux-sandbox`, since `sandbox-guard.py`
wraps dangerous commands inside the binary for execution.

## Related Issue

fixes #77

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Documentation-only change. No code logic was modified.

To verify:
1. Build and install with `./scripts/build-all.sh`
2. Start `cosh` and run `/hooks install`
3. Run `/hooks list` — confirm `sandbox-guard` and `sandbox-failure-handler` are enabled
4. Ask cosh to execute `sudo echo 1 >> /etc/test.txt` — confirm the command is
   intercepted and wrapped inside linux-sandbox, which enforces the current
   read-only policy on system paths (root readable, cwd/tmpdir writable)

## Additional Notes

Changed files:
- `docs/BUILDING.md` — added section 3.3 + note  in 3.2
- `docs/BUILDING_CN.md` — Chinese translation sync
- `docs/copilot-shell/users/quickstart.md` — added Step 4 + command table entries

The current sandbox file-system policy is statically configured:
system root is read-only, only the current working directory and tmpdir
are writable. Dynamic/customizable policy support is planned for a
future release.

Users can customize sandbox behavior by editing the installed hook script
at `~/.copilot-shell/hooks/sandbox-guard.py` — for example, adjusting
`DANGEROUS_PATTERNS`, `BLOCK_PATTERNS`, or the `SANDBOX_FS_POLICY` JSON
to fit their own security requirements.