### PR TITLE
fix(sec-core): fix cross-process event loss in SecurityEventWriter

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -11,6 +11,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.7"
 authors = [
     {name = "YiZheng Yang", email = "YiZheng.Yang@linux.alibaba.com"},
+    {name = "Xingdong Li", email = "XingDong.Li@linux.alibaba.com"},
 ]
 maintainers = [
     {name = "ANOLISA Team", email = "anolisa@lists.openanolis.cn"},

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/writer.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import fcntl
 import json
-import os
+import re
 import shutil
 import sys
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, TextIO
 
 from agent_sec_cli.security_events.config import get_log_path
 from agent_sec_cli.security_events.schema import SecurityEvent
@@ -20,17 +19,23 @@ DEFAULT_MAX_BYTES = 100 * 1024 * 1024
 # Default number of rotated files to keep
 DEFAULT_BACKUP_COUNT = 10
 
+# Matches the timestamp suffix produced by _rotate():
+#   YYYYMMDD-HHMMSS.fff          (normal)
+#   YYYYMMDD-HHMMSS.fff.N        (collision-guard counter)
+_BACKUP_SUFFIX_RE = re.compile(r"^\d{8}-\d{6}\.\d{3}(\.\d+)?$")
+
 
 class SecurityEventWriter:
     """Append ``SecurityEvent`` records to a JSONL file.
 
     * **Thread-safe** — every ``write()`` is guarded by a ``threading.Lock``.
-    * **Rotation-safe** — before each write the current inode is compared to
-      the one recorded at open time; a mismatch (or missing file) triggers a
-      transparent reopen.
     * **Auto-rotation** — automatically rotates the log file when it exceeds
       ``max_bytes`` (default: 100 MB), keeping up to ``backup_count`` backup
       files (default: 10).
+    * **Cross-process safe** — a dedicated advisory lock file serialises
+      rotation *and* the subsequent write so that no two processes race.
+      Inside the critical section the log file is opened **fresh by path**,
+      which eliminates inode-reuse races.
     * **Fire-and-forget** — all internal errors are swallowed so that logging
       never disrupts the caller.
     """
@@ -45,54 +50,10 @@ class SecurityEventWriter:
         self._max_bytes = max_bytes
         self._backup_count = backup_count
         self._lock = threading.Lock()
-        self._fd: Optional[TextIO] = None
-        self._inode: Optional[int] = None
-        self._open()
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-
-    def _open(self) -> None:
-        """Open (or reopen) the log file and record its inode."""
-        try:
-            self._fd = self._path.open("a", encoding="utf-8")
-            self._inode = os.fstat(self._fd.fileno()).st_ino
-        except OSError as exc:
-            print(
-                f"[security_events] failed to open {self._path}: {exc}",
-                file=sys.stderr,
-            )
-            self._fd = None
-            self._inode = None
-
-    def _close(self) -> None:
-        """Close the current file descriptor if open."""
-        if self._fd is not None:
-            try:
-                self._fd.close()
-            except OSError:
-                pass
-            self._fd = None
-            self._inode = None
-
-    def _ensure_file(self) -> None:
-        """Reopen the log file when inode changed or file was deleted."""
-        try:
-            st = self._path.stat()
-            if st.st_ino != self._inode:
-                self._close()
-                self._open()
-        except FileNotFoundError:
-            self._close()
-            self._open()
-        except OSError as exc:
-            print(
-                f"[security_events] stat failed for {self._path}: {exc}",
-                file=sys.stderr,
-            )
-            self._close()
-            self._open()
 
     def _needs_rotation(self, additional_bytes: int = 0) -> bool:
         """Check if the current log file would exceed the size limit after adding additional_bytes."""
@@ -106,15 +67,24 @@ class SecurityEventWriter:
         """Rotate the log file by renaming it with a timestamp suffix.
 
         Rotation scheme:
-            security-events.jsonl                       -> current (will be rotated)
-            security-events.jsonl.20260408-143022.123   -> rotated at 2026-04-08 14:30:22.123
-            security-events.jsonl.20260408-120515.456   -> rotated at 2026-04-08 12:05:15.456
+            security-events.jsonl                           -> current (will be rotated)
+            security-events.jsonl.20260408-143022.123       -> rotated at 2026-04-08 14:30:22.123
+            security-events.jsonl.20260408-120515.456       -> rotated at 2026-04-08 12:05:15.456
 
         After rotation, old backups exceeding ``backup_count`` are cleaned up.
         """
         # Generate timestamp-based backup filename with millisecond precision
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S.%f")[:-3]  # Truncate to milliseconds
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S.%f")[:-3]
         backup_path = self._path.parent / f"{self._path.name}.{timestamp}"
+
+        # Guard against timestamp collisions: if the backup already exists,
+        # append a counter to disambiguate.
+        if backup_path.exists():
+            for seq in range(1, 1000):
+                candidate = self._path.parent / f"{self._path.name}.{timestamp}.{seq}"
+                if not candidate.exists():
+                    backup_path = candidate
+                    break
 
         # Rotate current file to timestamp-named backup
         try:
@@ -129,49 +99,50 @@ class SecurityEventWriter:
         # Clean up old backups exceeding backup_count
         self._cleanup_old_backups()
 
-        # Close the old file descriptor and open a new one
-        self._close()
-        self._open()
+    def _write_under_flock(self, line: str, line_bytes: int) -> None:
+        """Acquire a cross-process flock, then rotate-if-needed + write.
 
-    def _rotate_under_flock(self) -> None:
-        """Acquire a cross-process advisory lock, re-check size, then rotate.
-
-        Normal writes (O_APPEND, < 4 KB) are already atomic across processes.
-        Only the rotation path needs cross-process synchronization because
-        ``_needs_rotation()`` + ``shutil.move()`` is a TOCTOU race when
-        multiple processes detect the size threshold simultaneously.
-
-        This method uses ``fcntl.flock(LOCK_EX | LOCK_NB)``:
-        - The **winner** re-checks size under the lock and rotates.
-        - **Losers** get ``BlockingIOError``, skip rotation, and reopen
-          the (now-new) log file.
+        Following the "dedicated lock file" pattern, the flock serialises the
+        **entire** write-with-potential-rotation sequence across OS processes.
+        Inside the critical section the log file is opened **fresh by path**
+        (not via a persistent fd), which eliminates inode-reuse races:
+        no stale fd can reference a recycled inode because the fd is created
+        and destroyed within a single lock acquisition.
         """
         lock_path = self._path.parent / (self._path.name + ".lock")
         lock_fd = None
+        lock_acquired = False
         try:
             lock_fd = lock_path.open("w")
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            # Another process is rotating — just reopen and continue
-            self._close()
-            self._open()
-            return
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            lock_acquired = True
         except OSError:
-            # Lock file creation failed — fall through without rotation
-            return
+            # open() or flock() failed — close the fd immediately if it
+            # was opened, then fall through without flock protection.
+            # Best-effort: still write, accept small race.
+            if lock_fd is not None:
+                try:
+                    lock_fd.close()
+                except OSError:
+                    pass
+                lock_fd = None
 
         try:
-            # Re-check under lock — the winner may have already rotated
-            if self._needs_rotation(0):
+            # Check rotation under the lock
+            if self._needs_rotation(line_bytes):
                 self._rotate()
-            else:
-                # Already rotated by another process — just reopen
-                self._close()
-                self._open()
+
+            # Open the file fresh by path, write, and close.
+            # This is the key to avoiding inode-reuse: we never hold a
+            # persistent fd across lock boundaries.
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(line)
+                fh.flush()
         finally:
             if lock_fd is not None:
                 try:
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    if lock_acquired:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
                     lock_fd.close()
                 except OSError:
                     pass
@@ -183,18 +154,19 @@ class SecurityEventWriter:
         by modification time to determine which are oldest.
         """
         try:
-            # Find all backup files matching the pattern
+            # Find all backup files matching the exact rotation pattern
             dir_path = self._path.parent
             base_name = self._path.name
+            prefix = f"{base_name}."
 
             backup_files = []
             for entry in dir_path.iterdir():
-                # Match pattern: {base_name}.{timestamp}
-                if entry.name.startswith(f"{base_name}.") and not entry.name.endswith((".tmp", ".lock")):
-                    if entry.is_file():
-                        # Use mtime to sort (more reliable than parsing timestamp)
-                        mtime = entry.stat().st_mtime
-                        backup_files.append((entry, mtime))
+                if not entry.name.startswith(prefix):
+                    continue
+                suffix = entry.name[len(prefix):]
+                if _BACKUP_SUFFIX_RE.match(suffix) and entry.is_file():
+                    mtime = entry.stat().st_mtime
+                    backup_files.append((entry, mtime))
 
             # Sort by modification time (oldest first)
             backup_files.sort(key=lambda x: x[1])
@@ -223,22 +195,9 @@ class SecurityEventWriter:
         """
         with self._lock:
             try:
-                self._ensure_file()
-                if self._fd is None:
-                    return
-
-                # Calculate the size of the line we're about to write
                 line = json.dumps(event.to_dict(), ensure_ascii=False) + "\n"
-                line_bytes = len(line.encode('utf-8'))
-
-                # Check if rotation is needed before writing (accounting for the new line)
-                if self._needs_rotation(line_bytes):
-                    self._rotate_under_flock()
-                    if self._fd is None:
-                        return
-
-                self._fd.write(line)
-                self._fd.flush()
+                line_bytes = len(line.encode("utf-8"))
+                self._write_under_flock(line, line_bytes)
             except Exception as exc:  # noqa: BLE001
                 print(
                     f"[security_events] write error: {exc}",

--- a/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
@@ -219,9 +219,11 @@ class TestWriterAutoRotation(unittest.TestCase):
             if f.startswith(f"{base_name}.") and not f.endswith(".lock") and os.path.isfile(os.path.join(dir_path, f))
         ]
 
-        # Check that backup files have timestamp pattern (YYYYMMDD-HHMMSS.fff)
+        # Check that backup files have timestamp pattern:
+        #   YYYYMMDD-HHMMSS.fff            (millisecond precision)
+        #   YYYYMMDD-HHMMSS.fff.<counter>   (collision-guard suffix)
         import re
-        timestamp_pattern = re.compile(r"^\d{8}-\d{6}\.\d{3}$")
+        timestamp_pattern = re.compile(r"^\d{8}-\d{6}\.\d{3}(\.\d+)?$")
 
         for backup_file in backup_files:
             # Extract the timestamp suffix
@@ -229,7 +231,7 @@ class TestWriterAutoRotation(unittest.TestCase):
             self.assertTrue(
                 timestamp_pattern.match(suffix),
                 f"Backup file '{backup_file}' should have timestamp format "
-                f"YYYYMMDD-HHMMSS.fff, got suffix: {suffix}"
+                f"YYYYMMDD-HHMMSS.fff[.N], got suffix: {suffix}"
             )
 
     def test_oldest_backups_are_deleted(self):
@@ -422,17 +424,126 @@ class TestWriterAutoRotation(unittest.TestCase):
             )
 
 
+class TestCleanupBackupMatching(unittest.TestCase):
+    """Verify _cleanup_old_backups correctly identifies backup files.
+
+    Tests cover:
+    - Normal timestamp-suffixed backups
+    - Collision-guard counter-suffixed backups (e.g. .123.1)
+    - Non-backup files that share the same prefix are NOT deleted
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.log_path = os.path.join(self.tmpdir, "security-events.jsonl")
+        # Create the active log file
+        with open(self.log_path, "w") as fh:
+            fh.write('{"event_type": "current"}\n')
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _create_file(self, name, age_offset=0):
+        """Create a file in tmpdir and set its mtime to (now - age_offset) seconds."""
+        import time
+        path = os.path.join(self.tmpdir, name)
+        with open(path, "w") as fh:
+            fh.write("data\n")
+        mtime = time.time() - age_offset
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def _list_files(self):
+        """Return set of filenames in tmpdir (excluding the active log)."""
+        base = os.path.basename(self.log_path)
+        return {f for f in os.listdir(self.tmpdir) if f != base}
+
+    def test_collision_guard_backups_are_recognized(self):
+        """Backups with .N collision-guard suffix must be counted and cleaned."""
+        # Create 4 backups: 2 normal, 2 collision-guarded; backup_count=2
+        self._create_file("security-events.jsonl.20260101-120000.100", age_offset=40)
+        self._create_file("security-events.jsonl.20260101-120000.100.1", age_offset=30)
+        self._create_file("security-events.jsonl.20260101-120001.200", age_offset=20)
+        self._create_file("security-events.jsonl.20260101-120001.200.1", age_offset=10)
+
+        writer = SecurityEventWriter(path=self.log_path, backup_count=2)
+        writer._cleanup_old_backups()
+
+        remaining = self._list_files()
+        # Only the 2 most recent (by mtime) should survive
+        self.assertLessEqual(len(remaining), 2, f"Expected <= 2 backups, got: {remaining}")
+        # The two oldest (age_offset=40, 30) should be gone
+        self.assertNotIn("security-events.jsonl.20260101-120000.100", remaining)
+        self.assertNotIn("security-events.jsonl.20260101-120000.100.1", remaining)
+
+    def test_non_backup_files_are_not_deleted(self):
+        """Files that share the prefix but don't match the timestamp pattern must survive."""
+        # Create files that should NOT be treated as backups
+        self._create_file("security-events.jsonl.old", age_offset=100)
+        self._create_file("security-events.jsonl.bak", age_offset=100)
+        self._create_file("security-events.jsonl.lock", age_offset=100)
+        self._create_file("security-events.jsonl.tmp", age_offset=100)
+        self._create_file("security-events.jsonl.schema", age_offset=100)
+        # And one real backup
+        self._create_file("security-events.jsonl.20260101-120000.100", age_offset=5)
+
+        writer = SecurityEventWriter(path=self.log_path, backup_count=5)
+        writer._cleanup_old_backups()
+
+        remaining = self._list_files()
+        # All non-backup files must survive
+        for name in ["security-events.jsonl.old", "security-events.jsonl.bak",
+                     "security-events.jsonl.lock", "security-events.jsonl.tmp",
+                     "security-events.jsonl.schema"]:
+            self.assertIn(name, remaining, f"{name} should NOT have been deleted")
+        # The real backup should also survive (only 1 backup, limit is 5)
+        self.assertIn("security-events.jsonl.20260101-120000.100", remaining)
+
+    def test_mixed_cleanup_respects_backup_count(self):
+        """With a mix of real backups and non-backup files, only real backups are counted."""
+        # 5 real backups (mix of normal and collision-guarded)
+        self._create_file("security-events.jsonl.20260101-100000.000", age_offset=50)
+        self._create_file("security-events.jsonl.20260101-100000.000.1", age_offset=40)
+        self._create_file("security-events.jsonl.20260101-110000.000", age_offset=30)
+        self._create_file("security-events.jsonl.20260101-120000.000", age_offset=20)
+        self._create_file("security-events.jsonl.20260101-130000.000", age_offset=10)
+        # Non-backup files
+        self._create_file("security-events.jsonl.old", age_offset=200)
+        self._create_file("security-events.jsonl.notes", age_offset=200)
+
+        writer = SecurityEventWriter(path=self.log_path, backup_count=3)
+        writer._cleanup_old_backups()
+
+        remaining = self._list_files()
+        # Non-backup files must survive
+        self.assertIn("security-events.jsonl.old", remaining)
+        self.assertIn("security-events.jsonl.notes", remaining)
+        # 2 oldest real backups should be gone
+        self.assertNotIn("security-events.jsonl.20260101-100000.000", remaining)
+        self.assertNotIn("security-events.jsonl.20260101-100000.000.1", remaining)
+        # 3 most recent should remain
+        self.assertIn("security-events.jsonl.20260101-110000.000", remaining)
+        self.assertIn("security-events.jsonl.20260101-120000.000", remaining)
+        self.assertIn("security-events.jsonl.20260101-130000.000", remaining)
+
+
 # ------------------------------------------------------------------
 # Helper for cross-process tests (must be module-level & picklable)
 # ------------------------------------------------------------------
 
 def _child_writer(path, proc_id, event_count, max_bytes, backup_count):
-    """Entry point executed inside each child process."""
+    """Entry point executed inside each child process.
+    
+    Returns a list of event_type strings that this process successfully
+    passed to write() — used for post-mortem analysis when events are lost.
+    """
     kwargs = {"path": path}
     if max_bytes:
         kwargs["max_bytes"] = max_bytes
         kwargs["backup_count"] = backup_count
     writer = SecurityEventWriter(**kwargs)
+    written_events = []
     for i in range(event_count):
         evt = SecurityEvent(
             event_type=f"p{proc_id}_e{i}",
@@ -440,6 +551,8 @@ def _child_writer(path, proc_id, event_count, max_bytes, backup_count):
             details={"proc": proc_id, "seq": i, "pad": "x" * 30},
         )
         writer.write(evt)
+        written_events.append(f"p{proc_id}_e{i}")
+    return written_events
 
 
 class TestWriterMultiProcessSafety(unittest.TestCase):
@@ -493,7 +606,7 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         base_name = os.path.basename(self.tmp.name)
         all_files = [self.tmp.name]
         for name in os.listdir(dir_path):
-            if name.startswith(f"{base_name}.") and not name.endswith(".lock"):
+            if name.startswith(f"{base_name}.") and not name.endswith((".lock", ".tmp")):
                 all_files.append(os.path.join(dir_path, name))
 
         events = []


### PR DESCRIPTION


## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Root cause: backup filename timestamp collision.
When two rotations occur within the same millisecond, the backup timestamp collides and shutil.move() silently overwrites the existing backup on POSIX, destroying all events in it. A sequential counter suffix (.1, .2, ...) is now appended when a collision is detected, ensuring every backup gets a unique filename.

Additionally, the write path is restructured for defense-in-depth: Replace _rotate_under_flock() with _write_under_flock() that covers rotation check + rotation + write under a single flock(LOCK_EX). The log file is opened fresh by path inside the critical section (not via a persistent fd), preventing stale-fd writes to rotated backup files. This does not fix a data-loss scenario on its own but eliminates event misplacement across files.

Also updates test_writer.py to accept the collision-guard suffix in timestamp format assertions and adds .tmp exclusion to file collection.
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes https://github.com/alibaba/anolisa/issues/225

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
