### PR TITLE
fix(anolisa): isolate dry-run smoke prefix

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/enable.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/enable.rs
@@ -943,21 +943,23 @@ mod tests {
         assert!(err.hint().unwrap_or("").contains("--with-adapter"));
     }
 
-    /// Smoke: with the bundled dev-tree manifests + index, the planner runs
-    /// end-to-end and produces a plan. We assert the call succeeds and that
-    /// the plan capability/install_mode match the request — we do not assert
-    /// a specific status because the host env (linux vs macOS) drives it.
+    /// Smoke: with the bundled dev-tree manifests + index, dry-run reaches the
+    /// renderer and returns a plan envelope. The temp prefix keeps registry
+    /// cache/config lookups away from system paths; we still do not assert a
+    /// specific status because the host env drives it.
     #[test]
-    fn enable_dry_run_happy_path_returns_plan_on_host() {
-        // We need an env-agnostic ctx, but ctx.install_mode=System with
-        // ctx.prefix=None defaults to / on system mode; that's fine for a
-        // bundled-catalog dry-run since nothing is written.
-        let _ = PathBuf::from("/tmp");
+    fn enable_dry_run_renders_plan_for_bundled_capability_with_temp_prefix() {
+        let tmp = tempdir().expect("tmpdir");
         let result = handle(
             args(&["agent-observability"]),
-            &ctx(true, true, InstallMode::System),
+            &ctx_with_prefix(
+                true,
+                true,
+                InstallMode::System,
+                Some(tmp.path().to_path_buf()),
+            ),
         );
-        result.expect("dry-run plan should not error on bundled fixtures");
+        result.expect("dry-run should render a plan for bundled fixtures");
     }
 
     /// On macOS the OS precheck for `agent-observability` (requires linux)


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->

Use a temporary system prefix for the enable dry-run smoke test so registry cache and config lookups stay under a tempdir instead of host system paths.

Rename the test and rustdoc-style test description to match the actual contract: the handler renders a dry-run plan envelope, but the plan may still be blocked or degraded depending on host prechecks.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
