### PR TITLE
feat(anolisa): support `anolisa self update` as alias for `update self`

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/self_.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/self_.rs
@@ -1,11 +1,12 @@
 //! Tier 2 surface — `anolisa self`: management of the anolisa CLI itself.
 //!
-//! Self-update lives under `anolisa update self`. A compatibility entry
-//! `anolisa self update` is kept here but returns a hint directing users
-//! to the canonical path. Other subcommands: adopt, completions.
+//! `anolisa self update` delegates to the same self-update logic as
+//! `anolisa update self` — both paths are supported as a user convenience.
+//! Other subcommands: adopt, completions.
 
 use clap::{Parser, Subcommand};
 
+use crate::commands::tier1::update::handle_self_update;
 use crate::context::CliContext;
 use crate::response::CliError;
 
@@ -34,7 +35,7 @@ pub enum SelfCommands {
         /// Target shell (bash, zsh, fish)
         shell: String,
     },
-    /// Self-update the CLI binary (redirects to `anolisa update self`)
+    /// Self-update the CLI binary (same as `anolisa update self`)
     #[command(name = "update")]
     Update,
 }
@@ -43,17 +44,14 @@ pub enum SelfCommands {
 ///
 /// # Errors
 ///
-/// Returns [`CliError`] for subcommands that are intentionally not implemented
-/// yet, including the compatibility `self update` redirect.
-pub fn handle(args: SelfArgs, _ctx: &CliContext) -> Result<(), CliError> {
+/// Returns [`CliError`] for subcommands that are not yet implemented, or
+/// propagates errors from [`handle_self_update`].
+pub fn handle(args: SelfArgs, ctx: &CliContext) -> Result<(), CliError> {
     match args.command {
         SelfCommands::Adopt { .. } => Err(CliError::not_implemented("self adopt")),
         SelfCommands::Completions { shell } => Err(CliError::not_implemented(format!(
             "self completions {shell}"
         ))),
-        SelfCommands::Update => Err(CliError::not_implemented_with_hint(
-            "self update",
-            "`anolisa self update` has moved — use `anolisa update self` instead",
-        )),
+        SelfCommands::Update => handle_self_update(ctx),
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -8,9 +8,9 @@
 //!   adapter object.
 //!
 //! Explicit invariant (spec §7.3, decision §11.2): `update all` does
-//! **not** include `self`. CLI self-update lives only behind `update
-//! self` so the CLI binary swap never shares a transaction with
-//! component updates.
+//! **not** include CLI self-update. The binary swap never shares a
+//! transaction with component updates. Self-update is reachable via
+//! both `anolisa update self` and `anolisa self update`.
 
 use clap::{Parser, Subcommand};
 use serde::Serialize;
@@ -68,7 +68,16 @@ pub fn handle(args: UpdateArgs, ctx: &CliContext) -> Result<(), CliError> {
     }
 }
 
-fn handle_self_update(ctx: &CliContext) -> Result<(), CliError> {
+/// Execute CLI self-update: fetch release manifest, compare versions,
+/// download and atomically replace the running binary.
+///
+/// Also called from `anolisa self update` as a convenience alias.
+///
+/// # Errors
+///
+/// Returns [`CliError::Runtime`] when the manifest fetch, version check,
+/// download, or binary replacement fails.
+pub(in crate::commands) fn handle_self_update(ctx: &CliContext) -> Result<(), CliError> {
     let url = self_update::update_url();
     let current_version = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Both `anolisa update self` and `anolisa self update` now execute the same self-update logic (manifest check, download, atomic binary replace). `handle_self_update` is exposed as pub(in crate::commands) with doc comment and # Errors section.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue: new feat

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
