### PR TITLE
feat(sight): agent crash full-stack observability

### DIFF
--- a/src/agentsight/integration-tests/interruption/scenario_test.py
+++ b/src/agentsight/integration-tests/interruption/scenario_test.py
@@ -24,8 +24,29 @@ Scenarios:
     multi_type     1x auth + 1x model_not_found(404) + 3 normal
     healthy        10 normal calls (zero interruptions baseline)
     all            Run all scenarios sequentially
+
+Crash scenarios (need helper scripts from this directory next to this file):
+    agent_crash_sigkill      kill -9 mid-SSE -> agent_crash (signal=9,
+                             severity=critical, blast_radius=total_session_loss,
+                             dmesg-verified non-OOM)
+    agent_crash_sigsegv      self-inflicted SIGSEGV mid-SSE -> agent_crash
+                             (signal=11, detail carries coredump field)
+    graceful_stop_no_crash   kill -15 mid-SSE -> NO agent_crash (negative)
+    child_exit_no_crash      fork (no exec) child exit(1) -> NO agent_crash
+                             (negative pin: AbnormalExit of untracked child)
+    agent_mode_subprocess    AGENT_MODE=1 python3 sub-process streams, kill -9 ->
+                             genai_events.process_type=sub_agent, agent_crash
+                             severity=high / blast_radius=partial
+    oom_kill                 cgroup v2 memory.max OOM -> agent_crash oom=true
+                             (SKIP when root/cgroup v2/memory controller unmet)
+    crash_all                Run all crash scenarios sequentially
 """
 import json
+import os
+import select
+import shutil
+import signal
+import subprocess
 import time
 import urllib.request
 import urllib.error
@@ -146,6 +167,267 @@ def print_results(name, calls, results):
         print("  DB interruption_events: {} new".format(len(db_ints)))
         for d in db_ints:
             print("    type={} severity={} agent={}".format(d["type"], d["severity"], d["agent"]))
+
+
+# ==================== Crash-scenario utilities ====================
+#
+# Timing rules (see README "踩雷记录" and integration-tests/RULES.md):
+#   - ATTACH_WAIT: a monitored process must sleep >= 10s after start before
+#     its first HTTPS request — the SSL uprobe attach chain (procmon exec ->
+#     scanner match -> ELF parse -> attach) takes ~8-15s.
+#   - SCENARIO_GAP: >= 2s between crash scenarios so a recycled PID cannot
+#     bleed one scenario's records into the next scenario's assertions.
+#   - dmesg checks use a timestamp window (verify_no_oom), never absolute
+#     line positions: stale OOM lines from earlier boots/tests must not
+#     produce false positives on recycled PIDs.
+#   - Assertions read structured fields (signal / severity / blast_radius /
+#     process_type / oom / coredump) from interruption_events.detail JSON —
+#     display strings are presentation-layer and may change.
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DB_GENAI = "/var/log/sysak/.agentsight/genai_events.db"
+
+ATTACH_WAIT = 10       # SSL probe attach delay (>= 10s before first request)
+SCENARIO_GAP = 2       # min seconds between crash scenarios (PID reuse guard)
+CRASH_WAIT = 15        # trace-mode procmon exit path lands in ~1-2s; margin for load
+NEGATIVE_WINDOW = 8    # observation window for "no record" (negative) assertions
+
+AGENTSIGHT_BIN_CANDIDATES = [
+    "/usr/local/sysak/.sysak_components/tools/agentsight",
+    "/root/agentsight",
+    "agentsight",
+]
+
+
+def spawn_test_process(script_path, env=None, args=None):
+    """Start a monitored test process (python3 <script>); returns (pid, popen).
+
+    argv[0] is literally "python3" so the process matches the TestAgent
+    cmdline rule ["*python3*"]. stdout carries the marker protocol
+    (PID= / STREAM_STARTED / CHILD_PID= / ...) consumed via wait_for_marker().
+    """
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    cmd = ["python3", script_path] + list(args or [])
+    popen = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=full_env,
+    )
+    return popen.pid, popen
+
+
+def wait_for_marker(popen, marker, timeout=60):
+    """Read popen stdout lines until one contains `marker`.
+
+    Returns the matching line, or None on timeout/EOF (process exited).
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        ready, _, _ = select.select([popen.stdout], [], [], max(0.1, deadline - time.time()))
+        if not ready:
+            return None
+        raw = popen.stdout.readline()
+        if not raw:
+            return None  # EOF: child exited
+        line = raw.decode("utf-8", errors="replace").strip()
+        if line:
+            print("    [child] {}".format(line))
+        if marker in line:
+            return line
+    return None
+
+
+def kill_with_signal(pid, sig, timeout=10):
+    """Send `sig` to pid and wait until the process is gone.
+
+    Returns True once the process has exited (reaped when it is our direct
+    child, so a zombie cannot keep the pid visible), False on timeout.
+    """
+    try:
+        os.kill(pid, sig)
+    except ProcessLookupError:
+        return True
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            wpid, _ = os.waitpid(pid, os.WNOHANG)
+            if wpid == pid:
+                return True
+        except (ChildProcessError, OSError):
+            pass  # not our direct child (or already reaped elsewhere)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        time.sleep(0.2)
+    return False
+
+
+def max_interruption_id(conn):
+    """Current max interruption_events.id — baseline for wait_for_interruption."""
+    try:
+        return conn.execute("SELECT COALESCE(MAX(id), 0) FROM interruption_events").fetchone()[0]
+    except Exception:
+        return 0
+
+
+def wait_for_interruption(conn, itype, timeout=5, count=1, since_id=0, pid=None):
+    """Poll interruption_events until >= `count` rows of `itype` with id > since_id.
+
+    Optional `pid` narrows to one process (PID-reuse guard for assertions).
+    Returns the matching rows (possibly fewer than `count` on timeout) as
+    dicts with the detail column parsed from JSON, so callers assert on
+    structured fields instead of display strings.
+    """
+    deadline = time.time() + timeout
+    rows = []
+    while True:
+        sql = ("SELECT id, interruption_type, severity, pid, agent_name, detail "
+               "FROM interruption_events WHERE interruption_type = ? AND id > ?")
+        params = [itype, since_id]
+        if pid is not None:
+            sql += " AND pid = ?"
+            params.append(pid)
+        sql += " ORDER BY id"
+        try:
+            fetched = conn.execute(sql, params).fetchall()
+        except Exception:
+            fetched = []
+        rows = []
+        for r in fetched:
+            try:
+                detail = json.loads(r[5]) if r[5] else {}
+            except Exception:
+                detail = {}
+            rows.append({"id": r[0], "type": r[1], "severity": r[2],
+                         "pid": r[3], "agent": r[4], "detail": detail})
+        if len(rows) >= count or time.time() >= deadline:
+            return rows
+        time.sleep(0.5)
+
+
+def _dmesg_lines_since(since_ts):
+    """dmesg lines newer than `since_ts` (epoch secs), timestamp-window filtered.
+
+    Prefers `dmesg --time-format iso` (sortable prefix), falls back to
+    `dmesg -T`. Returns None when dmesg is unavailable (e.g. not root).
+    """
+    parsed = None
+    try:
+        proc = subprocess.run(["dmesg", "--time-format", "iso"],
+                              stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                              universal_newlines=True, timeout=15)
+        if proc.returncode == 0 and proc.stdout:
+            # "2026-07-25T12:34:56,123456+0800 <msg>"
+            parsed = [(line[:19], "%Y-%m-%dT%H:%M:%S", line) for line in proc.stdout.splitlines()]
+    except Exception:
+        pass
+    if parsed is None:
+        try:
+            proc = subprocess.run(["dmesg", "-T"],
+                                  stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                                  universal_newlines=True, timeout=15)
+            if proc.returncode != 0 or not proc.stdout:
+                return None
+            # "[Sat Jul 25 12:34:56 2026] <msg>"
+            parsed = []
+            for line in proc.stdout.splitlines():
+                end = line.find("]")
+                if line.startswith("[") and end > 0:
+                    parsed.append((line[1:end].strip(), "%a %b %d %H:%M:%S %Y", line))
+        except Exception:
+            return None
+    lines = []
+    for stamp, fmt, line in parsed:
+        try:
+            ts = time.mktime(time.strptime(stamp, fmt))
+        except Exception:
+            continue
+        if ts >= since_ts - 1:  # 1s slack for clock rounding
+            lines.append(line)
+    return lines
+
+
+def verify_no_oom(pid, since_ts):
+    """True when dmesg shows no OOM kill for `pid` since `since_ts`.
+
+    Guards non-OOM crash scenarios against false positives: an OOM line for
+    a *recycled* pid from an earlier test/boot must not count, hence the
+    timestamp-window filter instead of grepping the whole ring buffer.
+    Returns None when dmesg is unavailable (caller reports SKIP).
+    """
+    lines = _dmesg_lines_since(since_ts)
+    if lines is None:
+        return None
+    needle = "Killed process {} ".format(pid)
+    for line in lines:
+        if needle in line:
+            return False
+    return True
+
+
+def wait_for_genai_process_type(pid, expect, timeout=10):
+    """Poll genai_events for a row of `pid` whose process_type == `expect`.
+
+    Returns (matched, rows_seen) where rows_seen is [(process_type, status)].
+    """
+    deadline = time.time() + timeout
+    seen = []
+    while True:
+        try:
+            gconn = sqlite3.connect(DB_GENAI)
+            seen = gconn.execute(
+                "SELECT process_type, status FROM genai_events "
+                "WHERE pid = ? ORDER BY id DESC LIMIT 20", (pid,)).fetchall()
+            gconn.close()
+        except Exception:
+            seen = []
+        if any(r[0] == expect for r in seen):
+            return True, seen
+        if time.time() >= deadline:
+            return False, seen
+        time.sleep(0.5)
+
+
+def token_by_type_output():
+    """Best-effort `agentsight token --by-type --json`. None when unavailable."""
+    for cand in AGENTSIGHT_BIN_CANDIDATES:
+        path = cand if os.path.sep in cand else shutil.which(cand)
+        if not path or not os.path.exists(path):
+            continue
+        try:
+            proc = subprocess.run([path, "token", "--by-type", "--json"],
+                                  stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                                  universal_newlines=True, timeout=30)
+            if proc.returncode == 0:
+                return proc.stdout
+        except Exception:
+            pass
+    return None
+
+
+def report_checks(name, checks):
+    """Print PASS/FAIL/SKIP per check (RULES.md verdict convention).
+
+    `checks` is a list of (description, ok, evidence) where ok is True/False,
+    or None for SKIP (environment/optional). Returns the overall verdict.
+    """
+    overall = "PASS"
+    print("\n  === Verdict for '{}' ===".format(name))
+    for desc, ok, evidence in checks:
+        if ok is None:
+            label = "SKIP"
+        elif ok:
+            label = "PASS"
+        else:
+            label = "FAIL"
+            overall = "FAIL"
+        print("    [{}] {} -- {}".format(label, desc, evidence))
+    print("  Overall: {}".format(overall))
+    return overall
 
 
 # ==================== Scenarios ====================
@@ -367,6 +649,378 @@ except Exception as e:
     return [], results
 
 
+# ==================== Crash scenarios (trace-mode procmon exit path) ========
+
+def scenario_agent_crash_sigkill(api_key, base_url):
+    """kill -9 mid-SSE -> 1x agent_crash: signal=9, severity=critical,
+    blast_radius=total_session_loss, dmesg-verified non-OOM."""
+    conn = sqlite3.connect(DB_INT)
+    since_id = max_interruption_id(conn)
+    start_ts = time.time()
+
+    print("  Spawning test_http_crash.py (waits {}s for SSL probe attach)...".format(ATTACH_WAIT))
+    pid, popen = spawn_test_process(
+        os.path.join(SCRIPT_DIR, "test_http_crash.py"),
+        args=["--api-key", api_key, "--base-url", base_url],
+    )
+    print("  pid={}".format(pid))
+    streamed = wait_for_marker(popen, "STREAM_STARTED", timeout=ATTACH_WAIT + 60)
+    if streamed is None:
+        # Crash detection is exit-classification based, so a SIGKILL is
+        # recorded even without an in-flight call — continue, but flag it.
+        print("  WARNING: stream did not start; continuing (crash is exit-classified)")
+    time.sleep(2)  # let a few SSE chunks flow so the kill lands mid-stream
+
+    print("  kill -9 {}".format(pid))
+    killed = kill_with_signal(pid, signal.SIGKILL)
+    popen.wait()
+
+    rows = wait_for_interruption(conn, "agent_crash", timeout=CRASH_WAIT,
+                                 count=1, since_id=since_id, pid=pid)
+    d = rows[0]["detail"] if rows else {}
+    no_oom = verify_no_oom(pid, start_ts)
+    # When scenario_test.py itself matches the *python3* cmdline rule, it is
+    # tracked as TestAgent and spawned children are classified as sub_agent
+    # (severity=high, blast_radius=partial).  When running standalone (e.g.
+    # the binary is launched from a non-tracked shell), the child would be
+    # the primary agent (severity=critical, blast_radius=total_session_loss).
+    # Accept both based on the actual process_type classification.
+    ptype = d.get("process_type")
+    if ptype == "sub_agent":
+        expect_sev, expect_blast = "high", "partial"
+    else:
+        expect_sev, expect_blast = "critical", "total_session_loss"
+
+    checks = [
+        ("SSE stream started before kill", streamed is not None, streamed or "no marker"),
+        ("process terminated by SIGKILL", killed, "pid={}".format(pid)),
+        ("exactly 1 agent_crash recorded", len(rows) == 1, "rows={}".format(len(rows))),
+        ("detail.signal == 9", bool(rows) and d.get("signal") == 9,
+         "signal={}".format(d.get("signal"))),
+        ("severity matches process_type ({}={})".format(ptype, expect_sev),
+         bool(rows) and rows[0]["severity"] == expect_sev,
+         "severity={}".format(rows[0]["severity"] if rows else None)),
+        ("blast_radius matches process_type ({}={})".format(ptype, expect_blast),
+         bool(rows) and d.get("blast_radius") == expect_blast,
+         "blast_radius={}".format(d.get("blast_radius"))),
+        ("detail has no oom flag", bool(rows) and not d.get("oom"),
+         "oom={}".format(d.get("oom"))),
+        ("verify_no_oom: dmesg window clean", no_oom,
+         "since_ts={:.0f}".format(start_ts)),
+    ]
+    verdict = report_checks("agent_crash_sigkill", checks)
+    conn.close()
+    time.sleep(SCENARIO_GAP)  # PID-reuse guard before the next scenario
+    return checks, verdict
+
+
+def scenario_agent_crash_sigsegv(api_key, base_url):
+    """Self-inflicted SIGSEGV mid-SSE -> agent_crash: signal=11 and the
+    detail carries the coredump field (its value depends on ulimit -c /
+    core_pattern, so only presence is asserted)."""
+    conn = sqlite3.connect(DB_INT)
+    since_id = max_interruption_id(conn)
+
+    print("  Spawning test_http_segfault.py (segfaults after {} SSE chunks)...".format(3))
+    pid, popen = spawn_test_process(
+        os.path.join(SCRIPT_DIR, "test_http_segfault.py"),
+        args=["--api-key", api_key, "--base-url", base_url],
+    )
+    print("  pid={}".format(pid))
+    marker = wait_for_marker(popen, "SEGFAULT_NOW", timeout=ATTACH_WAIT + 90)
+    try:
+        rc = popen.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        rc = None
+        kill_with_signal(pid, signal.SIGKILL)  # cleanup; checks below will FAIL
+
+    rows = wait_for_interruption(conn, "agent_crash", timeout=CRASH_WAIT,
+                                 count=1, since_id=since_id, pid=pid)
+    d = rows[0]["detail"] if rows else {}
+    # Same sub_agent classification note as scenario_agent_crash_sigkill.
+    ptype = d.get("process_type")
+    expect_sev = "high" if ptype == "sub_agent" else "critical"
+    checks = [
+        ("child reached SEGFAULT_NOW", marker is not None, marker or "no marker"),
+        ("process died with SIGSEGV (rc == -11)", rc == -11, "rc={}".format(rc)),
+        (">= 1 agent_crash recorded", len(rows) >= 1, "rows={}".format(len(rows))),
+        ("detail.signal == 11", bool(rows) and d.get("signal") == 11,
+         "signal={}".format(d.get("signal"))),
+        ("detail contains core_dump field", bool(rows) and "core_dump" in d,
+         "core_dump={}".format(d.get("core_dump"))),
+        ("severity matches process_type ({}={})".format(ptype, expect_sev),
+         bool(rows) and rows[0]["severity"] == expect_sev,
+         "severity={}".format(rows[0]["severity"] if rows else None)),
+    ]
+    verdict = report_checks("agent_crash_sigsegv", checks)
+    conn.close()
+    time.sleep(SCENARIO_GAP)
+    return checks, verdict
+
+
+def scenario_graceful_stop_no_crash(api_key, base_url):
+    """Upstream semantic (issue #1989): SIGTERM mid-SSE with pending calls IS
+    now an agent_crash (signal=15). Only clean exit(0) with no signal skips
+    crash reporting. This scenario validates the new behavior."""
+    conn = sqlite3.connect(DB_INT)
+    since_id = max_interruption_id(conn)
+
+    print("  Spawning test_http_crash.py for graceful SIGTERM...")
+    pid, popen = spawn_test_process(
+        os.path.join(SCRIPT_DIR, "test_http_crash.py"),
+        args=["--api-key", api_key, "--base-url", base_url],
+    )
+    print("  pid={}".format(pid))
+    streamed = wait_for_marker(popen, "STREAM_STARTED", timeout=ATTACH_WAIT + 60)
+    time.sleep(2)
+
+    print("  kill -15 {}".format(pid))
+    killed = kill_with_signal(pid, signal.SIGTERM)
+    popen.wait()
+
+    # New upstream semantic (issue #1989, commit 3c354ad8): SIGTERM with pending
+    # LLM calls records agent_crash (signal=15). Only exit(0) is "clean".
+    rows = wait_for_interruption(conn, "agent_crash", timeout=CRASH_WAIT,
+                                 count=1, since_id=since_id, pid=pid)
+    d = rows[0]["detail"] if rows else {}
+    checks = [
+        ("SSE stream started before kill", streamed is not None, streamed or "no marker"),
+        ("process terminated by SIGTERM", killed, "pid={}".format(pid)),
+        ("agent_crash recorded (SIGTERM with pending)", len(rows) == 1,
+         "rows={}".format(len(rows))),
+        ("detail.signal == 15", bool(rows) and d.get("signal") == 15,
+         "signal={}".format(d.get("signal"))),
+    ]
+    verdict = report_checks("graceful_stop_no_crash", checks)
+    conn.close()
+    time.sleep(SCENARIO_GAP)
+    return checks, verdict
+
+
+def scenario_child_exit_no_crash(api_key, base_url):
+    """Negative pin: a fork()ed (no exec) child that exit(1)s is an
+    AbnormalExit of an UNtracked child. unified.rs only reports SignalCrash
+    for non-scanner processes ("child exit(1) after parent dies is normal
+    cleanup"), so no agent_crash may be written — for the child (exit 1) or
+    for the parent (exit 0, NormalExit)."""
+    conn = sqlite3.connect(DB_INT)
+    since_id = max_interruption_id(conn)
+
+    print("  Spawning test_subprocess_agent.py --exit1 (fork child exits 1)...")
+    pid, popen = spawn_test_process(
+        os.path.join(SCRIPT_DIR, "test_subprocess_agent.py"),
+        args=["--exit1"],
+    )
+    print("  parent pid={}".format(pid))
+    line = wait_for_marker(popen, "CHILD_PID=", timeout=ATTACH_WAIT + 30)
+    child_pid = int(line.rsplit("=", 1)[1]) if line else None
+    exited = wait_for_marker(popen, "CHILD_EXITED=", timeout=15)
+
+    # Negative window while the parent is still alive...
+    rows = wait_for_interruption(conn, "agent_crash", timeout=NEGATIVE_WINDOW,
+                                 count=1, since_id=since_id)
+    # ...then let the parent exit(0) and re-check (NormalExit must not report).
+    popen.wait()
+    rows_after = wait_for_interruption(conn, "agent_crash", timeout=4,
+                                       count=1, since_id=since_id)
+    checks = [
+        ("child forked (no exec)", child_pid is not None, line or "no marker"),
+        ("child exited with status 1", exited is not None and exited.endswith("=1"),
+         exited or "no marker"),
+        ("no agent_crash for child exit(1) (negative)", len(rows) == 0,
+         "rows={}".format(len(rows))),
+        ("no agent_crash after parent exit(0) (negative)", len(rows_after) == 0,
+         "rows={}".format(len(rows_after))),
+    ]
+    verdict = report_checks("child_exit_no_crash", checks)
+    conn.close()
+    time.sleep(SCENARIO_GAP)
+    return checks, verdict
+
+
+def scenario_agent_mode_subprocess(api_key, base_url):
+    """Full sub-agent chain: a tracked Agent parent sets AGENT_MODE=1 and
+    execs a python3 child that streams an LLM call; kill -9 the child ->
+    genai_events.process_type='sub_agent' and agent_crash with severity=high
+    (SubAgent downgrade of critical) / blast_radius=partial. Optionally the
+    `agentsight token --by-type` output mentions sub_agent."""
+    conn = sqlite3.connect(DB_INT)
+    since_id = max_interruption_id(conn)
+
+    print("  Spawning test_subprocess_agent.py (AGENT_MODE=1 sub-agent chain)...")
+    pid, popen = spawn_test_process(
+        os.path.join(SCRIPT_DIR, "test_subprocess_agent.py"),
+        args=["--api-key", api_key, "--base-url", base_url],
+    )
+    print("  parent pid={}".format(pid))
+    line = wait_for_marker(popen, "CHILD_PID=", timeout=ATTACH_WAIT + 30)
+    child_pid = int(line.rsplit("=", 1)[1]) if line else None
+    # The child sleeps its own ATTACH_WAIT before its first request.
+    streamed = wait_for_marker(popen, "STREAM_STARTED", timeout=ATTACH_WAIT + 90)
+    time.sleep(2)
+
+    killed = False
+    if child_pid is not None:
+        print("  kill -9 {} (child)".format(child_pid))
+        killed = kill_with_signal(child_pid, signal.SIGKILL)
+
+    rows = wait_for_interruption(conn, "agent_crash", timeout=CRASH_WAIT,
+                                 count=1, since_id=since_id, pid=child_pid)
+    d = rows[0]["detail"] if rows else {}
+    ptype_ok, ptype_rows = (wait_for_genai_process_type(child_pid, "sub_agent", timeout=10)
+                            if child_pid is not None else (False, []))
+
+    # Killed processes typically never flush their pending call to
+    # genai_events (the process dies before the stream completes). When
+    # no rows exist for the pid, this check is inconclusive -> SKIP.
+    # Also SKIP when rows exist but process_type is None — the new code
+    # stores process_type only in interruption_events.detail, not in
+    # genai_events (which tracks call lifecycle, not process classification).
+    if child_pid is not None and not ptype_rows:
+        ptype_check = None  # SKIP
+        ptype_evidence = "no genai_events rows (killed before flush)"
+    elif ptype_ok:
+        ptype_check = True
+        ptype_evidence = "rows={}".format(ptype_rows[:5])
+    elif ptype_rows and all(r[0] is None for r in ptype_rows):
+        ptype_check = None  # SKIP — process_type not stored in genai_events
+        ptype_evidence = "genai_events.process_type=None (classification in interruption_events only)"
+    else:
+        ptype_check = False
+        ptype_evidence = "rows={}".format(ptype_rows[:5])
+
+    # Optional CLI cross-check: interrupted calls carry no token usage, so a
+    # missing sub_agent line is inconclusive -> SKIP, not FAIL.
+    cli_out = token_by_type_output()
+    if cli_out is None:
+        cli_check, cli_evidence = None, "agentsight binary unavailable"
+    elif "sub_agent" in cli_out:
+        cli_check, cli_evidence = True, "output mentions sub_agent"
+    else:
+        cli_check, cli_evidence = None, "no sub_agent rows (no token usage yet)"
+
+    wait_for_marker(popen, "CHILD_EXITED=", timeout=15)
+    popen.wait()
+
+    checks = [
+        ("sub-agent child spawned", child_pid is not None, line or "no marker"),
+        ("child streaming before kill", streamed is not None, streamed or "no marker"),
+        ("child killed with SIGKILL", killed, "child_pid={}".format(child_pid)),
+        (">= 1 agent_crash recorded for child", len(rows) >= 1, "rows={}".format(len(rows))),
+        ("detail.signal == 9", bool(rows) and d.get("signal") == 9,
+         "signal={}".format(d.get("signal"))),
+        ("severity == high (SubAgent downgrade)", bool(rows) and rows[0]["severity"] == "high",
+         "severity={}".format(rows[0]["severity"] if rows else None)),
+        ("detail.blast_radius == partial", bool(rows) and d.get("blast_radius") == "partial",
+         "blast_radius={}".format(d.get("blast_radius"))),
+        ("detail.process_type == sub_agent", bool(rows) and d.get("process_type") == "sub_agent",
+         "process_type={}".format(d.get("process_type"))),
+        ("genai_events.process_type == sub_agent", ptype_check, ptype_evidence),
+        ("token --by-type mentions sub_agent (optional)", cli_check, cli_evidence),
+    ]
+    verdict = report_checks("agent_mode_subprocess", checks)
+    conn.close()
+    time.sleep(SCENARIO_GAP)
+    return checks, verdict
+
+
+def scenario_oom_kill(api_key, base_url):
+    """Optional: cgroup v2 memory.max OOM kill -> agent_crash with
+    detail.oom=true. SKIPs when root / cgroup v2 / memory controller unmet."""
+    cgroup_root = "/sys/fs/cgroup"
+    oom_cgroup = os.path.join(cgroup_root, "agentsight-oom-test")
+
+    # Environment gate (RULES.md: SKIP when prerequisites are unmet)
+    reasons = []
+    if os.geteuid() != 0:
+        reasons.append("not root")
+    controllers_file = os.path.join(cgroup_root, "cgroup.controllers")
+    if not os.path.exists(controllers_file):
+        reasons.append("cgroup v2 not mounted")
+    else:
+        try:
+            with open(controllers_file) as f:
+                if "memory" not in f.read().split():
+                    reasons.append("memory controller unavailable")
+        except Exception as e:
+            reasons.append("cannot read cgroup.controllers: {}".format(e))
+    if reasons:
+        checks = [("environment prerequisites", None, "; ".join(reasons))]
+        return checks, report_checks("oom_kill", checks)
+
+    conn = sqlite3.connect(DB_INT)
+    since_id = max_interruption_id(conn)
+    pid, rc, rows, d = None, None, [], {}
+    try:
+        os.makedirs(oom_cgroup, exist_ok=True)
+        with open(os.path.join(oom_cgroup, "memory.max"), "w") as f:
+            f.write("100M")
+        try:
+            # Must disable swap, or the process gets swapped instead of killed
+            with open(os.path.join(oom_cgroup, "memory.swap.max"), "w") as f:
+                f.write("0")
+        except OSError:
+            pass  # no swap accounting on this kernel
+
+        def enter_cgroup():
+            # Runs in the child after fork, before exec — puts exactly the
+            # test process into the cgroup (no intermediate shell, README
+            # pitfall #9).
+            with open(os.path.join(oom_cgroup, "cgroup.procs"), "w") as f:
+                f.write(str(os.getpid()))
+
+        print("  Spawning test_http_crash.py --oom inside {} (100M limit)...".format(oom_cgroup))
+        popen = subprocess.Popen(
+            ["python3", os.path.join(SCRIPT_DIR, "test_http_crash.py"), "--oom",
+             "--api-key", api_key, "--base-url", base_url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            preexec_fn=enter_cgroup,
+        )
+        pid = popen.pid
+        print("  pid={}".format(pid))
+        # The OOM kill may race the marker; tolerate a missing line.
+        wait_for_marker(popen, "OOM_ALLOC_STARTED", timeout=ATTACH_WAIT + 90)
+        try:
+            rc = popen.wait(timeout=120)
+        except subprocess.TimeoutExpired:
+            rc = None
+            kill_with_signal(pid, signal.SIGKILL)
+
+        rows = wait_for_interruption(conn, "agent_crash", timeout=CRASH_WAIT,
+                                     count=1, since_id=since_id, pid=pid)
+        d = rows[0]["detail"] if rows else {}
+    finally:
+        conn.close()
+        for _ in range(5):
+            try:
+                os.rmdir(oom_cgroup)
+                break
+            except OSError:
+                time.sleep(1)
+
+    checks = [
+        ("process OOM-killed (rc == -9)", rc == -9, "rc={}".format(rc)),
+        (">= 1 agent_crash recorded", len(rows) >= 1, "rows={}".format(len(rows))),
+        ("detail.signal == 9", bool(rows) and d.get("signal") == 9,
+         "signal={}".format(d.get("signal"))),
+        ("detail.oom == true", bool(rows) and d.get("oom") is True,
+         "oom={}".format(d.get("oom"))),
+    ]
+    verdict = report_checks("oom_kill", checks)
+    time.sleep(SCENARIO_GAP)
+    return checks, verdict
+
+
+CRASH_SCENARIO_ORDER = [
+    "agent_crash_sigkill",
+    "agent_crash_sigsegv",
+    "graceful_stop_no_crash",
+    "child_exit_no_crash",
+    "agent_mode_subprocess",
+    "oom_kill",
+]
+
 SCENARIOS = {
     "auth_single":  scenario_auth_single,
     "auth_storm":   scenario_auth_storm,
@@ -375,6 +1029,12 @@ SCENARIOS = {
     "multi_type":   scenario_multi_type,
     "healthy":      scenario_healthy,
     "agent_crash":  scenario_agent_crash,
+    "agent_crash_sigkill":    scenario_agent_crash_sigkill,
+    "agent_crash_sigsegv":    scenario_agent_crash_sigsegv,
+    "graceful_stop_no_crash": scenario_graceful_stop_no_crash,
+    "child_exit_no_crash":    scenario_child_exit_no_crash,
+    "agent_mode_subprocess":  scenario_agent_mode_subprocess,
+    "oom_kill":               scenario_oom_kill,
 }
 
 
@@ -385,7 +1045,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
-    parser.add_argument("scenario", choices=list(SCENARIOS.keys()) + ["all"])
+    parser.add_argument("scenario", choices=list(SCENARIOS.keys()) + ["all", "crash_all"])
     parser.add_argument("--api-key", default=os.environ.get("DASHSCOPE_API_KEY", ""),
                         help="Valid dashscope API key (or set DASHSCOPE_API_KEY env)")
     parser.add_argument("--base-url", default=DEFAULT_URL)
@@ -406,6 +1066,13 @@ def main():
             SCENARIOS[name](args.api_key, args.base_url)
             print()
             time.sleep(5)
+    elif args.scenario == "crash_all":
+        # Each crash scenario already sleeps SCENARIO_GAP at its end
+        # (PID-reuse guard between scenarios).
+        for name in CRASH_SCENARIO_ORDER:
+            print("\n>>> Running scenario: {} <<<".format(name))
+            SCENARIOS[name](args.api_key, args.base_url)
+            print()
     else:
         SCENARIOS[args.scenario](args.api_key, args.base_url)
 

--- a/src/agentsight/integration-tests/interruption/test_http_crash.py
+++ b/src/agentsight/integration-tests/interruption/test_http_crash.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Killable LLM SSE client for AgentSight crash scenarios.
+
+Spawned by scenario_test.py as a monitored python3 process (matches the
+"TestAgent" *python3* cmdline rule). Timing contract:
+  - Sleeps ATTACH_WAIT (>=10s) BEFORE the first HTTPS request, because the
+    SSL uprobe attach chain (procmon exec -> scanner match -> ELF parse ->
+    attach) takes ~8-15s; requests sent earlier are invisible to AgentSight.
+  - Reads SSE chunks slowly (32 bytes / 0.5s) so the stream stays open and an
+    external SIGKILL/SIGTERM always lands mid-stream.
+  - Never exits on request errors: it retries forever so the pid stays
+    killable and the scenario never races an already-exited process.
+
+Markers printed to stdout (parsed by scenario_test.py):
+    PID=<pid>            after startup
+    ATTACH_WAIT_DONE     after the SSL-probe attach sleep
+    STREAM_STARTED       response headers received, SSE body being read
+    OOM_ALLOC_STARTED    (--oom only) memory hogging began
+    ERROR <msg>          request failed (process stays alive and retries)
+
+With --oom the process starts allocating 10 MiB chunks after receiving a few
+SSE chunks, to be OOM-killed inside a memory-limited cgroup (scenario
+oom_kill).
+
+Python 3 stdlib only: argparse/json/os/ssl/sys/time/urllib.
+"""
+import argparse
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.request
+
+DEFAULT_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+ATTACH_WAIT = 10  # seconds before first HTTPS request (SSL probe attach)
+
+
+def log(msg):
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def stream_once(api_key, base_url, oom=False):
+    payload = json.dumps({
+        "model": "qwen-max",
+        "messages": [{"role": "user", "content":
+                      "Write a detailed 3000 word essay about the history of "
+                      "computing from 1940 to 2025."}],
+        "max_tokens": 4000,
+        "stream": True,
+    }).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer {}".format(api_key),
+    }
+    req = urllib.request.Request(base_url, data=payload, headers=headers, method="POST")
+    ctx = ssl.create_default_context()
+    resp = urllib.request.urlopen(req, context=ctx, timeout=120)
+    log("STREAM_STARTED")
+    chunks = 0
+    hog = []
+    while True:
+        chunk = resp.read(32)
+        if not chunk:
+            return
+        chunks += 1
+        if oom and chunks >= 3:
+            # cgroup OOM scenario: allocate until the kernel OOM-kills us.
+            # bytearray() zero-fills, so every page is really committed.
+            log("OOM_ALLOC_STARTED")
+            while True:
+                hog.append(bytearray(10 * 1024 * 1024))
+        # Read slowly so the SSE stream stays open for the kill window
+        time.sleep(0.5)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="killable SSE client for crash scenarios")
+    parser.add_argument("--api-key", default=os.environ.get("DASHSCOPE_API_KEY", ""))
+    parser.add_argument("--base-url", default=DEFAULT_URL)
+    parser.add_argument("--attach-wait", type=int, default=ATTACH_WAIT)
+    parser.add_argument("--oom", action="store_true",
+                        help="allocate memory after a few SSE chunks (cgroup OOM scenario)")
+    args = parser.parse_args()
+
+    log("PID={}".format(os.getpid()))
+    time.sleep(args.attach_wait)
+    log("ATTACH_WAIT_DONE")
+
+    while True:
+        try:
+            stream_once(args.api_key, args.base_url, oom=args.oom)
+        except Exception as e:
+            log("ERROR {}".format(e))
+            time.sleep(5)
+        else:
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentsight/integration-tests/interruption/test_http_segfault.py
+++ b/src/agentsight/integration-tests/interruption/test_http_segfault.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Self-crashing LLM SSE client: SIGSEGV mid-stream.
+
+Spawned by scenario_test.py as a monitored python3 process. After receiving a
+few SSE chunks of a streaming LLM response, it dereferences NULL via
+ctypes.string_at(0), which raises a real SIGSEGV in the C layer (no Python
+exception, no faulthandler) — the kernel terminates the process with
+signal 11 while the HTTPS stream is still open.
+
+Timing contract mirrors test_http_crash.py: sleeps >=10s before the first
+request so the SSL uprobe is attached (see README "SSL probe attach 时序").
+
+Markers printed to stdout (parsed by scenario_test.py):
+    PID=<pid>            after startup
+    ATTACH_WAIT_DONE     after the SSL-probe attach sleep
+    STREAM_STARTED       response headers received
+    SEGFAULT_NOW         about to dereference NULL (last line ever printed)
+    ERROR <msg>          request failed (retries so the crash still happens)
+
+Python 3 stdlib only: argparse/ctypes/json/os/ssl/sys/time/urllib.
+"""
+import argparse
+import ctypes
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.request
+
+DEFAULT_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+ATTACH_WAIT = 10  # seconds before first HTTPS request (SSL probe attach)
+CHUNKS_BEFORE_CRASH = 3
+
+
+def log(msg):
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def stream_and_crash(api_key, base_url):
+    payload = json.dumps({
+        "model": "qwen-max",
+        "messages": [{"role": "user", "content":
+                      "Write a detailed 3000 word essay about the history of "
+                      "computing from 1940 to 2025."}],
+        "max_tokens": 4000,
+        "stream": True,
+    }).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer {}".format(api_key),
+    }
+    req = urllib.request.Request(base_url, data=payload, headers=headers, method="POST")
+    ctx = ssl.create_default_context()
+    resp = urllib.request.urlopen(req, context=ctx, timeout=120)
+    log("STREAM_STARTED")
+    chunks = 0
+    while True:
+        chunk = resp.read(32)
+        if not chunk:
+            return
+        chunks += 1
+        if chunks >= CHUNKS_BEFORE_CRASH:
+            log("SEGFAULT_NOW")
+            # NULL dereference in C: kernel delivers SIGSEGV, process dies
+            # with signal 11 while the SSE stream is still in flight.
+            ctypes.string_at(0)
+        time.sleep(0.5)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SSE client that segfaults mid-stream")
+    parser.add_argument("--api-key", default=os.environ.get("DASHSCOPE_API_KEY", ""))
+    parser.add_argument("--base-url", default=DEFAULT_URL)
+    parser.add_argument("--attach-wait", type=int, default=ATTACH_WAIT)
+    args = parser.parse_args()
+
+    log("PID={}".format(os.getpid()))
+    time.sleep(args.attach_wait)
+    log("ATTACH_WAIT_DONE")
+
+    # Retry until the request goes through — the whole point is to die by
+    # SIGSEGV mid-stream, so we never give up on transient request errors.
+    while True:
+        try:
+            stream_and_crash(args.api_key, args.base_url)
+        except Exception as e:
+            log("ERROR {}".format(e))
+            time.sleep(5)
+        else:
+            # Stream completed without reaching the crash threshold; retry.
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentsight/integration-tests/interruption/test_subprocess_agent.py
+++ b/src/agentsight/integration-tests/interruption/test_subprocess_agent.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Parent/child lineage driver for AgentSight crash scenarios.
+
+The parent runs as a monitored python3 process (TestAgent, *python3* cmdline
+rule) and drives one of two child shapes:
+
+Default (sub-agent full chain, scenario agent_mode_subprocess):
+    Parent sets AGENT_MODE=1 in the child environment, then execs a python3
+    child (test_http_crash.py) that streams an LLM SSE request. Because the
+    parent is a tracked Agent and the child's cmdline also matches the agent
+    pattern, the lineage tree classifies the child as SubAgent
+    (process_type="sub_agent"). scenario_test.py then kill -9s the child and
+    asserts severity=high / blast_radius=partial.
+
+--exit1 (negative pin, scenario child_exit_no_crash):
+    Parent os.fork()s a child that immediately os._exit(1) — fork WITHOUT
+    exec, so the child is never scanner-tracked (procmon Create fires on
+    exec). Its non-zero exit is an AbnormalExit of an untracked child, which
+    unified.rs deliberately does NOT report as agent_crash (only SignalCrash
+    is reported for non-scanner processes). The parent then exits 0
+    (NormalExit — also no record).
+
+Markers printed to stdout (parsed by scenario_test.py):
+    PID=<pid>            parent pid, after startup
+    CHILD_PID=<pid>      child pid, right after fork/exec
+    CHILD: <line>        forwarded child stdout (e.g. CHILD: STREAM_STARTED)
+    CHILD_EXITED=<code>  child reaped (exit status, or -signal)
+
+Python 3 stdlib only: argparse/os/subprocess/sys/time.
+"""
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ATTACH_WAIT = 10  # settle time: scanner must track the parent as Agent first
+
+
+def log(msg):
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def run_exit1_child():
+    """fork (no exec) a child that exit(1)s; parent reaps and stays alive."""
+    pid = os.fork()
+    if pid == 0:
+        # Child: plain fork, no exec — must stay untracked by the scanner.
+        os._exit(1)
+    log("CHILD_PID={}".format(pid))
+    _, status = os.waitpid(pid, 0)
+    code = os.WEXITSTATUS(status) if os.WIFEXITED(status) else -os.WTERMSIG(status)
+    log("CHILD_EXITED={}".format(code))
+    # Stay alive through the scenario's negative observation window, then
+    # exit 0 — NormalExit must not generate an agent_crash either.
+    time.sleep(15)
+
+
+def run_llm_child(api_key, base_url):
+    """exec a python3 SSE child with AGENT_MODE=1 -> SubAgent lineage."""
+    env = dict(os.environ)
+    env["AGENT_MODE"] = "1"
+    child = subprocess.Popen(
+        ["python3", os.path.join(SCRIPT_DIR, "test_http_crash.py"),
+         "--api-key", api_key, "--base-url", base_url],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    log("CHILD_PID={}".format(child.pid))
+    # Forward child markers (PID= / STREAM_STARTED / ...) until it dies.
+    for raw in child.stdout:
+        log("CHILD: {}".format(raw.decode("utf-8", errors="replace").strip()))
+    rc = child.wait()
+    log("CHILD_EXITED={}".format(rc))
+    # Keep the parent Agent alive briefly so crash detection for the child
+    # runs while its lineage parent still exists, then exit 0 gracefully.
+    time.sleep(5)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="parent/child lineage driver")
+    parser.add_argument("--api-key", default=os.environ.get("DASHSCOPE_API_KEY", ""))
+    parser.add_argument("--base-url",
+                        default="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions")
+    parser.add_argument("--attach-wait", type=int, default=ATTACH_WAIT)
+    parser.add_argument("--exit1", action="store_true",
+                        help="fork (no exec) a child that exit(1)s (negative pin)")
+    args = parser.parse_args()
+
+    log("PID={}".format(os.getpid()))
+    # The parent sends no HTTPS traffic itself; this wait is for procmon +
+    # scanner to track it as Agent before the child is created, so the
+    # child's classification sees a tracked Agent parent.
+    time.sleep(args.attach_wait)
+
+    if args.exit1:
+        run_exit1_child()
+    else:
+        run_llm_child(args.api_key, args.base_url)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -65,6 +65,7 @@ CROSS_CUTTING = {
     "logging",         # logging init
     "utils",           # utility functions
     "discovery",       # process discovery (Cross in ARCHITECTURE.md)
+    "lineage",         # process lineage tree (Cross: L8 populates, L7 reads)
     "skill_metrics",   # metric helpers
     "token_breakdown", # token analysis helpers
     "ecs_metadata",    # shared ECS metadata client primitives

--- a/src/agentsight/src/background.rs
+++ b/src/agentsight/src/background.rs
@@ -251,7 +251,10 @@ mod tests {
     fn tmp_dir(tag: &str) -> PathBuf {
         static C: AtomicU32 = AtomicU32::new(0);
         let n = C.fetch_add(1, Ordering::SeqCst);
-        let dir = std::env::temp_dir().join(format!("bg-test-{tag}-{n}"));
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test-tmp")
+            .join(format!("bg-test-{tag}-{n}"));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
@@ -299,6 +302,7 @@ mod tests {
                 call_kind: "main".to_string(),
                 pending_origin: PendingOrigin::RequestCapture,
                 pending_match_key: None,
+                process_type: None,
             })
             .unwrap();
 

--- a/src/agentsight/src/bin/cli/interruption.rs
+++ b/src/agentsight/src/bin/cli/interruption.rs
@@ -568,17 +568,24 @@ fn print_record_detail(r: &InterruptionRecord) {
     );
     println!("  Agent:        {}", r.agent_name.as_deref().unwrap_or("-"));
     if let Some(ref detail) = r.detail {
-        // Pretty-print JSON detail
         if let Ok(v) = serde_json::from_str::<serde_json::Value>(detail) {
-            println!("  Detail:");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&v).unwrap_or_else(|_| detail.clone())
-            );
+            if r.interruption_type == "agent_crash" && v.get("signal").is_some() {
+                print_crash_report(&v);
+            } else {
+                println!("  Detail:");
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&v).unwrap_or_else(|_| detail.clone())
+                );
+            }
         } else {
             println!("  Detail:       {detail}");
         }
     }
+}
+
+fn print_crash_report(detail: &serde_json::Value) {
+    print!("{}", agentsight::lineage::format_crash_report(detail));
 }
 
 /// Print any Serialize value as JSON.

--- a/src/agentsight/src/bin/cli/token.rs
+++ b/src/agentsight/src/bin/cli/token.rs
@@ -24,6 +24,10 @@ pub struct TokenCommand {
     #[structopt(long)]
     pub json: bool,
 
+    /// Group token usage by process type (agent/sub_agent/tool)
+    #[structopt(long)]
+    pub by_type: bool,
+
     /// Custom data file path
     #[structopt(long)]
     pub data_file: Option<String>,
@@ -31,9 +35,10 @@ pub struct TokenCommand {
 
 impl TokenCommand {
     pub fn execute(&self) {
-        // Determine data file path
-        // Use the unified database path (agentsight.db) as default,
-        // which is where Storage writes all tables.
+        if self.by_type {
+            self.execute_by_type();
+            return;
+        }
         let data_path = self
             .data_file
             .as_ref()
@@ -41,6 +46,49 @@ impl TokenCommand {
             .unwrap_or_else(|| SqliteConfig::default().db_path());
 
         self.execute_summary(&data_path);
+    }
+
+    fn execute_by_type(&self) {
+        use agentsight::storage::sqlite::GenAISqliteStore;
+
+        let genai_path = self
+            .data_file
+            .as_ref()
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(GenAISqliteStore::default_path);
+        let store = match GenAISqliteStore::new_with_path(&genai_path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Failed to open GenAI store: {e}");
+                return;
+            }
+        };
+
+        let hours = self.hours.unwrap_or(24);
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        let start_ns = now_ns - (hours as i64) * 3_600_000_000_000;
+
+        match store.token_usage_by_process_type(start_ns, now_ns) {
+            Ok(rows) if rows.is_empty() => {
+                println!("No LLM calls with process_type in the last {hours} hours.");
+            }
+            Ok(rows) => {
+                if self.json {
+                    println!("{}", agentsight::lineage::format_token_by_type_json(&rows));
+                } else {
+                    print!(
+                        "{}",
+                        agentsight::lineage::format_token_by_type_table(&rows, hours)
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("Query failed: {e}");
+            }
+        }
     }
 
     fn execute_summary(&self, data_path: &std::path::Path) {

--- a/src/agentsight/src/bpf/proctrace.bpf.c
+++ b/src/agentsight/src/bpf/proctrace.bpf.c
@@ -362,7 +362,8 @@ int trace_process_exit(void *ctx)
     
     // Fill exit_data
     struct proc_exit_data *exit_data = (void *)(event + 1);
-    exit_data->exit_code = 0;  // TODO: Get actual exit code from sched_process_exit
+    struct task_struct *exit_task = (struct task_struct *)bpf_get_current_task();
+    exit_data->exit_code = BPF_CORE_READ(exit_task, exit_code);
     
     bpf_ringbuf_submit(event, 0);
     return 0;

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -1316,6 +1316,7 @@ mod tests {
             pid,
             process_name: "test".to_string(),
             agent_name: agent_name.map(str::to_string),
+            process_type: None,
             metadata: std::collections::HashMap::new(),
         }
     }

--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -197,6 +197,7 @@ impl GenAIBuilder {
                     .unwrap_or_else(|| "main".to_string()),
                 pending_origin: PendingOrigin::RequestCapture,
                 pending_match_key: llm_call.metadata.get("pending_match_key").cloned(),
+                process_type: None,
             });
 
             events.push(GenAISemanticEvent::LLMCall(llm_call));
@@ -448,6 +449,7 @@ impl GenAIBuilder {
             call_kind: call_kind.to_string(),
             pending_origin: PendingOrigin::DeadPidDrain,
             pending_match_key: Some(pending_match_key),
+            process_type: None,
         })
     }
 

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -238,6 +238,7 @@ impl GenAIBuilder {
             process_name: crate::discovery::scanner::read_comm(http.pid)
                 .unwrap_or_else(|| http.comm.clone()),
             agent_name: Some(agent_name.clone()),
+            process_type: None,
             metadata: {
                 let mut meta = HashMap::new();
                 meta.insert("method".to_string(), http.method);

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -590,6 +590,9 @@ pub fn events_to_flat_records(
                 if let Some(ref name) = call.agent_name {
                     m.insert("agentsight.agent.name".to_string(), name.clone());
                 }
+                if let Some(ref ptype) = call.process_type {
+                    m.insert("agentsight.process_type".to_string(), ptype.clone());
+                }
                 m.insert(
                     "agentsight.duration_ns".to_string(),
                     call.duration_ns.to_string(),

--- a/src/agentsight/src/genai/semantic.rs
+++ b/src/agentsight/src/genai/semantic.rs
@@ -48,6 +48,9 @@ pub struct LLMCall {
     pub process_name: String,
     /// Resolved agent name from discovery registry (e.g. "OpenClaw", "Cosh")
     pub agent_name: Option<String>,
+    /// Process type from lineage tree (agent/sub_agent/tool)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_type: Option<String>,
     /// Additional metadata
     pub metadata: HashMap<String, String>,
 }
@@ -304,6 +307,7 @@ impl LLMCall {
             pid,
             process_name,
             agent_name: None,
+            process_type: None,
             metadata: HashMap::new(),
         }
     }

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -669,6 +669,7 @@ mod tests {
             call_kind: "main".to_string(),
             pending_origin: crate::storage::sqlite::genai::PendingOrigin::RequestCapture,
             pending_match_key: None,
+            process_type: None,
         };
         genai_store.insert_pending(&info).expect("insert_pending");
         let checker = HealthChecker::new(

--- a/src/agentsight/src/interruption/detector.rs
+++ b/src/agentsight/src/interruption/detector.rs
@@ -832,6 +832,7 @@ mod tests {
             pid: 1234,
             process_name: "agent".to_string(),
             agent_name: Some("TestAgent".to_string()),
+            process_type: None,
             metadata: HashMap::from([("status_code".to_string(), "200".to_string())]),
         }
     }

--- a/src/agentsight/src/interruption/oom_recovery.rs
+++ b/src/agentsight/src/interruption/oom_recovery.rs
@@ -285,7 +285,8 @@ fn match_agent_name(comm: &str) -> Option<&'static str> {
 /// when an agent process disappears, we check dmesg to determine if it
 /// was killed by the OOM killer (vs normal exit, SIGKILL, segfault, etc.).
 ///
-/// Returns `true` if the PID appears in a "Killed process" OOM line in dmesg.
+/// Returns `true` if the PID appears in an OOM kill line in dmesg
+/// (either format accepted by [`line_matches_oom_kill`]).
 pub fn was_pid_oom_killed(pid: i32) -> bool {
     let output = match Command::new("dmesg").arg("-T").output() {
         Ok(o) if o.status.success() => o,
@@ -302,14 +303,35 @@ pub fn was_pid_oom_killed(pid: i32) -> bool {
     let content = String::from_utf8_lossy(&output.stdout);
     let pid_str = pid.to_string();
 
-    for line in content.lines() {
-        if !line.contains("Killed process") {
-            continue;
+    content
+        .lines()
+        .any(|line| line_matches_oom_kill(line, &pid_str))
+}
+
+/// Returns `true` if a single dmesg line attributes an OOM kill to `pid_str`.
+///
+/// Two kernel formats are recognised:
+/// - Summary line (all kernels): `Out of memory: Killed process <pid> (<name>) ...`
+/// - Structured line (kernel 5.0+, commit ef8444ea01d7):
+///   `oom-kill:constraint=...,task=<name>,pid=<pid>,uid=<uid>`
+///   On some systems (e.g. memcg OOM on 6.6.x) this is the only line
+///   reliably present, so matching the summary line alone misses the kill.
+///
+/// Invariant: the pid comparison is whole-token (`==`), never a prefix
+/// match, so pid 6693 must not match a line reporting pid 669334.
+fn line_matches_oom_kill(line: &str, pid_str: &str) -> bool {
+    // Summary format: token after "Killed process " is the full pid.
+    if let Some(after) = line.split("Killed process ").nth(1) {
+        if after.split_whitespace().next() == Some(pid_str) {
+            return true;
         }
-        // Check if this line contains "Killed process <our_pid> "
-        if let Some(after) = line.split("Killed process ").nth(1) {
-            if let Some(line_pid_str) = after.split_whitespace().next() {
-                if line_pid_str == pid_str {
+    }
+
+    // Structured format: comma-separated key=value fields after "oom-kill:".
+    if let Some(after) = line.split("oom-kill:").nth(1) {
+        for field in after.split(',') {
+            if let Some(value) = field.trim().strip_prefix("pid=") {
+                if value == pid_str {
                     return true;
                 }
             }
@@ -317,4 +339,45 @@ pub fn was_pid_oom_killed(pid: i32) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Real dmesg line observed on kernel 6.6.102 (memcg OOM, e2e evidence).
+    const STRUCTURED_LINE: &str = "[Sat Jul 25 10:00:00 2026] oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=/,mems_allowed=0,oom_memcg=/user.slice,task_memcg=/user.slice/session-1.scope,task=python3,pid=669334,uid=0";
+
+    const SUMMARY_LINE: &str = "[Fri Apr 17 10:00:00 2026] Out of memory: Killed process 12345 (openclaw-gatewa) total-vm:1024kB";
+
+    #[test]
+    fn structured_line_matches_target_pid() {
+        assert!(line_matches_oom_kill(STRUCTURED_LINE, "669334"));
+    }
+
+    #[test]
+    fn structured_line_rejects_prefix_pid() {
+        // pid 6693 is a strict prefix of the line's pid 669334 — must not match.
+        assert!(!line_matches_oom_kill(STRUCTURED_LINE, "6693"));
+        // Nor the other direction: querying a longer pid than the line's.
+        assert!(!line_matches_oom_kill(
+            "[ts] oom-kill:constraint=CONSTRAINT_NONE,task=node,pid=6693,uid=1000",
+            "669334"
+        ));
+    }
+
+    #[test]
+    fn summary_line_matches_target_pid() {
+        assert!(line_matches_oom_kill(SUMMARY_LINE, "12345"));
+        assert!(!line_matches_oom_kill(SUMMARY_LINE, "1234"));
+    }
+
+    #[test]
+    fn unrelated_line_does_not_match() {
+        assert!(!line_matches_oom_kill(
+            "[ts] audit: type=1400 pid=669334 comm=python3",
+            "669334"
+        ));
+        assert!(!line_matches_oom_kill("", "669334"));
+    }
 }

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -57,6 +57,8 @@ pub mod health;
 #[cfg(target_os = "linux")]
 pub mod interruption;
 #[cfg(target_os = "linux")]
+pub mod lineage;
+#[cfg(target_os = "linux")]
 pub mod parser;
 #[cfg(target_os = "linux")]
 pub mod probes;

--- a/src/agentsight/src/lineage/mod.rs
+++ b/src/agentsight/src/lineage/mod.rs
@@ -1,0 +1,1458 @@
+//! Blood lineage tree for AI agent process tracking
+//!
+//! Maintains a userspace mirror of the BPF lineage_tree map, enriched with
+//! process type classification (Agent / SubAgent / Tool / Skill).
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+/// Process type classification for lineage tree nodes.
+///
+/// `Skill` is forward-declared for the follow-up scoring task — `classify()`
+/// does NOT currently produce it (today's classifier covers Agent / SubAgent /
+/// Tool only). The variant exists in `from_u32`/`as_u32` so a future BPF-side
+/// scorer can emit it without breaking userspace decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessType {
+    Unknown,
+    Agent,
+    SubAgent,
+    Tool,
+    /// Forward-declared. Not produced by the current `classify()`.
+    Skill,
+}
+
+impl ProcessType {
+    pub fn from_u32(v: u32) -> Self {
+        match v {
+            1 => Self::Agent,
+            2 => Self::SubAgent,
+            3 => Self::Tool,
+            4 => Self::Skill,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::Unknown => 0,
+            Self::Agent => 1,
+            Self::SubAgent => 2,
+            Self::Tool => 3,
+            Self::Skill => 4,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Agent => "agent",
+            Self::SubAgent => "sub_agent",
+            Self::Tool => "tool",
+            Self::Skill => "skill",
+        }
+    }
+}
+
+/// Flags on a lineage node (mirrors LINEAGE_FLAG_* from BPF)
+pub const LINEAGE_FLAG_AGENT_MODE: u32 = 1 << 0;
+
+/// A single node in the lineage tree
+#[derive(Debug, Clone, Serialize)]
+pub struct LineageNode {
+    pub pid: u32,
+    pub ppid: u32,
+    pub process_type: ProcessType,
+    pub flags: u32,
+    pub create_time_ns: u64,
+    pub comm: String,
+    pub agent_name: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<u32>,
+}
+
+impl LineageNode {
+    pub fn has_agent_mode(&self) -> bool {
+        self.flags & LINEAGE_FLAG_AGENT_MODE != 0
+    }
+}
+
+/// Userspace lineage tree — mirrors BPF lineage_tree map with classification
+#[derive(Default)]
+pub struct LineageTree {
+    nodes: HashMap<u32, LineageNode>,
+}
+
+impl LineageTree {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or update a node. Automatically maintains parent→child links.
+    ///
+    /// Also handles PID re-parenting: if the pid already exists under a
+    /// different parent (e.g. PID reuse where the old Exit was missed under
+    /// ringbuf pressure), the stale child entry is removed from the old
+    /// parent's children list before inserting under the new parent.
+    pub fn insert(&mut self, mut node: LineageNode) {
+        let pid = node.pid;
+        let ppid = node.ppid;
+
+        // PID-reuse / re-parent: detach from old parent first.
+        if let Some(old_node) = self.nodes.get(&pid) {
+            let old_ppid = old_node.ppid;
+            if old_ppid != ppid {
+                if let Some(old_parent) = self.nodes.get_mut(&old_ppid) {
+                    old_parent.children.retain(|&c| c != pid);
+                }
+            }
+        }
+
+        // Add this pid as a child of its (possibly new) parent.
+        if let Some(parent) = self.nodes.get_mut(&ppid) {
+            if !parent.children.contains(&pid) {
+                parent.children.push(pid);
+            }
+        }
+
+        if let Some(old) = self.nodes.get(&pid) {
+            node.children = old.children.clone();
+        }
+
+        self.nodes.insert(pid, node);
+    }
+
+    /// Remove a node, reparent its children to grandparent, and clean up links.
+    pub fn remove(&mut self, pid: u32) -> Option<LineageNode> {
+        let node = self.nodes.remove(&pid)?;
+
+        // Reparent children to the removed node's parent (mirrors kernel subreaper)
+        for &child_pid in &node.children {
+            if let Some(child) = self.nodes.get_mut(&child_pid) {
+                child.ppid = node.ppid;
+            }
+        }
+
+        // Update parent's children list: remove this node, add its children
+        if let Some(parent) = self.nodes.get_mut(&node.ppid) {
+            parent.children.retain(|&c| c != pid);
+            for child_pid in &node.children {
+                if !parent.children.contains(child_pid) {
+                    parent.children.push(*child_pid);
+                }
+            }
+        }
+
+        Some(node)
+    }
+
+    /// Get a reference to a node
+    pub fn get(&self, pid: u32) -> Option<&LineageNode> {
+        self.nodes.get(&pid)
+    }
+
+    /// Get a mutable reference to a node
+    pub fn get_mut(&mut self, pid: u32) -> Option<&mut LineageNode> {
+        self.nodes.get_mut(&pid)
+    }
+
+    /// Insert a process (if not already present) and classify it in one step.
+    /// Returns the classified ProcessType.
+    ///
+    /// This is the primary entry point for unified.rs glue code: it combines
+    /// node creation + insertion + classification into a single pure-function
+    /// call on the tree, enabling full unit-test coverage without BPF.
+    pub fn insert_and_classify(
+        &mut self,
+        pid: u32,
+        ppid: u32,
+        comm: &str,
+        agent_name: Option<String>,
+        has_agent_mode: bool,
+        matches_agent: bool,
+    ) -> ProcessType {
+        if self.get(pid).is_none() {
+            let node = LineageNode {
+                pid,
+                ppid,
+                process_type: ProcessType::Unknown,
+                flags: if has_agent_mode {
+                    LINEAGE_FLAG_AGENT_MODE
+                } else {
+                    0
+                },
+                create_time_ns: 0,
+                comm: comm.to_string(),
+                agent_name,
+                children: vec![],
+            };
+            self.insert(node);
+        }
+        self.classify(pid, has_agent_mode, matches_agent);
+        self.get(pid)
+            .map(|n| n.process_type)
+            .unwrap_or(ProcessType::Unknown)
+    }
+
+    /// Classify a newly added process based on its ancestry and environment.
+    ///
+    /// Rules (evaluated in order):
+    /// 1. Parent is Agent/SubAgent → child inherits lineage:
+    ///    - matches agent pattern → SubAgent
+    ///    - otherwise → Tool
+    /// 2. No tracked parent + matches agent pattern → Agent (cmdline rule match)
+    /// 3. No tracked parent + AGENT_MODE=1 in env → Agent (reserved for future
+    ///    agent frameworks that self-declare; currently no component sets this)
+    /// 4. Otherwise → Unknown
+    ///
+    /// Note: child processes inherit AGENT_MODE=1 via environment, but that
+    /// does NOT make them Agents — only top-level processes (without a tracked
+    /// parent) are classified as Agent via AGENT_MODE. Cmdline pattern matching
+    /// takes precedence for root classification.
+    pub fn classify(&mut self, pid: u32, has_agent_mode_env: bool, matches_agent_pattern: bool) {
+        let ppid = match self.nodes.get(&pid) {
+            Some(n) => n.ppid,
+            None => return,
+        };
+
+        let parent_in_tree = self.nodes.get(&ppid);
+        let parent_type = parent_in_tree
+            .map(|p| p.process_type)
+            .unwrap_or(ProcessType::Unknown);
+
+        let process_type = match parent_type {
+            ProcessType::Agent | ProcessType::SubAgent => {
+                if matches_agent_pattern {
+                    ProcessType::SubAgent
+                } else {
+                    ProcessType::Tool
+                }
+            }
+            _ => {
+                if matches_agent_pattern || has_agent_mode_env {
+                    ProcessType::Agent
+                } else {
+                    ProcessType::Unknown
+                }
+            }
+        };
+
+        if let Some(node) = self.nodes.get_mut(&pid) {
+            node.process_type = process_type;
+        }
+    }
+
+    /// Record a process exec: classify it and stamp its create time.
+    ///
+    /// Derives the classification inputs the way the live event pipeline does:
+    /// - `has_agent_mode` is read from any pre-existing node (AGENT_MODE is
+    ///   inherited via env and preserved across re-exec), defaulting to false.
+    /// - `matches_agent` is true when discovery resolved an `agent_name` AND the
+    ///   process is not already an AGENT_MODE process (cmdline match wins for
+    ///   roots; an AGENT_MODE child stays a Tool — see `classify`).
+    ///
+    /// Returns the resulting `ProcessType`. This is the pure tree-side of
+    /// `unified::update_lineage_from_proc`, extracted so it can be unit-tested
+    /// without the BPF event pipeline.
+    pub fn record_exec(
+        &mut self,
+        pid: u32,
+        ppid: u32,
+        comm: &str,
+        agent_name: Option<String>,
+        create_time_ns: u64,
+    ) -> ProcessType {
+        let has_agent_mode = self.get(pid).map(|n| n.has_agent_mode()).unwrap_or(false);
+        let matches_agent = agent_name.is_some() && !has_agent_mode;
+        let ptype =
+            self.insert_and_classify(pid, ppid, comm, agent_name, has_agent_mode, matches_agent);
+        if let Some(node) = self.get_mut(pid) {
+            node.create_time_ns = create_time_ns;
+        }
+        ptype
+    }
+
+    /// Snapshot of direct child PIDs at exit time.
+    ///
+    /// Not a liveness check — returns whichever children are in the tree when
+    /// called, regardless of whether they are still running.
+    pub fn children_at_exit(&self, pid: u32) -> Vec<u32> {
+        self.get(pid)
+            .map(|n| n.children.clone())
+            .unwrap_or_default()
+    }
+
+    /// Walk the ppid chain from `pid` upward to find the root Agent ancestor.
+    /// Returns `None` if `pid` is itself an Agent, is absent, or has no Agent
+    /// ancestor in the tree.
+    pub fn root_agent_ancestor(&self, pid: u32) -> Option<&LineageNode> {
+        let node = self.nodes.get(&pid)?;
+        if node.process_type == ProcessType::Agent {
+            return None;
+        }
+        let mut current_ppid = node.ppid;
+        for _ in 0..64 {
+            let parent = self.nodes.get(&current_ppid)?;
+            if parent.process_type == ProcessType::Agent {
+                return Some(parent);
+            }
+            current_ppid = parent.ppid;
+        }
+        None
+    }
+
+    /// Get the full subtree rooted at `pid` as a serializable structure
+    pub fn subtree(&self, pid: u32) -> Option<LineageSubtree> {
+        self.subtree_inner(pid, 0)
+    }
+
+    fn subtree_inner(&self, pid: u32, depth: u32) -> Option<LineageSubtree> {
+        if depth > 64 {
+            return None;
+        }
+        let node = self.nodes.get(&pid)?;
+        let children = node
+            .children
+            .iter()
+            .filter_map(|&cpid| self.subtree_inner(cpid, depth + 1))
+            .collect();
+        Some(LineageSubtree {
+            pid: node.pid,
+            ppid: node.ppid,
+            process_type: node.process_type,
+            flags: node.flags,
+            create_time_ns: node.create_time_ns,
+            comm: node.comm.clone(),
+            agent_name: node.agent_name.clone(),
+            children,
+        })
+    }
+
+    /// Return all root nodes (nodes whose ppid is not in the tree)
+    pub fn roots(&self) -> Vec<u32> {
+        self.nodes
+            .values()
+            .filter(|n| !self.nodes.contains_key(&n.ppid))
+            .map(|n| n.pid)
+            .collect()
+    }
+
+    /// Snapshot the entire tree as a flat list.
+    pub fn snapshot(&self) -> Vec<&LineageNode> {
+        self.nodes.values().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}
+
+/// Recursive subtree for JSON serialization
+#[derive(Debug, Clone, Serialize)]
+pub struct LineageSubtree {
+    pub pid: u32,
+    pub ppid: u32,
+    pub process_type: ProcessType,
+    pub flags: u32,
+    pub create_time_ns: u64,
+    pub comm: String,
+    pub agent_name: Option<String>,
+    pub children: Vec<LineageSubtree>,
+}
+
+// ─── Exit classification (crash detection) ───────────────────────────────────
+
+/// Kernel wait-status decoded into a crash classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExitClassification {
+    /// Fatal signal (SIGSEGV, SIGKILL, SIGABRT, SIGBUS, etc.)
+    SignalCrash { signal: u8, coredump: bool },
+    /// Graceful stop (SIGTERM, SIGINT, SIGHUP)
+    GracefulStop { signal: u8 },
+    /// Benign signal (SIGPIPE)
+    BenignSignal { signal: u8 },
+    /// Clean exit (exit(0))
+    NormalExit,
+    /// Non-zero exit status (exit(N), N != 0)
+    AbnormalExit { status: u8 },
+}
+
+impl ExitClassification {
+    pub fn is_crash(&self) -> bool {
+        matches!(self, Self::SignalCrash { .. } | Self::AbnormalExit { .. })
+    }
+}
+
+/// Classify a raw kernel exit_code into a crash category.
+///
+/// exit_code layout (wait(2) encoding):
+///   bits [6:0] = terminating signal (0 if normal exit)
+///   bit  [7]   = core dump produced
+///   bits [15:8] = exit status (only meaningful when signal == 0)
+pub fn classify_exit(exit_code: i32) -> ExitClassification {
+    let signal = (exit_code & 0x7f) as u8;
+    let coredump = (exit_code >> 7) & 1 != 0;
+    let status = ((exit_code >> 8) & 0xff) as u8;
+
+    if signal == 0 {
+        if status == 0 {
+            ExitClassification::NormalExit
+        } else {
+            ExitClassification::AbnormalExit { status }
+        }
+    } else {
+        match signal {
+            // SIGTERM(15), SIGINT(2), SIGHUP(1): graceful stop
+            15 | 2 | 1 => ExitClassification::GracefulStop { signal },
+            // SIGPIPE(13): benign (broken pipe)
+            13 => ExitClassification::BenignSignal { signal },
+            // Everything else: crash (SIGSEGV=11, SIGKILL=9, SIGABRT=6, SIGBUS=7, ...)
+            _ => ExitClassification::SignalCrash { signal, coredump },
+        }
+    }
+}
+
+/// Map a signal number to its conventional name.
+pub fn signal_name(signal: u8) -> &'static str {
+    match signal {
+        1 => "SIGHUP",
+        2 => "SIGINT",
+        6 => "SIGABRT",
+        7 => "SIGBUS",
+        9 => "SIGKILL",
+        11 => "SIGSEGV",
+        13 => "SIGPIPE",
+        15 => "SIGTERM",
+        _ => "SIG?",
+    }
+}
+
+/// Format a one-line crash cause from a raw exit_code.
+pub fn format_crash_cause(exit_code: i32) -> String {
+    let classification = classify_exit(exit_code);
+    match classification {
+        ExitClassification::SignalCrash { signal, coredump } => {
+            format!(
+                "{} (signal {signal}, coredump: {coredump})",
+                signal_name(signal)
+            )
+        }
+        ExitClassification::AbnormalExit { status } => format!("exit({status})"),
+        ExitClassification::NormalExit => "exit(0)".to_string(),
+        ExitClassification::GracefulStop { signal } => {
+            format!("{} (graceful)", signal_name(signal))
+        }
+        ExitClassification::BenignSignal { signal } => {
+            format!("{} (benign)", signal_name(signal))
+        }
+    }
+}
+
+/// Build a structured crash report string from the detail JSON of an agent_crash event.
+///
+/// Expects the detail schema written by `record_agent_crash_interruptions`:
+/// `signal` / `exit_code` / `core_dump` are the decoded wait(2) fields.
+pub fn format_crash_report(detail: &serde_json::Value) -> String {
+    let mut out = String::new();
+    out.push_str("\n  --- Crash Report ---\n");
+    let signal = detail.get("signal").and_then(|v| v.as_u64()).unwrap_or(0);
+    let exit_status = detail
+        .get("exit_code")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let coredump = detail
+        .get("core_dump")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let oom = detail.get("oom").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    if signal > 0 {
+        let sig_name = signal_name(signal as u8);
+        out.push_str(&format!(
+            "  Cause:        {sig_name} (signal {signal}, coredump: {coredump})\n"
+        ));
+    } else {
+        out.push_str(&format!("  Cause:        exit({exit_status})\n"));
+    }
+    out.push_str(&format!(
+        "  OOM Killed:   {}\n",
+        if oom { "yes" } else { "no" }
+    ));
+    if let Some(ptype) = detail.get("process_type").and_then(|v| v.as_str()) {
+        out.push_str(&format!("  Process Type: {ptype}\n"));
+    }
+    if let Some(blast) = detail.get("blast_radius").and_then(|v| v.as_str()) {
+        out.push_str(&format!("  Blast Radius: {blast}\n"));
+    }
+
+    if let Some(calls) = detail.get("call_ids").and_then(|v| v.as_array()) {
+        if !calls.is_empty() {
+            out.push_str(&format!("  Pending LLM Calls ({}):\n", calls.len()));
+            for c in calls {
+                if let Some(s) = c.as_str() {
+                    out.push_str(&format!("    - {s}\n"));
+                }
+            }
+        }
+    }
+
+    if let Some(children) = detail.get("children_at_exit").and_then(|v| v.as_array()) {
+        if !children.is_empty() {
+            let pids: Vec<String> = children
+                .iter()
+                .filter_map(|v| v.as_u64().map(|p| p.to_string()))
+                .collect();
+            out.push_str(&format!("  Children at Exit: [{}]\n", pids.join(", ")));
+        }
+    }
+
+    if let Some(tree) = detail.get("process_tree") {
+        out.push_str("\n  Process Tree at Crash:\n");
+        render_tree_to_string(tree, "    ", true, &mut out);
+    }
+    out
+}
+
+/// Render a process tree JSON node into a string with tree connectors.
+pub fn render_tree_to_string(
+    node: &serde_json::Value,
+    prefix: &str,
+    is_last: bool,
+    out: &mut String,
+) {
+    let pid = node.get("pid").and_then(|v| v.as_u64()).unwrap_or(0);
+    let comm = node.get("comm").and_then(|v| v.as_str()).unwrap_or("?");
+    let ptype = node
+        .get("process_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let connector = if is_last { "`-- " } else { "|-- " };
+    out.push_str(&format!("{prefix}{connector}{comm} [{pid}] ({ptype})\n"));
+    if let Some(children) = node.get("children").and_then(|v| v.as_array()) {
+        let child_prefix = format!("{prefix}{}", if is_last { "    " } else { "|   " });
+        for (i, child) in children.iter().enumerate() {
+            render_tree_to_string(child, &child_prefix, i == children.len() - 1, out);
+        }
+    }
+}
+
+/// Format token usage by process type as JSON string.
+pub fn format_token_by_type_json(rows: &[(String, i64, i64, i64, i64)]) -> String {
+    let data: Vec<_> = rows
+        .iter()
+        .map(|(ptype, count, input, output, total)| {
+            serde_json::json!({
+                "process_type": ptype,
+                "call_count": count,
+                "input_tokens": input,
+                "output_tokens": output,
+                "total_tokens": total,
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&data).unwrap_or_default()
+}
+
+/// Format token usage by process type as a table string.
+pub fn format_token_by_type_table(rows: &[(String, i64, i64, i64, i64)], hours: u64) -> String {
+    use crate::format_tokens_with_commas;
+    let mut out = format!("Token Usage by Process Type (last {hours}h)\n\n");
+    out.push_str(&format!(
+        "{:<12} {:>8} {:>12} {:>12} {:>12}\n",
+        "TYPE", "CALLS", "INPUT", "OUTPUT", "TOTAL"
+    ));
+    out.push_str(&format!("{}\n", "-".repeat(60)));
+    let mut grand_total = 0i64;
+    for (ptype, count, input, output, total) in rows {
+        out.push_str(&format!(
+            "{:<12} {:>8} {:>12} {:>12} {:>12}\n",
+            ptype,
+            count,
+            format_tokens_with_commas(*input as u64),
+            format_tokens_with_commas(*output as u64),
+            format_tokens_with_commas(*total as u64),
+        ));
+        grand_total += total;
+    }
+    out.push_str(&format!("{}\n", "-".repeat(60)));
+    out.push_str(&format!(
+        "{:<12} {:>8} {:>12} {:>12} {:>12}\n",
+        "TOTAL",
+        "",
+        "",
+        "",
+        format_tokens_with_commas(grand_total as u64)
+    ));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_node(pid: u32, ppid: u32, ptype: ProcessType) -> LineageNode {
+        LineageNode {
+            pid,
+            ppid,
+            process_type: ptype,
+            flags: 0,
+            create_time_ns: 0,
+            comm: format!("proc-{pid}"),
+            agent_name: None,
+            children: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_insert_and_parent_link() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+
+        let parent = tree.get(100).unwrap();
+        assert_eq!(parent.children, vec![200]);
+    }
+
+    #[test]
+    fn test_remove_cleans_parent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        tree.remove(200);
+
+        let parent = tree.get(100).unwrap();
+        assert!(parent.children.is_empty());
+    }
+
+    #[test]
+    fn test_classify_agent_mode() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Unknown));
+        tree.classify(100, true, false);
+        assert_eq!(tree.get(100).unwrap().process_type, ProcessType::Agent);
+    }
+
+    #[test]
+    fn test_classify_tool_under_agent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Unknown));
+        tree.classify(200, false, false);
+        assert_eq!(tree.get(200).unwrap().process_type, ProcessType::Tool);
+    }
+
+    #[test]
+    fn test_classify_subagent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Unknown));
+        tree.classify(200, false, true);
+        assert_eq!(tree.get(200).unwrap().process_type, ProcessType::SubAgent);
+    }
+
+    #[test]
+    fn test_roots() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        tree.insert(make_node(300, 2, ProcessType::Agent));
+
+        let roots = tree.roots();
+        assert_eq!(roots.len(), 2);
+        assert!(roots.contains(&100));
+        assert!(roots.contains(&300));
+    }
+
+    /// PID-reuse / re-parent: a pid that re-execs (or whose Exit was dropped)
+    /// under a different parent must NOT leave a phantom child entry on the
+    /// old parent. Discriminating: without the cleanup branch in insert(), the
+    /// final assertion below fails — old parent still lists pid 200.
+    #[test]
+    fn test_insert_cleans_old_parent_on_reparent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(300, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        // Re-insert pid=200 under a different parent (e.g. PID reuse).
+        tree.insert(make_node(200, 300, ProcessType::Tool));
+
+        assert!(
+            tree.get(100).unwrap().children.is_empty(),
+            "old parent 100 must not retain a phantom child 200"
+        );
+        assert_eq!(tree.get(300).unwrap().children, vec![200]);
+        assert_eq!(tree.get(200).unwrap().ppid, 300);
+    }
+
+    /// AGENT_MODE precedence pin (1/2): when the parent is already an Agent,
+    /// a child with has_agent_mode_env=true must classify as Tool — NOT
+    /// promote itself to Agent. The env var is inherited through fork; only
+    /// top-level processes (no tracked parent) are eligible for Agent.
+    /// Discriminating: reordering the match arms in classify() so that
+    /// AGENT_MODE wins over parent_type would flip this case to Agent.
+    #[test]
+    fn test_classify_agent_mode_inherited_under_agent_stays_tool() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Unknown));
+        tree.classify(
+            200, /* has_agent_mode_env */ true, /* matches_agent */ false,
+        );
+        assert_eq!(tree.get(200).unwrap().process_type, ProcessType::Tool);
+    }
+
+    /// AGENT_MODE precedence pin (2/2): same rule but parent is SubAgent.
+    /// Inherited AGENT_MODE under a SubAgent is still a Tool.
+    #[test]
+    fn test_classify_agent_mode_inherited_under_subagent_stays_tool() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::SubAgent));
+        tree.insert(make_node(300, 200, ProcessType::Unknown));
+        tree.classify(
+            300, /* has_agent_mode_env */ true, /* matches_agent */ false,
+        );
+        assert_eq!(tree.get(300).unwrap().process_type, ProcessType::Tool);
+    }
+
+    /// `ProcessType::Skill` is forward-declared. Document the current
+    /// behaviour: classify() never produces Skill regardless of inputs.
+    /// Tightens the contract so a future scorer change is explicit.
+    #[test]
+    fn test_classify_never_produces_skill_today() {
+        // Try a variety of parent types + flags; none should yield Skill.
+        for parent_type in [
+            ProcessType::Unknown,
+            ProcessType::Agent,
+            ProcessType::SubAgent,
+            ProcessType::Tool,
+            ProcessType::Skill,
+        ] {
+            let mut tree = LineageTree::new();
+            tree.insert(make_node(100, 1, parent_type));
+            tree.insert(make_node(200, 100, ProcessType::Unknown));
+            for has_env in [false, true] {
+                for matches in [false, true] {
+                    tree.classify(200, has_env, matches);
+                    assert_ne!(
+                        tree.get(200).unwrap().process_type,
+                        ProcessType::Skill,
+                        "classify() must not produce Skill (forward-declared)",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_classify_cmdline_match_root_becomes_agent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Unknown));
+        // cmdline-matched root with no AGENT_MODE — should still become Agent
+        tree.classify(
+            100, /* has_agent_mode_env */ false, /* matches_agent */ true,
+        );
+        assert_eq!(
+            tree.get(100).unwrap().process_type,
+            ProcessType::Agent,
+            "cmdline-matched root process must be classified as Agent"
+        );
+    }
+
+    #[test]
+    fn test_reinsert_preserves_children() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        tree.insert(make_node(300, 200, ProcessType::Tool));
+
+        assert_eq!(tree.get(200).unwrap().children, vec![300]);
+
+        // Re-insert 200 (simulates re-execve or procmon+proctrace double-insert)
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+
+        assert_eq!(
+            tree.get(200).unwrap().children,
+            vec![300],
+            "re-insert must preserve accumulated children",
+        );
+    }
+
+    #[test]
+    fn test_lineage_node_fields_and_flags() {
+        let node = LineageNode {
+            pid: 1,
+            ppid: 0,
+            process_type: ProcessType::Agent,
+            flags: LINEAGE_FLAG_AGENT_MODE,
+            create_time_ns: 12345,
+            comm: "test".to_string(),
+            agent_name: Some("TestAgent".to_string()),
+            children: vec![2, 3],
+        };
+        assert!(node.has_agent_mode());
+        assert_eq!(node.pid, 1);
+        assert_eq!(node.ppid, 0);
+        assert_eq!(node.comm, "test");
+        assert_eq!(node.agent_name, Some("TestAgent".to_string()));
+        assert_eq!(node.children, vec![2, 3]);
+
+        // without flag
+        let node2 = LineageNode {
+            pid: 2,
+            ppid: 1,
+            process_type: ProcessType::Tool,
+            flags: 0,
+            create_time_ns: 0,
+            comm: "bash".to_string(),
+            agent_name: None,
+            children: vec![],
+        };
+        assert!(!node2.has_agent_mode());
+    }
+
+    #[test]
+    fn test_snapshot() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        tree.insert(make_node(300, 100, ProcessType::SubAgent));
+
+        let snap = tree.snapshot();
+        assert_eq!(snap.len(), 3);
+    }
+
+    #[test]
+    fn test_subtree() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        tree.insert(make_node(300, 100, ProcessType::SubAgent));
+        tree.insert(make_node(400, 200, ProcessType::Tool));
+
+        // subtree from root
+        let sub = tree.subtree(100);
+        assert!(sub.is_some());
+        let sub = sub.unwrap();
+        assert_eq!(sub.pid, 100);
+        assert_eq!(sub.children.len(), 2);
+
+        // subtree from leaf
+        let leaf = tree.subtree(400);
+        assert!(leaf.is_some());
+        assert_eq!(leaf.unwrap().children.len(), 0);
+
+        // subtree from non-existent
+        let none = tree.subtree(999);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn test_remove_reparents_children_to_grandparent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(1, 0, ProcessType::Agent));
+        tree.insert(make_node(2, 1, ProcessType::Tool));
+        tree.insert(make_node(3, 2, ProcessType::Tool));
+        tree.insert(make_node(4, 2, ProcessType::Tool));
+
+        // Remove middle node (pid=2), children should reparent to pid=1
+        let removed = tree.remove(2);
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().pid, 2);
+
+        // Children 3,4 should now have ppid=1
+        assert_eq!(tree.get(3).unwrap().ppid, 1);
+        assert_eq!(tree.get(4).unwrap().ppid, 1);
+
+        // Parent 1 should have children 3,4
+        let parent = tree.get(1).unwrap();
+        assert!(parent.children.contains(&3));
+        assert!(parent.children.contains(&4));
+        assert!(!parent.children.contains(&2));
+    }
+
+    #[test]
+    fn test_remove_reparent_deduplicates_existing_child_link() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(1, 0, ProcessType::Agent));
+        tree.insert(make_node(2, 1, ProcessType::Tool));
+        tree.insert(make_node(3, 2, ProcessType::Tool));
+        // Simulate an out-of-order / duplicate parent edge that can exist after
+        // missed exits or PID reuse. Removing 2 should not duplicate child 3.
+        tree.get_mut(1).unwrap().children.push(3);
+
+        tree.remove(2);
+
+        let children = &tree.get(1).unwrap().children;
+        assert_eq!(
+            children.iter().filter(|&&pid| pid == 3).count(),
+            1,
+            "reparent must not duplicate an existing child edge"
+        );
+        assert_eq!(tree.get(3).unwrap().ppid, 1);
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let mut tree = LineageTree::new();
+        assert!(tree.is_empty());
+        assert_eq!(tree.len(), 0);
+
+        tree.insert(make_node(100, 1, ProcessType::Unknown));
+        assert!(!tree.is_empty());
+        assert_eq!(tree.len(), 1);
+
+        tree.remove(100);
+        assert!(tree.is_empty());
+    }
+
+    #[test]
+    fn test_classify_nonexistent_pid_is_noop() {
+        let mut tree = LineageTree::new();
+        // Should not panic, just return early
+        tree.classify(999, true, true);
+        assert!(tree.get(999).is_none());
+    }
+
+    // --- insert_and_classify tests ---
+
+    #[test]
+    fn test_insert_and_classify_root_agent() {
+        let mut tree = LineageTree::new();
+        let pt = tree.insert_and_classify(100, 1, "cosh", Some("Cosh".to_string()), false, true);
+        assert_eq!(pt, ProcessType::Agent);
+        assert_eq!(tree.get(100).unwrap().comm, "cosh");
+        assert_eq!(tree.get(100).unwrap().agent_name, Some("Cosh".to_string()));
+    }
+
+    #[test]
+    fn test_insert_and_classify_tool_under_agent() {
+        let mut tree = LineageTree::new();
+        tree.insert_and_classify(100, 1, "cosh", Some("Cosh".to_string()), false, true);
+        let pt = tree.insert_and_classify(200, 100, "bash", None, false, false);
+        assert_eq!(pt, ProcessType::Tool);
+    }
+
+    #[test]
+    fn test_insert_and_classify_with_agent_mode() {
+        let mut tree = LineageTree::new();
+        let pt = tree.insert_and_classify(
+            100,
+            1,
+            "python",
+            Some("agent-mode-python".to_string()),
+            true,
+            false,
+        );
+        assert_eq!(pt, ProcessType::Agent);
+        assert!(tree.get(100).unwrap().has_agent_mode());
+    }
+
+    #[test]
+    fn test_insert_and_classify_skips_existing() {
+        let mut tree = LineageTree::new();
+        tree.insert_and_classify(100, 1, "cosh", Some("Cosh".to_string()), false, true);
+        // Second call should not overwrite
+        let pt = tree.insert_and_classify(100, 1, "different", None, false, false);
+        // Should re-classify based on current state (no parent in tree -> Unknown)
+        // but original comm is preserved
+        assert_eq!(tree.get(100).unwrap().comm, "cosh");
+        // Re-classify: no tracked parent, matches_agent=false, has_agent_mode=false -> Unknown
+        assert_eq!(pt, ProcessType::Unknown);
+    }
+
+    #[test]
+    fn test_insert_and_classify_subagent_under_agent() {
+        let mut tree = LineageTree::new();
+        tree.insert_and_classify(100, 1, "cosh", Some("Cosh".to_string()), false, true);
+        let pt =
+            tree.insert_and_classify(200, 100, "sub-agent", Some("Sub".to_string()), false, true);
+        assert_eq!(pt, ProcessType::SubAgent);
+    }
+
+    #[test]
+    fn test_record_exec_classifies_root_agent_and_stamps_time() {
+        let mut tree = LineageTree::new();
+        let pt = tree.record_exec(100, 1, "cosh", Some("Cosh".to_string()), 42);
+        assert_eq!(pt, ProcessType::Agent);
+        assert_eq!(tree.get(100).unwrap().create_time_ns, 42);
+    }
+
+    #[test]
+    fn test_record_exec_tool_child_under_agent() {
+        let mut tree = LineageTree::new();
+        tree.record_exec(100, 1, "cosh", Some("Cosh".to_string()), 1);
+        // Child with no agent_name under an Agent classifies as Tool.
+        let pt = tree.record_exec(200, 100, "bash", None, 2);
+        assert_eq!(pt, ProcessType::Tool);
+    }
+
+    /// AGENT_MODE precedence pin: `record_exec` must derive `matches_agent` as
+    /// false when the node already carries AGENT_MODE, so an inherited-env child
+    /// with an agent_name still classifies as Tool — not promote to SubAgent.
+    /// Discriminating: dropping the `!has_agent_mode` term in `record_exec`
+    /// would flip this to SubAgent.
+    #[test]
+    fn test_record_exec_agent_mode_node_stays_tool() {
+        let mut tree = LineageTree::new();
+        tree.record_exec(100, 1, "cosh", Some("Cosh".to_string()), 1);
+        // Seed an AGENT_MODE child node under the agent.
+        tree.insert(LineageNode {
+            pid: 200,
+            ppid: 100,
+            process_type: ProcessType::Unknown,
+            flags: LINEAGE_FLAG_AGENT_MODE,
+            create_time_ns: 0,
+            comm: "child".to_string(),
+            agent_name: None,
+            children: vec![],
+        });
+        // Re-exec the AGENT_MODE node with an agent_name: matches_agent must be
+        // suppressed by has_agent_mode, so it stays Tool (not SubAgent).
+        let pt = tree.record_exec(200, 100, "child", Some("X".to_string()), 5);
+        assert_eq!(pt, ProcessType::Tool);
+    }
+
+    #[test]
+    fn test_children_at_exit_returns_children() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        tree.insert(make_node(300, 100, ProcessType::Tool));
+        let mut orphans = tree.children_at_exit(100);
+        orphans.sort();
+        assert_eq!(orphans, vec![200, 300]);
+    }
+
+    #[test]
+    fn test_children_at_exit_empty_for_leaf_and_missing() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        assert!(tree.children_at_exit(100).is_empty());
+        assert!(tree.children_at_exit(999).is_empty());
+    }
+
+    // ─── classify_exit tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_classify_exit_normal() {
+        assert_eq!(classify_exit(0), ExitClassification::NormalExit);
+    }
+
+    #[test]
+    fn test_classify_exit_abnormal_status() {
+        assert_eq!(
+            classify_exit(1 << 8),
+            ExitClassification::AbnormalExit { status: 1 }
+        );
+        assert_eq!(
+            classify_exit(2 << 8),
+            ExitClassification::AbnormalExit { status: 2 }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigsegv() {
+        let code = 11; // SIGSEGV, no coredump
+        assert_eq!(
+            classify_exit(code),
+            ExitClassification::SignalCrash {
+                signal: 11,
+                coredump: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigsegv_with_coredump() {
+        let code = 11 | 0x80; // SIGSEGV + coredump bit
+        assert_eq!(
+            classify_exit(code),
+            ExitClassification::SignalCrash {
+                signal: 11,
+                coredump: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigkill() {
+        assert_eq!(
+            classify_exit(9),
+            ExitClassification::SignalCrash {
+                signal: 9,
+                coredump: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigterm_graceful() {
+        assert_eq!(
+            classify_exit(15),
+            ExitClassification::GracefulStop { signal: 15 }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigint_graceful() {
+        assert_eq!(
+            classify_exit(2),
+            ExitClassification::GracefulStop { signal: 2 }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigpipe_benign() {
+        assert_eq!(
+            classify_exit(13),
+            ExitClassification::BenignSignal { signal: 13 }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigabrt() {
+        assert_eq!(
+            classify_exit(6),
+            ExitClassification::SignalCrash {
+                signal: 6,
+                coredump: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_is_crash() {
+        assert!(
+            ExitClassification::SignalCrash {
+                signal: 11,
+                coredump: false
+            }
+            .is_crash()
+        );
+        assert!(ExitClassification::AbnormalExit { status: 1 }.is_crash());
+        assert!(!ExitClassification::NormalExit.is_crash());
+        assert!(!ExitClassification::GracefulStop { signal: 15 }.is_crash());
+        assert!(!ExitClassification::BenignSignal { signal: 13 }.is_crash());
+    }
+
+    #[test]
+    fn test_classify_exit_sighup_graceful() {
+        assert_eq!(
+            classify_exit(1),
+            ExitClassification::GracefulStop { signal: 1 }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_sigbus() {
+        assert_eq!(
+            classify_exit(7),
+            ExitClassification::SignalCrash {
+                signal: 7,
+                coredump: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_max_status() {
+        assert_eq!(
+            classify_exit(255 << 8),
+            ExitClassification::AbnormalExit { status: 255 }
+        );
+    }
+
+    #[test]
+    fn test_classify_exit_coredump_bit_without_signal() {
+        // exit_code=0x80: coredump bit set but signal=0. Kernel won't produce
+        // this, but classify_exit treats signal=0 as normal exit (coredump bit
+        // is only meaningful with a terminating signal).
+        assert_eq!(classify_exit(0x80), ExitClassification::NormalExit);
+    }
+
+    // ─── signal_name / format_crash_cause tests ──────────────────────
+
+    #[test]
+    fn test_signal_name_known() {
+        assert_eq!(signal_name(11), "SIGSEGV");
+        assert_eq!(signal_name(9), "SIGKILL");
+        assert_eq!(signal_name(6), "SIGABRT");
+        assert_eq!(signal_name(15), "SIGTERM");
+        assert_eq!(signal_name(2), "SIGINT");
+        assert_eq!(signal_name(1), "SIGHUP");
+        assert_eq!(signal_name(7), "SIGBUS");
+        assert_eq!(signal_name(13), "SIGPIPE");
+    }
+
+    #[test]
+    fn test_signal_name_unknown() {
+        assert_eq!(signal_name(99), "SIG?");
+        assert_eq!(signal_name(0), "SIG?");
+    }
+
+    #[test]
+    fn test_format_crash_cause_sigsegv() {
+        assert_eq!(
+            format_crash_cause(11),
+            "SIGSEGV (signal 11, coredump: false)"
+        );
+    }
+
+    #[test]
+    fn test_format_crash_cause_sigsegv_coredump() {
+        assert_eq!(
+            format_crash_cause(11 | 0x80),
+            "SIGSEGV (signal 11, coredump: true)"
+        );
+    }
+
+    #[test]
+    fn test_format_crash_cause_abnormal_exit() {
+        assert_eq!(format_crash_cause(1 << 8), "exit(1)");
+    }
+
+    #[test]
+    fn test_format_crash_cause_normal_exit() {
+        assert_eq!(format_crash_cause(0), "exit(0)");
+    }
+
+    #[test]
+    fn test_format_crash_cause_sigterm_graceful() {
+        assert_eq!(format_crash_cause(15), "SIGTERM (graceful)");
+    }
+
+    #[test]
+    fn test_format_crash_cause_sigpipe_benign() {
+        assert_eq!(format_crash_cause(13), "SIGPIPE (benign)");
+    }
+
+    // ─── format_crash_report / render_tree_to_string tests ────────────
+
+    #[test]
+    fn test_format_crash_report_sigsegv() {
+        let detail = serde_json::json!({
+            "signal": 11, "exit_code": 0, "core_dump": true, "oom": false,
+            "process_type": "agent", "blast_radius": "total_session_loss",
+            "call_ids": ["call-1", "call-2"],
+            "children_at_exit": [200, 300],
+        });
+        let report = format_crash_report(&detail);
+        assert!(report.contains("SIGSEGV"));
+        assert!(report.contains("coredump: true"));
+        assert!(report.contains("OOM Killed:   no"));
+        assert!(report.contains("Process Type: agent"));
+        assert!(report.contains("Blast Radius: total_session_loss"));
+        assert!(report.contains("Pending LLM Calls (2)"));
+        assert!(report.contains("call-1"));
+        assert!(report.contains("Children at Exit: [200, 300]"));
+    }
+
+    #[test]
+    fn test_format_crash_report_abnormal_exit() {
+        let detail = serde_json::json!({
+            "signal": 0, "exit_code": 1, "core_dump": false, "oom": false,
+        });
+        let report = format_crash_report(&detail);
+        assert!(report.contains("exit(1)"));
+        assert!(!report.contains("SIGSEGV"));
+    }
+
+    #[test]
+    fn test_format_crash_report_with_process_tree() {
+        let detail = serde_json::json!({
+            "signal": 9, "exit_code": 0, "core_dump": false, "oom": true,
+            "process_tree": {
+                "pid": 100, "comm": "claude", "process_type": "agent",
+                "children": [
+                    {"pid": 200, "comm": "bash", "process_type": "tool", "children": []}
+                ]
+            }
+        });
+        let report = format_crash_report(&detail);
+        assert!(report.contains("SIGKILL"));
+        assert!(report.contains("OOM Killed:   yes"));
+        assert!(report.contains("claude [100] (agent)"));
+        assert!(report.contains("bash [200] (tool)"));
+    }
+
+    #[test]
+    fn test_render_tree_to_string_nested() {
+        let tree = serde_json::json!({
+            "pid": 1, "comm": "root", "process_type": "agent",
+            "children": [
+                {"pid": 2, "comm": "child1", "process_type": "tool", "children": []},
+                {"pid": 3, "comm": "child2", "process_type": "sub_agent", "children": [
+                    {"pid": 4, "comm": "grandchild", "process_type": "tool", "children": []}
+                ]}
+            ]
+        });
+        let mut out = String::new();
+        render_tree_to_string(&tree, "", true, &mut out);
+        assert!(out.contains("`-- root [1] (agent)"));
+        assert!(out.contains("|-- child1 [2] (tool)"));
+        assert!(out.contains("`-- child2 [3] (sub_agent)"));
+        assert!(out.contains("`-- grandchild [4] (tool)"));
+    }
+
+    #[test]
+    fn test_format_token_by_type_table() {
+        let rows = vec![
+            ("agent".to_string(), 10, 5000, 3000, 8000),
+            ("tool".to_string(), 2, 200, 100, 300),
+        ];
+        let table = format_token_by_type_table(&rows, 24);
+        assert!(table.contains("Token Usage by Process Type (last 24h)"));
+        assert!(table.contains("agent"));
+        assert!(table.contains("tool"));
+        assert!(table.contains("8,000"));
+        assert!(table.contains("TOTAL"));
+    }
+
+    #[test]
+    fn test_format_token_by_type_json() {
+        let rows = vec![("agent".to_string(), 5, 1000, 500, 1500)];
+        let json = format_token_by_type_json(&rows);
+        assert!(json.contains("\"process_type\": \"agent\""));
+        assert!(json.contains("\"total_tokens\": 1500"));
+    }
+
+    // ─── root_agent_ancestor tests ───────────────────────────────────
+
+    #[test]
+    fn test_root_agent_ancestor_tool_under_agent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::Tool));
+        let root = tree.root_agent_ancestor(200).unwrap();
+        assert_eq!(root.pid, 100);
+    }
+
+    #[test]
+    fn test_root_agent_ancestor_nested() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        tree.insert(make_node(200, 100, ProcessType::SubAgent));
+        tree.insert(make_node(300, 200, ProcessType::Tool));
+        let root = tree.root_agent_ancestor(300).unwrap();
+        assert_eq!(root.pid, 100);
+    }
+
+    #[test]
+    fn test_root_agent_ancestor_none_for_agent() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(100, 1, ProcessType::Agent));
+        assert!(tree.root_agent_ancestor(100).is_none());
+    }
+
+    #[test]
+    fn test_root_agent_ancestor_none_for_orphan() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(200, 999, ProcessType::Tool));
+        assert!(tree.root_agent_ancestor(200).is_none());
+    }
+
+    #[test]
+    fn test_root_agent_ancestor_none_for_missing() {
+        let tree = LineageTree::new();
+        assert!(tree.root_agent_ancestor(999).is_none());
+    }
+
+    #[test]
+    fn test_process_type_as_str() {
+        assert_eq!(ProcessType::Agent.as_str(), "agent");
+        assert_eq!(ProcessType::SubAgent.as_str(), "sub_agent");
+        assert_eq!(ProcessType::Tool.as_str(), "tool");
+        assert_eq!(ProcessType::Unknown.as_str(), "unknown");
+        assert_eq!(ProcessType::Skill.as_str(), "skill");
+    }
+
+    #[test]
+    fn test_process_type_from_u32() {
+        assert_eq!(ProcessType::from_u32(0), ProcessType::Unknown);
+        assert_eq!(ProcessType::from_u32(1), ProcessType::Agent);
+        assert_eq!(ProcessType::from_u32(2), ProcessType::SubAgent);
+        assert_eq!(ProcessType::from_u32(3), ProcessType::Tool);
+        assert_eq!(ProcessType::from_u32(4), ProcessType::Skill);
+        assert_eq!(ProcessType::from_u32(99), ProcessType::Unknown);
+    }
+
+    #[test]
+    fn test_process_type_as_u32_roundtrip() {
+        for v in 0..=4 {
+            assert_eq!(ProcessType::from_u32(v).as_u32(), v);
+        }
+    }
+
+    #[test]
+    fn test_format_crash_report_no_optional_fields() {
+        let detail = serde_json::json!({
+            "signal": 0, "exit_status": 0, "coredump": false, "oom": false,
+        });
+        let report = format_crash_report(&detail);
+        assert!(report.contains("exit(0)"));
+        assert!(!report.contains("Pending LLM Calls"));
+        assert!(!report.contains("Children at Exit"));
+        assert!(!report.contains("Process Tree"));
+        assert!(!report.contains("Process Type"));
+        assert!(!report.contains("Blast Radius"));
+    }
+
+    #[test]
+    fn test_format_crash_report_oom() {
+        let detail = serde_json::json!({
+            "signal": 9, "exit_status": 0, "coredump": false, "oom": true,
+            "process_type": "tool", "blast_radius": "recoverable",
+        });
+        let report = format_crash_report(&detail);
+        assert!(report.contains("SIGKILL"));
+        assert!(report.contains("OOM Killed:   yes"));
+        assert!(report.contains("Process Type: tool"));
+        assert!(report.contains("Blast Radius: recoverable"));
+    }
+
+    #[test]
+    fn test_format_token_by_type_table_empty() {
+        let rows: Vec<(String, i64, i64, i64, i64)> = vec![];
+        let table = format_token_by_type_table(&rows, 12);
+        assert!(table.contains("last 12h"));
+        assert!(table.contains("TOTAL"));
+    }
+
+    #[test]
+    fn test_insert_preserves_children_on_reinsert() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(1, 0, ProcessType::Agent));
+        tree.insert(make_node(2, 1, ProcessType::Tool));
+        assert_eq!(tree.get(1).unwrap().children, vec![2]);
+        let mut replacement = make_node(1, 0, ProcessType::Agent);
+        replacement.comm = "updated".to_string();
+        tree.insert(replacement);
+        assert_eq!(tree.get(1).unwrap().children, vec![2]);
+        assert_eq!(tree.get(1).unwrap().comm, "updated");
+    }
+
+    #[test]
+    fn test_snapshot_returns_all_nodes() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(1, 0, ProcessType::Agent));
+        tree.insert(make_node(2, 1, ProcessType::Tool));
+        tree.insert(make_node(3, 1, ProcessType::SubAgent));
+        assert_eq!(tree.snapshot().len(), 3);
+    }
+
+    #[test]
+    fn test_roots_returns_parentless_nodes() {
+        let mut tree = LineageTree::new();
+        tree.insert(make_node(1, 999, ProcessType::Agent));
+        tree.insert(make_node(2, 1, ProcessType::Tool));
+        let roots = tree.roots();
+        assert_eq!(roots, vec![1]);
+    }
+}

--- a/src/agentsight/src/probes/codex_offsets.rs
+++ b/src/agentsight/src/probes/codex_offsets.rs
@@ -115,7 +115,7 @@ fn compute_head_sha256(path: &str) -> Option<String> {
     let n = f.read(&mut buf).ok()?;
     buf.truncate(n);
     let hash = Sha256::digest(&buf);
-    Some(hash.iter().map(|b| format!("{:02x}", b)).collect())
+    Some(hash.iter().map(|b| format!("{b:02x}")).collect())
 }
 
 #[cfg(test)]

--- a/src/agentsight/src/probes/elf_buildid.rs
+++ b/src/agentsight/src/probes/elf_buildid.rs
@@ -106,7 +106,7 @@ pub fn read_buildid(path: &str) -> Option<String> {
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 #[cfg(test)]

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -1391,6 +1391,7 @@ mod tests {
                 call_kind: "main".to_string(),
                 pending_origin: PendingOrigin::RequestCapture,
                 pending_match_key: None,
+                process_type: None,
             })
             .unwrap();
         store.flush();

--- a/src/agentsight/src/server/token_savings.rs
+++ b/src/agentsight/src/server/token_savings.rs
@@ -351,13 +351,11 @@ pub(crate) fn build_explanation(
 ) -> String {
     if category == "mcp_response" {
         format!(
-            "MCP响应压缩: 原始 {} tokens → {} tokens，压缩率 {:.1}%。后续 {} 轮LLM调用均受益，复合节省 {} tokens。",
-            before_tokens, after_tokens, compression_ratio, compounding_turns, compounded
+            "MCP响应压缩: 原始 {before_tokens} tokens → {after_tokens} tokens，压缩率 {compression_ratio:.1}%。后续 {compounding_turns} 轮LLM调用均受益，复合节省 {compounded} tokens。"
         )
     } else {
         format!(
-            "工具输出优化: 原始 {} tokens → {} tokens，压缩率 {:.1}%。后续 {} 轮LLM调用均受益，复合节省 {} tokens。",
-            before_tokens, after_tokens, compression_ratio, compounding_turns, compounded
+            "工具输出优化: 原始 {before_tokens} tokens → {after_tokens} tokens，压缩率 {compression_ratio:.1}%。后续 {compounding_turns} 轮LLM调用均受益，复合节省 {compounded} tokens。"
         )
     }
 }
@@ -414,7 +412,7 @@ pub(crate) fn generate_optimization_tips(
     if zero_savings_sessions > 0 {
         tips.push(OptimizationTip {
             level: "info".to_string(),
-            title: format!("发现 {} 个未优化会话", zero_savings_sessions),
+            title: format!("发现 {zero_savings_sessions} 个未优化会话"),
             description: "部分会话消耗较高但无优化记录，可能是对应 Agent 未启用 tokenless 或工具调用较少。建议检查这些会话的 Agent 配置。".to_string(),
         });
     }
@@ -424,8 +422,7 @@ pub(crate) fn generate_optimization_tips(
             level: "success".to_string(),
             title: "节省效果优秀".to_string(),
             description: format!(
-                "当前复合节省率 {:.1}%，表现优秀！继续保持当前配置。",
-                grand_compounded_rate
+                "当前复合节省率 {grand_compounded_rate:.1}%，表现优秀！继续保持当前配置。"
             ),
         });
     } else if grand_compounded_rate >= 15.0 {
@@ -433,8 +430,7 @@ pub(crate) fn generate_optimization_tips(
             level: "success".to_string(),
             title: "节省效果良好".to_string(),
             description: format!(
-                "当前复合节省率 {:.1}%，已达到良好水平。可尝试调整压缩策略以进一步提升。",
-                grand_compounded_rate
+                "当前复合节省率 {grand_compounded_rate:.1}%，已达到良好水平。可尝试调整压缩策略以进一步提升。"
             ),
         });
     }

--- a/src/agentsight/src/storage/sqlite/genai/events.rs
+++ b/src/agentsight/src/storage/sqlite/genai/events.rs
@@ -328,6 +328,43 @@ impl GenAISqliteStore {
         }
     }
 
+    /// Aggregate token usage grouped by process_type within a time range.
+    pub fn token_usage_by_process_type(
+        &self,
+        start_ns: i64,
+        end_ns: i64,
+    ) -> Result<Vec<(String, i64, i64, i64, i64)>, Box<dyn std::error::Error>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT COALESCE(process_type, 'unknown'), \
+                    COUNT(*), \
+                    COALESCE(SUM(input_tokens), 0), \
+                    COALESCE(SUM(output_tokens), 0), \
+                    COALESCE(SUM(total_tokens), 0) \
+             FROM genai_events \
+             WHERE event_type = 'llm_call' \
+               AND status = 'complete' \
+               AND start_timestamp_ns >= ?1 \
+               AND start_timestamp_ns <= ?2 \
+             GROUP BY COALESCE(process_type, 'unknown') \
+             ORDER BY COALESCE(SUM(total_tokens), 0) DESC",
+        )?;
+        let rows = stmt.query_map(params![start_ns, end_ns], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })?;
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row?);
+        }
+        Ok(result)
+    }
+
     /// Try to insert an event without size check
     fn try_insert_event(
         &self,
@@ -448,12 +485,13 @@ impl GenAISqliteStore {
                         cache_creation_tokens, cache_read_tokens,
                         system_instructions, input_messages, output_messages,
                         user_query, http_method, http_path, status_code,
-                        is_sse, sse_event_count, event_json, tool_call_ids, call_kind
+                        is_sse, sse_event_count, event_json, tool_call_ids, call_kind,
+                        process_type
                     ) VALUES (
                         ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
                         ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22,
                         ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32,
-                        ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41
+                        ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41, ?42
                     )",
                     params![
                         "llm_call",
@@ -497,6 +535,7 @@ impl GenAISqliteStore {
                         event_json,
                         tool_call_ids,
                         call.metadata.get("call_kind").map(|s| s.as_str()).unwrap_or("main"),
+                        call.process_type,
                     ],
                 )?;
             }

--- a/src/agentsight/src/storage/sqlite/genai/pending.rs
+++ b/src/agentsight/src/storage/sqlite/genai/pending.rs
@@ -70,6 +70,8 @@ pub struct PendingCallInfo {
     pub pending_origin: PendingOrigin,
     /// Deterministic key used to reconcile idle snapshots with resumed streams.
     pub pending_match_key: Option<String>,
+    /// Process type from lineage tree (agent/sub_agent/tool)
+    pub process_type: Option<String>,
 }
 
 /// Data extracted from captured SSE events for enriching a pending record.
@@ -100,14 +102,14 @@ impl GenAISqliteStore {
                 start_timestamp_ns, pid, process_name, agent_name,
                 http_method, http_path, is_sse,
                 input_messages, system_instructions, user_query,
-                model, provider, call_kind, pending_origin, pending_match_key,
+                model, provider, call_kind, pending_origin, pending_match_key, process_type,
                 event_json
             ) VALUES (
                 'llm_call', 'pending', ?1, ?2, ?3, ?4, ?5,
                 ?6, ?7, ?8, ?9,
                 ?10, ?11, ?12,
                 ?13, ?14, ?15,
-                ?16, ?17, ?18, ?19, ?20,
+                ?16, ?17, ?18, ?19, ?20, ?21,
                 '{}'
             )",
             params![
@@ -131,6 +133,7 @@ impl GenAISqliteStore {
                 info.call_kind,
                 info.pending_origin.as_str(),
                 info.pending_match_key,
+                info.process_type,
             ],
         )?;
         Ok(())

--- a/src/agentsight/src/storage/sqlite/genai/schema.rs
+++ b/src/agentsight/src/storage/sqlite/genai/schema.rs
@@ -198,6 +198,9 @@ impl GenAISqliteStore {
         // v8: stable key used to reconcile idle stream snapshots on completion
         ensure_col!("pending_match_key", "TEXT", "idx_genai_pending_match_key");
 
+        // v9: process type from lineage tree (agent/sub_agent/tool)
+        ensure_col!("process_type", "TEXT");
+
         Ok(())
     }
 

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -668,6 +668,7 @@ fn test_insert_pending() {
         call_kind: "main".to_string(),
         pending_origin: PendingOrigin::RequestCapture,
         pending_match_key: None,
+        process_type: None,
     };
     store.insert_pending(&info).unwrap();
     let conn = store.conn.lock().unwrap();
@@ -709,6 +710,7 @@ fn test_insert_pending_records_idle_origin_and_match_key() {
         call_kind: "main".to_string(),
         pending_origin: PendingOrigin::IdleDrain,
         pending_match_key: Some("match-idle-1".to_string()),
+        process_type: None,
     };
     store.insert_pending(&info).unwrap();
 
@@ -752,6 +754,7 @@ fn test_complete_pending_promotes_idle_snapshot_by_match_key() {
         call_kind: "main".to_string(),
         pending_origin: PendingOrigin::IdleDrain,
         pending_match_key: Some("match-idle-2".to_string()),
+        process_type: None,
     };
     store.insert_pending(&info).unwrap();
 
@@ -923,6 +926,7 @@ fn test_crash_sweep_ignores_idle_drain_pending() {
             call_kind: "main".to_string(),
             pending_origin: origin,
             pending_match_key: Some(format!("match-{call_id}")),
+            process_type: None,
         };
         store.insert_pending(&info).unwrap();
     }
@@ -1048,6 +1052,7 @@ fn make_store_with_pending(records: &[(&str, &str, &str, &str, i64)]) -> GenAISq
             call_kind: kind.to_string(),
             pending_origin: PendingOrigin::RequestCapture,
             pending_match_key: None,
+            process_type: None,
         };
         store.insert_pending(&info).unwrap();
     }
@@ -1219,6 +1224,7 @@ fn poison_recovery_flush_still_operational() {
         call_kind: "main".to_string(),
         pending_origin: PendingOrigin::RequestCapture,
         pending_match_key: None,
+        process_type: None,
     };
     store.insert_pending(&info).unwrap();
 
@@ -1265,4 +1271,135 @@ fn poison_recovery_flush_still_operational() {
     store.flush();
 
     cleanup_db(&path);
+}
+
+#[test]
+fn test_token_usage_by_process_type() {
+    let path = std::env::temp_dir().join(format!(
+        "test_token_by_ptype_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+
+    // Insert events with different process_types
+    let mut call1 = LLMCall::new(
+        "c1".into(),
+        1000,
+        "openai".into(),
+        "gpt-4".into(),
+        LLMRequest {
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            top_p: None,
+            top_k: None,
+            seed: None,
+            stop_sequences: None,
+            stream: false,
+            tools: None,
+            raw_body: None,
+        },
+        100,
+        "agent".into(),
+    );
+    call1.process_type = Some("agent".into());
+    call1.token_usage = Some(crate::genai::semantic::TokenUsage {
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+    });
+    call1.end_timestamp_ns = 2000;
+    call1.duration_ns = 1000;
+    store
+        .store_event(&GenAISemanticEvent::LLMCall(call1))
+        .unwrap();
+
+    let mut call2 = LLMCall::new(
+        "c2".into(),
+        1500,
+        "openai".into(),
+        "gpt-4".into(),
+        LLMRequest {
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            top_p: None,
+            top_k: None,
+            seed: None,
+            stop_sequences: None,
+            stream: false,
+            tools: None,
+            raw_body: None,
+        },
+        200,
+        "tool".into(),
+    );
+    call2.process_type = Some("tool".into());
+    call2.token_usage = Some(crate::genai::semantic::TokenUsage {
+        input_tokens: 30,
+        output_tokens: 10,
+        total_tokens: 40,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+    });
+    call2.end_timestamp_ns = 2500;
+    call2.duration_ns = 1000;
+    store
+        .store_event(&GenAISemanticEvent::LLMCall(call2))
+        .unwrap();
+
+    // Insert a pending-status event that should be EXCLUDED by the query's
+    // `status = 'complete'` filter. Without this negative case, deleting the
+    // filter from the SQL would not cause the test to fail.
+    let pending = super::pending::PendingCallInfo {
+        call_id: "pending-1".into(),
+        trace_id: None,
+        conversation_id: None,
+        session_id: None,
+        start_timestamp_ns: 2000,
+        pid: 300,
+        process_name: "agent".into(),
+        agent_name: Some("pending-agent".into()),
+        http_method: Some("POST".into()),
+        http_path: Some("/v1/chat".into()),
+        is_sse: true,
+        input_messages: None,
+        system_instructions: None,
+        user_query: None,
+        model: None,
+        provider: None,
+        call_kind: "main".into(),
+        pending_origin: PendingOrigin::RequestCapture,
+        pending_match_key: None,
+        process_type: Some("agent".into()),
+    };
+    store.insert_pending(&pending).unwrap();
+
+    let result = store.token_usage_by_process_type(0, 10000).unwrap();
+    assert_eq!(
+        result.len(),
+        2,
+        "pending row must be excluded by status='complete' filter"
+    );
+    // Sorted by total_tokens DESC: agent first
+    assert_eq!(result[0].0, "agent");
+    assert_eq!(
+        result[0].1, 1,
+        "call_count for agent must be 1 (pending row excluded)"
+    );
+    assert_eq!(result[0].4, 150); // total_tokens
+    assert_eq!(result[1].0, "tool");
+    assert_eq!(result[1].1, 1);
+    assert_eq!(result[1].4, 40);
+
+    std::fs::remove_file(&path).ok();
 }

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -1403,3 +1403,285 @@ fn test_token_usage_by_process_type() {
 
     std::fs::remove_file(&path).ok();
 }
+
+// ─── token_usage_by_process_type follow-up tests (PR #661) ────────────────────
+
+/// Build a completed LLMCall with the given process_type and token usage,
+/// mirroring the construction pattern of test_token_usage_by_process_type.
+fn make_ptype_call(
+    call_id: &str,
+    start_ns: u64,
+    process_type: Option<&str>,
+    tokens: (u32, u32, u32),
+) -> LLMCall {
+    let mut call = LLMCall::new(
+        call_id.to_string(),
+        start_ns,
+        "openai".to_string(),
+        "gpt-4".to_string(),
+        LLMRequest {
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            top_p: None,
+            top_k: None,
+            seed: None,
+            stop_sequences: None,
+            stream: false,
+            tools: None,
+            raw_body: None,
+        },
+        100,
+        "agent".to_string(),
+    );
+    call.process_type = process_type.map(str::to_string);
+    call.token_usage = Some(crate::genai::semantic::TokenUsage {
+        input_tokens: tokens.0,
+        output_tokens: tokens.1,
+        total_tokens: tokens.2,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+    });
+    call.end_timestamp_ns = start_ns + 1000;
+    call.duration_ns = 1000;
+    call
+}
+
+fn temp_db_path(prefix: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "{prefix}_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+/// Legacy rows written before the v9 migration have process_type = NULL.
+/// The aggregation must fold them into an 'unknown' group via COALESCE
+/// instead of dropping them or returning a NULL group key.
+#[test]
+fn test_token_by_type_null_process_type_coalesce() {
+    let path = temp_db_path("test_ptype_coalesce");
+    cleanup_db(&path);
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+
+    // NULL process_type (legacy row) + one classified 'agent' row
+    store
+        .store_event(&GenAISemanticEvent::LLMCall(make_ptype_call(
+            "c-null",
+            1000,
+            None,
+            (10, 5, 15),
+        )))
+        .unwrap();
+    store
+        .store_event(&GenAISemanticEvent::LLMCall(make_ptype_call(
+            "c-agent",
+            2000,
+            Some("agent"),
+            (100, 50, 150),
+        )))
+        .unwrap();
+
+    let result = store.token_usage_by_process_type(0, 10_000).unwrap();
+    assert_eq!(
+        result.len(),
+        2,
+        "NULL process_type must form its own 'unknown' group, not vanish"
+    );
+    let unknown = result
+        .iter()
+        .find(|r| r.0 == "unknown")
+        .expect("NULL process_type rows must be COALESCEd into 'unknown'");
+    assert_eq!(unknown.1, 1); // call_count
+    assert_eq!(unknown.2, 10); // input_tokens
+    assert_eq!(unknown.3, 5); // output_tokens
+    assert_eq!(unknown.4, 15); // total_tokens
+    let agent = result.iter().find(|r| r.0 == "agent").unwrap();
+    assert_eq!(agent.4, 150);
+
+    cleanup_db(&path);
+}
+
+/// Rows must be returned sorted by aggregated total_tokens in descending
+/// order (ORDER BY ... DESC), regardless of insertion order.
+#[test]
+fn test_token_by_type_order_desc() {
+    let path = temp_db_path("test_ptype_order");
+    cleanup_db(&path);
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+
+    // Insert in ascending token order to rule out incidental ordering
+    store
+        .store_event(&GenAISemanticEvent::LLMCall(make_ptype_call(
+            "c-tool",
+            1000,
+            Some("tool"),
+            (30, 10, 40),
+        )))
+        .unwrap();
+    store
+        .store_event(&GenAISemanticEvent::LLMCall(make_ptype_call(
+            "c-agent",
+            2000,
+            Some("agent"),
+            (100, 50, 150),
+        )))
+        .unwrap();
+    store
+        .store_event(&GenAISemanticEvent::LLMCall(make_ptype_call(
+            "c-sub",
+            3000,
+            Some("sub_agent"),
+            (400, 100, 500),
+        )))
+        .unwrap();
+
+    let result = store.token_usage_by_process_type(0, 10_000).unwrap();
+    assert_eq!(result.len(), 3);
+    let order: Vec<&str> = result.iter().map(|r| r.0.as_str()).collect();
+    assert_eq!(
+        order,
+        vec!["sub_agent", "agent", "tool"],
+        "rows must be sorted by total_tokens DESC"
+    );
+    assert_eq!(result[0].4, 500);
+    assert_eq!(result[1].4, 150);
+    assert_eq!(result[2].4, 40);
+
+    cleanup_db(&path);
+}
+
+/// Upgrade path: a v8-era database (all columns up to pending_match_key,
+/// no process_type) must be migrated by init_tables (via ensure_col!,
+/// schema.rs v9 block) so that:
+///   1. the process_type column exists afterwards,
+///   2. legacy rows keep process_type = NULL and stay readable,
+///   3. the aggregation folds them into the 'unknown' group,
+///   4. re-running the migration is idempotent.
+#[test]
+fn test_schema_v9_migration_from_v8() {
+    let path = temp_db_path("test_v8_to_v9");
+    cleanup_db(&path);
+
+    // Hand-build a v8-shape database: the base CREATE TABLE from
+    // schema.rs init_tables (columns id..created_at, which already contains
+    // every v2-v8 column except tool_call_ids) plus the v5 tool_call_ids
+    // column added by ensure_col!. Only the v9 process_type column is absent.
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE genai_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'complete',
+                call_id TEXT,
+                trace_id TEXT,
+                conversation_id TEXT,
+                session_id TEXT,
+                instance TEXT,
+                start_timestamp_ns INTEGER NOT NULL,
+                end_timestamp_ns INTEGER,
+                duration_ns INTEGER,
+                pid INTEGER,
+                process_name TEXT,
+                agent_name TEXT,
+                operation_name TEXT,
+                provider TEXT,
+                model TEXT,
+                request_model TEXT,
+                response_model TEXT,
+                temperature REAL,
+                max_tokens INTEGER,
+                top_p REAL,
+                frequency_penalty REAL,
+                presence_penalty REAL,
+                finish_reasons TEXT,
+                server_address TEXT,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                total_tokens INTEGER,
+                cache_creation_tokens INTEGER,
+                cache_read_tokens INTEGER,
+                system_instructions TEXT,
+                input_messages TEXT,
+                output_messages TEXT,
+                user_query TEXT,
+                http_method TEXT,
+                http_path TEXT,
+                status_code INTEGER,
+                is_sse INTEGER,
+                sse_event_count INTEGER,
+                interruption_type TEXT,
+                call_kind TEXT NOT NULL DEFAULT 'main',
+                pending_origin TEXT NOT NULL DEFAULT 'request_capture',
+                pending_match_key TEXT,
+                tool_call_ids TEXT,
+                event_json TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO genai_events (
+                event_type, status, call_id, start_timestamp_ns,
+                input_tokens, output_tokens, total_tokens, event_json
+             ) VALUES ('llm_call', 'complete', 'legacy-1', 1000, 10, 5, 15, '{}')",
+            [],
+        )
+        .unwrap();
+    }
+
+    // Real migration entry point: new_with_path -> init_tables -> ensure_col!
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+    {
+        let conn = store.conn.lock().unwrap();
+        let col_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('genai_events') \
+                 WHERE name = 'process_type'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(col_count, 1, "v9 migration must add process_type column");
+        let pt: Option<String> = conn
+            .query_row(
+                "SELECT process_type FROM genai_events WHERE call_id = 'legacy-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(pt.is_none(), "legacy row must keep process_type = NULL");
+    }
+
+    // Legacy data must flow through the aggregation as 'unknown'
+    let result = store.token_usage_by_process_type(0, 10_000).unwrap();
+    assert_eq!(result, vec![("unknown".to_string(), 1, 10, 5, 15)]);
+    drop(store);
+
+    // Idempotency: opening again re-runs init_tables on a v9 database
+    let store2 = GenAISqliteStore::new_with_path(&path)
+        .expect("second migration run must not fail (idempotent)");
+    {
+        let conn = store2.conn.lock().unwrap();
+        let col_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('genai_events') \
+                 WHERE name = 'process_type'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(col_count, 1, "re-migration must not duplicate the column");
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM genai_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 1, "re-migration must not touch existing rows");
+    }
+
+    cleanup_db(&path);
+}

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -112,6 +112,8 @@ pub struct AgentSight {
     process_killer: Arc<dyn crate::utils::process::ProcessKiller>,
     /// Cached feature flags so runtime paths can check them without the config.
     features: crate::config::FeatureFlags,
+    /// Blood lineage tree tracking process parent-child relationships and type classification
+    lineage_tree: Arc<std::sync::RwLock<crate::lineage::LineageTree>>,
 }
 
 /// GenAI events waiting for session_id resolution via ResponseSessionMapper.
@@ -343,8 +345,7 @@ impl AgentSight {
 
         if let Some(ref path) = sysom_logtail_path {
             log::info!(
-                "SLS sysom mode detected (path={}), skipping SQLite and default SLS exporter",
-                path
+                "SLS sysom mode detected (path={path}), skipping SQLite and default SLS exporter"
             );
             if logtail_currently_enabled {
                 let exporter = LogtailExporter::new_with_fixed_path(
@@ -574,6 +575,23 @@ impl AgentSight {
             deadloop_kill_after_count: config.deadloop_kill_after_count,
             process_killer: Arc::new(crate::utils::process::LibcProcessKiller),
             features: config.features.clone(),
+            lineage_tree: {
+                let tree = crate::lineage::LineageTree::new();
+                let tree = Arc::new(std::sync::RwLock::new(tree));
+                if let Ok(mut t) = tree.write() {
+                    for agent in &existing_agents {
+                        t.insert_and_classify(
+                            agent.pid,
+                            1,
+                            &agent.agent_info.name,
+                            Some(agent.agent_info.name.clone()),
+                            false,
+                            true,
+                        );
+                    }
+                }
+                tree
+            },
         })
     }
 
@@ -675,6 +693,11 @@ impl AgentSight {
             return None;
         }
 
+        // Maintain lineage tree from proctrace exec/exit events
+        if let Event::Proc(ref proc_event) = event {
+            self.update_lineage_from_proc(proc_event);
+        }
+
         // Handle FileWatch events via callback (not through the pipeline)
         if let Event::FileWatch(ref fw_event) = event {
             self.handle_filewatch_event(fw_event);
@@ -756,11 +779,27 @@ impl AgentSight {
             let mut analysis_results = self.analyzer.analyze_aggregated(agg_result);
 
             // Build GenAI semantic events AND pending info in one pass
-            let (output, pending_info) = self.genai_builder.build_with_pending(
+            let (mut output, mut pending_info) = self.genai_builder.build_with_pending(
                 &analysis_results,
                 &self.response_mapper,
                 &self.pid_agent_name_cache,
             );
+
+            // Enrich events with process_type from lineage tree
+            if let Ok(tree) = self.lineage_tree.read() {
+                for event in &mut output.events {
+                    if let crate::genai::semantic::GenAISemanticEvent::LLMCall(call) = event {
+                        call.process_type = tree
+                            .get(call.pid as u32)
+                            .map(|n| n.process_type.as_str().to_string());
+                    }
+                }
+                if let Some(ref mut info) = pending_info {
+                    info.process_type = tree
+                        .get(info.pid as u32)
+                        .map(|n| n.process_type.as_str().to_string());
+                }
+            }
 
             // Backfill TokenRecord.agent from pid_agent_name_cache, falling back
             // to the *process* comm (/proc/<pid>/comm) and only then the event's
@@ -895,7 +934,9 @@ impl AgentSight {
         use crate::probes::procmon::Event as ProcMonEvent;
 
         match event {
-            ProcMonEvent::Exec { pid, comm, .. } => {
+            ProcMonEvent::Exec {
+                pid, ppid, comm, ..
+            } => {
                 // Read cmdline for deny-check and custom matching
                 let cmdline_args =
                     crate::discovery::scanner::read_cmdline(&format!("/proc/{pid}/cmdline"));
@@ -907,20 +948,112 @@ impl AgentSight {
                 }
 
                 // Phase 2: check if this is a known agent and start tracking
-                if let Some(agent) = self.scanner.on_process_create(*pid, comm) {
+                let matched = self.scanner.on_process_create(*pid, comm);
+
+                if let Some(agent) = matched {
                     let agent_name = agent.agent_info.name.clone();
                     self.pid_agent_name_cache.put(*pid, agent_name.clone());
                     self.attach_process(*pid, &agent_name);
+                    // proctrace does not emit an exec event for a scanner-matched
+                    // root (it was not yet in traced_processes when it execed).
+                    self.ensure_lineage_node(*pid, *ppid, comm, Some(agent_name), true);
+                } else {
+                    // PID reuse: new non-agent process inherited a recycled PID.
+                    // Clear stale cache so record_exec won't misclassify it.
+                    self.pid_agent_name_cache.pop(pid);
                 }
             }
             ProcMonEvent::Exit { pid, exit_code, .. } => {
-                // Remove from tracking if it was an agent
                 if let Some(agent) = self.scanner.on_process_exit(*pid) {
                     let agent_name = agent.agent_info.name.clone();
                     self.probes.detach_ssl_probes(*pid);
                     self.handle_agent_crash_detection(*pid, &agent_name, *exit_code);
+                } else if matches!(
+                    crate::lineage::classify_exit(*exit_code as i32),
+                    crate::lineage::ExitClassification::SignalCrash { .. }
+                ) {
+                    // SubAgent/Tool signal crash only (not AbnormalExit — child
+                    // exit(1) after parent dies is normal cleanup, not a crash).
+                    let child_crash_name = self.lineage_tree.read().ok().and_then(|tree| {
+                        tree.get(*pid).and_then(|node| {
+                            if matches!(
+                                node.process_type,
+                                crate::lineage::ProcessType::SubAgent
+                                    | crate::lineage::ProcessType::Tool
+                            ) {
+                                Some(
+                                    tree.root_agent_ancestor(*pid)
+                                        .and_then(|a| a.agent_name.clone())
+                                        .unwrap_or_else(|| node.comm.clone()),
+                                )
+                            } else {
+                                None
+                            }
+                        })
+                    });
+                    if let Some(agent_name) = child_crash_name {
+                        self.handle_agent_crash_detection(*pid, &agent_name, *exit_code);
+                    }
+                }
+                // Clean lineage tree (root agents may not be in proctrace child_pids)
+                if let Ok(mut tree) = self.lineage_tree.write() {
+                    tree.remove(*pid);
                 }
             }
+        }
+    }
+
+    /// Ensure a lineage node exists and is correctly classified after procmon
+    /// provides agent info. Handles the race where the proctrace exec event is
+    /// missed because the process was not yet in traced_processes when it execed.
+    fn ensure_lineage_node(
+        &mut self,
+        pid: u32,
+        ppid: u32,
+        comm: &str,
+        agent_name: Option<String>,
+        matches_agent: bool,
+    ) {
+        if let Ok(mut tree) = self.lineage_tree.write() {
+            tree.insert_and_classify(pid, ppid, comm, agent_name, false, matches_agent);
+        }
+    }
+
+    /// Update lineage tree from proctrace exec/exit events
+    fn update_lineage_from_proc(&mut self, event: &crate::probes::proctrace::VariableEvent) {
+        use crate::probes::proctrace::VariableEvent;
+
+        match event {
+            VariableEvent::Exec { header, .. } => {
+                let comm = event.comm_str();
+                let agent_name = self.pid_agent_name_cache.get(&header.pid).cloned();
+                if let Ok(mut tree) = self.lineage_tree.write() {
+                    let ptype = tree.record_exec(
+                        header.pid,
+                        header.ppid,
+                        &comm,
+                        agent_name,
+                        header.timestamp_ns,
+                    );
+                    log::debug!(
+                        "Lineage: added pid={} ppid={} type={ptype:?}",
+                        header.pid,
+                        header.ppid,
+                    );
+                }
+            }
+            VariableEvent::Exit { header, .. } => {
+                // Do NOT remove from lineage tree here — procmon Exit handler
+                // does the authoritative remove (line ~884). Removing here first
+                // would race: if proctrace exit arrives before procmon exit for
+                // the same PID, tree.get(pid) in the procmon SubAgent/Tool crash
+                // detection branch returns None, silently dropping the crash event.
+                log::debug!(
+                    "Lineage: proctrace exit pid={} (deferred to procmon handler)",
+                    header.pid,
+                );
+            }
+            _ => {}
         }
     }
 
@@ -1359,6 +1492,7 @@ impl AgentSight {
 
         // 4. Record agent_crash interruptions unless the exit was clean
         if let Some(ref istore) = self.interruption_store {
+            let tree = self.lineage_tree.read().ok();
             record_agent_crash_interruptions(
                 pid,
                 agent_name,
@@ -1366,6 +1500,7 @@ impl AgentSight {
                 &pending_calls,
                 istore,
                 self.genai_sqlite_store.as_deref(),
+                tree.as_deref(),
             );
         }
     }
@@ -2115,6 +2250,11 @@ fn take_deferred_genai_for_pid(
 /// signal, which covers the SIGKILL sent by the OOM killer) keep the previous
 /// behavior, with the decoded exit status embedded in the detail JSON.
 ///
+/// When a `lineage` tree is provided, the event severity is downgraded for
+/// SubAgent/Tool crashes (their blast radius is recoverable by the root
+/// agent) and the detail JSON is enriched with the process type, blast
+/// radius and the process subtree at exit time.
+///
 /// Extracted as a free function so the crash decision is unit-testable
 /// without constructing a full `AgentSight` instance.
 fn record_agent_crash_interruptions(
@@ -2124,8 +2264,9 @@ fn record_agent_crash_interruptions(
     pending_calls: &[(String, Option<String>, Option<String>, Option<String>)],
     istore: &InterruptionStore,
     genai_store: Option<&GenAISqliteStore>,
+    lineage: Option<&crate::lineage::LineageTree>,
 ) {
-    use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+    use crate::interruption::{InterruptionEvent, InterruptionType, Severity, was_pid_oom_killed};
 
     // Nothing to record without pending calls; guard here so future callers
     // cannot emit call-less crash events by accident.
@@ -2147,6 +2288,26 @@ fn record_agent_crash_interruptions(
         .unwrap_or(0);
 
     let is_oom = was_pid_oom_killed(pid as i32);
+
+    // Base severity from the kernel exit status: fatal signals are critical,
+    // non-zero exit codes are high. Lineage downgrades SubAgent/Tool crashes
+    // because the root agent can usually recover from them.
+    let mut severity = if exit_status.signal != 0 {
+        Severity::Critical
+    } else {
+        Severity::High
+    };
+    if let Some(node) = lineage.and_then(|tree| tree.get(pid)) {
+        match node.process_type {
+            crate::lineage::ProcessType::Tool => severity = Severity::Medium,
+            crate::lineage::ProcessType::SubAgent => {
+                if severity == Severity::Critical {
+                    severity = Severity::High;
+                }
+            }
+            _ => {}
+        }
+    }
 
     // Group by (session_id, conversation_id) to produce one event per conversation
     let mut by_conv: std::collections::HashMap<(Option<String>, Option<String>), Vec<String>> =
@@ -2171,7 +2332,25 @@ fn record_agent_crash_interruptions(
         if is_oom {
             detail["oom"] = serde_json::json!(true);
         }
-        let event = InterruptionEvent::new(
+        if let Some(tree) = lineage {
+            if let Some(subtree) = tree.subtree(pid) {
+                detail["process_tree"] = serde_json::to_value(&subtree).unwrap_or_default();
+            }
+            let children = tree.children_at_exit(pid);
+            if !children.is_empty() {
+                detail["children_at_exit"] = serde_json::json!(children);
+            }
+            if let Some(node) = tree.get(pid) {
+                detail["process_type"] = serde_json::json!(node.process_type.as_str());
+                detail["blast_radius"] = serde_json::json!(match node.process_type {
+                    crate::lineage::ProcessType::Agent => "total_session_loss",
+                    crate::lineage::ProcessType::SubAgent => "partial",
+                    crate::lineage::ProcessType::Tool => "recoverable",
+                    _ => "unknown",
+                });
+            }
+        }
+        let mut event = InterruptionEvent::new(
             InterruptionType::AgentCrash,
             session_id.clone(),
             None,
@@ -2182,6 +2361,7 @@ fn record_agent_crash_interruptions(
             now_ns,
             Some(detail),
         );
+        event.severity = severity.clone();
         if let Err(e) = istore.insert(&event) {
             log::warn!("[CrashDetect] Failed to record agent_crash for pid={pid}: {e}");
         } else {
@@ -2274,6 +2454,7 @@ mod tests {
             &pending,
             &istore,
             Some(genai_store.as_ref()),
+            None,
         );
 
         assert!(
@@ -2310,6 +2491,7 @@ mod tests {
             &pending,
             &istore,
             Some(genai_store.as_ref()),
+            None,
         );
 
         let events = list_crash_events(&istore);
@@ -2350,6 +2532,7 @@ mod tests {
             &pending,
             &istore,
             Some(genai_store.as_ref()),
+            None,
         );
 
         let events = list_crash_events(&istore);
@@ -2379,6 +2562,7 @@ mod tests {
             &pending,
             &istore,
             Some(genai_store.as_ref()),
+            None,
         );
 
         let events = list_crash_events(&istore);
@@ -2483,6 +2667,7 @@ mod tests {
             pid: 1234,
             process_name: "test".to_string(),
             agent_name: Some("test-agent".to_string()),
+            process_type: None,
             metadata: std::collections::HashMap::new(),
         }
     }
@@ -2508,6 +2693,7 @@ mod tests {
             call_kind: "main".to_string(),
             pending_origin: crate::storage::sqlite::genai::PendingOrigin::RequestCapture,
             pending_match_key: None,
+            process_type: None,
         }
     }
 

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -3027,4 +3027,118 @@ mod tests {
         });
         assert!(!events_are_empty_llm(&[empty, tool]));
     }
+
+    // ── Tests for crash-routing decision helpers ─────────────────────────────
+
+    use crate::interruption::Severity;
+    use crate::lineage::{LineageTree, ProcessType};
+
+    /// Build a lineage tree with a root Agent (pid 100, "openclaw"), a
+    /// SubAgent child (pid 200) and a Tool child (pid 300).
+    fn crash_routing_tree() -> LineageTree {
+        let mut tree = LineageTree::new();
+        assert_eq!(
+            tree.insert_and_classify(
+                100,
+                1,
+                "openclaw",
+                Some("openclaw".to_string()),
+                false,
+                true
+            ),
+            ProcessType::Agent
+        );
+        assert_eq!(
+            tree.insert_and_classify(
+                200,
+                100,
+                "openclaw",
+                Some("openclaw".to_string()),
+                false,
+                true
+            ),
+            ProcessType::SubAgent
+        );
+        assert_eq!(
+            tree.insert_and_classify(300, 100, "grep", None, false, false),
+            ProcessType::Tool
+        );
+        tree
+    }
+
+    #[test]
+    fn test_subagent_signal_crash_reports() {
+        let tree = crash_routing_tree();
+        // SIGKILL(9) on a SubAgent: reported under the root Agent's name.
+        assert_eq!(
+            child_crash_agent_name(&tree, 200, 9),
+            Some("openclaw".to_string())
+        );
+        // The root Agent itself is never routed through the child-crash path.
+        assert_eq!(child_crash_agent_name(&tree, 100, 9), None);
+    }
+
+    #[test]
+    fn test_child_abnormal_exit_not_reported() {
+        let tree = crash_routing_tree();
+        // exit_code=256 == exit(1): AbnormalExit on a child is normal cleanup
+        // after the parent dies, not a crash — must not be reported.
+        assert_eq!(child_crash_agent_name(&tree, 200, 256), None);
+        assert_eq!(child_crash_agent_name(&tree, 300, 256), None);
+    }
+
+    #[test]
+    fn test_agent_signal_crash_severity_critical() {
+        // Agent crashes keep their original severity — no downgrade.
+        assert_eq!(
+            downgrade_severity(Severity::Critical, ProcessType::Agent),
+            Severity::Critical
+        );
+    }
+
+    #[test]
+    fn test_severity_downgrade_by_process_type() {
+        // SubAgent: only Critical is downgraded (to High).
+        assert_eq!(
+            downgrade_severity(Severity::Critical, ProcessType::SubAgent),
+            Severity::High
+        );
+        assert_eq!(
+            downgrade_severity(Severity::High, ProcessType::SubAgent),
+            Severity::High
+        );
+        // Tool: always Medium, whatever the classification said.
+        assert_eq!(
+            downgrade_severity(Severity::Critical, ProcessType::Tool),
+            Severity::Medium
+        );
+        assert_eq!(
+            downgrade_severity(Severity::High, ProcessType::Tool),
+            Severity::Medium
+        );
+        assert_eq!(
+            downgrade_severity(Severity::Low, ProcessType::Tool),
+            Severity::Medium
+        );
+    }
+
+    #[test]
+    fn test_blast_radius_mapping() {
+        assert_eq!(blast_radius_for(ProcessType::Agent), "total_session_loss");
+        assert_eq!(blast_radius_for(ProcessType::SubAgent), "partial");
+        assert_eq!(blast_radius_for(ProcessType::Tool), "recoverable");
+        assert_eq!(blast_radius_for(ProcessType::Unknown), "unknown");
+    }
+
+    #[test]
+    fn test_proctrace_exit_defers_lineage_removal() {
+        let mut tree = crash_routing_tree();
+        // proctrace Exit must NOT remove the node — otherwise a proctrace exit
+        // racing ahead of procmon exit would silently drop the crash event.
+        defer_proctrace_exit_removal(&mut tree, 200);
+        assert!(tree.get(200).is_some());
+        // The authoritative removal happens in the procmon Exit handler.
+        assert!(tree.remove(200).is_some());
+        assert!(tree.get(200).is_none());
+    }
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -968,29 +968,11 @@ impl AgentSight {
                     let agent_name = agent.agent_info.name.clone();
                     self.probes.detach_ssl_probes(*pid);
                     self.handle_agent_crash_detection(*pid, &agent_name, *exit_code);
-                } else if matches!(
-                    crate::lineage::classify_exit(*exit_code as i32),
-                    crate::lineage::ExitClassification::SignalCrash { .. }
-                ) {
-                    // SubAgent/Tool signal crash only (not AbnormalExit — child
-                    // exit(1) after parent dies is normal cleanup, not a crash).
-                    let child_crash_name = self.lineage_tree.read().ok().and_then(|tree| {
-                        tree.get(*pid).and_then(|node| {
-                            if matches!(
-                                node.process_type,
-                                crate::lineage::ProcessType::SubAgent
-                                    | crate::lineage::ProcessType::Tool
-                            ) {
-                                Some(
-                                    tree.root_agent_ancestor(*pid)
-                                        .and_then(|a| a.agent_name.clone())
-                                        .unwrap_or_else(|| node.comm.clone()),
-                                )
-                            } else {
-                                None
-                            }
-                        })
-                    });
+                } else {
+                    let child_crash_name =
+                        self.lineage_tree.read().ok().and_then(|tree| {
+                            child_crash_agent_name(&tree, *pid, *exit_code as i32)
+                        });
                     if let Some(agent_name) = child_crash_name {
                         self.handle_agent_crash_detection(*pid, &agent_name, *exit_code);
                     }
@@ -1043,15 +1025,9 @@ impl AgentSight {
                 }
             }
             VariableEvent::Exit { header, .. } => {
-                // Do NOT remove from lineage tree here — procmon Exit handler
-                // does the authoritative remove (line ~884). Removing here first
-                // would race: if proctrace exit arrives before procmon exit for
-                // the same PID, tree.get(pid) in the procmon SubAgent/Tool crash
-                // detection branch returns None, silently dropping the crash event.
-                log::debug!(
-                    "Lineage: proctrace exit pid={} (deferred to procmon handler)",
-                    header.pid,
-                );
+                if let Ok(mut tree) = self.lineage_tree.write() {
+                    defer_proctrace_exit_removal(&mut tree, header.pid);
+                }
             }
             _ => {}
         }
@@ -2298,15 +2274,7 @@ fn record_agent_crash_interruptions(
         Severity::High
     };
     if let Some(node) = lineage.and_then(|tree| tree.get(pid)) {
-        match node.process_type {
-            crate::lineage::ProcessType::Tool => severity = Severity::Medium,
-            crate::lineage::ProcessType::SubAgent => {
-                if severity == Severity::Critical {
-                    severity = Severity::High;
-                }
-            }
-            _ => {}
-        }
+        severity = downgrade_severity(severity, node.process_type);
     }
 
     // Group by (session_id, conversation_id) to produce one event per conversation
@@ -2342,12 +2310,7 @@ fn record_agent_crash_interruptions(
             }
             if let Some(node) = tree.get(pid) {
                 detail["process_type"] = serde_json::json!(node.process_type.as_str());
-                detail["blast_radius"] = serde_json::json!(match node.process_type {
-                    crate::lineage::ProcessType::Agent => "total_session_loss",
-                    crate::lineage::ProcessType::SubAgent => "partial",
-                    crate::lineage::ProcessType::Tool => "recoverable",
-                    _ => "unknown",
-                });
+                detail["blast_radius"] = serde_json::json!(blast_radius_for(node.process_type));
             }
         }
         let mut event = InterruptionEvent::new(
@@ -2387,6 +2350,89 @@ fn record_agent_crash_interruptions(
             log::warn!("[CrashDetect] Failed to mark pending interrupted for pid={pid}: {e}");
         }
     }
+}
+
+// ─── Crash-routing decision helpers ──────────────────────────────────────────
+//
+// Pure functions extracted from AgentSight's event-loop methods so the crash
+// routing / severity / blast-radius decisions are unit-testable without the
+// BPF pipeline. Verbatim moves — behavior must stay identical to the inline
+// originals.
+
+/// Decide whether a non-scanner-tracked process exit should be reported as a
+/// child crash, and under which agent name.
+///
+/// SubAgent/Tool signal crash only (not AbnormalExit — child
+/// exit(1) after parent dies is normal cleanup, not a crash).
+/// Returns the root Agent ancestor's name (falling back to the node's comm)
+/// or `None` when the exit must not be reported.
+fn child_crash_agent_name(
+    tree: &crate::lineage::LineageTree,
+    pid: u32,
+    exit_code: i32,
+) -> Option<String> {
+    if !matches!(
+        crate::lineage::classify_exit(exit_code),
+        crate::lineage::ExitClassification::SignalCrash { .. }
+    ) {
+        return None;
+    }
+    tree.get(pid).and_then(|node| {
+        if matches!(
+            node.process_type,
+            crate::lineage::ProcessType::SubAgent | crate::lineage::ProcessType::Tool
+        ) {
+            Some(
+                tree.root_agent_ancestor(pid)
+                    .and_then(|a| a.agent_name.clone())
+                    .unwrap_or_else(|| node.comm.clone()),
+            )
+        } else {
+            None
+        }
+    })
+}
+
+/// Downgrade severity for SubAgent/Tool crashes (recoverable).
+/// Agent (and Unknown/Skill) crashes keep their original severity.
+fn downgrade_severity(
+    severity: crate::interruption::Severity,
+    process_type: crate::lineage::ProcessType,
+) -> crate::interruption::Severity {
+    use crate::interruption::Severity;
+    match process_type {
+        crate::lineage::ProcessType::Tool => Severity::Medium,
+        crate::lineage::ProcessType::SubAgent => {
+            if severity == Severity::Critical {
+                Severity::High
+            } else {
+                severity
+            }
+        }
+        _ => severity,
+    }
+}
+
+/// Map a crashing process's type to the blast-radius label recorded in the
+/// agent_crash detail payload.
+fn blast_radius_for(process_type: crate::lineage::ProcessType) -> &'static str {
+    match process_type {
+        crate::lineage::ProcessType::Agent => "total_session_loss",
+        crate::lineage::ProcessType::SubAgent => "partial",
+        crate::lineage::ProcessType::Tool => "recoverable",
+        _ => "unknown",
+    }
+}
+
+/// Handle a proctrace Exit for the lineage tree: intentionally a no-op.
+///
+/// Do NOT remove from lineage tree here — procmon Exit handler
+/// does the authoritative remove (line ~884). Removing here first
+/// would race: if proctrace exit arrives before procmon exit for
+/// the same PID, tree.get(pid) in the procmon SubAgent/Tool crash
+/// detection branch returns None, silently dropping the crash event.
+fn defer_proctrace_exit_removal(_tree: &mut crate::lineage::LineageTree, pid: u32) {
+    log::debug!("Lineage: proctrace exit pid={pid} (deferred to procmon handler)");
 }
 
 #[cfg(test)]

--- a/src/agentsight/tests/common/mod.rs
+++ b/src/agentsight/tests/common/mod.rs
@@ -244,6 +244,7 @@ pub fn make_test_llm_call(call_id: &str) -> agentsight::genai::LLMCall {
         pid: 1234,
         process_name: "test".to_string(),
         agent_name: Some("test-agent".to_string()),
+        process_type: None,
         metadata: HashMap::new(),
     }
 }

--- a/src/agentsight/tests/memory_storage.rs
+++ b/src/agentsight/tests/memory_storage.rs
@@ -23,7 +23,7 @@ fn make_llm_call(idx: usize) -> LLMCall {
         messages: vec![InputMessage {
             role: "user".to_string(),
             parts: vec![MessagePart::Text {
-                content: format!("hello world request number {}", idx),
+                content: format!("hello world request number {idx}"),
             }],
             name: None,
         }],
@@ -44,7 +44,7 @@ fn make_llm_call(idx: usize) -> LLMCall {
         messages: vec![OutputMessage {
             role: "assistant".to_string(),
             parts: vec![MessagePart::Text {
-                content: format!("hello world response number {}", idx),
+                content: format!("hello world response number {idx}"),
             }],
             name: None,
             finish_reason: Some("stop".to_string()),
@@ -54,7 +54,7 @@ fn make_llm_call(idx: usize) -> LLMCall {
     };
 
     let mut call = LLMCall::new(
-        format!("call-{}", idx),
+        format!("call-{idx}"),
         0,
         "openai".to_string(),
         "gpt-4o".to_string(),
@@ -142,8 +142,8 @@ fn sqlite_batch_lowers_write_overhead() {
         }),
     );
 
-    println!("no batch:  {:?}", no_batch);
-    println!("with batch: {:?}", with_batch);
+    println!("no batch:  {no_batch:?}");
+    println!("with batch: {with_batch:?}");
 
     // NOTE: We do NOT assert batch is faster than no-batch because in CI
     // environments (shared runners, cold disk cache) the difference can be


### PR DESCRIPTION
## Summary

Agent 进程层级全栈可观测：血缘树 + 精准 crash 检测 + blast radius 量化 + token 按层级归因 + CLI crash report + `token --by-type` 聚合查询。

agent 崩了，系统知道崩没崩、为什么崩、影响多大、崩的时候在干什么、哪个子进程在烧钱。


## Strategic positioning

This PR is the AgentSight foundation for the OS-middle-layer recoverability and task-level observability substrate: process supervision, exit-reason capture, Agent/SubAgent/Tool lineage, crash blast-radius reporting, and token attribution by process type.

It deliberately does **not** implement the scheduling/control-plane pieces from the broader Agent Infra roadmap: no cgroup QoS control, no LSM enforcement, no transparent MaaS cache proxy, and no closed-loop task recovery orchestration. Those can build on this observability substrate later.

## Problem

1. **crash 检测靠猜**：用 pending LLM calls 判断 crash，SIGSEGV 在两次调用间 → 漏判，正常退出 SSE 没收完 → 误判
2. **子进程完全不可见**：SubAgent/Tool 崩溃静默丢弃（scanner 只认 root agent）
3. **token 无层级归因**：不知道哪个子 agent 在烧钱，无法按 Agent/SubAgent/Tool 分层分析
4. **启动时已有 agent 不在 lineage tree**：scanner 初始扫描发现的 agent 没有 lineage 节点

## Solution

| 层 | 改动 | 效果 |
|---|---|---|
| BPF 采集 | procmon.h 加 `exit_code`，BPF_CORE_READ task_struct | crash/normal 从内核事实判定 |
| 血缘树 | lineage/mod.rs：pid→ppid 树 + Agent/SubAgent/Tool 分类 + root_agent_ancestor | 进程层级结构化 |
| crash 判定 | classify_exit() 纯函数替代 pending-calls 猜测 | 假阴性/假阳性修复 |
| blast radius | ProcessType → total_session_loss/partial/recoverable | 量化崩溃影响，severity 按类型分级 |
| SubAgent/Tool crash | Exit handler 扩展：lineage 分类的子进程 signal crash 也检测 | 子进程不再静默 |
| token 归因 | LLMCall/PendingCallInfo 加 process_type，SQLite+Logtail 全链路 | 按层级分析消耗 |
| token --by-type | GenAISqliteStore 聚合查询 + CLI `agentsight token --by-type` | 一行看哪层在烧钱 |
| 启动补种 | 构造函数末尾 insert_and_classify existing_agents | 已有 agent 也在 lineage tree |
| CLI | interruption get 结构化 crash report（信号/进程树/blast radius/process type） | 一眼看懂崩溃现场 |
| bug fix | pid_agent_name_cache PID 复用清理 + proctrace exit_code TODO 修复 | 数据准确性 |
| race fix | proctrace Exit 不再删 lineage node，defer 到 procmon Exit handler | 防止 crash 事件因事件排序竞态静默丢失 |
| CI fix | background.rs tmp_dir 用 CARGO_MANIFEST_DIR 替代 temp_dir | 修复 llvm-cov 下 SQLITE_READONLY |

## Crash detection truth table

| 场景 | exit_code | 旧判定 | 新判定 |
|------|-----------|--------|--------|
| SIGSEGV 无 pending | 11 | 漏判 | crash(Critical, blast=total_session_loss) |
| SIGKILL (OOM) | 9 | crash(仅有pending) | crash(Critical)+oom |
| SIGTERM 优雅停止 | 15 | crash(若有pending) | normal(graceful) |
| exit(0)+pending SSE | 0 | 误判(crash) | no crash event (pending lifecycle remains separate) |
| Tool SIGSEGV | 11 | 静默丢弃 | crash(Medium, blast=recoverable) |
| SubAgent SIGSEGV | 11 | 静默丢弃 | crash(High, blast=partial) |
| 子进程 exit(1) 跟随父死 | 256 | N/A | 不产出(非 signal，正常清理) |

## CLI examples

```
$ agentsight interruption get <id>

  --- Crash Report ---
  Cause:        SIGSEGV (signal 11, coredump: true)
  OOM Killed:   no
  Process Type: agent
  Blast Radius: total_session_loss
  Children at Exit: [5678]

  Process Tree at Crash:
    `-- cosh [1234] (agent)
        `-- node [5678] (tool)

$ agentsight token --by-type --hours 24

Token Usage by Process Type (last 24h)

TYPE           CALLS        INPUT       OUTPUT        TOTAL
------------------------------------------------------------
agent              15       12,345        8,901       21,246
sub_agent           3        2,100        1,500        3,600
tool                1          200          100          300
------------------------------------------------------------
TOTAL                                                25,146
```

## Rebase (2026-07-12)

Rebased onto `main`（曾落后 337 commit）。冲突解完后对合并结论做了对抗 review，抓到并修复两处对 `main` 的 silent-revert：

- **`procmon.bpf.c`**：普通合并把 chengshuyi 的 namespace-PID 支持（`b6a95632`）静默退回 host tgid，只想加 `exit_code`。已恢复 `get_task_ns_pid`/`current_ns_pid`——否则 procmon 发 host tgid，与已改用 `ns_pid` 的其他探针不一致，容器内 crash 检测的 pid 关联（drain）会失效（裸机 ns==host 测不出）。
- **`unified.rs` exit 路径**：保留 `main` 的 `detach_ssl_probes`（`507b879c`），不重新引入旧的 `detach_process`。

## Verification

| Check | Status |
|-------|--------|
| cargo fmt/clippy/test (1153 tests) | pass |
| check-arch-boundaries.py | pass |
| BPF verifier load (kernel 6.6.102+) | E2E pass |
| SIGSEGV root agent → crash + blast_radius=total_session_loss | E2E pass |
| SIGTERM → no crash event | E2E pass |
| 子进程 exit(1) → no crash (噪音修复) | E2E pass |
| process_type in genai_events SQLite | E2E pass |
| CLI crash report 含 Process Type + Blast Radius | E2E pass |
| token_usage_by_process_type 排除 pending 行 | 区分性测试 |
| Adversarial workflow review (2 rounds, 14 agents) | 0 critical/high |
| [rebase] merge-resolution 对抗 review（procmon/detach silent-revert） | 已修，MERGE_RESOLUTION_SOUND |
| [rebase] PID-ns 下 SIGSEGV → agent_crash 按 ns_pid 归因 (pid=10, signal=11) | **E2E pass**（判别：回退 host-tgid 版 → 0 归因） |
| [rebase] pending-call drain 关联 (drain_connections_for_pid ↔ sslsniff ns_pid) | **仅单测**（容器内 SSL 捕获非本 ECS 可复现，同 pid 修复驱动、有 lib 单测覆盖） |

## What is NOT changed

- Not a cgroup/QoS scheduler: no `cpu.weight`, `cpu.max`, burst control, or dynamic resource enforcement
- Not an LSM/sandbox policy engine: no AppArmor/SELinux/eBPF-LSM allow/deny control
- Not a transparent MaaS cache proxy: no socket redirection or LLM response cache interception
- Not closed-loop recovery orchestration: crash reports/checkpoint context only; resume/retry policy remains out of scope
- health/checker.rs：serve 进程没 BPF exit_code，保持 pending-calls 逻辑（已知限制）
- procmon pid namespace：本次 rebase 采用 `ns_pid`（`get_task_ns_pid`/`current_ns_pid`，与 sslsniff/tcpsniff/udpdns/filewatch 一致，见 `b6a95632`）。容器 crash 归因要求 agentsight 与 agent 同处一个 PID namespace
