### PR TITLE
refactor(anolisa): base user-mode layout on file-hierarchy(7)

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
@@ -236,7 +236,7 @@ fn handle_sandbox(command: SandboxCommands, ctx: &CliContext) -> Result<(), CliE
 
             // sandbox install writes to /etc, /var/lib, /usr/lib and enables
             // systemd units — all of which are system-scoped. The default
-            // global --install-mode is `user` (XDG), under which sandbox
+            // global --install-mode is `user`, under which sandbox
             // install would silently route audit log + state to
             // ~/.local/state/anolisa/ while the actual writes still target
             // /etc and /var/lib (and need root). Reject that mismatch up

--- a/src/anolisa/crates/anolisa-cli/src/context.rs
+++ b/src/anolisa/crates/anolisa-cli/src/context.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 
 use clap::ValueEnum;
 
-/// Where ANOLISA installs files: user-mode (XDG under `$HOME`) or system-mode
-/// (FHS under `/usr/local`, redirectable via `--prefix`).
+/// Where ANOLISA installs files: user-mode (`file-hierarchy(7)` under `$HOME`)
+/// or system-mode (FHS under `/usr/local`, redirectable via `--prefix`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "lowercase")]
 pub enum InstallMode {

--- a/src/anolisa/crates/anolisa-cli/src/packaged.rs
+++ b/src/anolisa/crates/anolisa-cli/src/packaged.rs
@@ -19,7 +19,7 @@
 //!   3. The install-mode default `layout.datadir` — what the
 //!      [`FsLayout`] resolution returns for the current
 //!      `--install-mode` (system: `/usr/local/share/anolisa`; user:
-//!      `$XDG_DATA_HOME/anolisa`). Kept as the final fallback so
+//!      `~/.local/share/anolisa`). Kept as the final fallback so
 //!      pre-P1-A installs (where the datadir matches the install-mode
 //!      root directly) still resolve.
 //!

--- a/src/anolisa/crates/anolisa-core/src/health/engine.rs
+++ b/src/anolisa/crates/anolisa-core/src/health/engine.rs
@@ -448,7 +448,7 @@ fn boundary_reason(err: &PathBoundaryError) -> String {
     }
 }
 
-/// Expand the FHS/XDG layout placeholders a manifest may use in a probe path.
+/// Expand the FHS / file-hierarchy layout placeholders a manifest may use in a probe path.
 /// The minimal-schema names (`{sysconfdir}`/`{sharedir}`) and the legacy ones
 /// (`{etcdir}`/`{datadir}`) both resolve to the same roots during the
 /// additive-compat window.

--- a/src/anolisa/crates/anolisa-core/src/service.rs
+++ b/src/anolisa/crates/anolisa-core/src/service.rs
@@ -11,7 +11,7 @@
 //! whose ops succeed with `state: NotSupported, supported: false,
 //! changed: false`. Callers treat that as a quiet skip rather than a
 //! warning, so the lifecycle on macOS / inside CI containers / under
-//! XDG-only user installs stays a no-op for services.
+//! user-mode installs stays a no-op for services.
 //!
 //! `FakeServiceManager` is the executor used by `service.rs`'s own unit
 //! tests and by integration tests that need to assert which ops the

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -32,7 +32,7 @@ fn default_true() -> bool {
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum InstallMode {
-    /// Per-user XDG install scope.
+    /// Per-user (`file-hierarchy(7)`) install scope.
     #[default]
     User,
     /// System-wide FHS install scope.

--- a/src/anolisa/crates/anolisa-env/src/cache.rs
+++ b/src/anolisa/crates/anolisa-env/src/cache.rs
@@ -8,7 +8,7 @@ pub fn cache_path(system_mode: bool) -> PathBuf {
     if system_mode {
         PathBuf::from("/var/lib/anolisa/env-facts.json")
     } else {
-        // XDG_STATE_HOME or fallback
+        // user state root override, else the $HOME-based default
         std::env::var("XDG_STATE_HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|_| {

--- a/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
+++ b/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
@@ -2,9 +2,11 @@
 //!
 //! `system-mode` strictly follows [FHS 3.0](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)
 //! (binaries under `/usr/local/bin`, state under `/var/lib/anolisa`, etc.);
-//! `user-mode` strictly follows the [XDG Base Directory
-//! Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-//! (`$XDG_DATA_HOME/anolisa` and friends). A custom prefix (typically
+//! `user-mode` strictly follows systemd [`file-hierarchy(7)`](https://www.freedesktop.org/software/systemd/man/latest/file-hierarchy.html)
+//! (`~/.local/bin`, `~/.local/lib`, plus the `~/.config`, `~/.local/share`,
+//! `~/.local/state`, `~/.cache` home roots it defines). When a home root's
+//! standard environment variable is set it overrides the `$HOME`-based
+//! default, and that override is honored. A custom prefix (typically
 //! `/opt/<name>`) may be supplied in system-mode to relocate the whole tree.
 //!
 //! Source of truth: `docs/anolisa/anolisa-cli-design.md` §"Filesystem Layout"
@@ -17,7 +19,7 @@
 
 use std::path::{Path, PathBuf};
 
-/// Application namespace folder appended to most FHS/XDG roots.
+/// Application namespace folder appended to most FHS / file-hierarchy roots.
 const NS: &str = "anolisa";
 /// Audit-log file name written under `log_dir`.
 const CENTRAL_LOG_NAME: &str = "central.jsonl";
@@ -45,35 +47,42 @@ mod fhs {
     pub const SYSTEMD_UNITS: &str = "/etc/systemd/system";
 }
 
-// ---- User-mode (XDG) leaf names -----------------------------------------
+// ---- User-mode (file-hierarchy(7)) leaf names ---------------------------
 
-/// Component-relative folders appended under the XDG roots for user-mode.
-mod xdg {
-    /// `~/.local/bin` is the de-facto XDG_BIN_HOME, kept independent of
-    /// `$XDG_DATA_HOME` per design.md L514.
+/// Home-relative leaf names for the user-mode layout per systemd
+/// `file-hierarchy(7)`. Each home root below is overridable by its
+/// standard environment variable (resolved in [`FsLayout::user`]).
+mod fh_user {
+    /// `~/.local/bin` — `file-hierarchy(7)` user binaries dir, kept
+    /// independent of the data root per design.md L514.
     pub const HOME_LOCAL_BIN: &str = ".local/bin";
+    /// `~/.local/lib` — `file-hierarchy(7)` user libraries dir; the
+    /// per-application `anolisa/` subtree nests here.
+    pub const HOME_LOCAL_LIB: &str = ".local/lib";
     pub const DATA_HOME: &str = ".local/share";
     pub const CONFIG_HOME: &str = ".config";
     pub const STATE_HOME: &str = ".local/state";
     pub const CACHE_HOME: &str = ".cache";
 
-    /// Sub-folders inside the per-user `$XDG_DATA_HOME/anolisa` tree.
-    pub const LIB_SUB: &str = "lib";
+    /// Helper-executable sub-dir. `file-hierarchy(7)` defines no
+    /// `~/.local/libexec`, so non-shell helpers live in a subdirectory of
+    /// the application's `~/.local/lib/anolisa/` tree.
     pub const LIBEXEC_SUB: &str = "libexec";
-    /// Sub-folder inside `$XDG_STATE_HOME/anolisa` used as the runtime
-    /// fallback when `$XDG_RUNTIME_DIR` is unset.
+    /// Sub-folder inside the state root used as the runtime fallback when
+    /// the user runtime directory is unset.
     pub const RUNTIME_FALLBACK_SUB: &str = "runtime";
-    /// User-mode systemd unit search dir, relative to `$XDG_CONFIG_HOME`.
+    /// User-mode systemd unit search dir, relative to the config root.
     pub const SYSTEMD_USER_SUB: &str = "systemd/user";
 }
 
-/// Where ANOLISA installs files: user-mode (XDG under `$HOME`) or
-/// system-mode (FHS under `/`, redirectable via a prefix).
+/// Where ANOLISA installs files: user-mode (`file-hierarchy(7)` under
+/// `$HOME`) or system-mode (FHS under `/`, redirectable via a prefix).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallMode {
     /// FHS-style installation under `/usr/local`, `/etc`, and `/var`.
     System,
-    /// Per-user installation under XDG roots derived from `$HOME`.
+    /// Per-user installation under the `file-hierarchy(7)` home roots
+    /// derived from `$HOME`.
     User,
 }
 
@@ -85,16 +94,17 @@ pub enum InstallMode {
 /// Note on `prefix`: in system-mode it is the install root that rebases
 /// every other path. In user-mode it is **not** a single root; it is kept
 /// for compatibility and points at the primary install root (i.e.
-/// `datadir`, `$XDG_DATA_HOME/anolisa`). User-mode honors the four XDG
-/// roots independently — `bin_dir`, `etc_dir`, `state_dir`, `cache_dir`
-/// each derive from a different XDG variable and are not children of
-/// `prefix`.
+/// `datadir`, `~/.local/share/anolisa`). User-mode resolves each
+/// `file-hierarchy(7)` home root independently — `bin_dir`, `lib_dir`,
+/// `etc_dir`, `state_dir`, `cache_dir` each derive from a different home
+/// root (`~/.local/bin`, `~/.local/lib`, `~/.config`, `~/.local/state`,
+/// `~/.cache`) and are not children of `prefix`.
 #[derive(Debug, Clone)]
 pub struct FsLayout {
     /// Install scope that selected the path policy.
     pub mode: InstallMode,
     /// Primary install root; in user mode this is the data root, not a
-    /// parent of every other XDG-derived path.
+    /// parent of every other home-derived path.
     pub prefix: PathBuf,
     /// Directory where user-invoked binaries are linked or copied.
     pub bin_dir: PathBuf,
@@ -164,57 +174,63 @@ impl FsLayout {
         }
     }
 
-    /// User (XDG) install layout under `home`. XDG environment
-    /// variables, when set, take precedence over the `$HOME`-based
-    /// defaults.
+    /// User (`file-hierarchy(7)`) install layout under `home`. When a home
+    /// root's standard environment variable is set, it takes precedence
+    /// over the `$HOME`-based default.
     pub fn user(home: PathBuf) -> Self {
-        let xdg_data = std::env::var_os("XDG_DATA_HOME").map(PathBuf::from);
-        let xdg_config = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
-        let xdg_state = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
-        let xdg_cache = std::env::var_os("XDG_CACHE_HOME").map(PathBuf::from);
-        let xdg_runtime = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from);
-        Self::user_with_xdg(
+        // The home-root overrides are read from their standard environment
+        // variables; an unset variable selects the `$HOME`-based default.
+        let data_override = std::env::var_os("XDG_DATA_HOME").map(PathBuf::from);
+        let config_override = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+        let state_override = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
+        let cache_override = std::env::var_os("XDG_CACHE_HOME").map(PathBuf::from);
+        let runtime_override = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from);
+        Self::user_with_overrides(
             home,
-            xdg_data,
-            xdg_config,
-            xdg_state,
-            xdg_cache,
-            xdg_runtime,
+            data_override,
+            config_override,
+            state_override,
+            cache_override,
+            runtime_override,
         )
     }
 
-    /// Test-friendly variant of [`Self::user`] that takes the XDG
-    /// directories explicitly instead of reading them from the process
-    /// environment.
+    /// Test-friendly variant of [`Self::user`] that takes the home-root
+    /// override directories explicitly instead of reading them from the
+    /// process environment.
     ///
-    /// Each `Option` corresponds to one XDG variable; `None` selects the
-    /// `$HOME`-based fallback documented by the XDG spec.
-    pub(crate) fn user_with_xdg(
+    /// Each `Option` is one home-root override; `None` selects the
+    /// `$HOME`-based home root that `file-hierarchy(7)` defines.
+    pub(crate) fn user_with_overrides(
         home: PathBuf,
-        xdg_data: Option<PathBuf>,
-        xdg_config: Option<PathBuf>,
-        xdg_state: Option<PathBuf>,
-        xdg_cache: Option<PathBuf>,
-        xdg_runtime: Option<PathBuf>,
+        data_override: Option<PathBuf>,
+        config_override: Option<PathBuf>,
+        state_override: Option<PathBuf>,
+        cache_override: Option<PathBuf>,
+        runtime_override: Option<PathBuf>,
     ) -> Self {
-        let data = sanitize_absolute_root(xdg_data, home.join(xdg::DATA_HOME));
-        let config = sanitize_absolute_root(xdg_config, home.join(xdg::CONFIG_HOME));
-        let state = sanitize_absolute_root(xdg_state, home.join(xdg::STATE_HOME));
-        let cache = sanitize_absolute_root(xdg_cache, home.join(xdg::CACHE_HOME));
+        let data = sanitize_absolute_root(data_override, home.join(fh_user::DATA_HOME));
+        let config = sanitize_absolute_root(config_override, home.join(fh_user::CONFIG_HOME));
+        let state = sanitize_absolute_root(state_override, home.join(fh_user::STATE_HOME));
+        let cache = sanitize_absolute_root(cache_override, home.join(fh_user::CACHE_HOME));
 
         let datadir = data.join(NS);
         let etc_dir = config.join(NS);
         let state_dir = state.join(NS);
         let cache_dir = cache.join(NS);
 
-        // bin lives at the user's de-facto XDG_BIN_HOME, independent of
-        // any of the other XDG roots — see design.md L514 and L530.
-        let bin_dir = home.join(xdg::HOME_LOCAL_BIN);
+        // bin lives at the file-hierarchy(7) `~/.local/bin`, independent of
+        // any other home root — see design.md L514 and L530.
+        let bin_dir = home.join(fh_user::HOME_LOCAL_BIN);
 
-        let lib_dir = datadir.join(xdg::LIB_SUB);
-        let libexec_dir = datadir.join(xdg::LIBEXEC_SUB);
+        // lib lives at the file-hierarchy(7) `~/.local/lib/anolisa`, NOT
+        // under the data root. file-hierarchy(7) defines no
+        // `~/.local/libexec`, so non-shell helpers nest in a subdirectory
+        // of the lib tree.
+        let lib_dir = home.join(fh_user::HOME_LOCAL_LIB).join(NS);
+        let libexec_dir = lib_dir.join(fh_user::LIBEXEC_SUB);
 
-        // Logs / lock / backups live under XDG_STATE_HOME so a cache wipe
+        // Logs / lock / backups live under the state root so a cache wipe
         // does not destroy audit history — see design.md L519 + L535 and
         // launch-spec §8.5.
         let log_dir = state_dir.clone();
@@ -222,16 +238,16 @@ impl FsLayout {
         let lock_file = state_dir.join(LOCK_NAME);
         let central_log = state_dir.join(CENTRAL_LOG_NAME);
 
-        // XDG_RUNTIME_DIR is not guaranteed to be set (e.g. headless
-        // installs); fall back to a subdir under state_dir per design.md
-        // L536 so socket/pid paths still resolve.
-        let runtime_dir = xdg_runtime
+        // The user runtime directory is not guaranteed to be set (e.g.
+        // headless installs); fall back to a subdir under state_dir per
+        // design.md L536 so socket/pid paths still resolve.
+        let runtime_dir = runtime_override
             .filter(|r| is_safe_absolute_root(r))
             .map(|r| r.join(NS))
-            .unwrap_or_else(|| state_dir.join(xdg::RUNTIME_FALLBACK_SUB));
+            .unwrap_or_else(|| state_dir.join(fh_user::RUNTIME_FALLBACK_SUB));
 
         let manifests_overlay = etc_dir.join(OVERLAY_NAME);
-        let systemd_unit_dir = config.join(xdg::SYSTEMD_USER_SUB);
+        let systemd_unit_dir = config.join(fh_user::SYSTEMD_USER_SUB);
 
         Self {
             mode: InstallMode::User,
@@ -359,27 +375,28 @@ mod tests {
 
     // ---- user-mode ----------------------------------------------------
 
-    fn user_no_xdg(home: &str) -> FsLayout {
+    fn user_no_overrides(home: &str) -> FsLayout {
         // env-free helper so parallel tests in other crates can't race
-        // us by mutating XDG_* in their own processes.
-        FsLayout::user_with_xdg(PathBuf::from(home), None, None, None, None, None)
+        // us by mutating the home-root env vars in their own processes.
+        FsLayout::user_with_overrides(PathBuf::from(home), None, None, None, None, None)
     }
 
     #[test]
-    fn user_layout_under_home_with_no_xdg() {
-        let layout = user_no_xdg("/tmp/h");
+    fn user_layout_under_home_with_no_overrides() {
+        let layout = user_no_overrides("/tmp/h");
         assert_eq!(layout.mode, InstallMode::User);
         assert_eq!(layout.prefix, PathBuf::from("/tmp/h/.local/share/anolisa"));
         assert_eq!(layout.datadir, PathBuf::from("/tmp/h/.local/share/anolisa"));
         assert_eq!(layout.bin_dir, PathBuf::from("/tmp/h/.local/bin"));
-        assert_eq!(
-            layout.lib_dir,
-            PathBuf::from("/tmp/h/.local/share/anolisa/lib")
-        );
+        // file-hierarchy(7): lib/libexec live under ~/.local/lib, NOT
+        // under the ~/.local/share data root.
+        assert_eq!(layout.lib_dir, PathBuf::from("/tmp/h/.local/lib/anolisa"));
         assert_eq!(
             layout.libexec_dir,
-            PathBuf::from("/tmp/h/.local/share/anolisa/libexec")
+            PathBuf::from("/tmp/h/.local/lib/anolisa/libexec")
         );
+        assert!(!layout.lib_dir.starts_with("/tmp/h/.local/share"));
+        assert!(!layout.libexec_dir.starts_with("/tmp/h/.local/share"));
         assert_eq!(layout.etc_dir, PathBuf::from("/tmp/h/.config/anolisa"));
         assert_eq!(
             layout.state_dir,
@@ -410,8 +427,8 @@ mod tests {
     }
 
     #[test]
-    fn user_layout_honors_explicit_xdg_dirs() {
-        let layout = FsLayout::user_with_xdg(
+    fn user_layout_honors_explicit_override_dirs() {
+        let layout = FsLayout::user_with_overrides(
             PathBuf::from("/tmp/h"),
             Some(PathBuf::from("/data")),
             Some(PathBuf::from("/conf")),
@@ -428,13 +445,20 @@ mod tests {
         assert_eq!(layout.lock_file, PathBuf::from("/state/anolisa/lock"));
         assert_eq!(layout.runtime_dir, PathBuf::from("/run/user/1000/anolisa"));
         assert_eq!(layout.systemd_unit_dir, PathBuf::from("/conf/systemd/user"));
-        // bin is HOME-rooted regardless of XDG_DATA_HOME — see next test.
+        // bin/lib/libexec are HOME-rooted regardless of the data-root
+        // override: file-hierarchy(7) places them under ~/.local/bin and
+        // ~/.local/lib, decoupled from the data root.
         assert_eq!(layout.bin_dir, PathBuf::from("/tmp/h/.local/bin"));
+        assert_eq!(layout.lib_dir, PathBuf::from("/tmp/h/.local/lib/anolisa"));
+        assert_eq!(
+            layout.libexec_dir,
+            PathBuf::from("/tmp/h/.local/lib/anolisa/libexec")
+        );
     }
 
     #[test]
-    fn user_layout_ignores_relative_or_traversing_xdg_dirs() {
-        let layout = FsLayout::user_with_xdg(
+    fn user_layout_ignores_relative_or_traversing_override_dirs() {
+        let layout = FsLayout::user_with_overrides(
             PathBuf::from("/tmp/h"),
             Some(PathBuf::from("relative-data")),
             Some(PathBuf::from("/conf/../escape")),
@@ -457,13 +481,13 @@ mod tests {
     }
 
     #[test]
-    fn user_log_under_xdg_state() {
-        // design.md L519/L535: audit log lives under $XDG_STATE_HOME so
+    fn user_log_under_state_root() {
+        // design.md L519/L535: audit log lives under the state root so
         // it survives a cache wipe.
-        let layout = user_no_xdg("/tmp/h");
+        let layout = user_no_overrides("/tmp/h");
         assert_eq!(layout.log_dir, layout.state_dir);
         assert_ne!(layout.log_dir, layout.cache_dir);
-        let with_xdg = FsLayout::user_with_xdg(
+        let with_override = FsLayout::user_with_overrides(
             PathBuf::from("/tmp/h"),
             None,
             None,
@@ -471,15 +495,15 @@ mod tests {
             Some(PathBuf::from("/cache")),
             None,
         );
-        assert_eq!(with_xdg.log_dir, PathBuf::from("/state/anolisa"));
-        assert_ne!(with_xdg.log_dir, with_xdg.cache_dir);
+        assert_eq!(with_override.log_dir, PathBuf::from("/state/anolisa"));
+        assert_ne!(with_override.log_dir, with_override.cache_dir);
     }
 
     #[test]
     fn user_bin_is_local_bin() {
-        // bin must be HOME/.local/bin regardless of XDG_DATA_HOME — see
-        // design.md L514/L530.
-        let layout = FsLayout::user_with_xdg(
+        // bin must be HOME/.local/bin regardless of the data-root
+        // override — see design.md L514/L530.
+        let layout = FsLayout::user_with_overrides(
             PathBuf::from("/tmp/h"),
             Some(PathBuf::from("/somewhere/else/data")),
             None,
@@ -491,9 +515,9 @@ mod tests {
     }
 
     #[test]
-    fn user_runtime_falls_back_when_xdg_runtime_unset() {
+    fn user_runtime_falls_back_when_runtime_override_unset() {
         // design.md L536 / runtime_dir fallback path.
-        let layout = FsLayout::user_with_xdg(
+        let layout = FsLayout::user_with_overrides(
             PathBuf::from("/tmp/h"),
             None,
             None,
@@ -502,8 +526,8 @@ mod tests {
             None,
         );
         assert_eq!(layout.runtime_dir, PathBuf::from("/state/anolisa/runtime"));
-        // ...and when XDG_RUNTIME_DIR is set, it wins.
-        let with_runtime = FsLayout::user_with_xdg(
+        // ...and when the runtime override is set, it wins.
+        let with_runtime = FsLayout::user_with_overrides(
             PathBuf::from("/tmp/h"),
             None,
             None,


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
  This PR updates user-mode filesystem layout resolution to follow systemd `file-hierarchy(7)` more
  directly.

  What changed:
  - User-mode `lib_dir` now resolves to `~/.local/lib/anolisa`.
  - User-mode `libexec_dir` now resolves to `~/.local/lib/anolisa/libexec`.
  - User-mode data/config/state/cache roots remain split across:
    - `~/.local/share/anolisa`
    - `~/.config/anolisa`
    - `~/.local/state/anolisa`
    - `~/.cache/anolisa`
  - Standard environment overrides are still honored for data/config/state/cache/runtime roots.
  - System-mode FHS paths and `--prefix` rebasing behavior are unchanged.
  - CLI/core/env comments were updated from the old “XDG layout” wording to the new `file-hierarchy(7)`
  terminology.

### limitations:
  - This PR does not migrate files from the previous user-mode lib path under `~/.local/share/anolisa/lib`.
  - Existing user-mode installs that already placed libraries or helper executables in the old path may
  need reinstall or a separate migration step.
  - `~/.local/bin` and `~/.local/lib` remain `$HOME`-based and are not redirected by `XDG_DATA_HOME`,
  matching the selected `file-hierarchy(7)` model.

  ## Design Note

  The previous implementation described user-mode as XDG-based and placed user libraries under the data
  root, for example `~/.local/share/anolisa/lib`. That made the layout look like a single application data
  tree, but it did not match the `file-hierarchy(7)` split between user data and user libraries.

  This PR makes the user-mode layout explicit:

  - command binaries: `~/.local/bin`
  - libraries: `~/.local/lib/anolisa`
  - helper executables: `~/.local/lib/anolisa/libexec`
  - shared data: `~/.local/share/anolisa`
  - config: `~/.config/anolisa`
  - state, logs, lock, backups: `~/.local/state/anolisa`
  - cache: `~/.cache/anolisa`
  - runtime: `$XDG_RUNTIME_DIR/anolisa`, falling back to `~/.local/state/anolisa/runtime`

  The `prefix` field remains for compatibility, but in user-mode it is not treated as a parent directory
  for every resolved path. It points at the primary data root, while each user-mode path is resolved from
  its own file-hierarchy home root.

  System-mode remains FHS-based and continues to rebase all absolute paths under `--prefix` when a custom
  prefix is provided.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo check --workspace --all-targets
cargo test --workspace

<img width="1026" height="396" alt="image" src="https://github.com/user-attachments/assets/ca569a75-a21b-4698-a52a-4d02cc636e4a" />

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
