### PR TITLE
feat(cosh): show authenticated models in /model dialog

### DIFF
--- a/src/copilot-shell/packages/cli/src/config/settingsSchema.ts
+++ b/src/copilot-shell/packages/cli/src/config/settingsSchema.ts
@@ -1091,6 +1091,16 @@ const SETTINGS_SCHEMA = {
             description: 'Last used model name for OpenAI authentication.',
             showInDialog: false,
           },
+          openaiModels: {
+            type: 'array',
+            label: 'OpenAI Models',
+            category: 'Security',
+            requiresRestart: false,
+            default: [] as string[],
+            description:
+              'Recently authenticated model names for OpenAI compatible authentication.',
+            showInDialog: false,
+          },
           aliyunModel: {
             type: 'string',
             label: 'Aliyun Model',
@@ -1098,6 +1108,16 @@ const SETTINGS_SCHEMA = {
             requiresRestart: true,
             default: undefined as string | undefined,
             description: 'Last used model name for Aliyun authentication.',
+            showInDialog: false,
+          },
+          aliyunModels: {
+            type: 'array',
+            label: 'Aliyun Models',
+            category: 'Security',
+            requiresRestart: false,
+            default: [] as string[],
+            description:
+              'Recently authenticated model names for Aliyun authentication.',
             showInDialog: false,
           },
         },

--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1113,6 +1113,8 @@ export default {
     'The latest Qwen Coder model from Alibaba Cloud ModelStudio (version: qwen3-coder-plus-2025-09-23)',
   'The latest Qwen Vision model from Alibaba Cloud ModelStudio (version: qwen3-vl-plus-2025-09-23)':
     'The latest Qwen Vision model from Alibaba Cloud ModelStudio (version: qwen3-vl-plus-2025-09-23)',
+  'Current /auth model': 'Current /auth model',
+  'Verified via /auth': 'Verified via /auth',
 
   // ============================================================================
   // Dialogs - Permissions

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -1054,6 +1054,8 @@ export default {
     '来自阿里云 ModelStudio 的最新 Qwen Coder 模型（版本：qwen3-coder-plus-2025-09-23）',
   'The latest Qwen Vision model from Alibaba Cloud ModelStudio (version: qwen3-vl-plus-2025-09-23)':
     '来自阿里云 ModelStudio 的最新 Qwen Vision 模型（版本：qwen3-vl-plus-2025-09-23）',
+  'Current /auth model': '当前 /auth 模型',
+  'Verified via /auth': '已通过 /auth 验证',
 
   // ============================================================================
   // Dialogs - Permissions

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.test.ts
@@ -126,14 +126,23 @@ describe('useAuthCommand', () => {
     const openaiModelCall = calls.find(
       ([, key]) => key === 'security.auth.openaiModel',
     );
+    const openaiModelsCall = calls.find(
+      ([, key]) => key === 'security.auth.openaiModels',
+    );
     expect(modelNameCall).toBeDefined();
     expect(modelNameCall![2]).toBe('my-model');
     expect(openaiModelCall).toBeDefined();
     expect(openaiModelCall![2]).toBe('my-model');
+    expect(openaiModelsCall).toBeDefined();
+    expect(openaiModelsCall![2]).toEqual(['my-model']);
   });
 
   it('should persist validated fallback model over submitted model', async () => {
     const settings = createMockSettings();
+    settings.merged.security!.auth!.openaiModels = [
+      'qwen3.5-plus',
+      'qwen3-coder-plus',
+    ];
     const config = createMockConfig();
     const addItem = vi.fn();
     vi.mocked(config.refreshAuth).mockResolvedValue(undefined);
@@ -162,10 +171,15 @@ describe('useAuthCommand', () => {
     const openaiModelCall = calls.find(
       ([, key]) => key === 'security.auth.openaiModel',
     );
+    const openaiModelsCall = calls.find(
+      ([, key]) => key === 'security.auth.openaiModels',
+    );
     expect(modelNameCall).toBeDefined();
     expect(modelNameCall![2]).toBe('qwen3-coder-plus');
     expect(openaiModelCall).toBeDefined();
     expect(openaiModelCall![2]).toBe('qwen3-coder-plus');
+    expect(openaiModelsCall).toBeDefined();
+    expect(openaiModelsCall![2]).toEqual(['qwen3-coder-plus', 'qwen3.5-plus']);
   });
 
   it('should set authError and keep isAuthenticating for OpenAI on failure', async () => {

--- a/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
+++ b/src/copilot-shell/packages/cli/src/ui/auth/useAuth.ts
@@ -27,6 +27,22 @@ import { AuthState, MessageType } from '../types.js';
 import type { HistoryItem } from '../types.js';
 import { t } from '../../i18n/index.js';
 
+const RECENT_AUTH_MODELS_LIMIT = 10;
+
+function prependRecentModel(
+  existing: string[] | undefined,
+  model: string,
+): string[] {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return existing ?? [];
+  }
+  return [
+    trimmed,
+    ...(existing ?? []).filter((item) => item.trim() !== trimmed),
+  ].slice(0, RECENT_AUTH_MODELS_LIMIT);
+}
+
 export const useAuthCommand = (
   settings: LoadedSettings,
   config: Config,
@@ -162,11 +178,27 @@ export const useAuthCommand = (
               'security.auth.openaiModel',
               resolvedModel,
             );
+            settings.setValue(
+              authTypeScope,
+              'security.auth.openaiModels',
+              prependRecentModel(
+                settings.merged.security?.auth?.openaiModels,
+                resolvedModel,
+              ),
+            );
           } else if (authType === AuthType.USE_ALIYUN) {
             settings.setValue(
               authTypeScope,
               'security.auth.aliyunModel',
               resolvedModel,
+            );
+            settings.setValue(
+              authTypeScope,
+              'security.auth.aliyunModels',
+              prependRecentModel(
+                settings.merged.security?.auth?.aliyunModels,
+                resolvedModel,
+              ),
             );
           }
         }
@@ -392,6 +424,14 @@ export const useAuthCommand = (
                 authTypeScope,
                 'security.auth.aliyunModel',
                 credentials.model.trim(),
+              );
+              settings.setValue(
+                authTypeScope,
+                'security.auth.aliyunModels',
+                prependRecentModel(
+                  settings.merged.security?.auth?.aliyunModels,
+                  credentials.model.trim(),
+                ),
               );
             }
 

--- a/src/copilot-shell/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -359,4 +359,313 @@ describe('<ModelDialog />', () => {
     expect(mockedSelect).toHaveBeenCalledTimes(2);
     expect(mockedSelect.mock.calls[1][0].initialIndex).toBe(1);
   });
+
+  it('shows the /auth configured OpenAI-compatible model when registry is empty', () => {
+    const mockSettings = {
+      isTrusted: true,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      merged: {
+        security: {
+          auth: {
+            openaiModel: 'qwen3-max',
+          },
+        },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const mockConfig = {
+      getModel: vi.fn(() => 'qwen3-max'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAvailableModelsForAuthType: vi.fn(() => []),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3-max',
+      })),
+      switchModel: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Config;
+
+    render(
+      <SettingsContext.Provider value={mockSettings}>
+        <ConfigContext.Provider value={mockConfig}>
+          <ModelDialog onClose={vi.fn()} />
+        </ConfigContext.Provider>
+      </SettingsContext.Provider>,
+    );
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+    const items = mockedSelect.mock.calls[0][0].items;
+    expect(items).toHaveLength(1);
+    expect(items[0].value).toBe(`${AuthType.USE_OPENAI}::qwen3-max`);
+    expect(items[0].description).toBe('Current /auth model');
+  });
+
+  it('combines registered models with the /auth configured OpenAI-compatible model', () => {
+    const mockSettings = {
+      isTrusted: true,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      merged: {
+        security: {
+          auth: {
+            openaiModel: 'qwen3.6-plus',
+            openaiModels: ['qwen3.6-plus', 'qwen3.5-plus'],
+          },
+        },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const mockConfig = {
+      getModel: vi.fn(() => 'qwen3.6-plus'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAvailableModelsForAuthType: vi.fn((t: AuthType) => {
+        if (t === AuthType.USE_OPENAI) {
+          return [
+            {
+              id: 'qwen3-max',
+              label: 'qwen3-max',
+              authType: AuthType.USE_OPENAI,
+            },
+          ];
+        }
+        return [];
+      }),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3.6-plus',
+      })),
+      switchModel: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Config;
+
+    render(
+      <SettingsContext.Provider value={mockSettings}>
+        <ConfigContext.Provider value={mockConfig}>
+          <ModelDialog onClose={vi.fn()} />
+        </ConfigContext.Provider>
+      </SettingsContext.Provider>,
+    );
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+    const items = mockedSelect.mock.calls[0][0].items;
+    expect(items.map((item) => item.value)).toEqual([
+      `${AuthType.USE_OPENAI}::qwen3-max`,
+      `${AuthType.USE_OPENAI}::qwen3.6-plus`,
+      `${AuthType.USE_OPENAI}::qwen3.5-plus`,
+    ]);
+    expect(items[1].description).toBe('Current /auth model');
+    expect(items[2].description).toBe('Verified via /auth');
+  });
+
+  it('does not duplicate the /auth configured model when it is already registered', () => {
+    const mockSettings = {
+      isTrusted: true,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      merged: {
+        security: {
+          auth: {
+            openaiModel: 'qwen3-max',
+          },
+        },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const mockConfig = {
+      getModel: vi.fn(() => 'qwen3-max'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAvailableModelsForAuthType: vi.fn((t: AuthType) => {
+        if (t === AuthType.USE_OPENAI) {
+          return [
+            {
+              id: 'qwen3-max',
+              label: 'qwen3-max',
+              authType: AuthType.USE_OPENAI,
+            },
+          ];
+        }
+        return [];
+      }),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3-max',
+      })),
+      switchModel: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Config;
+
+    render(
+      <SettingsContext.Provider value={mockSettings}>
+        <ConfigContext.Provider value={mockConfig}>
+          <ModelDialog onClose={vi.fn()} />
+        </ConfigContext.Provider>
+      </SettingsContext.Provider>,
+    );
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+    const items = mockedSelect.mock.calls[0][0].items;
+    expect(items.map((item) => item.value)).toEqual([
+      `${AuthType.USE_OPENAI}::qwen3-max`,
+    ]);
+  });
+
+  it('does not overwrite the /auth configured model when selecting a registered model', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const mockSettings = {
+      isTrusted: true,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      merged: {
+        security: {
+          auth: {
+            openaiModel: 'qwen3.6-plus',
+          },
+        },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const mockConfig = {
+      getModel: vi.fn(() => 'qwen3-max'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAvailableModelsForAuthType: vi.fn((t: AuthType) => {
+        if (t === AuthType.USE_OPENAI) {
+          return [
+            {
+              id: 'qwen3-max',
+              label: 'qwen3-max',
+              authType: AuthType.USE_OPENAI,
+            },
+          ];
+        }
+        return [];
+      }),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3-max',
+      })),
+      getUsageStatisticsEnabled: vi.fn(() => false),
+      getSessionId: vi.fn(() => 'mock-session-id'),
+      getDebugMode: vi.fn(() => false),
+      getProxy: vi.fn(() => undefined),
+      switchModel,
+    } as unknown as Config;
+
+    render(
+      <SettingsContext.Provider value={mockSettings}>
+        <ConfigContext.Provider value={mockConfig}>
+          <ModelDialog onClose={vi.fn()} />
+        </ConfigContext.Provider>
+      </SettingsContext.Provider>,
+    );
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    await childOnSelect(`${AuthType.USE_OPENAI}::qwen3-max`);
+
+    expect(mockSettings.setValue).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'security.auth.openaiModel',
+      expect.anything(),
+    );
+  });
+
+  it('selecting an /auth configured model does not call startNewSession or resetChat', async () => {
+    const startNewSession = vi.fn();
+    const resetChat = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+
+    const mockSettings = {
+      isTrusted: true,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      merged: {
+        security: {
+          auth: {
+            openaiModel: 'qwen3.6-plus',
+          },
+        },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const mockConfig = {
+      getModel: vi.fn(() => 'qwen3.6-plus'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAvailableModelsForAuthType: vi.fn(() => []),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3.6-plus',
+      })),
+      getUsageStatisticsEnabled: vi.fn(() => false),
+      getSessionId: vi.fn(() => 'mock-session-id'),
+      getDebugMode: vi.fn(() => false),
+      getProxy: vi.fn(() => undefined),
+      switchModel,
+      startNewSession,
+      resetChat,
+    } as unknown as Config;
+
+    render(
+      <SettingsContext.Provider value={mockSettings}>
+        <ConfigContext.Provider value={mockConfig}>
+          <ModelDialog onClose={vi.fn()} />
+        </ConfigContext.Provider>
+      </SettingsContext.Provider>,
+    );
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    await childOnSelect(`${AuthType.USE_OPENAI}::qwen3.6-plus`);
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3.6-plus',
+      undefined,
+      expect.objectContaining({ reason: 'user_manual' }),
+    );
+    expect(startNewSession).not.toHaveBeenCalled();
+    expect(resetChat).not.toHaveBeenCalled();
+  });
+
+  it('shows only the /auth configured model for non-registered OpenAI-compatible providers', () => {
+    const mockSettings = {
+      isTrusted: true,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      merged: {
+        security: {
+          auth: {
+            openaiModel: 'gpt-4o',
+            baseUrl: 'https://api.openai.com/v1',
+          },
+        },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const mockConfig = {
+      getModel: vi.fn(() => 'gpt-4o'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAvailableModelsForAuthType: vi.fn(() => []),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4o',
+        baseUrl: 'https://api.openai.com/v1',
+      })),
+      switchModel: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Config;
+
+    render(
+      <SettingsContext.Provider value={mockSettings}>
+        <ConfigContext.Provider value={mockConfig}>
+          <ModelDialog onClose={vi.fn()} />
+        </ConfigContext.Provider>
+      </SettingsContext.Provider>,
+    );
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1);
+    const items = mockedSelect.mock.calls[0][0].items;
+    expect(items.length).toBe(1);
+    expect(items[0].value).toBe(`${AuthType.USE_OPENAI}::gpt-4o`);
+  });
 });

--- a/src/copilot-shell/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/ModelDialog.tsx
@@ -22,6 +22,7 @@ import { ConfigContext } from '../contexts/ConfigContext.js';
 import { UIStateContext } from '../contexts/UIStateContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import {
+  type AvailableModel,
   getAvailableModelsForAuthType,
   MAINLINE_CODER,
 } from '../models/availableModels.js';
@@ -138,6 +139,41 @@ function ConfigRow({
   );
 }
 
+function appendConfiguredModel(
+  models: AvailableModel[],
+  modelId: string | undefined,
+  description: string,
+): AvailableModel[] {
+  const id = modelId?.trim();
+  if (!id || models.some((model) => model.id === id)) {
+    return models;
+  }
+  return [
+    ...models,
+    {
+      id,
+      label: id,
+      description,
+    },
+  ];
+}
+
+function appendConfiguredModels(
+  models: AvailableModel[],
+  currentModelId: string | undefined,
+  recentModelIds: Array<string | undefined> | undefined,
+): AvailableModel[] {
+  let result = appendConfiguredModel(
+    models,
+    currentModelId,
+    t('Current /auth model'),
+  );
+  for (const modelId of recentModelIds ?? []) {
+    result = appendConfiguredModel(result, modelId, t('Verified via /auth'));
+  }
+  return result;
+}
+
 export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
   const config = useContext(ConfigContext);
   const uiState = useContext(UIStateContext);
@@ -162,32 +198,21 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
           config ?? undefined,
         );
 
-        // modelProviders 注册表中无模型时的降级处理：
-        // 通过 /auth 对话框配置的 OpenAI 和 Aliyun 模型保存在
-        // 按认证方式隔离的 settings 字段中，而非注册在 modelProviders/modelRegistry。
-        if (models.length === 0 && config) {
+        // modelProviders 是显式注册模型；/auth 保存的是用户已经验证并
+        // 实际使用过的当前模型。两者合并展示，避免凭端点猜测模型清单。
+        if (config) {
           if (authTypeEntry === AuthType.USE_OPENAI) {
-            const storedModel = settings.merged?.security?.auth?.openaiModel;
-            if (storedModel) {
-              models = [
-                {
-                  id: storedModel,
-                  label: storedModel,
-                  description: '已通过 /auth 配置',
-                },
-              ];
-            }
+            models = appendConfiguredModels(
+              models,
+              settings.merged?.security?.auth?.openaiModel,
+              settings.merged?.security?.auth?.openaiModels,
+            );
           } else if (authTypeEntry === AuthType.USE_ALIYUN) {
-            const storedModel = settings.merged?.security?.auth?.aliyunModel;
-            if (storedModel) {
-              models = [
-                {
-                  id: storedModel,
-                  label: storedModel,
-                  description: '已通过 /auth 配置',
-                },
-              ];
-            }
+            models = appendConfiguredModels(
+              models,
+              settings.merged?.security?.auth?.aliyunModel,
+              settings.merged?.security?.auth?.aliyunModels,
+            );
           }
         }
 


### PR DESCRIPTION
## Description

The `/model` dialog previously only showed `/auth`-configured models
as a fallback when the `modelProviders` registry was empty. This meant
users with registered models could never see or switch to their
`/auth`-verified models.

This PR merges both sources: registered models appear first, followed
by the current `/auth` model (labeled "Current /auth model") and any
previously authenticated models (labeled "Verified via /auth"), with
deduplication. A new `openaiModels` / `aliyunModels` array setting
tracks the MRU list of authenticated models (capped at 10). Selecting
a registered model from `/model` no longer overwrites the `/auth`
model setting.

## Related Issue

closes #1021

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
./node_modules/.bin/vitest run \
  packages/cli/src/ui/models/availableModels.test.ts \
  packages/cli/src/ui/components/ModelDialog.test.tsx \
  packages/cli/src/ui/auth/useAuth.test.ts
# 39 passed