### PR TITLE
fix(sec-core): remove dynamic import at middleware router

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/router.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/router.py
@@ -1,76 +1,54 @@
-"""Router — action name to backend module registry with lazy imports."""
+"""Router — action name to backend instance registry with explicit imports."""
 
-import importlib
-from typing import Any, Dict
+from typing import Any
+
+from agent_sec_cli.security_middleware.backends.asset_verify import (
+    AssetVerifyBackend,
+)
+from agent_sec_cli.security_middleware.backends.code_scan import CodeScanBackend
+from agent_sec_cli.security_middleware.backends.hardening import (
+    HardeningBackend,
+)
+from agent_sec_cli.security_middleware.backends.sandbox import SandboxBackend
+from agent_sec_cli.security_middleware.backends.skill_ledger import (
+    SkillLedgerBackend,
+)
+from agent_sec_cli.security_middleware.backends.summary import SummaryBackend
 
 # ---------------------------------------------------------------------------
-# Action → backend module mapping
+# Action → backend class mapping (static, no hot-swapping allowed)
 # ---------------------------------------------------------------------------
 
-_REGISTRY: Dict[str, str] = {
-    "sandbox_prehook": "agent_sec_cli.security_middleware.backends.sandbox",
-    "harden": "agent_sec_cli.security_middleware.backends.hardening",
-    "verify": "agent_sec_cli.security_middleware.backends.asset_verify",
-    "summary": "agent_sec_cli.security_middleware.backends.summary",
-    "code_scan": "agent_sec_cli.security_middleware.backends.code_scan",
-    "skill_ledger": "agent_sec_cli.security_middleware.backends.skill_ledger",
+_BACKEND_CLASSES: dict[str, type] = {
+    "sandbox_prehook": SandboxBackend,
+    "harden": HardeningBackend,
+    "verify": AssetVerifyBackend,
+    "summary": SummaryBackend,
+    "code_scan": CodeScanBackend,
+    "skill_ledger": SkillLedgerBackend,
 }
 
-# Module base name → expected class name convention.
-_CLASS_SUFFIX = "Backend"
-
 # Cache of already-instantiated backends keyed by action.
-_backend_cache: Dict[str, Any] = {}
-
-
-def _module_to_class_name(module_path: str) -> str:
-    """Derive the class name from the last segment of the module path.
-
-    Convention:  ``security_middleware.backends.sandbox``
-                 → module name ``sandbox``
-                 → class ``SandboxBackend``
-    """
-    base = module_path.rsplit(".", 1)[-1]
-    # Convert snake_case to PascalCase and append "Backend"
-    parts = base.split("_")
-    pascal = "".join(p.capitalize() for p in parts)
-    return f"{pascal}{_CLASS_SUFFIX}"
+_backend_cache: dict[str, Any] = {}
 
 
 def get_backend(action: str) -> Any:
     """Return the backend instance responsible for *action*.
 
-    The backend module is imported lazily on first access and the instance is
-    cached for subsequent calls.
+    The backend instance is created on first access and cached for subsequent calls.
 
     Raises:
         ValueError:  If *action* is not found in the registry.
-        ImportError:  If the backend module cannot be imported.
-        AttributeError:  If the expected class is missing from the module.
     """
-    if action not in _REGISTRY:
-        registered = ", ".join(sorted(_REGISTRY))
+    if action not in _BACKEND_CLASSES:
+        registered = ", ".join(sorted(_BACKEND_CLASSES))
         raise ValueError(f"Unknown action {action!r}. Registered actions: {registered}")
 
     if action in _backend_cache:
         return _backend_cache[action]
 
-    module_path = _REGISTRY[action]
-    module = importlib.import_module(module_path)
-
-    class_name = _module_to_class_name(module_path)
-    backend_cls = getattr(module, class_name)
+    backend_cls = _BACKEND_CLASSES[action]
     instance = backend_cls()
 
     _backend_cache[action] = instance
     return instance
-
-
-def register_action(action: str, module_path: str) -> None:
-    """Dynamically register a new action → module mapping.
-
-    This is primarily useful for plugins or tests.
-    """
-    _REGISTRY[action] = module_path
-    # Invalidate any cached instance for this action.
-    _backend_cache.pop(action, None)

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_router.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_router.py
@@ -1,80 +1,37 @@
 """Unit tests for security_middleware.router — action→backend routing."""
 
-import unittest
-
+import pytest
 from agent_sec_cli.security_middleware import router
+from agent_sec_cli.security_middleware.backends.sandbox import SandboxBackend
 
 
-class TestModuleToClassName(unittest.TestCase):
-    def test_sandbox(self):
-        name = router._module_to_class_name(
-            "agent_sec_cli.security_middleware.backends.sandbox"
-        )
-        self.assertEqual(name, "SandboxBackend")
-
-    def test_asset_verify(self):
-        name = router._module_to_class_name(
-            "agent_sec_cli.security_middleware.backends.asset_verify"
-        )
-        self.assertEqual(name, "AssetVerifyBackend")
-
-    def test_hardening(self):
-        name = router._module_to_class_name(
-            "agent_sec_cli.security_middleware.backends.hardening"
-        )
-        self.assertEqual(name, "HardeningBackend")
-
-    def test_single_word(self):
-        name = router._module_to_class_name("some.module.foobar")
-        self.assertEqual(name, "FoobarBackend")
+def test_unknown_action_raises_value_error():
+    with pytest.raises(ValueError, match="nonexistent_action"):
+        router.get_backend("nonexistent_action")
 
 
-class TestGetBackend(unittest.TestCase):
-    def test_unknown_action_raises_value_error(self):
-        with self.assertRaises(ValueError) as cm:
-            router.get_backend("nonexistent_action")
-        self.assertIn("nonexistent_action", str(cm.exception))
-
-    def test_sandbox_prehook_returns_backend(self):
-        backend = router.get_backend("sandbox_prehook")
-        self.assertTrue(hasattr(backend, "execute"))
-
-    def test_backend_is_cached(self):
-        b1 = router.get_backend("sandbox_prehook")
-        b2 = router.get_backend("sandbox_prehook")
-        self.assertIs(b1, b2)
+def test_sandbox_prehook_returns_backend():
+    backend = router.get_backend("sandbox_prehook")
+    assert isinstance(backend, SandboxBackend)
+    assert hasattr(backend, "execute")
 
 
-class TestRegisterAction(unittest.TestCase):
-    def setUp(self):
-        # Clean up test registrations after each test
-        self._original_registry = dict(router._REGISTRY)
-        self._original_cache = dict(router._backend_cache)
-
-    def tearDown(self):
-        router._REGISTRY.clear()
-        router._REGISTRY.update(self._original_registry)
-        router._backend_cache.clear()
-        router._backend_cache.update(self._original_cache)
-
-    def test_register_new_action(self):
-        router.register_action(
-            "custom_test", "agent_sec_cli.security_middleware.backends.sandbox"
-        )
-        backend = router.get_backend("custom_test")
-        self.assertTrue(hasattr(backend, "execute"))
-
-    def test_register_invalidates_cache(self):
-        # Pre-cache sandbox_prehook
-        b1 = router.get_backend("sandbox_prehook")
-        # Re-register should invalidate cache
-        router.register_action(
-            "sandbox_prehook", "agent_sec_cli.security_middleware.backends.sandbox"
-        )
-        b2 = router.get_backend("sandbox_prehook")
-        # After invalidation, a new instance is created
-        self.assertIsNot(b1, b2)
+def test_all_registered_actions_work():
+    """Test that all registered actions can be retrieved."""
+    actions = [
+        "sandbox_prehook",
+        "harden",
+        "verify",
+        "summary",
+        "code_scan",
+        "skill_ledger",
+    ]
+    for action in actions:
+        backend = router.get_backend(action)
+        assert hasattr(backend, "execute"), f"Action {action!r} missing execute method"
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_backend_is_cached():
+    b1 = router.get_backend("sandbox_prehook")
+    b2 = router.get_backend("sandbox_prehook")
+    assert b1 is b2


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
