### PR TITLE
chore(anolisa): bump version to 0.1.7

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-06-13
+
+### Changed
+
+- **file-hierarchy(7) user layout**: user-mode `lib_dir` now resolves to
+  `~/.local/lib/anolisa` and `libexec_dir` to
+  `~/.local/lib/anolisa/libexec`, while data/config/state/cache/runtime roots
+  continue to honor their standard `XDG_*` environment overrides.
+
+### Fixed
+
+- **Remote raw install contracts**: `anolisa install` no longer requires the
+  component to exist in the local manifest catalog before raw backend
+  execution; it resolves the artifact from the remote distribution index,
+  verifies and downloads the artifact, then reads the embedded
+  `.anolisa/component.toml` install contract.
+- `anolisa install --dry-run` can now use version-level sidecar `meta.toml`
+  metadata to preview files and services without downloading the install
+  artifact, and legacy raw `binary` artifacts can still install when a sidecar
+  or matching local catalog contract is available.
+
 ## [0.1.6] - 2026-06-12
 
 ### Added
@@ -230,6 +251,24 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.1.7] - 2026-06-13
+
+### 变更
+
+- **file-hierarchy(7) 用户态布局**：user-mode 下 `lib_dir` 现在解析为
+  `~/.local/lib/anolisa`，`libexec_dir` 解析为
+  `~/.local/lib/anolisa/libexec`；data/config/state/cache/runtime 根目录仍然
+  继续遵循标准 `XDG_*` 环境变量覆盖。
+
+### 修复
+
+- **远程 raw 安装契约**：`anolisa install` 不再要求 raw 后端执行前组件必须存在于
+  本地 manifest catalog；现在会先从远程 distribution index 解析 artifact，
+  校验并下载后，再读取 artifact 内嵌的 `.anolisa/component.toml` 安装契约。
+- `anolisa install --dry-run` 现在可使用版本级 sidecar `meta.toml` 元数据预览
+  文件和服务，而无需下载安装 artifact；legacy raw `binary` artifact 在存在
+  sidecar 或匹配本地 catalog 契约时仍可安装。
 
 ## [0.1.6] - 2026-06-12
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
Document CLI changes since 0.1.6 and bump version to 0.1.7.

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo check --workspace --all-targets
cargo test --workspace

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
