### PR TITLE
feat(sec-core): add sqldb writer&reader and query command at cli interface

### DIFF
--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -16,7 +16,8 @@ python-code-pretty: ## Format Python code using black and isort
 test-python: ## Run Python unit and integration tests
 	@echo "🧪 Running Python tests..."
 	cd agent-sec-cli && uv sync
-	uv run --project agent-sec-cli pytest tests/ --ignore=tests/e2e -v
+	uv run --project agent-sec-cli pytest tests/ --ignore=tests/e2e/ -v
+	uv run --project agent-sec-cli pytest tests/e2e/cli -v
 
 .PHONY: test-rust
 test-rust: ## Run Rust sandbox tests

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -1,11 +1,19 @@
 """CLI entry point for agent-sec-cli package."""
 
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any
+
 import typer
 from agent_sec_cli.prompt_scanner.cli import scanner_app
+from agent_sec_cli.security_events import get_reader
+from agent_sec_cli.security_events.summary_formatter import format_summary
 from agent_sec_cli.security_middleware import invoke
 from agent_sec_cli.security_middleware.backends.hardening import (
     DEFAULT_HARDEN_CONFIG,
 )
+from agent_sec_cli.security_middleware.lifecycle import _ACTION_CATEGORY
 from agent_sec_cli.skill_ledger.cli import app as skill_ledger_app
 
 app = typer.Typer(
@@ -14,9 +22,13 @@ app = typer.Typer(
     add_completion=True,
 )
 
+
 # Mount skill-ledger as a subcommand group: agent-sec-cli skill-ledger <cmd>
 app.add_typer(skill_ledger_app, name="skill-ledger")
 
+# ---------------------------------------------------------------------------
+# Command: harden
+# ---------------------------------------------------------------------------
 _HARDEN_HELP_TEXT = f"""\
 Usage: agent-sec-cli harden [SEHARDEN_ARGS]...
 
@@ -63,6 +75,9 @@ def _with_default_harden_args(args: list[str]) -> list[str]:
 app.add_typer(scanner_app, name="scan-prompt")
 
 
+# ---------------------------------------------------------------------------
+# Command: log-sandbox (internal — called by sandbox-guard.py)
+# ---------------------------------------------------------------------------
 @app.command(name="log-sandbox", hidden=True)
 def log_sandbox(
     decision: str = typer.Option(
@@ -144,6 +159,9 @@ def harden(
     raise typer.Exit(code=result.exit_code)
 
 
+# ---------------------------------------------------------------------------
+# Command: verify
+# ---------------------------------------------------------------------------
 @app.command()
 def verify(
     skill: str = typer.Option(
@@ -161,6 +179,9 @@ def verify(
     raise typer.Exit(code=result.exit_code)
 
 
+# ---------------------------------------------------------------------------
+# Command: code-scan
+# ---------------------------------------------------------------------------
 @app.command(name="code-scan")
 def code_scan(
     code: str = typer.Option("", "--code", help="Source code to scan"),
@@ -178,7 +199,303 @@ def code_scan(
     raise typer.Exit(code=result.exit_code)
 
 
-def main():
+# ---------------------------------------------------------------------------
+# Command: events
+#
+# Examples:
+#   # List recent events (default: table format, last 100)
+#   agent-sec-cli events --last-hours 24
+#
+#   # Filter by type and show as JSON
+#   agent-sec-cli events --event-type harden --output json
+#
+#   # Count hardening events in the last 8 hours
+#   agent-sec-cli events --count --category hardening --last-hours 8
+#
+#   # Breakdown by category
+#   agent-sec-cli events --count-by category --last-hours 24
+#
+#   # Paginate: skip first 50, show next 20
+#   agent-sec-cli events --offset 50 --limit 20
+#
+#   # Stream events for scripting (one JSON object per line)
+#   agent-sec-cli events --last-hours 1 --output jsonl | jq '.result'
+# ---------------------------------------------------------------------------
+
+_COUNT_BY_ALLOWED = {"category", "event_type", "trace_id"}
+_OUTPUT_FORMATS = {"table", "json", "jsonl"}
+
+# Canonical event types and categories — dynamically derived from lifecycle.py
+# _ACTION_CATEGORY mapping to ensure automatic synchronization.
+# Keys → event types, Values → categories
+# Note: Success/failure is tracked via the `result` field (succeeded/failed),
+# NOT via _error suffix in event_type. This keeps the event model clean and
+# makes it easy to query all events of a type regardless of outcome.
+_VALID_EVENT_TYPES = set(_ACTION_CATEGORY.keys())
+
+_VALID_CATEGORIES = set(_ACTION_CATEGORY.values())
+
+
+def _resolve_time_range(
+    last_hours: float | None,
+    since: str | None,
+    until: str | None,
+) -> tuple[str | None, str | None]:
+    """Resolve since/until from either explicit values or last_hours.
+
+    Ensures consistent time range handling across all query modes.
+    """
+    if last_hours is not None:
+        now = time.time()
+        since_epoch = now - last_hours * 3600
+        since = datetime.fromtimestamp(since_epoch, tz=timezone.utc).isoformat()
+        until = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+    return since, until
+
+
+def _format_timestamp(ts: str) -> str:
+    """Truncate ISO-8601 timestamp to seconds for table display.
+
+    Reduces column width from ~32 to 19 characters while preserving
+    all meaningful precision for security event browsing.
+    """
+    try:
+        dt = datetime.fromisoformat(ts)
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, TypeError):
+        return ts  # Fallback to original if parsing fails
+
+
+def _format_table(events_list: list[Any]) -> str:
+    """Format events as a kubectl-style columnar table.
+
+    Column widths are computed dynamically from the data (like kubectl)
+    so that long values never bleed into adjacent columns.
+    """
+    if not events_list:
+        return "No events found."
+
+    headers = ("EVENT_TYPE", "CATEGORY", "RESULT", "TIMESTAMP")
+    rows = [
+        (
+            e.to_dict().get("event_type", ""),
+            e.to_dict().get("category", ""),
+            e.to_dict().get("result", "succeeded"),
+            _format_timestamp(e.to_dict().get("timestamp", "")),
+        )
+        for e in events_list
+    ]
+
+    # Compute column widths: max(header, all values) + 2 padding
+    col_widths = [
+        max(len(h), *(len(r[i]) for r in rows)) + 2 for i, h in enumerate(headers)
+    ]
+
+    lines: list[str] = []
+    lines.append("".join(h.ljust(w) for h, w in zip(headers, col_widths)).rstrip())
+    for row in rows:
+        lines.append("".join(v.ljust(w) for v, w in zip(row, col_widths)).rstrip())
+
+    count = len(events_list)
+    lines.append("")
+    lines.append(f"{count} event{'s' if count != 1 else ''}")
+
+    return "\n".join(lines)
+
+
+@app.command()
+def events(
+    event_type: str | None = typer.Option(
+        None,
+        "--event-type",
+        help=(
+            "Filter by event type. "
+            f"Known types: {', '.join(sorted(_VALID_EVENT_TYPES))}. "
+            "(Success/failure is tracked in the RESULT column, not in event_type)"
+        ),
+    ),
+    category: str | None = typer.Option(
+        None,
+        "--category",
+        help=(
+            "Filter by category. "
+            f"Known categories: {', '.join(sorted(_VALID_CATEGORIES))}."
+        ),
+    ),
+    trace_id: str | None = typer.Option(None, "--trace-id", help="Filter by trace ID."),
+    since: str | None = typer.Option(
+        None, "--since", help="Inclusive lower bound (ISO-8601 timestamp)."
+    ),
+    until: str | None = typer.Option(
+        None, "--until", help="Exclusive upper bound (ISO-8601 timestamp)."
+    ),
+    last_hours: float | None = typer.Option(
+        None,
+        "--last-hours",
+        help="Query events from the last N hours (mutually exclusive with --since/--until).",
+    ),
+    limit: int = typer.Option(100, "--limit", help="Max results (default 100)."),
+    offset: int = typer.Option(0, "--offset", help="Skip N results (default 0)."),
+    count: bool = typer.Option(
+        False, "--count", help="Output only the count of matching events."
+    ),
+    count_by: str | None = typer.Option(
+        None,
+        "--count-by",
+        help="Output grouped counts as JSON object. Allowed: category, event_type, trace_id.",
+    ),
+    output: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table (default, human-readable), json, jsonl.",
+    ),
+    summary: bool = typer.Option(
+        False,
+        "--summary",
+        help=(
+            "Output a human-readable security posture summary. "
+            "Incompatible with --count, --count-by, --output."
+        ),
+    ),
+):
+    """Query security events from the local SQLite store."""
+    # TODO: Support paging with limit and continue
+
+    # --- validation ---
+    if summary and (count or count_by is not None):
+        typer.echo(
+            "Error: --summary is incompatible with --count and --count-by.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if summary and output != "table":
+        typer.echo(
+            "Error: --summary is incompatible with --output (summary has its own format).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if output not in _OUTPUT_FORMATS:
+        typer.echo(
+            f"Error: --output must be one of: {', '.join(sorted(_OUTPUT_FORMATS))}.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if event_type is not None and event_type not in _VALID_EVENT_TYPES:
+        typer.echo(
+            f"Warning: Unknown event_type '{event_type}'. "
+            f"Known types: {', '.join(sorted(_VALID_EVENT_TYPES))}",
+            err=True,
+        )
+        # Don't reject — allow future event types, just warn
+
+    if category is not None and category not in _VALID_CATEGORIES:
+        typer.echo(
+            f"Warning: Unknown category '{category}'. "
+            f"Known categories: {', '.join(sorted(_VALID_CATEGORIES))}",
+            err=True,
+        )
+        # Don't reject — allow future categories, just warn
+
+    if last_hours is not None and (since is not None or until is not None):
+        typer.echo(
+            "Error: --last-hours is mutually exclusive with --since/--until.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if count and count_by is not None:
+        typer.echo("Error: --count and --count-by are mutually exclusive.", err=True)
+        raise typer.Exit(code=1)
+
+    if count_by is not None and count_by not in _COUNT_BY_ALLOWED:
+        typer.echo(
+            f"Error: --count-by must be one of: {', '.join(sorted(_COUNT_BY_ALLOWED))}.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    reader = get_reader()
+
+    # --- summary mode ---
+    if summary:
+        # Default to last 24 hours if no time range specified
+        summary_hours = last_hours if last_hours is not None else None
+        if summary_hours is None and since is None and until is None:
+            summary_hours = 24.0
+
+        resolved_since, resolved_until = _resolve_time_range(
+            summary_hours, since, until
+        )
+        events_list = reader.query(
+            event_type=event_type,
+            category=category,
+            trace_id=trace_id,
+            since=resolved_since,
+            until=resolved_until,
+            limit=10000,
+            offset=0,
+        )
+        time_label = (
+            f"last {summary_hours:.0f} hours"
+            if summary_hours is not None
+            else f"{since or '...'} to {until or 'now'}"
+        )
+
+        typer.echo(format_summary(events_list, time_label))
+        raise typer.Exit(code=0)
+
+    # --- count mode ---
+    if count:
+        resolved_since, resolved_until = _resolve_time_range(last_hours, since, until)
+        result = reader.count(
+            event_type=event_type,
+            category=category,
+            since=resolved_since,
+            until=resolved_until,
+        )
+        typer.echo(json.dumps(result, ensure_ascii=False, indent=2))
+        raise typer.Exit(code=0)
+
+    # --- count-by mode ---
+    if count_by is not None:
+        resolved_since, resolved_until = _resolve_time_range(last_hours, since, until)
+        result = reader.count_by(count_by, since=resolved_since, until=resolved_until)
+        typer.echo(json.dumps(result, ensure_ascii=False, indent=2))
+        raise typer.Exit(code=0)
+
+    # --- list mode ---
+    resolved_since, resolved_until = _resolve_time_range(last_hours, since, until)
+    events_list = reader.query(
+        event_type=event_type,
+        category=category,
+        trace_id=trace_id,
+        since=resolved_since,
+        until=resolved_until,
+        limit=limit,
+        offset=offset,
+    )
+
+    if output == "table":
+        typer.echo(_format_table(events_list))
+    elif output == "json":
+        output_data = [e.to_dict() for e in events_list]
+        typer.echo(json.dumps(output_data, ensure_ascii=False, indent=2))
+    elif output == "jsonl":
+        for e in events_list:
+            typer.echo(json.dumps(e.to_dict(), ensure_ascii=False))
+    raise typer.Exit(code=0)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
     """Main entry point."""
     app()
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/__init__.py
@@ -1,38 +1,71 @@
-"""security_events — fire-and-forget JSONL security event logging.
+"""security_events — fire-and-forget dual-write security event logging (JSONL + SQLite).
 
 Public API
 ----------
-- ``log_event(event)``  — append a ``SecurityEvent`` to the JSONL log
-- ``get_writer()``      — obtain the singleton ``SecurityEventWriter``
-- ``SecurityEvent``     — the canonical event dataclass
+- ``log_event(event)``        — append a ``SecurityEvent`` to both JSONL and SQLite
+- ``get_writer()``            — obtain the singleton JSONL ``SecurityEventWriter``
+- ``get_sqlite_writer()``     — obtain the singleton ``SqliteEventWriter``
+- ``get_reader()``            — obtain the singleton ``SqliteEventReader``
+- ``SecurityEvent``           — the canonical event dataclass
 """
 
-from typing import Optional
+import atexit
 
 from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
+from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
 from agent_sec_cli.security_events.writer import SecurityEventWriter
 
-_writer: Optional[SecurityEventWriter] = None
+_writer: SecurityEventWriter | None = None
+_sqlite_writer: SqliteEventWriter | None = None
+_reader: SqliteEventReader | None = None
 
 
 def get_writer() -> SecurityEventWriter:
-    """Return the module-level singleton writer (created lazily)."""
+    """Return the module-level singleton JSONL writer (created lazily)."""
     global _writer  # noqa: PLW0603
     if _writer is None:
         _writer = SecurityEventWriter()
     return _writer
 
 
-def log_event(event: SecurityEvent) -> None:
-    """Persist *event* to the JSONL log.
+def get_sqlite_writer() -> SqliteEventWriter:
+    """Return the module-level singleton SQLite writer (created lazily)."""
+    global _sqlite_writer  # noqa: PLW0603
+    if _sqlite_writer is None:
+        _sqlite_writer = SqliteEventWriter()
+        atexit.register(_sqlite_writer.close)
+    return _sqlite_writer
 
-    This is deliberately **fire-and-forget**: any failure is silently
-    swallowed so that callers are never disrupted by logging issues.
+
+def get_reader() -> SqliteEventReader:
+    """Return the module-level singleton SQLite reader (created lazily)."""
+    global _reader  # noqa: PLW0603
+    if _reader is None:
+        _reader = SqliteEventReader()
+    return _reader
+
+
+def log_event(event: SecurityEvent) -> None:
+    """Persist *event* to JSONL and SQLite.
+
+    This is deliberately **fire-and-forget**: any failure in either
+    writer is silently swallowed so that callers are never disrupted.
     """
     try:
         get_writer().write(event)
     except Exception:  # noqa: BLE001
         pass
+    try:
+        get_sqlite_writer().write(event)
+    except Exception:  # noqa: BLE001
+        pass
 
 
-__all__ = ["log_event", "get_writer", "SecurityEvent"]
+__all__ = [
+    "log_event",
+    "get_writer",
+    "get_sqlite_writer",
+    "get_reader",
+    "SecurityEvent",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/config.py
@@ -8,64 +8,71 @@ PRIMARY_LOG_PATH = "/var/log/agent-sec/security-events.jsonl"
 FALLBACK_LOG_PATH = str(Path.home() / ".agent-sec-core" / "security-events.jsonl")
 
 
-def _safe_tmp_log_path() -> str:
-    """Return a log path inside a private per-user directory under ``/tmp``.
-
-    Creates ``/tmp/agent-sec-<uid>/`` with mode ``0o700`` and validates
-    ownership via :func:`os.lstat` (no symlink following) to prevent
-    symlink and file-squatting attacks in the world-writable ``/tmp``.
-
-    Raises :class:`OSError` if the directory cannot be created or passes
-    the safety checks.
-    """
+def _safe_tmp_dir() -> Path:
+    """Return a validated per-user tmp directory, raising on symlink/ownership issues."""
     uid = os.getuid()
     safe_dir = Path("/tmp") / f"agent-sec-{uid}"
-
     safe_dir.mkdir(mode=0o700, exist_ok=True)
-
-    # lstat() does NOT follow symlinks — catches attacker-planted links.
     st = safe_dir.lstat()
     if stat.S_ISLNK(st.st_mode):
         raise OSError(f"{safe_dir} is a symlink — refusing to use")
     if st.st_uid != uid:
         raise OSError(f"{safe_dir} not owned by uid {uid}")
-
-    # Tighten permissions in case the directory pre-existed with looser mode.
     safe_dir.chmod(0o700)
+    return safe_dir
 
-    return str(safe_dir / "security-events.jsonl")
+
+def _resolve_data_dir() -> Path:
+    """Resolve the data directory using a 3-tier fallback strategy.
+
+    Override: set ``AGENT_SEC_DATA_DIR`` to force a specific directory.
+    This is primarily useful for tests that need an isolated DB/log path.
+
+    Security: All directories are created with mode 0o700 (owner-only access)
+    to protect sensitive security event data.
+    """
+    # Env-var override — highest priority
+    override = os.environ.get("AGENT_SEC_DATA_DIR")
+    if override:
+        p = Path(override)
+        p.mkdir(parents=True, exist_ok=True, mode=0o700)
+        p.chmod(0o700)  # Explicit permission guarantee (defensive against umask)
+        return p
+
+    # Tier 1: system-wide directory
+    primary_dir = Path(PRIMARY_LOG_PATH).parent
+    try:
+        primary_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        primary_dir.chmod(0o700)  # Explicit permission guarantee
+        if primary_dir.is_dir() and os.access(primary_dir, os.W_OK):
+            return primary_dir
+    except OSError:
+        pass
+
+    # Tier 2: user home directory
+    fallback_dir = Path(FALLBACK_LOG_PATH).parent
+    try:
+        fallback_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fallback_dir.chmod(0o700)  # Explicit permission guarantee
+        return fallback_dir
+    except OSError:
+        pass
+
+    # Tier 3: secure per-user tmp directory
+    try:
+        return _safe_tmp_dir()
+    except OSError:
+        pass
+
+    # Last resort: return tmp path anyway
+    return Path("/tmp") / f"agent-sec-{os.getuid()}"
 
 
 def get_log_path() -> str:
-    """Return the best available log file path.
+    """Return the path for the security-events JSONL log file."""
+    return str(_resolve_data_dir() / "security-events.jsonl")
 
-    Tries the primary path first (checks that its parent directory exists and
-    is writeable).  Falls back to a per-user path under ``~/.agent-sec-core/``.
-    Last resort is a private per-user directory under ``/tmp`` with symlink
-    and ownership validation.
-    Directories are created automatically when they do not exist.
-    """
-    primary_dir = Path(PRIMARY_LOG_PATH).parent
-    try:
-        primary_dir.mkdir(parents=True, exist_ok=True)
-        if primary_dir.is_dir() and os.access(primary_dir, os.W_OK):
-            return PRIMARY_LOG_PATH
-    except OSError:
-        pass
 
-    fallback_dir = Path(FALLBACK_LOG_PATH).parent
-    try:
-        fallback_dir.mkdir(parents=True, exist_ok=True)
-        return FALLBACK_LOG_PATH
-    except OSError:
-        pass
-
-    # Last resort: private per-user directory under /tmp with symlink protection
-    try:
-        return _safe_tmp_log_path()
-    except OSError:
-        pass
-
-    # Absolute last resort — return the safe path anyway; the writer's _open()
-    # will handle the failure gracefully.
-    return str(Path("/tmp") / f"agent-sec-{os.getuid()}" / "security-events.jsonl")
+def get_db_path() -> str:
+    """Return the path for the security-events SQLite database."""
+    return str(_resolve_data_dir() / "security-events.db")

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/schema.py
@@ -3,7 +3,7 @@
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -25,6 +25,7 @@ class SecurityEvent(BaseModel):
         details     — backend-specific structured data
 
     Auto-filled fields:
+        result      — succeeded (default) | failed
         trace_id    — injected by middleware (empty string until then)
         timestamp   — ISO-8601
         event_id    — UUID
@@ -34,15 +35,16 @@ class SecurityEvent(BaseModel):
 
     event_type: str
     category: str
-    details: Dict[str, Any]
+    details: dict[str, Any]
+    result: Literal["succeeded", "failed"] = "succeeded"
     trace_id: str = ""
     timestamp: str = Field(default_factory=_now_iso)
     event_id: str = Field(default_factory=_new_uuid)
     pid: int = Field(default_factory=os.getpid)
     uid: int = Field(default_factory=os.getuid)
-    session_id: Optional[str] = None
+    session_id: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Return a plain ``dict`` suitable for ``json.dumps``."""
         d = self.model_dump()
         # Return keys in the canonical order expected by callers.
@@ -50,6 +52,7 @@ class SecurityEvent(BaseModel):
             "event_id": d["event_id"],
             "event_type": d["event_type"],
             "category": d["category"],
+            "result": d["result"],
             "timestamp": d["timestamp"],
             "trace_id": d["trace_id"],
             "pid": d["pid"],

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
@@ -1,0 +1,259 @@
+"""Read-only SQLite reader for querying security events."""
+
+import json
+import re
+import sqlite3
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from agent_sec_cli.security_events.config import get_db_path
+from agent_sec_cli.security_events.schema import SecurityEvent
+
+
+class SqliteEventReader:
+    """Read-only SQLite reader for security events.
+
+    Uses per-call connections via URI mode (?mode=ro).
+    Thread-safe by design — no shared state between calls.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path else Path(get_db_path())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a read-only connection. Raises OperationalError if DB missing."""
+        conn = sqlite3.connect(f"file:{self._path}?mode=ro", uri=True)
+        conn.execute("PRAGMA query_only=ON")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _build_where(
+        self,
+        *,
+        event_type: str | None = None,
+        category: str | None = None,
+        trace_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> tuple[str, list[Any]]:
+        """Build WHERE clause and params list from non-None filters."""
+        conditions: list[str] = []
+        params: list[Any] = []
+        if event_type is not None:
+            conditions.append("event_type = ?")
+            params.append(event_type)
+        if category is not None:
+            conditions.append("category = ?")
+            params.append(category)
+        if trace_id is not None:
+            conditions.append("trace_id = ?")
+            params.append(trace_id)
+        if since is not None:
+            conditions.append("timestamp_epoch >= ?")
+            params.append(datetime.fromisoformat(since).timestamp())
+        if until is not None:
+            conditions.append("timestamp_epoch < ?")
+            params.append(datetime.fromisoformat(until).timestamp())
+        where = " WHERE " + " AND ".join(conditions) if conditions else ""
+        return where, params
+
+    def _row_to_event(self, row: sqlite3.Row) -> SecurityEvent | None:
+        """Convert a DB row to SecurityEvent. Returns None on parse error."""
+        try:
+            return SecurityEvent(
+                event_id=row["event_id"],
+                event_type=row["event_type"],
+                category=row["category"],
+                result=row["result"],
+                timestamp=row["timestamp"],
+                trace_id=row["trace_id"],
+                pid=row["pid"],
+                uid=row["uid"],
+                session_id=row["session_id"],
+                details=json.loads(row["details"]),
+            )
+        except (json.JSONDecodeError, IndexError, KeyError, TypeError) as exc:
+            print(f"[security_events] malformed row skipped: {exc}", file=sys.stderr)
+            return None
+
+    # ------------------------------------------------------------------
+    # Public query API
+    # ------------------------------------------------------------------
+
+    def query(
+        self,
+        event_type: str | None = None,
+        category: str | None = None,
+        trace_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> list[SecurityEvent]:
+        """Query security events with optional filters.
+
+        Parameters
+        ----------
+        event_type : str, optional
+            Filter by event type.
+        category : str, optional
+            Filter by category.
+        trace_id : str, optional
+            Filter by trace ID.
+        since : str, optional
+            Inclusive lower bound (ISO-8601 timestamp).
+        until : str, optional
+            Exclusive upper bound (ISO-8601 timestamp).
+        limit : int
+            Maximum number of results (default 1000).
+        offset : int
+            Number of results to skip (default 0).
+
+        Returns
+        -------
+        list[SecurityEvent]
+            Matching events ordered by timestamp descending.
+        """
+        try:
+            conn = self._connect()
+            try:
+                where, params = self._build_where(
+                    event_type=event_type,
+                    category=category,
+                    trace_id=trace_id,
+                    since=since,
+                    until=until,
+                )
+                sql = (
+                    "SELECT event_id, event_type, category, result, timestamp, "
+                    "timestamp_epoch, trace_id, pid, uid, session_id, details "
+                    f"FROM security_events{where} "
+                    "ORDER BY timestamp_epoch DESC "
+                    "LIMIT ? OFFSET ?"
+                )
+                params.extend([limit, offset])
+                cursor = conn.execute(sql, params)
+                rows = cursor.fetchall()
+            finally:
+                conn.close()
+        except sqlite3.OperationalError:
+            return []
+
+        events: list[SecurityEvent] = []
+        for row in rows:
+            event = self._row_to_event(row)
+            if event is not None:
+                events.append(event)
+        return events
+
+    def count(
+        self,
+        event_type: str | None = None,
+        category: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> int:
+        """Count events matching the given filters.
+
+        Parameters
+        ----------
+        event_type : str, optional
+            Filter by event type.
+        category : str, optional
+            Filter by category.
+        since : str, optional
+            Inclusive lower bound (ISO-8601 timestamp).
+        until : str, optional
+            Exclusive upper bound (ISO-8601 timestamp).
+
+        Returns
+        -------
+        int
+            Number of matching events.
+        """
+        try:
+            conn = self._connect()
+            try:
+                where, params = self._build_where(
+                    event_type=event_type,
+                    category=category,
+                    since=since,
+                    until=until,
+                )
+                sql = f"SELECT COUNT(*) FROM security_events{where}"
+                cursor = conn.execute(sql, params)
+                result = cursor.fetchone()
+                return result[0] if result else 0
+            finally:
+                conn.close()
+        except sqlite3.OperationalError:
+            return 0
+
+    def count_by(
+        self,
+        group_field: str,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> dict[str, int]:
+        """Count events grouped by a specific field.
+
+        Parameters
+        ----------
+        group_field : str
+            Field to group by. Must be one of: category, event_type, trace_id.
+        since : str, optional
+            Inclusive lower bound (ISO-8601 timestamp).
+        until : str, optional
+            Exclusive upper bound (ISO-8601 timestamp).
+
+        Returns
+        -------
+        dict[str, int]
+            Mapping of field value to event count.
+
+        Raises
+        ------
+        ValueError
+            If group_field is not in the allowlist.
+        """
+        # Explicit column mapping for defense-in-depth — prevents SQL injection
+        # even if allowlist validation is accidentally bypassed
+        allowed_columns = {"category", "event_type", "trace_id"}
+        if group_field not in allowed_columns:
+            raise ValueError(
+                f"Invalid group_field: {group_field!r}. "
+                "Must be one of: category, event_type, trace_id"
+            )
+
+        # Validate column name is a safe identifier
+        # This is a belt-and-suspenders check — the allowlist above already
+        # guarantees safety, but this prevents future regressions if the
+        # allowlist is modified incorrectly
+        if not re.match(r"^[a-z_]+$", group_field):
+            raise ValueError(
+                f"group_field contains invalid characters: {group_field!r}"
+            )
+
+        try:
+            conn = self._connect()
+            try:
+                where, params = self._build_where(since=since, until=until)
+                sql = (
+                    f"SELECT {group_field}, COUNT(*) "
+                    f"FROM security_events{where} "
+                    f"GROUP BY {group_field}"
+                )
+                cursor = conn.execute(sql, params)
+                rows = cursor.fetchall()
+                return {row[0]: row[1] for row in rows}
+            finally:
+                conn.close()
+        except sqlite3.OperationalError:
+            return {}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
@@ -1,0 +1,293 @@
+"""Fire-and-forget SQLite writer for security events.
+
+Runs alongside the existing JSONL writer (dual-write pattern).
+Thread-safe, corruption-resilient, self-pruning.
+All exceptions are swallowed — never raises to callers.
+"""
+
+import json
+import re
+import sqlite3
+import sys
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+from agent_sec_cli.security_events.config import get_db_path
+from agent_sec_cli.security_events.schema import SecurityEvent
+
+# ---------------------------------------------------------------------------
+# Schema constants
+# ---------------------------------------------------------------------------
+
+_SCHEMA_VERSION = 1
+
+_CREATE_TABLE_SQL = """\
+PRAGMA auto_vacuum = INCREMENTAL;
+
+CREATE TABLE IF NOT EXISTS security_events (
+    event_id        TEXT PRIMARY KEY,
+    event_type      TEXT NOT NULL,
+    category        TEXT NOT NULL,
+    result          TEXT NOT NULL DEFAULT 'succeeded',
+    timestamp       TEXT NOT NULL,
+    timestamp_epoch REAL NOT NULL,
+    trace_id        TEXT NOT NULL DEFAULT '',
+    pid             INTEGER NOT NULL,
+    uid             INTEGER NOT NULL,
+    session_id      TEXT,
+    details         TEXT NOT NULL
+);
+"""
+
+_CREATE_INDEXES_SQL = """\
+CREATE INDEX IF NOT EXISTS idx_event_type      ON security_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_category_epoch  ON security_events(category, timestamp_epoch);
+CREATE INDEX IF NOT EXISTS idx_trace_id        ON security_events(trace_id);
+CREATE INDEX IF NOT EXISTS idx_timestamp_epoch ON security_events(timestamp_epoch);
+"""
+
+# Declarative column registry for convergent migration.
+# To add a column: insert an entry and bump _SCHEMA_VERSION.
+_COLUMNS: dict[str, str] = {
+    # "severity": "TEXT DEFAULT 'info'",  # Future: uncomment and bump version
+}
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+class SqliteEventWriter:
+    """Fire-and-forget SQLite writer for security events.
+
+    Thread-safe, corruption-resilient, self-pruning.
+    All exceptions are swallowed — never raises to callers.
+    """
+
+    def __init__(
+        self,
+        path: str | Path | None = None,
+        max_age_days: int = 30,
+    ) -> None:
+        self._path = Path(path) if path else Path(get_db_path())
+        self._max_age_days = max_age_days
+        self._lock = threading.Lock()
+        self._conn: sqlite3.Connection | None = None
+        # Per-process flag: prevents futile repeated rename attempts within
+        # a single CLI invocation (e.g. batch scan writing 200 events).
+        # Resets naturally on next process — allows retry if the filesystem
+        # issue was transient.
+        self._disabled = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def write(self, event: SecurityEvent) -> None:
+        """Insert *event* into SQLite.  Fire-and-forget — never raises."""
+        if self._disabled:
+            return
+
+        # Validate event params BEFORE acquiring lock to avoid holding lock
+        # during potentially failing serialization
+        try:
+            params = self._event_params(event)
+        except (ValueError, TypeError) as exc:
+            print(
+                f"[security_events] invalid event params: {exc}",
+                file=sys.stderr,
+            )
+            return
+
+        with self._lock:
+            try:
+                self._ensure_connection()
+                if self._conn is None:
+                    return
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO security_events "
+                    "(event_id, event_type, category, result, timestamp, timestamp_epoch, "
+                    "trace_id, pid, uid, session_id, details) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    params,
+                )
+            except sqlite3.DatabaseError as exc:
+                # Hard corruption — delete and retry once with fresh DB
+                self._handle_corruption(exc)
+                if self._disabled:
+                    return
+                try:
+                    self._ensure_connection()
+                    if self._conn is None:
+                        return
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO security_events "
+                        "(event_id, event_type, category, result, timestamp, timestamp_epoch, "
+                        "trace_id, pid, uid, session_id, details) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        params,
+                    )
+                except Exception:  # noqa: BLE001
+                    pass  # Best effort — give up silently on second failure
+            except (sqlite3.Error, OSError) as exc:
+                print(
+                    f"[security_events] sqlite write error: {exc}",
+                    file=sys.stderr,
+                )
+                self._conn = None  # Reset connection for next retry
+
+    @staticmethod
+    def _event_params(event: SecurityEvent) -> tuple:
+        """Build the parameter tuple for INSERT."""
+        return (
+            event.event_id,
+            event.event_type,
+            event.category,
+            event.result,
+            event.timestamp,
+            datetime.fromisoformat(event.timestamp).timestamp(),
+            event.trace_id,
+            event.pid,
+            event.uid,
+            event.session_id,
+            json.dumps(event.details, ensure_ascii=False),
+        )
+
+    def close(self) -> None:
+        """Best-effort prune, WAL checkpoint, and close.  Lock-free — safe for atexit.
+
+        Pruning is done here (not inside write()) because agent-sec-cli is a
+        short-lived CLI: each invocation is a separate process, so an in-process
+        write counter would never accumulate across invocations.  Pruning at
+        close() guarantees exactly one prune attempt per process lifetime,
+        regardless of how many events were written.
+        """
+        conn = self._conn
+        if conn is None:
+            return
+        # Prune expired events — bounded cost (single DELETE by indexed epoch)
+        try:
+            cutoff = time.time() - (self._max_age_days * 86400)
+            conn.execute(
+                "DELETE FROM security_events WHERE timestamp_epoch < ?", (cutoff,)
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        # WAL checkpoint — TRUNCATE is safe at exit (exclusive lock likely)
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+        self._conn = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_connection(self) -> None:
+        """Lazily open the database and apply schema migrations.
+
+        If corruption is detected, deletes the corrupt file and retries once
+        to create a fresh DB — so the current write is not lost.
+        """
+        if self._conn is not None:
+            return
+        for attempt in range(
+            2
+        ):  # noqa: B007 — at most one retry after corruption cleanup
+            try:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                conn = sqlite3.connect(
+                    str(self._path),
+                    check_same_thread=False,
+                    isolation_level=None,
+                )
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("PRAGMA synchronous=NORMAL")
+                conn.execute("PRAGMA busy_timeout=200")
+                conn.execute("PRAGMA wal_autocheckpoint=100")
+                self._ensure_schema(conn)
+                self._conn = conn
+
+                # Set restrictive file permissions on first creation
+                # 0o600 = owner read/write only (no group/others access)
+                try:
+                    self._path.chmod(0o600)
+                except OSError:
+                    pass  # Best effort — may fail on some filesystems
+
+                return
+            except sqlite3.DatabaseError as exc:
+                self._handle_corruption(exc)
+                if self._disabled:
+                    return  # unlink failed — give up
+
+    @staticmethod
+    def _ensure_schema(conn: sqlite3.Connection) -> None:
+        """Create tables/indexes and apply convergent column migrations."""
+        conn.executescript(_CREATE_TABLE_SQL)
+        conn.executescript(_CREATE_INDEXES_SQL)
+
+        # Introspect existing columns for convergent migration
+        existing = {
+            row[1] for row in conn.execute("PRAGMA table_info(security_events)")
+        }
+        for col, typedef in _COLUMNS.items():
+            if col not in existing:
+                # Validate column name is safe for dynamic SQL
+                if not re.match(r"^[a-z_]+$", col):
+                    raise ValueError(f"Invalid column name in schema: {col!r}")
+                conn.execute(f"ALTER TABLE security_events ADD COLUMN {col} {typedef}")
+
+        # Version-gated escape hatch
+        current = conn.execute("PRAGMA user_version").fetchone()[0]  # noqa: F841
+        # if current < 2: ...
+
+        # Stamp current version
+        conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+
+        # Currently no-op under autocommit, retained for future DML migrations
+        conn.commit()
+
+    def _handle_corruption(self, exc: Exception) -> None:
+        """Delete the corrupt database and prepare for a fresh start.
+
+        The SQLite DB is an expendable queryable index — JSONL is the source
+        of truth.  A corrupt DB has no forensic value (it's unreadable), so we
+        simply delete it rather than renaming/accumulating corrupt copies.
+        """
+        print(
+            f"[security_events] corrupt DB detected, recreating: {exc}",
+            file=sys.stderr,
+        )
+        # Close existing connection
+        try:
+            self._conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+        self._conn = None
+
+        # Delete corrupt file — next _ensure_connection() will create fresh
+        try:
+            self._path.unlink(missing_ok=True)
+            # Also remove orphaned WAL/SHM files
+            # Use string concatenation instead of with_suffix() to handle
+            # paths with any extension (or no extension) correctly
+            wal = Path(str(self._path) + "-wal")
+            shm = Path(str(self._path) + "-shm")
+            wal.unlink(missing_ok=True)
+            shm.unlink(missing_ok=True)
+        except OSError as delete_exc:
+            self._disabled = True
+            print(
+                f"[security_events] cannot delete corrupt db, "
+                f"writer disabled: {delete_exc}",
+                file=sys.stderr,
+            )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
@@ -1,0 +1,359 @@
+"""Human-readable security posture summary from SecurityEvent records.
+
+Aggregates events by category and produces an actionable text report
+suitable for CLI stdout or upstream consumer display.
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_sec_cli.security_events.schema import SecurityEvent
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def format_summary(events: list[SecurityEvent], time_label: str) -> str:
+    """Produce a human-readable summary from a list of security events.
+
+    Parameters
+    ----------
+    events : list[SecurityEvent]
+        Pre-queried events (ordering not required; sorted internally).
+    time_label : str
+        Human label for the time window (e.g., "last 24 hours").
+
+    Returns
+    -------
+    str
+        Formatted multi-section summary text.
+    """
+    if not events:
+        return "No security events recorded.\n"
+
+    by_category = _group_by_category(events)
+    sections: list[str] = []
+
+    harden_events = by_category.get("hardening", [])
+    asset_events = by_category.get("asset_verify", [])
+    code_scan_events = by_category.get("code_scan", [])
+    sandbox_events = by_category.get("sandbox", [])
+
+    if harden_events:
+        sections.append(_summarize_hardening(harden_events))
+    if asset_events:
+        sections.append(_summarize_asset_verify(asset_events))
+    if code_scan_events:
+        sections.append(_summarize_code_scan(code_scan_events))
+    if sandbox_events:
+        sections.append(_summarize_sandbox(sandbox_events))
+
+    header = _compute_posture(harden_events, asset_events, time_label)
+    footer = _build_footer(events, harden_events)
+    return "\n\n".join([header, *sections, footer])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _group_by_category(events: list[SecurityEvent]) -> dict[str, list[SecurityEvent]]:
+    """Group events into a dict keyed by category, newest-first."""
+    by_category: dict[str, list[SecurityEvent]] = defaultdict(list)
+    for e in events:
+        by_category[e.category].append(e)
+    # Ensure each group is sorted newest-first regardless of input order.
+    for cat in by_category:
+        by_category[cat].sort(key=lambda e: e.timestamp, reverse=True)
+    return by_category
+
+
+def _safe_details(event: SecurityEvent) -> dict[str, Any]:
+    """Return event.details safely, defaulting to empty dict."""
+    return event.details if isinstance(event.details, dict) else {}
+
+
+def _get_result(event: SecurityEvent) -> dict[str, Any]:
+    """Extract details.result dict from an event."""
+    d = _safe_details(event)
+    result = d.get("result")
+    return result if isinstance(result, dict) else {}
+
+
+def _get_request(event: SecurityEvent) -> dict[str, Any]:
+    """Extract details.request dict from an event."""
+    d = _safe_details(event)
+    request = d.get("request")
+    return request if isinstance(request, dict) else {}
+
+
+def _get_mode(event: SecurityEvent) -> str:
+    """Extract hardening mode from details.result, fallback to parsing request.args.
+
+    The mode field is written by HardeningBackend._build_result_data into
+    ActionResult.data, which lifecycle.post_action stores as details.result.
+    The CLI passes raw args (e.g. ["--scan", "--config", ...]) as
+    details.request.args, so we parse those as a fallback.
+    """
+    result = _get_result(event)
+    mode = result.get("mode")
+    if mode:
+        return mode
+    # Fallback: parse request.args for --scan/--reinforce/--dry-run
+    args = _get_request(event).get("args", [])
+    if isinstance(args, (list, tuple)):
+        if "--dry-run" in args:
+            return "dry-run"
+        if "--reinforce" in args:
+            return "reinforce"
+        if "--scan" in args:
+            return "scan"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Per-category formatters
+# ---------------------------------------------------------------------------
+
+
+def _summarize_hardening(events: list[SecurityEvent]) -> str:
+    """Summarize hardening category events."""
+    lines = ["--- Hardening ---"]
+
+    # Classify by mode in a single pass (mode lives in details.result)
+    scans: list[SecurityEvent] = []
+    reinforcements: list[SecurityEvent] = []
+    for e in events:
+        mode = _get_mode(e)
+        if mode == "scan":
+            scans.append(e)
+        elif mode == "reinforce":
+            reinforcements.append(e)
+
+    scans_ok = sum(1 for e in scans if e.result == "succeeded")
+    scans_fail = len(scans) - scans_ok
+    lines.append(
+        f"  Scans performed:  {len(scans)} (succeeded: {scans_ok}, failed: {scans_fail})"
+    )
+
+    if reinforcements:
+        reinf_ok = sum(1 for e in reinforcements if e.result == "succeeded")
+        reinf_fail = len(reinforcements) - reinf_ok
+        lines.append(
+            f"  Reinforcements:   {len(reinforcements)} "
+            f"(succeeded: {reinf_ok}, failed: {reinf_fail})"
+        )
+
+    # Latest scan result details (prefer succeeded, fall back to latest failed)
+    latest_scan = next((e for e in scans if e.result == "succeeded"), None)
+    if latest_scan:
+        result = _get_result(latest_scan)
+        passed = result.get("passed", 0)
+        total = result.get("total", 0)
+        failures = result.get("failures", [])
+
+        if total > 0:
+            pct = passed / total * 100
+            lines.append("")
+            lines.append("  Latest scan result:")
+            lines.append(f"    Compliance: {passed}/{total} rules passed ({pct:.1f}%)")
+
+            if failures:
+                lines.append(
+                    "    Check system status using `agent-sec-cli harden --scan`"
+                )
+    elif scans:
+        # All scans failed — show the latest error so users aren't left in the dark
+        latest_error = scans[0]
+        error_msg = _safe_details(latest_error).get("error", "unknown error")
+        lines.append("")
+        lines.append(f"  Latest scan failed: {error_msg}")
+
+    return "\n".join(lines)
+
+
+def _summarize_asset_verify(events: list[SecurityEvent]) -> str:
+    """Summarize asset_verify category events."""
+    lines = ["--- Asset Verification ---"]
+
+    ok_count = 0
+    latest: SecurityEvent | None = None
+    for e in events:
+        if e.result == "succeeded":
+            ok_count += 1
+            if latest is None:
+                latest = e
+    fail_count = len(events) - ok_count
+    lines.append(
+        f"  Verifications performed: {len(events)} "
+        f"(succeeded: {ok_count}, failed: {fail_count})"
+    )
+
+    # Latest successful result
+    if latest:
+        result = _get_result(latest)
+        passed = result.get("passed", 0)
+        failed = result.get("failed", 0)
+        lines.append("")
+        lines.append("  Latest result:")
+        lines.append(f"    {passed} passed, {failed} failed")
+        if failed == 0:
+            lines.append("    Integrity status: ALL CLEAR")
+        else:
+            lines.append("    Integrity status: FAILURES DETECTED")
+            lines.append("    Check details using `agent-sec-cli verify`")
+
+    return "\n".join(lines)
+
+
+def _summarize_code_scan(events: list[SecurityEvent]) -> str:
+    """Summarize code_scan category events."""
+    lines = ["--- Code Scanning ---"]
+
+    ok_count = 0
+    verdict_counts: dict[str, int] = defaultdict(int)
+    for e in events:
+        if e.result == "succeeded":
+            ok_count += 1
+            result = _get_result(e)
+            verdict = result.get("verdict", "unknown")
+            verdict_counts[verdict] += 1
+    fail_count = len(events) - ok_count
+    lines.append(
+        f"  Scans performed: {len(events)} (succeeded: {ok_count}, failed: {fail_count})"
+    )
+
+    if verdict_counts:
+        parts = [f"{v}: {c}" for v, c in sorted(verdict_counts.items())]
+        lines.append(f"  Verdict: {', '.join(parts)}")
+
+    return "\n".join(lines)
+
+
+def _summarize_sandbox(events: list[SecurityEvent]) -> str:
+    """Summarize sandbox category events."""
+    lines = ["--- Sandbox Guard ---"]
+    total = len(events)
+    lines.append(f"  Total interventions: {total}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Posture and footer
+# ---------------------------------------------------------------------------
+
+
+def _compute_posture(
+    hardening_events: list[SecurityEvent],
+    verify_events: list[SecurityEvent],
+    time_label: str,
+) -> str:
+    """Compute overall security posture status.
+
+    Status is determined solely by the latest hardening and asset_verify
+    results.
+    """
+
+    needs_attention = False
+
+    # --- Hardening (latest event) ---
+    if hardening_events:
+        latest_harden = hardening_events[0]  # events ordered desc
+        if latest_harden.result == "failed":
+            needs_attention = True
+        elif latest_harden.result == "succeeded":
+            result = _get_result(latest_harden)
+            failures = result.get("failures", [])
+            if failures:
+                needs_attention = True
+
+    # --- Asset Verification (latest event) ---
+    if verify_events:
+        latest_verify = verify_events[0]
+        if latest_verify.result == "failed":
+            needs_attention = True
+        elif latest_verify.result == "succeeded":
+            result = _get_result(latest_verify)
+            if result.get("failed", 0) > 0:
+                needs_attention = True
+
+    # Determine status
+    if needs_attention:
+        status_line = "System Status: Needs attention \u26a0"
+    else:
+        status_line = "System Status: Good \u2713"
+
+    lines = [
+        f"Security Posture Summary ({time_label})",
+        "",
+        status_line,
+    ]
+    return "\n".join(lines)
+
+
+def _build_footer(
+    events: list[SecurityEvent],
+    hardening_events: list[SecurityEvent],
+) -> str:
+    """Build footer with stats and suggested actions."""
+    total = len(events)
+    failed = sum(1 for e in events if e.result == "failed")
+
+    # Find the newest event in O(n) instead of sorting
+    newest = max(events, key=lambda e: e.timestamp) if events else None
+    last_event_str = _time_since_last_event(newest) if newest else "N/A"
+
+    lines = [
+        "---",
+        f"Total events: {total}  |  Failed: {failed}  |  Last event: {last_event_str}",
+    ]
+
+    # Suggested actions
+    suggestions = _compute_suggestions(hardening_events)
+    if suggestions:
+        lines.append("")
+        lines.append("Suggested actions:")
+        for s in suggestions:
+            lines.append(f"  {s}")
+
+    return "\n".join(lines)
+
+
+def _time_since_last_event(event: SecurityEvent) -> str:
+    """Compute human-readable time since the given event."""
+    try:
+        event_dt = datetime.fromisoformat(event.timestamp)
+        now = datetime.now(timezone.utc)
+        delta = now - event_dt
+        minutes = int(delta.total_seconds() / 60)
+        if minutes < 1:
+            return "just now"
+        if minutes < 60:
+            return f"{minutes} min ago"
+        hours = minutes // 60
+        if hours < 24:
+            return f"{hours}h ago"
+        days = hours // 24
+        return f"{days}d ago"
+    except (ValueError, TypeError):
+        return "unknown"
+
+
+def _compute_suggestions(hardening_events: list[SecurityEvent]) -> list[str]:
+    """Generate actionable suggestions based on latest hardening event."""
+    suggestions: list[str] = []
+
+    if not hardening_events:
+        return suggestions
+
+    latest = hardening_events[0]  # newest-first after _group_by_category sort
+    if latest.result == "succeeded":
+        result = _get_result(latest)
+        if result.get("failures"):
+            suggestions.append("agent-sec-cli harden --reinforce    Fix failed rules")
+
+    return suggestions

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/__init__.py
@@ -9,7 +9,7 @@ Public API
 
 import sys
 from pathlib import PurePath
-from typing import List
+from typing import Any
 
 from agent_sec_cli.security_middleware import lifecycle, router
 from agent_sec_cli.security_middleware.context import RequestContext
@@ -50,15 +50,16 @@ def _detect_caller() -> str:
 # ---------------------------------------------------------------------------
 
 
-def invoke(action: str, **kwargs) -> ActionResult:
+def invoke(action: str, **kwargs: Any) -> ActionResult:
     """Sole public entry point for all security capabilities.
 
     1. Builds a :class:`RequestContext` (auto ``trace_id``, ``timestamp``).
     2. Calls ``pre_action`` (no-op under the single-event model).
     3. Routes to the appropriate backend and calls ``execute(ctx, **kwargs)``.
-    4. Logs a single ``<action>`` completion event (post-hook) — or a single
-       ``<action>_error`` event on failure, each containing both the request
-       kwargs and the result/error details.
+    4. Logs a single ``<action>`` completion event (post-hook) with
+       ``result="succeeded"``, or logs the same event type with
+       ``result="failed"`` on failure (on_error). Each event contains both
+       the request kwargs and the result/error details.
     5. Returns the :class:`ActionResult` produced by the backend.
 
     Raises whatever exception the backend raises (after logging it).
@@ -79,4 +80,4 @@ def invoke(action: str, **kwargs) -> ActionResult:
     return result
 
 
-__all__: List[str] = ["invoke", "ActionResult", "RequestContext"]
+__all__: list[str] = ["invoke", "ActionResult", "RequestContext"]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/summary.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/summary.py
@@ -1,22 +1,68 @@
-"""Summary backend — future stub for security event aggregation."""
+"""Summary backend — security event aggregation and reporting."""
 
+import time
+from datetime import datetime, timezone
 from typing import Any
 
+from agent_sec_cli.security_events import get_reader
 from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
 
 
 class SummaryBackend(BaseBackend):
-    """Placeholder for security event summary and reporting.
-
-    This backend will eventually aggregate events from the JSONL log
-    and produce time-windowed, categorised reports.
-    """
+    """Aggregates and reports security event statistics."""
 
     def execute(self, ctx: RequestContext, **kwargs: Any) -> ActionResult:
-        """Not yet implemented — always returns failure."""
-        return ActionResult(
-            success=False,
-            error="Security event summary not yet implemented",
+        """Query security events and produce a summary report."""
+        hours: float = kwargs.get("hours", 24)
+        category: str | None = kwargs.get("category", None)
+        event_type: str | None = kwargs.get("event_type", None)
+
+        # Compute time range
+        now = time.time()
+        since_epoch = now - hours * 3600
+        since_iso = datetime.fromtimestamp(since_epoch, tz=timezone.utc).isoformat()
+        until_iso = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+
+        # Query via reader
+        reader = get_reader()
+        total_events = reader.count(
+            category=category,
+            event_type=event_type,
+            since=since_iso,
+            until=until_iso,
         )
+        by_category = reader.count_by("category", since=since_iso, until=until_iso)
+        by_event_type = reader.count_by("event_type", since=since_iso, until=until_iso)
+
+        # Build summary data
+        data = {
+            "total_events": total_events,
+            "time_range": {"since": since_iso, "until": until_iso},
+            "by_category": by_category,
+            "by_event_type": by_event_type,
+        }
+
+        # Format stdout
+        lines = [
+            f"Security Events Summary (last {hours:.0f}h)",
+            "=" * 40,
+            f"Total events: {total_events}",
+            "",
+            "By category:",
+        ]
+        for cat, cnt in sorted(by_category.items(), key=lambda x: -x[1]):
+            lines.append(f"  {cat}: {cnt}")
+        if not by_category:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append("By event type:")
+        for et, cnt in sorted(by_event_type.items(), key=lambda x: -x[1]):
+            lines.append(f"  {et}: {cnt}")
+        if not by_event_type:
+            lines.append("  (none)")
+
+        stdout = "\n".join(lines)
+
+        return ActionResult(success=True, data=data, stdout=stdout)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/lifecycle.py
@@ -1,7 +1,7 @@
 """Lifecycle hooks — transparent pre/post/error logging via security_events."""
 
 import copy
-from typing import Any, Dict
+from typing import Any
 
 from agent_sec_cli.security_events import SecurityEvent, log_event
 from agent_sec_cli.security_middleware.context import RequestContext
@@ -11,7 +11,7 @@ from agent_sec_cli.security_middleware.result import ActionResult
 # Action → SecurityEvent category mapping
 # ---------------------------------------------------------------------------
 
-_ACTION_CATEGORY: Dict[str, str] = {
+_ACTION_CATEGORY: dict[str, str] = {
     "sandbox_prehook": "sandbox",
     "harden": "hardening",
     "verify": "asset_verify",
@@ -31,7 +31,7 @@ def _category_for(action: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def pre_action(ctx: RequestContext, kwargs: Dict[str, Any]) -> None:
+def pre_action(ctx: RequestContext, kwargs: dict[str, Any]) -> None:
     """No-op — kept for future extensibility.
 
     Single-event model: we only emit one event per invocation, either on
@@ -43,7 +43,7 @@ def pre_action(ctx: RequestContext, kwargs: Dict[str, Any]) -> None:
 
 
 def post_action(
-    ctx: RequestContext, result: ActionResult, kwargs: Dict[str, Any]
+    ctx: RequestContext, result: ActionResult, kwargs: dict[str, Any]
 ) -> None:
     """Log the single completion event after the backend completes.
 
@@ -51,7 +51,7 @@ def post_action(
     single event so the full request/response context is captured in one record.
     """
     try:
-        details: Dict[str, Any] = {
+        details: dict[str, Any] = {
             "request": copy.deepcopy(kwargs),
             "result": copy.deepcopy(result.data),
         }
@@ -67,21 +67,22 @@ def post_action(
         pass
 
 
-def on_error(ctx: RequestContext, exception: Exception, kwargs: Dict[str, Any]) -> None:
+def on_error(ctx: RequestContext, exception: Exception, kwargs: dict[str, Any]) -> None:
     """Log the single error event when the backend raises.
 
     Merges *kwargs* (request inputs) and error details into a single event so
     the full request context is captured alongside the failure.
     """
     try:
-        details: Dict[str, Any] = {
+        details: dict[str, Any] = {
             "request": copy.deepcopy(kwargs),
             "error": str(exception),
             "error_type": type(exception).__name__,
         }
         event = SecurityEvent(
-            event_type=f"{ctx.action}_error",
+            event_type=ctx.action,
             category=_category_for(ctx.action),
+            result="failed",
             details=details,
             trace_id=ctx.trace_id,
             session_id=ctx.session_id,

--- a/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
@@ -1,0 +1,438 @@
+"""E2E test: CLI capability invocation → event query pipeline.
+
+Validates that invoking security capabilities through the CLI produces
+queryable security events in the SQLite store.
+
+NOTE: These tests verify the event-logging pipeline, not the security
+capabilities themselves.  `harden` may exit 127 (loongshield missing),
+`verify` may find zero skills — both are acceptable as long as an event
+is recorded.
+
+Isolation: Each test function uses its own dedicated temp directory (via
+AGENT_SEC_DATA_DIR env var) so that tests are fully independent — no
+shared state, no ordering dependency, no cascade failures.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Use the same Python interpreter that runs pytest to invoke the CLI module.
+# This works in all environments: local venv, CI (uv run), tox, etc.
+_PYTHON = sys.executable
+_CLI_MODULE = "agent_sec_cli.cli"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_dir(tmp_path):
+    """Create a function-scoped temp directory for security event data.
+
+    Each test gets a completely fresh SQLite DB — no cross-test pollution,
+    no ordering dependency, no cascade failures.
+    """
+    data_dir = tmp_path / "agent-sec-e2e"
+    data_dir.mkdir()
+    os.environ["AGENT_SEC_DATA_DIR"] = str(data_dir)
+    yield
+    os.environ.pop("AGENT_SEC_DATA_DIR", None)
+
+
+def _run_cli(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    """Run `python -m agent_sec_cli.cli <args>` and return CompletedProcess."""
+    cmd = [_PYTHON, "-m", _CLI_MODULE, *args]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=30,
+        env=os.environ.copy(),  # inherits AGENT_SEC_DATA_DIR
+    )
+
+
+def _iso_now() -> str:
+    """Return current UTC time as ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHardenEventLogging:
+    """Verify that invoking `harden` produces a queryable event."""
+
+    def test_harden_produces_event(self):
+        """After `agent-sec-cli harden`, an event with event_type=harden is queryable."""
+        since = _iso_now()
+
+        # Small delay to ensure timestamp ordering
+        time.sleep(0.05)
+
+        # Invoke harden — exit code doesn't matter (loongshield may be absent)
+        _run_cli("harden")
+
+        # Small delay to let SQLite WAL flush
+        time.sleep(0.1)
+
+        # Query events since the start of this test
+        result = _run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0, f"events query failed: {result.stderr}"
+
+        events = json.loads(result.stdout)
+        assert isinstance(events, list)
+        assert (
+            len(events) == 1
+        ), f"Expected exactly 1 harden event since {since}, got {len(events)}"
+
+        # Verify event structure
+        event = events[0]
+        assert event["event_type"] == "harden"
+        assert event["category"] == "hardening"
+        assert "event_id" in event
+        assert "timestamp" in event
+        assert "details" in event
+
+    def test_harden_event_count(self):
+        """--count returns exactly 1 after a single harden invocation."""
+        since = _iso_now()
+        time.sleep(0.05)
+
+        _run_cli("harden")
+        time.sleep(0.1)
+
+        result = _run_cli(
+            "events", "--count", "--event-type", "harden", "--since", since
+        )
+        assert result.returncode == 0
+        count = json.loads(result.stdout)
+        assert count == 1
+
+
+class TestVerifyEventLogging:
+    """Verify that invoking `verify` produces a queryable event."""
+
+    def test_verify_produces_event(self):
+        """After `agent-sec-cli verify`, an event with event_type=verify is queryable."""
+        since = _iso_now()
+        time.sleep(0.05)
+
+        # Invoke verify — may fail (no skills configured), that's acceptable
+        _run_cli("verify")
+        time.sleep(0.1)
+
+        # Query events
+        result = _run_cli(
+            "events", "--event-type", "verify", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+
+        events = json.loads(result.stdout)
+        assert isinstance(events, list)
+        assert (
+            len(events) == 1
+        ), f"Expected exactly 1 verify event since {since}, got {len(events)}"
+
+        event = events[0]
+        assert event["event_type"] == "verify"
+        assert event["category"] == "asset_verify"
+        assert "details" in event
+
+    def test_verify_event_count_by_category(self):
+        """--count-by category shows asset_verify: 1 after a single verify invocation."""
+        since = _iso_now()
+        time.sleep(0.05)
+
+        _run_cli("verify")
+        time.sleep(0.1)
+
+        result = _run_cli("events", "--count-by", "category", "--since", since)
+        assert result.returncode == 0
+
+        counts = json.loads(result.stdout)
+        assert isinstance(counts, dict)
+        assert counts == {"asset_verify": 1}
+
+
+class TestEventQueryFilters:
+    """Verify that query filters work end-to-end."""
+
+    def test_last_hours_filter(self):
+        """--last-hours returns exactly the single event just created."""
+        _run_cli("harden")
+        time.sleep(0.1)
+
+        # Fresh DB: only this test's event exists.
+        result = _run_cli(
+            "events", "--event-type", "harden", "--last-hours", "1", "--output", "json"
+        )
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert len(events) == 1
+
+    def test_nonexistent_type_returns_empty(self):
+        """Filtering by a non-existent event_type returns empty list."""
+        result = _run_cli(
+            "events",
+            "--event-type",
+            "does_not_exist_xyz",
+            "--last-hours",
+            "1",
+            "--output",
+            "json",
+        )
+        assert result.returncode == 0
+
+        events = json.loads(result.stdout)
+        assert events == []
+
+    def test_default_table_output(self):
+        """Default output is human-readable table format."""
+        since = _iso_now()
+        time.sleep(0.05)
+        _run_cli("harden")
+        time.sleep(0.1)
+
+        result = _run_cli("events", "--event-type", "harden", "--since", since)
+        assert result.returncode == 0
+        # Default output is table — should NOT be parseable as JSON
+        lines = result.stdout.strip().split("\n")
+        # Header + 1 data row + blank line + footer
+        assert len(lines) == 4
+        assert lines[0].startswith("EVENT_TYPE")
+        assert "harden" in lines[1]
+        assert "succeeded" in lines[1]
+        assert "1 event" in lines[3]
+
+
+class TestCLIValidation:
+    """Verify CLI parameter validation and error handling."""
+
+    def test_invalid_output_format(self):
+        """Verify that invalid --output format returns error."""
+        result = _run_cli("events", "--output", "xml")
+        assert result.returncode == 1
+        assert "Error:" in result.stderr
+        assert "--output must be one of" in result.stderr
+
+    def test_last_hours_and_since_mutual_exclusion(self):
+        """Verify that --last-hours and --since are mutually exclusive."""
+        result = _run_cli(
+            "events",
+            "--last-hours",
+            "24",
+            "--since",
+            "2026-01-01T00:00:00Z",
+        )
+        assert result.returncode == 1
+        assert "Error:" in result.stderr
+        assert "mutually exclusive" in result.stderr
+
+    def test_count_and_count_by_mutual_exclusion(self):
+        """Verify that --count and --count-by are mutually exclusive."""
+        result = _run_cli("events", "--count", "--count-by", "category")
+        assert result.returncode == 1
+        assert "Error:" in result.stderr
+        assert "mutually exclusive" in result.stderr
+
+    def test_invalid_count_by_field(self):
+        """Verify that invalid --count-by field returns error."""
+        result = _run_cli("events", "--count-by", "invalid_field")
+        assert result.returncode == 1
+        assert "Error:" in result.stderr
+        assert "--count-by must be one of" in result.stderr
+
+    def test_unknown_event_type_warning(self):
+        """Verify that unknown event_type produces a warning but doesn't fail."""
+        result = _run_cli(
+            "events",
+            "--event-type",
+            "unknown_type",
+            "--last-hours",
+            "1",
+            "--output",
+            "json",
+        )
+        # Should succeed (exit 0) but print warning to stderr
+        assert result.returncode == 0
+        assert "Warning:" in result.stderr
+        assert "Unknown event_type" in result.stderr
+
+    def test_unknown_category_warning(self):
+        """Verify that unknown category produces a warning but doesn't fail."""
+        result = _run_cli(
+            "events",
+            "--category",
+            "unknown_category",
+            "--last-hours",
+            "1",
+            "--output",
+            "json",
+        )
+        # Should succeed (exit 0) but print warning to stderr
+        assert result.returncode == 0
+        assert "Warning:" in result.stderr
+        assert "Unknown category" in result.stderr
+
+    def test_json_output_format(self):
+        """Verify that --output json returns a valid JSON array with complete event data."""
+        since = _iso_now()
+        time.sleep(0.05)
+        _run_cli("harden")
+        time.sleep(0.1)
+
+        result = _run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+
+        # Should be valid JSON array
+        events = json.loads(result.stdout)
+        assert isinstance(events, list)
+        assert len(events) == 1
+
+        # Verify event structure
+        event = events[0]
+        assert "event_id" in event
+        assert "event_type" in event
+        assert "category" in event
+        assert "result" in event
+        assert "timestamp" in event
+        assert "details" in event
+        assert event["event_type"] == "harden"
+        assert event["result"] == "succeeded"
+
+    def test_jsonl_output_format(self):
+        """Verify that --output jsonl returns one JSON object per line."""
+        since = _iso_now()
+        time.sleep(0.05)
+        _run_cli("harden")
+        time.sleep(0.1)
+
+        result = _run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "jsonl"
+        )
+        assert result.returncode == 0
+
+        # Should be newline-delimited JSON
+        lines = result.stdout.strip().split("\n")
+        assert len(lines) == 1
+
+        # Each line should be valid JSON
+        event = json.loads(lines[0])
+        assert isinstance(event, dict)
+        assert event["event_type"] == "harden"
+        assert "event_id" in event
+        assert "details" in event
+
+    def test_result_field_in_table_output(self):
+        """Verify that result column shows 'succeeded' in table format."""
+        since = _iso_now()
+        time.sleep(0.05)
+        _run_cli("harden")
+        time.sleep(0.1)
+
+        result = _run_cli("events", "--event-type", "harden", "--since", since)
+        assert result.returncode == 0
+
+        # Table output should contain RESULT column with 'succeeded'
+        assert "RESULT" in result.stdout
+        assert "succeeded" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: --summary flag
+# ---------------------------------------------------------------------------
+
+
+class TestEventsSummaryFlag:
+    """Verify the --summary flag on the events command."""
+
+    def test_summary_happy_path(self):
+        """--summary produces a human-readable posture report after harden + verify."""
+        _run_cli("harden")
+        _run_cli("verify")
+        time.sleep(0.1)
+
+        result = _run_cli("events", "--summary", "--last-hours", "1")
+        assert result.returncode == 0
+
+        out = result.stdout
+        # Header
+        assert "Security Posture Summary" in out
+        assert "System Status:" in out
+        # At least one section present
+        assert "--- Hardening ---" in out
+        # Footer
+        assert "Total events:" in out
+
+    def test_summary_incompatible_with_count(self):
+        """--summary --count must be rejected with exit code 1."""
+        result = _run_cli("events", "--summary", "--count")
+        assert result.returncode == 1
+        assert "incompatible" in result.stderr.lower()
+
+    def test_summary_incompatible_with_output_json(self):
+        """--summary --output json must be rejected with exit code 1."""
+        result = _run_cli("events", "--summary", "--output", "json")
+        assert result.returncode == 1
+        assert "incompatible" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Error event persistence
+# ---------------------------------------------------------------------------
+
+
+class TestErrorEventPersistence:
+    """Verify that error events are correctly persisted to SQLite."""
+
+    def test_error_event_writes_to_sqlite(self):
+        """Integration test: verify that error events are actually written to SQLite with result='failed'."""
+        from agent_sec_cli.security_events import get_reader, log_event
+        from agent_sec_cli.security_events.schema import SecurityEvent
+
+        # Create an error event (simulating what lifecycle.on_error does)
+        error_event = SecurityEvent(
+            event_type="harden",
+            category="hardening",
+            result="failed",
+            details={
+                "request": {"config": "default"},
+                "error": "loongshield not found",
+                "error_type": "FileNotFoundError",
+            },
+            trace_id="error-trace-123",
+        )
+
+        # Write it via log_event (dual-write)
+        log_event(error_event)
+
+        # Read it back from SQLite
+        reader = get_reader()
+        events = reader.query(event_type="harden")
+
+        assert len(events) == 1
+        event = events[0]
+
+        # Verify error event was written correctly
+        assert event.event_type == "harden"  # NOT "harden_error"
+        assert event.result == "failed"
+        assert event.category == "hardening"
+        assert event.details["error"] == "loongshield not found"
+        assert event.details["error_type"] == "FileNotFoundError"
+        assert event.trace_id == "error-trace-123"

--- a/src/agent-sec-core/tests/unit-test/conftest.py
+++ b/src/agent-sec-core/tests/unit-test/conftest.py
@@ -1,0 +1,32 @@
+"""Global fixtures for unit tests — isolate all security-event I/O."""
+
+import os
+
+import agent_sec_cli.security_events as _security_events
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _isolate_data_dir(tmp_path_factory):
+    """Redirect all security-event I/O to a disposable temp directory.
+
+    Prevents unit tests from polluting the production SQLite DB / JSONL log
+    at ``~/.agent-sec-core/``.
+    """
+    data_dir = tmp_path_factory.mktemp("unit-test-data")
+    os.environ["AGENT_SEC_DATA_DIR"] = str(data_dir)
+
+    # Reset module-level singletons to force re-initialization with new data dir.
+    # This prevents test pollution when singletons were lazily initialized
+    # before this fixture ran (e.g., during module import phase).
+    _security_events._writer = None
+    _security_events._sqlite_writer = None
+    _security_events._reader = None
+
+    yield
+
+    # Cleanup: reset singletons and remove env var
+    _security_events._writer = None
+    _security_events._sqlite_writer = None
+    _security_events._reader = None
+    os.environ.pop("AGENT_SEC_DATA_DIR", None)

--- a/src/agent-sec-core/tests/unit-test/security_events/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_config.py
@@ -1,38 +1,74 @@
 """Unit tests for security_events.config — log path selection."""
 
+import os
 import unittest
 from unittest.mock import patch
 
 from agent_sec_cli.security_events.config import (
     FALLBACK_LOG_PATH,
     PRIMARY_LOG_PATH,
+    get_db_path,
     get_log_path,
 )
 
+# Remove AGENT_SEC_DATA_DIR for these tests so we exercise the real path logic.
+_env_without_override = {
+    k: v for k, v in os.environ.items() if k != "AGENT_SEC_DATA_DIR"
+}
 
+
+@patch.dict(os.environ, _env_without_override, clear=True)
 class TestGetLogPath(unittest.TestCase):
     @patch("agent_sec_cli.security_events.config.os.access", return_value=True)
     @patch("agent_sec_cli.security_events.config.Path.is_dir", return_value=True)
     @patch("agent_sec_cli.security_events.config.Path.mkdir")
-    def test_primary_path_when_writable(self, mock_mkdir, mock_isdir, mock_access):
+    @patch("agent_sec_cli.security_events.config.Path.chmod")
+    def test_primary_path_when_writable(
+        self, mock_chmod, mock_mkdir, mock_isdir, mock_access
+    ):
         path = get_log_path()
         self.assertEqual(path, PRIMARY_LOG_PATH)
 
     @patch("agent_sec_cli.security_events.config.os.access", return_value=False)
     @patch("agent_sec_cli.security_events.config.Path.is_dir", return_value=True)
     @patch("agent_sec_cli.security_events.config.Path.mkdir")
+    @patch("agent_sec_cli.security_events.config.Path.chmod")
     def test_fallback_when_primary_not_writable(
-        self, mock_mkdir, mock_isdir, mock_access
+        self, mock_chmod, mock_mkdir, mock_isdir, mock_access
     ):
         path = get_log_path()
         self.assertEqual(path, FALLBACK_LOG_PATH)
 
     @patch("agent_sec_cli.security_events.config.Path.mkdir")
-    def test_fallback_when_makedirs_fails(self, mock_mkdir):
+    @patch("agent_sec_cli.security_events.config.Path.chmod")
+    def test_fallback_when_makedirs_fails(self, mock_chmod, mock_mkdir):
         # First call (primary) raises, second call (fallback) succeeds
         mock_mkdir.side_effect = [OSError("permission denied"), None]
         path = get_log_path()
         self.assertEqual(path, FALLBACK_LOG_PATH)
+
+
+@patch.dict(os.environ, _env_without_override, clear=True)
+class TestGetDbPath(unittest.TestCase):
+    @patch("agent_sec_cli.security_events.config.os.access", return_value=True)
+    @patch("agent_sec_cli.security_events.config.Path.is_dir", return_value=True)
+    @patch("agent_sec_cli.security_events.config.Path.mkdir")
+    @patch("agent_sec_cli.security_events.config.Path.chmod")
+    def test_db_path_uses_primary_dir(
+        self, mock_chmod, mock_mkdir, mock_isdir, mock_access
+    ):
+        path = get_db_path()
+        self.assertEqual(path, "/var/log/agent-sec/security-events.db")
+
+    @patch("agent_sec_cli.security_events.config.os.access", return_value=False)
+    @patch("agent_sec_cli.security_events.config.Path.is_dir", return_value=True)
+    @patch("agent_sec_cli.security_events.config.Path.mkdir")
+    @patch("agent_sec_cli.security_events.config.Path.chmod")
+    def test_db_path_uses_fallback_dir(
+        self, mock_chmod, mock_mkdir, mock_isdir, mock_access
+    ):
+        path = get_db_path()
+        self.assertTrue(path.endswith(".agent-sec-core/security-events.db"))
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/tests/unit-test/security_events/test_log_event.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_log_event.py
@@ -10,13 +10,9 @@ class TestGetWriter(unittest.TestCase):
     def test_singleton_returns_same_instance(self):
         import agent_sec_cli.security_events
 
-        # Reset singleton
-        agent_sec_cli.security_events._writer = None
         w1 = agent_sec_cli.security_events.get_writer()
         w2 = agent_sec_cli.security_events.get_writer()
         self.assertIs(w1, w2)
-        # Cleanup
-        agent_sec_cli.security_events._writer = None
 
 
 class TestLogEvent(unittest.TestCase):
@@ -43,6 +39,67 @@ class TestLogEvent(unittest.TestCase):
         evt = SecurityEvent(event_type="t", category="c", details={})
         # Should not raise
         log_event(evt)
+
+
+class TestGetSqliteWriter(unittest.TestCase):
+    def test_singleton_returns_same_instance(self):
+        import agent_sec_cli.security_events
+
+        w1 = agent_sec_cli.security_events.get_sqlite_writer()
+        w2 = agent_sec_cli.security_events.get_sqlite_writer()
+        self.assertIs(w1, w2)
+
+
+class TestDualWrite(unittest.TestCase):
+    @patch("agent_sec_cli.security_events.get_sqlite_writer")
+    @patch("agent_sec_cli.security_events.get_writer")
+    def test_log_event_writes_to_both(self, mock_get_writer, mock_get_sqlite_writer):
+        mock_jsonl = MagicMock()
+        mock_sqlite = MagicMock()
+        mock_get_writer.return_value = mock_jsonl
+        mock_get_sqlite_writer.return_value = mock_sqlite
+
+        from agent_sec_cli.security_events import log_event
+
+        evt = SecurityEvent(event_type="t", category="c", details={})
+        log_event(evt)
+        mock_jsonl.write.assert_called_once_with(evt)
+        mock_sqlite.write.assert_called_once_with(evt)
+
+    @patch("agent_sec_cli.security_events.get_sqlite_writer")
+    @patch("agent_sec_cli.security_events.get_writer")
+    def test_jsonl_failure_does_not_block_sqlite(
+        self, mock_get_writer, mock_get_sqlite_writer
+    ):
+        mock_jsonl = MagicMock()
+        mock_jsonl.write.side_effect = RuntimeError("disk full")
+        mock_sqlite = MagicMock()
+        mock_get_writer.return_value = mock_jsonl
+        mock_get_sqlite_writer.return_value = mock_sqlite
+
+        from agent_sec_cli.security_events import log_event
+
+        evt = SecurityEvent(event_type="t", category="c", details={})
+        log_event(evt)
+        # SQLite write should still be called even though JSONL failed
+        mock_sqlite.write.assert_called_once_with(evt)
+
+    @patch("agent_sec_cli.security_events.get_sqlite_writer")
+    @patch("agent_sec_cli.security_events.get_writer")
+    def test_sqlite_failure_does_not_block_jsonl(
+        self, mock_get_writer, mock_get_sqlite_writer
+    ):
+        mock_jsonl = MagicMock()
+        mock_sqlite = MagicMock()
+        mock_sqlite.write.side_effect = RuntimeError("corruption")
+        mock_get_writer.return_value = mock_jsonl
+        mock_get_sqlite_writer.return_value = mock_sqlite
+
+        from agent_sec_cli.security_events import log_event
+
+        evt = SecurityEvent(event_type="t", category="c", details={})
+        log_event(evt)
+        mock_jsonl.write.assert_called_once_with(evt)
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_schema.py
@@ -40,6 +40,14 @@ class TestSecurityEventAutoFill(unittest.TestCase):
         evt = SecurityEvent(event_type="t", category="c", details={})
         self.assertEqual(evt.uid, os.getuid())
 
+    def test_result_default_succeeded(self):
+        evt = SecurityEvent(event_type="t", category="c", details={})
+        self.assertEqual(evt.result, "succeeded")
+
+    def test_result_can_be_failed(self):
+        evt = SecurityEvent(event_type="t", category="c", details={}, result="failed")
+        self.assertEqual(evt.result, "failed")
+
     def test_trace_id_default_empty(self):
         evt = SecurityEvent(event_type="t", category="c", details={})
         self.assertEqual(evt.trace_id, "")
@@ -57,6 +65,7 @@ class TestSecurityEventToDict(unittest.TestCase):
             "event_id",
             "event_type",
             "category",
+            "result",
             "timestamp",
             "trace_id",
             "pid",

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_reader.py
@@ -1,0 +1,282 @@
+"""Unit tests for security_events.sqlite_reader — SqliteEventReader."""
+
+import io
+import json
+import sqlite3
+import sys
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
+from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
+
+
+def _make_event(
+    event_type: str = "test_event", category: str = "test", **kwargs: Any
+) -> SecurityEvent:
+    return SecurityEvent(
+        event_type=event_type,
+        category=category,
+        details=kwargs.get("details", {"key": "value"}),
+        trace_id=kwargs.get("trace_id", ""),
+    )
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "test.db")
+
+
+@pytest.fixture()
+def writer(db_path: str) -> SqliteEventWriter:
+    w = SqliteEventWriter(path=db_path)
+    yield w
+    w.close()
+
+
+@pytest.fixture()
+def reader(db_path: str) -> SqliteEventReader:
+    return SqliteEventReader(path=db_path)
+
+
+class TestSqliteEventReader:
+    def test_write_read_roundtrip(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        """Verify that a complete SecurityEvent can be written and read back with all fields intact.
+
+        This is the most critical data path test — validates Writer → SQLite → Reader
+        entire pipeline including _event_params, INSERT, SELECT, and _row_to_event.
+        """
+        # Create a comprehensive event with all fields
+        original_event = SecurityEvent(
+            event_type="harden",
+            category="hardening",
+            result="failed",
+            timestamp="2026-04-20T13:47:00.123456+00:00",
+            trace_id="test-trace-456",
+            session_id="session-xyz",
+            details={
+                "request": {"config": "default", "dry_run": True},
+                "result": {"violations": ["RULE_001", "RULE_002"]},
+                "unicode": "测试中文🎉",
+                "nested": {"level1": {"level2": "value"}},
+                "list_data": [1, "two", 3.0, None],
+                "empty_string": "",
+                "null_value": None,
+            },
+        )
+
+        # Write the event
+        writer.write(original_event)
+        writer.close()
+
+        # Read it back
+        events = reader.query(event_type="harden")
+        assert len(events) == 1
+
+        retrieved_event = events[0]
+
+        # Verify all fields match
+        assert retrieved_event.event_id == original_event.event_id
+        assert retrieved_event.event_type == original_event.event_type
+        assert retrieved_event.category == original_event.category
+        assert retrieved_event.result == original_event.result
+        assert retrieved_event.timestamp == original_event.timestamp
+        assert retrieved_event.trace_id == original_event.trace_id
+        assert retrieved_event.pid == original_event.pid
+        assert retrieved_event.uid == original_event.uid
+        assert retrieved_event.session_id == original_event.session_id
+
+        # Verify details JSON round-trip
+        assert retrieved_event.details == original_event.details
+        assert retrieved_event.details["unicode"] == "测试中文🎉"
+        assert retrieved_event.details["nested"]["level1"]["level2"] == "value"
+        assert retrieved_event.details["list_data"] == [1, "two", 3.0, None]
+        assert retrieved_event.details["null_value"] is None
+
+    def test_malformed_details_are_skipped(
+        self, db_path: str, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        """Verify that rows with malformed JSON in details are skipped gracefully."""
+        # Write a valid event first
+        writer.write(_make_event(event_type="valid_event"))
+
+        # Manually insert a row with invalid JSON in details
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "INSERT INTO security_events "
+            "(event_id, event_type, category, result, timestamp, timestamp_epoch, "
+            "trace_id, pid, uid, session_id, details) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "malformed-event-id",
+                "malformed_event",
+                "test",
+                "succeeded",
+                "2026-04-20T13:47:00+00:00",
+                1745298420.0,
+                "",
+                12345,
+                1000,
+                None,
+                "NOT VALID JSON{{{",  # Intentionally malformed
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        # Capture stderr to verify warning is printed
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+
+        try:
+            # Query should return only the valid event, skipping the malformed one
+            events = reader.query()
+            stderr_output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+
+        # Should have skipped the malformed row
+        assert len(events) == 1
+        assert events[0].event_type == "valid_event"
+
+        # Should have printed warning to stderr
+        assert "malformed row skipped" in stderr_output
+
+    def test_query_returns_all_events(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        for _ in range(5):
+            writer.write(_make_event())
+        events = reader.query()
+        assert len(events) == 5
+
+    def test_query_filter_by_event_type(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(event_type="alpha"))
+        writer.write(_make_event(event_type="alpha"))
+        writer.write(_make_event(event_type="beta"))
+        events = reader.query(event_type="alpha")
+        assert len(events) == 2
+        for e in events:
+            assert e.event_type == "alpha"
+
+    def test_query_filter_by_category(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(category="sandbox"))
+        writer.write(_make_event(category="sandbox"))
+        writer.write(_make_event(category="hardening"))
+        events = reader.query(category="sandbox")
+        assert len(events) == 2
+        for e in events:
+            assert e.category == "sandbox"
+
+    def test_query_filter_by_trace_id(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(trace_id="trace-abc"))
+        writer.write(_make_event(trace_id="trace-abc"))
+        writer.write(_make_event(trace_id="trace-xyz"))
+        events = reader.query(trace_id="trace-abc")
+        assert len(events) == 2
+        for e in events:
+            assert e.trace_id == "trace-abc"
+
+    def test_query_time_range_since_until(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(hours=2)
+        future = now + timedelta(hours=2)
+
+        for _ in range(3):
+            writer.write(_make_event())
+
+        since_iso = past.isoformat()
+        until_iso = future.isoformat()
+        events = reader.query(since=since_iso, until=until_iso)
+        assert len(events) == 3
+
+    def test_query_ordering_desc(
+        self, db_path: str, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event())
+        time.sleep(0.02)
+        writer.write(_make_event())
+        time.sleep(0.02)
+        writer.write(_make_event())
+
+        events = reader.query()
+        assert len(events) == 3
+        # Results should be in descending order by time — verify via DB directly
+        conn = sqlite3.connect(db_path)
+        rows = conn.execute(
+            "SELECT timestamp_epoch FROM security_events ORDER BY timestamp_epoch DESC"
+        ).fetchall()
+        conn.close()
+        epochs = [r[0] for r in rows]
+        assert epochs == sorted(epochs, reverse=True)
+
+    def test_query_limit_offset(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        for _ in range(10):
+            writer.write(_make_event())
+            time.sleep(0.005)
+
+        events = reader.query(limit=3, offset=2)
+        assert len(events) == 3
+
+    def test_count_returns_total(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        for _ in range(5):
+            writer.write(_make_event())
+        assert reader.count() == 5
+
+    def test_count_with_filters(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(category="sandbox"))
+        writer.write(_make_event(category="sandbox"))
+        writer.write(_make_event(category="hardening"))
+        assert reader.count(category="sandbox") == 2
+
+    def test_count_by_category(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(category="sandbox"))
+        writer.write(_make_event(category="sandbox"))
+        writer.write(_make_event(category="hardening"))
+        result = reader.count_by("category")
+        assert result["sandbox"] == 2
+        assert result["hardening"] == 1
+
+    def test_count_by_event_type(
+        self, writer: SqliteEventWriter, reader: SqliteEventReader
+    ) -> None:
+        writer.write(_make_event(event_type="alpha"))
+        writer.write(_make_event(event_type="alpha"))
+        writer.write(_make_event(event_type="beta"))
+        result = reader.count_by("event_type")
+        assert result["alpha"] == 2
+        assert result["beta"] == 1
+
+    def test_count_by_invalid_field_raises(self, reader: SqliteEventReader) -> None:
+        with pytest.raises(ValueError):
+            reader.count_by("invalid_field")
+
+    def test_missing_db_returns_empty(self, tmp_path: Path) -> None:
+        missing_path = str(tmp_path / "nonexistent.db")
+        reader = SqliteEventReader(path=missing_path)
+        assert reader.query() == []
+        assert reader.count() == 0
+        assert reader.count_by("category") == {}

--- a/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_sqlite_writer.py
@@ -1,0 +1,338 @@
+"""Unit tests for security_events.sqlite_writer — SqliteEventWriter."""
+
+import io
+import json
+import os
+import sqlite3
+import stat
+import sys
+import tempfile
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
+
+
+def _make_event(
+    event_type: str = "test_event", category: str = "test", **kwargs: Any
+) -> SecurityEvent:
+    return SecurityEvent(
+        event_type=event_type,
+        category=category,
+        details=kwargs.get("details", {"key": "value"}),
+        trace_id=kwargs.get("trace_id", ""),
+    )
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "test.db")
+
+
+class TestSqliteEventWriter:
+    def test_write_with_invalid_timestamp(self, db_path: str) -> None:
+        """Verify that invalid timestamps are caught and logged to stderr."""
+        writer = SqliteEventWriter(path=db_path)
+
+        # Create event with malformed timestamp
+        evt = SecurityEvent(
+            event_type="test",
+            category="test",
+            details={"key": "value"},
+            timestamp="not-a-valid-timestamp",
+        )
+
+        # Capture stderr
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+
+        try:
+            writer.write(evt)
+            stderr_output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+
+        # Should print warning to stderr
+        assert "invalid event params" in stderr_output
+
+        # DB file should not be created since write fails before connection
+        assert not Path(db_path).exists()
+
+        writer.close()
+
+    def test_write_with_non_serializable_details(self, db_path: str) -> None:
+        """Verify that non-serializable details are caught and logged."""
+        writer = SqliteEventWriter(path=db_path)
+
+        # Create event with non-serializable details (custom object)
+        class CustomObject:
+            pass
+
+        evt = SecurityEvent(
+            event_type="test",
+            category="test",
+            details={"obj": CustomObject()},  # json.dumps will fail
+        )
+
+        # Capture stderr
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+
+        try:
+            writer.write(evt)
+            stderr_output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+
+        # Should print warning to stderr
+        assert "invalid event params" in stderr_output
+
+        # DB file should not be created since write fails before connection
+        assert not Path(db_path).exists()
+
+        writer.close()
+
+    def test_write_column_values_are_correct(self, db_path: str) -> None:
+        """Verify that all column values are correctly written to SQLite.
+
+        This is a critical data integrity test — validates the entire
+        _event_params conversion and INSERT correctness.
+        """
+        writer = SqliteEventWriter(path=db_path)
+
+        # Create a comprehensive event with all fields
+        evt = SecurityEvent(
+            event_type="harden",
+            category="hardening",
+            result="failed",
+            timestamp="2026-04-20T13:47:00.123456+00:00",
+            trace_id="test-trace-123",
+            session_id="session-abc",
+            details={
+                "nested": {"key": "value"},
+                "list": [1, 2, 3],
+                "unicode": "测试中文",
+                "null_value": None,
+                "empty_string": "",
+            },
+        )
+
+        writer.write(evt)
+        writer.close()
+
+        # Directly query the database to verify all column values
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM security_events").fetchone()
+        conn.close()
+
+        # Verify all columns
+        assert row is not None
+        assert row["event_id"] == evt.event_id
+        assert row["event_type"] == "harden"
+        assert row["category"] == "hardening"
+        assert row["result"] == "failed"
+        assert row["timestamp"] == "2026-04-20T13:47:00.123456+00:00"
+        assert row["trace_id"] == "test-trace-123"
+        assert row["pid"] == evt.pid
+        assert row["uid"] == evt.uid
+        assert row["session_id"] == "session-abc"
+
+        # Verify timestamp_epoch is correct
+        expected_epoch = datetime.fromisoformat(evt.timestamp).timestamp()
+        assert abs(row["timestamp_epoch"] - expected_epoch) < 0.001
+
+        # Verify details JSON serialization
+        details_dict = json.loads(row["details"])
+        assert details_dict["nested"] == {"key": "value"}
+        assert details_dict["list"] == [1, 2, 3]
+        assert details_dict["unicode"] == "测试中文"
+        assert details_dict["null_value"] is None
+        assert details_dict["empty_string"] == ""
+
+    def test_write_creates_db_and_inserts(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        evt = _make_event()
+        writer.write(evt)
+
+        assert Path(db_path).exists()
+
+        conn = sqlite3.connect(db_path)
+        rows = conn.execute("SELECT * FROM security_events").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        writer.close()
+
+    def test_db_file_permissions_are_restrictive(self, db_path: str) -> None:
+        """Verify that the database file is created with 0o600 permissions."""
+        writer = SqliteEventWriter(path=db_path)
+        writer.write(_make_event())
+
+        # Check file permissions
+        file_stat = Path(db_path).stat()
+        mode = stat.S_IMODE(file_stat.st_mode)
+
+        # Should be 0o600 (owner read/write only)
+        assert (
+            mode == 0o600
+        ), f"Database file has permissions {oct(mode)}, expected 0o600"
+
+        writer.close()
+
+    def test_wal_mode_enabled(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        writer.write(_make_event())
+
+        conn = sqlite3.connect(db_path)
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        assert mode == "wal"
+        writer.close()
+
+    def test_fire_and_forget_never_raises(self) -> None:
+        invalid_path = "/nonexistent/dir/test.db"
+        writer = SqliteEventWriter(path=invalid_path)
+        # Should not raise
+        writer.write(_make_event())
+
+    def test_insert_or_ignore_dedup(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        evt = _make_event()
+        writer.write(evt)
+        writer.write(evt)  # Same event_id
+
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM security_events").fetchone()[0]
+        conn.close()
+        assert count == 1
+        writer.close()
+
+    def test_thread_safety(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        errors: list[Exception] = []
+
+        def write_events(thread_id: int) -> None:
+            try:
+                for i in range(10):
+                    writer.write(
+                        _make_event(
+                            trace_id=f"thread-{thread_id}-event-{i}",
+                        )
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=write_events, args=(t,)) for t in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM security_events").fetchone()[0]
+        conn.close()
+        assert count == 100
+        writer.close()
+
+    def test_pruning_at_close(self, db_path: str) -> None:
+        """Pruning happens in close(), not during writes.
+
+        agent-sec-cli is short-lived: each invocation is a separate process,
+        so counter-based pruning inside write() would never accumulate across
+        invocations.  Instead, close() (called via atexit) prunes once per
+        process lifetime.
+        """
+        writer = SqliteEventWriter(path=db_path, max_age_days=0)
+
+        for _ in range(10):
+            writer.write(_make_event())
+        time.sleep(0.01)  # Ensure events are in the past relative to close()
+
+        # Before close: all events still present
+        conn = sqlite3.connect(db_path)
+        count_before = conn.execute("SELECT COUNT(*) FROM security_events").fetchone()[
+            0
+        ]
+        conn.close()
+        assert count_before == 10
+
+        # After close: pruning removes events (max_age_days=0 means cutoff=now)
+        writer.close()
+
+        conn = sqlite3.connect(db_path)
+        count_after = conn.execute("SELECT COUNT(*) FROM security_events").fetchone()[0]
+        conn.close()
+        assert count_after < 10
+
+    def test_corruption_detection_and_rebuild(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        writer.write(_make_event())
+        writer.close()
+
+        # Corrupt the DB file
+        with open(db_path, "r+b") as f:
+            f.write(b"CORRUPT_GARBAGE" * 100)
+
+        # Create new writer on same path — should detect corruption, delete,
+        # recreate fresh DB, and successfully write the current event
+        writer2 = SqliteEventWriter(path=db_path)
+        writer2.write(_make_event())
+
+        # Fresh DB should exist with the event (no event dropped)
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM security_events").fetchone()[0]
+        conn.close()
+        assert count == 1
+        writer2.close()
+
+    def test_schema_migration_adds_columns(self, db_path: str) -> None:
+        # _COLUMNS dict is currently empty, so just verify _ensure_schema runs without error
+        writer = SqliteEventWriter(path=db_path)
+        writer.write(_make_event())
+
+        conn = sqlite3.connect(db_path)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(security_events)")}
+        conn.close()
+        # Verify core columns exist
+        assert "event_id" in columns
+        assert "event_type" in columns
+        assert "category" in columns
+        assert "timestamp_epoch" in columns
+        writer.close()
+
+    def test_close_performs_checkpoint(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        writer.write(_make_event())
+        writer.write(_make_event())
+
+        writer.close()
+        assert writer._conn is None
+
+    def test_disabled_after_delete_failure(self, db_path: str) -> None:
+        writer = SqliteEventWriter(path=db_path)
+        writer.write(_make_event())
+        writer.close()
+
+        # Corrupt the DB
+        with open(db_path, "r+b") as f:
+            f.write(b"CORRUPT_GARBAGE" * 100)
+
+        writer2 = SqliteEventWriter(path=db_path)
+
+        # Mock Path.unlink to raise OSError
+        with patch.object(Path, "unlink", side_effect=OSError("permission denied")):
+            writer2.write(_make_event())
+
+        # Writer should be disabled now
+        assert writer2._disabled
+
+        # Subsequent writes should be no-ops
+        writer2.write(_make_event())

--- a/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
@@ -1,0 +1,865 @@
+"""Unit tests for security_events.summary_formatter."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.summary_formatter import format_summary
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    event_type: str = "test",
+    category: str = "test",
+    result: str = "succeeded",
+    details: dict[str, Any] | None = None,
+    timestamp: str | None = None,
+) -> SecurityEvent:
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+    return SecurityEvent(
+        event_type=event_type,
+        category=category,
+        result=result,
+        details=details or {},
+        timestamp=timestamp,
+    )
+
+
+def _ts_minutes_ago(minutes: int) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(minutes=minutes)
+    return dt.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Test: empty events
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyEvents:
+    def test_empty_list_returns_guidance_message(self):
+        output = format_summary([], "last 24 hours")
+        assert "No security events recorded" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: hardening summary
+# ---------------------------------------------------------------------------
+
+
+class TestHardeningSummary:
+    def test_scan_count_and_compliance(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan", "--config", "agentos_baseline"]},
+                    "result": {
+                        "mode": "scan",
+                        "config": "agentos_baseline",
+                        "passed": 45,
+                        "failed": 3,
+                        "total": 48,
+                        "failures": [
+                            {
+                                "rule_id": "SEC-001",
+                                "status": "FAIL",
+                                "message": "SSH root login not disabled",
+                            },
+                            {
+                                "rule_id": "SEC-003",
+                                "status": "FAIL",
+                                "message": "Firewall rules not updated",
+                            },
+                            {
+                                "rule_id": "SEC-005",
+                                "status": "FAIL",
+                                "message": "Audit log disabled",
+                            },
+                        ],
+                        "fixed": 0,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan", "--config", "agentos_baseline"]},
+                    "result": {
+                        "mode": "scan",
+                        "config": "agentos_baseline",
+                        "passed": 48,
+                        "failed": 0,
+                        "total": 48,
+                        "failures": [],
+                        "fixed": 0,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(60),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+
+        assert "--- Hardening ---" in output
+        assert "Scans performed:  2 (succeeded: 2, failed: 0)" in output
+        assert "45/48 rules passed (93.8%)" in output
+        assert "agent-sec-cli harden --scan" in output
+
+    def test_reinforcement_count(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {
+                        "args": ["--reinforce", "--config", "agentos_baseline"]
+                    },
+                    "result": {
+                        "mode": "reinforce",
+                        "config": "agentos_baseline",
+                        "passed": 48,
+                        "failed": 0,
+                        "total": 48,
+                        "failures": [],
+                        "fixed": 2,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Reinforcements:   1 (succeeded: 1, failed: 0)" in output
+
+    def test_failed_scan(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={
+                    "request": {"args": ["--scan", "--config", "agentos_baseline"]},
+                    "error": "loongshield not found",
+                    "error_type": "FileNotFoundError",
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Scans performed:  1 (succeeded: 0, failed: 1)" in output
+        assert "Latest scan failed: loongshield not found" in output
+        # Latest harden failed -> needs_attention (not critical)
+        assert "Needs attention" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: asset verify summary
+# ---------------------------------------------------------------------------
+
+
+class TestAssetVerifySummary:
+    def test_successful_verifications(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {"passed": 5, "failed": 0},
+                },
+                timestamp=_ts_minutes_ago(14),
+            ),
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": "/opt/skills/my-skill"},
+                    "result": {"passed": 3, "failed": 1},
+                },
+                timestamp=_ts_minutes_ago(120),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+
+        assert "--- Asset Verification ---" in output
+        assert "Verifications performed: 2 (succeeded: 2, failed: 0)" in output
+        assert "5 passed, 0 failed" in output
+        assert "ALL CLEAR" in output
+
+    def test_failed_verification(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {"passed": 3, "failed": 2},
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "FAILURES DETECTED" in output
+        assert "3 passed, 2 failed" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: code scan summary
+# ---------------------------------------------------------------------------
+
+
+class TestCodeScanSummary:
+    def test_deny_findings(self):
+        events = [
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "rm -rf /", "language": "bash"},
+                    "result": {
+                        "ok": False,
+                        "verdict": "deny",
+                        "summary": "Dangerous code detected",
+                        "findings": [
+                            {
+                                "rule_id": "BASH-001",
+                                "severity": "deny",
+                                "desc_en": "Remote code execution",
+                                "desc_zh": "远程代码执行",
+                                "evidence": ["rm -rf /"],
+                            },
+                        ],
+                        "language": "bash",
+                        "engine_version": "0.1.0",
+                        "elapsed_ms": 5,
+                    },
+                },
+                timestamp=_ts_minutes_ago(3),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+
+        assert "--- Code Scanning ---" in output
+        assert "Scans performed: 1 (succeeded: 1, failed: 0)" in output
+        assert "deny: 1" in output
+
+    def test_pass_verdict_no_deny_section(self):
+        events = [
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "echo hello", "language": "bash"},
+                    "result": {
+                        "ok": True,
+                        "verdict": "pass",
+                        "summary": "No issues",
+                        "findings": [],
+                        "language": "bash",
+                        "engine_version": "0.1.0",
+                        "elapsed_ms": 2,
+                    },
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "pass: 1" in output
+        assert "Recent deny findings" not in output
+
+    def test_mixed_verdicts_breakdown(self):
+        events = [
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "x", "language": "bash"},
+                    "result": {"ok": True, "verdict": "pass", "findings": []},
+                },
+                timestamp=_ts_minutes_ago(1),
+            ),
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "y", "language": "bash"},
+                    "result": {
+                        "ok": True,
+                        "verdict": "warn",
+                        "findings": [
+                            {
+                                "rule_id": "W1",
+                                "severity": "warn",
+                                "desc_en": "w",
+                                "desc_zh": "w",
+                                "evidence": [],
+                            }
+                        ],
+                    },
+                },
+                timestamp=_ts_minutes_ago(2),
+            ),
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "z", "language": "bash"},
+                    "result": {"ok": True, "verdict": "pass", "findings": []},
+                },
+                timestamp=_ts_minutes_ago(3),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "pass: 2, warn: 1" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: sandbox summary
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxSummary:
+    def test_sandbox_interventions(self):
+        events = [
+            _make_event(
+                event_type="sandbox_prehook",
+                category="sandbox",
+                result="succeeded",
+                details={
+                    "request": {
+                        "decision": "sandbox",
+                        "command": "rm -rf /tmp/data",
+                        "reasons": "recursive delete",
+                        "network_policy": "none",
+                        "cwd": "/home/user",
+                    },
+                    "result": {
+                        "decision": "sandbox",
+                        "command": "rm -rf /tmp/data",
+                        "reasons": "recursive delete",
+                        "network_policy": "none",
+                        "cwd": "/home/user",
+                    },
+                },
+                timestamp=_ts_minutes_ago(2),
+            ),
+            _make_event(
+                event_type="sandbox_prehook",
+                category="sandbox",
+                result="succeeded",
+                details={
+                    "request": {
+                        "decision": "block",
+                        "command": "chmod 777 /etc/shadow",
+                        "reasons": "permission escalation",
+                        "network_policy": "none",
+                        "cwd": "/home/user",
+                    },
+                    "result": {
+                        "decision": "block",
+                        "command": "chmod 777 /etc/shadow",
+                        "reasons": "permission escalation",
+                        "network_policy": "none",
+                        "cwd": "/home/user",
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+
+        assert "--- Sandbox Guard ---" in output
+        assert "Total interventions: 2" in output
+        # Sandbox no longer exposes raw commands for security reasons
+        assert "rm -rf /tmp/data" not in output
+        assert "chmod 777" not in output
+
+
+# ---------------------------------------------------------------------------
+# Test: posture computation
+# ---------------------------------------------------------------------------
+
+
+class TestPostureComputation:
+    def test_good_status(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={"request": {}, "result": {"passed": 5, "failed": 0}},
+                timestamp=_ts_minutes_ago(10),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Good" in output
+        assert "\u2713" in output
+
+    def test_sandbox_block_does_not_affect_posture(self):
+        """Sandbox events are independent — they must NOT affect posture status."""
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan"]},
+                    "result": {
+                        "mode": "scan",
+                        "passed": 48,
+                        "failed": 0,
+                        "total": 48,
+                        "failures": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+            _make_event(
+                event_type="sandbox_prehook",
+                category="sandbox",
+                result="succeeded",
+                details={
+                    "request": {
+                        "decision": "block",
+                        "command": "rm /etc/passwd",
+                        "reasons": "critical file",
+                        "network_policy": "none",
+                        "cwd": "/",
+                    },
+                    "result": {
+                        "decision": "block",
+                        "command": "rm /etc/passwd",
+                        "reasons": "critical file",
+                        "network_policy": "none",
+                        "cwd": "/",
+                    },
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Good" in output
+        assert "\u2713" in output
+
+    def test_critical_on_harden_failure(self):
+        """Latest harden failed -> needs_attention (tool error, not security violation)."""
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={
+                    "request": {"args": ["--scan"]},
+                    "error": "tool not found",
+                    "error_type": "FileNotFoundError",
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Needs attention" in output
+        assert "\u26a0" in output
+
+    def test_code_deny_does_not_affect_posture(self):
+        """Code scan is an independent category — deny must NOT affect posture."""
+        events = [
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "bad", "language": "bash"},
+                    "result": {
+                        "ok": False,
+                        "verdict": "deny",
+                        "summary": "Deny",
+                        "findings": [
+                            {
+                                "rule_id": "X",
+                                "severity": "deny",
+                                "desc_en": "bad",
+                                "desc_zh": "bad",
+                                "evidence": [],
+                            }
+                        ],
+                        "language": "bash",
+                        "engine_version": "0.1.0",
+                        "elapsed_ms": 1,
+                    },
+                },
+                timestamp=_ts_minutes_ago(1),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Good" in output
+        assert "\u2713" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: defensive sort (events given in wrong order)
+# ---------------------------------------------------------------------------
+
+
+class TestDefensiveSort:
+    def test_asc_order_events_still_pick_latest(self):
+        """Events passed in ascending order must still produce correct 'latest' results."""
+        older = _make_event(
+            event_type="harden",
+            category="hardening",
+            result="succeeded",
+            details={
+                "request": {"args": ["--scan"]},
+                "result": {
+                    "mode": "scan",
+                    "passed": 48,
+                    "failed": 0,
+                    "total": 48,
+                    "failures": [],
+                },
+            },
+            timestamp=_ts_minutes_ago(60),
+        )
+        newer = _make_event(
+            event_type="harden",
+            category="hardening",
+            result="succeeded",
+            details={
+                "request": {"args": ["--scan"]},
+                "result": {
+                    "mode": "scan",
+                    "passed": 40,
+                    "failed": 8,
+                    "total": 48,
+                    "failures": [{"rule_id": "SEC-001"}],
+                },
+            },
+            timestamp=_ts_minutes_ago(5),
+        )
+        # Pass in ASCENDING order — older first
+        output = format_summary([older, newer], "last 24 hours")
+        # Latest (newer) has 40/48 compliance — not the older 48/48
+        assert "40/48 rules passed" in output
+        assert "Needs attention" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: posture – verify failed path
+# ---------------------------------------------------------------------------
+
+
+class TestPostureVerifyFailed:
+    def test_verify_event_failed_triggers_needs_attention(self):
+        """Latest verify event.result=='failed' triggers needs_attention."""
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="failed",
+                details={
+                    "request": {"skill": None},
+                    "error": "timeout",
+                    "error_type": "TimeoutError",
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Needs attention" in output
+        assert "\u26a0" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: suggestions edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestionsEdgeCases:
+    def test_no_suggestion_when_latest_harden_failed(self):
+        """If latest harden event.result=='failed', do NOT suggest --reinforce."""
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={"request": {"args": ["--scan"]}, "error": "not found"},
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "agent-sec-cli harden --reinforce" not in output
+
+    def test_no_suggestion_when_no_hardening_events(self):
+        """Only sandbox events — no suggestion at all."""
+        events = [
+            _make_event(
+                event_type="sandbox_prehook",
+                category="sandbox",
+                result="succeeded",
+                details={
+                    "request": {"decision": "block", "command": "x"},
+                    "result": {"decision": "block"},
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Suggested actions" not in output
+
+
+# ---------------------------------------------------------------------------
+# Test: output format exact prefixes
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormatPrefixes:
+    def test_system_status_good_prefix(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={"request": {}, "result": {"passed": 5, "failed": 0}},
+                timestamp=_ts_minutes_ago(10),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "System Status: Good" in output
+
+    def test_system_status_needs_attention_prefix(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={"request": {"args": ["--scan"]}, "error": "err"},
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "System Status: Needs attention" in output
+
+    def test_verdict_prefix_in_code_scan(self):
+        events = [
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "ls", "language": "bash"},
+                    "result": {"ok": True, "verdict": "pass", "findings": []},
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Verdict: pass: 1" in output
+
+
+# ---------------------------------------------------------------------------
+# Test: mixed categories
+# ---------------------------------------------------------------------------
+
+
+class TestMixedCategories:
+    def test_combined_report_structure(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan", "--config", "agentos_baseline"]},
+                    "result": {
+                        "mode": "scan",
+                        "config": "agentos_baseline",
+                        "passed": 46,
+                        "failed": 2,
+                        "total": 48,
+                        "failures": [
+                            {"rule_id": "SEC-001", "status": "FAIL", "message": "Issue"}
+                        ],
+                        "fixed": 0,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {"passed": 5, "failed": 0},
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+            _make_event(
+                event_type="code_scan",
+                category="code_scan",
+                result="succeeded",
+                details={
+                    "request": {"code": "echo hi", "language": "bash"},
+                    "result": {
+                        "ok": True,
+                        "verdict": "pass",
+                        "summary": "OK",
+                        "findings": [],
+                        "language": "bash",
+                        "engine_version": "0.1.0",
+                        "elapsed_ms": 1,
+                    },
+                },
+                timestamp=_ts_minutes_ago(15),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+
+        # Verify all sections present
+        assert "Security Posture Summary (last 24 hours)" in output
+        assert "--- Hardening ---" in output
+        assert "--- Asset Verification ---" in output
+        assert "--- Code Scanning ---" in output
+        assert "Total events: 3" in output
+
+        # Verify sections appear in correct order
+        hardening_pos = output.index("--- Hardening ---")
+        verify_pos = output.index("--- Asset Verification ---")
+        code_pos = output.index("--- Code Scanning ---")
+        assert hardening_pos < verify_pos < code_pos
+
+
+# ---------------------------------------------------------------------------
+# Test: footer and suggestions
+# ---------------------------------------------------------------------------
+
+
+class TestFooter:
+    def test_footer_stats(self):
+        """Latest harden succeeded so posture not critical; footer shows stats."""
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan"]},
+                    "result": {
+                        "mode": "scan",
+                        "passed": 48,
+                        "failed": 0,
+                        "total": 48,
+                        "failures": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(14),
+            ),
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="failed",
+                details={
+                    "request": {"args": ["--scan"]},
+                    "error": "timeout",
+                    "error_type": "TimeoutError",
+                },
+                timestamp=_ts_minutes_ago(30),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Total events: 2" in output
+        assert "Failed: 1" in output
+        # Latest event succeeded, so posture should be Good, not Critical
+        assert "Good" in output
+
+    def test_suggested_action_for_failed_rules(self):
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan"]},
+                    "result": {
+                        "mode": "scan",
+                        "passed": 45,
+                        "failed": 3,
+                        "total": 48,
+                        "failures": [
+                            {"rule_id": "SEC-001", "status": "FAIL", "message": "issue"}
+                        ],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "agent-sec-cli harden --reinforce" in output
+        # Latest harden has failures -> needs_attention
+        assert "Needs attention" in output
+
+    def test_needs_attention_on_latest_harden_failures(self):
+        """Latest successful scan with non-empty failures triggers needs_attention."""
+        events = [
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan"]},
+                    "result": {
+                        "mode": "scan",
+                        "passed": 45,
+                        "failed": 3,
+                        "total": 48,
+                        "failures": [{"rule_id": "SEC-001"}],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Needs attention" in output
+        assert "\u26a0" in output
+
+    def test_needs_attention_on_latest_verify_failures(self):
+        """Latest verify with failed > 0 triggers needs_attention."""
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={"request": {}, "result": {"passed": 3, "failed": 1}},
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+        assert "Needs attention" in output
+        assert "\u26a0" in output

--- a/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
@@ -620,6 +620,7 @@ class TestWriterMultiProcessSafety(unittest.TestCase):
         "event_id",
         "event_type",
         "category",
+        "result",
         "timestamp",
         "trace_id",
         "pid",

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_summary_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_summary_backend.py
@@ -1,19 +1,73 @@
-"""Unit tests for security_middleware.backends.summary — SummaryBackend (stub)."""
+"""Unit tests for security_middleware.backends.summary — SummaryBackend."""
 
+import tempfile
+import time
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
+from agent_sec_cli.security_events.schema import SecurityEvent
+from agent_sec_cli.security_events.sqlite_reader import SqliteEventReader
+from agent_sec_cli.security_events.sqlite_writer import SqliteEventWriter
 from agent_sec_cli.security_middleware.backends.summary import SummaryBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 
 
+def _make_event(event_type="test_event", category="sandbox", **kwargs):
+    return SecurityEvent(
+        event_type=event_type,
+        category=category,
+        details=kwargs.get("details", {"key": "value"}),
+    )
+
+
 class TestSummaryBackend(unittest.TestCase):
-    def test_always_fails(self):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.db_path = str(Path(self.tmp_dir) / "test.db")
+        self.writer = SqliteEventWriter(path=self.db_path)
+        self.reader = SqliteEventReader(path=self.db_path)
+
+    def tearDown(self):
+        self.writer.close()
+
+    @patch("agent_sec_cli.security_middleware.backends.summary.get_reader")
+    def test_summary_with_events(self, mock_get_reader):
+        # Write test events
+        for i in range(5):
+            self.writer.write(_make_event(category="sandbox"))
+        for i in range(3):
+            self.writer.write(
+                _make_event(category="hardening", event_type="hardening_scan")
+            )
+
+        mock_get_reader.return_value = self.reader
+
+        backend = SummaryBackend()
+        ctx = RequestContext(action="summary")
+        result = backend.execute(ctx, hours=24)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["total_events"], 8)
+        self.assertIn("sandbox", result.data["by_category"])
+        self.assertEqual(result.data["by_category"]["sandbox"], 5)
+        self.assertEqual(result.data["by_category"]["hardening"], 3)
+        self.assertIn("Total events: 8", result.stdout)
+
+    @patch("agent_sec_cli.security_middleware.backends.summary.get_reader")
+    def test_summary_empty_db(self, mock_get_reader):
+        # Non-existent DB path
+        reader = SqliteEventReader(path=str(Path(self.tmp_dir) / "nonexistent.db"))
+        mock_get_reader.return_value = reader
+
         backend = SummaryBackend()
         ctx = RequestContext(action="summary")
         result = backend.execute(ctx)
 
-        self.assertFalse(result.success)
-        self.assertIn("not yet implemented", result.error.lower())
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["total_events"], 0)
+        self.assertEqual(result.data["by_category"], {})
+        self.assertEqual(result.data["by_event_type"], {})
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -63,8 +63,9 @@ class TestOnError(unittest.TestCase):
 
         mock_log.assert_called_once()
         event = mock_log.call_args[0][0]
-        self.assertEqual(event.event_type, "verify_error")
+        self.assertEqual(event.event_type, "verify")
         self.assertEqual(event.category, "asset_verify")
+        self.assertEqual(event.result, "failed")
         self.assertIn("error", event.details)
         self.assertEqual(event.details["error"], "test error")
         self.assertEqual(event.details["error_type"], "RuntimeError")


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Core storage engine:
- Add SqliteEventWriter: thread-safe, corruption-resilient, self-pruning SQLite writer with convergent schema migration and dual-write support
- Add SqliteEventReader: sqlite3.Row name-based access, defense-in-depth SQL injection prevention (allowlist + regex assertion in count_by)
- Introduce `result` field (succeeded/failed) in SecurityEvent schema, replacing the _error suffix convention in event_type

CLI `events` command:
- kubectl-style table output with dynamic column widths (default format)
- Support --output table|json|jsonl for progressive disclosure
- Filters: --event-type, --category, --trace-id, --since, --until, --last-hours
- Aggregation: --count, --count-by (category|event_type|trace_id)
- Pagination: --limit, --offset
- Soft validation: warn on unknown event_type/category without rejecting
- Timestamp truncation to seconds in table display for readability
- Inline usage examples in source-level section comments

Event model refactoring:
- lifecycle.on_error now emits event_type=`action` with result="failed" instead of event_type=`action`_error (cleaner query semantics)
- SummaryBackend upgraded from stub to functional aggregation engine (removed db_health diagnostic logic as unnecessary)

Test infrastructure:
- Function-scoped e2e fixture (per-test DB isolation, no ordering dependency)
- Session-scoped unit-test conftest redirects AGENT_SEC_DATA_DIR to tmp
- Comprehensive e2e coverage: event logging, count, count-by, filters, table/json/jsonl output, CLI validation error paths
- Unit tests for writer (multiprocess, corruption recovery, pruning), reader (query, count_by, edge cases), schema, and summary backend

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
