### PR TITLE
feat(skill): preflight model endpoint before gateway startup

### DIFF
--- a/src/os-skills/ai/install-openclaw/SKILL.md
+++ b/src/os-skills/ai/install-openclaw/SKILL.md
@@ -5,7 +5,7 @@ description: Install and configure OpenClaw non-interactively with Alibaba Cloud
 
 # OpenClaw Non-Interactive Setup
 
-Use this skill to turn a user's one-sentence request into a complete local OpenClaw setup. The normal path is one script command: install Node.js/npm/OpenClaw when needed, write Alibaba Cloud Model Studio config, install/restart the local gateway service, and verify `openclaw gateway health`.
+Use this skill to turn a user's one-sentence request into a complete local OpenClaw setup. The normal path is one script command: resolve the Alibaba Cloud Model Studio plan, validate the API key/Base URL/model combination with the official `anthropic-messages` endpoint shape, install Node.js/npm/OpenClaw when needed, write config, install/restart the local gateway service, and verify `openclaw gateway health`.
 
 Do not use `openclaw onboard` unless the user explicitly asks for interactive setup. Do not configure DingTalk unless the user provides DingTalk credentials or asks for DingTalk access.
 
@@ -29,7 +29,7 @@ Default to `--billing payg --region china` when the user does not specify billin
 - Coding Plan: https://bailian.console.aliyun.com/cn-beijing/?tab=model#/efm/coding_plan
 - Token Plan: https://bailian.console.aliyun.com/?tab=plan#/efm/subscription/overview
 
-Use `--region singapore` only for pay-as-you-go Singapore. For deeper billing details, read `references/aliyun-model-studio-openclaw.md`.
+Use `--region singapore` only for pay-as-you-go Singapore. If the user gives a custom Alibaba Cloud compatible endpoint, pass it through with `--base-url`; otherwise use the billing-specific defaults from the official OpenClaw guide. For deeper billing details, read `references/aliyun-model-studio-openclaw.md`.
 
 ## Execute
 
@@ -62,7 +62,8 @@ python3 <install-openclaw-skill-dir>/scripts/install_openclaw.py ...
 
 The authoritative implementation is `scripts/install_openclaw.py`.
 The normal parameters are `--billing`, `--api-key`, `--api-key-env`, `--region`,
-`--model-id`, `--npm-registry`, `--precheck-only`, `--skip-tokenless`, and DingTalk-specific flags.
+`--base-url`, `--model-id`, `--npm-registry`, `--dry-run`, `--precheck-only`,
+`--skip-preflight`, `--skip-tokenless`, and DingTalk-specific flags.
 
 ## Examples
 
@@ -98,6 +99,15 @@ python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_op
   --api-key-env BAILIAN_API_KEY
 ```
 
+Custom endpoint:
+
+```bash
+python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_openclaw.py \
+  --billing payg \
+  --api-key-env BAILIAN_API_KEY \
+  --base-url "https://dashscope.aliyuncs.com/apps/anthropic"
+```
+
 With DingTalk:
 
 ```bash
@@ -113,6 +123,9 @@ python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_op
 
 - Checks Node.js/npm and installs them with `dnf`/`yum` when needed.
 - Runs dependency precheck before installing or writing config.
+- Runs a model endpoint pre-flight check before writing config or starting Gateway. It uses the official Alibaba Cloud OpenClaw `anthropic-messages` shape and validates the resolved API key, Base URL, and model ID. Pass `--skip-preflight` only when the endpoint is temporarily unreachable and the user accepts deferring validation to Gateway startup.
+- With `--dry-run`, still resolves config and runs the model pre-flight check, but skips local install/config/gateway changes. Combine with `--skip-preflight` only for an offline local-flow preview.
+- With `--precheck-only`, checks only local dependencies and prints the API key source; it does not require or validate an API key.
 - Installs OpenClaw with npm unless `--skip-install-openclaw` is passed.
 - Uses npm registry `https://registry.npmmirror.com` by default; override with `--npm-registry`.
 - Writes only OpenClaw schema-supported config fields.

--- a/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
+++ b/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
@@ -10,9 +10,12 @@ and starts the local gateway service.
 import argparse
 import json
 import os
+import socket
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 
@@ -395,13 +398,135 @@ def build_config(args):
         "base_url": base_url,
         "api": args.provider_api,
         "primary_model": primary_ref,
+        "model_id": model_id,
+        "api_key": api_key,
         "api_key_url": plan["api_key_url"],
         "model_catalog_url": plan["model_catalog_url"],
     }
 
 
-def apply_config(config, config_path):
+def anthropic_messages_url(base_url):
+    base = base_url.rstrip("/")
+    if base.endswith("/v1/messages"):
+        return base
+    if base.endswith("/v1"):
+        return f"{base}/messages"
+    return f"{base}/v1/messages"
+
+
+def extract_error_message(body):
+    if not body:
+        return ""
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        return body.strip()[:500]
+    error = parsed.get("error") if isinstance(parsed, dict) else None
+    if isinstance(error, dict):
+        for key in ("message", "msg", "description"):
+            if error.get(key):
+                return str(error[key])
+    for key in ("message", "msg", "description", "request_id"):
+        if isinstance(parsed, dict) and parsed.get(key):
+            return str(parsed[key])
+    return json.dumps(parsed, ensure_ascii=False)[:500]
+
+
+def preflight_hint(status, metadata):
+    plan_name = BILLING_PLANS[metadata["billing"]]["name"]
+    if status in (401, 403):
+        return (
+            "Authentication failed. Check that the API key belongs to "
+            f"{plan_name} and matches baseUrl {metadata['base_url']}. "
+            f"Get the correct key from: {metadata['api_key_url']}"
+        )
+    if status == 404:
+        return (
+            "Endpoint or model was not found. Check --base-url and --model-id; "
+            f"model catalog: {metadata['model_catalog_url']}"
+        )
+    if status == 400:
+        return (
+            "The endpoint rejected the request shape or model id. Check that "
+            f"model {metadata['model_id']} is available for {plan_name}."
+        )
+    if status == 429:
+        return (
+            "The endpoint is reachable but returned rate limit or quota errors. "
+            "Check quota, billing status, or retry later."
+        )
+    return "Check API key, baseUrl, model id, and network reachability."
+
+
+def preflight_model_call(args, metadata):
+    if args.skip_preflight:
+        print("\n--- Skipping model pre-flight check (--skip-preflight) ---\n")
+        return
+    if metadata["api"] != "anthropic-messages":
+        print(
+            "\n--- Skipping model pre-flight check "
+            f"(unsupported provider api: {metadata['api']}) ---\n"
+        )
+        return
+
+    print("\n--- Model endpoint pre-flight check ---\n")
+    url = anthropic_messages_url(metadata["base_url"])
+    payload = {
+        "model": metadata["model_id"],
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "install-openclaw-preflight/1.0",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": metadata["api_key"],
+        },
+    )
+
+    print(f"  endpoint={url}")
+    print(f"  model={metadata['model_id']}")
+    try:
+        with urllib.request.urlopen(request, timeout=args.preflight_timeout) as response:
+            response.read(1024)
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        message = extract_error_message(error_body)
+        hint = preflight_hint(exc.code, metadata)
+        detail = f"\n  provider message: {message}" if message else ""
+        raise SystemExit(
+            "Model pre-flight check failed before writing OpenClaw config.\n"
+            f"  HTTP {exc.code} from {url}{detail}\n"
+            f"  hint: {hint}\n"
+            "Fix the values or rerun with --skip-preflight only if you want "
+            "to defer validation to OpenClaw Gateway startup."
+        ) from exc
+    except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
+        reason = getattr(exc, "reason", exc)
+        raise SystemExit(
+            "Model pre-flight check failed before writing OpenClaw config.\n"
+            f"  endpoint: {url}\n"
+            f"  error: {reason}\n"
+            "Check --base-url, DNS/proxy/network access, or rerun with "
+            "--skip-preflight to defer validation."
+        ) from exc
+
+    print("  [OK] API key, baseUrl, and model id accepted by endpoint")
+
+
+def apply_config(config, config_path, *, dry_run=False):
     print("\n--- Writing OpenClaw config ---\n")
+    if dry_run:
+        print(f"  # dry-run: would write OpenClaw config to {config_path}")
+        for key in config:
+            print(f"  [OK] {key}")
+        return
 
     existing = {}
     if config_path.exists():
@@ -1042,7 +1167,14 @@ def parse_args():
         default=str(Path("~/.openclaw/setup-gateway-start.log").expanduser()),
     )
     parser.add_argument("--doctor-fix", action="store_true")
-    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Preview the full flow without local changes. Model pre-flight "
+            "still runs unless --skip-preflight is set."
+        ),
+    )
     parser.add_argument(
         "--precheck-only",
         action="store_true",
@@ -1052,6 +1184,17 @@ def parse_args():
         "--skip-tokenless",
         action="store_true",
         help="Do not install the tokenless OpenClaw plugin after OpenClaw installation.",
+    )
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="Skip the model endpoint API check before writing config and starting Gateway.",
+    )
+    parser.add_argument(
+        "--preflight-timeout",
+        type=int,
+        default=20,
+        help="Seconds to wait for the model endpoint pre-flight API call.",
     )
 
     parser.add_argument("--dingtalk-client-id", default="")
@@ -1072,12 +1215,14 @@ def main():
         print_api_key_guidance(args)
         return
 
+    config, metadata = build_config(args)
+    preflight_model_call(args, metadata)
+
     if not args.skip_install_openclaw:
         install_openclaw(args)
         install_tokenless_plugin(args)
 
-    config, metadata = build_config(args)
-    apply_config(config, Path(args.config).expanduser())
+    apply_config(config, Path(args.config).expanduser(), dry_run=args.dry_run)
 
     if args.install_dingtalk_plugin:
         install_dingtalk_plugin(args)


### PR DESCRIPTION
## Description

Add a pre-flight validation step to `install_openclaw.py` that checks the
resolved API key, Base URL, and model ID against the live endpoint before
writing config or starting Gateway. On failure the script exits with an
actionable diagnosis (auth, model not found, rate limit, network) instead
of letting the user discover a vague gateway error after startup.

Also updates SKILL.md to document `--base-url` usage, custom endpoint
examples, and the new `--skip-preflight` / `--preflight-timeout` flags.

## Related Issue

closes #1022

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [x] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `skill`: Skill directory structure is valid and shell scripts pass syntax check

## Testing

Tested manually with real Alibaba Cloud keys against 6 scenarios:

1. Coding Plan + valid sk-sp key → preflight passes
2. PAYG + valid sk key → preflight passes
3. Coding Plan + invalid key → preflight catches HTTP 401
4. Coding Plan + non-existent model → preflight catches HTTP 400
5. `--skip-preflight` + invalid key → preflight skipped, exit 0
6. PAYG key on coding endpoint → key format validation rejects before preflight

## Additional Notes

Only `anthropic-messages` provider API is supported for preflight;
other provider APIs are skipped with a log message.
Uses stdlib `urllib.request` only — no new dependencies.