### PR TITLE
feat(anolisa): add OpenClaw adapter

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -1,53 +1,50 @@
-//! `anolisa adapter` sub-surface: scan, install, and remove adapters.
+//! `anolisa adapter` sub-surface: scan, enable, disable, status.
 //!
 //! Adapters bridge ANOLISA-managed components into agent frameworks
-//! (e.g. `tokenless/openclaw`). The adapter state is tracked in
-//! `installed.toml` as [`ObjectKind::Adapter`] objects.
+//! (e.g. `tokenless/openclaw`). Component install lays each adapter's
+//! resources under `{datadir}/adapters/<component>/<framework>/`; this
+//! surface drives the framework side from those resources via the
+//! [`AdapterManager`], which owns the install lock, receipts, and the
+//! controlled framework-CLI boundary.
 //!
 //! ## `adapter scan`
 //!
-//! Read-only probe of every `[[adapters]]` entry across the catalog,
-//! reporting which frameworks are detected on the host.
+//! Read-only: reads installed component manifests, then overlays local
+//! resource-directory, framework-detection, and receipt state.
 //!
-//! ## `adapter install <component> <framework>`
+//! ## `adapter enable <component> [<framework>]`
 //!
-//! Resolves the manifest adapter, downloads the component artifact from
-//! the distribution index, extracts files per the adapter source/dest
-//! mapping, writes state and central log. On failure after partial file
-//! copy, installed files are cleaned up so no phantom state remains.
+//! Runs the framework driver's enable (e.g. registers an OpenClaw plugin)
+//! and writes a receipt. `--dry-run` (global flag) reports the plan
+//! without touching framework state. `<framework>` may be omitted when the
+//! component ships adapters for exactly one framework.
 //!
-//! ## `adapter remove <component> <framework>`
+//! ## `adapter disable <component> [<framework>]`
 //!
-//! Safe file deletion with four-layer guard:
+//! Reverses enable using the receipt only, then removes it. Idempotent:
+//! disabling something not enabled is a successful no-op. If cleanup
+//! cannot complete, the receipt is kept (marked `cleanup_failed`) and the
+//! command exits degraded so the state is not silently lost.
 //!
-//! 1. **Owner check** — only `FileOwner::Anolisa` files are removed.
-//! 2. **Path boundary** — [`validate_owned_path`] rejects escapes.
-//! 3. **Symlink guard** — refuses to follow symlinks.
-//! 4. **Directory guard** — refuses to `remove_file` a directory.
+//! ## `adapter status [<component>]`
+//!
+//! Read-only: reports each receipt's health summary and the individual
+//! conditions behind it. Verification that cannot run reports `unknown`
+//! rather than a faked healthy/absent verdict.
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
-use chrono::{SecondsFormat, Utc};
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 
-use anolisa_core::adapter::{detect_framework, expand_layout_placeholders};
-use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
-use anolisa_core::distribution::ArtifactType;
-use anolisa_core::download::DownloadCache;
-use anolisa_core::install_runner::{InstallRunner, ResolvedInstallFile};
-use anolisa_core::lock::InstallLock;
-use anolisa_core::path_safety::validate_owned_path;
-use anolisa_core::state::{
-    FileOwner, InstallMode as StateInstallMode, InstalledObject, ObjectKind, ObjectStatus,
-    OperationRecord, OwnedFile,
+use anolisa_core::adapter::AdapterError;
+use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus};
+use anolisa_core::adapter::driver::{AdapterStatusReport, DriverPlan};
+use anolisa_core::adapter::manager::{
+    AdapterManager, DisableOutcome, EnableOutcome, ScanEntry, ScanReport, StatusReport,
 };
-use anolisa_core::{DistributionIndex, ResolveQuery};
+use anolisa_platform::fs_layout::FsLayout;
 
-use crate::color::Palette;
 use crate::commands::common;
-use crate::context::CliContext;
+use crate::context::{CliContext, InstallMode};
 use crate::response::{CliError, render_json};
 
 /// CLI arguments for the `adapter` sub-surface.
@@ -61,2027 +58,487 @@ pub struct AdapterArgs {
 /// Subcommands under `anolisa adapter`.
 #[derive(Subcommand)]
 pub enum AdapterCommands {
-    /// List registered adapters.
-    List,
-    /// Install an adapter for a component into a framework.
-    Install {
-        /// Component name (e.g., tokenless).
-        component: String,
-        /// Target framework (e.g., openclaw, hermes).
-        framework: String,
-    },
-    /// Remove an installed adapter.
-    Remove {
-        /// Component name (e.g., tokenless).
-        component: String,
-        /// Target framework (e.g., openclaw, hermes).
-        framework: String,
-        /// Also remove adapter-specific configuration and state (not yet implemented).
-        #[arg(long)]
-        purge: bool,
-    },
-    /// Auto-detect available adapter integrations.
+    /// Discover installed adapter declarations and local resource/receipt state.
     Scan,
+    /// Enable a component's adapter for a framework.
+    Enable {
+        /// Component name (e.g. `tokenless`).
+        component: String,
+        /// Target framework (e.g. `openclaw`). Omit when the component
+        /// ships adapters for exactly one framework.
+        framework: Option<String>,
+    },
+    /// Disable a previously enabled adapter.
+    Disable {
+        /// Component name.
+        component: String,
+        /// Target framework. Omit to disable the component's single
+        /// enabled adapter.
+        framework: Option<String>,
+    },
+    /// Report adapter receipt status.
+    Status {
+        /// Limit to one component; omit for all receipts.
+        component: Option<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
 // JSON payloads
 // ---------------------------------------------------------------------------
 
-/// One entry in the adapter scan result.
-#[derive(Debug, Clone, Serialize)]
-struct ScanEntry {
+/// One row of `adapter scan` JSON output.
+#[derive(Serialize)]
+struct ScanRow {
     component: String,
     framework: String,
-    detected: bool,
-    reason: String,
-}
-
-/// Top-level scan output.
-#[derive(Serialize)]
-struct ScanResult {
-    adapters: Vec<ScanEntry>,
-}
-
-/// Dry-run plan for adapter install.
-#[derive(Serialize)]
-struct InstallPlan {
-    component: String,
-    framework: String,
-    source: Option<String>,
-    dest: String,
-    detected: bool,
-    detect_reason: String,
-    /// Framework CLI registration command that real execution would run
-    /// after extracting the plugin (e.g. `openclaw plugins install …`).
-    /// `None` for frameworks wired in without a CLI step.
+    declared: bool,
+    resource_present: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    register_command: Option<String>,
+    resource_root: Option<String>,
+    driver_available: bool,
+    framework_detected: bool,
+    enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claim_status: Option<ClaimStatus>,
 }
 
-/// JSON output for successful adapter install.
+/// `adapter scan` JSON output.
 #[derive(Serialize)]
-struct InstallResult {
+struct ScanPayload {
+    adapters: Vec<ScanRow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
+}
+
+/// `adapter enable` JSON output.
+#[derive(Serialize)]
+struct EnablePayload {
     component: String,
     framework: String,
-    adapter: String,
-    version: String,
-    operation_id: String,
-    files_installed: Vec<String>,
-}
-
-/// JSON output for adapter remove (both dry-run and real execution).
-#[derive(Serialize)]
-struct RemoveResult {
-    adapter: String,
-    files_removed: Vec<String>,
-    files_skipped: Vec<SkippedFile>,
     dry_run: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plan: Option<DriverPlan>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claim: Option<AdapterClaim>,
 }
 
-/// A file that was skipped during removal with an explanation.
+/// `adapter disable` JSON output.
 #[derive(Serialize)]
-struct SkippedFile {
-    path: String,
-    reason: String,
+struct DisablePayload {
+    component: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    framework: Option<String>,
+    claim_removed: bool,
+    cleanup_complete: bool,
+    messages: Vec<String>,
+}
+
+/// One row of `adapter status` JSON output.
+#[derive(Serialize)]
+struct StatusRow {
+    component: String,
+    framework: String,
+    #[serde(flatten)]
+    report: AdapterStatusReport,
+}
+
+/// `adapter status` JSON output.
+#[derive(Serialize)]
+struct StatusPayload {
+    receipts: Vec<StatusRow>,
 }
 
 // ---------------------------------------------------------------------------
 // Dispatch
 // ---------------------------------------------------------------------------
 
-/// Handle the `anolisa adapter <subcommand>` dispatch.
+/// Entry point for `anolisa adapter`.
 pub fn handle(args: AdapterArgs, ctx: &CliContext) -> Result<(), CliError> {
     match args.command {
         AdapterCommands::Scan => handle_scan(ctx),
-        AdapterCommands::Install {
+        AdapterCommands::Enable {
             component,
             framework,
-        } => handle_install(ctx, &component, &framework),
-        AdapterCommands::Remove {
+        } => handle_enable(ctx, &component, framework.as_deref()),
+        AdapterCommands::Disable {
             component,
             framework,
-            purge,
-        } => handle_remove(&component, &framework, purge, ctx),
-        AdapterCommands::List => Err(CliError::not_implemented("adapter list")),
+        } => handle_disable(ctx, &component, framework.as_deref()),
+        AdapterCommands::Status { component } => handle_status(ctx, component.as_deref()),
     }
 }
 
-// ---------------------------------------------------------------------------
-// adapter scan
-// ---------------------------------------------------------------------------
-
-/// Read-only scan of all adapter entries in the catalog, probing the host
-/// for each framework.
-fn handle_scan(ctx: &CliContext) -> Result<(), CliError> {
-    let catalog = common::load_bundled_catalog(ctx, "adapter scan")?;
-
-    let mut entries: Vec<ScanEntry> = Vec::new();
-    for comp in catalog.list_components() {
-        if comp.adapters.is_empty() {
-            continue;
-        }
-        for adapter in &comp.adapters {
-            let framework = adapter
-                .framework
-                .as_deref()
-                .unwrap_or("unknown")
-                .to_string();
-            let result = detect_framework(adapter);
-            entries.push(ScanEntry {
-                component: comp.component.name.clone(),
-                framework,
-                detected: result.detected,
-                reason: result.reason,
-            });
-        }
+/// Build a manager for the active layout. A user-mode CLI also searches
+/// the packaged/system datadir so system-installed adapter resources are
+/// still discoverable.
+fn build_manager(ctx: &CliContext) -> AdapterManager {
+    let layout = common::resolve_layout(ctx);
+    let env = anolisa_env::EnvService::detect();
+    let system_datadir = crate::packaged::packaged_datadir_root(&layout);
+    let mut manager = AdapterManager::new(layout, Some(env.home), env.user);
+    if let Some(root) = system_datadir {
+        manager.push_datadir_root(root);
     }
+    if ctx.install_mode == InstallMode::User {
+        manager.push_state_root(FsLayout::system(ctx.prefix.clone()).state_dir);
+    }
+    manager
+}
+
+// ---------------------------------------------------------------------------
+// scan
+// ---------------------------------------------------------------------------
+
+fn handle_scan(ctx: &CliContext) -> Result<(), CliError> {
+    const COMMAND: &str = "adapter scan";
+    let manager = build_manager(ctx);
+    let report: ScanReport = manager.scan().map_err(|e| map_err(COMMAND, e))?;
 
     if ctx.json {
-        return render_json("adapter scan", ScanResult { adapters: entries });
+        let adapters = report.entries.iter().map(scan_row_from_entry).collect();
+        return render_json(
+            COMMAND,
+            ScanPayload {
+                adapters,
+                warnings: report.warnings,
+            },
+        );
     }
 
+    if !ctx.quiet {
+        for warning in &report.warnings {
+            eprintln!("warning: {warning}");
+        }
+    }
+
+    if report.entries.is_empty() {
+        println!("No adapter declarations or resources found.");
+        return Ok(());
+    }
     println!(
-        "{:<16} {:<16} {:<12} REASON",
-        "COMPONENT", "FRAMEWORK", "DETECTED"
+        "{:<16} {:<10} {:<9} {:<9} {:<9} {:<8} STATE",
+        "COMPONENT", "FRAMEWORK", "DECLARED", "RESOURCE", "DRIVER", "DETECTED"
     );
-    for e in &entries {
+    for row in &report.entries {
         println!(
-            "{:<16} {:<16} {:<12} {}",
-            e.component, e.framework, e.detected, e.reason
+            "{:<16} {:<10} {:<9} {:<9} {:<9} {:<8} {}",
+            row.component,
+            row.framework,
+            yes_no(row.declared),
+            if row.resource_root.is_some() {
+                "present"
+            } else {
+                "missing"
+            },
+            yes_no(row.driver_available),
+            yes_no(row.framework_detected),
+            scan_state_label(row),
         );
     }
     Ok(())
 }
 
+fn scan_row_from_entry(row: &ScanEntry) -> ScanRow {
+    ScanRow {
+        component: row.component.clone(),
+        framework: row.framework.clone(),
+        declared: row.declared,
+        resource_present: row.resource_root.is_some(),
+        resource_root: row
+            .resource_root
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        driver_available: row.driver_available,
+        framework_detected: row.framework_detected,
+        enabled: row.enabled,
+        claim_status: row.claim_status,
+    }
+}
+
+fn scan_state_label(row: &ScanEntry) -> &'static str {
+    match (row.enabled, row.claim_status) {
+        (true, Some(ClaimStatus::Enabled)) => "enabled",
+        (true, Some(ClaimStatus::CleanupFailed)) => "cleanup_failed",
+        (true, None) => "enabled",
+        (false, _) => "-",
+    }
+}
+
 // ---------------------------------------------------------------------------
-// adapter install
+// enable
 // ---------------------------------------------------------------------------
 
-/// Install an adapter for `component` into `framework`.
-///
-/// The adapter spec is read from the **published** artifact's embedded
-/// `.anolisa/component.toml` (not the dev-tree catalog), so `source`/`dest`
-/// and the version come from what was actually shipped. After the plugin
-/// directory is extracted into the ANOLISA datadir, frameworks that register
-/// through their own CLI (e.g. OpenClaw) are wired in by invoking that CLI —
-/// a bare file copy is not loaded by OpenClaw.
-fn handle_install(ctx: &CliContext, component: &str, framework: &str) -> Result<(), CliError> {
-    let command = format!("adapter install {component} {framework}");
-    let layout = common::resolve_layout(ctx);
+fn handle_enable(
+    ctx: &CliContext,
+    component: &str,
+    framework: Option<&str>,
+) -> Result<(), CliError> {
+    const COMMAND: &str = "adapter enable";
+    let manager = build_manager(ctx);
+    let outcome = manager
+        .enable(component, framework, ctx.dry_run)
+        .map_err(|e| map_err(COMMAND, e))?;
 
-    // Resolve artifact from the distribution index. Version-agnostic: pick
-    // the highest semver published for this component/platform — the
-    // published artifact, not the dev-tree catalog, is authoritative.
-    let dist_index =
-        common::load_distribution_index(ctx, &command)?.ok_or_else(|| CliError::Runtime {
-            command: command.clone(),
-            reason: "no distribution index available — cannot resolve artifact".to_string(),
-        })?;
-
-    let entry = resolve_adapter_artifact(&dist_index, component, None, ctx, &command)?;
-
-    // Adapter install only supports tar_gz — we must read the embedded
-    // manifest and map a source directory into a directory-typed dest.
-    if entry.artifact_type != ArtifactType::TarGz {
-        return Err(CliError::Runtime {
-            command,
-            reason: format!(
-                "adapter install requires a tar_gz artifact, got '{}'",
-                artifact_type_wire(&entry.artifact_type)
-            ),
-        });
-    }
-
-    let sha256 = entry.sha256.as_deref().ok_or_else(|| CliError::Runtime {
-        command: command.clone(),
-        reason: format!(
-            "distribution entry for '{component}' has no sha256 — refusing to install unverified artifact"
-        ),
-    })?;
-
-    // Download artifact to cache. Done before the dry-run branch too, so the
-    // displayed source/dest come from the real embedded manifest.
-    let cache = DownloadCache::new(layout.cache_dir.clone());
-    let downloaded = cache
-        .fetch(&entry.url, Some(sha256))
-        .map_err(|err| CliError::Runtime {
-            command: command.clone(),
-            reason: format!("failed to download artifact: {err}"),
-        })?;
-
-    // Read the published install contract embedded in the artifact and take
-    // the adapter spec from there (source = the in-tar path, version = the
-    // shipped version).
-    let manifest =
-        anolisa_core::install_runner::read_embedded_component_manifest(&downloaded.cached_path)
-            .map_err(|err| CliError::Runtime {
-                command: command.clone(),
-                reason: format!("failed to read embedded component manifest: {err}"),
-            })?
-            .ok_or_else(|| CliError::Runtime {
-                command: command.clone(),
-                reason: format!(
-                    "published artifact for '{component}' has no embedded .anolisa/component.toml — cannot resolve adapters"
-                ),
-            })?;
-
-    let adapter = manifest
-        .adapters
-        .iter()
-        .find(|a| a.framework.as_deref() == Some(framework))
-        .ok_or_else(|| CliError::InvalidArgument {
-            command: command.clone(),
-            reason: format!(
-                "no adapter for framework '{framework}' in published component '{component}'"
-            ),
-        })?;
-
-    let version = manifest.component.version.clone();
-    let adapter_name = format!("{component}/{framework}");
-
-    let dest_template = adapter.dest.as_deref().unwrap_or_default();
-    let expanded_dest =
-        expand_layout_placeholders(dest_template, &layout, &[("component", component)]).map_err(
-            |err| CliError::InvalidArgument {
-                command: command.clone(),
-                reason: format!("failed to expand adapter dest: {err}"),
-            },
-        )?;
-
-    validate_owned_path(&layout, &expanded_dest).map_err(|err| CliError::InvalidArgument {
-        command: command.clone(),
-        reason: format!(
-            "adapter destination '{}' failed path safety check: {err}",
-            expanded_dest.display()
-        ),
-    })?;
-
-    let detect_result = detect_framework(adapter);
-
-    // A framework that registers via its own CLI cannot be wired in when the
-    // framework is absent — fail fast before extracting anything.
-    if framework_needs_cli(framework) && !detect_result.detected {
-        return Err(CliError::Runtime {
-            command,
-            reason: format!(
-                "framework '{framework}' not detected ({}) — cannot register the adapter via its CLI",
-                detect_result.reason
-            ),
-        });
-    }
-    if !detect_result.detected && !ctx.quiet {
-        eprintln!(
-            "warning: framework '{framework}' not detected on this host: {}",
-            detect_result.reason
-        );
-    }
-
-    let register_invocation = openclaw_install_for(framework, &expanded_dest);
-
-    if ctx.dry_run {
-        let plan = InstallPlan {
-            component: component.to_string(),
-            framework: framework.to_string(),
-            source: adapter.source.clone(),
-            dest: expanded_dest.display().to_string(),
-            detected: detect_result.detected,
-            detect_reason: detect_result.reason.clone(),
-            register_command: register_invocation.as_ref().map(|i| i.display_command()),
-        };
-
-        if ctx.json {
-            return render_json(&command, plan);
-        }
-
-        println!("adapter install plan (dry-run):");
-        println!("  component:     {}", plan.component);
-        println!("  framework:     {}", plan.framework);
-        println!(
-            "  source:        {}",
-            plan.source.as_deref().unwrap_or("<none>")
-        );
-        println!("  dest:          {}", plan.dest);
-        println!("  detected:      {}", plan.detected);
-        println!("  detect_reason: {}", plan.detect_reason);
-        if let Some(cmd) = &plan.register_command {
-            println!("  register:      {cmd}");
-        }
-        return Ok(());
-    }
-
-    // -- Real execution: extract, register via framework CLI, write state/log --
-
-    let started_at = now_iso8601();
-
-    // Construct source→dest file mapping.
-    let files = vec![ResolvedInstallFile {
-        source: adapter.source.clone(),
-        dest: expanded_dest.clone(),
-        mode: None,
-        kind: anolisa_core::FileKind::Data,
-    }];
-
-    // Acquire lock, then load state inside the lock so a concurrent writer
-    // cannot be overwritten and so state-load failures happen before file copy.
-    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
-        command: command.clone(),
-        reason: format!("failed to acquire install lock: {err}"),
-    })?;
-
-    let mut state = load_state_for_install(ctx, &command)?;
-
-    // Generate operation_id after lock acquisition with nanosecond precision
-    // to avoid collisions between concurrent processes.
-    let lock_ts = Utc::now();
-    let operation_id = format!(
-        "op-adapter-install-{}-{}",
-        lock_ts.format("%Y%m%d%H%M%S"),
-        lock_ts.timestamp_subsec_nanos()
-    );
-
-    // Execute file copy.
-    let runner = InstallRunner::new(&layout);
-    let outcome = runner
-        .install_files("tar_gz", &downloaded.cached_path, &files)
-        .map_err(|err| CliError::Runtime {
-            command: command.clone(),
-            reason: format!("install failed: {err}"),
-        })?;
-
-    // From this point, files are on disk — any failure must roll them back.
-
-    // Register the adapter into its framework via the framework's own CLI
-    // (OpenClaw loads plugins from its registry, not from a dropped dir).
-    if let Some(inv) = &register_invocation {
-        if !ctx.quiet {
+    match outcome {
+        EnableOutcome::Planned(plan) => {
+            if ctx.json {
+                let payload = EnablePayload {
+                    component: plan.component.clone(),
+                    framework: plan.framework.clone(),
+                    dry_run: true,
+                    plan: Some(plan),
+                    claim: None,
+                };
+                return render_json(COMMAND, payload);
+            }
             println!(
-                "registering adapter into {framework}: {}",
-                inv.display_command()
+                "[dry-run] would enable {}/{}:",
+                plan.component, plan.framework
             );
+            for action in &plan.actions {
+                println!("  - {action}");
+            }
+            if let Some(cmd) = &plan.register_command {
+                println!("  command: {cmd}");
+            }
+            Ok(())
         }
-        if let Err(err) = run_openclaw(inv, ctx.quiet) {
-            rollback_installed_files(&outcome.files);
-            return Err(CliError::Runtime {
-                command,
-                reason: format!(
-                    "extracted adapter files but {framework} CLI registration failed (rolled back): {}",
-                    err.message()
-                ),
-            });
+        EnableOutcome::Enabled(claim) => {
+            if ctx.json {
+                let payload = EnablePayload {
+                    component: claim.component.clone(),
+                    framework: claim.framework.clone(),
+                    dry_run: false,
+                    plan: None,
+                    claim: Some(*claim),
+                };
+                return render_json(COMMAND, payload);
+            }
+            println!("Enabled {}/{}.", claim.component, claim.framework);
+            if let Some(pid) = &claim.plugin_id {
+                println!("  plugin: {pid}");
+            }
+            Ok(())
         }
     }
+}
 
-    let owned_files: Vec<OwnedFile> = outcome
-        .files
-        .iter()
-        .map(|f| OwnedFile {
-            path: f.path.clone(),
-            owner: FileOwner::Anolisa,
-            sha256: Some(f.sha256.clone()),
-        })
-        .collect();
+// ---------------------------------------------------------------------------
+// disable
+// ---------------------------------------------------------------------------
 
-    let installed_file_paths: Vec<String> = outcome
-        .files
-        .iter()
-        .map(|f| f.path.display().to_string())
-        .collect();
+fn handle_disable(
+    ctx: &CliContext,
+    component: &str,
+    framework: Option<&str>,
+) -> Result<(), CliError> {
+    const COMMAND: &str = "adapter disable";
+    let manager = build_manager(ctx);
+    let outcome: DisableOutcome = manager
+        .disable(component, framework)
+        .map_err(|e| map_err(COMMAND, e))?;
 
-    let obj = InstalledObject {
-        kind: ObjectKind::Adapter,
-        name: adapter_name.clone(),
-        version: version.clone(),
-        status: ObjectStatus::Installed,
-        manifest_digest: None,
-        distribution_source: Some(entry.url.clone()),
-        install_backend: Some(entry.backend.clone()),
-        installed_at: started_at.clone(),
-        last_operation_id: Some(operation_id.clone()),
-        managed: true,
-        adopted: false,
-        subscription_scope: Default::default(),
-        enabled_features: Vec::new(),
-        component_refs: vec![component.to_string()],
-        files: owned_files,
-        external_modified_files: Vec::new(),
-        services: Vec::new(),
-        health: Vec::new(),
-    };
-
-    state.install_mode = match ctx.install_mode {
-        crate::context::InstallMode::System => StateInstallMode::System,
-        crate::context::InstallMode::User => StateInstallMode::User,
-    };
-    state.prefix = layout.prefix.clone();
-    state.upsert_object(obj);
-    state.operations.push(OperationRecord {
-        id: operation_id.clone(),
-        command: command.clone(),
-        status: "ok".to_string(),
-        started_at: started_at.clone(),
-        finished_at: Some(now_iso8601()),
+    // Cleanup that did not complete is a degraded outcome: the receipt was
+    // kept (marked cleanup_failed) so the operator can retry. Surface a
+    // non-zero exit rather than a silent success.
+    let degraded = (!outcome.report.cleanup_complete).then(|| CliError::Degraded {
+        command: COMMAND.to_string(),
+        reason: format!(
+            "adapter '{}' cleanup incomplete; receipt kept for retry",
+            outcome.component
+        ),
     });
 
-    let state_path = layout.state_dir.join("installed.toml");
-    if let Err(err) = state.save(&state_path) {
-        rollback_installed_files(&outcome.files);
-        return Err(CliError::Runtime {
-            command,
-            reason: format!(
-                "failed to save state; attempted best-effort rollback of installed files (some may remain on disk): {err}"
-            ),
-        });
-    }
-
-    // Central log.
-    let log = CentralLog::open(layout.central_log.clone());
-    let record = LogRecord {
-        kind: LogKind::Operation,
-        operation_id: Some(operation_id.clone()),
-        command: format!("adapter install {adapter_name}"),
-        source: "anolisa-cli".to_string(),
-        component: Some(component.to_string()),
-        severity: Severity::Info,
-        message: format!("adapter {adapter_name} installed"),
-        actor: "cli".to_string(),
-        install_mode: Some(ctx.install_mode.as_str().to_string()),
-        started_at: started_at.clone(),
-        finished_at: Some(now_iso8601()),
-        status: Some(LogStatus::Ok),
-        objects: vec![adapter_name.clone()],
-        backup_ids: Vec::new(),
-        warnings: Vec::new(),
-        details: serde_json::Value::Null,
-    };
-    if let Err(err) = log.append(&record) {
-        eprintln!("warning: failed to write central log: {err}");
-    }
-
-    // Output.
     if ctx.json {
-        return render_json(
-            &command,
-            InstallResult {
-                component: component.to_string(),
-                framework: framework.to_string(),
-                adapter: adapter_name,
-                version,
-                operation_id,
-                files_installed: installed_file_paths,
-            },
-        );
-    }
-
-    if !ctx.quiet {
-        let color = Palette::new(ctx.no_color);
-        println!(
-            "{} {} {}",
-            color.command("adapter install"),
-            adapter_name,
-            color.ok("succeeded")
-        );
-        println!(
-            "{} {}",
-            color.label("operation_id:"),
-            color.id(&operation_id)
-        );
-        println!(
-            "{} {}",
-            color.label("files installed:"),
-            installed_file_paths.len()
-        );
-        for p in &installed_file_paths {
-            println!("  - {}", color.path(p));
+        if let Some(err) = degraded {
+            return Err(err);
         }
+        let payload = DisablePayload {
+            component: outcome.component.clone(),
+            framework: outcome.framework.clone(),
+            claim_removed: outcome.claim_removed,
+            cleanup_complete: outcome.report.cleanup_complete,
+            messages: outcome.report.messages.clone(),
+        };
+        return render_json(COMMAND, payload);
     }
 
-    Ok(())
-}
-
-/// Resolve the artifact entry for a component from the distribution index.
-///
-/// `version = None` lets the index pick the highest published semver for the
-/// host platform — adapter install pins to whatever was actually shipped
-/// rather than a version read from the dev-tree catalog.
-fn resolve_adapter_artifact(
-    dist_index: &DistributionIndex,
-    component: &str,
-    version: Option<&str>,
-    ctx: &CliContext,
-    command: &str,
-) -> Result<anolisa_core::DistributionEntry, CliError> {
-    let env = anolisa_env::EnvService::detect();
-    let preferred = [ArtifactType::TarGz];
-    let query = ResolveQuery {
-        component,
-        version,
-        channel: None,
-        install_mode: ctx.install_mode.as_str(),
-        os: &env.os,
-        arch: &env.arch,
-        libc: env.libc.as_deref(),
-        pkg_base: env.pkg_base.as_deref(),
-        preferred_types: &preferred,
+    let target = match &outcome.framework {
+        Some(f) => format!("{}/{}", outcome.component, f),
+        None => outcome.component.clone(),
     };
-    dist_index.resolve(&query).map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("failed to resolve artifact for '{component}': {err}"),
-    })
+    if outcome.claim_removed {
+        println!("Disabled {target}.");
+    } else if outcome.report.cleanup_complete {
+        println!("Nothing to disable for {target}.");
+    } else {
+        println!("Disable of {target} did not complete cleanly:");
+    }
+    for msg in &outcome.report.messages {
+        println!("  - {msg}");
+    }
+    degraded.map_or(Ok(()), Err)
 }
 
 // ---------------------------------------------------------------------------
-// Framework CLI registration (OpenClaw)
+// status
 // ---------------------------------------------------------------------------
 
-/// True when `framework` is wired in by invoking its own CLI rather than by a
-/// bare file copy. OpenClaw loads plugins from its managed registry
-/// (`openclaw plugins install`), so a dropped directory alone is not loaded.
-fn framework_needs_cli(framework: &str) -> bool {
-    framework == "openclaw"
-}
+fn handle_status(ctx: &CliContext, component: Option<&str>) -> Result<(), CliError> {
+    const COMMAND: &str = "adapter status";
+    let manager = build_manager(ctx);
+    let report: StatusReport = manager.status(component).map_err(|e| map_err(COMMAND, e))?;
 
-/// A resolved OpenClaw CLI invocation. Built purely (the only env read is
-/// `OPENCLAW_BIN`) so the argv/env contract — mirroring
-/// `openclaw/scripts/install.sh` — can be unit-tested without spawning.
-struct OpenclawInvocation {
-    /// Executable to run (`OPENCLAW_BIN` override, else `openclaw`).
-    program: String,
-    /// Arguments, e.g. `plugins install <dest> --force …`.
-    args: Vec<String>,
-    /// `OPENCLAW_STATE_DIR` value set on the child; `OPENCLAW_HOME` is unset.
-    state_dir: PathBuf,
-    /// Directories prepended to `PATH` before spawning.
-    path_prepend: Vec<PathBuf>,
-}
-
-impl OpenclawInvocation {
-    /// Human-readable form for dry-run/preview output.
-    fn display_command(&self) -> String {
-        let mut s = format!(
-            "OPENCLAW_STATE_DIR={} {}",
-            self.state_dir.display(),
-            self.program
-        );
-        for a in &self.args {
-            s.push(' ');
-            s.push_str(a);
-        }
-        s
-    }
-}
-
-/// Why an OpenClaw CLI invocation failed.
-enum OpenclawError {
-    /// The binary was not found on `PATH`.
-    NotFound,
-    /// The process failed to spawn for another reason.
-    Spawn(String),
-    /// The process ran but exited non-zero.
-    Exit(String),
-}
-
-impl OpenclawError {
-    fn message(&self) -> String {
-        match self {
-            OpenclawError::NotFound => "openclaw CLI not found on PATH".to_string(),
-            OpenclawError::Spawn(s) => s.clone(),
-            OpenclawError::Exit(s) => s.clone(),
-        }
-    }
-}
-
-/// `OPENCLAW_BIN` override, else `openclaw`.
-fn openclaw_bin() -> String {
-    std::env::var("OPENCLAW_BIN")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "openclaw".to_string())
-}
-
-/// Resolve the OpenClaw home (also the state dir): `OPENCLAW_HOME`, else
-/// `$HOME/.openclaw`. Trailing slashes are trimmed to match the script.
-fn openclaw_home() -> Option<PathBuf> {
-    if let Some(h) = std::env::var_os("OPENCLAW_HOME") {
-        let s = h.to_string_lossy();
-        let trimmed = s.trim_end_matches('/');
-        if !trimmed.is_empty() {
-            return Some(PathBuf::from(trimmed));
-        }
-    }
-    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".openclaw"))
-}
-
-/// PATH prefix dirs, mirroring `install.sh`:
-/// `$HOME/.local/bin`, `<state_dir>/bin`, `/usr/local/bin`.
-fn openclaw_path_prepend(home: &Path, user_home: Option<&Path>) -> Vec<PathBuf> {
-    let mut v = Vec::new();
-    if let Some(uh) = user_home {
-        v.push(uh.join(".local/bin"));
-    }
-    v.push(home.join("bin"));
-    v.push(PathBuf::from("/usr/local/bin"));
-    v
-}
-
-/// Build the `openclaw plugins install <dest> …` invocation. Pure.
-fn build_openclaw_install(
-    program: &str,
-    dest: &Path,
-    home: &Path,
-    user_home: Option<&Path>,
-) -> OpenclawInvocation {
-    OpenclawInvocation {
-        program: program.to_string(),
-        args: vec![
-            "plugins".to_string(),
-            "install".to_string(),
-            dest.display().to_string(),
-            "--force".to_string(),
-            "--dangerously-force-unsafe-install".to_string(),
-        ],
-        state_dir: home.to_path_buf(),
-        path_prepend: openclaw_path_prepend(home, user_home),
-    }
-}
-
-/// Build the `openclaw plugins uninstall <plugin_id> --force` invocation. Pure.
-///
-/// `--force` skips OpenClaw's interactive `[y/N]` confirmation — required
-/// because anolisa drives the CLI non-interactively (no TTY). Mirrors the
-/// official `openclaw/scripts/uninstall.sh` contract.
-fn build_openclaw_uninstall(
-    program: &str,
-    plugin_id: &str,
-    home: &Path,
-    user_home: Option<&Path>,
-) -> OpenclawInvocation {
-    OpenclawInvocation {
-        program: program.to_string(),
-        args: vec![
-            "plugins".to_string(),
-            "uninstall".to_string(),
-            plugin_id.to_string(),
-            "--force".to_string(),
-        ],
-        state_dir: home.to_path_buf(),
-        path_prepend: openclaw_path_prepend(home, user_home),
-    }
-}
-
-/// The install invocation for `framework`, or `None` when not CLI-registered.
-fn openclaw_install_for(framework: &str, dest: &Path) -> Option<OpenclawInvocation> {
-    if framework != "openclaw" {
-        return None;
-    }
-    let home = openclaw_home()?;
-    let user_home = std::env::var_os("HOME").map(PathBuf::from);
-    Some(build_openclaw_install(
-        &openclaw_bin(),
-        dest,
-        &home,
-        user_home.as_deref(),
-    ))
-}
-
-/// The uninstall invocation for `framework`, or `None` when not CLI-registered.
-fn openclaw_uninstall_for(framework: &str, plugin_id: &str) -> Option<OpenclawInvocation> {
-    if framework != "openclaw" {
-        return None;
-    }
-    let home = openclaw_home()?;
-    let user_home = std::env::var_os("HOME").map(PathBuf::from);
-    Some(build_openclaw_uninstall(
-        &openclaw_bin(),
-        plugin_id,
-        &home,
-        user_home.as_deref(),
-    ))
-}
-
-/// Spawn an OpenClaw CLI invocation, replicating the env contract from
-/// `openclaw/scripts/install.sh` (unset `OPENCLAW_HOME`, set
-/// `OPENCLAW_STATE_DIR`, prepend PATH) without executing the script itself.
-fn run_openclaw(inv: &OpenclawInvocation, quiet: bool) -> Result<(), OpenclawError> {
-    let mut cmd = Command::new(&inv.program);
-    cmd.args(&inv.args);
-    cmd.env_remove("OPENCLAW_HOME");
-    cmd.env("OPENCLAW_STATE_DIR", &inv.state_dir);
-
-    let existing = std::env::var_os("PATH").unwrap_or_default();
-    let mut paths = inv.path_prepend.clone();
-    paths.extend(std::env::split_paths(&existing));
-    if let Ok(joined) = std::env::join_paths(&paths) {
-        cmd.env("PATH", joined);
-    }
-    if quiet {
-        cmd.stdout(std::process::Stdio::null());
-        cmd.stderr(std::process::Stdio::null());
+    if ctx.json {
+        let receipts = report
+            .entries
+            .into_iter()
+            .map(|e| StatusRow {
+                component: e.component,
+                framework: e.framework,
+                report: e.report,
+            })
+            .collect();
+        return render_json(COMMAND, StatusPayload { receipts });
     }
 
-    match cmd.status() {
-        Ok(status) if status.success() => Ok(()),
-        Ok(status) => Err(OpenclawError::Exit(format!(
-            "'{}' exited with {status}",
-            inv.program
-        ))),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(OpenclawError::NotFound),
-        Err(e) => Err(OpenclawError::Spawn(format!(
-            "failed to run '{}': {e}",
-            inv.program
-        ))),
-    }
-}
-
-/// Load installed state, mapping errors to CliError::Runtime. Called inside
-/// the lock and before file copy so a corrupted state file doesn't leave
-/// orphan adapter files on disk.
-fn load_state_for_install(
-    ctx: &CliContext,
-    command: &str,
-) -> Result<anolisa_core::InstalledState, CliError> {
-    common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("failed to load installed state: {err}"),
-    })
-}
-
-/// Wire-form artifact type string for the install runner.
-fn artifact_type_wire(t: &ArtifactType) -> &'static str {
-    match t {
-        ArtifactType::TarGz => "tar_gz",
-        ArtifactType::Binary => "binary",
-        ArtifactType::Rpm => "rpm",
-        ArtifactType::Deb => "deb",
-        ArtifactType::Zip => "zip",
-        ArtifactType::Oci => "oci",
-        ArtifactType::File => "file",
-    }
-}
-
-/// Best-effort cleanup of installed files after a state-save failure.
-fn rollback_installed_files(files: &[anolisa_core::InstalledFile]) {
-    for f in files {
-        let _ = std::fs::remove_file(&f.path);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// adapter remove
-// ---------------------------------------------------------------------------
-
-/// Handle `adapter remove <component> <framework>`.
-fn handle_remove(
-    component: &str,
-    framework: &str,
-    purge: bool,
-    ctx: &CliContext,
-) -> Result<(), CliError> {
-    let command_str = format!("adapter remove {component} {framework}");
-    if purge {
-        return Err(CliError::not_implemented_with_hint(
-            "adapter remove --purge",
-            "adapter remove --purge is not yet implemented; omit --purge to remove the adapter files",
-        ));
-    }
-
-    let adapter_name = format!("{component}/{framework}");
-    let started_at = now_iso8601();
-    let layout = common::resolve_layout(ctx);
-    let state_path = layout.state_dir.join("installed.toml");
-
-    // Dry-run: unlocked read-only preview.
-    if ctx.dry_run {
-        let state = common::load_installed_state(ctx, &command_str)?;
-        let adapter_obj = state
-            .find_object(ObjectKind::Adapter, &adapter_name)
-            .ok_or_else(|| CliError::InvalidArgument {
-                command: command_str.clone(),
-                reason: format!("adapter '{adapter_name}' is not installed"),
-            })?;
-
-        let (would_remove, would_skip) = classify_files(&adapter_obj.files, &layout);
-
-        if ctx.json {
-            return render_json(
-                &command_str,
-                RemoveResult {
-                    adapter: adapter_name,
-                    files_removed: would_remove,
-                    files_skipped: would_skip,
-                    dry_run: true,
-                },
-            );
-        }
-        if !ctx.quiet {
-            let color = Palette::new(ctx.no_color);
-            println!(
-                "{} {} {}",
-                color.command("adapter remove"),
-                adapter_name,
-                color.muted("(dry-run)")
-            );
-            if let Some(inv) = openclaw_uninstall_for(framework, component) {
-                println!("{} {}", color.label("would run:"), inv.display_command());
-            }
-            if !would_remove.is_empty() {
-                println!("{}", color.label("would remove:"));
-                for p in &would_remove {
-                    println!("  - {}", color.path(p));
-                }
-            }
-            if !would_skip.is_empty() {
-                println!("{}", color.warn("would skip:"));
-                for s in &would_skip {
-                    println!("  - {} ({})", color.path(&s.path), s.reason);
-                }
-            }
-            if would_remove.is_empty() && would_skip.is_empty() {
-                println!("  {}", color.muted("(no files recorded)"));
-            }
-        }
+    if report.entries.is_empty() {
+        println!("No adapter receipts.");
         return Ok(());
     }
-
-    // Real execution: lock first, then re-load state inside the lock so a
-    // concurrent writer cannot be overwritten.
-    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
-        command: command_str.clone(),
-        reason: format!("failed to acquire install lock: {err}"),
-    })?;
-
-    let mut state = common::load_installed_state(ctx, &command_str)?;
-    let adapter_obj = state
-        .find_object(ObjectKind::Adapter, &adapter_name)
-        .ok_or_else(|| CliError::InvalidArgument {
-            command: command_str.clone(),
-            reason: format!("adapter '{adapter_name}' is not installed"),
-        })?
-        .clone();
-
-    // Symmetric framework de-registration: unwire from the framework's CLI
-    // before deleting the local copy. A missing framework binary means there
-    // is nothing to unregister (not fatal); a real uninstall failure is
-    // retryable, so we keep state and bail.
-    if let Some(inv) = openclaw_uninstall_for(framework, component) {
-        match run_openclaw(&inv, ctx.quiet) {
-            Ok(()) => {}
-            Err(OpenclawError::NotFound) => {
-                if !ctx.quiet {
-                    eprintln!(
-                        "warning: openclaw CLI not found — skipping plugin uninstall for {adapter_name}"
-                    );
-                }
-            }
-            Err(err) => {
-                return Err(CliError::Runtime {
-                    command: command_str.clone(),
-                    reason: format!(
-                        "framework de-registration failed (state kept so removal can be retried): {}",
-                        err.message()
-                    ),
-                });
-            }
-        }
-    }
-
-    let mut removed: Vec<String> = Vec::new();
-    let mut skipped: Vec<SkippedFile> = Vec::new();
-    let mut warnings: Vec<String> = Vec::new();
-    let mut remove_errors: Vec<String> = Vec::new();
-
-    for file in &adapter_obj.files {
-        if file.owner != FileOwner::Anolisa {
-            let msg = format!("skipped {} — externally owned file", file.path.display());
-            warnings.push(msg);
-            skipped.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: "file is externally owned — refusing to delete".to_string(),
-            });
-            continue;
-        }
-        if let Err(err) = validate_owned_path(&layout, &file.path) {
-            let msg = format!("skipped {} — path boundary: {err}", file.path.display());
-            warnings.push(msg);
-            skipped.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: format!("path boundary check failed: {err}"),
-            });
-            continue;
-        }
-        if file.path.is_symlink() {
-            let msg = format!(
-                "skipped {} — refusing to follow symlink",
-                file.path.display()
-            );
-            warnings.push(msg);
-            skipped.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: "refusing to follow symlink".to_string(),
-            });
-            continue;
-        }
-        if file.path.is_dir() {
-            let msg = format!(
-                "skipped {} — refusing to remove directory",
-                file.path.display()
-            );
-            warnings.push(msg);
-            skipped.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: "refusing to remove directory".to_string(),
-            });
-            continue;
-        }
-        if !file.path.exists() {
-            continue;
-        }
-        if let Err(err) = std::fs::remove_file(&file.path) {
-            let msg = format!("failed to remove {}: {err}", file.path.display());
-            warnings.push(msg);
-            remove_errors.push(format!("{} ({err})", file.path.display()));
-            skipped.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: format!("remove_file failed: {err}"),
-            });
-        } else {
-            removed.push(file.path.display().to_string());
-        }
-    }
-
-    if !remove_errors.is_empty() {
-        let details = remove_errors.join(", ");
-        return Err(CliError::Runtime {
-            command: command_str,
-            reason: format!(
-                "failed to remove {count} adapter file(s); state kept so removal can be retried: {details}",
-                count = remove_errors.len(),
-            ),
-        });
-    }
-
-    // Update state — set metadata from ctx in case this is a fresh file.
-    state.install_mode = match ctx.install_mode {
-        crate::context::InstallMode::System => StateInstallMode::System,
-        crate::context::InstallMode::User => StateInstallMode::User,
-    };
-    state.prefix = layout.prefix.clone();
-    state.remove_object(ObjectKind::Adapter, &adapter_name);
-    state.save(&state_path).map_err(|err| CliError::Runtime {
-        command: command_str.clone(),
-        reason: format!("failed to save installed state: {err}"),
-    })?;
-
-    // Central log.
-    let operation_id = format!(
-        "op-adapter-remove-{}",
-        started_at.replace([':', '-', 'T', 'Z'], "")
-    );
-    let log = CentralLog::open(layout.central_log.clone());
-    let record = LogRecord {
-        kind: LogKind::Operation,
-        operation_id: Some(operation_id.clone()),
-        command: format!("adapter remove {adapter_name}"),
-        source: "anolisa-cli".to_string(),
-        component: Some(component.to_string()),
-        severity: if warnings.is_empty() {
-            Severity::Info
-        } else {
-            Severity::Warn
-        },
-        message: format!("adapter {adapter_name} removed"),
-        actor: "cli".to_string(),
-        install_mode: Some(ctx.install_mode.as_str().to_string()),
-        started_at: started_at.clone(),
-        finished_at: Some(now_iso8601()),
-        status: Some(LogStatus::Ok),
-        objects: vec![adapter_name.clone()],
-        backup_ids: Vec::new(),
-        warnings: warnings.clone(),
-        details: serde_json::Value::Null,
-    };
-    if let Err(err) = log.append(&record) {
-        eprintln!("warning: failed to write central log: {err}");
-    }
-
-    // Output.
-    if ctx.json {
-        return render_json(
-            &command_str,
-            RemoveResult {
-                adapter: adapter_name,
-                files_removed: removed,
-                files_skipped: skipped,
-                dry_run: false,
-            },
-        );
-    }
-
-    if !ctx.quiet {
-        let color = Palette::new(ctx.no_color);
+    for e in &report.entries {
         println!(
-            "{} {} {}",
-            color.command("adapter remove"),
-            adapter_name,
-            color.ok("succeeded")
+            "{}/{}: {}",
+            e.component,
+            e.framework,
+            summary_label(&e.report.summary),
         );
-        println!(
-            "{} {}",
-            color.label("operation_id:"),
-            color.id(&operation_id)
-        );
-        println!("{} {}", color.label("files removed:"), removed.len());
-        for p in &removed {
-            println!("  - {}", color.path(p));
-        }
-        if !skipped.is_empty() {
-            println!("{} {}", color.label("files skipped:"), skipped.len());
-            for s in &skipped {
-                println!("  - {} ({})", color.path(&s.path), s.reason);
-            }
-        }
-        if !warnings.is_empty() {
-            println!("{}", color.warn("warnings:"));
-            for w in &warnings {
-                println!("  - {w}");
-            }
+        for cond in &e.report.conditions {
+            let reason = cond
+                .reason
+                .as_deref()
+                .map(|r| format!(" ({r})"))
+                .unwrap_or_default();
+            println!("  {:?} = {:?}{}", cond.kind, cond.status, reason);
         }
     }
-
     Ok(())
 }
 
-/// Classify adapter files into removable vs skipped without mutating
-/// anything. Used by the dry-run preview.
-fn classify_files(
-    files: &[OwnedFile],
-    layout: &anolisa_platform::fs_layout::FsLayout,
-) -> (Vec<String>, Vec<SkippedFile>) {
-    let mut would_remove = Vec::new();
-    let mut would_skip = Vec::new();
-    for file in files {
-        if file.owner != FileOwner::Anolisa {
-            would_skip.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: "file is externally owned — refusing to delete".to_string(),
-            });
-        } else if let Err(err) = validate_owned_path(layout, &file.path) {
-            would_skip.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: format!("path boundary check failed: {err}"),
-            });
-        } else if file.path.is_symlink() {
-            would_skip.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: "refusing to follow symlink".to_string(),
-            });
-        } else if file.path.is_dir() {
-            would_skip.push(SkippedFile {
-                path: file.path.display().to_string(),
-                reason: "refusing to remove directory".to_string(),
-            });
-        } else {
-            would_remove.push(file.path.display().to_string());
-        }
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Map an [`AdapterError`] to the CLI error model. Input/environment
+/// problems are `INVALID_ARGUMENT` (exit 2); machine-side failures (CLI
+/// spawn, lock, state/log IO) are `EXECUTION_FAILED` (exit 1).
+fn map_err(command: &str, err: AdapterError) -> CliError {
+    match err {
+        AdapterError::UnknownPlaceholder { .. }
+        | AdapterError::UnknownFramework { .. }
+        | AdapterError::AmbiguousFramework { .. }
+        | AdapterError::ComponentNotInstalled { .. }
+        | AdapterError::AdapterNotDeclared { .. }
+        | AdapterError::ResourceRootNotFound { .. }
+        | AdapterError::FrameworkNotDetected { .. }
+        | AdapterError::BundleInvalid { .. }
+        | AdapterError::ClaimValidation(_) => CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: err.to_string(),
+        },
+        AdapterError::AdapterManifest { .. }
+        | AdapterError::FrameworkCli { .. }
+        | AdapterError::Lock(_)
+        | AdapterError::State(_)
+        | AdapterError::Log(_)
+        | AdapterError::Io { .. } => CliError::Runtime {
+            command: command.to_string(),
+            reason: err.to_string(),
+        },
     }
-    (would_remove, would_skip)
 }
 
-/// ISO 8601 UTC timestamp with second precision.
-fn now_iso8601() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+/// Human-facing one-line label for a status summary.
+fn summary_label(summary: &anolisa_core::adapter::driver::AdapterSummary) -> &'static str {
+    use anolisa_core::adapter::driver::AdapterSummary::*;
+    match summary {
+        Healthy => "healthy",
+        Degraded => "degraded",
+        CleanupFailed => "cleanup_failed",
+        Unknown => "unknown",
+    }
+}
+
+fn yes_no(b: bool) -> &'static str {
+    if b { "yes" } else { "no" }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
-    use std::path::PathBuf;
-
-    use anolisa_core::state::{InstalledObject, InstalledState, ObjectStatus, OwnedFile};
-    use anolisa_platform::fs_layout::FsLayout;
-    use tempfile::tempdir;
-
-    use crate::context::InstallMode;
-
-    fn ctx_with_prefix(
-        json: bool,
-        dry_run: bool,
-        install_mode: InstallMode,
-        prefix: Option<PathBuf>,
-    ) -> CliContext {
-        CliContext {
-            install_mode,
-            prefix,
-            json,
-            dry_run,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
-    }
-
-    fn adapter_object(name: &str, files: Vec<OwnedFile>) -> InstalledObject {
-        InstalledObject {
-            kind: ObjectKind::Adapter,
-            name: name.to_string(),
-            version: "0.1.0".to_string(),
-            status: ObjectStatus::Installed,
-            manifest_digest: None,
-            distribution_source: None,
-            install_backend: None,
-            installed_at: "2026-06-01T10:00:00Z".to_string(),
-            last_operation_id: None,
-            managed: true,
-            adopted: false,
-            subscription_scope: Default::default(),
-            enabled_features: Vec::new(),
-            component_refs: Vec::new(),
-            files,
-            external_modified_files: Vec::new(),
-            services: Vec::new(),
-            health: Vec::new(),
-        }
-    }
-
-    // -- remove: adapter not installed → InvalidArgument ---------------------
-
-    #[test]
-    fn remove_unknown_adapter_returns_invalid_argument() {
-        let tmp = tempdir().expect("tmpdir");
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        let err = handle_remove("tokenless", "cosh", false, &ctx)
-            .expect_err("must error for unknown adapter");
-        assert_eq!(err.code(), "INVALID_ARGUMENT");
-        assert!(err.reason().contains("not installed"));
-    }
-
-    // -- remove: --purge returns NOT_IMPLEMENTED ----------------------------
-
-    #[test]
-    fn remove_purge_returns_not_implemented() {
-        let tmp = tempdir().expect("tmpdir");
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        let err = handle_remove("tokenless", "cosh", true, &ctx).expect_err("purge must error");
-        assert_eq!(err.code(), "NOT_IMPLEMENTED");
-    }
-
-    // -- remove: dry-run previews without modifying state --------------------
-
-    #[test]
-    fn remove_dry_run_does_not_delete_files_or_modify_state() {
-        let tmp = tempdir().expect("tmpdir");
-        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-
-        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
-        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
-        let owned = layout.bin_dir.join("tokenless-adapter");
-        std::fs::write(&owned, b"adapter-binary").expect("write owned");
-
-        let mut state = InstalledState::default();
-        state.upsert_object(adapter_object(
-            "tokenless/cosh",
-            vec![OwnedFile {
-                path: owned.clone(),
-                owner: FileOwner::Anolisa,
-                sha256: None,
-            }],
-        ));
-        let state_path = layout.state_dir.join("installed.toml");
-        state.save(&state_path).expect("save state");
-        let prior_bytes = std::fs::read(&state_path).expect("read prior");
-
-        let ctx = ctx_with_prefix(
-            false,
-            true,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        handle_remove("tokenless", "cosh", false, &ctx).expect("dry-run must succeed");
-
-        assert!(owned.exists(), "dry-run must not delete files");
-        let after_bytes = std::fs::read(&state_path).expect("read after");
-        assert_eq!(after_bytes, prior_bytes, "dry-run must not modify state");
-    }
-
-    // -- remove: real delete + state update ---------------------------------
-
-    #[test]
-    fn remove_deletes_owned_files_and_drops_state_object() {
-        let tmp = tempdir().expect("tmpdir");
-        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-
-        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
-        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
-        let owned = layout.bin_dir.join("tokenless-adapter");
-        std::fs::write(&owned, b"adapter-binary").expect("write owned");
-
-        let mut state = InstalledState::default();
-        state.upsert_object(adapter_object(
-            "tokenless/cosh",
-            vec![OwnedFile {
-                path: owned.clone(),
-                owner: FileOwner::Anolisa,
-                sha256: None,
-            }],
-        ));
-        let state_path = layout.state_dir.join("installed.toml");
-        state.save(&state_path).expect("save state");
-
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        handle_remove("tokenless", "cosh", false, &ctx).expect("remove must succeed");
-
-        assert!(!owned.exists(), "owned file must be removed");
-
-        let after = InstalledState::load(&state_path).expect("reload state");
-        assert!(
-            after
-                .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                .is_none(),
-            "adapter object must be dropped"
-        );
-
-        assert!(layout.central_log.exists(), "central log must be written");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn remove_file_failure_keeps_state_for_retry() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let tmp = tempdir().expect("tmpdir");
-        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-
-        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
-        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
-
-        let removable = layout.bin_dir.join("removable-adapter-file");
-        std::fs::write(&removable, b"removable").expect("write removable");
-
-        let locked_dir = layout.bin_dir.join("locked-dir");
-        std::fs::create_dir_all(&locked_dir).expect("mkdir locked dir");
-        let blocked = locked_dir.join("blocked-adapter-file");
-        std::fs::write(&blocked, b"blocked").expect("write blocked");
-        std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o555))
-            .expect("make locked dir read-only");
-
-        let mut state = InstalledState::default();
-        state.upsert_object(adapter_object(
-            "tokenless/cosh",
-            vec![
-                OwnedFile {
-                    path: removable.clone(),
-                    owner: FileOwner::Anolisa,
-                    sha256: None,
-                },
-                OwnedFile {
-                    path: blocked.clone(),
-                    owner: FileOwner::Anolisa,
-                    sha256: None,
-                },
-            ],
-        ));
-        let state_path = layout.state_dir.join("installed.toml");
-        state.save(&state_path).expect("save state");
-
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        let err = handle_remove("tokenless", "cosh", false, &ctx)
-            .expect_err("remove must fail when a file cannot be deleted");
-
-        std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o755))
-            .expect("restore locked dir permissions");
-
-        assert_eq!(err.code(), "EXECUTION_FAILED");
-        assert!(
-            err.reason().contains("state kept"),
-            "error should explain retryable state retention: {}",
-            err.reason()
-        );
-        assert!(
-            !removable.exists(),
-            "files removed before the failure stay removed"
-        );
-        assert!(blocked.exists(), "failed file must remain on disk");
-
-        let after = InstalledState::load(&state_path).expect("reload state");
-        assert!(
-            after
-                .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                .is_some(),
-            "adapter state must remain so remove can be retried"
-        );
-    }
-
-    // -- remove: idempotent for already-deleted files -----------------------
-
-    #[test]
-    fn remove_is_idempotent_for_missing_files() {
-        let tmp = tempdir().expect("tmpdir");
-        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-
-        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
-        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
-
-        let ghost = layout.bin_dir.join("already-gone");
-
-        let mut state = InstalledState::default();
-        state.upsert_object(adapter_object(
-            "tokenless/cosh",
-            vec![OwnedFile {
-                path: ghost,
-                owner: FileOwner::Anolisa,
-                sha256: None,
-            }],
-        ));
-        let state_path = layout.state_dir.join("installed.toml");
-        state.save(&state_path).expect("save state");
-
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        handle_remove("tokenless", "cosh", false, &ctx)
-            .expect("remove must succeed for missing files");
-    }
-
-    // -- remove: external-owned files skipped -------------------------------
-
-    #[test]
-    fn remove_skips_externally_owned_files() {
-        let tmp = tempdir().expect("tmpdir");
-        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-
-        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
-        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
-        let external = layout.bin_dir.join("external-config");
-        std::fs::write(&external, b"external").expect("write external");
-        let owned = layout.bin_dir.join("owned-binary");
-        std::fs::write(&owned, b"owned").expect("write owned");
-
-        let mut state = InstalledState::default();
-        state.upsert_object(adapter_object(
-            "tokenless/cosh",
-            vec![
-                OwnedFile {
-                    path: external.clone(),
-                    owner: FileOwner::External,
-                    sha256: None,
-                },
-                OwnedFile {
-                    path: owned.clone(),
-                    owner: FileOwner::Anolisa,
-                    sha256: None,
-                },
-            ],
-        ));
-        let state_path = layout.state_dir.join("installed.toml");
-        state.save(&state_path).expect("save state");
-
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        handle_remove("tokenless", "cosh", false, &ctx).expect("remove must succeed");
-
-        assert!(external.exists(), "external file must not be deleted");
-        assert!(!owned.exists(), "owned file must be deleted");
-    }
-
-    // -- remove: path outside owned roots is skipped ------------------------
-
-    #[test]
-    fn remove_skips_files_outside_owned_roots() {
-        let tmp = tempdir().expect("tmpdir");
-        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-
-        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
-        let outside = tmp.path().join("not-owned").join("rogue.conf");
-        std::fs::create_dir_all(outside.parent().unwrap()).expect("mkdir outside");
-        std::fs::write(&outside, b"rogue").expect("write outside");
-
-        let mut state = InstalledState::default();
-        state.upsert_object(adapter_object(
-            "tokenless/cosh",
-            vec![OwnedFile {
-                path: outside.clone(),
-                owner: FileOwner::Anolisa,
-                sha256: None,
-            }],
-        ));
-        let state_path = layout.state_dir.join("installed.toml");
-        state.save(&state_path).expect("save state");
-
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        handle_remove("tokenless", "cosh", false, &ctx).expect("remove must succeed");
-
-        assert!(outside.exists(), "file outside roots must not be deleted");
-    }
-
-    // -- remove: symlinks are skipped ---------------------------------------
-
-    #[cfg(unix)]
-    #[test]
-    fn remove_skips_symlinks() {
-        let tmp = tempdir().expect("tmpdir");
-        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-
-        std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bin");
-        std::fs::create_dir_all(&layout.state_dir).expect("mkdir state");
-
-        let target = layout.bin_dir.join("real-file");
-        std::fs::write(&target, b"target").expect("write target");
-        let link = layout.bin_dir.join("link-file");
-        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
-
-        let mut state = InstalledState::default();
-        state.upsert_object(adapter_object(
-            "tokenless/cosh",
-            vec![OwnedFile {
-                path: link.clone(),
-                owner: FileOwner::Anolisa,
-                sha256: None,
-            }],
-        ));
-        let state_path = layout.state_dir.join("installed.toml");
-        state.save(&state_path).expect("save state");
-
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        handle_remove("tokenless", "cosh", false, &ctx).expect("remove must succeed");
-
-        assert!(link.is_symlink(), "symlink must not be removed");
-        assert!(target.exists(), "symlink target must not be removed");
-    }
-
-    // -- dispatch: list returns NOT_IMPLEMENTED -----------------------------
-
-    #[test]
-    fn list_returns_not_implemented() {
-        let tmp = tempdir().expect("tmpdir");
-        let ctx = ctx_with_prefix(
-            false,
-            false,
-            InstallMode::System,
-            Some(tmp.path().to_path_buf()),
-        );
-        let err = handle(
-            AdapterArgs {
-                command: AdapterCommands::List,
-            },
-            &ctx,
-        )
-        .expect_err("list must return not implemented");
-        assert_eq!(err.code(), "NOT_IMPLEMENTED");
-    }
-
-    // -- openclaw CLI invocation construction (pure, no spawn) --------------
-
-    #[test]
-    fn framework_needs_cli_is_openclaw_only() {
-        assert!(framework_needs_cli("openclaw"));
-        assert!(!framework_needs_cli("cosh"));
-        assert!(!framework_needs_cli("hermes"));
+    /// Wrapper so we can parse the adapter subcommand in isolation.
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: AdapterCommands,
     }
 
     #[test]
-    fn build_openclaw_install_mirrors_install_sh_contract() {
-        let inv = build_openclaw_install(
-            "openclaw",
-            std::path::Path::new("/data/adapters/tokenless/openclaw"),
-            std::path::Path::new("/home/u/.openclaw"),
-            Some(std::path::Path::new("/home/u")),
-        );
-        assert_eq!(inv.program, "openclaw");
-        assert_eq!(
-            inv.args,
-            vec![
-                "plugins".to_string(),
-                "install".to_string(),
-                "/data/adapters/tokenless/openclaw".to_string(),
-                "--force".to_string(),
-                "--dangerously-force-unsafe-install".to_string(),
-            ]
-        );
-        // OPENCLAW_STATE_DIR == home; OPENCLAW_HOME is unset at spawn time.
-        assert_eq!(inv.state_dir, PathBuf::from("/home/u/.openclaw"));
-        // PATH prefix order matches install.sh: ~/.local/bin, <state>/bin,
-        // /usr/local/bin.
-        assert_eq!(
-            inv.path_prepend,
-            vec![
-                PathBuf::from("/home/u/.local/bin"),
-                PathBuf::from("/home/u/.openclaw/bin"),
-                PathBuf::from("/usr/local/bin"),
-            ]
-        );
-        let shown = inv.display_command();
-        assert!(shown.contains("OPENCLAW_STATE_DIR=/home/u/.openclaw"));
-        assert!(shown.contains("plugins install /data/adapters/tokenless/openclaw"));
-        assert!(shown.contains("--dangerously-force-unsafe-install"));
-    }
-
-    #[test]
-    fn build_openclaw_uninstall_targets_plugin_id() {
-        let inv = build_openclaw_uninstall(
-            "openclaw",
-            "tokenless",
-            std::path::Path::new("/home/u/.openclaw"),
-            Some(std::path::Path::new("/home/u")),
-        );
-        assert_eq!(
-            inv.args,
-            vec![
-                "plugins".to_string(),
-                "uninstall".to_string(),
-                "tokenless".to_string(),
-                "--force".to_string(),
-            ]
-        );
-        assert_eq!(inv.state_dir, PathBuf::from("/home/u/.openclaw"));
-    }
-
-    // =========================================================================
-    // Integration tests: adapter install + remove end-to-end
-    // =========================================================================
-
-    mod install_integration {
-        use super::*;
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
-        use sha2::{Digest, Sha256};
-        use std::fs;
-        use tar::{Builder, Header};
-
-        fn sha256_hex(bytes: &[u8]) -> String {
-            let mut h = Sha256::new();
-            h.update(bytes);
-            let digest = h.finalize();
-            digest.iter().map(|b| format!("{b:02x}")).collect()
-        }
-
-        fn build_tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
-            let buf: Vec<u8> = Vec::new();
-            let enc = GzEncoder::new(buf, Compression::default());
-            let mut tar = Builder::new(enc);
-            for (path, data) in entries {
-                let mut hdr = Header::new_gnu();
-                hdr.set_size(data.len() as u64);
-                hdr.set_mode(0o644);
-                hdr.set_cksum();
-                tar.append_data(&mut hdr, path, *data).unwrap();
+    fn enable_parses_optional_framework() {
+        let cli = TestCli::try_parse_from(["x", "enable", "tokenless"]).expect("parse");
+        match cli.command {
+            AdapterCommands::Enable {
+                component,
+                framework,
+            } => {
+                assert_eq!(component, "tokenless");
+                assert!(framework.is_none());
             }
-            let enc = tar.into_inner().unwrap();
-            enc.finish().unwrap()
+            _ => panic!("expected enable"),
         }
 
-        /// Sets up a complete test environment:
-        /// - system prefix under tmp
-        /// - overlay manifests with distribution index pointing to a file:// tar.gz
-        /// - the tar.gz built from provided entries
-        ///
-        /// Returns (ctx, tar_gz_sha256)
-        fn setup_env(
-            tmp: &std::path::Path,
-            tar_entries: &[(&str, &[u8])],
-            component: &str,
-            version: &str,
-        ) -> (CliContext, String) {
-            let layout = FsLayout::system(Some(tmp.to_path_buf()));
-
-            // Build tar.gz artifact. The fixture embeds a published install
-            // contract (`.anolisa/component.toml`) declaring a `cosh` adapter so
-            // `handle_install` reads source/dest/version from the artifact — not
-            // from the dev-tree catalog. `cosh` is a non-CLI framework, so no
-            // real `openclaw` binary is ever spawned during the test.
-            let embedded = format!(
-                "[component]\n\
-                 name = \"{component}\"\n\
-                 version = \"{version}\"\n\
-                 \n\
-                 [[adapters]]\n\
-                 framework = \"cosh\"\n\
-                 kind = \"third-party\"\n\
-                 plugin_id = \"{component}\"\n\
-                 source = \"target/release/cosh-ext/\"\n\
-                 dest = \"{{datadir}}/adapters/{component}/cosh/\"\n",
-            );
-            let mut entries: Vec<(&str, &[u8])> = tar_entries.to_vec();
-            entries.push((".anolisa/component.toml", embedded.as_bytes()));
-            let tar_bytes = build_tar_gz(&entries);
-            let tar_sha = sha256_hex(&tar_bytes);
-            let artifact_dir = tmp.join("artifacts");
-            fs::create_dir_all(&artifact_dir).unwrap();
-            let tar_path = artifact_dir.join("adapter.tar.gz");
-            fs::write(&tar_path, &tar_bytes).unwrap();
-            let tar_url = format!("file://{}", tar_path.display());
-
-            // Write overlay distribution index.
-            let dist_dir = layout.manifests_overlay.join("distribution-index");
-            fs::create_dir_all(&dist_dir).unwrap();
-            let index_content = format!(
-                r#"schema_version = 1
-
-[[entries]]
-component = "{component}"
-version = "{version}"
-channel = "stable"
-artifact_type = "tar_gz"
-backend = "tar"
-url = "{tar_url}"
-os = "{os}"
-arch = "{arch}"
-install_modes = ["system"]
-sha256 = "{tar_sha}"
-"#,
-                os = anolisa_env::EnvService::detect().os,
-                arch = anolisa_env::EnvService::detect().arch,
-            );
-            fs::write(dist_dir.join("index.toml"), &index_content).unwrap();
-
-            // Ensure state/cache dirs exist.
-            fs::create_dir_all(&layout.state_dir).unwrap();
-            fs::create_dir_all(&layout.cache_dir).unwrap();
-
-            let ctx = ctx_with_prefix(false, false, InstallMode::System, Some(tmp.to_path_buf()));
-            (ctx, tar_sha)
+        let cli = TestCli::try_parse_from(["x", "enable", "tokenless", "openclaw"]).expect("parse");
+        match cli.command {
+            AdapterCommands::Enable { framework, .. } => {
+                assert_eq!(framework.as_deref(), Some("openclaw"));
+            }
+            _ => panic!("expected enable"),
         }
+    }
 
-        // -- install: end-to-end success -----------------------------------------
+    #[test]
+    fn status_component_is_optional() {
+        let cli = TestCli::try_parse_from(["x", "status"]).expect("parse");
+        assert!(matches!(
+            cli.command,
+            AdapterCommands::Status { component: None }
+        ));
+    }
 
-        #[test]
-        fn install_downloads_copies_files_and_writes_state() {
-            let tmp = tempdir().expect("tmpdir");
-            let plugin_json = br#"{"name":"tokenless"}"#;
-            let index_js = b"console.log('adapter loaded');";
-            let (ctx, _sha) = setup_env(
-                tmp.path(),
-                &[
-                    ("target/release/cosh-ext/plugin.json", plugin_json),
-                    ("target/release/cosh-ext/dist/index.js", index_js),
-                ],
-                "tokenless",
-                TEST_VERSION,
-            );
+    #[test]
+    fn ambiguous_framework_maps_to_invalid_argument() {
+        let err = map_err(
+            "adapter enable",
+            AdapterError::AmbiguousFramework {
+                component: "x".to_string(),
+                frameworks: vec!["a".to_string(), "b".to_string()],
+            },
+        );
+        assert!(matches!(err, CliError::InvalidArgument { .. }));
+    }
 
-            handle_install(&ctx, "tokenless", "cosh").expect("install must succeed");
-
-            // Verify files exist at the expanded destination.
-            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-            let dest_root = layout.datadir.join("adapters/tokenless/cosh");
-            assert!(
-                dest_root.join("plugin.json").exists(),
-                "plugin.json must be installed"
-            );
-            assert!(
-                dest_root.join("dist/index.js").exists(),
-                "dist/index.js must be installed"
-            );
-            assert_eq!(
-                fs::read(dest_root.join("plugin.json")).unwrap(),
-                plugin_json
-            );
-            assert_eq!(fs::read(dest_root.join("dist/index.js")).unwrap(), index_js);
-
-            // Verify state has the adapter object.
-            let state_path = layout.state_dir.join("installed.toml");
-            let state = InstalledState::load(&state_path).expect("load state");
-            let obj = state
-                .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                .expect("adapter object must exist in state");
-            assert_eq!(obj.status, ObjectStatus::Installed);
-            assert_eq!(obj.component_refs, vec!["tokenless".to_string()]);
-            assert_eq!(obj.files.len(), 2);
-            assert!(obj.files.iter().all(|f| f.owner == FileOwner::Anolisa));
-            assert!(obj.files.iter().all(|f| f.sha256.is_some()));
-
-            // Verify central log written.
-            assert!(layout.central_log.exists(), "central log must be written");
-        }
-
-        // -- install then remove: full lifecycle ---------------------------------
-
-        #[test]
-        fn install_then_remove_leaves_no_files_or_state() {
-            let tmp = tempdir().expect("tmpdir");
-            let plugin_json = br#"{"name":"tokenless"}"#;
-            let (ctx, _sha) = setup_env(
-                tmp.path(),
-                &[("target/release/cosh-ext/plugin.json", plugin_json)],
-                "tokenless",
-                TEST_VERSION,
-            );
-
-            handle_install(&ctx, "tokenless", "cosh").expect("install must succeed");
-
-            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-            let dest_root = layout.datadir.join("adapters/tokenless/cosh");
-            assert!(dest_root.join("plugin.json").exists());
-
-            handle_remove("tokenless", "cosh", false, &ctx).expect("remove must succeed");
-
-            assert!(
-                !dest_root.join("plugin.json").exists(),
-                "file must be removed"
-            );
-            let state_path = layout.state_dir.join("installed.toml");
-            let state = InstalledState::load(&state_path).expect("load state");
-            assert!(
-                state
-                    .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                    .is_none(),
-                "adapter object must be removed from state"
-            );
-        }
-
-        // -- install: missing sha256 in distribution entry -----------------------
-
-        #[test]
-        fn install_rejects_entry_without_sha256() {
-            let tmp = tempdir().expect("tmpdir");
-            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-            fs::create_dir_all(&layout.state_dir).unwrap();
-            fs::create_dir_all(&layout.cache_dir).unwrap();
-
-            // Write a distribution index with no sha256.
-            let dist_dir = layout.manifests_overlay.join("distribution-index");
-            fs::create_dir_all(&dist_dir).unwrap();
-            let env = anolisa_env::EnvService::detect();
-            let index_content = format!(
-                r#"schema_version = 1
-
-[[entries]]
-component = "tokenless"
-version = "{version}"
-channel = "stable"
-artifact_type = "tar_gz"
-backend = "tar"
-url = "file:///nonexistent/artifact.tar.gz"
-os = "{os}"
-arch = "{arch}"
-install_modes = ["system"]
-"#,
-                version = TEST_VERSION,
-                os = env.os,
-                arch = env.arch,
-            );
-            fs::write(dist_dir.join("index.toml"), &index_content).unwrap();
-
-            let ctx = ctx_with_prefix(
-                false,
-                false,
-                InstallMode::System,
-                Some(tmp.path().to_path_buf()),
-            );
-            let err =
-                handle_install(&ctx, "tokenless", "cosh").expect_err("must reject missing sha256");
-            assert_eq!(err.code(), "EXECUTION_FAILED");
-            assert!(err.reason().contains("sha256"));
-
-            // No state written.
-            let state_path = layout.state_dir.join("installed.toml");
-            let state = InstalledState::load(&state_path).expect("load state");
-            assert!(
-                state
-                    .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                    .is_none(),
-                "no phantom state on sha256 rejection"
-            );
-        }
-
-        // -- install: checksum mismatch does not leave state ---------------------
-
-        #[test]
-        fn install_checksum_mismatch_does_not_leave_state() {
-            let tmp = tempdir().expect("tmpdir");
-            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-            fs::create_dir_all(&layout.state_dir).unwrap();
-            fs::create_dir_all(&layout.cache_dir).unwrap();
-
-            // Build a tar.gz but declare a wrong sha256 in the index.
-            let tar_bytes = build_tar_gz(&[("target/release/cosh-ext/plugin.json", b"data")]);
-            let artifact_dir = tmp.path().join("artifacts");
-            fs::create_dir_all(&artifact_dir).unwrap();
-            let tar_path = artifact_dir.join("adapter.tar.gz");
-            fs::write(&tar_path, &tar_bytes).unwrap();
-            let tar_url = format!("file://{}", tar_path.display());
-
-            let dist_dir = layout.manifests_overlay.join("distribution-index");
-            fs::create_dir_all(&dist_dir).unwrap();
-            let env = anolisa_env::EnvService::detect();
-            let index_content = format!(
-                r#"schema_version = 1
-
-[[entries]]
-component = "tokenless"
-version = "{version}"
-channel = "stable"
-artifact_type = "tar_gz"
-backend = "tar"
-url = "{tar_url}"
-os = "{os}"
-arch = "{arch}"
-install_modes = ["system"]
-sha256 = "{wrong_sha}"
-"#,
-                version = TEST_VERSION,
-                os = env.os,
-                arch = env.arch,
-                wrong_sha = "0".repeat(64),
-            );
-            fs::write(dist_dir.join("index.toml"), &index_content).unwrap();
-
-            let ctx = ctx_with_prefix(
-                false,
-                false,
-                InstallMode::System,
-                Some(tmp.path().to_path_buf()),
-            );
-            let err = handle_install(&ctx, "tokenless", "cosh")
-                .expect_err("must reject checksum mismatch");
-            assert_eq!(err.code(), "EXECUTION_FAILED");
-
-            // No state or files left.
-            let state_path = layout.state_dir.join("installed.toml");
-            let state = InstalledState::load(&state_path).expect("load state");
-            assert!(
-                state
-                    .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                    .is_none(),
-                "no state on checksum failure"
-            );
-            let dest_root = layout.datadir.join("adapters/tokenless/cosh");
-            assert!(!dest_root.exists(), "no adapter files on checksum failure");
-        }
-
-        // -- install: dest already exists rejects without leaving state -----------
-
-        #[test]
-        fn install_dest_exists_does_not_leave_state() {
-            let tmp = tempdir().expect("tmpdir");
-            let plugin_json = br#"{"name":"pre-existing"}"#;
-            let (ctx, _sha) = setup_env(
-                tmp.path(),
-                &[("target/release/cosh-ext/plugin.json", b"new-data")],
-                "tokenless",
-                TEST_VERSION,
-            );
-
-            // Pre-create the dest file to trigger DestExists.
-            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-            let dest_root = layout.datadir.join("adapters/tokenless/cosh");
-            fs::create_dir_all(&dest_root).unwrap();
-            fs::write(dest_root.join("plugin.json"), plugin_json).unwrap();
-
-            let err = handle_install(&ctx, "tokenless", "cosh")
-                .expect_err("must reject when dest exists");
-            assert_eq!(err.code(), "EXECUTION_FAILED");
-
-            // Pre-existing file untouched.
-            assert_eq!(
-                fs::read(dest_root.join("plugin.json")).unwrap(),
-                plugin_json
-            );
-
-            // No state written.
-            let state_path = layout.state_dir.join("installed.toml");
-            let state = InstalledState::load(&state_path).expect("load state");
-            assert!(
-                state
-                    .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                    .is_none(),
-                "no state when dest exists"
-            );
-        }
-
-        // -- install: binary-only entry rejected for adapter install -------------
-
-        #[test]
-        fn install_rejects_binary_artifact_type() {
-            let tmp = tempdir().expect("tmpdir");
-            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-            fs::create_dir_all(&layout.state_dir).unwrap();
-            fs::create_dir_all(&layout.cache_dir).unwrap();
-
-            // Write a distribution index with only a binary entry.
-            let dist_dir = layout.manifests_overlay.join("distribution-index");
-            fs::create_dir_all(&dist_dir).unwrap();
-            let env = anolisa_env::EnvService::detect();
-            let index_content = format!(
-                r#"schema_version = 1
-
-[[entries]]
-component = "tokenless"
-version = "{version}"
-channel = "stable"
-artifact_type = "binary"
-backend = "binary"
-url = "file:///nonexistent/tokenless"
-os = "{os}"
-arch = "{arch}"
-install_modes = ["system"]
-sha256 = "{sha}"
-"#,
-                version = TEST_VERSION,
-                os = env.os,
-                arch = env.arch,
-                sha = "0".repeat(64),
-            );
-            fs::write(dist_dir.join("index.toml"), &index_content).unwrap();
-
-            let ctx = ctx_with_prefix(
-                false,
-                false,
-                InstallMode::System,
-                Some(tmp.path().to_path_buf()),
-            );
-            let err = handle_install(&ctx, "tokenless", "cosh")
-                .expect_err("must reject binary artifact type");
-            assert_eq!(err.code(), "EXECUTION_FAILED");
-            assert!(
-                err.reason().contains("tar_gz"),
-                "error should mention tar_gz requirement: {}",
-                err.reason()
-            );
-
-            // No state or files left.
-            let state_path = layout.state_dir.join("installed.toml");
-            let state = InstalledState::load(&state_path).expect("load state");
-            assert!(
-                state
-                    .find_object(ObjectKind::Adapter, "tokenless/cosh")
-                    .is_none(),
-                "no state on binary rejection"
-            );
-        }
-
-        // -- install: corrupted state file rejected without leaving files ---------
-
-        #[test]
-        fn install_corrupted_state_does_not_leave_files() {
-            let tmp = tempdir().expect("tmpdir");
-            let plugin_json = br#"{"name":"tokenless"}"#;
-            let (ctx, _sha) = setup_env(
-                tmp.path(),
-                &[("target/release/cosh-ext/plugin.json", plugin_json)],
-                "tokenless",
-                TEST_VERSION,
-            );
-
-            // Write a corrupted installed.toml so load_installed_state fails.
-            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-            let state_path = layout.state_dir.join("installed.toml");
-            fs::write(&state_path, b"this is not valid toml [[[[").unwrap();
-
-            let err =
-                handle_install(&ctx, "tokenless", "cosh").expect_err("must reject corrupted state");
-            assert_eq!(err.code(), "EXECUTION_FAILED");
-
-            // No adapter files written (state load happens before file copy).
-            let dest_root = layout.datadir.join("adapters/tokenless/cosh");
-            assert!(
-                !dest_root.join("plugin.json").exists(),
-                "no adapter files when state is corrupted"
-            );
-        }
-
-        /// Fixed published version for the fixtures. Decoupled from
-        /// `manifests/runtime/tokenless.toml`: adapter install resolves the
-        /// shipped artifact by highest semver, so the index entry and the
-        /// embedded manifest only need to agree with each other, not with the
-        /// dev-tree catalog.
-        const TEST_VERSION: &str = "0.5.0";
+    #[test]
+    fn framework_cli_failure_maps_to_runtime() {
+        let err = map_err(
+            "adapter enable",
+            AdapterError::FrameworkCli {
+                program: "openclaw".to_string(),
+                reason: "boom".to_string(),
+            },
+        );
+        assert!(matches!(err, CliError::Runtime { .. }));
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -7,8 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use anolisa_core::{
-    Catalog, CatalogLayers, DistributionIndex, FetchFailure, HttpFetch, InstalledState,
-    ObjectStatus, UreqFetch,
+    Catalog, CatalogLayers, FetchFailure, HttpFetch, InstalledState, ObjectStatus, UreqFetch,
 };
 use anolisa_platform::fs_layout::FsLayout;
 
@@ -20,12 +19,11 @@ use crate::response::CliError;
 /// Subdirectory under `datadir` and `etc_dir` where component
 /// manifests live (e.g. `share/anolisa/manifests`, `etc/anolisa/manifests`).
 const MANIFESTS_SUBDIR: &str = "manifests";
-
-/// Subdirectory under `manifests/` that holds DistributionIndex files.
-const DIST_INDEX_SUBDIR: &str = "distribution-index";
-
-/// Default file name for the bundled DistributionIndex.
-const DIST_INDEX_FILE: &str = "index.toml";
+/// State subdirectory where install stores the exact component contract
+/// used for each installed component.
+const INSTALLED_COMPONENT_MANIFESTS_SUBDIR: &str = "component-manifests";
+/// Filename used for the locally persisted installed component contract.
+const INSTALLED_COMPONENT_MANIFEST_FILE: &str = "component.toml";
 
 /// Build the layout for the active install mode, honoring `--prefix`
 /// (system-mode) and resolving `$HOME` via `EnvService::detect` (user-mode).
@@ -51,6 +49,36 @@ pub fn load_installed_state(ctx: &CliContext, command: &str) -> Result<Installed
             path.display()
         ),
     })
+}
+
+/// Path for the component manifest saved as part of an installed component's
+/// local state.
+pub fn installed_component_manifest_path(
+    layout: &FsLayout,
+    component: &str,
+    command: &str,
+) -> Result<PathBuf, CliError> {
+    validate_component_path_segment(component, command)?;
+    Ok(layout
+        .state_dir
+        .join(INSTALLED_COMPONENT_MANIFESTS_SUBDIR)
+        .join(component)
+        .join(INSTALLED_COMPONENT_MANIFEST_FILE))
+}
+
+fn validate_component_path_segment(component: &str, command: &str) -> Result<(), CliError> {
+    if component.trim().is_empty()
+        || component == "."
+        || component == ".."
+        || component.contains('/')
+        || component.contains('\\')
+    {
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!("component name '{component}' cannot be used as a local path segment"),
+        });
+    }
+    Ok(())
 }
 
 /// Load the layered catalog.
@@ -112,58 +140,6 @@ fn dev_tree_manifests() -> Option<PathBuf> {
         .join("..")
         .join("manifests");
     candidate.is_dir().then_some(candidate)
-}
-
-/// Load the `DistributionIndex`. Search order mirrors
-/// [`load_bundled_catalog`]'s layering so an overlay can substitute the
-/// index without rebuilding the bundle:
-///
-///   1. `manifests_overlay/distribution-index/index.toml` (e.g.
-///      `/etc/anolisa/manifests/...` in system mode,
-///      `~/.config/anolisa/manifests/...` in user mode).
-///   2. Packaged: `datadir/manifests/distribution-index/index.toml`.
-///   3. Dev-tree fallback so `cargo run` works without an install.
-///
-/// Returns `Ok(None)` when no index file is present anywhere — callers may
-/// treat that as "no prebuilt artifacts known" rather than an error so
-/// fresh checkouts without an index still produce a useful plan. The
-/// `enable --dry-run` handler in particular substitutes an empty
-/// [`DistributionIndex`] in that case so the plan still renders.
-///
-/// Today the overlay fully replaces the bundled index when present (no
-/// per-entry merging). The launch spec leaves merge semantics for a later
-/// milestone; document the current behavior in the user-facing docs.
-pub fn load_distribution_index(
-    ctx: &CliContext,
-    command: &str,
-) -> Result<Option<DistributionIndex>, CliError> {
-    let layout = resolve_layout(ctx);
-    let path = distribution_index_path(&layout);
-    let Some(path) = path else {
-        return Ok(None);
-    };
-    DistributionIndex::load(&path)
-        .map(Some)
-        .map_err(|err| CliError::InvalidArgument {
-            command: command.to_string(),
-            reason: format!(
-                "failed to load distribution index at {}: {err}",
-                path.display(),
-            ),
-        })
-}
-
-fn distribution_index_path(layout: &FsLayout) -> Option<PathBuf> {
-    let overlay_candidate = layout
-        .manifests_overlay
-        .join(DIST_INDEX_SUBDIR)
-        .join(DIST_INDEX_FILE);
-    if overlay_candidate.is_file() {
-        return Some(overlay_candidate);
-    }
-    let manifests_root = packaged_manifests_root(layout).or_else(dev_tree_manifests)?;
-    let candidate = manifests_root.join(DIST_INDEX_SUBDIR).join(DIST_INDEX_FILE);
-    candidate.is_file().then_some(candidate)
 }
 
 // ── Component catalog URL resolution ────────────────────────────────

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -17,12 +17,15 @@
 
 use clap::Parser;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
 use anolisa_core::download::{DownloadCache, DownloadError};
 use anolisa_core::install_runner::{
-    InstallRunner, ResolvedInstallFile, SUPPORTED_ARTIFACT_TYPES, read_embedded_component_manifest,
+    InstallRunner, ResolvedInstallFile, SUPPORTED_ARTIFACT_TYPES,
+    read_embedded_component_manifest_text,
 };
 use anolisa_core::lock::InstallLock;
 use anolisa_core::path_safety::validate_owned_path;
@@ -96,6 +99,14 @@ struct PreparedInstall {
     artifact_path: PathBuf,
     files: Vec<ResolvedInstallFile>,
     services: Vec<String>,
+    manifest_toml: String,
+}
+
+/// Parsed install contract plus the TOML persisted as the local install fact.
+struct LoadedInstallContract {
+    manifest: ComponentManifest,
+    source: InstallContractSource,
+    toml: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -367,8 +378,7 @@ fn build_install_preview(
         ));
     }
 
-    let Some((manifest, source)) = load_lightweight_install_contract(ctx, layout, &resolution)?
-    else {
+    let Some(contract) = load_lightweight_install_contract(ctx, layout, &resolution)? else {
         resolution.warnings.push(format!(
             "dry-run did not download artifact {}; file and service details are unavailable",
             resolution.artifact_url
@@ -381,14 +391,14 @@ fn build_install_preview(
     };
 
     let (files, services) = match resolve_manifest_contract(
-        &manifest,
+        &contract.manifest,
         layout,
         &resolution,
         ctx.install_mode.as_str(),
-        source,
+        contract.source,
     ) {
-        Ok(contract) => contract,
-        Err(err) if source == InstallContractSource::LocalCatalog => {
+        Ok(contract_files) => contract_files,
+        Err(err) if contract.source == InstallContractSource::LocalCatalog => {
             resolution.warnings.push(format!(
                 "local catalog manifest does not match resolved artifact; file and service details are unavailable: {}",
                 err.reason()
@@ -431,14 +441,14 @@ fn prepare_raw_execution(
             ),
         })?;
 
-    let (manifest, source) =
+    let contract =
         load_execution_install_contract(ctx, layout, &resolution, &artifact.cached_path)?;
     let (files, services) = resolve_manifest_contract(
-        &manifest,
+        &contract.manifest,
         layout,
         &resolution,
         ctx.install_mode.as_str(),
-        source,
+        contract.source,
     )?;
 
     Ok(PreparedInstall {
@@ -446,6 +456,7 @@ fn prepare_raw_execution(
         artifact_path: artifact.cached_path,
         files,
         services,
+        manifest_toml: contract.toml,
     })
 }
 
@@ -453,11 +464,11 @@ fn load_execution_install_contract(
     ctx: &CliContext,
     layout: &FsLayout,
     resolution: &RawResolution,
-    artifact_path: &std::path::Path,
-) -> Result<(ComponentManifest, InstallContractSource), CliError> {
+    artifact_path: &Path,
+) -> Result<LoadedInstallContract, CliError> {
     match resolution.entry.artifact_type {
         ArtifactType::TarGz => {
-            let manifest = read_embedded_component_manifest(artifact_path)
+            let toml = read_embedded_component_manifest_text(artifact_path)
                 .map_err(|err| CliError::Runtime {
                     command: COMMAND.to_string(),
                     reason: format!(
@@ -472,7 +483,20 @@ fn load_execution_install_contract(
                         resolution.package
                     ),
                 })?;
-            Ok((manifest, InstallContractSource::EmbeddedArtifact))
+            let manifest = ComponentManifest::from_toml_str(&toml).map_err(|err| {
+                CliError::Runtime {
+                    command: COMMAND.to_string(),
+                    reason: format!(
+                        "failed to parse embedded component manifest from {}: {err}",
+                        resolution.artifact_url
+                    ),
+                }
+            })?;
+            Ok(LoadedInstallContract {
+                manifest,
+                source: InstallContractSource::EmbeddedArtifact,
+                toml,
+            })
         }
         ArtifactType::Binary => {
             load_lightweight_install_contract(ctx, layout, resolution)?.ok_or_else(|| {
@@ -500,19 +524,18 @@ fn load_lightweight_install_contract(
     ctx: &CliContext,
     layout: &FsLayout,
     resolution: &RawResolution,
-) -> Result<Option<(ComponentManifest, InstallContractSource)>, CliError> {
-    if let Some(manifest) = fetch_sidecar_meta_manifest(layout, resolution)? {
-        return Ok(Some((manifest, InstallContractSource::SidecarMeta)));
+) -> Result<Option<LoadedInstallContract>, CliError> {
+    if let Some(contract) = fetch_sidecar_meta_manifest(layout, resolution)? {
+        return Ok(Some(contract));
     }
 
-    Ok(load_catalog_manifest(ctx, &resolution.component)?
-        .map(|manifest| (manifest, InstallContractSource::LocalCatalog)))
+    load_catalog_manifest(ctx, &resolution.component)
 }
 
 fn fetch_sidecar_meta_manifest(
     layout: &FsLayout,
     resolution: &RawResolution,
-) -> Result<Option<ComponentManifest>, CliError> {
+) -> Result<Option<LoadedInstallContract>, CliError> {
     let Some(meta_url) = sidecar_meta_url(
         &resolution.artifact_url,
         &resolution.entry.component,
@@ -535,7 +558,7 @@ fn fetch_sidecar_meta_manifest(
             });
         }
     };
-    let text =
+    let toml =
         std::fs::read_to_string(&downloaded.cached_path).map_err(|err| CliError::Runtime {
             command: COMMAND.to_string(),
             reason: format!(
@@ -543,20 +566,44 @@ fn fetch_sidecar_meta_manifest(
                 downloaded.cached_path.display()
             ),
         })?;
-    ComponentManifest::from_toml_str(&text)
-        .map(Some)
-        .map_err(|err| CliError::Runtime {
-            command: COMMAND.to_string(),
-            reason: format!("failed to parse sidecar metadata {meta_url}: {err}"),
-        })
+    let manifest = ComponentManifest::from_toml_str(&toml).map_err(|err| CliError::Runtime {
+        command: COMMAND.to_string(),
+        reason: format!("failed to parse sidecar metadata {meta_url}: {err}"),
+    })?;
+    Ok(Some(LoadedInstallContract {
+        manifest,
+        source: InstallContractSource::SidecarMeta,
+        toml,
+    }))
 }
 
 fn load_catalog_manifest(
     ctx: &CliContext,
     component: &str,
-) -> Result<Option<ComponentManifest>, CliError> {
+) -> Result<Option<LoadedInstallContract>, CliError> {
     let catalog = common::load_bundled_catalog(ctx, COMMAND)?;
-    Ok(catalog.component(component).cloned())
+    let Some(manifest) = catalog.component(component).cloned() else {
+        return Ok(None);
+    };
+    let toml = serialize_manifest_toml(&manifest, InstallContractSource::LocalCatalog)?;
+    Ok(Some(LoadedInstallContract {
+        manifest,
+        source: InstallContractSource::LocalCatalog,
+        toml,
+    }))
+}
+
+fn serialize_manifest_toml(
+    manifest: &ComponentManifest,
+    source: InstallContractSource,
+) -> Result<String, CliError> {
+    toml::to_string_pretty(manifest).map_err(|err| CliError::Runtime {
+        command: COMMAND.to_string(),
+        reason: format!(
+            "failed to serialize {} for local install metadata: {err}",
+            source.label()
+        ),
+    })
 }
 
 fn manifest_digest_sha256(digest: Option<&str>) -> Result<Option<&str>, CliError> {
@@ -632,7 +679,7 @@ fn resolve_manifest_contract(
         });
     }
 
-    let files = resolve_manifest_files(manifest, layout, &resolution.component)?;
+    let mut files = resolve_manifest_files(manifest, layout, &resolution.component)?;
     if files.is_empty() {
         return Err(CliError::Runtime {
             command: COMMAND.to_string(),
@@ -642,6 +689,15 @@ fn resolve_manifest_contract(
             ),
         });
     }
+    // Adapter resources are laid alongside the component's own files, from
+    // the same artifact. Install only *places* them under the standard
+    // `{datadir}/adapters/<component>/<framework>/` tree — enabling them
+    // against a framework is the separate `anolisa adapter enable` step.
+    files.extend(resolve_adapter_files(
+        manifest,
+        layout,
+        &resolution.component,
+    )?);
 
     Ok((files, manifest.install.services.clone()))
 }
@@ -707,6 +763,89 @@ fn resolve_manifest_files(
     Ok(files)
 }
 
+/// Render the manifest's `[[adapters]]` entries into install file mappings.
+///
+/// Install only *places* adapter resources under the standard
+/// `{datadir}/adapters/<component>/<framework>/` tree; it never runs a
+/// framework CLI or touches user framework state — that is
+/// `anolisa adapter enable`.
+///
+/// Each entry is linted up front for the fields install needs: a framework,
+/// a source, and a destination. The framework does not have to be supported
+/// by this ANOLISA build; install only lays data down, while
+/// `anolisa adapter enable` decides whether a built-in driver exists.
+fn resolve_adapter_files(
+    manifest: &ComponentManifest,
+    layout: &FsLayout,
+    component: &str,
+) -> Result<Vec<ResolvedInstallFile>, CliError> {
+    if manifest.adapters.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::with_capacity(manifest.adapters.len());
+    for adapter in &manifest.adapters {
+        let framework = adapter
+            .framework
+            .as_deref()
+            .ok_or_else(|| CliError::InvalidArgument {
+                command: COMMAND.to_string(),
+                reason: format!(
+                    "component '{component}' has an [[adapters]] entry with no framework"
+                ),
+            })?;
+        let source = adapter
+            .source
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| CliError::InvalidArgument {
+                command: COMMAND.to_string(),
+                reason: format!(
+                    "component '{component}' adapter for '{framework}' declares no source"
+                ),
+            })?;
+        let dest_template = adapter
+            .dest
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| CliError::InvalidArgument {
+                command: COMMAND.to_string(),
+                reason: format!(
+                    "component '{component}' adapter for '{framework}' declares no dest"
+                ),
+            })?;
+        let dest = expand_layout_placeholders(dest_template, layout, &[("component", component)])
+            .map_err(|err| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!("failed to expand adapter dest '{dest_template}': {err}"),
+        })?;
+        validate_owned_path(layout, &dest).map_err(|err| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "adapter destination '{}' failed path safety check: {err}",
+                dest.display()
+            ),
+        })?;
+        // The runner lays an entire archive subtree only when the source key
+        // ends with '/'. An adapter bundle is always a directory, so force
+        // directory-prefix semantics regardless of how the manifest wrote it.
+        let source = if source.ends_with('/') {
+            source.to_string()
+        } else {
+            format!("{source}/")
+        };
+        files.push(ResolvedInstallFile {
+            source: Some(source),
+            dest,
+            // Bundle contents are framework-loaded data, not directly
+            // executed by ANOLISA; lay them 0644. Per-file modes inside a
+            // bundle are not expressible in `[[adapters]]` in the MVP.
+            mode: Some("0644".to_string()),
+            kind: FileKind::Data,
+        });
+    }
+    Ok(files)
+}
+
 /// Execute the resolved install: download+verify, copy files under the
 /// install lock, persist state, and append the audit record. Files already
 /// on disk are rolled back when a later step fails, so no phantom install
@@ -722,6 +861,7 @@ fn execute_raw(
         artifact_path,
         files,
         services,
+        manifest_toml,
     } = prepared;
     let started_at = now_iso8601();
 
@@ -765,8 +905,16 @@ fn execute_raw(
         })?;
 
     // From this point files are on disk — failures must roll them back.
+    let manifest_path =
+        match write_installed_component_manifest(layout, &resolution.component, &manifest_toml) {
+            Ok(path) => path,
+            Err(err) => {
+                rollback_installed_files(&outcome.files);
+                return Err(err);
+            }
+        };
 
-    let owned_files: Vec<OwnedFile> = outcome
+    let mut owned_files: Vec<OwnedFile> = outcome
         .files
         .iter()
         .map(|f| OwnedFile {
@@ -775,11 +923,17 @@ fn execute_raw(
             sha256: Some(f.sha256.clone()),
         })
         .collect();
-    let installed_paths: Vec<String> = outcome
+    owned_files.push(OwnedFile {
+        path: manifest_path.clone(),
+        owner: FileOwner::Anolisa,
+        sha256: None,
+    });
+    let mut installed_paths: Vec<String> = outcome
         .files
         .iter()
         .map(|f| f.path.display().to_string())
         .collect();
+    installed_paths.push(manifest_path.display().to_string());
 
     let service_manager = match ctx.install_mode {
         crate::context::InstallMode::System => "systemd",
@@ -844,6 +998,7 @@ fn execute_raw(
     let state_path = layout.state_dir.join("installed.toml");
     if let Err(err) = state.save(&state_path) {
         rollback_installed_files(&outcome.files);
+        rollback_installed_manifest(&manifest_path);
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
@@ -1137,6 +1292,55 @@ fn rollback_installed_files(files: &[anolisa_core::InstalledFile]) {
     }
 }
 
+fn write_installed_component_manifest(
+    layout: &FsLayout,
+    component: &str,
+    toml: &str,
+) -> Result<PathBuf, CliError> {
+    let path = common::installed_component_manifest_path(layout, component, COMMAND)?;
+    write_atomic_text(&path, toml).map_err(|err| CliError::Runtime {
+        command: COMMAND.to_string(),
+        reason: format!(
+            "failed to write installed component manifest at {}: {err}",
+            path.display()
+        ),
+    })?;
+    Ok(path)
+}
+
+fn write_atomic_text(path: &Path, content: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("component.toml");
+    let nanos = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let tmp = parent.join(format!(".{name}.tmp-{}-{nanos}", std::process::id()));
+
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o644);
+    }
+    let mut file = options.open(&tmp)?;
+    file.write_all(content.as_bytes())?;
+    drop(file);
+    if let Err(err) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn rollback_installed_manifest(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
 /// ISO 8601 UTC timestamp with second precision.
 fn now_iso8601() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
@@ -1231,6 +1435,97 @@ type = "executable"
             (".anolisa/component.toml", manifest.as_bytes()),
             (bin_path.as_str(), payload.as_bytes()),
         ])
+    }
+
+    /// Build a manifest with a single `[[adapters]]` entry, optionally
+    /// overriding the framework and whether source/dest are present.
+    fn adapter_manifest(framework: &str, source: Option<&str>, dest: Option<&str>) -> String {
+        let mut toml = String::from(
+            "[component]\nname = \"tokenless\"\nversion = \"0.1.0\"\n\n\
+             [component.layout]\nmodes = [\"system\"]\n\n\
+             [[adapters]]\n",
+        );
+        toml.push_str(&format!("framework = \"{framework}\"\n"));
+        if let Some(s) = source {
+            toml.push_str(&format!("source = \"{s}\"\n"));
+        }
+        if let Some(d) = dest {
+            toml.push_str(&format!("dest = \"{d}\"\n"));
+        }
+        toml
+    }
+
+    #[test]
+    fn resolve_adapter_files_lays_bundle_under_datadir() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let toml = adapter_manifest(
+            "openclaw",
+            Some("adapters/tokenless/openclaw"),
+            Some("{datadir}/adapters/{component}/openclaw/"),
+        );
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let files = resolve_adapter_files(&manifest, &layout, "tokenless").expect("resolve");
+
+        assert_eq!(files.len(), 1);
+        let f = &files[0];
+        // Source is normalized to a directory prefix so the whole bundle
+        // tree is laid down by the runner.
+        assert_eq!(f.source.as_deref(), Some("adapters/tokenless/openclaw/"));
+        assert_eq!(f.dest, layout.datadir.join("adapters/tokenless/openclaw"));
+        assert_eq!(f.kind, FileKind::Data);
+        assert_eq!(f.mode.as_deref(), Some("0644"));
+    }
+
+    #[test]
+    fn resolve_adapter_files_allows_unknown_framework() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let toml = adapter_manifest(
+            "hermes",
+            Some("adapters/tokenless/hermes"),
+            Some("{datadir}/adapters/{component}/hermes/"),
+        );
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let files = resolve_adapter_files(&manifest, &layout, "tokenless").expect("resolve");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].source.as_deref(),
+            Some("adapters/tokenless/hermes/")
+        );
+        assert_eq!(
+            files[0].dest,
+            layout.datadir.join("adapters/tokenless/hermes")
+        );
+    }
+
+    #[test]
+    fn resolve_adapter_files_rejects_missing_source() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let toml = adapter_manifest(
+            "openclaw",
+            None,
+            Some("{datadir}/adapters/{component}/openclaw/"),
+        );
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let err = resolve_adapter_files(&manifest, &layout, "tokenless")
+            .expect_err("missing source must be rejected");
+        assert!(
+            matches!(err, CliError::InvalidArgument { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_adapter_files_empty_when_no_adapters() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let toml = component_manifest_toml("tokenless", "0.1.0", &["system"]);
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let files = resolve_adapter_files(&manifest, &layout, "tokenless").expect("resolve");
+        assert!(files.is_empty());
     }
 
     fn write_empty_repo(root: &Path) -> String {
@@ -1753,6 +2048,17 @@ base_url = "https://example.com/yum-repo"
         let layout = FsLayout::system(Some(prefix));
         let bin = layout.bin_dir.join("agentsight");
         assert!(bin.exists(), "binary must be installed at {{bindir}}");
+        let manifest_path =
+            common::installed_component_manifest_path(&layout, "agentsight", COMMAND)
+                .expect("manifest path");
+        assert!(
+            manifest_path.exists(),
+            "installed component manifest must be persisted"
+        );
+        let saved_manifest =
+            ComponentManifest::from_file(&manifest_path).expect("saved manifest parses");
+        assert_eq!(saved_manifest.component.name, "agentsight");
+        assert_eq!(saved_manifest.component.version, "0.2.0");
 
         let state = anolisa_core::InstalledState::load(&layout.state_dir.join("installed.toml"))
             .expect("state must load");
@@ -1761,7 +2067,11 @@ base_url = "https://example.com/yum-repo"
             .expect("component object must be recorded");
         assert_eq!(obj.version, "0.2.0");
         assert_eq!(obj.status, ObjectStatus::Installed);
-        assert_eq!(obj.files.len(), 1);
+        assert_eq!(obj.files.len(), 2);
+        assert!(
+            obj.files.iter().any(|file| file.path == manifest_path),
+            "installed manifest must be tracked as an owned file"
+        );
         assert!(
             obj.distribution_source
                 .as_deref()

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -95,6 +95,28 @@ pub fn handle(args: UninstallArgs, ctx: &CliContext) -> Result<(), CliError> {
             ),
         });
     }
+    // Adapter receipts must be released before the component is removed.
+    // Uninstall does not auto-cascade into framework state (a framework CLI
+    // might be unavailable, and silently orphaning a registered plugin is
+    // worse than refusing). Block the real run and point the user at
+    // `adapter disable`; a dry-run still renders its preview.
+    if !ctx.dry_run {
+        let claims = installed.adapter_claims_for_component(target);
+        if !claims.is_empty() {
+            let mut frameworks: Vec<&str> = claims.iter().map(|c| c.framework.as_str()).collect();
+            frameworks.sort_unstable();
+            frameworks.dedup();
+            return Err(CliError::InvalidArgument {
+                command,
+                reason: format!(
+                    "'{target}' has enabled adapters ({}); run `anolisa adapter disable {target}` \
+                     for each framework before uninstalling",
+                    frameworks.join(", ")
+                ),
+            });
+        }
+    }
+
     let plan = match operation {
         LifecycleOperation::Uninstall => LifecyclePlan::for_component_uninstall(target, &installed),
         LifecycleOperation::Purge => LifecyclePlan::for_component_purge(target, &installed),

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -20,6 +20,12 @@ use anolisa_platform::fs_layout::FsLayout;
 
 use crate::manifest::AdapterSpec;
 
+pub mod claim;
+pub mod driver;
+pub mod manager;
+pub mod openclaw;
+pub mod registry;
+
 // ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
@@ -34,6 +40,122 @@ pub enum AdapterError {
         placeholder: String,
         /// The full template string that contained it.
         template: String,
+    },
+
+    /// No driver is registered for the requested framework.
+    #[error("no built-in driver for framework '{framework}'")]
+    UnknownFramework {
+        /// Framework name with no registered driver.
+        framework: String,
+    },
+
+    /// The caller omitted the framework and the component ships adapters
+    /// for more than one, so the choice is ambiguous.
+    #[error(
+        "component '{component}' has adapters for multiple frameworks ({}); specify one",
+        .frameworks.join(", ")
+    )]
+    AmbiguousFramework {
+        /// Component the caller asked about.
+        component: String,
+        /// Candidate frameworks discovered for it.
+        frameworks: Vec<String>,
+    },
+
+    /// `enable` requires the framework to be usable on the host, but
+    /// detection failed (e.g. the framework CLI is not installed).
+    #[error("framework '{framework}' not detected: {reason}")]
+    FrameworkNotDetected {
+        /// Framework that could not be detected.
+        framework: String,
+        /// Human-readable detection failure reason.
+        reason: String,
+    },
+
+    /// The component is not installed in any visible (user or system)
+    /// state, so its adapters cannot be enabled.
+    #[error("component '{component}' is not installed")]
+    ComponentNotInstalled {
+        /// Component the caller asked to enable.
+        component: String,
+    },
+
+    /// The installed component manifest does not declare the requested
+    /// framework adapter.
+    #[error("component '{component}' does not declare an adapter for framework '{framework}'")]
+    AdapterNotDeclared {
+        /// Component the caller asked to enable.
+        component: String,
+        /// Framework absent from the installed component manifest.
+        framework: String,
+    },
+
+    /// The installed component manifest required by adapter enable is
+    /// missing, unreadable, or inconsistent with state.
+    #[error("invalid installed component manifest for '{component}' at {path}: {reason}")]
+    AdapterManifest {
+        /// Component whose installed manifest was read.
+        component: String,
+        /// Manifest path that failed.
+        path: PathBuf,
+        /// Human-readable failure detail.
+        reason: String,
+    },
+
+    /// No resource directory was found for the component/framework under
+    /// any visible `{datadir}/adapters/<component>/<framework>/` root.
+    #[error("no adapter resources found for '{component}/{framework}' under any datadir root")]
+    ResourceRootNotFound {
+        /// Component name.
+        component: String,
+        /// Framework name.
+        framework: String,
+    },
+
+    /// The resource bundle is missing required files or is otherwise
+    /// unreadable by the driver.
+    #[error("invalid adapter bundle at {root}: {reason}")]
+    BundleInvalid {
+        /// Resource root inspected.
+        root: PathBuf,
+        /// What was wrong.
+        reason: String,
+    },
+
+    /// A framework CLI invocation failed to spawn, exited non-zero, or was
+    /// killed after the timeout.
+    #[error("framework CLI '{program}' failed: {reason}")]
+    FrameworkCli {
+        /// Program that was invoked.
+        program: String,
+        /// Failure detail (exit status, spawn error, or timeout).
+        reason: String,
+    },
+
+    /// A receipt's claim resources failed re-validation.
+    #[error("adapter claim validation failed: {0}")]
+    ClaimValidation(#[from] claim::ClaimValidationError),
+
+    /// Failed to take the install lock.
+    #[error("install lock error: {0}")]
+    Lock(#[from] crate::lock::LockError),
+
+    /// Failed to read or write installed state.
+    #[error("installed state error: {0}")]
+    State(#[from] crate::state::StateError),
+
+    /// Failed to append to the central log.
+    #[error("central log error: {0}")]
+    Log(#[from] crate::central_log::CentralLogError),
+
+    /// Filesystem error while discovering resources or computing a digest.
+    #[error("io error while accessing {path}: {source}")]
+    Io {
+        /// Path that failed.
+        path: PathBuf,
+        /// Underlying IO error.
+        #[source]
+        source: std::io::Error,
     },
 }
 

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -1,0 +1,500 @@
+//! Adapter receipt schema (`AdapterClaim`) and its security-boundary
+//! [`ClaimResource`] model.
+//!
+//! A receipt is **pure data**: it records what a framework driver took
+//! over on behalf of one component, so [`status`](super::manager) and
+//! [`disable`](super::manager) can run later without re-reading the
+//! resource directory and without trusting any executable instruction
+//! from disk. Receipts never carry argv, shell strings, script paths, or
+//! reverse commands — the framework CLI invocation is constructed by the
+//! built-in driver, not read back from the receipt.
+//!
+//! Every value that `status`/`disable` would interpret as a path, a
+//! symlink, or a framework-registry entry must live in [`ClaimResource`],
+//! the closed set the Manager re-validates before handing the claim to a
+//! driver. The framework-specific [`DriverPayload`] may only hold typed
+//! data the driver needs to *understand* the receipt; it is never a path
+//! safety boundary and must reference paths by [`ClaimResource::id`]
+//! rather than duplicating them.
+//!
+//! Wire format note: the enums here are **externally tagged** (serde
+//! default, no `#[serde(flatten)]`). `toml` 0.8 mis-serializes
+//! internally-tagged enums combined with `flatten`; externally-tagged
+//! variants round-trip cleanly as long as scalar fields are declared
+//! before nested tables/arrays. The round-trip is pinned by the
+//! `adapter_claim_toml_round_trip` test.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::path_safety::{PathBoundaryError, canonicalize_nearest_existing, validate_owned_path};
+use anolisa_platform::fs_layout::FsLayout;
+
+/// Schema version for the generic claim shape and [`ClaimResource`].
+/// Persisted in every receipt so a future on-disk migration can branch.
+pub const CLAIM_SCHEMA_VERSION: u32 = 1;
+
+/// Schema version for [`DriverPayload`]. Bumped independently of
+/// [`CLAIM_SCHEMA_VERSION`] when a driver's typed payload changes shape.
+pub const DRIVER_SCHEMA_VERSION: u32 = 1;
+
+/// A single adapter receipt: "the current user's `component` has, through
+/// `framework`'s driver, taken over the framework-side state described by
+/// `resources`".
+///
+/// Persisted in the user-level `installed.toml` as `[[adapter_claims]]`,
+/// alongside `[[objects]]`. Scalar fields are declared first so the TOML
+/// serializer emits them before the `resources` array and the
+/// `driver_payload` table (TOML requires scalars to precede sub-tables
+/// within a table).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdapterClaim {
+    /// Generic claim + [`ClaimResource`] schema version
+    /// ([`CLAIM_SCHEMA_VERSION`] at write time).
+    pub claim_schema: u32,
+    /// ANOLISA component this receipt belongs to.
+    pub component: String,
+    /// Framework name; must resolve to a built-in driver.
+    pub framework: String,
+    /// Framework-native plugin id, when the framework has one. Sanitized
+    /// before it ever enters an argv (see [`validate_plugin_id`]). The
+    /// authoritative copy for CLI use lives in the
+    /// [`ClaimResourceKind::FrameworkPlugin`] resource; this top-level
+    /// field is a convenience for listing/scan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_id: Option<String>,
+    /// RFC3339 UTC timestamp when enable last wrote this receipt.
+    pub enabled_at: String,
+    /// Resource directory read at enable time. Kept for status display and
+    /// upgrade detection; `disable` must NOT depend on it still existing.
+    pub resource_root: PathBuf,
+    /// Digest of the resource tree at enable time, for drift/upgrade
+    /// detection. Optional: a driver may decline to compute one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_digest: Option<String>,
+    /// [`DriverPayload`] schema version ([`DRIVER_SCHEMA_VERSION`] at write
+    /// time).
+    pub driver_schema: u32,
+    /// Lifecycle status of the receipt itself.
+    pub status: ClaimStatus,
+    /// Manager-validatable resource declarations — the receipt's security
+    /// boundary. Re-validated before every `status`/`disable`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resources: Vec<ClaimResource>,
+    /// Framework-specific typed payload. Closed enum, no free-form map.
+    pub driver_payload: DriverPayload,
+}
+
+impl AdapterClaim {
+    /// Find a resource by its stable `id`.
+    pub fn resource(&self, id: &str) -> Option<&ClaimResource> {
+        self.resources.iter().find(|r| r.id == id)
+    }
+
+    /// Re-validate every [`ClaimResource`] against the current layout and
+    /// the driver's static external roots, plus any embedded `plugin_id`.
+    ///
+    /// The Manager calls this before writing a receipt, after reading one
+    /// back, and before handing the claim to a driver's `status`/`disable`
+    /// — so a forged `installed.toml` cannot widen ANOLISA's authority to
+    /// an arbitrary path or smuggle a shell metacharacter into an argv.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`ClaimValidationError`] encountered: an owned
+    /// path outside ANOLISA roots, an external path outside every
+    /// `allowed_external_roots` entry, a traversal/symlink escape, or an
+    /// invalid plugin id.
+    pub fn validate(
+        &self,
+        layout: &FsLayout,
+        allowed_external_roots: &[PathBuf],
+    ) -> Result<(), ClaimValidationError> {
+        if let Some(pid) = &self.plugin_id {
+            validate_plugin_id(pid)?;
+        }
+        for resource in &self.resources {
+            resource.validate(layout, allowed_external_roots)?;
+        }
+        Ok(())
+    }
+}
+
+/// Lifecycle status of a receipt.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimStatus {
+    /// Adapter is enabled and the receipt is authoritative.
+    Enabled,
+    /// A prior `disable` could not fully clean up; the receipt is kept so
+    /// the cleanup can be retried.
+    CleanupFailed,
+}
+
+/// One entry in a receipt's `resources` list — the unit the Manager
+/// validates.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClaimResource {
+    /// Stable id referenced from [`DriverPayload`] and condition reports.
+    pub id: String,
+    /// Human-facing role, e.g. `openclaw_state_dir`.
+    pub purpose: String,
+    /// The typed, validatable resource.
+    pub kind: ClaimResourceKind,
+}
+
+impl ClaimResource {
+    /// Validate this resource against ANOLISA-owned roots (for owned
+    /// paths) or the driver's static external roots (for external paths),
+    /// and sanitize any embedded plugin id.
+    ///
+    /// # Errors
+    ///
+    /// See [`AdapterClaim::validate`].
+    pub fn validate(
+        &self,
+        layout: &FsLayout,
+        allowed_external_roots: &[PathBuf],
+    ) -> Result<(), ClaimValidationError> {
+        match &self.kind {
+            ClaimResourceKind::OwnedPath { path } => {
+                validate_owned_path(layout, path).map_err(|source| {
+                    ClaimValidationError::OwnedPath {
+                        id: self.id.clone(),
+                        source,
+                    }
+                })
+            }
+            ClaimResourceKind::ExternalPath { path } => {
+                validate_external_path(path, allowed_external_roots).map_err(|source| {
+                    ClaimValidationError::ExternalPath {
+                        id: self.id.clone(),
+                        source,
+                    }
+                })
+            }
+            ClaimResourceKind::FrameworkPlugin { plugin_id, .. } => validate_plugin_id(plugin_id),
+        }
+    }
+}
+
+/// The closed set of resource kinds a receipt may declare.
+///
+/// MVP implements only the three kinds OpenClaw needs. Additional kinds
+/// (`Tree`, `JsonKeys`, `Symlink`, `FrameworkMarketplace`) are introduced
+/// when their first driver lands — adding a variant here is a deliberate,
+/// reviewed extension of the security boundary, never an open map.
+///
+/// Externally tagged with snake_case variant keys (`owned_path`,
+/// `external_path`, `framework_plugin`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimResourceKind {
+    /// A path inside an ANOLISA-owned root; validated by
+    /// [`validate_owned_path`].
+    OwnedPath {
+        /// Absolute owned path.
+        path: PathBuf,
+    },
+    /// A path in a framework/user directory. Validated against the
+    /// driver's static `allowed_external_roots` only — the receipt does
+    /// **not** get to declare its own allowed root (that would let a
+    /// forged receipt authorize itself).
+    ExternalPath {
+        /// Absolute external path.
+        path: PathBuf,
+    },
+    /// A record in a framework's plugin registry. `plugin_id` is
+    /// whitelist-sanitized before it enters any argv.
+    FrameworkPlugin {
+        /// Framework that owns the registry (e.g. `openclaw`).
+        framework: String,
+        /// Native plugin id.
+        plugin_id: String,
+    },
+}
+
+/// Framework-specific typed payload. Closed enum — there is no runtime
+/// custom-type escape hatch. The variant key doubles as the
+/// `driver_payload_kind` discriminator.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DriverPayload {
+    /// OpenClaw driver payload.
+    #[serde(rename = "openclaw")]
+    OpenClaw(OpenClawClaim),
+}
+
+/// OpenClaw driver payload. Holds only [`ClaimResource::id`] references —
+/// never the paths themselves — so the validated `resources` list stays
+/// the single source of truth for path data.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpenClawClaim {
+    /// Resource id of the OpenClaw state/home directory
+    /// ([`ClaimResourceKind::ExternalPath`]).
+    pub state_dir_resource: String,
+    /// Resource id of the registered plugin
+    /// ([`ClaimResourceKind::FrameworkPlugin`]).
+    pub plugin_resource: String,
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/// Reasons a receipt's resources or plugin id fail validation.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ClaimValidationError {
+    /// An [`ClaimResourceKind::OwnedPath`] is outside ANOLISA-owned roots.
+    #[error("owned-path resource '{id}' failed boundary check: {source}")]
+    OwnedPath {
+        /// Offending resource id.
+        id: String,
+        /// Underlying boundary error.
+        #[source]
+        source: PathBoundaryError,
+    },
+    /// An [`ClaimResourceKind::ExternalPath`] is outside every allowed
+    /// external root, or contains a traversal/symlink escape.
+    #[error("external-path resource '{id}' failed boundary check: {source}")]
+    ExternalPath {
+        /// Offending resource id.
+        id: String,
+        /// Underlying boundary error.
+        #[source]
+        source: ExternalPathError,
+    },
+    /// A `plugin_id` is empty or contains characters outside the
+    /// argv-safe whitelist.
+    #[error("invalid plugin id '{plugin_id}': {reason}")]
+    PluginId {
+        /// The rejected id.
+        plugin_id: String,
+        /// Why it was rejected.
+        reason: String,
+    },
+}
+
+/// Reasons an external path is rejected.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ExternalPathError {
+    /// Path contains a `.` or `..` segment.
+    #[error("path '{path}' contains a '.' or '..' segment")]
+    Traversal {
+        /// Rejected path.
+        path: PathBuf,
+    },
+    /// Path is not under any allowed external root (lexically or after
+    /// canonicalizing the deepest existing ancestor).
+    #[error("path '{path}' is not under any allowed external root for this driver")]
+    OutsideAllowedRoots {
+        /// Rejected path.
+        path: PathBuf,
+    },
+}
+
+/// Validate an external path: reject traversal, require containment under
+/// one of `allowed_roots` both lexically and after canonicalizing the
+/// deepest existing ancestor (defeats a symlinked ancestor that escapes
+/// the root). Mirrors [`validate_owned_path`] but against driver-declared
+/// roots instead of the layout's owned roots.
+///
+/// # Errors
+///
+/// [`ExternalPathError::Traversal`] for `.`/`..` segments;
+/// [`ExternalPathError::OutsideAllowedRoots`] when no allowed root
+/// contains the path.
+pub fn validate_external_path(
+    path: &Path,
+    allowed_roots: &[PathBuf],
+) -> Result<(), ExternalPathError> {
+    use std::path::Component;
+    for component in path.components() {
+        if matches!(component, Component::ParentDir | Component::CurDir) {
+            return Err(ExternalPathError::Traversal {
+                path: path.to_path_buf(),
+            });
+        }
+    }
+    if !allowed_roots.iter().any(|root| path.starts_with(root)) {
+        return Err(ExternalPathError::OutsideAllowedRoots {
+            path: path.to_path_buf(),
+        });
+    }
+    if let Some(canonical) = canonicalize_nearest_existing(path) {
+        let canonical_roots: Vec<PathBuf> = allowed_roots
+            .iter()
+            .filter_map(|r| canonicalize_nearest_existing(r))
+            .collect();
+        if !canonical_roots.is_empty() && !canonical_roots.iter().any(|r| canonical.starts_with(r))
+        {
+            return Err(ExternalPathError::OutsideAllowedRoots {
+                path: path.to_path_buf(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Reject a plugin id unless it is a non-empty string of argv-safe
+/// characters (`[A-Za-z0-9._-]`) that is neither `.`/`..` nor leading
+/// with `-` (which an argv parser could mistake for a flag).
+///
+/// # Errors
+///
+/// [`ClaimValidationError::PluginId`] with a specific reason.
+pub fn validate_plugin_id(plugin_id: &str) -> Result<(), ClaimValidationError> {
+    let reject = |reason: &str| {
+        Err(ClaimValidationError::PluginId {
+            plugin_id: plugin_id.to_string(),
+            reason: reason.to_string(),
+        })
+    };
+    if plugin_id.is_empty() {
+        return reject("must not be empty");
+    }
+    if plugin_id == "." || plugin_id == ".." {
+        return reject("must not be '.' or '..'");
+    }
+    if plugin_id.starts_with('-') {
+        return reject("must not start with '-' (would be parsed as a flag)");
+    }
+    if let Some(bad) = plugin_id
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
+    {
+        return Err(ClaimValidationError::PluginId {
+            plugin_id: plugin_id.to_string(),
+            reason: format!("contains disallowed character '{bad}'"),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_claim() -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            plugin_id: Some("tokenless".to_string()),
+            enabled_at: "2026-06-12T10:30:45Z".to_string(),
+            resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/openclaw"),
+            bundle_digest: Some("sha256:abc".to_string()),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: vec![
+                ClaimResource {
+                    id: "openclaw_state_dir".to_string(),
+                    purpose: "openclaw_state_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.openclaw"),
+                    },
+                },
+                ClaimResource {
+                    id: "openclaw_plugin".to_string(),
+                    purpose: "openclaw_plugin".to_string(),
+                    kind: ClaimResourceKind::FrameworkPlugin {
+                        framework: "openclaw".to_string(),
+                        plugin_id: "tokenless".to_string(),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "openclaw_state_dir".to_string(),
+                plugin_resource: "openclaw_plugin".to_string(),
+            }),
+        }
+    }
+
+    /// The receipt must round-trip through TOML losslessly. This is the
+    /// pin against the `toml` 0.8 enum-serialization footgun: if a future
+    /// edit reaches for `#[serde(flatten)]` or an internally-tagged enum,
+    /// this test fails.
+    #[test]
+    fn adapter_claim_toml_round_trip() {
+        // Wrap in a table so the array-of-tables nesting matches how the
+        // claim is stored inside `InstalledState`.
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            adapter_claims: Vec<AdapterClaim>,
+        }
+        let wrapper = Wrapper {
+            adapter_claims: vec![sample_claim()],
+        };
+        let text = toml::to_string_pretty(&wrapper).expect("serialize to TOML");
+        let parsed: Wrapper = toml::from_str(&text).expect("parse from TOML");
+        assert_eq!(wrapper, parsed, "round-trip mismatch; TOML was:\n{text}");
+    }
+
+    #[test]
+    fn adapter_claim_json_round_trip() {
+        let claim = sample_claim();
+        let json = serde_json::to_string(&claim).expect("serialize JSON");
+        let parsed: AdapterClaim = serde_json::from_str(&json).expect("parse JSON");
+        assert_eq!(claim, parsed);
+    }
+
+    #[test]
+    fn validate_plugin_id_accepts_safe_ids() {
+        validate_plugin_id("tokenless").expect("plain");
+        validate_plugin_id("ws-ckpt").expect("dash");
+        validate_plugin_id("a.b_c-1").expect("mixed");
+    }
+
+    #[test]
+    fn validate_plugin_id_rejects_unsafe_ids() {
+        assert!(validate_plugin_id("").is_err(), "empty");
+        assert!(validate_plugin_id("..").is_err(), "dotdot");
+        assert!(validate_plugin_id("-rf").is_err(), "leading dash");
+        assert!(validate_plugin_id("a/b").is_err(), "slash");
+        assert!(validate_plugin_id("a b").is_err(), "space");
+        assert!(validate_plugin_id("a;b").is_err(), "semicolon");
+        assert!(validate_plugin_id("a$b").is_err(), "dollar");
+    }
+
+    #[test]
+    fn validate_external_path_rejects_traversal() {
+        let roots = vec![PathBuf::from("/home/alice/.openclaw")];
+        let err = validate_external_path(Path::new("/home/alice/.openclaw/../.ssh"), &roots)
+            .expect_err("must reject");
+        assert!(matches!(err, ExternalPathError::Traversal { .. }));
+    }
+
+    #[test]
+    fn validate_external_path_rejects_outside_root() {
+        let roots = vec![PathBuf::from("/home/alice/.openclaw")];
+        let err =
+            validate_external_path(Path::new("/etc/passwd"), &roots).expect_err("must reject");
+        assert!(matches!(err, ExternalPathError::OutsideAllowedRoots { .. }));
+    }
+
+    #[test]
+    fn validate_external_path_accepts_under_root() {
+        let roots = vec![PathBuf::from("/home/alice/.openclaw")];
+        validate_external_path(
+            Path::new("/home/alice/.openclaw/extensions/tokenless"),
+            &roots,
+        )
+        .expect("under root must pass");
+    }
+
+    /// A forged receipt pointing an "external" path at `/etc` must be
+    /// rejected by the full claim validation, using the driver's allowed
+    /// roots — not any root the receipt names for itself.
+    #[test]
+    fn forged_external_path_rejected_by_claim_validate() {
+        let layout = FsLayout::system(None);
+        let allowed = vec![PathBuf::from("/home/alice/.openclaw")];
+        let mut claim = sample_claim();
+        claim.resources[0].kind = ClaimResourceKind::ExternalPath {
+            path: PathBuf::from("/etc/cron.d/evil"),
+        };
+        let err = claim.validate(&layout, &allowed).expect_err("must reject");
+        assert!(matches!(err, ClaimValidationError::ExternalPath { .. }));
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -1,0 +1,374 @@
+//! Framework driver trait and the value types it exchanges with the
+//! [`AdapterManager`](super::manager).
+//!
+//! A driver understands one framework's enable/disable/status semantics.
+//! It never spawns processes or deletes paths directly: dangerous IO goes
+//! through the controlled [`AdapterOps`] handle the Manager injects via
+//! [`DriverCtx`], so timeout/truncation/logging and path-boundary policy
+//! stay centralized. The split is deliberate — **driver owns framework
+//! semantics, Manager owns dangerous-resource boundaries**.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Serialize;
+
+use anolisa_platform::fs_layout::FsLayout;
+
+use super::AdapterError;
+use super::claim::AdapterClaim;
+
+/// Read-only host facts a driver may inspect during [`FrameworkDriver::detect`].
+#[derive(Debug, Clone, Default)]
+pub struct HostEnv {
+    /// Current caller's home directory, when resolvable. Frameworks whose
+    /// state lives under `$HOME` use this to locate it.
+    pub user_home: Option<PathBuf>,
+}
+
+/// Detection outcome for a framework.
+#[derive(Debug, Clone, Serialize)]
+pub struct DetectResult {
+    /// Whether the framework appears usable on this host.
+    pub detected: bool,
+    /// Human-readable explanation (binary path found, home dir present, …).
+    pub reason: String,
+}
+
+/// Everything a driver needs for one operation, constructed by the
+/// Manager. The driver never locates state/log/lock paths itself.
+pub struct DriverCtx<'a> {
+    /// Component being enabled/disabled/queried.
+    pub component: String,
+    /// Framework name (matches the driver's [`FrameworkDriver::name`]).
+    pub framework: String,
+    /// Resolved filesystem layout for the active install mode.
+    pub layout: &'a FsLayout,
+    /// Resource directory under `{datadir}/adapters/<component>/<framework>/`.
+    pub resource_root: PathBuf,
+    /// Caller's home directory, when resolvable.
+    pub user_home: Option<PathBuf>,
+    /// Plugin id declared in the component's adapter manifest, if any.
+    /// A driver may fall back to it when the bundle does not name one.
+    pub declared_plugin_id: Option<String>,
+    /// True when the caller passed `--dry-run`; drivers must not mutate
+    /// framework state in this mode (the Manager also guards this).
+    pub dry_run: bool,
+    /// Controlled IO helpers. The only sanctioned way to run a framework
+    /// CLI.
+    pub ops: &'a dyn AdapterOps,
+}
+
+/// Parsed framework-native bundle from the resource directory.
+#[derive(Debug, Clone)]
+pub struct AdapterBundle {
+    /// Resource root the bundle was read from.
+    pub resource_root: PathBuf,
+    /// Digest of the resource tree, for drift/upgrade detection. `None`
+    /// when the driver declined to compute one.
+    pub digest: Option<String>,
+    /// Framework-native plugin id resolved from the bundle (or the
+    /// manifest-declared fallback).
+    pub plugin_id: Option<String>,
+}
+
+/// What [`FrameworkDriver::apply_enable`] would do, for `--dry-run` and
+/// human confirmation. Carries no executable data.
+#[derive(Debug, Clone, Serialize)]
+pub struct DriverPlan {
+    /// Framework name.
+    pub framework: String,
+    /// Component name.
+    pub component: String,
+    /// Ordered human-readable descriptions of the enable steps.
+    pub actions: Vec<String>,
+    /// Display form of the framework CLI registration command, when one is
+    /// run. Display-only — never parsed back into an argv.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub register_command: Option<String>,
+}
+
+/// Outcome of [`FrameworkDriver::disable`].
+#[derive(Debug, Clone, Serialize)]
+pub struct DisableReport {
+    /// True when every claimed resource was successfully released. When
+    /// false, the Manager keeps the receipt and marks it `cleanup_failed`.
+    pub cleanup_complete: bool,
+    /// Human-readable notes (e.g. "openclaw CLI not found; assuming
+    /// registry absent").
+    pub messages: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Status report
+// ---------------------------------------------------------------------------
+
+/// Full status of one receipt: a human summary plus machine-readable
+/// conditions. JSON output must keep `conditions` so distinct failures are
+/// not flattened into one label.
+#[derive(Debug, Clone, Serialize)]
+pub struct AdapterStatusReport {
+    /// One-line health summary.
+    pub summary: AdapterSummary,
+    /// Individual signals behind the summary.
+    pub conditions: Vec<AdapterCondition>,
+}
+
+/// Human-facing one-line adapter health summary.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AdapterSummary {
+    /// Every critical signal is healthy.
+    Healthy,
+    /// At least one critical signal is missing or has drifted.
+    Degraded,
+    /// A prior cleanup did not complete.
+    CleanupFailed,
+    /// State cannot currently be verified reliably.
+    Unknown,
+}
+
+/// One machine-readable signal contributing to a status summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct AdapterCondition {
+    /// Which signal this is.
+    pub kind: AdapterConditionKind,
+    /// Tri-state result.
+    pub status: ConditionStatus,
+    /// Optional human explanation (e.g. "plugin not in `plugins list`").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional pointer to the claim resource this condition is about.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource: Option<ClaimResourceRef>,
+}
+
+/// Reference to a [`ClaimResource`](super::claim::ClaimResource) by id.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimResourceRef {
+    /// Resource id.
+    pub id: String,
+}
+
+/// The kinds of signal a condition can report.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AdapterConditionKind {
+    /// The framework itself is detectable on the host.
+    FrameworkDetected,
+    /// The installed resource bundle still matches the enable-time digest.
+    ResourceBundleMatches,
+    /// The plugin is still present in the framework registry.
+    PluginRegistered,
+    /// A marketplace source is still registered (future drivers).
+    MarketplaceRegistered,
+    /// A claimed directory tree still exists unmodified (future drivers).
+    TreePresent,
+    /// Injected JSON keys still equal ANOLISA's last-applied values
+    /// (future drivers).
+    JsonKeysPresent,
+    /// A claimed symlink still points at the expected target (future
+    /// drivers).
+    SymlinkPresent,
+    /// A prior cleanup completed.
+    CleanupComplete,
+    /// Whether this driver supports reliable read-only verification at
+    /// all. `False` means the related conditions are `Unknown` rather than
+    /// faked healthy.
+    VerificationSupported,
+}
+
+/// Tri-state condition result. `Unknown` is distinct from `False`: it
+/// means "could not verify", never "verified absent".
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConditionStatus {
+    /// Signal verified present/healthy.
+    True,
+    /// Signal verified absent/unhealthy.
+    False,
+    /// Signal could not be verified.
+    Unknown,
+}
+
+// ---------------------------------------------------------------------------
+// Controlled IO helpers
+// ---------------------------------------------------------------------------
+
+/// A framework CLI invocation, built by a driver from a static command
+/// template plus validated arguments. Executed by [`AdapterOps`] as an
+/// argv array — never through a shell.
+#[derive(Debug, Clone)]
+pub struct FrameworkCommand {
+    /// Executable to run (resolved via `PATH` with [`Self::path_prepend`]).
+    pub program: String,
+    /// Argument vector. Each element is passed verbatim; no shell parsing.
+    pub args: Vec<String>,
+    /// Environment variables to set on the child.
+    pub env_set: Vec<(String, String)>,
+    /// Environment variables to remove from the child.
+    pub env_remove: Vec<String>,
+    /// Directories prepended to `PATH` before spawning.
+    pub path_prepend: Vec<PathBuf>,
+    /// Hard timeout; the child is killed if it exceeds this.
+    pub timeout: Duration,
+}
+
+/// Captured output of a [`FrameworkCommand`]. stdout/stderr are truncated
+/// to a bounded size before being returned and logged.
+#[derive(Debug, Clone)]
+pub struct CliOutput {
+    /// Exit code, or `None` when the child was killed (e.g. on timeout).
+    pub status: Option<i32>,
+    /// True when the child was killed because it exceeded the timeout.
+    pub timed_out: bool,
+    /// Truncated stdout (UTF-8 lossy).
+    pub stdout: String,
+    /// Truncated stderr (UTF-8 lossy).
+    pub stderr: String,
+}
+
+impl CliOutput {
+    /// True iff the process exited zero and was not killed by timeout.
+    pub fn success(&self) -> bool {
+        self.status == Some(0) && !self.timed_out
+    }
+}
+
+/// The closed set of dangerous IO a driver may perform, mediated by the
+/// Manager.
+///
+/// MVP exposes only [`run_framework_cli`](AdapterOps::run_framework_cli);
+/// the file/JSON/symlink helpers from the design land with the drivers
+/// that need them (Cosh, Qoder, Hermes), so the boundary grows one
+/// reviewed method at a time rather than shipping unused surface.
+pub trait AdapterOps {
+    /// Spawn a framework CLI with a timeout, capture and truncate its
+    /// output, and record the invocation in the central log. The argv is
+    /// executed directly (no shell), so receipt-derived data cannot inject
+    /// extra commands.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when the process cannot be spawned.
+    /// A non-zero exit or a timeout is reported through [`CliOutput`], not
+    /// as an error, so the driver decides how to interpret it.
+    fn run_framework_cli(&self, cmd: FrameworkCommand) -> Result<CliOutput, AdapterError>;
+}
+
+// ---------------------------------------------------------------------------
+// Driver trait
+// ---------------------------------------------------------------------------
+
+/// One framework's adapter semantics. Built-in and closed: new frameworks
+/// ship in an ANOLISA release, never as a runtime plugin.
+pub trait FrameworkDriver: Send + Sync {
+    /// Framework name, e.g. `"openclaw"`.
+    fn name(&self) -> &'static str;
+
+    /// Read-only probe for whether the framework is usable. May inspect
+    /// `PATH` and the filesystem; must not spawn the framework.
+    fn detect(&self, env: &HostEnv) -> DetectResult;
+
+    /// External roots (outside ANOLISA-owned roots) this driver is allowed
+    /// to write into. The Manager validates every
+    /// [`ClaimResourceKind::ExternalPath`](super::claim::ClaimResourceKind::ExternalPath)
+    /// against this set. The result may expand `ctx.user_home`, but must
+    /// not be derived from receipt contents (which would let a forged
+    /// receipt authorize itself).
+    fn allowed_external_roots(&self, ctx: &DriverCtx) -> Vec<PathBuf>;
+
+    /// Parse the framework-native bundle from the resource directory.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::BundleInvalid`] when required files are missing or
+    /// unreadable.
+    fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError>;
+
+    /// Describe what [`Self::apply_enable`] would do, for dry-run and
+    /// confirmation.
+    ///
+    /// # Errors
+    ///
+    /// Propagates bundle/validation errors encountered while planning.
+    fn plan_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<DriverPlan, AdapterError>;
+
+    /// Build the pure-data receipt for a future enable operation without
+    /// mutating framework state.
+    ///
+    /// The Manager validates and persists this claim before
+    /// [`Self::apply_enable`] runs, so a later framework-side failure stays
+    /// visible to status/disable.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::BundleInvalid`] when the bundle cannot produce the
+    /// framework identifiers needed for a receipt.
+    fn prepare_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterClaim, AdapterError>;
+
+    /// Idempotently apply an already-persisted enable receipt to framework
+    /// state.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] or [`AdapterError::BundleInvalid`] on
+    /// failure.
+    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError>;
+
+    /// Read-only status check against a receipt. Must not mutate state.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when a verification probe cannot run
+    /// (as opposed to running and finding the plugin absent).
+    fn status(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterStatusReport, AdapterError>;
+
+    /// Idempotently disable the adapter, removing only what the receipt
+    /// declares ANOLISA took over.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when de-registration fails in a way
+    /// that is not simply "framework absent".
+    fn disable(&self, claim: &AdapterClaim, ctx: &DriverCtx)
+    -> Result<DisableReport, AdapterError>;
+}
+
+/// Scan candidate directories of `PATH` for an executable named `name`,
+/// honoring the executable bit on Unix. Shared by drivers' `detect`.
+pub fn find_binary_in_path(name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if candidate.is_file() && is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    true
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -1,0 +1,1184 @@
+//! Adapter manager: the trusted orchestrator that owns the
+//! dangerous-resource boundary.
+//!
+//! The Manager is the only thing that takes the install lock, reads and
+//! writes adapter receipts in `installed.toml`, re-validates every
+//! [`ClaimResource`](super::claim::ClaimResource) against a driver's static
+//! external roots, runs framework CLIs through a single controlled
+//! [`AdapterOps`] implementation, and records to the central log. Drivers
+//! own framework *semantics*; the Manager owns *trust and IO*. A driver
+//! never spawns a process, deletes a path, or persists state on its own.
+//!
+//! Resource discovery follows the layout convention
+//! `{datadir}/adapters/<component>/<framework>/`. Multiple datadir roots
+//! may be searched (e.g. the user datadir preferred over the system one);
+//! the first root that contains the directory wins.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anolisa_platform::fs_layout::{FsLayout, InstallMode};
+
+use super::AdapterError;
+use super::claim::{AdapterClaim, ClaimStatus};
+use super::driver::{
+    AdapterOps, AdapterStatusReport, CliOutput, DisableReport, DriverCtx, DriverPlan,
+    FrameworkCommand, HostEnv,
+};
+use super::registry::DriverRegistry;
+use crate::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
+use crate::lock::InstallLock;
+use crate::manifest::ComponentManifest;
+use crate::state::{InstalledState, ObjectKind, ObjectStatus};
+
+/// Per-CLI-call producer name recorded in the central log.
+const LOG_SOURCE: &str = "anolisa-cli";
+
+/// Cap on captured stdout/stderr per framework CLI invocation (bytes).
+/// Output beyond this is drained (so the child never blocks on a full
+/// pipe) but discarded before logging.
+const OUTPUT_CAP: usize = 64 * 1024;
+/// State subdirectory where install stores component manifests used for
+/// future adapter enable checks.
+const INSTALLED_COMPONENT_MANIFESTS_SUBDIR: &str = "component-manifests";
+/// Filename used for each saved installed component contract.
+const INSTALLED_COMPONENT_MANIFEST_FILE: &str = "component.toml";
+
+/// Outcome of [`AdapterManager::enable`].
+#[derive(Debug, Clone)]
+pub enum EnableOutcome {
+    /// `--dry-run`: what enable *would* do, no state mutated.
+    Planned(DriverPlan),
+    /// Enable ran; the persisted receipt.
+    Enabled(Box<AdapterClaim>),
+}
+
+/// Outcome of [`AdapterManager::disable`].
+#[derive(Debug, Clone)]
+pub struct DisableOutcome {
+    /// Component the disable targeted.
+    pub component: String,
+    /// Resolved framework, when one was determined (`None` only for the
+    /// "component has no enabled adapters" no-op).
+    pub framework: Option<String>,
+    /// The driver's cleanup report.
+    pub report: DisableReport,
+    /// True when the receipt was removed; false when it was kept and
+    /// marked `cleanup_failed` for retry.
+    pub claim_removed: bool,
+}
+
+/// One row of [`AdapterManager::scan`].
+#[derive(Debug, Clone)]
+pub struct ScanEntry {
+    /// Component the adapter belongs to.
+    pub component: String,
+    /// Framework the adapter targets.
+    pub framework: String,
+    /// Whether the installed component manifest declares this adapter.
+    pub declared: bool,
+    /// Resource directory, when present under a visible datadir root.
+    pub resource_root: Option<PathBuf>,
+    /// Whether a built-in driver exists for `framework`.
+    pub driver_available: bool,
+    /// Whether the framework was detected on the host (best-effort;
+    /// `false` when no driver is available to probe).
+    pub framework_detected: bool,
+    /// Whether a receipt for `(component, framework)` exists in state.
+    pub enabled: bool,
+    /// Lifecycle status of the receipt, when one exists.
+    pub claim_status: Option<ClaimStatus>,
+}
+
+/// Full result of [`AdapterManager::scan`].
+#[derive(Debug, Clone, Default)]
+pub struct ScanReport {
+    /// Adapter entries from manifest declarations and/or resource
+    /// directories, sorted by `(component, framework)`.
+    pub entries: Vec<ScanEntry>,
+    /// Non-fatal manifest/state issues encountered while scanning fallback
+    /// roots.
+    pub warnings: Vec<String>,
+}
+
+/// One row of [`AdapterManager::status`].
+#[derive(Debug, Clone)]
+pub struct StatusEntry {
+    /// Component the receipt belongs to.
+    pub component: String,
+    /// Framework the receipt targets.
+    pub framework: String,
+    /// The driver's status report for this receipt.
+    pub report: AdapterStatusReport,
+}
+
+/// Full result of [`AdapterManager::status`].
+#[derive(Debug, Clone, Default)]
+pub struct StatusReport {
+    /// Per-receipt status entries.
+    pub entries: Vec<StatusEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct AdapterDecl {
+    component: String,
+    framework: String,
+}
+
+/// Trusted orchestrator for adapter enable/disable/status/scan.
+pub struct AdapterManager {
+    layout: FsLayout,
+    registry: DriverRegistry,
+    state_path: PathBuf,
+    /// State roots searched for installed component records/manifests, in
+    /// preference order. Receipts are always written only to
+    /// [`Self::state_path`].
+    state_roots: Vec<PathBuf>,
+    /// Datadir roots searched for `adapters/<component>/<framework>/`, in
+    /// preference order (first match wins).
+    datadir_roots: Vec<PathBuf>,
+    user_home: Option<PathBuf>,
+    /// Identity recorded as the central-log actor.
+    actor: String,
+}
+
+impl AdapterManager {
+    /// Build a manager for the given layout. The state file is
+    /// `{state_dir}/installed.toml`; the primary datadir root is
+    /// `layout.datadir`, and the primary component-manifest root is
+    /// `layout.state_dir`. Use [`Self::push_datadir_root`] and
+    /// [`Self::push_state_root`] to add fallbacks (e.g. system roots when
+    /// running in user mode).
+    pub fn new(layout: FsLayout, user_home: Option<PathBuf>, actor: String) -> Self {
+        let state_path = layout.state_dir.join("installed.toml");
+        let state_roots = vec![layout.state_dir.clone()];
+        let datadir_roots = vec![layout.datadir.clone()];
+        Self {
+            layout,
+            registry: DriverRegistry::builtin(),
+            state_path,
+            state_roots,
+            datadir_roots,
+            user_home,
+            actor,
+        }
+    }
+
+    /// Append an additional datadir root to search after the ones already
+    /// registered. Ignored if already present.
+    pub fn push_datadir_root(&mut self, root: PathBuf) {
+        if !self.datadir_roots.contains(&root) {
+            self.datadir_roots.push(root);
+        }
+    }
+
+    /// Append an additional installed-state root to search for component
+    /// installation records and saved component manifests. Receipts still
+    /// belong to the manager's primary state root.
+    pub fn push_state_root(&mut self, root: PathBuf) {
+        if !self.state_roots.contains(&root) {
+            self.state_roots.push(root);
+        }
+    }
+
+    /// Built-in driver registry, for callers that want to introspect
+    /// supported frameworks.
+    pub fn registry(&self) -> &DriverRegistry {
+        &self.registry
+    }
+
+    // -- scan ---------------------------------------------------------------
+
+    /// Discover adapter declarations from visible installed component
+    /// manifests, merge them with resource directories under the datadir
+    /// roots, then annotate each row with driver availability, framework
+    /// detection, and receipt state. Read-only.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::State`] if the state file cannot be read.
+    pub fn scan(&self) -> Result<ScanReport, AdapterError> {
+        let state = InstalledState::load(&self.state_path)?;
+        let mut entries: BTreeMap<(String, String), ScanEntry> = BTreeMap::new();
+        for (component, framework, resource_root) in self.discover_all() {
+            let driver = self.registry.get(&framework);
+            let driver_available = driver.is_some();
+            let framework_detected = driver
+                .map(|d| {
+                    d.detect(&HostEnv {
+                        user_home: self.user_home.clone(),
+                    })
+                    .detected
+                })
+                .unwrap_or(false);
+            let claim = state.find_adapter_claim(&component, &framework);
+            entries.insert(
+                (component.clone(), framework.clone()),
+                ScanEntry {
+                    component,
+                    framework,
+                    declared: false,
+                    resource_root: Some(resource_root),
+                    driver_available,
+                    framework_detected,
+                    enabled: claim.is_some(),
+                    claim_status: claim.map(|c| c.status),
+                },
+            );
+        }
+
+        let (declarations, warnings) = self.load_visible_adapter_declarations(&state);
+        for declaration in declarations {
+            let key = (declaration.component.clone(), declaration.framework.clone());
+            if let Some(entry) = entries.get_mut(&key) {
+                entry.declared = true;
+                continue;
+            }
+            let driver = self.registry.get(&declaration.framework);
+            let driver_available = driver.is_some();
+            let framework_detected = driver
+                .map(|d| {
+                    d.detect(&HostEnv {
+                        user_home: self.user_home.clone(),
+                    })
+                    .detected
+                })
+                .unwrap_or(false);
+            let claim = state.find_adapter_claim(&declaration.component, &declaration.framework);
+            entries.insert(
+                key,
+                ScanEntry {
+                    component: declaration.component,
+                    framework: declaration.framework,
+                    declared: true,
+                    resource_root: None,
+                    driver_available,
+                    framework_detected,
+                    enabled: claim.is_some(),
+                    claim_status: claim.map(|c| c.status),
+                },
+            );
+        }
+
+        Ok(ScanReport {
+            entries: entries.into_values().collect(),
+            warnings,
+        })
+    }
+
+    // -- enable -------------------------------------------------------------
+
+    /// Enable `component`'s adapter for `framework` (resolved automatically
+    /// when `None` and exactly one framework is present). When `dry_run`,
+    /// returns the plan without mutating any state.
+    ///
+    /// Takes the install lock for the whole operation.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::ComponentNotInstalled`], [`AdapterError::AdapterNotDeclared`],
+    /// [`AdapterError::AdapterManifest`], [`AdapterError::UnknownFramework`],
+    /// [`AdapterError::AmbiguousFramework`], [`AdapterError::ResourceRootNotFound`],
+    /// [`AdapterError::FrameworkNotDetected`], [`AdapterError::BundleInvalid`],
+    /// [`AdapterError::FrameworkCli`], [`AdapterError::ClaimValidation`], or
+    /// state/lock/log errors.
+    pub fn enable(
+        &self,
+        component: &str,
+        framework: Option<&str>,
+        dry_run: bool,
+    ) -> Result<EnableOutcome, AdapterError> {
+        let _lock = InstallLock::acquire(&self.layout.lock_file)?;
+        let mut state = InstalledState::load(&self.state_path)?;
+
+        let manifest = self.load_visible_component_manifest(component, &state)?;
+        let framework = self.resolve_framework(component, framework, &manifest)?;
+        let declared_plugin_id = declared_plugin_id(&manifest, &framework);
+        let driver =
+            self.registry
+                .get(&framework)
+                .ok_or_else(|| AdapterError::UnknownFramework {
+                    framework: framework.clone(),
+                })?;
+
+        let resource_root = self.discover_resource_root(component, &framework).ok_or(
+            AdapterError::ResourceRootNotFound {
+                component: component.to_string(),
+                framework: framework.clone(),
+            },
+        )?;
+
+        let label = format!("adapter enable {component} {framework}");
+        let ops = ManagerOps::new(
+            self.central_log(),
+            self.actor.clone(),
+            install_mode_str(self.layout.mode).to_string(),
+            component.to_string(),
+            label.clone(),
+        );
+        let ctx = DriverCtx {
+            component: component.to_string(),
+            framework: framework.clone(),
+            layout: &self.layout,
+            resource_root: resource_root.clone(),
+            user_home: self.user_home.clone(),
+            declared_plugin_id,
+            dry_run,
+            ops: &ops,
+        };
+
+        let bundle = driver.read_bundle(&ctx)?;
+
+        if dry_run {
+            let plan = driver.plan_enable(&bundle, &ctx)?;
+            return Ok(EnableOutcome::Planned(plan));
+        }
+
+        // enable mutates framework state, so the framework must be usable.
+        let detect = driver.detect(&HostEnv {
+            user_home: self.user_home.clone(),
+        });
+        if !detect.detected {
+            return Err(AdapterError::FrameworkNotDetected {
+                framework: framework.clone(),
+                reason: detect.reason,
+            });
+        }
+
+        let claim = driver.prepare_enable(&bundle, &ctx)?;
+        // Defense in depth: the driver must not emit a claim that points
+        // outside its own declared roots. Reject before persisting.
+        claim.validate(&self.layout, &driver.allowed_external_roots(&ctx))?;
+
+        state.upsert_adapter_claim(claim.clone());
+        state.save(&self.state_path)?;
+        if let Err(err) = driver.apply_enable(&claim, &ctx) {
+            let mut failed_claim = claim.clone();
+            failed_claim.status = ClaimStatus::CleanupFailed;
+            state.upsert_adapter_claim(failed_claim);
+            if let Err(save_err) = state.save(&self.state_path) {
+                self.log_operation(
+                    &label,
+                    component,
+                    LogStatus::Partial,
+                    "adapter enable failed; receipt status update failed",
+                    Some(format!(
+                        "enable error: {err}; failed to mark receipt cleanup_failed: {save_err}"
+                    )),
+                );
+            } else {
+                self.log_operation(
+                    &label,
+                    component,
+                    LogStatus::Failed,
+                    "adapter enable failed; receipt kept for cleanup retry",
+                    Some(err.to_string()),
+                );
+            }
+            return Err(err);
+        }
+        self.log_operation(&label, component, LogStatus::Ok, "adapter enabled", None);
+
+        Ok(EnableOutcome::Enabled(Box::new(claim)))
+    }
+
+    // -- disable ------------------------------------------------------------
+
+    /// Disable `component`'s adapter for `framework` (resolved from existing
+    /// receipts when `None`). Idempotent: disabling something with no
+    /// receipt is a successful no-op.
+    ///
+    /// Takes the install lock for the whole operation.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::AmbiguousFramework`] when `framework` is omitted and
+    /// the component has receipts for more than one; [`AdapterError::UnknownFramework`],
+    /// [`AdapterError::ClaimValidation`], [`AdapterError::FrameworkCli`], or
+    /// state/lock/log errors.
+    pub fn disable(
+        &self,
+        component: &str,
+        framework: Option<&str>,
+    ) -> Result<DisableOutcome, AdapterError> {
+        let _lock = InstallLock::acquire(&self.layout.lock_file)?;
+        let mut state = InstalledState::load(&self.state_path)?;
+
+        let framework = match framework {
+            Some(f) => f.to_string(),
+            None => {
+                let claimed: Vec<String> = state
+                    .adapter_claims_for_component(component)
+                    .iter()
+                    .map(|c| c.framework.clone())
+                    .collect();
+                match claimed.len() {
+                    0 => {
+                        return Ok(DisableOutcome {
+                            component: component.to_string(),
+                            framework: None,
+                            report: DisableReport {
+                                cleanup_complete: true,
+                                messages: vec![format!(
+                                    "component '{component}' has no enabled adapters"
+                                )],
+                            },
+                            claim_removed: false,
+                        });
+                    }
+                    1 => claimed[0].clone(),
+                    _ => {
+                        return Err(AdapterError::AmbiguousFramework {
+                            component: component.to_string(),
+                            frameworks: claimed,
+                        });
+                    }
+                }
+            }
+        };
+
+        let claim = match state.find_adapter_claim(component, &framework) {
+            Some(c) => c.clone(),
+            None => {
+                // Idempotent: nothing to disable.
+                return Ok(DisableOutcome {
+                    component: component.to_string(),
+                    framework: Some(framework.clone()),
+                    report: DisableReport {
+                        cleanup_complete: true,
+                        messages: vec![format!(
+                            "no receipt for '{component}/{framework}'; nothing to disable"
+                        )],
+                    },
+                    claim_removed: false,
+                });
+            }
+        };
+
+        let driver =
+            self.registry
+                .get(&framework)
+                .ok_or_else(|| AdapterError::UnknownFramework {
+                    framework: framework.clone(),
+                })?;
+
+        // resource_root may be gone after an uninstall of the bundle; that
+        // is fine — disable must not depend on it. Fall back to the
+        // receipt's recorded root for context only.
+        let resource_root = self
+            .discover_resource_root(component, &framework)
+            .unwrap_or_else(|| claim.resource_root.clone());
+
+        let label = format!("adapter disable {component} {framework}");
+        let ops = ManagerOps::new(
+            self.central_log(),
+            self.actor.clone(),
+            install_mode_str(self.layout.mode).to_string(),
+            component.to_string(),
+            label.clone(),
+        );
+        let ctx = DriverCtx {
+            component: component.to_string(),
+            framework: framework.clone(),
+            layout: &self.layout,
+            resource_root,
+            user_home: self.user_home.clone(),
+            declared_plugin_id: None,
+            dry_run: false,
+            ops: &ops,
+        };
+
+        // Re-validate the receipt before acting on it (forged-state guard).
+        claim.validate(&self.layout, &driver.allowed_external_roots(&ctx))?;
+
+        let report = driver.disable(&claim, &ctx)?;
+        let claim_removed = report.cleanup_complete;
+        if claim_removed {
+            state.remove_adapter_claim(component, &framework);
+            self.log_operation(&label, component, LogStatus::Ok, "adapter disabled", None);
+        } else {
+            // Keep the receipt so cleanup can be retried; mark it failed.
+            let mut kept = claim;
+            kept.status = ClaimStatus::CleanupFailed;
+            state.upsert_adapter_claim(kept);
+            self.log_operation(
+                &label,
+                component,
+                LogStatus::Failed,
+                "adapter cleanup incomplete; receipt kept",
+                Some(report.messages.join("; ")),
+            );
+        }
+        state.save(&self.state_path)?;
+
+        Ok(DisableOutcome {
+            component: component.to_string(),
+            framework: Some(framework),
+            report,
+            claim_removed,
+        })
+    }
+
+    // -- status -------------------------------------------------------------
+
+    /// Report status for every receipt, or only those of `component` when
+    /// given. Read-only; never mutates state.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::ClaimValidation`] if a stored receipt fails
+    /// re-validation, or state errors. A missing driver or undetectable
+    /// framework is reported in the per-entry conditions, not as an error.
+    pub fn status(&self, component: Option<&str>) -> Result<StatusReport, AdapterError> {
+        let state = InstalledState::load(&self.state_path)?;
+        let mut entries = Vec::new();
+
+        for claim in &state.adapter_claims {
+            if let Some(c) = component
+                && claim.component != c
+            {
+                continue;
+            }
+            let framework = claim.framework.clone();
+            let driver = match self.registry.get(&framework) {
+                Some(d) => d,
+                None => {
+                    // No driver: cannot verify. Surface an unverified report
+                    // rather than skipping the receipt silently.
+                    entries.push(StatusEntry {
+                        component: claim.component.clone(),
+                        framework,
+                        report: unverified_report("no built-in driver for framework"),
+                    });
+                    continue;
+                }
+            };
+
+            let resource_root = self
+                .discover_resource_root(&claim.component, &framework)
+                .unwrap_or_else(|| claim.resource_root.clone());
+            let label = format!("adapter status {} {framework}", claim.component);
+            let ops = ManagerOps::new(
+                self.central_log(),
+                self.actor.clone(),
+                install_mode_str(self.layout.mode).to_string(),
+                claim.component.clone(),
+                label,
+            );
+            let ctx = DriverCtx {
+                component: claim.component.clone(),
+                framework: framework.clone(),
+                layout: &self.layout,
+                resource_root,
+                user_home: self.user_home.clone(),
+                declared_plugin_id: None,
+                dry_run: false,
+                ops: &ops,
+            };
+
+            claim.validate(&self.layout, &driver.allowed_external_roots(&ctx))?;
+            let report = driver.status(claim, &ctx)?;
+            entries.push(StatusEntry {
+                component: claim.component.clone(),
+                framework,
+                report,
+            });
+        }
+
+        Ok(StatusReport { entries })
+    }
+
+    // -- discovery helpers --------------------------------------------------
+
+    /// Resolve the framework for an operation from the installed manifest:
+    /// use the explicit one when declared, else the single declared
+    /// framework, else error.
+    fn resolve_framework(
+        &self,
+        component: &str,
+        framework: Option<&str>,
+        manifest: &ComponentManifest,
+    ) -> Result<String, AdapterError> {
+        let declared = declared_frameworks(manifest);
+        if let Some(f) = framework {
+            if declared.iter().any(|decl| decl == f) {
+                return Ok(f.to_string());
+            }
+            return Err(AdapterError::AdapterNotDeclared {
+                component: component.to_string(),
+                framework: f.to_string(),
+            });
+        }
+        match declared.len() {
+            0 => Err(AdapterError::AdapterNotDeclared {
+                component: component.to_string(),
+                framework: "<any>".to_string(),
+            }),
+            1 => Ok(declared[0].clone()),
+            _ => Err(AdapterError::AmbiguousFramework {
+                component: component.to_string(),
+                frameworks: declared,
+            }),
+        }
+    }
+
+    /// Load the installed component manifest from the first visible state
+    /// root that records `component` as installed.
+    fn load_visible_component_manifest(
+        &self,
+        component: &str,
+        current_state: &InstalledState,
+    ) -> Result<ComponentManifest, AdapterError> {
+        let Some(state_dir) = self.find_component_state_dir(component, current_state)? else {
+            return Err(AdapterError::ComponentNotInstalled {
+                component: component.to_string(),
+            });
+        };
+        let path = installed_component_manifest_path(&state_dir, component);
+        let manifest =
+            ComponentManifest::from_file(&path).map_err(|err| AdapterError::AdapterManifest {
+                component: component.to_string(),
+                path: path.clone(),
+                reason: err.to_string(),
+            })?;
+        if manifest.component.name != component {
+            return Err(AdapterError::AdapterManifest {
+                component: component.to_string(),
+                path,
+                reason: format!("manifest declares component '{}'", manifest.component.name),
+            });
+        }
+        Ok(manifest)
+    }
+
+    /// First visible state root whose installed state contains `component`.
+    fn find_component_state_dir(
+        &self,
+        component: &str,
+        current_state: &InstalledState,
+    ) -> Result<Option<PathBuf>, AdapterError> {
+        for state_dir in &self.state_roots {
+            let installed = if state_dir == &self.layout.state_dir {
+                current_state
+                    .find_object(ObjectKind::Component, component)
+                    .is_some()
+            } else {
+                let state_path = state_dir.join("installed.toml");
+                InstalledState::load(&state_path)?
+                    .find_object(ObjectKind::Component, component)
+                    .is_some()
+            };
+            if installed {
+                return Ok(Some(state_dir.clone()));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Adapter declarations from installed component manifests in visible
+    /// state roots. Earlier roots shadow later roots for the same component,
+    /// matching enable's user-before-system resolution.
+    fn load_visible_adapter_declarations(
+        &self,
+        current_state: &InstalledState,
+    ) -> (Vec<AdapterDecl>, Vec<String>) {
+        let mut declarations = BTreeSet::new();
+        let mut seen_components = BTreeSet::new();
+        let mut warnings = Vec::new();
+
+        for state_dir in &self.state_roots {
+            let state_path = state_dir.join("installed.toml");
+            let state = if state_dir == &self.layout.state_dir {
+                current_state.clone()
+            } else {
+                match InstalledState::load(&state_path) {
+                    Ok(state) => state,
+                    Err(err) => {
+                        warnings.push(format!(
+                            "failed to load installed state at {}: {err}",
+                            state_path.display()
+                        ));
+                        continue;
+                    }
+                }
+            };
+
+            for object in state
+                .objects
+                .iter()
+                .filter(|object| object.kind == ObjectKind::Component)
+                .filter(|object| object.status == ObjectStatus::Installed)
+            {
+                if !seen_components.insert(object.name.clone()) {
+                    continue;
+                }
+
+                let path = installed_component_manifest_path(state_dir, &object.name);
+                if !path.exists() {
+                    warnings.push(format!(
+                        "installed component '{}' has no local component manifest at {}",
+                        object.name,
+                        path.display()
+                    ));
+                    continue;
+                }
+                let manifest = match ComponentManifest::from_file(&path) {
+                    Ok(manifest) => manifest,
+                    Err(err) => {
+                        warnings.push(format!(
+                            "failed to read installed component manifest for '{}' at {}: {err}",
+                            object.name,
+                            path.display()
+                        ));
+                        continue;
+                    }
+                };
+                if manifest.component.name != object.name {
+                    warnings.push(format!(
+                        "installed component manifest at {} declares component '{}', expected '{}'",
+                        path.display(),
+                        manifest.component.name,
+                        object.name
+                    ));
+                    continue;
+                }
+
+                for framework in declared_frameworks(&manifest) {
+                    declarations.insert(AdapterDecl {
+                        component: object.name.clone(),
+                        framework,
+                    });
+                }
+            }
+        }
+
+        (declarations.into_iter().collect(), warnings)
+    }
+
+    /// First datadir root that contains
+    /// `adapters/<component>/<framework>/` as a directory.
+    fn discover_resource_root(&self, component: &str, framework: &str) -> Option<PathBuf> {
+        for root in &self.datadir_roots {
+            let candidate = root.join("adapters").join(component).join(framework);
+            if candidate.is_dir() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// Every `(component, framework, resource_root)` discoverable under the
+    /// datadir roots, deduped on `(component, framework)` and sorted.
+    fn discover_all(&self) -> Vec<(String, String, PathBuf)> {
+        let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
+        let mut out: Vec<(String, String, PathBuf)> = Vec::new();
+        for root in &self.datadir_roots {
+            let adapters = root.join("adapters");
+            let Ok(components) = adapters.read_dir() else {
+                continue;
+            };
+            for comp_entry in components.flatten() {
+                if !comp_entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                let component = comp_entry.file_name().to_string_lossy().into_owned();
+                let Ok(frameworks) = comp_entry.path().read_dir() else {
+                    continue;
+                };
+                for fw_entry in frameworks.flatten() {
+                    if !fw_entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                        continue;
+                    }
+                    let framework = fw_entry.file_name().to_string_lossy().into_owned();
+                    if seen.insert((component.clone(), framework.clone())) {
+                        out.push((component.clone(), framework, fw_entry.path()));
+                    }
+                }
+            }
+        }
+        out.sort_by(|a, b| (a.0.as_str(), a.1.as_str()).cmp(&(b.0.as_str(), b.1.as_str())));
+        out
+    }
+
+    // -- logging ------------------------------------------------------------
+
+    fn central_log(&self) -> CentralLog {
+        CentralLog::open(self.layout.central_log.clone())
+    }
+
+    /// Append one operation-summary record. Logging failures are
+    /// swallowed: an audit-log hiccup must not fail an otherwise-successful
+    /// adapter operation.
+    fn log_operation(
+        &self,
+        command: &str,
+        component: &str,
+        status: LogStatus,
+        message: &str,
+        detail: Option<String>,
+    ) {
+        let severity = match status {
+            LogStatus::Ok => Severity::Info,
+            LogStatus::Partial => Severity::Warn,
+            LogStatus::Failed | LogStatus::RolledBack => Severity::Error,
+        };
+        let now = now_iso8601();
+        let record = LogRecord {
+            kind: LogKind::Operation,
+            operation_id: None,
+            command: command.to_string(),
+            source: LOG_SOURCE.to_string(),
+            component: Some(component.to_string()),
+            severity,
+            message: message.to_string(),
+            actor: self.actor.clone(),
+            install_mode: Some(install_mode_str(self.layout.mode).to_string()),
+            started_at: now.clone(),
+            finished_at: Some(now),
+            status: Some(status),
+            objects: vec![component.to_string()],
+            backup_ids: Vec::new(),
+            warnings: detail.into_iter().collect(),
+            details: serde_json::Value::Null,
+        };
+        let _ = self.central_log().append(&record);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Controlled IO
+// ---------------------------------------------------------------------------
+
+/// The Manager's [`AdapterOps`] implementation: spawns framework CLIs with
+/// a timeout, captures and truncates their output, and records each
+/// invocation in the central log. The argv is executed directly (no
+/// shell), so receipt-derived data can never inject extra commands.
+struct ManagerOps {
+    log: CentralLog,
+    actor: String,
+    install_mode: String,
+    component: String,
+    /// Human-readable operation label for the log `command` field.
+    label: String,
+}
+
+impl ManagerOps {
+    fn new(
+        log: CentralLog,
+        actor: String,
+        install_mode: String,
+        component: String,
+        label: String,
+    ) -> Self {
+        Self {
+            log,
+            actor,
+            install_mode,
+            component,
+            label,
+        }
+    }
+
+    /// Record one framework CLI invocation. Best-effort; a log failure
+    /// never propagates.
+    fn record(&self, cmd: &FrameworkCommand, output: &CliOutput) {
+        let severity = if output.success() {
+            Severity::Debug
+        } else {
+            Severity::Warn
+        };
+        let argv = std::iter::once(cmd.program.clone())
+            .chain(cmd.args.iter().cloned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let now = now_iso8601();
+        let record = LogRecord {
+            kind: LogKind::Operation,
+            operation_id: None,
+            command: self.label.clone(),
+            source: LOG_SOURCE.to_string(),
+            component: Some(self.component.clone()),
+            severity,
+            message: format!("framework cli: {argv}"),
+            actor: self.actor.clone(),
+            install_mode: Some(self.install_mode.clone()),
+            started_at: now.clone(),
+            finished_at: Some(now),
+            status: Some(if output.success() {
+                LogStatus::Ok
+            } else {
+                LogStatus::Failed
+            }),
+            objects: vec![self.component.clone()],
+            backup_ids: Vec::new(),
+            warnings: Vec::new(),
+            details: serde_json::json!({
+                "exit": output.status,
+                "timed_out": output.timed_out,
+            }),
+        };
+        let _ = self.log.append(&record);
+    }
+}
+
+impl AdapterOps for ManagerOps {
+    fn run_framework_cli(&self, cmd: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+        let output = run_capture(&cmd)?;
+        self.record(&cmd, &output);
+        Ok(output)
+    }
+}
+
+/// Spawn `cmd` as a direct argv (no shell), enforce its timeout, and return
+/// truncated output. The child's stdout/stderr are drained on separate
+/// threads so a full pipe can never deadlock the wait loop.
+fn run_capture(cmd: &FrameworkCommand) -> Result<CliOutput, AdapterError> {
+    let mut command = Command::new(&cmd.program);
+    command
+        .args(&cmd.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    for key in &cmd.env_remove {
+        command.env_remove(key);
+    }
+    for (key, value) in &cmd.env_set {
+        command.env(key, value);
+    }
+    if !cmd.path_prepend.is_empty() {
+        command.env("PATH", prepend_path(&cmd.path_prepend));
+    }
+
+    let mut child = crate::process::spawn_retry_etxtbsy(&mut command).map_err(|source| {
+        AdapterError::FrameworkCli {
+            program: cmd.program.clone(),
+            reason: format!("failed to spawn: {source}"),
+        }
+    })?;
+
+    let stdout_handle = child.stdout.take().map(|r| spawn_drain(r, OUTPUT_CAP));
+    let stderr_handle = child.stderr.take().map(|r| spawn_drain(r, OUTPUT_CAP));
+
+    let start = Instant::now();
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if start.elapsed() >= cmd.timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    timed_out = true;
+                    break None;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(source) => {
+                return Err(AdapterError::FrameworkCli {
+                    program: cmd.program.clone(),
+                    reason: format!("failed to wait: {source}"),
+                });
+            }
+        }
+    };
+
+    let stdout = collect_drain(stdout_handle);
+    let stderr = collect_drain(stderr_handle);
+
+    Ok(CliOutput {
+        status: status.and_then(|s| s.code()),
+        timed_out,
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+    })
+}
+
+/// Build a `PATH` value with `prepend` dirs in front of the current one.
+fn prepend_path(prepend: &[PathBuf]) -> std::ffi::OsString {
+    let mut parts: Vec<PathBuf> = prepend.to_vec();
+    if let Some(existing) = std::env::var_os("PATH") {
+        parts.extend(std::env::split_paths(&existing));
+    }
+    // join_paths only fails if a component contains the path separator,
+    // which our dirs do not; fall back to the prepend dirs alone.
+    std::env::join_paths(&parts)
+        .unwrap_or_else(|_| std::env::join_paths(prepend).unwrap_or_default())
+}
+
+/// Drain a child pipe to EOF on its own thread, keeping at most `cap`
+/// bytes. Reading to EOF (even past the cap) keeps the child from blocking
+/// on a full pipe.
+fn spawn_drain<R: Read + Send + 'static>(mut reader: R, cap: usize) -> JoinHandle<Vec<u8>> {
+    thread::spawn(move || {
+        let mut kept = Vec::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if kept.len() < cap {
+                        let take = (cap - kept.len()).min(n);
+                        kept.extend_from_slice(&chunk[..take]);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        kept
+    })
+}
+
+/// Join a drain thread, returning its captured bytes (empty on panic or
+/// absent pipe).
+fn collect_drain(handle: Option<JoinHandle<Vec<u8>>>) -> Vec<u8> {
+    handle.and_then(|h| h.join().ok()).unwrap_or_default()
+}
+
+/// ISO 8601 UTC timestamp, second precision.
+fn now_iso8601() -> String {
+    use chrono::{SecondsFormat, Utc};
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+/// Stable string for the central log's `install_mode` field.
+fn install_mode_str(mode: InstallMode) -> &'static str {
+    match mode {
+        InstallMode::System => "system",
+        InstallMode::User => "user",
+    }
+}
+
+fn installed_component_manifest_path(state_dir: &Path, component: &str) -> PathBuf {
+    state_dir
+        .join(INSTALLED_COMPONENT_MANIFESTS_SUBDIR)
+        .join(component)
+        .join(INSTALLED_COMPONENT_MANIFEST_FILE)
+}
+
+fn declared_frameworks(manifest: &ComponentManifest) -> Vec<String> {
+    let mut set = BTreeSet::new();
+    for adapter in &manifest.adapters {
+        if let Some(framework) = adapter.framework.as_deref().map(str::trim)
+            && !framework.is_empty()
+        {
+            set.insert(framework.to_string());
+        }
+    }
+    set.into_iter().collect()
+}
+
+fn declared_plugin_id(manifest: &ComponentManifest, framework: &str) -> Option<String> {
+    manifest
+        .adapters
+        .iter()
+        .find(|adapter| adapter.framework.as_deref().map(str::trim) == Some(framework))
+        .and_then(|adapter| adapter.plugin_id.as_deref())
+        .map(str::trim)
+        .filter(|plugin_id| !plugin_id.is_empty())
+        .map(str::to_string)
+}
+
+/// A status report for a receipt that cannot be verified at all (e.g. no
+/// driver). Reports `Unknown` rather than faking a healthy/absent verdict.
+fn unverified_report(reason: &str) -> AdapterStatusReport {
+    use super::driver::{AdapterCondition, AdapterConditionKind, AdapterSummary, ConditionStatus};
+    AdapterStatusReport {
+        summary: AdapterSummary::Unknown,
+        conditions: vec![AdapterCondition {
+            kind: AdapterConditionKind::VerificationSupported,
+            status: ConditionStatus::False,
+            reason: Some(reason.to_string()),
+            resource: None,
+        }],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepend_path_puts_dirs_in_front() {
+        // SAFETY: single-threaded test mutating PATH; restored after.
+        let saved = std::env::var_os("PATH");
+        unsafe {
+            std::env::set_var("PATH", "/usr/bin:/bin");
+        }
+        let joined = prepend_path(&[PathBuf::from("/opt/a"), PathBuf::from("/opt/b")]);
+        let dirs: Vec<PathBuf> = std::env::split_paths(&joined).collect();
+        assert_eq!(dirs[0], PathBuf::from("/opt/a"));
+        assert_eq!(dirs[1], PathBuf::from("/opt/b"));
+        assert!(dirs.contains(&PathBuf::from("/usr/bin")));
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+
+    #[test]
+    fn run_capture_captures_stdout_and_exit() {
+        let cmd = FrameworkCommand {
+            program: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "printf hello; exit 0".to_string()],
+            env_set: Vec::new(),
+            env_remove: Vec::new(),
+            path_prepend: Vec::new(),
+            timeout: Duration::from_secs(5),
+        };
+        let out = run_capture(&cmd).expect("run");
+        assert!(out.success());
+        assert_eq!(out.stdout, "hello");
+        assert!(!out.timed_out);
+    }
+
+    #[test]
+    fn run_capture_reports_nonzero_exit() {
+        let cmd = FrameworkCommand {
+            program: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "exit 3".to_string()],
+            env_set: Vec::new(),
+            env_remove: Vec::new(),
+            path_prepend: Vec::new(),
+            timeout: Duration::from_secs(5),
+        };
+        let out = run_capture(&cmd).expect("run");
+        assert_eq!(out.status, Some(3));
+        assert!(!out.success());
+    }
+
+    #[test]
+    fn run_capture_times_out_and_kills() {
+        let cmd = FrameworkCommand {
+            program: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "sleep 30".to_string()],
+            env_set: Vec::new(),
+            env_remove: Vec::new(),
+            path_prepend: Vec::new(),
+            timeout: Duration::from_millis(150),
+        };
+        let out = run_capture(&cmd).expect("run");
+        assert!(out.timed_out, "expected timeout");
+        assert!(!out.success());
+    }
+
+    #[test]
+    fn spawn_failure_is_framework_cli_error() {
+        let cmd = FrameworkCommand {
+            program: "/no/such/binary/xyz".to_string(),
+            args: Vec::new(),
+            env_set: Vec::new(),
+            env_remove: Vec::new(),
+            path_prepend: Vec::new(),
+            timeout: Duration::from_secs(5),
+        };
+        let err = run_capture(&cmd).expect_err("spawn must fail");
+        assert!(matches!(err, AdapterError::FrameworkCli { .. }));
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -1,0 +1,822 @@
+//! OpenClaw framework driver.
+//!
+//! OpenClaw loads plugins from a CLI-managed registry, not from a dropped
+//! directory, so `enable` runs `openclaw plugins install <resource_root>`
+//! and `disable` runs `openclaw plugins uninstall <plugin_id>`. Status is
+//! the read-only `openclaw plugins list`. All three go through the
+//! Manager's [`run_framework_cli`](super::driver::AdapterOps::run_framework_cli)
+//! helper (timeout, output
+//! truncation, central log) — the driver only builds argv arrays from
+//! validated data.
+//!
+//! The CLI env contract mirrors `openclaw/scripts/install.sh`: unset
+//! `OPENCLAW_HOME`, set `OPENCLAW_STATE_DIR` to the resolved home, and
+//! prepend the standard bin dirs to `PATH`. `OPENCLAW_BIN` overrides the
+//! executable (used by tests to point at a fake CLI).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+
+use super::AdapterError;
+use super::claim::{
+    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
+    DRIVER_SCHEMA_VERSION, DriverPayload, OpenClawClaim, validate_plugin_id,
+};
+use super::driver::{
+    AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
+    ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
+    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+};
+
+/// Default timeout for an OpenClaw CLI invocation.
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Resource ids used in OpenClaw receipts. Stable strings referenced from
+/// the [`OpenClawClaim`] payload and condition reports.
+const RES_STATE_DIR: &str = "openclaw_state_dir";
+const RES_PLUGIN: &str = "openclaw_plugin";
+
+/// OpenClaw driver. Stateless; all per-operation context arrives via
+/// [`DriverCtx`].
+pub struct OpenClawDriver;
+
+impl OpenClawDriver {
+    /// Construct the driver.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for OpenClawDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameworkDriver for OpenClawDriver {
+    fn name(&self) -> &'static str {
+        "openclaw"
+    }
+
+    fn detect(&self, env: &HostEnv) -> DetectResult {
+        match find_binary_in_path(&openclaw_bin()) {
+            Some(path) => DetectResult {
+                detected: true,
+                reason: format!("openclaw CLI found at {}", path.display()),
+            },
+            None => {
+                // The CLI is what enable/disable need; a bare home dir is
+                // not sufficient. Report not-detected but mention the home
+                // so a user understands the framework is partially present.
+                let home_note = openclaw_home(env.user_home.as_deref())
+                    .filter(|h| h.exists())
+                    .map(|h| format!(" (home {} exists but CLI is not on PATH)", h.display()))
+                    .unwrap_or_default();
+                DetectResult {
+                    detected: false,
+                    reason: format!("openclaw CLI not found on PATH{home_note}"),
+                }
+            }
+        }
+    }
+
+    fn allowed_external_roots(&self, ctx: &DriverCtx) -> Vec<PathBuf> {
+        // The only external root OpenClaw writes is its own home/state dir.
+        openclaw_home(ctx.user_home.as_deref())
+            .into_iter()
+            .collect()
+    }
+
+    fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError> {
+        let root = &ctx.resource_root;
+        if !root.is_dir() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root does not exist or is not a directory".to_string(),
+            });
+        }
+        let is_empty = root
+            .read_dir()
+            .map_err(|source| AdapterError::Io {
+                path: root.clone(),
+                source,
+            })?
+            .next()
+            .is_none();
+        if is_empty {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root is empty".to_string(),
+            });
+        }
+
+        let plugin_id = ctx
+            .declared_plugin_id
+            .clone()
+            .or(read_plugin_manifest_id(root)?)
+            .or_else(|| Some(ctx.component.clone()));
+
+        Ok(AdapterBundle {
+            resource_root: root.clone(),
+            digest: digest_tree(root),
+            plugin_id,
+        })
+    }
+
+    fn plan_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<DriverPlan, AdapterError> {
+        let plugin_id = require_plugin_id(bundle)?;
+        validate_plugin_id(&plugin_id)?;
+        let home = require_home(ctx)?;
+        let cmd = build_install_cmd(&bundle.resource_root, &home, ctx.user_home.as_deref());
+        Ok(DriverPlan {
+            framework: self.name().to_string(),
+            component: ctx.component.clone(),
+            actions: vec![format!(
+                "register openclaw plugin '{plugin_id}' from {}",
+                bundle.resource_root.display()
+            )],
+            register_command: Some(display_command(&cmd)),
+        })
+    }
+
+    fn prepare_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterClaim, AdapterError> {
+        let plugin_id = require_plugin_id(bundle)?;
+        validate_plugin_id(&plugin_id)?;
+        let home = require_home(ctx)?;
+
+        let resources = vec![
+            ClaimResource {
+                id: RES_STATE_DIR.to_string(),
+                purpose: "openclaw_state_dir".to_string(),
+                kind: ClaimResourceKind::ExternalPath { path: home.clone() },
+            },
+            ClaimResource {
+                id: RES_PLUGIN.to_string(),
+                purpose: "openclaw_plugin".to_string(),
+                kind: ClaimResourceKind::FrameworkPlugin {
+                    framework: self.name().to_string(),
+                    plugin_id: plugin_id.clone(),
+                },
+            },
+        ];
+
+        Ok(AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: ctx.component.clone(),
+            framework: self.name().to_string(),
+            plugin_id: Some(plugin_id),
+            enabled_at: now_iso8601(),
+            resource_root: bundle.resource_root.clone(),
+            bundle_digest: bundle.digest.clone(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources,
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: RES_STATE_DIR.to_string(),
+                plugin_resource: RES_PLUGIN.to_string(),
+            }),
+        })
+    }
+
+    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+        let plugin_id = claim_plugin_id(claim).ok_or_else(|| AdapterError::BundleInvalid {
+            root: claim.resource_root.clone(),
+            reason: "openclaw receipt has no plugin id".to_string(),
+        })?;
+        validate_plugin_id(&plugin_id)?;
+        let home = require_home(ctx)?;
+
+        let cmd = build_install_cmd(&claim.resource_root, &home, ctx.user_home.as_deref());
+        let program = cmd.program.clone();
+        let output = ctx.ops.run_framework_cli(cmd)?;
+        if output.success() {
+            Ok(())
+        } else {
+            Err(AdapterError::FrameworkCli {
+                program,
+                reason: cli_failure_reason("plugins install", &output),
+            })
+        }
+    }
+
+    fn status(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterStatusReport, AdapterError> {
+        let mut conditions = Vec::new();
+
+        // 1. Framework detectable?
+        let detect = self.detect(&HostEnv {
+            user_home: ctx.user_home.clone(),
+        });
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::FrameworkDetected,
+            status: bool_status(detect.detected),
+            reason: Some(detect.reason.clone()),
+            resource: None,
+        });
+
+        // 2. Resource bundle still matches the enable-time digest?
+        conditions.push(self.bundle_match_condition(claim));
+
+        // 3. Plugin still registered? Requires the CLI for a read-only
+        //    `plugins list`.
+        let plugin_id = claim_plugin_id(claim);
+        let (plugin_cond, verify_cond, plugin_registered) = if !detect.detected {
+            (
+                AdapterCondition {
+                    kind: AdapterConditionKind::PluginRegistered,
+                    status: ConditionStatus::Unknown,
+                    reason: Some("framework not detected; cannot verify".to_string()),
+                    resource: plugin_id.as_ref().map(|_| ClaimResourceRef {
+                        id: RES_PLUGIN.to_string(),
+                    }),
+                },
+                AdapterCondition {
+                    kind: AdapterConditionKind::VerificationSupported,
+                    status: ConditionStatus::False,
+                    reason: Some("openclaw CLI unavailable".to_string()),
+                    resource: None,
+                },
+                ConditionStatus::Unknown,
+            )
+        } else if let Some(pid) = &plugin_id {
+            self.plugin_registered_condition(pid, ctx)
+        } else {
+            (
+                AdapterCondition {
+                    kind: AdapterConditionKind::PluginRegistered,
+                    status: ConditionStatus::Unknown,
+                    reason: Some("receipt has no plugin id".to_string()),
+                    resource: None,
+                },
+                AdapterCondition {
+                    kind: AdapterConditionKind::VerificationSupported,
+                    status: ConditionStatus::True,
+                    reason: None,
+                    resource: None,
+                },
+                ConditionStatus::Unknown,
+            )
+        };
+        conditions.push(plugin_cond);
+        conditions.push(verify_cond);
+
+        let summary = summarize(claim.status, detect.detected, plugin_registered);
+        Ok(AdapterStatusReport {
+            summary,
+            conditions,
+        })
+    }
+
+    fn disable(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        let plugin_id = match claim_plugin_id(claim) {
+            Some(p) => p,
+            None => {
+                // No plugin recorded: nothing to unregister.
+                return Ok(DisableReport {
+                    cleanup_complete: true,
+                    messages: vec!["receipt records no plugin to unregister".to_string()],
+                });
+            }
+        };
+        validate_plugin_id(&plugin_id)?;
+
+        if find_binary_in_path(&openclaw_bin()).is_none() {
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![
+                    "openclaw CLI not found on PATH; receipt kept so cleanup can be retried"
+                        .to_string(),
+                ],
+            });
+        }
+
+        let home = require_home(ctx)?;
+        let cmd = build_uninstall_cmd(&plugin_id, &home, ctx.user_home.as_deref());
+        let output = ctx.ops.run_framework_cli(cmd)?;
+        if output.success() {
+            Ok(DisableReport {
+                cleanup_complete: true,
+                messages: vec![format!("unregistered openclaw plugin '{plugin_id}'")],
+            })
+        } else {
+            // Keep the receipt (Manager marks cleanup_failed) so disable can
+            // be retried — do NOT delete anything else.
+            Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![format!(
+                    "openclaw plugin uninstall failed: {}",
+                    cli_failure_reason("plugins uninstall", &output)
+                )],
+            })
+        }
+    }
+}
+
+impl OpenClawDriver {
+    /// Build the `ResourceBundleMatches` condition by re-digesting the
+    /// resource root and comparing to the enable-time digest.
+    fn bundle_match_condition(&self, claim: &AdapterClaim) -> AdapterCondition {
+        let kind = AdapterConditionKind::ResourceBundleMatches;
+        match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
+            (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+                kind,
+                status: ConditionStatus::True,
+                reason: None,
+                resource: None,
+            },
+            (Some(_), Some(_)) => AdapterCondition {
+                kind,
+                status: ConditionStatus::False,
+                reason: Some("resource bundle changed since enable".to_string()),
+                resource: None,
+            },
+            _ => AdapterCondition {
+                kind,
+                status: ConditionStatus::Unknown,
+                reason: Some("no digest recorded or resource root unavailable".to_string()),
+                resource: None,
+            },
+        }
+    }
+
+    /// Run `openclaw plugins list` and decide whether `plugin_id` is still
+    /// registered. Returns `(plugin_condition, verification_condition,
+    /// plugin_registered_status)`.
+    fn plugin_registered_condition(
+        &self,
+        plugin_id: &str,
+        ctx: &DriverCtx,
+    ) -> (AdapterCondition, AdapterCondition, ConditionStatus) {
+        let plugin_ref = Some(ClaimResourceRef {
+            id: RES_PLUGIN.to_string(),
+        });
+        let home = match openclaw_home(ctx.user_home.as_deref()) {
+            Some(h) => h,
+            None => {
+                return (
+                    AdapterCondition {
+                        kind: AdapterConditionKind::PluginRegistered,
+                        status: ConditionStatus::Unknown,
+                        reason: Some("cannot resolve openclaw home".to_string()),
+                        resource: plugin_ref,
+                    },
+                    AdapterCondition {
+                        kind: AdapterConditionKind::VerificationSupported,
+                        status: ConditionStatus::False,
+                        reason: Some("openclaw home unresolved".to_string()),
+                        resource: None,
+                    },
+                    ConditionStatus::Unknown,
+                );
+            }
+        };
+        let cmd = build_list_cmd(&home, ctx.user_home.as_deref());
+        match ctx.ops.run_framework_cli(cmd) {
+            Ok(output) if output.success() => {
+                let registered = list_contains_plugin(&output.stdout, plugin_id);
+                (
+                    AdapterCondition {
+                        kind: AdapterConditionKind::PluginRegistered,
+                        status: bool_status(registered),
+                        reason: (!registered)
+                            .then(|| "plugin not present in `plugins list`".to_string()),
+                        resource: plugin_ref,
+                    },
+                    AdapterCondition {
+                        kind: AdapterConditionKind::VerificationSupported,
+                        status: ConditionStatus::True,
+                        reason: None,
+                        resource: None,
+                    },
+                    bool_status(registered),
+                )
+            }
+            // The list probe ran but failed, or could not spawn: we cannot
+            // verify. Report Unknown, never a faked healthy/absent.
+            Ok(_) | Err(_) => (
+                AdapterCondition {
+                    kind: AdapterConditionKind::PluginRegistered,
+                    status: ConditionStatus::Unknown,
+                    reason: Some("`plugins list` did not return a usable result".to_string()),
+                    resource: plugin_ref,
+                },
+                AdapterCondition {
+                    kind: AdapterConditionKind::VerificationSupported,
+                    status: ConditionStatus::False,
+                    reason: Some("`plugins list` unavailable".to_string()),
+                    resource: None,
+                },
+                ConditionStatus::Unknown,
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no spawning) — unit-testable
+// ---------------------------------------------------------------------------
+
+/// `OPENCLAW_BIN` override, else `openclaw`.
+fn openclaw_bin() -> String {
+    std::env::var("OPENCLAW_BIN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "openclaw".to_string())
+}
+
+/// Resolve the OpenClaw home (also the state dir): `OPENCLAW_HOME`, else
+/// `<user_home>/.openclaw`. Trailing slashes are trimmed to match the
+/// official script.
+fn openclaw_home(user_home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(h) = std::env::var_os("OPENCLAW_HOME") {
+        let s = h.to_string_lossy();
+        let trimmed = s.trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    user_home.map(|h| h.join(".openclaw"))
+}
+
+/// PATH prefix dirs, mirroring `install.sh`:
+/// `<user_home>/.local/bin`, `<home>/bin`, `/usr/local/bin`.
+fn path_prepend(home: &Path, user_home: Option<&Path>) -> Vec<PathBuf> {
+    let mut v = Vec::new();
+    if let Some(uh) = user_home {
+        v.push(uh.join(".local/bin"));
+    }
+    v.push(home.join("bin"));
+    v.push(PathBuf::from("/usr/local/bin"));
+    v
+}
+
+/// Shared env contract for every OpenClaw invocation: unset
+/// `OPENCLAW_HOME`, set `OPENCLAW_STATE_DIR` to the home, prepend PATH.
+fn base_cmd(args: Vec<String>, home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
+    FrameworkCommand {
+        program: openclaw_bin(),
+        args,
+        env_set: vec![(
+            "OPENCLAW_STATE_DIR".to_string(),
+            home.to_string_lossy().into_owned(),
+        )],
+        env_remove: vec!["OPENCLAW_HOME".to_string()],
+        path_prepend: path_prepend(home, user_home),
+        timeout: CLI_TIMEOUT,
+    }
+}
+
+/// Build `openclaw plugins install <resource_root> --force
+/// --dangerously-force-unsafe-install`.
+fn build_install_cmd(
+    resource_root: &Path,
+    home: &Path,
+    user_home: Option<&Path>,
+) -> FrameworkCommand {
+    base_cmd(
+        vec![
+            "plugins".to_string(),
+            "install".to_string(),
+            resource_root.to_string_lossy().into_owned(),
+            "--force".to_string(),
+            "--dangerously-force-unsafe-install".to_string(),
+        ],
+        home,
+        user_home,
+    )
+}
+
+/// Build `openclaw plugins uninstall <plugin_id> --force`.
+///
+/// `--force` skips OpenClaw's interactive confirmation — ANOLISA drives
+/// the CLI non-interactively. `plugin_id` is validated by the caller.
+fn build_uninstall_cmd(plugin_id: &str, home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
+    base_cmd(
+        vec![
+            "plugins".to_string(),
+            "uninstall".to_string(),
+            plugin_id.to_string(),
+            "--force".to_string(),
+        ],
+        home,
+        user_home,
+    )
+}
+
+/// Build the read-only `openclaw plugins list`.
+fn build_list_cmd(home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
+    base_cmd(
+        vec!["plugins".to_string(), "list".to_string()],
+        home,
+        user_home,
+    )
+}
+
+/// Plugin id declared by the OpenClaw-native plugin manifest, when present.
+fn read_plugin_manifest_id(root: &Path) -> Result<Option<String>, AdapterError> {
+    #[derive(serde::Deserialize)]
+    struct PluginManifest {
+        id: Option<String>,
+    }
+
+    let path = root.join("openclaw.plugin.json");
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(AdapterError::Io { path, source }),
+    };
+    let manifest: PluginManifest =
+        serde_json::from_slice(&bytes).map_err(|source| AdapterError::BundleInvalid {
+            root: root.to_path_buf(),
+            reason: format!(
+                "failed to parse {} as OpenClaw plugin manifest: {source}",
+                path.display()
+            ),
+        })?;
+    let id =
+        manifest
+            .id
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| AdapterError::BundleInvalid {
+                root: root.to_path_buf(),
+                reason: format!("{} does not declare a non-empty id", path.display()),
+            })?;
+    Ok(Some(id))
+}
+
+/// Human-readable form of a command for dry-run/preview output. Display
+/// only — never parsed back into an argv.
+fn display_command(cmd: &FrameworkCommand) -> String {
+    let mut s = String::new();
+    for (k, v) in &cmd.env_set {
+        s.push_str(&format!("{k}={v} "));
+    }
+    s.push_str(&cmd.program);
+    for a in &cmd.args {
+        s.push(' ');
+        s.push_str(a);
+    }
+    s
+}
+
+/// True when `plugin_id` appears as a whole whitespace-delimited token on
+/// any line of `plugins list` output. Tolerant of decoration like
+/// `- tokenless (v1.2)`.
+fn list_contains_plugin(stdout: &str, plugin_id: &str) -> bool {
+    stdout
+        .lines()
+        .any(|line| line.split_whitespace().any(|tok| tok == plugin_id))
+}
+
+/// Extract the validated plugin id from a claim's `FrameworkPlugin`
+/// resource, falling back to the top-level `plugin_id` field.
+fn claim_plugin_id(claim: &AdapterClaim) -> Option<String> {
+    for res in &claim.resources {
+        if let ClaimResourceKind::FrameworkPlugin { plugin_id, .. } = &res.kind {
+            return Some(plugin_id.clone());
+        }
+    }
+    claim.plugin_id.clone()
+}
+
+/// Plugin id from a bundle, or [`AdapterError::BundleInvalid`] when none is
+/// resolvable.
+fn require_plugin_id(bundle: &AdapterBundle) -> Result<String, AdapterError> {
+    bundle
+        .plugin_id
+        .clone()
+        .ok_or_else(|| AdapterError::BundleInvalid {
+            root: bundle.resource_root.clone(),
+            reason: "no plugin id declared in manifest and none discoverable".to_string(),
+        })
+}
+
+/// OpenClaw home, or [`AdapterError::FrameworkCli`] when `$HOME` is
+/// unresolvable (no `user_home`, no `OPENCLAW_HOME`).
+fn require_home(ctx: &DriverCtx) -> Result<PathBuf, AdapterError> {
+    openclaw_home(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
+        program: openclaw_bin(),
+        reason: "cannot resolve OpenClaw home (no $HOME and no OPENCLAW_HOME)".to_string(),
+    })
+}
+
+/// Compose a failure reason string from a non-success [`CliOutput`].
+fn cli_failure_reason(verb: &str, output: &super::driver::CliOutput) -> String {
+    if output.timed_out {
+        return format!("'{verb}' timed out");
+    }
+    let code = output
+        .status
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "killed".to_string());
+    let mut reason = format!("'{verb}' exited with {code}");
+    let stderr = output.stderr.trim();
+    if !stderr.is_empty() {
+        reason.push_str(": ");
+        reason.push_str(stderr);
+    }
+    reason
+}
+
+/// Map a bool to a [`ConditionStatus`] (`true`→`True`, `false`→`False`).
+fn bool_status(b: bool) -> ConditionStatus {
+    if b {
+        ConditionStatus::True
+    } else {
+        ConditionStatus::False
+    }
+}
+
+/// Roll the framework-detect and plugin-registration signals into a
+/// summary, honoring a `cleanup_failed` receipt.
+fn summarize(
+    claim_status: ClaimStatus,
+    framework_detected: bool,
+    plugin_registered: ConditionStatus,
+) -> AdapterSummary {
+    if claim_status == ClaimStatus::CleanupFailed {
+        return AdapterSummary::CleanupFailed;
+    }
+    if !framework_detected {
+        return AdapterSummary::Degraded;
+    }
+    match plugin_registered {
+        ConditionStatus::True => AdapterSummary::Healthy,
+        ConditionStatus::False => AdapterSummary::Degraded,
+        ConditionStatus::Unknown => AdapterSummary::Unknown,
+    }
+}
+
+/// SHA-256 digest of a directory tree, stable across runs: files are
+/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
+/// `None` on any IO error so callers fall back to `Unknown` rather than a
+/// wrong verdict.
+fn digest_tree(root: &Path) -> Option<String> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    collect_files(root, &mut files).ok()?;
+    files.sort();
+    let mut hasher = Sha256::new();
+    for path in &files {
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        let bytes = std::fs::read(path).ok()?;
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update([0u8]);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update([0u8]);
+        hasher.update(&bytes);
+    }
+    Some(format!("sha256:{:x}", hasher.finalize()))
+}
+
+/// Recursively collect regular-file paths under `dir`. Symlinks are not
+/// followed into directories (their link path is recorded as a file).
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            collect_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// ISO 8601 UTC timestamp, second precision.
+fn now_iso8601() -> String {
+    use chrono::{SecondsFormat, Utc};
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_contains_plugin_matches_whole_token() {
+        assert!(list_contains_plugin("tokenless\nother\n", "tokenless"));
+        assert!(list_contains_plugin("- tokenless (v1.2)\n", "tokenless"));
+        assert!(!list_contains_plugin("tokenless-extra\n", "tokenless"));
+        assert!(!list_contains_plugin("", "tokenless"));
+    }
+
+    #[test]
+    fn install_cmd_mirrors_script_contract() {
+        let cmd = build_install_cmd(
+            Path::new("/data/adapters/tokenless/openclaw"),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+        );
+        assert_eq!(cmd.program, "openclaw");
+        assert_eq!(
+            cmd.args,
+            vec![
+                "plugins",
+                "install",
+                "/data/adapters/tokenless/openclaw",
+                "--force",
+                "--dangerously-force-unsafe-install",
+            ]
+        );
+        assert!(cmd.env_remove.contains(&"OPENCLAW_HOME".to_string()));
+        assert_eq!(
+            cmd.env_set,
+            vec![(
+                "OPENCLAW_STATE_DIR".to_string(),
+                "/home/u/.openclaw".to_string()
+            )]
+        );
+        assert_eq!(cmd.path_prepend[0], PathBuf::from("/home/u/.local/bin"));
+    }
+
+    #[test]
+    fn uninstall_cmd_uses_force() {
+        let cmd = build_uninstall_cmd(
+            "tokenless",
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+        );
+        assert_eq!(
+            cmd.args,
+            vec!["plugins", "uninstall", "tokenless", "--force"]
+        );
+    }
+
+    #[test]
+    fn plugin_manifest_id_is_read_from_real_openclaw_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("openclaw.plugin.json"),
+            br#"{"id":"tokenless","name":"Tokenless"}"#,
+        )
+        .expect("write manifest");
+
+        assert_eq!(
+            read_plugin_manifest_id(dir.path()).expect("read"),
+            Some("tokenless".to_string())
+        );
+    }
+
+    #[test]
+    fn summarize_prioritizes_cleanup_failed() {
+        assert_eq!(
+            summarize(ClaimStatus::CleanupFailed, true, ConditionStatus::True),
+            AdapterSummary::CleanupFailed
+        );
+    }
+
+    #[test]
+    fn summarize_healthy_only_when_detected_and_registered() {
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, true, ConditionStatus::True),
+            AdapterSummary::Healthy
+        );
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, false, ConditionStatus::True),
+            AdapterSummary::Degraded
+        );
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, true, ConditionStatus::False),
+            AdapterSummary::Degraded
+        );
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, true, ConditionStatus::Unknown),
+            AdapterSummary::Unknown
+        );
+    }
+
+    #[test]
+    fn digest_tree_is_stable_and_detects_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("a.txt"), b"hello").expect("write");
+        std::fs::create_dir(dir.path().join("sub")).expect("mkdir");
+        std::fs::write(dir.path().join("sub/b.txt"), b"world").expect("write");
+
+        let d1 = digest_tree(dir.path()).expect("digest");
+        let d2 = digest_tree(dir.path()).expect("digest again");
+        assert_eq!(d1, d2, "digest must be stable");
+
+        std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
+        let d3 = digest_tree(dir.path()).expect("digest after change");
+        assert_ne!(d1, d3, "digest must change when a file changes");
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
@@ -1,0 +1,65 @@
+//! Built-in framework-driver registry.
+//!
+//! The set of supported frameworks is closed and compiled in: a framework
+//! is supported only if an ANOLISA release ships a driver for it. There is
+//! no runtime plugin loading. MVP registers only the OpenClaw driver.
+
+use super::driver::FrameworkDriver;
+use super::openclaw::OpenClawDriver;
+
+/// Immutable collection of the built-in framework drivers.
+pub struct DriverRegistry {
+    drivers: Vec<Box<dyn FrameworkDriver>>,
+}
+
+impl DriverRegistry {
+    /// Build the registry of all built-in drivers.
+    pub fn builtin() -> Self {
+        Self {
+            drivers: vec![Box::new(OpenClawDriver::new())],
+        }
+    }
+
+    /// Look up a driver by framework name.
+    pub fn get(&self, framework: &str) -> Option<&dyn FrameworkDriver> {
+        self.drivers
+            .iter()
+            .find(|d| d.name() == framework)
+            .map(|d| d.as_ref())
+    }
+
+    /// True iff a driver exists for `framework`.
+    pub fn contains(&self, framework: &str) -> bool {
+        self.get(framework).is_some()
+    }
+
+    /// Names of all registered frameworks.
+    pub fn names(&self) -> Vec<&'static str> {
+        self.drivers.iter().map(|d| d.name()).collect()
+    }
+}
+
+impl Default for DriverRegistry {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_registers_openclaw_only() {
+        let reg = DriverRegistry::builtin();
+        assert!(reg.contains("openclaw"));
+        assert!(!reg.contains("cosh"), "MVP ships OpenClaw only");
+        assert_eq!(reg.names(), vec!["openclaw"]);
+    }
+
+    #[test]
+    fn get_unknown_framework_is_none() {
+        let reg = DriverRegistry::builtin();
+        assert!(reg.get("hermes").is_none());
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/install_runner.rs
+++ b/src/anolisa/crates/anolisa-core/src/install_runner.rs
@@ -201,6 +201,28 @@ pub enum InstallError {
 pub fn read_embedded_component_manifest(
     artifact: &Path,
 ) -> Result<Option<crate::manifest::ComponentManifest>, InstallError> {
+    let Some(text) = read_embedded_component_manifest_text(artifact)? else {
+        return Ok(None);
+    };
+    let manifest = crate::manifest::ComponentManifest::from_toml_str(&text)
+        .map_err(|e| InstallError::EmbeddedManifestParse(e.to_string()))?;
+    Ok(Some(manifest))
+}
+
+/// Extract the embedded `.anolisa/component.toml` text from a tar.gz
+/// artifact.
+///
+/// Returns `Ok(None)` when the archive has no such entry. This is used when
+/// callers need to persist the published component contract byte-for-byte as
+/// local install metadata.
+///
+/// # Errors
+/// [`InstallError::Io`] when the archive cannot be opened or read;
+/// [`InstallError::Archive`] when gzip/tar decoding fails;
+/// [`InstallError::EmbeddedManifestParse`] when the entry is not valid UTF-8.
+pub fn read_embedded_component_manifest_text(
+    artifact: &Path,
+) -> Result<Option<String>, InstallError> {
     let io_err = |source: std::io::Error| InstallError::Io {
         path: artifact.to_path_buf(),
         source,
@@ -223,9 +245,7 @@ pub fn read_embedded_component_manifest(
             entry.read_to_end(&mut bytes).map_err(io_err)?;
             let text = String::from_utf8(bytes)
                 .map_err(|e| InstallError::EmbeddedManifestParse(e.to_string()))?;
-            let manifest = crate::manifest::ComponentManifest::from_toml_str(&text)
-                .map_err(|e| InstallError::EmbeddedManifestParse(e.to_string()))?;
-            return Ok(Some(manifest));
+            return Ok(Some(text));
         }
     }
     Ok(None)

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -31,6 +31,12 @@ pub mod state;
 pub mod transaction;
 pub mod upload;
 
+pub use adapter::claim::{AdapterClaim, ClaimResource, ClaimResourceKind, ClaimStatus};
+pub use adapter::driver::{AdapterStatusReport, AdapterSummary, ConditionStatus, DriverPlan};
+pub use adapter::manager::{
+    AdapterManager, DisableOutcome, EnableOutcome, ScanReport, StatusReport,
+};
+pub use adapter::registry::DriverRegistry;
 pub use adapter::{AdapterError, DetectResult, detect_framework, expand_layout_placeholders};
 pub use backup::{BackupEntry, BackupSet};
 pub use catalog::{Catalog, CatalogError, CatalogLayers};

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -18,10 +18,16 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::adapter::claim::AdapterClaim;
+
 /// Current `installed.toml` schema version. Bump on incompatible changes.
 /// When bumped, [`InstalledState::load`] must migrate older on-disk versions
 /// into the current in-memory shape before returning.
-pub const STATE_SCHEMA_VERSION: u32 = 1;
+///
+/// v2 added the `adapter_claims` array (adapter receipts). The field
+/// default-deserializes, so v1 files load unchanged and are silently
+/// upgraded to v2 on the next save.
+pub const STATE_SCHEMA_VERSION: u32 = 2;
 
 /// Default for `bool` fields that should serialise to `true` when absent.
 fn default_true() -> bool {
@@ -283,6 +289,11 @@ pub struct InstalledState {
     /// Lightweight operation history mirrored by central logs.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub operations: Vec<OperationRecord>,
+    /// Adapter receipts written by `anolisa adapter enable`. Per-user
+    /// state: each records a framework driver's takeover of framework-side
+    /// state for one component. Empty on fresh and pre-v2 state files.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub adapter_claims: Vec<AdapterClaim>,
 }
 
 impl Default for InstalledState {
@@ -296,6 +307,7 @@ impl Default for InstalledState {
             objects: Vec::new(),
             backups: Vec::new(),
             operations: Vec::new(),
+            adapter_claims: Vec::new(),
         }
     }
 }
@@ -444,6 +456,49 @@ impl InstalledState {
     /// Append an operation record.
     pub fn append_operation(&mut self, op: OperationRecord) {
         self.operations.push(op);
+    }
+
+    /// Find an adapter receipt by `(component, framework)`.
+    pub fn find_adapter_claim(&self, component: &str, framework: &str) -> Option<&AdapterClaim> {
+        self.adapter_claims
+            .iter()
+            .find(|c| c.component == component && c.framework == framework)
+    }
+
+    /// Insert or replace an adapter receipt, deduped by
+    /// `(component, framework)`.
+    pub fn upsert_adapter_claim(&mut self, claim: AdapterClaim) {
+        if let Some(slot) = self
+            .adapter_claims
+            .iter_mut()
+            .find(|c| c.component == claim.component && c.framework == claim.framework)
+        {
+            *slot = claim;
+        } else {
+            self.adapter_claims.push(claim);
+        }
+    }
+
+    /// Remove an adapter receipt by `(component, framework)`, returning the
+    /// removed value.
+    pub fn remove_adapter_claim(
+        &mut self,
+        component: &str,
+        framework: &str,
+    ) -> Option<AdapterClaim> {
+        let idx = self
+            .adapter_claims
+            .iter()
+            .position(|c| c.component == component && c.framework == framework)?;
+        Some(self.adapter_claims.remove(idx))
+    }
+
+    /// All adapter receipts for a component, across frameworks.
+    pub fn adapter_claims_for_component(&self, component: &str) -> Vec<&AdapterClaim> {
+        self.adapter_claims
+            .iter()
+            .filter(|c| c.component == component)
+            .collect()
     }
 }
 

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -1,0 +1,628 @@
+//! End-to-end adapter manager tests driving a fake OpenClaw CLI.
+//!
+//! These exercise the full enable → status → disable lifecycle through the
+//! real [`AdapterManager`] and [`OpenClawDriver`], using a shell script as
+//! a stand-in for the `openclaw` binary. They cover the P3 acceptance
+//! cases: install/list/uninstall success and failure, "CLI missing must
+//! not clean up arbitrary paths", and forged-receipt rejection.
+//!
+//! The fake CLI is controlled entirely through the same env contract the
+//! real driver uses (`OPENCLAW_BIN`, `OPENCLAW_HOME`, plus a test-only
+//! `FAKE_OPENCLAW_FAIL` knob). Because those are process-global, every test
+//! serializes on [`ENV_LOCK`].
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use anolisa_core::adapter::AdapterError;
+use anolisa_core::adapter::claim::{ClaimResourceKind, ClaimStatus};
+use anolisa_core::adapter::driver::{AdapterSummary, ConditionStatus};
+use anolisa_core::adapter::manager::{AdapterManager, EnableOutcome};
+use anolisa_core::state::InstalledState;
+use anolisa_platform::fs_layout::FsLayout;
+
+/// Serializes the process-global env mutation across tests.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const COMPONENT: &str = "tokenless";
+const FRAMEWORK: &str = "openclaw";
+
+/// A staged test world: a prefix-rooted layout, openclaw home, fake CLI,
+/// and a seeded `installed.toml`.
+struct World {
+    _root: tempfile::TempDir,
+    layout: FsLayout,
+    user_home: PathBuf,
+    openclaw_home: PathBuf,
+    fake_bin: PathBuf,
+    resource_root: PathBuf,
+}
+
+impl World {
+    fn manager(&self) -> AdapterManager {
+        AdapterManager::new(
+            self.layout.clone(),
+            Some(self.user_home.clone()),
+            "tester".to_string(),
+        )
+    }
+
+    /// Apply this world's env contract. Must be called while holding
+    /// [`ENV_LOCK`].
+    fn apply_env(&self, fail: Option<&str>) {
+        apply_openclaw_env(&self.fake_bin, &self.openclaw_home, fail);
+    }
+
+    fn load_state(&self) -> InstalledState {
+        InstalledState::load(&self.layout.state_dir.join("installed.toml")).expect("load state")
+    }
+}
+
+fn apply_openclaw_env(fake_bin: &Path, openclaw_home: &Path, fail: Option<&str>) {
+    // SAFETY: callers hold ENV_LOCK, so no other test thread in this
+    // binary reads these vars concurrently.
+    unsafe {
+        std::env::set_var("OPENCLAW_BIN", fake_bin);
+        std::env::set_var("OPENCLAW_HOME", openclaw_home);
+        match fail {
+            Some(stage) => std::env::set_var("FAKE_OPENCLAW_FAIL", stage),
+            None => std::env::remove_var("FAKE_OPENCLAW_FAIL"),
+        }
+    }
+}
+
+/// Build a fully staged world: layout under a temp prefix, an openclaw
+/// home, a fake CLI, the adapter resource bundle, and a seeded state file
+/// recording the component as installed.
+fn stage() -> World {
+    let root = tempfile::tempdir().expect("tempdir");
+    let prefix = root.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+
+    let user_home = prefix.join("home");
+    std::fs::create_dir_all(&user_home).expect("home");
+
+    let openclaw_home = prefix.join("openclaw-home");
+    std::fs::create_dir_all(&openclaw_home).expect("openclaw home");
+
+    // Adapter resource bundle with the same native manifest shape shipped by
+    // tokenless' OpenClaw plugin.
+    let resource_root = layout
+        .datadir
+        .join("adapters")
+        .join(COMPONENT)
+        .join(FRAMEWORK);
+    std::fs::create_dir_all(&resource_root).expect("resource root");
+    std::fs::write(
+        resource_root.join("openclaw.plugin.json"),
+        format!(r#"{{"id":"{COMPONENT}","name":"Tokenless"}}"#),
+    )
+    .expect("plugin manifest");
+
+    let fake_bin = write_fake_openclaw(&prefix);
+    seed_state(&layout, &prefix);
+
+    World {
+        _root: root,
+        layout,
+        user_home,
+        openclaw_home,
+        fake_bin,
+        resource_root,
+    }
+}
+
+/// Write a fake `openclaw` CLI honoring the driver's argv/env contract.
+///
+/// - `plugins install <root> ...` reads `<root>/openclaw.plugin.json` and
+///   touches a marker in `$OPENCLAW_STATE_DIR/registry/<id>`.
+/// - `plugins uninstall <id> ...` removes that marker.
+/// - `plugins list` prints the registry markers, one id per line.
+/// - `FAKE_OPENCLAW_FAIL=install|install_after_register|uninstall`
+///   forces that verb to exit non-zero.
+fn write_fake_openclaw(dir: &Path) -> PathBuf {
+    let script = r#"#!/bin/sh
+sub="$1"; action="$2"; arg3="$3"
+reg="$OPENCLAW_STATE_DIR/registry"
+mkdir -p "$reg" 2>/dev/null
+if [ "$sub" != "plugins" ]; then echo "unknown subcommand: $sub" >&2; exit 2; fi
+case "$action" in
+  install)
+    if [ "${FAKE_OPENCLAW_FAIL:-}" = "install" ]; then echo "boom-install" >&2; exit 7; fi
+    id=$(sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$arg3/openclaw.plugin.json" | head -n 1)
+    if [ -z "$id" ]; then echo "missing plugin id" >&2; exit 9; fi
+    : > "$reg/$id"
+    if [ "${FAKE_OPENCLAW_FAIL:-}" = "install_after_register" ]; then echo "boom-after-register" >&2; exit 10; fi
+    echo "installed $id"
+    ;;
+  uninstall)
+    if [ "${FAKE_OPENCLAW_FAIL:-}" = "uninstall" ]; then echo "boom-uninstall" >&2; exit 8; fi
+    rm -f "$reg/$arg3"
+    echo "uninstalled $arg3"
+    ;;
+  list)
+    ls "$reg" 2>/dev/null || true
+    ;;
+  *)
+    echo "unknown action: $action" >&2; exit 2 ;;
+esac
+exit 0
+"#;
+    let path = dir.join("openclaw");
+    std::fs::write(&path, script).expect("write fake cli");
+    let mut perms = std::fs::metadata(&path).expect("meta").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod");
+    path
+}
+
+/// Seed `installed.toml` with the component recorded as installed so
+/// `enable`'s precondition passes.
+fn seed_state(layout: &FsLayout, prefix: &Path) {
+    let state_path = layout.state_dir.join("installed.toml");
+    std::fs::create_dir_all(state_path.parent().unwrap()).expect("state dir");
+    let toml = format!(
+        r#"schema_version = 2
+updated_at = "2026-06-15T00:00:00Z"
+install_mode = "system"
+prefix = "{prefix}"
+anolisa_version = "0.1.7"
+
+[[objects]]
+kind = "component"
+name = "{COMPONENT}"
+version = "0.1.0"
+status = "installed"
+installed_at = "2026-06-15T00:00:00Z"
+"#,
+        prefix = prefix.display(),
+    );
+    std::fs::write(&state_path, toml).expect("seed state");
+    write_installed_manifest(layout, FRAMEWORK);
+}
+
+fn write_installed_manifest(layout: &FsLayout, framework: &str) {
+    let manifest_path = layout
+        .state_dir
+        .join("component-manifests")
+        .join(COMPONENT)
+        .join("component.toml");
+    std::fs::create_dir_all(manifest_path.parent().unwrap()).expect("manifest dir");
+    std::fs::write(
+        manifest_path,
+        format!(
+            r#"[component]
+name = "{COMPONENT}"
+version = "0.1.0"
+
+[component.layout]
+modes = ["system"]
+
+[[adapters]]
+framework = "{framework}"
+source = "adapters/{COMPONENT}/{framework}"
+dest = "{{datadir}}/adapters/{{component}}/{framework}/"
+"#
+        ),
+    )
+    .expect("seed component manifest");
+}
+
+#[test]
+fn enable_status_disable_happy_path() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(None);
+    let manager = world.manager();
+
+    // enable
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let claim = match outcome {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned(_) => panic!("expected enabled, got plan"),
+    };
+    assert_eq!(claim.component, COMPONENT);
+    assert_eq!(claim.framework, FRAMEWORK);
+    assert_eq!(claim.plugin_id.as_deref(), Some(COMPONENT));
+    assert_eq!(claim.status, ClaimStatus::Enabled);
+    // Receipt records the external home + the plugin, no owned paths.
+    assert!(claim.resources.iter().any(|r| matches!(
+        &r.kind,
+        ClaimResourceKind::FrameworkPlugin { plugin_id, .. } if plugin_id == COMPONENT
+    )));
+
+    // Persisted to state.
+    let state = world.load_state();
+    assert!(state.find_adapter_claim(COMPONENT, FRAMEWORK).is_some());
+
+    // The framework CLI invocation reached the central log.
+    let log = std::fs::read_to_string(&world.layout.central_log).expect("central log");
+    assert!(
+        log.contains("framework cli"),
+        "central log should record the CLI invocation: {log}"
+    );
+
+    // status → healthy (framework detected + plugin registered).
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries.len(), 1);
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+    // The plugin-registered condition must be verified True.
+    assert!(status.entries[0].report.conditions.iter().any(|c| matches!(
+        c.kind,
+        anolisa_core::adapter::driver::AdapterConditionKind::PluginRegistered
+    ) && c.status
+        == ConditionStatus::True));
+
+    // disable → removes receipt.
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK))
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_none(),
+        "receipt must be gone after successful disable"
+    );
+}
+
+#[test]
+fn user_layout_enable_accepts_system_installed_component() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let root = tempfile::tempdir().expect("tempdir");
+    let prefix = root.path().to_path_buf();
+    let system_prefix = prefix.join("system");
+    let system_layout = FsLayout::system(Some(system_prefix.clone()));
+    let user_home = prefix.join("home");
+    std::fs::create_dir_all(&user_home).expect("home");
+    let user_layout = FsLayout::user(user_home.clone());
+
+    let openclaw_home = prefix.join("openclaw-home");
+    std::fs::create_dir_all(&openclaw_home).expect("openclaw home");
+    let resource_root = system_layout
+        .datadir
+        .join("adapters")
+        .join(COMPONENT)
+        .join(FRAMEWORK);
+    std::fs::create_dir_all(&resource_root).expect("resource root");
+    std::fs::write(
+        resource_root.join("openclaw.plugin.json"),
+        format!(r#"{{"id":"{COMPONENT}","name":"Tokenless"}}"#),
+    )
+    .expect("plugin manifest");
+    seed_state(&system_layout, &system_prefix);
+    let fake_bin = write_fake_openclaw(&prefix);
+    apply_openclaw_env(&fake_bin, &openclaw_home, None);
+
+    let mut manager =
+        AdapterManager::new(user_layout.clone(), Some(user_home), "tester".to_string());
+    manager.push_datadir_root(system_layout.datadir.clone());
+    manager.push_state_root(system_layout.state_dir.clone());
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable system component from user layout");
+
+    let user_state =
+        InstalledState::load(&user_layout.state_dir.join("installed.toml")).expect("user state");
+    assert!(
+        user_state
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_some(),
+        "receipt is written to the invoking user's state"
+    );
+    let system_state = InstalledState::load(&system_layout.state_dir.join("installed.toml"))
+        .expect("system state");
+    assert!(
+        system_state
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_none(),
+        "system install state is read as a source, not used for user receipts"
+    );
+}
+
+#[test]
+fn enable_rejects_resource_directory_not_declared_by_manifest() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    write_installed_manifest(&world.layout, "hermes");
+    world.apply_env(None);
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("directory discovery alone must not authorize enable");
+    assert!(
+        matches!(err, AdapterError::AdapterNotDeclared { .. }),
+        "got {err:?}"
+    );
+    assert!(
+        !world
+            .openclaw_home
+            .join("registry")
+            .join(COMPONENT)
+            .exists(),
+        "framework driver must not run when manifest does not declare it"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_none(),
+        "no receipt should be created for an undeclared adapter"
+    );
+}
+
+#[test]
+fn failed_enable_keeps_cleanup_receipt_for_retry() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(Some("install"));
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("install failure must surface");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "got {err:?}"
+    );
+
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("failed enable receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+#[test]
+fn failed_enable_after_framework_side_effect_keeps_visible_receipt() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(Some("install_after_register"));
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("install failure must surface");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "got {err:?}"
+    );
+
+    assert!(
+        world
+            .openclaw_home
+            .join("registry")
+            .join(COMPONENT)
+            .exists(),
+        "fake framework registered the plugin before returning failure"
+    );
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("receipt must remain visible for disable/status");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+#[test]
+fn dry_run_enable_does_not_register_or_persist() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(None);
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run enable");
+    match outcome {
+        EnableOutcome::Planned(plan) => {
+            assert_eq!(plan.component, COMPONENT);
+            assert!(plan.register_command.is_some());
+        }
+        EnableOutcome::Enabled(_) => panic!("dry-run must not enable"),
+    }
+
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_none(),
+        "dry-run must not persist a receipt"
+    );
+    // Nothing should have been written into the openclaw registry.
+    assert!(
+        !world
+            .openclaw_home
+            .join("registry")
+            .join(COMPONENT)
+            .exists()
+    );
+}
+
+#[test]
+fn disable_keeps_receipt_when_uninstall_fails() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+
+    // Now force uninstall to fail.
+    world.apply_env(Some("uninstall"));
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK))
+        .expect("disable runs");
+    assert!(
+        !disabled.claim_removed,
+        "receipt must be kept on cleanup failure"
+    );
+    assert!(!disabled.report.cleanup_complete);
+
+    // Receipt is kept and marked cleanup_failed for retry.
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+#[test]
+fn disable_without_cli_keeps_receipt_for_retry() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+
+    // Point OPENCLAW_BIN at a path that does not exist: disable cannot run
+    // the CLI, so it must keep the receipt for a later retry instead of
+    // pretending cleanup completed.
+    let missing = world._root.path().join("no-such-openclaw");
+    // SAFETY: ENV_LOCK held.
+    unsafe {
+        std::env::set_var("OPENCLAW_BIN", &missing);
+    }
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK))
+        .expect("disable");
+    assert!(!disabled.claim_removed, "receipt kept when CLI absent");
+    assert!(!disabled.report.cleanup_complete);
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+#[test]
+fn forged_external_path_receipt_is_rejected_by_status() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+
+    // Tamper with the persisted receipt: repoint the external-path resource
+    // at /etc, outside the driver's allowed roots.
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    {
+        let claim = state
+            .adapter_claims
+            .iter_mut()
+            .find(|c| c.component == COMPONENT)
+            .expect("claim");
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::ExternalPath { path } = &mut res.kind {
+                *path = PathBuf::from("/etc/cron.d/evil");
+            }
+        }
+    }
+    state.save(&state_path).expect("save tampered state");
+
+    let err = manager
+        .status(Some(COMPONENT))
+        .expect_err("forged receipt must be rejected");
+    assert!(
+        matches!(err, AdapterError::ClaimValidation(_)),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn scan_includes_manifest_declaration_without_resource_directory() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let root = tempfile::tempdir().expect("tempdir");
+    let prefix = root.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+    seed_state(&layout, &prefix);
+    let manager = AdapterManager::new(
+        layout.clone(),
+        Some(prefix.join("home")),
+        "tester".to_string(),
+    );
+
+    let report = manager.scan().expect("scan");
+    let entry = report
+        .entries
+        .iter()
+        .find(|e| e.component == COMPONENT && e.framework == FRAMEWORK)
+        .expect("manifest declaration entry");
+    assert!(entry.declared);
+    assert!(entry.resource_root.is_none());
+    assert!(entry.driver_available);
+    assert!(!entry.enabled);
+}
+
+#[test]
+fn user_scan_includes_system_state_declaration() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let root = tempfile::tempdir().expect("tempdir");
+    let prefix = root.path().to_path_buf();
+    let system_prefix = prefix.join("system");
+    let system_layout = FsLayout::system(Some(system_prefix.clone()));
+    seed_state(&system_layout, &system_prefix);
+
+    let user_home = prefix.join("home");
+    std::fs::create_dir_all(&user_home).expect("home");
+    let user_layout = FsLayout::user(user_home.clone());
+    let mut manager = AdapterManager::new(user_layout, Some(user_home), "tester".to_string());
+    manager.push_state_root(system_layout.state_dir.clone());
+
+    let report = manager.scan().expect("scan");
+    let entry = report
+        .entries
+        .iter()
+        .find(|e| e.component == COMPONENT && e.framework == FRAMEWORK)
+        .expect("system declaration entry");
+    assert!(entry.declared);
+    assert!(entry.resource_root.is_none());
+    assert!(!entry.enabled);
+}
+
+#[test]
+fn scan_lists_resource_with_detection_and_receipt_state() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let world = stage();
+    world.apply_env(None);
+    let manager = world.manager();
+
+    // Before enable: discovered, driver available, detected, not enabled.
+    let report = manager.scan().expect("scan");
+    let entry = report
+        .entries
+        .iter()
+        .find(|e| e.component == COMPONENT && e.framework == FRAMEWORK)
+        .expect("entry");
+    assert!(entry.driver_available);
+    assert!(entry.framework_detected);
+    assert!(!entry.enabled);
+    assert!(entry.declared);
+    assert_eq!(entry.resource_root.as_ref(), Some(&world.resource_root));
+
+    // After enable: reported as enabled.
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let report = manager.scan().expect("scan again");
+    let entry = report
+        .entries
+        .iter()
+        .find(|e| e.component == COMPONENT)
+        .expect("entry");
+    assert!(entry.enabled);
+    assert_eq!(entry.claim_status, Some(ClaimStatus::Enabled));
+}


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
  - Add the adapter core, driver registry, adapter manager, claim receipts, and OpenClaw tokenless driver.
  - Wire `anolisa adapter scan/status/enable/disable` through the manager and persist adapter claims in installed state
  schema v2.
  - Persist installed `component.toml` files during install so `adapter scan` reads local installation facts instead of
  fetching OSS metadata.
  - Block component uninstall while enabled adapter claims exist, requiring users to disable framework integrations
  first.

  The follows the Framework Driver + Claim Receipt design. Component manifests declare adapter support and
  resources, while behavior stays in built-in Rust drivers instead of component-provided scripts or a generic DSL.

  `install` remains a resource deployment step: it lays out adapter resources and saves the installed component
  manifest locally. `adapter enable` is the only path that mutates framework-side state, and it writes a pure-data
  receipt containing claim resources and driver payload.

  For the first slice, the only built-in driver is OpenClaw tokenless. `adapter scan` intentionally uses installed
  local manifests as the source of declared adapters; it does not query OSS catalog, index, or meta files during scan.

  ## Ship Note
  This ships the first adapter MVP slice for OpenClaw tokenless only. The new explicit workflow is:

  - `anolisa adapter scan`
  - `anolisa adapter enable <component> [framework]`
  - `anolisa adapter status [component]`
  - `anolisa adapter disable <component> [framework]`

  Installed component manifests are now persisted locally during install, and `adapter scan` reads those local
  installation facts instead of querying OSS metadata.

  Current limitations and intentionally unimplemented parts:

  - Only the OpenClaw tokenless combination is supported in this PR.
  - Cosh, Hermes, Qoder, Claude Code, Codex, and other frameworks are not implemented yet.
  - OpenClaw CLI is expected to already be installed and available on `PATH`.
  - `anolisa install` does not auto-enable adapters.
  - `anolisa install --enable` is not implemented.
  - `anolisa status` does not include adapter summaries yet; use `anolisa adapter status`.
  - `adapter scan` does not fetch `catalog.json`, `index.toml`, or component `meta.toml` from OSS.
  - `adapter scan` depends on locally installed `component.toml`; missing or corrupt local manifests are reported as
  warnings.
  - Adapter enable/disable is per-user; cross-user receipt cleanup is not implemented.
  - Component uninstall is blocked while current-user adapter claims exist; automatic cascade disable is not
  implemented.
  - There is no runtime adapter plugin system or generic adapter DSL; new frameworks require built-in driver support.
 
## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

closes #864

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->
  - `cargo fmt --all -- --check`
  - `cargo test --workspace`
  - `cargo check --workspace --all-targets`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo doc --workspace --no-deps`
## Additional Notes

<!-- Any additional information, screenshots, or context. -->
