### PR TITLE
fix(template): restore bug report issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,6 @@ body:
         - tokenless
         - ckpt
         - memory
-        - anolisa
         - other
     validations:
       required: true


### PR DESCRIPTION
Fix duplicated `anolisa` option in the bug report issue form.

The duplicate dropdown option made GitHub hide the Bug Report template on the
new issue page. This keeps the simplified template and only removes the extra
entry.