### PR TITLE
fix(sec-core): apply corruption whitelist to stop false-positive DB r…

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/sqlite_writer.py
@@ -56,6 +56,27 @@ _COLUMNS: dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+# Only TRUE on-disk corruption markers justify a destructive rebuild.
+# Everything else (lock, busy, full, readonly, protocol, I/O) is transient
+# or environmental — skipping is mandatory, or concurrent writers wipe
+# legitimate data via false-positive rebuilds.
+_CORRUPTION_MARKERS: tuple[str, ...] = (
+    "malformed",  # SQLITE_CORRUPT: "database disk image is malformed"
+    "not a database",  # SQLITE_NOTADB: "file is not a database"
+    "file is encrypted",  # SQLITE_NOTADB variant: encrypted DB without key
+    "disk image",  # SQLITE_CORRUPT variant
+)
+
+
+def _is_corruption(exc: Exception) -> bool:
+    """Return True only for messages indicating true on-disk corruption."""
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _CORRUPTION_MARKERS)
+
+
+# ---------------------------------------------------------------------------
 # Writer
 # ---------------------------------------------------------------------------
 
@@ -115,7 +136,13 @@ class SqliteEventWriter:
                     params,
                 )
             except sqlite3.DatabaseError as exc:
-                # Hard corruption — delete and retry once with fresh DB
+                # Only true on-disk corruption triggers destructive rebuild;
+                # transient errors (lock/busy/full/readonly) are skipped to
+                # avoid catastrophic data loss from false-positive rebuilds.
+                if not _is_corruption(exc):
+                    return
+
+                # True database corruption — delete and retry once with fresh DB
                 self._handle_corruption(exc)
                 if self._disabled:
                     return
@@ -225,6 +252,12 @@ class SqliteEventWriter:
 
                 return
             except sqlite3.DatabaseError as exc:
+                # Under concurrent load, PRAGMA/schema statements can raise
+                # OperationalError("database is locked"); treat any non-corruption
+                # error as transient and skip — only true corruption rebuilds.
+                if not _is_corruption(exc):
+                    self._conn = None
+                    return
                 self._handle_corruption(exc)
                 if self._disabled:
                     return  # unlink failed — give up


### PR DESCRIPTION
…ebuilds

## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Under concurrent writes, OperationalError("database is locked") at PRAGMA/schema time was misclassified as corruption and triggered DB deletion, causing ~91% data loss in multi-proc stress tests. Centralize the check via _is_corruption() and reuse it in both write() and _ensure_connection().
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
