### PR TITLE
fix(anolisa): infer install-mode from euid when flag is omitted

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -40,9 +40,10 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
 
-    /// Install scope: user (~/.local) or system (/usr/local)
-    #[arg(long, global = true, value_enum, default_value_t = InstallMode::User)]
-    pub install_mode: InstallMode,
+    /// Install scope: user (~/.local) or system (/usr/local).
+    /// When omitted, defaults to system if running as root, user otherwise.
+    #[arg(long, global = true, value_enum)]
+    pub install_mode: Option<InstallMode>,
 
     /// Custom install prefix (system-mode only)
     #[arg(long, global = true, value_name = "PATH")]
@@ -248,6 +249,8 @@ fn has_dot_segment(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use clap::FromArgMatches as _;
+
     use super::*;
 
     fn ctx_with_prefix(prefix: PathBuf) -> CliContext {
@@ -321,5 +324,23 @@ mod tests {
             help.contains("ls"),
             "visible alias `ls` should appear in help output"
         );
+    }
+
+    #[test]
+    fn install_mode_is_none_when_omitted() {
+        let cmd = build_cli();
+        let matches = cmd.try_get_matches_from(["anolisa", "status"]).unwrap();
+        let cli = Cli::from_arg_matches(&matches).unwrap();
+        assert_eq!(cli.install_mode, None);
+    }
+
+    #[test]
+    fn install_mode_is_some_when_explicitly_set() {
+        let cmd = build_cli();
+        let matches = cmd
+            .try_get_matches_from(["anolisa", "--install-mode=system", "status"])
+            .unwrap();
+        let cli = Cli::from_arg_matches(&matches).unwrap();
+        assert_eq!(cli.install_mode, Some(InstallMode::System));
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/context.rs
+++ b/src/anolisa/crates/anolisa-cli/src/context.rs
@@ -6,9 +6,13 @@
 //! every command handler. Handlers must not re-parse globals from the args
 //! struct; instead they read from the shared context so that semantics stay
 //! consistent across surfaces.
+//!
+//! When `--install-mode` is omitted, the effective scope is inferred from
+//! the process's effective UID: root defaults to system, non-root to user.
 
 use std::path::PathBuf;
 
+use anolisa_platform::privilege;
 use clap::ValueEnum;
 
 /// Where ANOLISA installs files: user-mode (`file-hierarchy(7)` under `$HOME`)
@@ -47,13 +51,40 @@ pub struct CliContext {
     pub no_color: bool,
 }
 
+/// Resolve the effective install mode from the explicit CLI value and a
+/// privilege flag.
+///
+/// When the user passes `--install-mode`, that value wins unconditionally.
+/// Otherwise the default is inferred from the process's effective UID:
+/// root → [`InstallMode::System`], non-root → [`InstallMode::User`].
+fn resolve_install_mode(explicit: Option<InstallMode>, is_root: bool) -> InstallMode {
+    match explicit {
+        Some(mode) => mode,
+        None if is_root => InstallMode::System,
+        None => InstallMode::User,
+    }
+}
+
 impl CliContext {
     /// Build a context from the parsed top-level [`crate::commands::Cli`].
     ///
     /// Borrows the CLI so the caller can still consume `cli.command` after.
+    /// The effective [`InstallMode`] is inferred from euid when
+    /// `--install-mode` is not provided on the command line.
     pub fn from_cli(cli: &crate::commands::Cli) -> Self {
+        let is_root = privilege::is_root();
+        let effective_mode = resolve_install_mode(cli.install_mode, is_root);
+
+        if cli.install_mode == Some(InstallMode::User) && is_root && !cli.quiet {
+            eprintln!(
+                "warning: running as root with --install-mode=user; \
+                 state will resolve under the root user's home directory, \
+                 not the system store"
+            );
+        }
+
         Self {
-            install_mode: cli.install_mode,
+            install_mode: effective_mode,
             prefix: cli.prefix.clone(),
             json: cli.json,
             dry_run: cli.dry_run,
@@ -61,5 +92,36 @@ impl CliContext {
             quiet: cli.quiet,
             no_color: cli.no_color,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn omitted_as_root_resolves_to_system() {
+        assert_eq!(resolve_install_mode(None, true), InstallMode::System);
+    }
+
+    #[test]
+    fn omitted_as_non_root_resolves_to_user() {
+        assert_eq!(resolve_install_mode(None, false), InstallMode::User);
+    }
+
+    #[test]
+    fn explicit_user_stays_user_even_as_root() {
+        assert_eq!(
+            resolve_install_mode(Some(InstallMode::User), true),
+            InstallMode::User,
+        );
+    }
+
+    #[test]
+    fn explicit_system_stays_system_even_as_non_root() {
+        assert_eq!(
+            resolve_install_mode(Some(InstallMode::System), false),
+            InstallMode::System,
+        );
     }
 }


### PR DESCRIPTION
## Description

Makes `--install-mode` scope resolution euid-aware so that `sudo anolisa update <component>` automatically resolves to system scope without requiring an explicit `--install-mode=system` flag (#996).

Previously `--install-mode` defaulted to `user` unconditionally via `default_value_t`. The privilege gate (`privilege::is_root()`) and scope resolution (`resolve_layout`) were decided by independent inputs — euid and the CLI flag respectively — that could contradict each other: root passed the privilege check but still resolved the user-scope layout, operating on the wrong state store.

Behavior after this change:
- `--install-mode` omitted + root → system scope (inferred).
- `--install-mode` omitted + non-root → user scope (inferred, same as before).
- `--install-mode=system` explicit → system scope (respected unconditionally).
- `--install-mode=user` explicit + root → user scope (respected, stderr warning emitted).

## Design Note

The `Cli.install_mode` field type changes from `InstallMode` (with `default_value_t = User`) to `Option<InstallMode>`. This lets clap distinguish "omitted" from "explicitly set to user". A new pure function `resolve_install_mode(explicit, is_root)` in `context.rs` encapsulates the inference logic and is called by `CliContext::from_cli` with `privilege::is_root()`. `CliContext.install_mode` remains `InstallMode` (never `Option`), so all 40+ downstream callsites that read `ctx.install_mode` — including `resolve_layout`, privilege gates, and the osbase system-only validation — are unchanged.

## Ship Note

- The osbase sandbox install gate (`ctx.install_mode == System`) now passes automatically under `sudo` instead of requiring the explicit flag — this is a user-facing improvement, not a regression.
- The stderr warning for root + explicit `--install-mode=user` is suppressed by `--quiet`.

## Test

- Unit (context): four-case matrix for `resolve_install_mode` — omitted/root → System, omitted/non-root → User, explicit User + root → User, explicit System + non-root → System.
- Unit (commands): clap parse tests — omitted yields `None`, explicit `--install-mode=system` yields `Some(System)`.
- Full gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo test --workspace`.

Closes #996