### PR TITLE
fix(sec-core): add e2e test and fix bugs revealed during testing

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__main__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running the package as a module: python -m agent_sec_cli"""
+
+from agent_sec_cli.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -16,11 +16,37 @@ from agent_sec_cli.security_middleware.backends.hardening import (
 from agent_sec_cli.security_middleware.lifecycle import _ACTION_CATEGORY
 from agent_sec_cli.skill_ledger.cli import app as skill_ledger_app
 
+# Get version from package metadata
+try:
+    from importlib.metadata import version as get_version
+
+    __version__ = get_version("agent-sec-cli")
+except Exception:
+    __version__ = "0.3.0"  # Fallback version
+
 app = typer.Typer(
     name="agent-sec-cli",
     help="AgentSecCore unified CLI entry point",
     add_completion=True,
+    rich_markup_mode="rich",
 )
+
+
+@app.callback(invoke_without_command=True)
+def main_callback(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-v",
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+) -> None:
+    """Main callback for version option."""
+    if version:
+        typer.echo(f"agent-sec-cli {__version__}")
+        raise typer.Exit()
 
 
 # Mount skill-ledger as a subcommand group: agent-sec-cli skill-ledger <cmd>
@@ -244,7 +270,32 @@ def _resolve_time_range(
     """Resolve since/until from either explicit values or last_hours.
 
     Ensures consistent time range handling across all query modes.
+
+    Raises
+    ------
+    ValueError
+        If since or until parameters are not valid ISO-8601 format.
     """
+    # Validate since parameter if provided
+    if since is not None:
+        try:
+            datetime.fromisoformat(since)
+        except ValueError:
+            raise ValueError(
+                f"Invalid time format for --since: {since!r}. "
+                "Expected ISO 8601 format (e.g., 2024-01-01 or 2024-01-01T12:00:00)"
+            )
+
+    # Validate until parameter if provided
+    if until is not None:
+        try:
+            datetime.fromisoformat(until)
+        except ValueError:
+            raise ValueError(
+                f"Invalid time format for --until: {until!r}. "
+                "Expected ISO 8601 format (e.g., 2024-01-01 or 2024-01-01T12:00:00)"
+            )
+
     if last_hours is not None:
         now = time.time()
         since_epoch = now - last_hours * 3600
@@ -344,8 +395,8 @@ def events(
         "--count-by",
         help="Output grouped counts as JSON object. Allowed: category, event_type, trace_id.",
     ),
-    output: str = typer.Option(
-        "table",
+    output: str | None = typer.Option(
+        None,
         "--output",
         "-o",
         help="Output format: table (default, human-readable), json, jsonl.",
@@ -370,12 +421,17 @@ def events(
         )
         raise typer.Exit(code=1)
 
-    if summary and output != "table":
+    # --summary is incompatible with ANY explicit --output format
+    if summary and output is not None:
         typer.echo(
             "Error: --summary is incompatible with --output (summary has its own format).",
             err=True,
         )
         raise typer.Exit(code=1)
+
+    # Apply default output format if not specified
+    if output is None:
+        output = "table"
 
     if output not in _OUTPUT_FORMATS:
         typer.echo(
@@ -427,9 +483,14 @@ def events(
         if summary_hours is None and since is None and until is None:
             summary_hours = 24.0
 
-        resolved_since, resolved_until = _resolve_time_range(
-            summary_hours, since, until
-        )
+        try:
+            resolved_since, resolved_until = _resolve_time_range(
+                summary_hours, since, until
+            )
+        except ValueError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1)
+
         events_list = reader.query(
             event_type=event_type,
             category=category,
@@ -450,25 +511,47 @@ def events(
 
     # --- count mode ---
     if count:
-        resolved_since, resolved_until = _resolve_time_range(last_hours, since, until)
+        try:
+            resolved_since, resolved_until = _resolve_time_range(
+                last_hours, since, until
+            )
+        except ValueError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1)
+
         result = reader.count(
             event_type=event_type,
             category=category,
             since=resolved_since,
             until=resolved_until,
+            offset=offset,
         )
         typer.echo(json.dumps(result, ensure_ascii=False, indent=2))
         raise typer.Exit(code=0)
 
     # --- count-by mode ---
     if count_by is not None:
-        resolved_since, resolved_until = _resolve_time_range(last_hours, since, until)
-        result = reader.count_by(count_by, since=resolved_since, until=resolved_until)
+        try:
+            resolved_since, resolved_until = _resolve_time_range(
+                last_hours, since, until
+            )
+        except ValueError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1)
+
+        result = reader.count_by(
+            count_by, since=resolved_since, until=resolved_until, offset=offset
+        )
         typer.echo(json.dumps(result, ensure_ascii=False, indent=2))
         raise typer.Exit(code=0)
 
     # --- list mode ---
-    resolved_since, resolved_until = _resolve_time_range(last_hours, since, until)
+    try:
+        resolved_since, resolved_until = _resolve_time_range(last_hours, since, until)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
     events_list = reader.query(
         event_type=event_type,
         category=category,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_reader.py
@@ -5,7 +5,7 @@ import re
 import sqlite3
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -57,10 +57,18 @@ class SqliteEventReader:
             params.append(trace_id)
         if since is not None:
             conditions.append("timestamp_epoch >= ?")
-            params.append(datetime.fromisoformat(since).timestamp())
+            dt = datetime.fromisoformat(since)
+            # If naive (no timezone), assume UTC to match event storage
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            params.append(dt.timestamp())
         if until is not None:
             conditions.append("timestamp_epoch < ?")
-            params.append(datetime.fromisoformat(until).timestamp())
+            dt = datetime.fromisoformat(until)
+            # If naive (no timezone), assume UTC to match event storage
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            params.append(dt.timestamp())
         where = " WHERE " + " AND ".join(conditions) if conditions else ""
         return where, params
 
@@ -159,6 +167,7 @@ class SqliteEventReader:
         category: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        offset: int = 0,
     ) -> int:
         """Count events matching the given filters.
 
@@ -172,11 +181,13 @@ class SqliteEventReader:
             Inclusive lower bound (ISO-8601 timestamp).
         until : str, optional
             Exclusive upper bound (ISO-8601 timestamp).
+        offset : int
+            Number of results to skip (default 0).
 
         Returns
         -------
         int
-            Number of matching events.
+            Number of matching events after applying offset.
         """
         try:
             conn = self._connect()
@@ -187,7 +198,14 @@ class SqliteEventReader:
                     since=since,
                     until=until,
                 )
-                sql = f"SELECT COUNT(*) FROM security_events{where}"
+                # Use subquery to apply OFFSET before counting
+                # COUNT(*) on the full set returns 1 row, which OFFSET would skip
+                sql = (
+                    f"SELECT COUNT(*) FROM ("
+                    f"SELECT 1 FROM security_events{where} "
+                    f"LIMIT -1 OFFSET ?)"
+                )
+                params.append(offset)
                 cursor = conn.execute(sql, params)
                 result = cursor.fetchone()
                 return result[0] if result else 0
@@ -201,6 +219,7 @@ class SqliteEventReader:
         group_field: str,
         since: str | None = None,
         until: str | None = None,
+        offset: int = 0,
     ) -> dict[str, int]:
         """Count events grouped by a specific field.
 
@@ -212,11 +231,13 @@ class SqliteEventReader:
             Inclusive lower bound (ISO-8601 timestamp).
         until : str, optional
             Exclusive upper bound (ISO-8601 timestamp).
+        offset : int
+            Number of results to skip (default 0).
 
         Returns
         -------
         dict[str, int]
-            Mapping of field value to event count.
+            Mapping of field value to event count after applying offset.
 
         Raises
         ------
@@ -245,11 +266,25 @@ class SqliteEventReader:
             conn = self._connect()
             try:
                 where, params = self._build_where(since=since, until=until)
-                sql = (
-                    f"SELECT {group_field}, COUNT(*) "
-                    f"FROM security_events{where} "
-                    f"GROUP BY {group_field}"
-                )
+
+                if offset == 0:
+                    # No offset: use simple GROUP BY
+                    sql = (
+                        f"SELECT {group_field}, COUNT(*) "
+                        f"FROM security_events{where} "
+                        f"GROUP BY {group_field}"
+                    )
+                else:
+                    # With offset: apply offset to individual events before grouping
+                    # Use subquery to skip 'offset' events, then group the remainder
+                    sql = (
+                        f"SELECT {group_field}, COUNT(*) FROM ("
+                        f"SELECT {group_field} FROM security_events{where} "
+                        f"LIMIT -1 OFFSET ?) "
+                        f"GROUP BY {group_field}"
+                    )
+                    params.append(offset)
+
                 cursor = conn.execute(sql, params)
                 rows = cursor.fetchall()
                 return {row[0]: row[1] for row in rows}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
@@ -95,6 +95,17 @@ def _get_request(event: SecurityEvent) -> dict[str, Any]:
     return request if isinstance(request, dict) else {}
 
 
+def _is_full_verify(event: SecurityEvent) -> bool:
+    """Check if a verify event is a full-skill verification.
+
+    Full verify events have skill=None in the request.
+    Single-skill verify events have a specific skill path or name.
+    """
+    request = _get_request(event)
+    # Full verify when skill key is absent or explicitly None
+    return request.get("skill") is None
+
+
 def _get_mode(event: SecurityEvent) -> str:
     """Extract hardening mode from details.result, fallback to parsing request.args.
 
@@ -169,13 +180,31 @@ def _summarize_hardening(events: list[SecurityEvent]) -> str:
         total = result.get("total", 0)
         failures = result.get("failures", [])
 
+        # Include fixed count from reinforce operations in compliance calculation
+        fixed_count = 0
+        for e in reinforcements:
+            if e.result == "succeeded":
+                reinf_result = _get_result(e)
+                fixed_count += reinf_result.get("fixed", 0)
+
+        # Compliance includes both passed and fixed items
+        effective_passed = passed + fixed_count
+
         if total > 0:
-            pct = passed / total * 100
+            pct = effective_passed / total * 100
             lines.append("")
             lines.append("  Latest scan result:")
-            lines.append(f"    Compliance: {passed}/{total} rules passed ({pct:.1f}%)")
+            if fixed_count > 0:
+                lines.append(
+                    f"    Compliance: {effective_passed}/{total} rules passed "
+                    f"({passed} passed + {fixed_count} fixed, {pct:.1f}%)"
+                )
+            else:
+                lines.append(
+                    f"    Compliance: {passed}/{total} rules passed ({pct:.1f}%)"
+                )
 
-            if failures:
+            if failures and fixed_count == 0:
                 lines.append(
                     "    Check system status using `agent-sec-cli harden --scan`"
                 )
@@ -334,15 +363,21 @@ def _compute_posture(
             if failures:
                 needs_attention = True
 
-    # --- Asset Verification (latest event) ---
+    # --- Asset Verification (latest FULL verify event) ---
+    # Only consider full-skill verifications (skill=None) for posture calculation
+    # Single-skill verifications should not affect overall system status
     if verify_events:
-        latest_verify = verify_events[0]
-        if latest_verify.result == "failed":
-            needs_attention = True
-        elif latest_verify.result == "succeeded":
-            result = _get_result(latest_verify)
-            if result.get("failed", 0) > 0:
+        # Find the latest full verify event
+        latest_full_verify = next(
+            (e for e in verify_events if _is_full_verify(e)), None
+        )
+        if latest_full_verify:
+            if latest_full_verify.result == "failed":
                 needs_attention = True
+            elif latest_full_verify.result == "succeeded":
+                result = _get_result(latest_full_verify)
+                if result.get("failed", 0) > 0:
+                    needs_attention = True
 
     # --- Prompt Scan (any DENY verdict) ---
     for e in prompt_scan_events:

--- a/src/agent-sec-core/tests/e2e/cli/__init__.py
+++ b/src/agent-sec-core/tests/e2e/cli/__init__.py
@@ -1,0 +1,1 @@
+# E2E tests for agent-sec-cli

--- a/src/agent-sec-core/tests/e2e/cli/conftest.py
+++ b/src/agent-sec-core/tests/e2e/cli/conftest.py
@@ -1,0 +1,163 @@
+"""Shared fixtures and helpers for CLI e2e tests.
+
+This module provides common test infrastructure used across all CLI e2e
+test files.  It isolates each test with a fresh SQLite database and
+provides helper functions for invoking the CLI and parsing outputs.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Use the same Python interpreter that runs pytest to invoke the CLI module.
+# This works in all environments: local venv, CI (uv run), tox, etc.
+PYTHON = sys.executable
+
+# ---------------------------------------------------------------------------
+# CLI resolution — supports both installed and dev-mode environments
+# ---------------------------------------------------------------------------
+
+_CLI_BIN = shutil.which("agent-sec-cli")
+_CLI_MODE = "binary" if _CLI_BIN else "python -m"
+
+# Check if loongshield is available
+LOONGSHIELD_AVAILABLE = shutil.which("loongshield") is not None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_data_dir(tmp_path):
+    """Create a function-scoped temp directory for security event data.
+
+    Each test gets a completely fresh SQLite DB — no cross-test pollution,
+    no ordering dependency, no cascade failures.
+
+    Sets AGENT_SEC_DATA_DIR env var to isolate the SQLite store.
+    """
+    data_dir = tmp_path / "agent-sec-e2e"
+    data_dir.mkdir()
+    os.environ["AGENT_SEC_DATA_DIR"] = str(data_dir)
+    yield
+    os.environ.pop("AGENT_SEC_DATA_DIR", None)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def run_cli(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    """Run agent-sec-cli command and return CompletedProcess.
+
+    Automatically detects whether to use the installed binary or
+    `python -m agent_sec_cli` based on environment.
+
+    Args:
+        *args: CLI arguments to pass to the command.
+        check: If True, raise CalledProcessError on non-zero exit code.
+
+    Returns:
+        subprocess.CompletedProcess with stdout, stderr, and returncode.
+    """
+    if _CLI_MODE == "binary":
+        cmd = [_CLI_BIN, *args]
+    else:
+        cmd = [PYTHON, "-m", "agent_sec_cli", *args]
+
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=30,
+        env=os.environ.copy(),  # inherits AGENT_SEC_DATA_DIR
+    )
+
+
+def iso_now() -> str:
+    """Return current UTC time as ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_events_json(stdout: str) -> list[dict[str, Any]]:
+    """Parse events JSON output and return list of event dicts.
+
+    Args:
+        stdout: CLI stdout output (JSON array).
+
+    Returns:
+        List of event dictionaries.
+    """
+    events = json.loads(stdout)
+    assert isinstance(events, list), f"Expected JSON array, got {type(events)}"
+    return events
+
+
+def parse_table_output(stdout: str) -> list[str]:
+    """Parse table format output and return non-empty lines.
+
+    Args:
+        stdout: CLI stdout output (table format).
+
+    Returns:
+        List of non-empty lines from the table.
+    """
+    return [line for line in stdout.strip().split("\n") if line.strip()]
+
+
+def assert_event_structure(event: dict[str, Any]) -> None:
+    """Validate that an event dict has all required fields.
+
+    Args:
+        event: Event dictionary from JSON output.
+
+    Raises:
+        AssertionError if any required field is missing.
+    """
+    required_fields = [
+        "event_id",
+        "event_type",
+        "category",
+        "result",
+        "timestamp",
+        "trace_id",
+        "details",
+    ]
+    for field in required_fields:
+        assert field in event, f"Missing required field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# Loongshield availability check
+# ---------------------------------------------------------------------------
+
+
+def require_loongshield():
+    """Skip test if loongshield is not installed.
+
+    Use this at the beginning of tests that require actual loongshield
+    execution to produce meaningful result data (passed/failed/total fields).
+
+    Example:
+        def test_compliance_with_real_data():
+            require_loongshield()
+            # ... test code that needs loongshield output ...
+    """
+    if not LOONGSHIELD_AVAILABLE:
+        pytest.skip("loongshield not installed")

--- a/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_events_e2e.py
@@ -14,57 +14,12 @@ shared state, no ordering dependency, no cascade failures.
 """
 
 import json
-import os
-import shutil
-import subprocess
-import sys
 import time
-from datetime import datetime, timezone
-from pathlib import Path
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-# Use the same Python interpreter that runs pytest to invoke the CLI module.
-# This works in all environments: local venv, CI (uv run), tox, etc.
-_PYTHON = sys.executable
-_CLI_MODULE = "agent_sec_cli.cli"
-
-
-@pytest.fixture(autouse=True)
-def _isolated_data_dir(tmp_path):
-    """Create a function-scoped temp directory for security event data.
-
-    Each test gets a completely fresh SQLite DB — no cross-test pollution,
-    no ordering dependency, no cascade failures.
-    """
-    data_dir = tmp_path / "agent-sec-e2e"
-    data_dir.mkdir()
-    os.environ["AGENT_SEC_DATA_DIR"] = str(data_dir)
-    yield
-    os.environ.pop("AGENT_SEC_DATA_DIR", None)
-
-
-def _run_cli(*args: str, check: bool = False) -> subprocess.CompletedProcess:
-    """Run `python -m agent_sec_cli.cli <args>` and return CompletedProcess."""
-    cmd = [_PYTHON, "-m", _CLI_MODULE, *args]
-    return subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        check=check,
-        timeout=30,
-        env=os.environ.copy(),  # inherits AGENT_SEC_DATA_DIR
-    )
-
-
-def _iso_now() -> str:
-    """Return current UTC time as ISO-8601 string."""
-    return datetime.now(timezone.utc).isoformat()
-
+# Import shared helpers from conftest.py
+from .conftest import iso_now, require_loongshield, run_cli
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -76,19 +31,19 @@ class TestHardenEventLogging:
 
     def test_harden_produces_event(self):
         """After `agent-sec-cli harden`, an event with event_type=harden is queryable."""
-        since = _iso_now()
+        since = iso_now()
 
         # Small delay to ensure timestamp ordering
         time.sleep(0.05)
 
         # Invoke harden — exit code doesn't matter (loongshield may be absent)
-        _run_cli("harden")
+        run_cli("harden")
 
         # Small delay to let SQLite WAL flush
         time.sleep(0.1)
 
         # Query events since the start of this test
-        result = _run_cli(
+        result = run_cli(
             "events", "--event-type", "harden", "--since", since, "--output", "json"
         )
         assert result.returncode == 0, f"events query failed: {result.stderr}"
@@ -109,13 +64,13 @@ class TestHardenEventLogging:
 
     def test_harden_event_count(self):
         """--count returns exactly 1 after a single harden invocation."""
-        since = _iso_now()
+        since = iso_now()
         time.sleep(0.05)
 
-        _run_cli("harden")
+        run_cli("harden")
         time.sleep(0.1)
 
-        result = _run_cli(
+        result = run_cli(
             "events", "--count", "--event-type", "harden", "--since", since
         )
         assert result.returncode == 0
@@ -128,15 +83,15 @@ class TestVerifyEventLogging:
 
     def test_verify_produces_event(self):
         """After `agent-sec-cli verify`, an event with event_type=verify is queryable."""
-        since = _iso_now()
+        since = iso_now()
         time.sleep(0.05)
 
         # Invoke verify — may fail (no skills configured), that's acceptable
-        _run_cli("verify")
+        run_cli("verify")
         time.sleep(0.1)
 
         # Query events
-        result = _run_cli(
+        result = run_cli(
             "events", "--event-type", "verify", "--since", since, "--output", "json"
         )
         assert result.returncode == 0
@@ -154,13 +109,13 @@ class TestVerifyEventLogging:
 
     def test_verify_event_count_by_category(self):
         """--count-by category shows asset_verify: 1 after a single verify invocation."""
-        since = _iso_now()
+        since = iso_now()
         time.sleep(0.05)
 
-        _run_cli("verify")
+        run_cli("verify")
         time.sleep(0.1)
 
-        result = _run_cli("events", "--count-by", "category", "--since", since)
+        result = run_cli("events", "--count-by", "category", "--since", since)
         assert result.returncode == 0
 
         counts = json.loads(result.stdout)
@@ -173,11 +128,11 @@ class TestEventQueryFilters:
 
     def test_last_hours_filter(self):
         """--last-hours returns exactly the single event just created."""
-        _run_cli("harden")
+        run_cli("harden")
         time.sleep(0.1)
 
         # Fresh DB: only this test's event exists.
-        result = _run_cli(
+        result = run_cli(
             "events", "--event-type", "harden", "--last-hours", "1", "--output", "json"
         )
         assert result.returncode == 0
@@ -186,7 +141,7 @@ class TestEventQueryFilters:
 
     def test_nonexistent_type_returns_empty(self):
         """Filtering by a non-existent event_type returns empty list."""
-        result = _run_cli(
+        result = run_cli(
             "events",
             "--event-type",
             "does_not_exist_xyz",
@@ -202,12 +157,12 @@ class TestEventQueryFilters:
 
     def test_default_table_output(self):
         """Default output is human-readable table format."""
-        since = _iso_now()
+        since = iso_now()
         time.sleep(0.05)
-        _run_cli("harden")
+        run_cli("harden")
         time.sleep(0.1)
 
-        result = _run_cli("events", "--event-type", "harden", "--since", since)
+        result = run_cli("events", "--event-type", "harden", "--since", since)
         assert result.returncode == 0
         # Default output is table — should NOT be parseable as JSON
         lines = result.stdout.strip().split("\n")
@@ -224,14 +179,14 @@ class TestCLIValidation:
 
     def test_invalid_output_format(self):
         """Verify that invalid --output format returns error."""
-        result = _run_cli("events", "--output", "xml")
+        result = run_cli("events", "--output", "xml")
         assert result.returncode == 1
         assert "Error:" in result.stderr
         assert "--output must be one of" in result.stderr
 
     def test_last_hours_and_since_mutual_exclusion(self):
         """Verify that --last-hours and --since are mutually exclusive."""
-        result = _run_cli(
+        result = run_cli(
             "events",
             "--last-hours",
             "24",
@@ -244,21 +199,21 @@ class TestCLIValidation:
 
     def test_count_and_count_by_mutual_exclusion(self):
         """Verify that --count and --count-by are mutually exclusive."""
-        result = _run_cli("events", "--count", "--count-by", "category")
+        result = run_cli("events", "--count", "--count-by", "category")
         assert result.returncode == 1
         assert "Error:" in result.stderr
         assert "mutually exclusive" in result.stderr
 
     def test_invalid_count_by_field(self):
         """Verify that invalid --count-by field returns error."""
-        result = _run_cli("events", "--count-by", "invalid_field")
+        result = run_cli("events", "--count-by", "invalid_field")
         assert result.returncode == 1
         assert "Error:" in result.stderr
         assert "--count-by must be one of" in result.stderr
 
     def test_unknown_event_type_warning(self):
         """Verify that unknown event_type produces a warning but doesn't fail."""
-        result = _run_cli(
+        result = run_cli(
             "events",
             "--event-type",
             "unknown_type",
@@ -274,7 +229,7 @@ class TestCLIValidation:
 
     def test_unknown_category_warning(self):
         """Verify that unknown category produces a warning but doesn't fail."""
-        result = _run_cli(
+        result = run_cli(
             "events",
             "--category",
             "unknown_category",
@@ -290,12 +245,12 @@ class TestCLIValidation:
 
     def test_json_output_format(self):
         """Verify that --output json returns a valid JSON array with complete event data."""
-        since = _iso_now()
+        since = iso_now()
         time.sleep(0.05)
-        _run_cli("harden")
+        run_cli("harden")
         time.sleep(0.1)
 
-        result = _run_cli(
+        result = run_cli(
             "events", "--event-type", "harden", "--since", since, "--output", "json"
         )
         assert result.returncode == 0
@@ -318,12 +273,12 @@ class TestCLIValidation:
 
     def test_jsonl_output_format(self):
         """Verify that --output jsonl returns one JSON object per line."""
-        since = _iso_now()
+        since = iso_now()
         time.sleep(0.05)
-        _run_cli("harden")
+        run_cli("harden")
         time.sleep(0.1)
 
-        result = _run_cli(
+        result = run_cli(
             "events", "--event-type", "harden", "--since", since, "--output", "jsonl"
         )
         assert result.returncode == 0
@@ -341,12 +296,12 @@ class TestCLIValidation:
 
     def test_result_field_in_table_output(self):
         """Verify that result column shows 'succeeded' in table format."""
-        since = _iso_now()
+        since = iso_now()
         time.sleep(0.05)
-        _run_cli("harden")
+        run_cli("harden")
         time.sleep(0.1)
 
-        result = _run_cli("events", "--event-type", "harden", "--since", since)
+        result = run_cli("events", "--event-type", "harden", "--since", since)
         assert result.returncode == 0
 
         # Table output should contain RESULT column with 'succeeded'
@@ -364,11 +319,11 @@ class TestEventsSummaryFlag:
 
     def test_summary_happy_path(self):
         """--summary produces a human-readable posture report after harden + verify."""
-        _run_cli("harden")
-        _run_cli("verify")
+        run_cli("harden")
+        run_cli("verify")
         time.sleep(0.1)
 
-        result = _run_cli("events", "--summary", "--last-hours", "1")
+        result = run_cli("events", "--summary", "--last-hours", "1")
         assert result.returncode == 0
 
         out = result.stdout
@@ -382,13 +337,13 @@ class TestEventsSummaryFlag:
 
     def test_summary_incompatible_with_count(self):
         """--summary --count must be rejected with exit code 1."""
-        result = _run_cli("events", "--summary", "--count")
+        result = run_cli("events", "--summary", "--count")
         assert result.returncode == 1
         assert "incompatible" in result.stderr.lower()
 
     def test_summary_incompatible_with_output_json(self):
         """--summary --output json must be rejected with exit code 1."""
-        result = _run_cli("events", "--summary", "--output", "json")
+        result = run_cli("events", "--summary", "--output", "json")
         assert result.returncode == 1
         assert "incompatible" in result.stderr.lower()
 
@@ -436,3 +391,686 @@ class TestErrorEventPersistence:
         assert event.details["error"] == "loongshield not found"
         assert event.details["error_type"] == "FileNotFoundError"
         assert event.trace_id == "error-trace-123"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Events default output and format validation (TC-005, TC-006)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsDefaultOutput:
+    """Verify events command default output formats (TC-005, TC-006)."""
+
+    def test_default_table_output(self):
+        """TC-005: Default output is human-readable table format."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli("events", "--event-type", "harden", "--since", since)
+        assert result.returncode == 0
+
+        # Default output is table — should NOT be parseable as JSON
+        lines = result.stdout.strip().split("\n")
+        # Header + 1 data row + blank line + footer
+        assert len(lines) == 4
+        assert lines[0].startswith("EVENT_TYPE")
+        assert "harden" in lines[1]
+        assert "succeeded" in lines[1]
+        assert "1 event" in lines[3]
+
+    def test_json_output_completeness(self):
+        """TC-006: JSON output contains complete event structure.
+
+        NOTE: Harden event structure varies depending on:
+        - Whether loongshield is installed
+        - Whether harden ran in scan or reinforce mode
+        - The actual output from the harden command
+
+        We verify core fields that ALWAYS exist, and make statistical
+        fields (passed/failed/total) conditional.
+        """
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+
+        events = json.loads(result.stdout)
+        assert isinstance(events, list)
+        assert len(events) == 1
+
+        # Verify complete event structure (core fields - always present)
+        event = events[0]
+        assert "event_id" in event
+        assert "event_type" in event
+        assert "category" in event
+        assert "result" in event
+        assert "timestamp" in event
+        assert "trace_id" in event
+        assert "pid" in event
+        assert "uid" in event
+        assert "session_id" in event
+        assert "details" in event
+
+        # Verify details structure
+        assert "request" in event["details"]
+        assert "result" in event["details"]
+
+        # Verify result sub-object contains command execution info
+        # Structure varies: may have argv (raw command) or mode/config (parsed)
+        result_data = event["details"]["result"]
+        assert "argv" in result_data or "mode" in result_data
+
+        # Statistical fields (passed/failed/total) only present if loongshield
+        # is installed and harden completed successfully
+        # When loongshield is missing, harden may exit 127 without stats
+        if "passed" in result_data:
+            # If one statistical field exists, all should exist
+            assert (
+                "failed" in result_data
+            ), "Expected 'failed' field when 'passed' exists"
+            assert "total" in result_data, "Expected 'total' field when 'passed' exists"
+            # Validate consistency
+            assert isinstance(result_data["passed"], int)
+            assert isinstance(result_data["failed"], int)
+            assert isinstance(result_data["total"], int)
+
+    def test_harden_event_with_loongshield_stats(self):
+        """TC-006 (extended): When loongshield is installed, verify full stats.
+
+        This test validates that when loongshield is available, the harden
+        event contains complete statistical data (passed/failed/total fields).
+        """
+        require_loongshield()
+
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+
+        events = json.loads(result.stdout)
+        assert len(events) == 1
+
+        # With loongshield, statistical fields should be present
+        result_data = events[0]["details"]["result"]
+        assert "passed" in result_data, "Expected 'passed' field with loongshield"
+        assert "failed" in result_data, "Expected 'failed' field with loongshield"
+        assert "total" in result_data, "Expected 'total' field with loongshield"
+
+        # Validate data types and consistency
+        assert isinstance(result_data["passed"], int)
+        assert isinstance(result_data["failed"], int)
+        assert isinstance(result_data["total"], int)
+        assert result_data["total"] > 0, "Total rules should be > 0"
+        assert result_data["passed"] + result_data["failed"] == result_data["total"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Events category filtering (TC-007, TC-024)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsCategoryFiltering:
+    """Verify events category filtering (TC-007, TC-024)."""
+
+    def test_category_filter_hardening(self):
+        """TC-007: --category hardening returns only hardening events."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--category", "hardening", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+
+        events = json.loads(result.stdout)
+        assert len(events) >= 1
+        for event in events:
+            assert event["category"] == "hardening"
+
+    def test_prompt_scan_category_valid(self):
+        """TC-024: prompt_scan is a valid category.
+
+        The prompt_scan category is registered in lifecycle.py _ACTION_CATEGORY
+        and should be recognized by the events command without warnings.
+
+        This test verifies that the category validation works correctly.
+        """
+        result = run_cli("events", "--category", "prompt_scan")
+        # Should NOT show warning about unknown category
+        assert "Unknown category" not in result.stderr
+        # Should succeed (may return 0 events if no prompt scans have been run)
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Events time range filtering (TC-008, TC-028, TC-029, TC-030)
+# ---------------------------------------------------------------------------
+class TestEventsTimeRange:
+    """Verify events time range filtering (TC-008, TC-028, TC-029, TC-030)."""
+
+    def test_last_hours_decimal_precision(self):
+        """TC-008: --last-hours works with decimal values."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        # Query with small time window (0.17 hours ≈ 10 minutes)
+        result = run_cli(
+            "events",
+            "--event-type",
+            "harden",
+            "--last-hours",
+            "0.17",
+            "--output",
+            "json",
+        )
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert len(events) == 1
+
+    def test_since_invalid_format_error(self):
+        """TC-028: --since with invalid format should show friendly error.
+
+        Expected: "Invalid time format. Expected ISO 8601 format"
+        Actual: Python traceback ValueError from datetime.fromisoformat('now')
+        """
+        result = run_cli("events", "--since", "now")
+        # Should return error with friendly message, not Python traceback
+        assert result.returncode != 0
+        assert "Invalid" in result.stderr or "Error" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_since_until_time_filtering(self):
+        """TC-029/TC-030: Verify --since and --until filters work correctly with time boundaries.
+
+        This test validates that:
+        - Events created between t1 and t2 are returned by --since t1
+        - Events created between t1 and t2 are NOT returned by --since t2
+        - Events created between t1 and t2 are NOT returned by --until t1
+        - Events created between t1 and t2 are returned by --until t2
+
+        Uses isolated data directory (autouse fixture) to prevent parallel test interference.
+        """
+        # Step 1: Record time t1
+        t1 = iso_now()
+        time.sleep(0.1)  # Small delay to ensure timestamp ordering
+
+        # Step 2: Create an event (code-scan)
+        run_cli("code-scan", "--code", "print('hello')", "--language", "python")
+        time.sleep(0.1)  # Allow SQLite to flush
+
+        # Step 3: Record time t2 (after event creation)
+        t2 = iso_now()
+
+        # Step 4: events --since t1 should have results (event created after t1)
+        result_since_t1 = run_cli("events", "--since", t1, "--output", "json")
+        assert result_since_t1.returncode == 0
+        events_since_t1 = json.loads(result_since_t1.stdout)
+        assert (
+            len(events_since_t1) == 1
+        ), f"Expected 1 event with --since t1, got {len(events_since_t1)}"
+        assert events_since_t1[0]["event_type"] == "code_scan"
+
+        # Step 5: events --since t2 should have NO results (event created before t2)
+        result_since_t2 = run_cli("events", "--since", t2, "--output", "json")
+        assert result_since_t2.returncode == 0
+        events_since_t2 = json.loads(result_since_t2.stdout)
+        assert (
+            len(events_since_t2) == 0
+        ), f"Expected 0 events with --since t2, got {len(events_since_t2)}"
+
+        # Step 6: events --until t1 should have NO results (event created after t1)
+        result_until_t1 = run_cli("events", "--until", t1, "--output", "json")
+        assert result_until_t1.returncode == 0
+        events_until_t1 = json.loads(result_until_t1.stdout)
+        assert (
+            len(events_until_t1) == 0
+        ), f"Expected 0 events with --until t1, got {len(events_until_t1)}"
+
+        # Step 7: events --until t2 should have results (event created before t2)
+        result_until_t2 = run_cli("events", "--until", t2, "--output", "json")
+        assert result_until_t2.returncode == 0
+        events_until_t2 = json.loads(result_until_t2.stdout)
+        assert (
+            len(events_until_t2) == 1
+        ), f"Expected 1 event with --until t2, got {len(events_until_t2)}"
+        assert events_until_t2[0]["event_type"] == "code_scan"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Events pagination (TC-032, TC-033, TC-034)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsPagination:
+    """Verify events pagination parameters (TC-032, TC-033, TC-034)."""
+
+    def _create_multiple_events(self, count: int = 10):
+        """Helper to create multiple events for pagination testing."""
+        for _ in range(count):
+            run_cli("harden")
+            time.sleep(0.05)
+
+    def test_limit_parameter(self):
+        """TC-032: --limit restricts number of returned events."""
+        self._create_multiple_events(10)
+        time.sleep(0.1)
+
+        result = run_cli("events", "--limit", "3", "--output", "json")
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert len(events) == 3
+
+    def test_limit_invalid_value(self):
+        """TC-032: --limit with invalid value returns error."""
+        result = run_cli("events", "--limit", "aaa")
+        assert result.returncode != 0
+        assert "Invalid value" in result.stderr or "Error" in result.stderr
+
+    def test_offset_pagination(self):
+        """TC-033: --offset skips N results."""
+        self._create_multiple_events(13)
+        time.sleep(0.1)
+
+        # Get all events count
+        result_all = run_cli("events", "--output", "json")
+        all_events = json.loads(result_all.stdout)
+        total_count = len(all_events)
+        assert total_count >= 13
+
+        # Query with offset 5
+        result_offset = run_cli("events", "--offset", "5", "--output", "json")
+        assert result_offset.returncode == 0
+        offset_events = json.loads(result_offset.stdout)
+        assert len(offset_events) == total_count - 5
+
+    def test_offset_with_limit(self):
+        """TC-033: --offset works with --limit for proper pagination."""
+        self._create_multiple_events(10)
+        time.sleep(0.1)
+
+        result = run_cli("events", "--offset", "5", "--limit", "3", "--output", "json")
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert len(events) == 3
+
+    def test_offset_invalid_value(self):
+        """TC-033: --offset with invalid value returns error."""
+        result = run_cli("events", "--offset", "aaa")
+        assert result.returncode != 0
+        assert "Invalid value" in result.stderr or "Error" in result.stderr
+
+    def test_count_with_offset(self):
+        """TC-034: --count should respect --offset parameter.
+
+        Expected: Count of events after applying offset
+        """
+        self._create_multiple_events(13)
+        time.sleep(0.1)
+
+        # Get total count
+        result_total = run_cli("events", "--count")
+        total_count = json.loads(result_total.stdout)
+
+        # Get count with offset
+        result_offset = run_cli("events", "--offset", "10", "--count")
+        offset_count = json.loads(result_offset.stdout)
+
+        # Should be different (offset count < total count)
+        assert offset_count < total_count
+
+    def test_count_by_with_offset(self):
+        """TC-034 (extended): --count-by should respect --offset parameter.
+
+        Expected: Count-by statistics after applying offset
+        """
+        self._create_multiple_events(13)
+        time.sleep(0.1)
+
+        # Get full count-by
+        result_full = run_cli("events", "--count-by", "category", "--output", "json")
+        assert result_full.returncode == 0
+        full_counts = json.loads(result_full.stdout)
+
+        total_events = sum(full_counts.values())
+        assert total_events >= 13
+
+        # Get count-by with offset 10
+        result_offset = run_cli(
+            "events", "--offset", "10", "--count-by", "category", "--output", "json"
+        )
+        assert result_offset.returncode == 0
+        offset_counts = json.loads(result_offset.stdout)
+
+        offset_total = sum(offset_counts.values())
+
+        # After offset 10, should have fewer events
+        assert offset_total < total_events
+        assert offset_total == total_events - 10
+
+
+# ---------------------------------------------------------------------------
+# Tests: Events output formats (TC-035, TC-036, TC-037)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsOutputFormats:
+    """Verify events output format compatibility (TC-035, TC-036, TC-037)."""
+
+    def test_json_output_format(self):
+        """TC-035: --output json returns valid JSON array."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert isinstance(events, list)
+
+    def test_jsonl_output_format(self):
+        """TC-035: --output jsonl returns one JSON object per line."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "jsonl"
+        )
+        assert result.returncode == 0
+
+        lines = result.stdout.strip().split("\n")
+        assert len(lines) == 1
+
+        # Each line should be valid JSON
+        event = json.loads(lines[0])
+        assert isinstance(event, dict)
+        assert event["event_type"] == "harden"
+
+    def test_table_output_format(self):
+        """TC-035: --output table returns formatted table."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "table"
+        )
+        assert result.returncode == 0
+        assert "EVENT_TYPE" in result.stdout
+        assert "harden" in result.stdout
+
+    def test_summary_table_incompatibility(self):
+        """TC-036: --summary with --output table should show error.
+
+        Expected: Error "--summary is incompatible with --output"
+        Actual: Executes normally (only --output json is checked in cli.py)
+        Root cause: Validation only checks `output != "table"`, should check
+                    all non-default output formats
+        """
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli("events", "--summary", "--output", "table")
+        # Should return error
+        assert result.returncode != 0
+        assert "incompatible" in result.stderr.lower()
+
+    def test_summary_json_incompatibility(self):
+        """TC-037: --summary with --output json shows error."""
+        result = run_cli("events", "--summary", "--output", "json")
+        assert result.returncode != 0
+        assert "incompatible" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Events summary calculation (TC-009, TC-010, TC-013, TC-015, TC-019, TC-023)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsSummaryCalculation:
+    """Verify events summary calculations (TC-009, TC-010, TC-013, TC-015, TC-019, TC-023)."""
+
+    def test_compliance_after_rescan(self):
+        """TC-010: Compliance calculation after re-scan shows correct result."""
+        # This test requires loongshield to produce scan result data
+        require_loongshield()
+
+        # Run scan multiple times
+        run_cli("harden")
+        time.sleep(0.1)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli("events", "--summary", "--last-hours", "1")
+        assert result.returncode == 0
+
+        # Should show scan results with compliance data
+        assert "Compliance:" in result.stdout
+        assert "Scans performed:" in result.stdout
+
+    def test_summary_with_verify_failures(self):
+        """TC-013: Summary shows verify failures correctly."""
+        run_cli("harden")
+        time.sleep(0.1)
+        run_cli("verify")
+        time.sleep(0.1)
+
+        result = run_cli("events", "--summary", "--last-hours", "1")
+        assert result.returncode == 0
+
+        # Should show hardening section
+        assert "--- Hardening ---" in result.stdout
+        # Should show verification section (may show failures)
+        assert "Total events:" in result.stdout
+
+    def test_sandbox_summary_interventions(self):
+        """TC-019: Sandbox summary shows total interventions count."""
+        # Create sandbox events (log-sandbox is hidden command)
+        run_cli("log-sandbox")
+        time.sleep(0.05)
+        run_cli("log-sandbox", "--command", "rm -rf a.txt")
+        time.sleep(0.1)
+
+        result = run_cli("events", "--category", "sandbox", "--summary")
+        assert result.returncode == 0
+
+        # Should show intervention count
+        assert "Total interventions:" in result.stdout
+        assert "2" in result.stdout
+
+    def test_code_scan_verdict_statistics(self):
+        """TC-023: Code scan summary shows verdict statistics."""
+        # Run scans with different verdicts
+        run_cli("code-scan", "--code", "rm -f a.txt", "--language", "bash")  # pass
+        time.sleep(0.05)
+        run_cli("code-scan", "--code", "rm -rf a.txt", "--language", "bash")  # warn
+        time.sleep(0.1)
+
+        result = run_cli("events", "--category", "code_scan", "--summary")
+        assert result.returncode == 0
+
+        # Should show verdict statistics
+        assert "--- Code Scanning ---" in result.stdout
+        assert "Verdict:" in result.stdout or "Scans performed:" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: Events parameter validation (TC-025, TC-026, TC-027)
+# ---------------------------------------------------------------------------
+
+
+class TestEventTypeValidation:
+    """Verify events parameter validation (TC-025, TC-026, TC-027)."""
+
+    def test_event_type_no_argument(self):
+        """TC-025: --event-type without argument shows error."""
+        result = run_cli("events", "--event-type")
+        assert result.returncode != 0
+        assert "requires an argument" in result.stderr
+
+    def test_event_type_invalid_value(self):
+        """TC-025: --event-type with invalid value shows warning."""
+        result = run_cli(
+            "events", "--event-type", "unknown_type_xyz", "--output", "json"
+        )
+        # Should succeed but show warning
+        assert result.returncode == 0
+        assert "Warning:" in result.stderr
+        assert "Unknown event_type" in result.stderr
+
+        # Should return empty results
+        events = json.loads(result.stdout)
+        assert events == []
+
+    def test_event_type_valid_value(self):
+        """TC-025: --event-type with valid value filters correctly."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert len(events) >= 1
+        assert events[0]["event_type"] == "harden"
+
+    def test_category_no_argument(self):
+        """TC-026: --category without argument shows error."""
+        result = run_cli("events", "--category")
+        assert result.returncode != 0
+        assert "requires an argument" in result.stderr
+
+    def test_category_invalid_value(self):
+        """TC-026: --category with invalid value shows warning."""
+        result = run_cli(
+            "events", "--category", "unknown_category_xyz", "--output", "json"
+        )
+        # Should succeed but show warning
+        assert result.returncode == 0
+        assert "Warning:" in result.stderr
+        assert "Unknown category" in result.stderr
+
+        # Should return empty results
+        events = json.loads(result.stdout)
+        assert events == []
+
+    def test_category_valid_value(self):
+        """TC-026: --category with valid value filters correctly."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("verify")
+        time.sleep(0.1)
+
+        result = run_cli(
+            "events", "--category", "asset_verify", "--since", since, "--output", "json"
+        )
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert len(events) >= 1
+        assert events[0]["category"] == "asset_verify"
+
+    def test_trace_id_valid_lookup(self):
+        """TC-027: --trace-id with valid ID returns matching event."""
+        since = iso_now()
+        time.sleep(0.05)
+        run_cli("harden")
+        time.sleep(0.1)
+
+        # Get trace_id from JSON output
+        result = run_cli(
+            "events", "--event-type", "harden", "--since", since, "--output", "json"
+        )
+        events = json.loads(result.stdout)
+        assert len(events) >= 1
+        trace_id = events[0]["trace_id"]
+
+        # Query by trace_id
+        result = run_cli("events", "--trace-id", trace_id, "--output", "json")
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert len(events) == 1
+        assert events[0]["trace_id"] == trace_id
+
+    def test_trace_id_nonexistent(self):
+        """TC-027: --trace-id with non-existent ID returns empty."""
+        result = run_cli(
+            "events",
+            "--trace-id",
+            "00000000-0000-0000-0000-000000000000",
+            "--output",
+            "json",
+        )
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert events == []
+
+    def test_trace_id_invalid_format(self):
+        """TC-027: --trace-id with invalid format returns empty (no error)."""
+        result = run_cli("events", "--trace-id", "wrongid", "--output", "json")
+        assert result.returncode == 0
+        events = json.loads(result.stdout)
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI help and version (TC-001, TC-038)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsHelpAndVersion:
+    """Verify CLI help and version options (TC-001, TC-038)."""
+
+    def test_main_help_format(self):
+        """TC-001: Main help message shows all commands with aligned descriptions.
+
+        Optimization items (not failures):
+        - code-scan description missing period at end
+        - scan-prompt description missing period at end
+        """
+        result = run_cli("--help")
+        assert result.returncode == 0
+
+        # Verify all expected commands are listed
+        assert "harden" in result.stdout
+        assert "verify" in result.stdout
+        assert "code-scan" in result.stdout
+        assert "events" in result.stdout
+        assert "skill-ledger" in result.stdout
+        assert "scan-prompt" in result.stdout
+
+        # Verify help structure
+        assert "Commands" in result.stdout
+
+    def test_version_option(self):
+        """TC-038: --version option should show version number.
+
+        Expected: "agent-sec-cli 0.3.0"
+        """
+        result = run_cli("--version")
+        assert result.returncode == 0
+        assert "agent-sec-cli" in result.stdout
+        assert "0.3.0" in result.stdout or "0." in result.stdout

--- a/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
@@ -51,6 +51,80 @@ class TestEmptyEvents:
 
 
 class TestHardeningSummary:
+    def test_compliance_includes_fixed_count(self):
+        """Compliance calculation should include fixed items: (passed + fixed) / total.
+
+        After reinforce without rescan, the compliance should reflect both
+        passed items from scan and fixed items from reinforce.
+
+        Example: 15 passed from scan + 8 fixed from reinforce = 23/23 (100%)
+        """
+        events = [
+            # Initial scan with failures
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {"args": ["--scan", "--config", "agentos_baseline"]},
+                    "result": {
+                        "mode": "scan",
+                        "config": "agentos_baseline",
+                        "passed": 15,
+                        "failed": 8,
+                        "total": 23,
+                        "failures": [
+                            {
+                                "rule_id": "SEC-001",
+                                "status": "FAIL",
+                                "message": "SSH config",
+                            },
+                            {
+                                "rule_id": "SEC-002",
+                                "status": "FAIL",
+                                "message": "Firewall",
+                            },
+                        ],
+                        "fixed": 0,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": [],
+                    },
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+            # Reinforce operation that fixes the failures
+            _make_event(
+                event_type="harden",
+                category="hardening",
+                result="succeeded",
+                details={
+                    "request": {
+                        "args": ["--reinforce", "--config", "agentos_baseline"]
+                    },
+                    "result": {
+                        "mode": "reinforce",
+                        "config": "agentos_baseline",
+                        "passed": 15,
+                        "failed": 0,
+                        "total": 23,
+                        "failures": [],
+                        "fixed": 8,
+                        "manual": 0,
+                        "dry_run_pending": 0,
+                        "fixed_items": ["SEC-001", "SEC-002"],
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+
+        # Should show 100% compliance: (15 passed + 8 fixed) / 23 total
+        assert "Compliance:" in output
+        # The compliance should reflect the fixed count
+        assert "100.0%" in output or "23/23" in output
+
     def test_scan_count_and_compliance(self):
         events = [
             _make_event(
@@ -221,6 +295,52 @@ class TestAssetVerifySummary:
         output = format_summary(events, "last 24 hours")
         assert "FAILURES DETECTED" in output
         assert "3 passed, 2 failed" in output
+
+    def test_single_skill_verify_after_full_verify(self):
+        """After full verify + single skill verify, summary shows latest result.
+
+        When a single skill is verified after a full verify, the summary
+        currently shows only the latest single-skill result.
+
+        This test documents the current behavior: the summary formatter
+        reads only the latest verify event and doesn't aggregate across
+        multiple verify invocations.
+        """
+        events = [
+            # Full verify of all skills
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {"passed": 0, "failed": 5},
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+            # Single skill verify
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": "regex-mastery"},
+                    "result": {"passed": 1, "failed": 0},
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+        output = format_summary(events, "last 24 hours")
+
+        # Should show verification section
+        # System status should be "Needs attention" because full verify had 5 failures
+        # (single-skill verify should not affect posture)
+        assert "Needs attention" in output
+        assert "--- Asset Verification ---" in output
+        assert "Verifications performed: 2 (succeeded: 2, failed: 0)" in output
+        # Latest result shows single skill result (1 passed, 0 failed)
+        assert "Latest result:" in output
+        assert "1 passed, 0 failed" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->


## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
