### PR TITLE
feat(anolisa): extend adapter manifest contract

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -97,6 +97,9 @@ struct ScanRow {
     resource_root: Option<String>,
     driver_available: bool,
     framework_detected: bool,
+    /// The `adapter_type` declared in the component manifest, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    adapter_type: Option<String>,
     enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     claim_status: Option<ClaimStatus>,
@@ -204,14 +207,15 @@ fn handle_scan(ctx: &CliContext) -> Result<(), CliError> {
         return Ok(());
     }
     println!(
-        "{:<16} {:<10} {:<9} {:<9} {:<9} {:<8} STATE",
-        "COMPONENT", "FRAMEWORK", "DECLARED", "RESOURCE", "DRIVER", "DETECTED"
+        "{:<16} {:<10} {:<14} {:<9} {:<9} {:<9} {:<8} STATE",
+        "COMPONENT", "FRAMEWORK", "TYPE", "DECLARED", "RESOURCE", "DRIVER", "DETECTED"
     );
     for row in &report.entries {
         println!(
-            "{:<16} {:<10} {:<9} {:<9} {:<9} {:<8} {}",
+            "{:<16} {:<10} {:<14} {:<9} {:<9} {:<9} {:<8} {}",
             row.component,
             row.framework,
+            row.adapter_type.as_deref().unwrap_or("-"),
             yes_no(row.declared),
             if row.resource_root.is_some() {
                 "present"
@@ -238,6 +242,7 @@ fn scan_row_from_entry(row: &ScanEntry) -> ScanRow {
             .map(|path| path.display().to_string()),
         driver_available: row.driver_available,
         framework_detected: row.framework_detected,
+        adapter_type: row.adapter_type.clone(),
         enabled: row.enabled,
         claim_status: row.claim_status,
     }
@@ -425,6 +430,7 @@ fn map_err(command: &str, err: AdapterError) -> CliError {
         AdapterError::UnknownPlaceholder { .. }
         | AdapterError::UnknownFramework { .. }
         | AdapterError::AmbiguousFramework { .. }
+        | AdapterError::UnsupportedAdapterType { .. }
         | AdapterError::ComponentNotInstalled { .. }
         | AdapterError::AdapterNotDeclared { .. }
         | AdapterError::ResourceRootNotFound { .. }
@@ -527,5 +533,52 @@ mod tests {
             },
         );
         assert!(matches!(err, CliError::Runtime { .. }));
+    }
+
+    #[test]
+    fn unsupported_adapter_type_maps_to_invalid_argument() {
+        let err = map_err(
+            "adapter enable",
+            AdapterError::UnsupportedAdapterType {
+                component: "tokenless".to_string(),
+                framework: "openclaw".to_string(),
+                adapter_type: "skill_bundle".to_string(),
+            },
+        );
+        assert!(matches!(err, CliError::InvalidArgument { .. }));
+    }
+
+    #[test]
+    fn scan_row_includes_adapter_type() {
+        let entry = ScanEntry {
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            declared: true,
+            resource_root: None,
+            driver_available: true,
+            framework_detected: true,
+            adapter_type: Some("plugin".to_string()),
+            enabled: false,
+            claim_status: None,
+        };
+        let row = scan_row_from_entry(&entry);
+        assert_eq!(row.adapter_type.as_deref(), Some("plugin"));
+    }
+
+    #[test]
+    fn scan_row_adapter_type_none_when_not_declared() {
+        let entry = ScanEntry {
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            declared: false,
+            resource_root: Some(std::path::PathBuf::from("/tmp/adapters/tokenless/openclaw")),
+            driver_available: true,
+            framework_detected: true,
+            adapter_type: None,
+            enabled: false,
+            claim_status: None,
+        };
+        let row = scan_row_from_entry(&entry);
+        assert!(row.adapter_type.is_none());
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -241,16 +241,41 @@ pub(crate) fn status_is_enabled(status_label: &str) -> bool {
 /// Build an [`AdapterManager`] for the active layout, shared between
 /// `adapter` and `status` handlers.
 pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
+    use anolisa_core::adapter::manager::VisibleRoot;
+
     let layout = resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
-    let system_datadir = packaged::packaged_datadir_root(&layout);
-    let mut manager = AdapterManager::new(layout, Some(env.home), env.user);
-    if let Some(root) = system_datadir {
-        manager.push_datadir_root(root);
-    }
+    let mut manager = AdapterManager::new(layout.clone(), Some(env.home), env.user);
+
     if ctx.install_mode == InstallMode::User {
-        manager.push_state_root(FsLayout::system(ctx.prefix.clone()).state_dir);
+        // In user mode, the primary visible root is the user layout (set
+        // by `new`).  Add a system visible root so user-mode CLI can
+        // enable adapters for system-installed components.  The system
+        // root pairs with the system datadir + packaged datadir, which
+        // may differ (RPM uses /usr/share, CLI installs to /usr/local/share).
+        let system_layout = FsLayout::system(ctx.prefix.clone());
+        let mut system_datadirs = vec![system_layout.datadir.clone()];
+        if let Some(packaged) = packaged::packaged_datadir_root(&system_layout) {
+            if !system_datadirs.contains(&packaged) {
+                system_datadirs.push(packaged);
+            }
+        }
+        manager.push_visible_root(VisibleRoot {
+            state_dir: system_layout.state_dir,
+            contract_datadir_roots: system_datadirs,
+        });
+    } else {
+        // In system mode, the primary visible root uses `layout.datadir`.
+        // If the packaged datadir differs (exe-sibling vs install prefix),
+        // add it to the primary root's contract datadirs so RPM-installed
+        // contracts at /usr/share/... are found.
+        if let Some(packaged) = packaged::packaged_datadir_root(&layout) {
+            if packaged != layout.datadir {
+                manager.push_primary_datadir_root(packaged);
+            }
+        }
     }
+
     manager
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -771,6 +771,12 @@ fn execute_adopt(
         reason: format!("failed to save state: {err}"),
     })?;
 
+    // Best-effort: snapshot the datadir component contract so adapter commands
+    // can discover declared adapters. Missing or unwritable contracts produce
+    // warnings, never failures.
+    let snapshot_warnings = snapshot_datadir_contract(layout, component, command);
+    warnings.extend(snapshot_warnings);
+
     // Audit log is best-effort: the adopt already persisted, so a log failure
     // downgrades to a warning instead of unwinding.
     let log = CentralLog::open(layout.central_log.clone());
@@ -799,6 +805,7 @@ fn execute_adopt(
     }
 
     payload.operation_id = Some(operation_id);
+    payload.warnings = warnings;
     render_adopt(ctx, &payload);
     Ok(InstallOutcome::Adopted)
 }
@@ -975,7 +982,7 @@ fn execute_delegated_install(
         }
     };
 
-    let operation_id = persist_delegated_install(
+    let (operation_id, snapshot_warnings) = persist_delegated_install(
         ctx,
         layout,
         command,
@@ -985,6 +992,7 @@ fn execute_delegated_install(
         source_repo.as_deref(),
         &warnings,
     )?;
+    warnings.extend(snapshot_warnings);
 
     let payload = DelegatedInstallPayload {
         component: component.to_string(),
@@ -1020,7 +1028,7 @@ fn persist_delegated_install(
     info: &PackageInfo,
     source_repo: Option<&str>,
     warnings: &[String],
-) -> Result<String, CliError> {
+) -> Result<(String, Vec<String>), CliError> {
     let evr = info.version.to_string();
     let started_at = now_iso8601();
 
@@ -1097,6 +1105,13 @@ fn persist_delegated_install(
         reason: format!("failed to save state: {err}"),
     })?;
 
+    // Best-effort: snapshot the datadir component contract so adapter commands
+    // can discover declared adapters. Missing or unwritable contracts produce
+    // warnings, never failures.
+    let snapshot_warnings = snapshot_datadir_contract(layout, component, command);
+    let mut all_warnings = warnings.to_vec();
+    all_warnings.extend(snapshot_warnings.clone());
+
     // Audit log is best-effort: the install already persisted, so a log failure
     // downgrades to a warning instead of unwinding.
     let log = CentralLog::open(layout.central_log.clone());
@@ -1117,14 +1132,14 @@ fn persist_delegated_install(
         status: Some(LogStatus::Ok),
         objects: vec![component.to_string()],
         backup_ids: Vec::new(),
-        warnings: warnings.to_vec(),
+        warnings: all_warnings,
         details: serde_json::Value::Null,
     };
     if let Err(err) = log.append(&record) {
         eprintln!("warning: failed to write central log: {err}");
     }
 
-    Ok(operation_id)
+    Ok((operation_id, snapshot_warnings))
 }
 
 /// Render a delegated-install result (JSON envelope or human text). Silent in
@@ -2596,6 +2611,93 @@ fn write_installed_component_manifest(
         ),
     })?;
     Ok(path)
+}
+
+/// Best-effort snapshot of the datadir component contract for RPM paths.
+///
+/// After an RPM adopt or delegated install the package-owned contract lives
+/// at `{datadir}/components/<component>/component.toml`. Real RPMs install
+/// to `%{_datadir}` (`/usr/share/anolisa/`), which may differ from the CLI
+/// install prefix (`/usr/local/share/anolisa/`). To handle both, this
+/// function probes the packaged datadir root first (exe-sibling /
+/// `ANOLISA_DATA_DIR` / `layout.datadir`), then falls back to
+/// `layout.datadir` if the packaged root differs. The first existing
+/// contract wins.
+///
+/// The contract is copied verbatim (no TOML parsing) to the state snapshot
+/// at `{state_dir}/component-manifests/<component>/component.toml` so that
+/// later `adapter enable` can discover the component's declared adapters.
+///
+/// Returns any warning messages that should be surfaced to the user.
+/// Neither a missing contract nor a write failure is fatal — both produce
+/// a warning instead of an error.
+fn snapshot_datadir_contract(layout: &FsLayout, component: &str, command: &str) -> Vec<String> {
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Build the set of datadir roots to search, deduped, in priority
+    // order.  packaged_datadir_root already covers env override →
+    // exe-sibling → layout.datadir, but its last probe is is_dir()
+    // gated.  We always include layout.datadir as the final fallback
+    // so the path appears in the "not found" warning.
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Some(packaged) = crate::packaged::packaged_datadir_root(layout) {
+        roots.push(packaged);
+    }
+    if !roots.iter().any(|r| r == &layout.datadir) {
+        roots.push(layout.datadir.clone());
+    }
+
+    let mut content: Option<String> = None;
+    let mut searched: Vec<PathBuf> = Vec::new();
+    for root in &roots {
+        let source = FsLayout::component_contract_path(root, component);
+        match std::fs::read_to_string(&source) {
+            Ok(c) => {
+                content = Some(c);
+                break;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                searched.push(source);
+            }
+            Err(err) => {
+                warnings.push(format!(
+                    "could not read datadir component contract at {}: {err}",
+                    source.display()
+                ));
+                return warnings;
+            }
+        }
+    }
+
+    let Some(content) = content else {
+        let paths: Vec<String> = searched.iter().map(|p| p.display().to_string()).collect();
+        warnings.push(format!(
+            "component '{component}' does not publish an ANOLISA component contract at {}",
+            paths.join(" or ")
+        ));
+        return warnings;
+    };
+
+    let dest = match common::installed_component_manifest_path(layout, component, command) {
+        Ok(p) => p,
+        Err(err) => {
+            warnings.push(format!(
+                "could not resolve snapshot path for component '{component}': {err}"
+            ));
+            return warnings;
+        }
+    };
+
+    if let Err(err) = write_atomic_text(&dest, &content) {
+        let msg = format!(
+            "failed to snapshot component contract to {}: {err}",
+            dest.display()
+        );
+        eprintln!("warning: {msg}");
+        warnings.push(msg);
+    }
+
+    warnings
 }
 
 fn write_atomic_text(path: &Path, content: &str) -> std::io::Result<()> {
@@ -4661,5 +4763,187 @@ scope = "@anolisa"
         assert_eq!(batch_status(InstallOutcome::Installed, true), "planned");
         assert_eq!(batch_status(InstallOutcome::Adopted, false), "adopted");
         assert_eq!(batch_status(InstallOutcome::Adopted, true), "adopt-planned");
+    }
+
+    // ── contract snapshot tests ────────────────────────────────────────
+
+    /// Place a component contract in the datadir so RPM adopt/delegated-install
+    /// can discover it.
+    fn seed_datadir_contract(layout: &FsLayout, component: &str, toml: &str) {
+        let dir = layout.datadir.join("components").join(component);
+        std::fs::create_dir_all(&dir).expect("create datadir component dir");
+        std::fs::write(dir.join("component.toml"), toml).expect("write datadir contract");
+    }
+
+    #[test]
+    fn adopt_snapshots_datadir_contract() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
+        seed_datadir_contract(&layout, "copilot-shell", &contract);
+
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            ..Default::default()
+        };
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("adopt ok");
+        assert_eq!(outcome, InstallOutcome::Adopted);
+
+        let snapshot = common::installed_component_manifest_path(&layout, "copilot-shell", COMMAND)
+            .expect("snapshot path");
+        assert!(
+            snapshot.exists(),
+            "adopt must snapshot the datadir contract to {snapshot:?}"
+        );
+        let content = std::fs::read_to_string(&snapshot).expect("read snapshot");
+        assert_eq!(content, contract, "snapshot must be a verbatim copy");
+    }
+
+    #[test]
+    fn adopt_without_datadir_contract_succeeds_with_warning() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        // Deliberately do NOT seed a datadir contract.
+
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            ..Default::default()
+        };
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("adopt must succeed even without a contract");
+        assert_eq!(outcome, InstallOutcome::Adopted);
+
+        let snapshot = common::installed_component_manifest_path(&layout, "copilot-shell", COMMAND)
+            .expect("snapshot path");
+        assert!(
+            !snapshot.exists(),
+            "no snapshot when the datadir contract is absent"
+        );
+    }
+
+    #[test]
+    fn delegated_install_snapshots_datadir_contract() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
+        seed_datadir_contract(&layout, "copilot-shell", &contract);
+
+        let fake = FakeInstaller::new(
+            "anolisa-copilot-shell",
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        )
+        .with_origin("anolisa");
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+
+        let outcome = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+            .expect("delegated install ok");
+        assert_eq!(outcome, InstallOutcome::Installed);
+
+        let snapshot = common::installed_component_manifest_path(&layout, "copilot-shell", COMMAND)
+            .expect("snapshot path");
+        assert!(
+            snapshot.exists(),
+            "delegated install must snapshot the datadir contract to {snapshot:?}"
+        );
+        let content = std::fs::read_to_string(&snapshot).expect("read snapshot");
+        assert_eq!(content, contract, "snapshot must be a verbatim copy");
+    }
+
+    #[test]
+    fn delegated_install_without_datadir_contract_succeeds() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        // No datadir contract seeded.
+
+        let fake = FakeInstaller::new(
+            "anolisa-copilot-shell",
+            pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        )
+        .with_origin("anolisa");
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+
+        let outcome = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+            .expect("delegated install must succeed without a contract");
+        assert_eq!(outcome, InstallOutcome::Installed);
+
+        let snapshot = common::installed_component_manifest_path(&layout, "copilot-shell", COMMAND)
+            .expect("snapshot path");
+        assert!(
+            !snapshot.exists(),
+            "no snapshot when the datadir contract is absent"
+        );
+    }
+
+    /// Regression: when the contract lives only in the packaged datadir
+    /// (simulated via `ANOLISA_DATA_DIR`), not in `layout.datadir`,
+    /// adopt must still write the snapshot.
+    #[test]
+    fn adopt_snapshots_packaged_datadir_contract() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+
+        // Seed the contract in a separate "packaged" dir (not layout.datadir).
+        let packaged = _tmp.path().join("packaged_share_anolisa");
+        let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
+        let contract_dir = packaged.join("components").join("copilot-shell");
+        std::fs::create_dir_all(&contract_dir).expect("mkdir packaged contract");
+        std::fs::write(contract_dir.join("component.toml"), &contract)
+            .expect("write packaged contract");
+
+        // Guard sets ANOLISA_DATA_DIR and restores on drop (panic-safe).
+        let _env_guard = crate::packaged::DataDirEnvGuard::set(&packaged);
+
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            ..Default::default()
+        };
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("adopt ok");
+
+        assert_eq!(outcome, InstallOutcome::Adopted);
+
+        let snapshot = common::installed_component_manifest_path(&layout, "copilot-shell", COMMAND)
+            .expect("snapshot path");
+        assert!(
+            snapshot.exists(),
+            "adopt must snapshot from packaged datadir to {snapshot:?}"
+        );
+        let content = std::fs::read_to_string(&snapshot).expect("read snapshot");
+        assert_eq!(
+            content, contract,
+            "snapshot must be a verbatim copy of the packaged contract"
+        );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -2008,6 +2008,7 @@ mod tests {
             ))),
             driver_available: true,
             framework_detected: true,
+            adapter_type: Some("plugin".to_string()),
             enabled,
             claim_status: if enabled {
                 Some(ClaimStatus::Enabled)

--- a/src/anolisa/crates/anolisa-cli/src/packaged.rs
+++ b/src/anolisa/crates/anolisa-cli/src/packaged.rs
@@ -67,82 +67,98 @@ pub fn packaged_datadir_root(layout: &FsLayout) -> Option<PathBuf> {
     None
 }
 
+/// Crate-wide mutex for tests that mutate `ANOLISA_DATA_DIR`. Cargo runs
+/// tests within a crate concurrently, and `ANOLISA_DATA_DIR` is
+/// process-global, so every test that sets or reads it must hold this lock.
+#[cfg(test)]
+pub(crate) static DATA_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII guard that sets `ANOLISA_DATA_DIR` on creation and restores (or
+/// removes) the original value on drop — even if the test panics.
+#[cfg(test)]
+pub(crate) struct DataDirEnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    saved: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+impl DataDirEnvGuard {
+    /// Acquire the env lock, save the current `ANOLISA_DATA_DIR`, and set
+    /// the new value.
+    pub(crate) fn set(value: &std::path::Path) -> Self {
+        let lock = DATA_DIR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = std::env::var_os(DATA_DIR_ENV);
+        // SAFETY: guarded by DATA_DIR_ENV_LOCK.
+        unsafe {
+            std::env::set_var(DATA_DIR_ENV, value);
+        }
+        Self { _lock: lock, saved }
+    }
+
+    /// Acquire the env lock and remove `ANOLISA_DATA_DIR` so the test
+    /// runs as if no env override is set. The original value is restored
+    /// on drop.
+    pub(crate) fn clear() -> Self {
+        let lock = DATA_DIR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = std::env::var_os(DATA_DIR_ENV);
+        // SAFETY: guarded by DATA_DIR_ENV_LOCK.
+        unsafe {
+            std::env::remove_var(DATA_DIR_ENV);
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+#[cfg(test)]
+impl Drop for DataDirEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: guarded by the lock held in self._lock.
+        unsafe {
+            match &self.saved {
+                Some(v) => std::env::set_var(DATA_DIR_ENV, v),
+                None => std::env::remove_var(DATA_DIR_ENV),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
 
-    /// `ANOLISA_DATA_DIR` takes precedence over every other probe. We
-    /// scope the env mutation to this test only — and use a tmpdir we
-    /// know exists so the `is_dir()` guard passes deterministically.
-    ///
-    /// `std::env::set_var` is not thread-safe; we run the env-mutating
-    /// tests in a single module-level mutex to avoid racing other
-    /// tests that read env vars. Cargo test runs tests in the same
-    /// crate concurrently so this matters.
+    /// `ANOLISA_DATA_DIR` takes precedence over every other probe.
     #[test]
     fn env_override_wins() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempdir().expect("tmp");
-        // Layout that points at a non-existent path so we can prove env
-        // wins rather than just matching layout.datadir.
         let layout = FsLayout::system(Some(PathBuf::from("/nonexistent-anolisa-prefix")));
-        // SAFETY: env mutation guarded by ENV_LOCK.
-        unsafe {
-            std::env::set_var(DATA_DIR_ENV, tmp.path());
-        }
+        let _guard = DataDirEnvGuard::set(tmp.path());
         let got = packaged_datadir_root(&layout);
-        unsafe {
-            std::env::remove_var(DATA_DIR_ENV);
-        }
         assert_eq!(got.as_deref(), Some(tmp.path()));
     }
 
     /// When `ANOLISA_DATA_DIR` points at a path that does not exist,
-    /// we fall through to the next probe instead of returning the
-    /// missing path. Pins that the env override is gated on
-    /// `is_dir()`, not blindly returned.
+    /// we fall through to the next probe.
     #[test]
     fn env_override_falls_through_when_missing() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let layout = FsLayout::system(Some(PathBuf::from("/nonexistent-anolisa-prefix")));
-        unsafe {
-            std::env::set_var(DATA_DIR_ENV, "/definitely/does/not/exist/anolisa");
-        }
+        let _guard =
+            DataDirEnvGuard::set(std::path::Path::new("/definitely/does/not/exist/anolisa"));
         let got = packaged_datadir_root(&layout);
-        unsafe {
-            std::env::remove_var(DATA_DIR_ENV);
-        }
-        // Layout.datadir is also missing, and current_exe() in test
-        // builds points at the test runner under target/, whose
-        // ../share/anolisa is unlikely to exist on the host — so we
-        // assert None instead of pinning a specific fallback.
         assert!(got.is_none(), "expected fallthrough, got {got:?}");
     }
 
     /// Without env override, an existing layout.datadir wins over a
-    /// missing exe-sibling probe. The exe-sibling probe is gated on
-    /// `is_dir()`, so we can rely on it failing for a test binary.
+    /// missing exe-sibling probe.
     #[test]
     fn layout_datadir_used_when_it_exists() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = DataDirEnvGuard::clear();
         let tmp = tempdir().expect("tmp");
         let prefix = tmp.path().to_path_buf();
         let layout = FsLayout::system(Some(prefix.clone()));
-        // System layout under prefix → datadir = prefix/usr/local/share/anolisa.
         fs::create_dir_all(&layout.datadir).expect("mkdir datadir");
-        // Clear env to make sure step 1 falls through.
-        unsafe {
-            std::env::remove_var(DATA_DIR_ENV);
-        }
         let got = packaged_datadir_root(&layout);
         assert_eq!(got.as_deref(), Some(layout.datadir.as_path()));
     }
-
-    /// A serial-execution mutex so the env-mutating tests above can
-    /// share a single `set_var` / `remove_var` window without racing.
-    /// Plain `Mutex<()>` instead of `OnceLock<Mutex>` because the
-    /// tests are few and ordering is not load-bearing.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -21,6 +21,7 @@ use anolisa_platform::fs_layout::FsLayout;
 use crate::manifest::AdapterSpec;
 
 pub mod claim;
+pub mod contract;
 pub mod driver;
 pub mod manager;
 pub mod openclaw;
@@ -88,6 +89,21 @@ pub enum AdapterError {
         component: String,
         /// Framework absent from the installed component manifest.
         framework: String,
+    },
+
+    /// The manifest declares an `adapter_type` that is not yet supported
+    /// by any built-in driver (e.g. `skill_bundle`, `extension`). Only
+    /// `plugin` (or absent, defaulting to plugin) is implemented.
+    #[error(
+        "adapter type '{adapter_type}' for {component}/{framework} is not supported; only 'plugin' is implemented"
+    )]
+    UnsupportedAdapterType {
+        /// Component whose adapter was requested.
+        component: String,
+        /// Framework the adapter targets.
+        framework: String,
+        /// The unsupported `adapter_type` value from the manifest.
+        adapter_type: String,
     },
 
     /// The installed component manifest required by adapter enable is

--- a/src/anolisa/crates/anolisa-core/src/adapter/contract.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/contract.rs
@@ -1,0 +1,288 @@
+//! Component contract discovery.
+//!
+//! Resolves a [`ComponentManifest`] for an installed component by searching
+//! a caller-supplied list of candidate paths in priority order. The typical
+//! ordering is:
+//!
+//! 1. **State snapshots** — one per state root
+//!    (`{state_dir}/component-manifests/<component>/component.toml`).
+//! 2. **Datadir contracts** — one per datadir root
+//!    (`{datadir}/components/<component>/component.toml`).
+//!
+//! The first file found wins. A TOML parse error is surfaced immediately
+//! (it must not be masked as "unavailable").
+
+use std::path::{Path, PathBuf};
+
+use anolisa_platform::fs_layout::FsLayout;
+
+use crate::manifest::{ComponentManifest, ManifestError};
+
+/// Errors from component contract resolution.
+#[derive(Debug, thiserror::Error)]
+pub enum ContractError {
+    /// No contract file was found under any searched root.
+    #[error(
+        "component contract unavailable for '{component}': no file found at any of {searched:?}"
+    )]
+    Unavailable {
+        /// Component whose contract was requested.
+        component: String,
+        /// Paths that were tried, in search order.
+        searched: Vec<PathBuf>,
+    },
+
+    /// A contract file exists but its TOML content could not be parsed.
+    #[error("malformed component contract at {path}: {reason}")]
+    ParseError {
+        /// Path of the file that failed to parse.
+        path: PathBuf,
+        /// Human-readable parse failure detail.
+        reason: String,
+    },
+
+    /// A filesystem error occurred while reading a contract file (other
+    /// than "not found", which is handled by the search loop).
+    #[error("io error reading component contract at {path}: {source}")]
+    Io {
+        /// Path that triggered the error.
+        path: PathBuf,
+        /// Underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Build the ordered list of candidate contract paths for `component`
+/// across `state_roots` (snapshot priority) then `datadir_roots` (package
+/// contract fallback). Path computation is delegated to [`FsLayout`] so
+/// the segment constants live in one place.
+pub fn candidate_paths(
+    component: &str,
+    state_roots: &[PathBuf],
+    datadir_roots: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut paths = Vec::with_capacity(state_roots.len() + datadir_roots.len());
+    for state_root in state_roots {
+        paths.push(FsLayout::component_manifest_snapshot_path(
+            state_root, component,
+        ));
+    }
+    for datadir_root in datadir_roots {
+        paths.push(FsLayout::component_contract_path(datadir_root, component));
+    }
+    paths
+}
+
+/// Resolve the component contract for `component` by searching state roots
+/// then datadir roots in the supplied order.
+///
+/// Internally builds the candidate list via [`candidate_paths`] and
+/// delegates to [`resolve_from_candidates`].
+pub fn resolve_component_contract(
+    component: &str,
+    state_roots: &[PathBuf],
+    datadir_roots: &[PathBuf],
+) -> Result<ComponentManifest, ContractError> {
+    let candidates = candidate_paths(component, state_roots, datadir_roots);
+    resolve_from_candidates(component, &candidates)
+}
+
+/// Try each candidate path in order and return the first valid manifest.
+///
+/// An IO error other than `NotFound` (e.g. permission denied) is returned
+/// as [`ContractError::Io`]; a present-but-malformed TOML file is returned
+/// as [`ContractError::ParseError`] — it is never silently skipped.
+pub fn resolve_from_candidates(
+    component: &str,
+    candidates: &[PathBuf],
+) -> Result<ComponentManifest, ContractError> {
+    let mut searched = Vec::new();
+
+    for path in candidates {
+        match try_load_contract(path) {
+            TryLoad::Loaded(manifest) => return Ok(*manifest),
+            TryLoad::NotFound => {
+                searched.push(path.clone());
+            }
+            TryLoad::Error(err) => return Err(err),
+        }
+    }
+
+    Err(ContractError::Unavailable {
+        component: component.to_string(),
+        searched,
+    })
+}
+
+/// Three-way outcome of trying to load a single candidate path.
+enum TryLoad {
+    Loaded(Box<ComponentManifest>),
+    NotFound,
+    Error(ContractError),
+}
+
+/// Attempt to load a contract from `path`, distinguishing "file absent" from
+/// "file present but broken" from "file present and valid".
+fn try_load_contract(path: &Path) -> TryLoad {
+    match ComponentManifest::from_file(path) {
+        Ok(manifest) => TryLoad::Loaded(Box::new(manifest)),
+        Err(ManifestError::Io(_, ref io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => {
+            TryLoad::NotFound
+        }
+        Err(ManifestError::Io(_, source)) => TryLoad::Error(ContractError::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+        Err(ManifestError::Parse(_, reason)) => TryLoad::Error(ContractError::ParseError {
+            path: path.to_path_buf(),
+            reason,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Minimal valid component TOML for testing.
+    fn valid_toml(name: &str) -> String {
+        format!(
+            r#"
+[component]
+name = "{name}"
+version = "0.1.0"
+layer = "runtime"
+"#
+        )
+    }
+
+    fn write_snapshot(state_root: &Path, component: &str, content: &str) {
+        let path = FsLayout::component_manifest_snapshot_path(state_root, component);
+        fs::create_dir_all(path.parent().unwrap()).expect("create dir");
+        fs::write(&path, content).expect("write");
+    }
+
+    fn write_datadir(datadir_root: &Path, component: &str, content: &str) {
+        let path = FsLayout::component_contract_path(datadir_root, component);
+        fs::create_dir_all(path.parent().unwrap()).expect("create dir");
+        fs::write(&path, content).expect("write");
+    }
+
+    /// Minimal valid component TOML with a specific version, used to
+    /// distinguish which file was loaded.
+    fn valid_toml_versioned(name: &str, version: &str) -> String {
+        format!(
+            r#"
+[component]
+name = "{name}"
+version = "{version}"
+layer = "runtime"
+"#
+        )
+    }
+
+    #[test]
+    fn snapshot_preferred_over_datadir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        write_snapshot(&state, "mycomp", &valid_toml_versioned("mycomp", "1.0.0"));
+        write_datadir(&data, "mycomp", &valid_toml_versioned("mycomp", "2.0.0"));
+
+        let manifest =
+            resolve_component_contract("mycomp", &[state], &[data]).expect("should resolve");
+        assert_eq!(manifest.component.name, "mycomp");
+        assert_eq!(manifest.component.version, "1.0.0");
+    }
+
+    #[test]
+    fn datadir_found_when_snapshot_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        write_datadir(&data, "mycomp", &valid_toml("mycomp"));
+
+        let manifest =
+            resolve_component_contract("mycomp", &[state], &[data]).expect("should resolve");
+        assert_eq!(manifest.component.name, "mycomp");
+    }
+
+    #[test]
+    fn both_absent_returns_unavailable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        let err = resolve_component_contract("mycomp", &[state], &[data])
+            .expect_err("should be unavailable");
+        assert!(
+            matches!(err, ContractError::Unavailable { .. }),
+            "expected Unavailable, got: {err}"
+        );
+    }
+
+    #[test]
+    fn malformed_toml_returns_parse_error_not_unavailable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        write_snapshot(&state, "mycomp", "this is not valid toml = [[[");
+
+        let err = resolve_component_contract("mycomp", &[state], &[data])
+            .expect_err("should be parse error");
+        assert!(
+            matches!(err, ContractError::ParseError { .. }),
+            "expected ParseError, got: {err}"
+        );
+    }
+
+    #[test]
+    fn malformed_snapshot_not_masked_by_valid_datadir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        write_snapshot(&state, "mycomp", "bad toml {{{{");
+        write_datadir(&data, "mycomp", &valid_toml("mycomp"));
+
+        let err = resolve_component_contract("mycomp", &[state], &[data])
+            .expect_err("should be parse error");
+        assert!(
+            matches!(err, ContractError::ParseError { .. }),
+            "expected ParseError, got: {err}"
+        );
+    }
+
+    #[test]
+    fn multiple_state_roots_searched_in_order() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state1 = tmp.path().join("state1");
+        let state2 = tmp.path().join("state2");
+        let data = tmp.path().join("data");
+
+        write_snapshot(&state2, "mycomp", &valid_toml("mycomp"));
+
+        let manifest = resolve_component_contract("mycomp", &[state1, state2], &[data])
+            .expect("should resolve from state2");
+        assert_eq!(manifest.component.name, "mycomp");
+    }
+
+    #[test]
+    fn multiple_datadir_roots_searched_in_order() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data1 = tmp.path().join("data1");
+        let data2 = tmp.path().join("data2");
+
+        write_datadir(&data2, "mycomp", &valid_toml("mycomp"));
+
+        let manifest = resolve_component_contract("mycomp", &[state], &[data1, data2])
+            .expect("should resolve from data2");
+        assert_eq!(manifest.component.name, "mycomp");
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -16,7 +16,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -42,12 +42,6 @@ const LOG_SOURCE: &str = "anolisa-cli";
 /// Output beyond this is drained (so the child never blocks on a full
 /// pipe) but discarded before logging.
 const OUTPUT_CAP: usize = 64 * 1024;
-/// State subdirectory where install stores component manifests used for
-/// future adapter enable checks.
-const INSTALLED_COMPONENT_MANIFESTS_SUBDIR: &str = "component-manifests";
-/// Filename used for each saved installed component contract.
-const INSTALLED_COMPONENT_MANIFEST_FILE: &str = "component.toml";
-
 /// Outcome of [`AdapterManager::enable`].
 #[derive(Debug, Clone)]
 pub enum EnableOutcome {
@@ -88,6 +82,10 @@ pub struct ScanEntry {
     /// Whether the framework was detected on the host (best-effort;
     /// `false` when no driver is available to probe).
     pub framework_detected: bool,
+    /// The `adapter_type` declared in the component manifest for this
+    /// adapter entry, when the manifest was readable (`None` when the
+    /// entry came from resource-directory discovery only).
+    pub adapter_type: Option<String>,
     /// Whether a receipt for `(component, framework)` exists in state.
     pub enabled: bool,
     /// Lifecycle status of the receipt, when one exists.
@@ -127,6 +125,22 @@ pub struct StatusReport {
 struct AdapterDecl {
     component: String,
     framework: String,
+    /// The `adapter_type` from the manifest entry, if present.
+    adapter_type: Option<String>,
+}
+
+/// A state root paired with the datadir roots it may use for component
+/// contract resolution. Contract lookup for a component found in this
+/// state root searches only the paired datadir roots — not datadirs
+/// from other visible roots — so a user-scope component cannot
+/// silently fall back to a system-scope contract.
+#[derive(Debug, Clone)]
+pub struct VisibleRoot {
+    /// State directory containing `installed.toml`.
+    pub state_dir: PathBuf,
+    /// Datadir roots searched for component contracts when a component
+    /// is found in this state root. Searched in order; first match wins.
+    pub contract_datadir_roots: Vec<PathBuf>,
 }
 
 /// Trusted orchestrator for adapter enable/disable/status/scan.
@@ -134,54 +148,83 @@ pub struct AdapterManager {
     layout: FsLayout,
     registry: DriverRegistry,
     state_path: PathBuf,
-    /// State roots searched for installed component records/manifests, in
-    /// preference order. Receipts are always written only to
-    /// [`Self::state_path`].
-    state_roots: Vec<PathBuf>,
-    /// Datadir roots searched for `adapters/<component>/<framework>/`, in
-    /// preference order (first match wins).
-    datadir_roots: Vec<PathBuf>,
+    /// Paired visible roots, in preference order. Each pairs a state root
+    /// with its contract-visible datadir roots. Receipts are always
+    /// written only to [`Self::state_path`] (the primary root's state).
+    visible_roots: Vec<VisibleRoot>,
+    /// All datadir roots (across all visible roots, deduped), used for
+    /// resource-directory discovery (`adapters/<component>/<framework>/`).
+    /// Resource discovery is scope-independent: a user-mode enable may
+    /// use adapter resources from a system-installed package.
+    all_datadir_roots: Vec<PathBuf>,
     user_home: Option<PathBuf>,
     /// Identity recorded as the central-log actor.
     actor: String,
 }
 
 impl AdapterManager {
-    /// Build a manager for the given layout. The state file is
-    /// `{state_dir}/installed.toml`; the primary datadir root is
-    /// `layout.datadir`, and the primary component-manifest root is
-    /// `layout.state_dir`. Use [`Self::push_datadir_root`] and
-    /// [`Self::push_state_root`] to add fallbacks (e.g. system roots when
-    /// running in user mode).
+    /// Build a manager for the given layout. The primary visible root
+    /// pairs `layout.state_dir` with `layout.datadir`. Use
+    /// [`Self::push_visible_root`] to add fallback roots (e.g. system
+    /// roots when running in user mode).
     pub fn new(layout: FsLayout, user_home: Option<PathBuf>, actor: String) -> Self {
         let state_path = layout.state_dir.join("installed.toml");
-        let state_roots = vec![layout.state_dir.clone()];
-        let datadir_roots = vec![layout.datadir.clone()];
+        let primary = VisibleRoot {
+            state_dir: layout.state_dir.clone(),
+            contract_datadir_roots: vec![layout.datadir.clone()],
+        };
+        let all_datadir_roots = vec![layout.datadir.clone()];
         Self {
             layout,
             registry: DriverRegistry::builtin(),
             state_path,
-            state_roots,
-            datadir_roots,
+            visible_roots: vec![primary],
+            all_datadir_roots,
             user_home,
             actor,
         }
     }
 
-    /// Append an additional datadir root to search after the ones already
-    /// registered. Ignored if already present.
-    pub fn push_datadir_root(&mut self, root: PathBuf) {
-        if !self.datadir_roots.contains(&root) {
-            self.datadir_roots.push(root);
+    /// Add a visible root with explicit contract-scope datadir pairing.
+    ///
+    /// The state root is appended to the search order (lower priority
+    /// than roots registered earlier). Its `contract_datadir_roots` are
+    /// only used for contract resolution when a component is found in
+    /// this state root — they are not mixed into other roots' contract
+    /// scope.
+    ///
+    /// All datadir roots are also added to the global resource-discovery
+    /// set (for `adapters/<component>/<framework>/` lookups), since
+    /// adapter resource directories are scope-independent.
+    pub fn push_visible_root(&mut self, root: VisibleRoot) {
+        if self
+            .visible_roots
+            .iter()
+            .any(|r| r.state_dir == root.state_dir)
+        {
+            return;
         }
+        for dd in &root.contract_datadir_roots {
+            if !self.all_datadir_roots.contains(dd) {
+                self.all_datadir_roots.push(dd.clone());
+            }
+        }
+        self.visible_roots.push(root);
     }
 
-    /// Append an additional installed-state root to search for component
-    /// installation records and saved component manifests. Receipts still
-    /// belong to the manager's primary state root.
-    pub fn push_state_root(&mut self, root: PathBuf) {
-        if !self.state_roots.contains(&root) {
-            self.state_roots.push(root);
+    /// Add a datadir root to the primary visible root's contract scope
+    /// and to the global resource-discovery set. Use this when the
+    /// system-mode packaged datadir differs from `layout.datadir`
+    /// (e.g. exe-sibling `/usr/share/anolisa/` vs install prefix
+    /// `/usr/local/share/anolisa/`).
+    pub fn push_primary_datadir_root(&mut self, root: PathBuf) {
+        if let Some(primary) = self.visible_roots.first_mut() {
+            if !primary.contract_datadir_roots.contains(&root) {
+                primary.contract_datadir_roots.push(root.clone());
+            }
+        }
+        if !self.all_datadir_roots.contains(&root) {
+            self.all_datadir_roots.push(root);
         }
     }
 
@@ -225,6 +268,7 @@ impl AdapterManager {
                     resource_root: Some(resource_root),
                     driver_available,
                     framework_detected,
+                    adapter_type: None,
                     enabled: claim.is_some(),
                     claim_status: claim.map(|c| c.status),
                 },
@@ -236,6 +280,7 @@ impl AdapterManager {
             let key = (declaration.component.clone(), declaration.framework.clone());
             if let Some(entry) = entries.get_mut(&key) {
                 entry.declared = true;
+                entry.adapter_type = declaration.adapter_type.clone();
                 continue;
             }
             let driver = self.registry.get(&declaration.framework);
@@ -258,6 +303,7 @@ impl AdapterManager {
                     resource_root: None,
                     driver_available,
                     framework_detected,
+                    adapter_type: declaration.adapter_type,
                     enabled: claim.is_some(),
                     claim_status: claim.map(|c| c.status),
                 },
@@ -282,7 +328,8 @@ impl AdapterManager {
     ///
     /// [`AdapterError::ComponentNotInstalled`], [`AdapterError::AdapterNotDeclared`],
     /// [`AdapterError::AdapterManifest`], [`AdapterError::UnknownFramework`],
-    /// [`AdapterError::AmbiguousFramework`], [`AdapterError::ResourceRootNotFound`],
+    /// [`AdapterError::AmbiguousFramework`], [`AdapterError::UnsupportedAdapterType`],
+    /// [`AdapterError::ResourceRootNotFound`],
     /// [`AdapterError::FrameworkNotDetected`], [`AdapterError::BundleInvalid`],
     /// [`AdapterError::FrameworkCli`], [`AdapterError::ClaimValidation`], or
     /// state/lock/log errors.
@@ -297,6 +344,21 @@ impl AdapterManager {
 
         let manifest = self.load_visible_component_manifest(component, &state)?;
         let framework = self.resolve_framework(component, framework, &manifest)?;
+
+        // Fail-closed: only `plugin` (or absent/None, defaulting to
+        // plugin) is supported. Any other adapter_type must be rejected
+        // before we invoke a driver.
+        let adapter_type = declared_adapter_type(&manifest, &framework);
+        if let Some(ref at) = adapter_type {
+            if at != "plugin" {
+                return Err(AdapterError::UnsupportedAdapterType {
+                    component: component.to_string(),
+                    framework: framework.clone(),
+                    adapter_type: at.clone(),
+                });
+            }
+        }
+
         let declared_plugin_id = declared_plugin_id(&manifest, &framework);
         let driver =
             self.registry
@@ -626,73 +688,89 @@ impl AdapterManager {
         }
     }
 
-    /// Load the installed component manifest from the first visible state
-    /// root that records `component` as installed.
+    /// Load the component contract for an installed component.
+    ///
+    /// The component must be recorded as installed in a visible state root.
+    /// Once that gate passes, the contract is resolved using only the
+    /// matched visible root's paired state and datadir roots — a user-scope
+    /// component never falls back to a system-scope contract.
     fn load_visible_component_manifest(
         &self,
         component: &str,
         current_state: &InstalledState,
     ) -> Result<ComponentManifest, AdapterError> {
-        let Some(state_dir) = self.find_component_state_dir(component, current_state)? else {
-            return Err(AdapterError::ComponentNotInstalled {
+        let vr = self
+            .find_component_visible_root(component, current_state)?
+            .ok_or_else(|| AdapterError::ComponentNotInstalled {
                 component: component.to_string(),
-            });
-        };
-        let path = installed_component_manifest_path(&state_dir, component);
-        let manifest =
-            ComponentManifest::from_file(&path).map_err(|err| AdapterError::AdapterManifest {
-                component: component.to_string(),
-                path: path.clone(),
-                reason: err.to_string(),
             })?;
+
+        let manifest = super::contract::resolve_component_contract(
+            component,
+            &[vr.state_dir.clone()],
+            &vr.contract_datadir_roots,
+        )
+        .map_err(|err| map_contract_error(component, err))?;
+
         if manifest.component.name != component {
             return Err(AdapterError::AdapterManifest {
                 component: component.to_string(),
-                path,
+                path: PathBuf::new(),
                 reason: format!("manifest declares component '{}'", manifest.component.name),
             });
         }
         Ok(manifest)
     }
 
-    /// First visible state root whose installed state contains `component`.
-    fn find_component_state_dir(
+    /// First visible root whose installed state contains `component` in
+    /// an adapter-visible status ([`Installed`](ObjectStatus::Installed) or
+    /// [`Adopted`](ObjectStatus::Adopted)). Returns the full
+    /// [`VisibleRoot`] so callers can scope contract resolution to the
+    /// paired datadir roots.
+    fn find_component_visible_root(
         &self,
         component: &str,
         current_state: &InstalledState,
-    ) -> Result<Option<PathBuf>, AdapterError> {
-        for state_dir in &self.state_roots {
-            let installed = if state_dir == &self.layout.state_dir {
+    ) -> Result<Option<&VisibleRoot>, AdapterError> {
+        for vr in &self.visible_roots {
+            let visible = if vr.state_dir == self.layout.state_dir {
                 current_state
                     .find_object(ObjectKind::Component, component)
-                    .is_some()
+                    .is_some_and(|obj| is_adapter_visible_status(obj.status))
             } else {
-                let state_path = state_dir.join("installed.toml");
+                let state_path = vr.state_dir.join("installed.toml");
                 InstalledState::load(&state_path)?
                     .find_object(ObjectKind::Component, component)
-                    .is_some()
+                    .is_some_and(|obj| is_adapter_visible_status(obj.status))
             };
-            if installed {
-                return Ok(Some(state_dir.clone()));
+            if visible {
+                return Ok(Some(vr));
             }
         }
         Ok(None)
     }
 
-    /// Adapter declarations from installed component manifests in visible
-    /// state roots. Earlier roots shadow later roots for the same component,
-    /// matching enable's user-before-system resolution.
+    /// Adapter declarations from component contracts visible to the
+    /// manager. Uses the same scope-paired contract resolution as `enable`
+    /// so scan and enable agree.
+    ///
+    /// When a component appears in multiple visible roots (e.g. user and
+    /// system), only the first (highest-priority) root owns the
+    /// resolution — its paired state snapshot and datadir roots are
+    /// searched. A lower-priority root's contract is never used as a
+    /// fallback.
     fn load_visible_adapter_declarations(
         &self,
         current_state: &InstalledState,
     ) -> (Vec<AdapterDecl>, Vec<String>) {
         let mut declarations = BTreeSet::new();
-        let mut seen_components = BTreeSet::new();
+        // Map component name → the VisibleRoot where it was first seen.
+        let mut component_vr: BTreeMap<String, &VisibleRoot> = BTreeMap::new();
         let mut warnings = Vec::new();
 
-        for state_dir in &self.state_roots {
-            let state_path = state_dir.join("installed.toml");
-            let state = if state_dir == &self.layout.state_dir {
+        for vr in &self.visible_roots {
+            let state_path = vr.state_dir.join("installed.toml");
+            let state = if vr.state_dir == self.layout.state_dir {
                 current_state.clone()
             } else {
                 match InstalledState::load(&state_path) {
@@ -711,46 +789,63 @@ impl AdapterManager {
                 .objects
                 .iter()
                 .filter(|object| object.kind == ObjectKind::Component)
-                .filter(|object| object.status == ObjectStatus::Installed)
+                .filter(|object| is_adapter_visible_status(object.status))
             {
-                if !seen_components.insert(object.name.clone()) {
-                    continue;
-                }
+                component_vr.entry(object.name.clone()).or_insert(vr);
+            }
+        }
 
-                let path = installed_component_manifest_path(state_dir, &object.name);
-                if !path.exists() {
-                    warnings.push(format!(
-                        "installed component '{}' has no local component manifest at {}",
-                        object.name,
-                        path.display()
-                    ));
-                    continue;
-                }
-                let manifest = match ComponentManifest::from_file(&path) {
-                    Ok(manifest) => manifest,
-                    Err(err) => {
+        for (component, vr) in &component_vr {
+            let manifest = match super::contract::resolve_component_contract(
+                component,
+                &[vr.state_dir.clone()],
+                &vr.contract_datadir_roots,
+            ) {
+                Ok(m) => m,
+                Err(super::contract::ContractError::Unavailable { .. }) => {
+                    let other_scope_exists = self.visible_roots.iter().any(|other| {
+                        other.state_dir != vr.state_dir
+                            && super::contract::resolve_component_contract(
+                                component,
+                                &[other.state_dir.clone()],
+                                &other.contract_datadir_roots,
+                            )
+                            .is_ok()
+                    });
+                    if other_scope_exists {
                         warnings.push(format!(
-                            "failed to read installed component manifest for '{}' at {}: {err}",
-                            object.name,
-                            path.display()
+                            "installed component '{component}' has no component contract in its scope; a contract exists in another scope but was not used because the component is scoped to {}", vr.state_dir.display()
                         ));
-                        continue;
+                    } else {
+                        warnings.push(format!(
+                            "installed component '{component}' has no component contract; adapter declarations unavailable"
+                        ));
                     }
-                };
-                if manifest.component.name != object.name {
+                    continue;
+                }
+                Err(err) => {
                     warnings.push(format!(
-                        "installed component manifest at {} declares component '{}', expected '{}'",
-                        path.display(),
-                        manifest.component.name,
-                        object.name
+                        "failed to read component contract for '{component}': {err}"
                     ));
                     continue;
                 }
+            };
+            if manifest.component.name != component.as_str() {
+                warnings.push(format!(
+                    "component contract for '{component}' declares component '{}', expected '{component}'",
+                    manifest.component.name,
+                ));
+                continue;
+            }
 
-                for framework in declared_frameworks(&manifest) {
+            for adapter in &manifest.adapters {
+                if let Some(framework) = adapter.framework.as_deref().map(str::trim)
+                    && !framework.is_empty()
+                {
                     declarations.insert(AdapterDecl {
-                        component: object.name.clone(),
-                        framework,
+                        component: component.clone(),
+                        framework: framework.to_string(),
+                        adapter_type: adapter.adapter_type.clone(),
                     });
                 }
             }
@@ -762,7 +857,7 @@ impl AdapterManager {
     /// First datadir root that contains
     /// `adapters/<component>/<framework>/` as a directory.
     fn discover_resource_root(&self, component: &str, framework: &str) -> Option<PathBuf> {
-        for root in &self.datadir_roots {
+        for root in &self.all_datadir_roots {
             let candidate = root.join("adapters").join(component).join(framework);
             if candidate.is_dir() {
                 return Some(candidate);
@@ -776,7 +871,7 @@ impl AdapterManager {
     fn discover_all(&self) -> Vec<(String, String, PathBuf)> {
         let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
         let mut out: Vec<(String, String, PathBuf)> = Vec::new();
-        for root in &self.datadir_roots {
+        for root in &self.all_datadir_roots {
             let adapters = root.join("adapters");
             let Ok(components) = adapters.read_dir() else {
                 continue;
@@ -1053,11 +1148,30 @@ fn install_mode_str(mode: InstallMode) -> &'static str {
     }
 }
 
-fn installed_component_manifest_path(state_dir: &Path, component: &str) -> PathBuf {
-    state_dir
-        .join(INSTALLED_COMPONENT_MANIFESTS_SUBDIR)
-        .join(component)
-        .join(INSTALLED_COMPONENT_MANIFEST_FILE)
+/// Map a [`super::contract::ContractError`] to the existing [`AdapterError`]
+/// family for backward-compatible CLI rendering.
+fn map_contract_error(component: &str, err: super::contract::ContractError) -> AdapterError {
+    match err {
+        super::contract::ContractError::Unavailable { searched, .. } => {
+            AdapterError::AdapterManifest {
+                component: component.to_string(),
+                path: searched.into_iter().next().unwrap_or_default(),
+                reason: "component contract not found in the matched component scope".to_string(),
+            }
+        }
+        super::contract::ContractError::ParseError { path, reason } => {
+            AdapterError::AdapterManifest {
+                component: component.to_string(),
+                path,
+                reason,
+            }
+        }
+        super::contract::ContractError::Io { path, source } => AdapterError::AdapterManifest {
+            component: component.to_string(),
+            path,
+            reason: source.to_string(),
+        },
+    }
 }
 
 fn declared_frameworks(manifest: &ComponentManifest) -> Vec<String> {
@@ -1070,6 +1184,26 @@ fn declared_frameworks(manifest: &ComponentManifest) -> Vec<String> {
         }
     }
     set.into_iter().collect()
+}
+
+/// Extract the `adapter_type` from the first `[[adapters]]` entry whose
+/// `framework` matches. Returns `None` when the manifest omits the field
+/// (which the caller treats as defaulting to `"plugin"`).
+fn declared_adapter_type(manifest: &ComponentManifest, framework: &str) -> Option<String> {
+    manifest
+        .adapters
+        .iter()
+        .find(|adapter| adapter.framework.as_deref().map(str::trim) == Some(framework))
+        .and_then(|adapter| adapter.adapter_type.as_deref())
+        .map(str::trim)
+        .filter(|at| !at.is_empty())
+        .map(str::to_string)
+}
+
+/// Whether a component status makes it visible to adapter scan/enable.
+/// Both fully-installed and adopted components should be adapter-visible.
+fn is_adapter_visible_status(status: ObjectStatus) -> bool {
+    matches!(status, ObjectStatus::Installed | ObjectStatus::Adopted)
 }
 
 fn declared_plugin_id(manifest: &ComponentManifest, framework: &str) -> Option<String> {
@@ -1180,5 +1314,420 @@ mod tests {
         };
         let err = run_capture(&cmd).expect_err("spawn must fail");
         assert!(matches!(err, AdapterError::FrameworkCli { .. }));
+    }
+
+    // -- declared_adapter_type ------------------------------------------------
+
+    fn manifest_with_adapter_type(adapter_type: Option<&str>) -> ComponentManifest {
+        use crate::manifest::*;
+        ComponentManifest {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            component: ComponentMeta {
+                name: "test-comp".to_string(),
+                version: "0.1.0".to_string(),
+                layer: "runtime".to_string(),
+                domain: None,
+                display_name: None,
+                owner: None,
+                license: None,
+                repository: None,
+            },
+            contract: ContractSpec::default(),
+            artifact: ArtifactSpec::default(),
+            source: SourceSpec::default(),
+            distribution_selectors: Vec::new(),
+            build: BuildSpec::default(),
+            install: InstallSpec::default(),
+            backends: ManifestBackends::default(),
+            env_requirements: EnvRequirements::default(),
+            dependencies: DependenciesSpec::default(),
+            features: Vec::new(),
+            adapters: vec![AdapterSpec {
+                framework: Some("openclaw".to_string()),
+                adapter_type: adapter_type.map(str::to_string),
+                ..Default::default()
+            }],
+            health_check: None,
+            health_checks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn declared_adapter_type_returns_plugin() {
+        let manifest = manifest_with_adapter_type(Some("plugin"));
+        assert_eq!(
+            declared_adapter_type(&manifest, "openclaw"),
+            Some("plugin".to_string())
+        );
+    }
+
+    #[test]
+    fn declared_adapter_type_returns_none_when_absent() {
+        let manifest = manifest_with_adapter_type(None);
+        assert_eq!(declared_adapter_type(&manifest, "openclaw"), None);
+    }
+
+    #[test]
+    fn declared_adapter_type_returns_skill_bundle() {
+        let manifest = manifest_with_adapter_type(Some("skill_bundle"));
+        assert_eq!(
+            declared_adapter_type(&manifest, "openclaw"),
+            Some("skill_bundle".to_string())
+        );
+    }
+
+    #[test]
+    fn declared_adapter_type_returns_none_for_wrong_framework() {
+        let manifest = manifest_with_adapter_type(Some("plugin"));
+        assert_eq!(declared_adapter_type(&manifest, "hermes"), None);
+    }
+
+    #[test]
+    fn unsupported_adapter_type_error_contains_details() {
+        let err = AdapterError::UnsupportedAdapterType {
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            adapter_type: "skill_bundle".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("skill_bundle"));
+        assert!(msg.contains("tokenless"));
+        assert!(msg.contains("openclaw"));
+        assert!(msg.contains("only 'plugin' is implemented"));
+    }
+
+    #[test]
+    fn unsupported_adapter_type_extension() {
+        let err = AdapterError::UnsupportedAdapterType {
+            component: "agentsight".to_string(),
+            framework: "openclaw".to_string(),
+            adapter_type: "extension".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("extension"));
+        assert!(msg.contains("agentsight"));
+    }
+
+    #[test]
+    fn unsupported_adapter_type_unknown_value() {
+        let err = AdapterError::UnsupportedAdapterType {
+            component: "agentsight".to_string(),
+            framework: "openclaw".to_string(),
+            adapter_type: "magic".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("magic"));
+        assert!(msg.contains("only 'plugin' is implemented"));
+    }
+
+    #[test]
+    fn plugin_adapter_type_passes_gate() {
+        let manifest = manifest_with_adapter_type(Some("plugin"));
+        let at = declared_adapter_type(&manifest, "openclaw");
+        let should_reject = at.as_ref().is_some_and(|t| t != "plugin");
+        assert!(!should_reject, "plugin must pass the gate");
+    }
+
+    #[test]
+    fn absent_adapter_type_passes_gate() {
+        let manifest = manifest_with_adapter_type(None);
+        let at = declared_adapter_type(&manifest, "openclaw");
+        let should_reject = at.as_ref().is_some_and(|t| t != "plugin");
+        assert!(!should_reject, "absent adapter_type must pass the gate");
+    }
+
+    #[test]
+    fn skill_bundle_adapter_type_fails_gate() {
+        let manifest = manifest_with_adapter_type(Some("skill_bundle"));
+        let at = declared_adapter_type(&manifest, "openclaw");
+        let should_reject = at.as_ref().is_some_and(|t| t != "plugin");
+        assert!(should_reject, "skill_bundle must be rejected");
+    }
+
+    // -- scan with Adopted + datadir-only contract ----------------------------
+
+    /// Regression: an RPM-adopted component with no state snapshot but a
+    /// datadir contract must still appear as `declared=true` in scan, and
+    /// its `adapter_type` must be surfaced.
+    #[test]
+    fn scan_adopted_component_with_datadir_only_contract() {
+        use crate::state::{InstalledObject, ObjectKind, ObjectStatus, Ownership};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        // Write installed.toml with an Adopted component, no snapshot.
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "sec-core".to_string(),
+            version: "0.1.0".to_string(),
+            status: ObjectStatus::Adopted,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmObserved),
+            rpm_metadata: None,
+            installed_at: "2026-06-18T00:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: false,
+            adopted: true,
+            subscription_scope: crate::state::SubscriptionScope::None,
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        std::fs::create_dir_all(&state_dir).expect("mkdir state");
+        state
+            .save(&state_dir.join("installed.toml"))
+            .expect("save state");
+
+        // Write a datadir contract (no state snapshot).
+        let contract = r#"
+[component]
+name = "sec-core"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "sec-core"
+source = "adapters/openclaw"
+dest = "{datadir}/adapters/{component}/openclaw/"
+"#;
+        let contract_dir = datadir.join("components").join("sec-core");
+        std::fs::create_dir_all(&contract_dir).expect("mkdir contract");
+        std::fs::write(contract_dir.join("component.toml"), contract).expect("write contract");
+
+        // Build a manager pointing at our temp dirs.
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager =
+            AdapterManager::new(layout, Some(tmp.path().to_path_buf()), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.clone(),
+            contract_datadir_roots: vec![datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![datadir.clone()];
+
+        let report = manager.scan().expect("scan");
+
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw")
+            .expect("sec-core/openclaw should be in scan results");
+        assert!(
+            entry.declared,
+            "adopted component with datadir contract must be declared"
+        );
+        assert_eq!(
+            entry.adapter_type.as_deref(),
+            Some("plugin"),
+            "adapter_type must be surfaced from the contract"
+        );
+    }
+
+    // -- user/system scope isolation ------------------------------------------
+
+    fn valid_contract_toml(name: &str) -> String {
+        format!(
+            r#"
+[component]
+name = "{name}"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "{name}"
+source = "adapters/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+"#
+        )
+    }
+
+    fn seed_installed_state(state_dir: &std::path::Path, component: &str, status: ObjectStatus) {
+        use crate::state::{InstalledObject, ObjectKind, Ownership, SubscriptionScope};
+
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: "0.1.0".to_string(),
+            status,
+            manifest_digest: None,
+            distribution_source: None,
+            install_backend: Some(if status == ObjectStatus::Adopted {
+                "rpm".to_string()
+            } else {
+                "raw".to_string()
+            }),
+            ownership: Some(if status == ObjectStatus::Adopted {
+                Ownership::RpmObserved
+            } else {
+                Ownership::RawManaged
+            }),
+            rpm_metadata: None,
+            installed_at: "2026-06-18T00:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: status != ObjectStatus::Adopted,
+            adopted: status == ObjectStatus::Adopted,
+            subscription_scope: SubscriptionScope::None,
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        std::fs::create_dir_all(state_dir).expect("mkdir state");
+        state
+            .save(&state_dir.join("installed.toml"))
+            .expect("save state");
+    }
+
+    fn write_contract(datadir: &std::path::Path, component: &str) {
+        let dir = datadir.join("components").join(component);
+        std::fs::create_dir_all(&dir).expect("mkdir contract");
+        std::fs::write(dir.join("component.toml"), valid_contract_toml(component))
+            .expect("write contract");
+    }
+
+    /// User component must NOT fall back to system datadir contract.
+    #[test]
+    fn user_component_does_not_fallback_to_system_contract() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let user_state = tmp.path().join("user_state");
+        let user_data = tmp.path().join("user_data");
+        let sys_state = tmp.path().join("sys_state");
+        let sys_data = tmp.path().join("sys_data");
+
+        // User state has tokenless installed, no contract anywhere in user scope.
+        seed_installed_state(&user_state, "tokenless", ObjectStatus::Installed);
+        // System datadir has a valid contract.
+        write_contract(&sys_data, "tokenless");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager =
+            AdapterManager::new(layout, Some(tmp.path().to_path_buf()), "test".into());
+        manager.state_path = user_state.join("installed.toml");
+        manager.visible_roots = vec![
+            VisibleRoot {
+                state_dir: user_state.clone(),
+                contract_datadir_roots: vec![user_data.clone()],
+            },
+            VisibleRoot {
+                state_dir: sys_state.clone(),
+                contract_datadir_roots: vec![sys_data.clone()],
+            },
+        ];
+        manager.all_datadir_roots = vec![user_data, sys_data];
+
+        // Scan: tokenless must NOT be declared (no user contract).
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "openclaw");
+        assert!(
+            entry.is_none() || !entry.unwrap().declared,
+            "user component must not use system contract"
+        );
+        assert!(
+            report.warnings.iter().any(|w| w.contains("tokenless")
+                && w.contains("no component contract")
+                && w.contains("another scope")),
+            "scan must warn that user contract is missing and system exists, got: {:?}",
+            report.warnings
+        );
+    }
+
+    /// System component can use system/packaged datadir contract.
+    #[test]
+    fn system_component_uses_system_datadir_contract() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sys_state = tmp.path().join("sys_state");
+        let sys_data = tmp.path().join("sys_data");
+        let pkg_data = tmp.path().join("pkg_data");
+
+        seed_installed_state(&sys_state, "tokenless", ObjectStatus::Installed);
+        // Contract in pkg_data (simulates /usr/share vs /usr/local/share).
+        write_contract(&pkg_data, "tokenless");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager =
+            AdapterManager::new(layout, Some(tmp.path().to_path_buf()), "test".into());
+        manager.state_path = sys_state.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: sys_state.clone(),
+            contract_datadir_roots: vec![sys_data, pkg_data.clone()],
+        }];
+        manager.all_datadir_roots = vec![pkg_data];
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "openclaw")
+            .expect("tokenless/openclaw should be declared");
+        assert!(
+            entry.declared,
+            "system component must find contract in packaged datadir"
+        );
+    }
+
+    /// User-mode scan includes system-installed component via system
+    /// visible root (contract resolved from system datadir).
+    #[test]
+    fn user_scan_includes_system_component_via_system_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let user_state = tmp.path().join("user_state");
+        let user_data = tmp.path().join("user_data");
+        let sys_state = tmp.path().join("sys_state");
+        let sys_data = tmp.path().join("sys_data");
+
+        // Only system state has tokenless; contract in system datadir.
+        seed_installed_state(&sys_state, "tokenless", ObjectStatus::Installed);
+        write_contract(&sys_data, "tokenless");
+
+        // User state is empty.
+        std::fs::create_dir_all(&user_state).expect("mkdir user_state");
+        InstalledState::default()
+            .save(&user_state.join("installed.toml"))
+            .expect("save empty user state");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager =
+            AdapterManager::new(layout, Some(tmp.path().to_path_buf()), "test".into());
+        manager.state_path = user_state.join("installed.toml");
+        manager.visible_roots = vec![
+            VisibleRoot {
+                state_dir: user_state,
+                contract_datadir_roots: vec![user_data],
+            },
+            VisibleRoot {
+                state_dir: sys_state,
+                contract_datadir_roots: vec![sys_data],
+            },
+        ];
+
+        // scan must find tokenless via the system root.
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "openclaw")
+            .expect("tokenless/openclaw should be in scan");
+        assert!(
+            entry.declared,
+            "system component must be declared via system root"
+        );
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -357,8 +357,9 @@ pub struct AdapterSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     /// Adapter type within the framework (`plugin`, `extension`,
-    /// `service`, ...). Informational; driver behavior is not keyed on
-    /// this value.
+    /// `service`, `skill_bundle`, ...). The adapter manager gates on this
+    /// value: only `"plugin"` (or absent/`None`, defaulting to plugin) is
+    /// supported; all other values are rejected at enable time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub adapter_type: Option<String>,
     /// Trust level (`first-party`, `third-party`, `protocol`). Separate

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -347,12 +347,24 @@ pub struct AdapterSpec {
     /// Adapter display or manifest name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Human-facing adapter label for CLI output and documentation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     /// Framework this adapter targets.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub framework: Option<String>,
     /// Adapter kind (`first-party`, `third-party`, `protocol`, ...).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
+    /// Adapter type within the framework (`plugin`, `extension`,
+    /// `service`, ...). Informational; driver behavior is not keyed on
+    /// this value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adapter_type: Option<String>,
+    /// Trust level (`first-party`, `third-party`, `protocol`). Separate
+    /// from `kind` so both dimensions remain usable independently.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust: Option<String>,
     /// Framework-native plugin identifier, when one exists.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_id: Option<String>,
@@ -362,9 +374,56 @@ pub struct AdapterSpec {
     /// Destination path after layout placeholder expansion.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dest: Option<String>,
+    /// Bundle description: how the driver should read the adapter's
+    /// resource directory.
+    #[serde(default, skip_serializing_if = "AdapterBundleSpec::is_empty")]
+    pub bundle: AdapterBundleSpec,
+    /// Compatibility metadata: driver schema and framework version
+    /// constraints.
+    #[serde(default, skip_serializing_if = "AdapterCompatSpec::is_empty")]
+    pub compat: AdapterCompatSpec,
     /// Framework-specific detection hints preserved as TOML values.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub detect: BTreeMap<String, toml::Value>,
+}
+
+/// Bundle description for an adapter resource directory. The driver uses
+/// `entry` as a hint to locate the framework-native manifest inside the
+/// bundle; it is NOT an executable path.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AdapterBundleSpec {
+    /// Bundle schema version, for future evolution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<u32>,
+    /// Entry-point file inside the bundle directory (e.g.
+    /// `"plugin.json"`). The driver reads this file to understand the
+    /// bundle; it is never executed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry: Option<String>,
+}
+
+impl AdapterBundleSpec {
+    fn is_empty(&self) -> bool {
+        self.schema.is_none() && self.entry.is_none()
+    }
+}
+
+/// Compatibility metadata for an adapter entry. Lets packaging and the
+/// driver gate on schema evolution and framework version constraints.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AdapterCompatSpec {
+    /// Driver-side schema version this adapter targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub driver_schema: Option<u32>,
+    /// Semver constraint on the target framework, e.g. `">=0.1.0"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub framework_version: Option<String>,
+}
+
+impl AdapterCompatSpec {
+    fn is_empty(&self) -> bool {
+        self.driver_schema.is_none() && self.framework_version.is_none()
+    }
 }
 
 /// One `[[health_checks]]` entry. Multiple checks per component are
@@ -617,9 +676,15 @@ struct AdapterRaw {
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
     framework: Option<String>,
     #[serde(default)]
     kind: Option<String>,
+    #[serde(default)]
+    adapter_type: Option<String>,
+    #[serde(default)]
+    trust: Option<String>,
     #[serde(default)]
     plugin_id: Option<String>,
     #[serde(default)]
@@ -627,7 +692,27 @@ struct AdapterRaw {
     #[serde(default)]
     dest: Option<String>,
     #[serde(default)]
+    bundle: AdapterBundleRaw,
+    #[serde(default)]
+    compat: AdapterCompatRaw,
+    #[serde(default)]
     detect: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Deserialize, Default)]
+struct AdapterBundleRaw {
+    #[serde(default)]
+    schema: Option<u32>,
+    #[serde(default)]
+    entry: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct AdapterCompatRaw {
+    #[serde(default)]
+    driver_schema: Option<u32>,
+    #[serde(default)]
+    framework_version: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -794,11 +879,22 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             .into_iter()
             .map(|a| AdapterSpec {
                 name: a.name,
+                display_name: a.display_name,
                 framework: a.framework,
                 kind: a.kind,
+                adapter_type: a.adapter_type,
+                trust: a.trust,
                 plugin_id: a.plugin_id,
                 source: a.source,
                 dest: a.dest,
+                bundle: AdapterBundleSpec {
+                    schema: a.bundle.schema,
+                    entry: a.bundle.entry,
+                },
+                compat: AdapterCompatSpec {
+                    driver_schema: a.compat.driver_schema,
+                    framework_version: a.compat.framework_version,
+                },
                 detect: a.detect,
             })
             .collect();
@@ -1613,6 +1709,177 @@ mod tests {
             Some("agentsight.service")
         );
         assert_eq!(m.health_checks[1].optional, Some(true));
+    }
+
+    #[test]
+    fn adapter_new_fields_parse_full_example() {
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.1.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            name = "sec-core-openclaw"
+            display_name = "Sec Core for OpenClaw"
+            adapter_type = "plugin"
+            trust = "first-party"
+            plugin_id = "sec-core"
+            source = "adapters/openclaw"
+            dest = "{datadir}/adapters/{component}/openclaw/"
+
+            [adapters.bundle]
+            schema = 1
+            entry = "plugin.json"
+
+            [adapters.compat]
+            driver_schema = 1
+            framework_version = ">=0.1.0"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.adapters.len(), 1);
+        let a = &m.adapters[0];
+        assert_eq!(a.name.as_deref(), Some("sec-core-openclaw"));
+        assert_eq!(a.display_name.as_deref(), Some("Sec Core for OpenClaw"));
+        assert_eq!(a.framework.as_deref(), Some("openclaw"));
+        assert_eq!(a.adapter_type.as_deref(), Some("plugin"));
+        assert_eq!(a.trust.as_deref(), Some("first-party"));
+        assert_eq!(a.plugin_id.as_deref(), Some("sec-core"));
+        assert_eq!(a.source.as_deref(), Some("adapters/openclaw"));
+        assert_eq!(
+            a.dest.as_deref(),
+            Some("{datadir}/adapters/{component}/openclaw/")
+        );
+        assert_eq!(a.bundle.schema, Some(1));
+        assert_eq!(a.bundle.entry.as_deref(), Some("plugin.json"));
+        assert_eq!(a.compat.driver_schema, Some(1));
+        assert_eq!(a.compat.framework_version.as_deref(), Some(">=0.1.0"));
+    }
+
+    #[test]
+    fn adapter_new_fields_round_trip() {
+        let toml_text = r#"
+            [component]
+            name = "roundtrip"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            name = "rt-adapter"
+            display_name = "RT Adapter"
+            adapter_type = "extension"
+            trust = "third-party"
+            plugin_id = "rt"
+            source = "adapters/openclaw"
+            dest = "{datadir}/adapters/{component}/openclaw/"
+
+            [adapters.bundle]
+            schema = 2
+            entry = "manifest.json"
+
+            [adapters.compat]
+            driver_schema = 3
+            framework_version = ">=1.0.0"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        let m2 = ComponentManifest::from_toml_str(&serialized).expect("re-parse");
+        assert_eq!(
+            m.adapters, m2.adapters,
+            "round-trip must preserve all adapter fields"
+        );
+    }
+
+    #[test]
+    fn adapter_minimal_fields_still_parse() {
+        let toml_text = r#"
+            [component]
+            name = "minimal"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            source = "adapters/openclaw"
+            dest = "{datadir}/adapters/{component}/openclaw/"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.adapters.len(), 1);
+        let a = &m.adapters[0];
+        assert_eq!(a.framework.as_deref(), Some("openclaw"));
+        assert!(a.display_name.is_none());
+        assert!(a.adapter_type.is_none());
+        assert!(a.trust.is_none());
+        assert!(a.bundle.is_empty());
+        assert!(a.compat.is_empty());
+    }
+
+    #[test]
+    fn adapter_empty_adapters_array_still_parses() {
+        let toml_text = r#"
+            [component]
+            name = "no-adapters"
+            version = "1.0.0"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert!(m.adapters.is_empty());
+    }
+
+    #[test]
+    fn adapter_new_fields_default_to_none_when_absent() {
+        let toml_text = r#"
+            [component]
+            name = "agentsight"
+            version = "0.2.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            kind = "third-party"
+            plugin_id = "agentsight-openclaw"
+            source = "adapters/agentsight/openclaw"
+            dest = "{datadir}/adapters/{component}/openclaw/"
+
+            [adapters.detect]
+            config_path = "~/.openclaw/config.toml"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let a = &m.adapters[0];
+        assert!(a.display_name.is_none());
+        assert!(a.adapter_type.is_none());
+        assert!(a.trust.is_none());
+        assert!(a.bundle.schema.is_none());
+        assert!(a.bundle.entry.is_none());
+        assert!(a.compat.driver_schema.is_none());
+        assert!(a.compat.framework_version.is_none());
+        // Existing fields preserved.
+        assert_eq!(a.kind.as_deref(), Some("third-party"));
+        assert_eq!(
+            a.detect.get("config_path").and_then(|v| v.as_str()),
+            Some("~/.openclaw/config.toml")
+        );
+    }
+
+    #[test]
+    fn adapter_bundle_and_compat_skip_serializing_when_empty() {
+        let toml_text = r#"
+            [component]
+            name = "skiptest"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "cosh"
+            source = "adapters/cosh"
+            dest = "{datadir}/adapters/{component}/cosh/"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        assert!(
+            !serialized.contains("[bundle]"),
+            "empty bundle must be skipped in serialization"
+        );
+        assert!(
+            !serialized.contains("[compat]"),
+            "empty compat must be skipped in serialization"
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -302,8 +302,10 @@ fn user_layout_enable_accepts_system_installed_component() {
 
     let mut manager =
         AdapterManager::new(user_layout.clone(), Some(user_home), "tester".to_string());
-    manager.push_datadir_root(system_layout.datadir.clone());
-    manager.push_state_root(system_layout.state_dir.clone());
+    manager.push_visible_root(anolisa_core::adapter::manager::VisibleRoot {
+        state_dir: system_layout.state_dir.clone(),
+        contract_datadir_roots: vec![system_layout.datadir.clone()],
+    });
 
     manager
         .enable(COMPONENT, Some(FRAMEWORK), false)
@@ -580,7 +582,10 @@ fn user_scan_includes_system_state_declaration() {
     std::fs::create_dir_all(&user_home).expect("home");
     let user_layout = FsLayout::user(user_home.clone());
     let mut manager = AdapterManager::new(user_layout, Some(user_home), "tester".to_string());
-    manager.push_state_root(system_layout.state_dir.clone());
+    manager.push_visible_root(anolisa_core::adapter::manager::VisibleRoot {
+        state_dir: system_layout.state_dir.clone(),
+        contract_datadir_roots: vec![system_layout.datadir.clone()],
+    });
 
     let report = manager.scan().expect("scan");
     let entry = report

--- a/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
+++ b/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
@@ -21,6 +21,15 @@ use std::path::{Path, PathBuf};
 
 /// Application namespace folder appended to most FHS / file-hierarchy roots.
 const NS: &str = "anolisa";
+/// Subdirectory under `datadir` where package-owned component contracts
+/// are installed (e.g. `{datadir}/components/<component>/component.toml`).
+const COMPONENTS_SUBDIR: &str = "components";
+/// Subdirectory under `state_dir` where ANOLISA stores its runtime copy of
+/// component contracts after install/adopt.
+const COMPONENT_MANIFESTS_SUBDIR: &str = "component-manifests";
+/// Filename used for both the package-owned component contract and the
+/// runtime state snapshot.
+const COMPONENT_MANIFEST_FILE: &str = "component.toml";
 /// Audit-log file name written under `log_dir`.
 const CENTRAL_LOG_NAME: &str = "central.jsonl";
 /// Lock file name written under `state_dir`.
@@ -269,6 +278,48 @@ impl FsLayout {
             manifests_overlay,
             systemd_unit_dir,
         }
+    }
+
+    /// Package-owned component contract path under this layout's datadir:
+    /// `{datadir}/components/<component>/component.toml`.
+    ///
+    /// RPM packages and raw archives install the ANOLISA component
+    /// contract at this location. The path derives from [`Self::datadir`],
+    /// so it respects system-mode prefixes and user-mode XDG overrides.
+    pub fn contract_path(&self, component: &str) -> PathBuf {
+        Self::component_contract_path(&self.datadir, component)
+    }
+
+    /// Installed-state snapshot path under this layout's state_dir:
+    /// `{state_dir}/component-manifests/<component>/component.toml`.
+    ///
+    /// ANOLISA copies the resolved contract into this location after
+    /// install or adopt. Commands such as `adapter enable` read from here
+    /// first, falling back to the package-owned contract when absent.
+    pub fn snapshot_path(&self, component: &str) -> PathBuf {
+        Self::component_manifest_snapshot_path(&self.state_dir, component)
+    }
+
+    /// Package-owned component contract path under an arbitrary datadir root.
+    ///
+    /// Use this when computing candidates across multiple roots; for a
+    /// single layout prefer [`Self::contract_path`].
+    pub fn component_contract_path(datadir_root: &Path, component: &str) -> PathBuf {
+        datadir_root
+            .join(COMPONENTS_SUBDIR)
+            .join(component)
+            .join(COMPONENT_MANIFEST_FILE)
+    }
+
+    /// Installed-state snapshot path under an arbitrary state root.
+    ///
+    /// Use this when computing candidates across multiple roots; for a
+    /// single layout prefer [`Self::snapshot_path`].
+    pub fn component_manifest_snapshot_path(state_root: &Path, component: &str) -> PathBuf {
+        state_root
+            .join(COMPONENT_MANIFESTS_SUBDIR)
+            .join(component)
+            .join(COMPONENT_MANIFEST_FILE)
     }
 }
 
@@ -538,6 +589,79 @@ mod tests {
         assert_eq!(
             with_runtime.runtime_dir,
             PathBuf::from("/run/user/42/anolisa")
+        );
+    }
+
+    // ---- component contract paths ----------------------------------------
+
+    #[test]
+    fn system_component_contract_path_derives_from_datadir() {
+        let layout = FsLayout::system(None);
+        assert_eq!(
+            layout.contract_path("sec-core"),
+            PathBuf::from("/usr/local/share/anolisa/components/sec-core/component.toml")
+        );
+    }
+
+    #[test]
+    fn system_component_manifest_snapshot_path_derives_from_state_dir() {
+        let layout = FsLayout::system(None);
+        assert_eq!(
+            layout.snapshot_path("sec-core"),
+            PathBuf::from("/var/lib/anolisa/component-manifests/sec-core/component.toml")
+        );
+    }
+
+    #[test]
+    fn system_component_contract_path_with_prefix() {
+        let layout = FsLayout::system(Some(PathBuf::from("/opt/x")));
+        assert_eq!(
+            layout.contract_path("tokenless"),
+            PathBuf::from("/opt/x/usr/local/share/anolisa/components/tokenless/component.toml")
+        );
+        assert_eq!(
+            layout.snapshot_path("tokenless"),
+            PathBuf::from("/opt/x/var/lib/anolisa/component-manifests/tokenless/component.toml")
+        );
+    }
+
+    #[test]
+    fn user_component_contract_path_derives_from_datadir() {
+        let layout = user_no_overrides("/tmp/h");
+        assert_eq!(
+            layout.contract_path("os-skills"),
+            PathBuf::from("/tmp/h/.local/share/anolisa/components/os-skills/component.toml")
+        );
+    }
+
+    #[test]
+    fn user_component_manifest_snapshot_path_derives_from_state_dir() {
+        let layout = user_no_overrides("/tmp/h");
+        assert_eq!(
+            layout.snapshot_path("os-skills"),
+            PathBuf::from(
+                "/tmp/h/.local/state/anolisa/component-manifests/os-skills/component.toml"
+            )
+        );
+    }
+
+    #[test]
+    fn user_component_contract_path_honors_xdg_overrides() {
+        let layout = FsLayout::user_with_overrides(
+            PathBuf::from("/tmp/h"),
+            Some(PathBuf::from("/data")),
+            None,
+            Some(PathBuf::from("/state")),
+            None,
+            None,
+        );
+        assert_eq!(
+            layout.contract_path("sec-core"),
+            PathBuf::from("/data/anolisa/components/sec-core/component.toml")
+        );
+        assert_eq!(
+            layout.snapshot_path("sec-core"),
+            PathBuf::from("/state/anolisa/component-manifests/sec-core/component.toml")
         );
     }
 }

--- a/src/anolisa/docs/COMPONENT_CONTRACT.md
+++ b/src/anolisa/docs/COMPONENT_CONTRACT.md
@@ -1,0 +1,132 @@
+# ANOLISA Component Contract
+
+This document defines where a packaged component exposes its ANOLISA
+component contract and how ANOLISA should consume that contract across RPM and
+raw backends.
+
+## Package Location
+
+RPM packages that expose ANOLISA component metadata MUST install the component
+contract at:
+
+```text
+/usr/share/anolisa/components/<component>/component.toml
+```
+
+In RPM spec files, use the datadir macro rather than hard-coding
+`/usr/share`:
+
+```spec
+%global anolisa_component sec-core
+
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/components/%{anolisa_component}
+install -m 0644 .anolisa/component.toml \
+  %{buildroot}%{_datadir}/anolisa/components/%{anolisa_component}/component.toml
+
+%files
+%dir %{_datadir}/anolisa/components
+%dir %{_datadir}/anolisa/components/%{anolisa_component}
+%{_datadir}/anolisa/components/%{anolisa_component}/component.toml
+```
+
+Examples:
+
+```text
+/usr/share/anolisa/components/sec-core/component.toml
+/usr/share/anolisa/components/tokenless/component.toml
+/usr/share/anolisa/components/os-skills/component.toml
+```
+
+## Rationale
+
+`component.toml` is static, package-owned, architecture-independent metadata.
+Under the Filesystem Hierarchy Standard, that makes `/usr/share` the right
+system location.
+
+Do not install the component contract under:
+
+- `/etc`: reserved for administrator-editable configuration.
+- `/var/lib`: reserved for runtime state.
+- `/usr/libexec`: reserved for helper executables.
+- `/opt`: reserved for private package trees, not ANOLISA discovery contracts.
+- `/usr/share/anolisa/adapters/<component>`: reserved for adapter payloads.
+
+The adapter payload tree remains separate:
+
+```text
+/usr/share/anolisa/adapters/<component>/<framework>/...
+```
+
+The component contract is component-level metadata. It may describe adapters,
+services, health checks, files, backend compatibility, and future lifecycle
+behavior, so it should not live inside the adapter namespace.
+
+## User And Raw Installs
+
+For user-mode or raw installs, the same logical datadir layout applies.
+ANOLISA follows the user roots described by `file-hierarchy(7)`: the default
+data root is `~/.local/share`, and `XDG_DATA_HOME` may override that data root.
+
+The default location is:
+
+```text
+~/.local/share/anolisa/components/<component>/component.toml
+```
+
+When `XDG_DATA_HOME` is set, use the overridden data root:
+
+```text
+$XDG_DATA_HOME/anolisa/components/<component>/component.toml
+```
+
+Raw archives may also carry the source contract at:
+
+```text
+.anolisa/component.toml
+```
+
+ANOLISA should normalize that source contract into the installed datadir layout
+or directly into the installed-state snapshot described below.
+
+## Installed-State Snapshot
+
+ANOLISA should keep package-owned contract files separate from its runtime
+state. After install or adopt, ANOLISA may copy the resolved contract into its
+state directory:
+
+```text
+{state_dir}/component-manifests/<component>/component.toml
+```
+
+Typical paths:
+
+```text
+/var/lib/anolisa/component-manifests/<component>/component.toml
+~/.local/state/anolisa/component-manifests/<component>/component.toml
+```
+
+The package-owned contract is the source provided by RPM or raw artifacts. The
+state snapshot is ANOLISA's runtime record and may be used by commands such as
+`anolisa adapter install <component> <framework>` after the component has been
+installed or adopted.
+
+## Discovery Order
+
+For an installed component, ANOLISA should resolve the component contract in
+this order:
+
+1. Existing installed-state snapshot:
+   `{state_dir}/component-manifests/<component>/component.toml`.
+2. Package datadir contract:
+   `{datadir}/components/<component>/component.toml`.
+3. Raw archive source contract during install:
+   `.anolisa/component.toml`.
+
+If an RPM-installed component has no package datadir contract, commands should
+treat adapter declarations as unavailable and report that the RPM does not
+publish an ANOLISA component contract.
+
+## Contract Template
+
+Use `src/anolisa/templates/component-runtime.toml` as the example schema for
+new component contracts.

--- a/src/anolisa/templates/component-runtime.toml
+++ b/src/anolisa/templates/component-runtime.toml
@@ -1,5 +1,17 @@
 # Template: runtime component manifest v2.
 # Copy to src/anolisa/manifests/runtime/<component>.toml.
+#
+# Packaged components that expose this contract to ANOLISA install it at:
+#
+#   /usr/share/anolisa/components/<component>/component.toml
+#
+# RPM specs should use the %{_datadir} macro:
+#
+#   %{_datadir}/anolisa/components/<component>/component.toml
+#
+# Raw archives may carry the source contract at .anolisa/component.toml. During
+# install or adopt, ANOLISA may copy the resolved contract into its state
+# snapshot at {state_dir}/component-manifests/<component>/component.toml.
 
 manifest_version = 2
 anolisa_min_version = "0.1.0"

--- a/src/anolisa/templates/component-runtime.toml
+++ b/src/anolisa/templates/component-runtime.toml
@@ -111,10 +111,21 @@ btf_available = "true"
 
 [[adapters]]
 framework = "openclaw"
-kind = "third-party" # first-party | third-party | protocol
+name = "agentsight-openclaw"
+display_name = "AgentSight for OpenClaw"
+adapter_type = "plugin"            # plugin | extension | service
+trust = "first-party"              # first-party | third-party | protocol
 plugin_id = "agentsight-openclaw"
-source = "adapters/agentsight/openclaw"
+source = "adapters/openclaw"
 dest = "{datadir}/adapters/{component}/openclaw/"
+
+[adapters.bundle]
+schema = 1
+entry = "openclaw.plugin.json"    # driver reads this to understand the bundle; not executed
+
+[adapters.compat]
+driver_schema = 1
+framework_version = ">=0.1.0"
 
 [adapters.detect]
 config_path = "~/.openclaw/config.toml"


### PR DESCRIPTION
## Description

### Ship Note

This PR adds the first-stage adapter manifest contract for ANOLISA components.

What changed:

- Extended `component.toml` adapter schema with display metadata,
  adapter type, trust level, bundle metadata, and compatibility metadata.
- Kept adapter manifests as publishing contracts only; no executable
  commands, scripts, argv, or generic DSL are introduced.
- Updated the runtime component template to use the standardized
  artifact-side adapter layout: `adapters/<framework>`.
- Preserved current install behavior: `anolisa install` only lays adapter
  resources under `{datadir}/adapters/{component}/{framework}/`.

Known limitations:

- This is a foundation step for agent integrations, not the full framework
  implementation.
- No new framework drivers are implemented in this PR.
- RPM package manifest extraction is not implemented here.
- No `adapter install` alias is added; current CLI remains
  `adapter enable/disable/status/scan`.

## Related Issue

refs #998

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran targeted checks:

```bash
cargo fmt --all -- --check
cargo test -p anolisa-core --locked adapter_
cargo test -p anolisa-cli --locked adapter
cargo test -p anolisa-cli --locked install
```

## Additional Notes

This PR intentionally references #998 instead of closing it because #998 tracks
the broader adapter framework integration work across multiple agent platforms.