### PR TITLE
feat(anolisa): extend adapter framework drivers

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -431,6 +431,7 @@ fn map_err(command: &str, err: AdapterError) -> CliError {
         | AdapterError::UnknownFramework { .. }
         | AdapterError::AmbiguousFramework { .. }
         | AdapterError::UnsupportedAdapterType { .. }
+        | AdapterError::InvalidAdapterInput { .. }
         | AdapterError::ComponentNotInstalled { .. }
         | AdapterError::AdapterNotDeclared { .. }
         | AdapterError::ResourceRootNotFound { .. }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -345,6 +345,8 @@ mod tests {
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "state".to_string(),
                 plugin_resource: "plugin".to_string(),
+                skill_resources: Vec::new(),
+                config_resources: Vec::new(),
             }),
         }
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1505,6 +1505,8 @@ mod tests {
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "state".to_string(),
                 plugin_resource: "plugin".to_string(),
+                skill_resources: Vec::new(),
+                config_resources: Vec::new(),
             }),
         }
     }

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -23,6 +23,7 @@ use crate::manifest::AdapterSpec;
 pub mod claim;
 pub mod contract;
 pub mod driver;
+pub mod hermes;
 pub mod manager;
 pub mod openclaw;
 pub mod registry;
@@ -104,6 +105,18 @@ pub enum AdapterError {
         framework: String,
         /// The unsupported `adapter_type` value from the manifest.
         adapter_type: String,
+    },
+
+    /// A skill name or config key from the manifest failed validation
+    /// (empty, contains path traversal, or has unsafe characters).
+    #[error("invalid adapter input for {component}/{framework}: {reason}")]
+    InvalidAdapterInput {
+        /// Component whose manifest declared the invalid input.
+        component: String,
+        /// Framework the adapter targets.
+        framework: String,
+        /// What was wrong.
+        reason: String,
     },
 
     /// The installed component manifest required by adapter enable is

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -116,6 +116,19 @@ impl AdapterClaim {
         }
         for resource in &self.resources {
             resource.validate(layout, allowed_external_roots)?;
+            match &resource.kind {
+                ClaimResourceKind::FrameworkPlugin { framework, .. }
+                | ClaimResourceKind::FrameworkConfig { framework, .. }
+                    if framework != &self.framework =>
+                {
+                    return Err(ClaimValidationError::FrameworkMismatch {
+                        id: resource.id.clone(),
+                        resource_framework: framework.clone(),
+                        claim_framework: self.framework.clone(),
+                    });
+                }
+                _ => {}
+            }
         }
         Ok(())
     }
@@ -175,6 +188,18 @@ impl ClaimResource {
                 })
             }
             ClaimResourceKind::FrameworkPlugin { plugin_id, .. } => validate_plugin_id(plugin_id),
+            ClaimResourceKind::FrameworkConfig { key, .. } => {
+                if key.is_empty() {
+                    return Err(ClaimValidationError::ConfigKey {
+                        id: self.id.clone(),
+                        reason: "config key must not be empty".to_string(),
+                    });
+                }
+                validate_config_key(key).map_err(|_| ClaimValidationError::ConfigKey {
+                    id: self.id.clone(),
+                    reason: format!("config key '{key}' contains unsafe characters"),
+                })
+            }
         }
     }
 }
@@ -213,6 +238,15 @@ pub enum ClaimResourceKind {
         /// Native plugin id.
         plugin_id: String,
     },
+    /// A framework configuration key/value pair that ANOLISA applied.
+    /// The key path is framework-specific; the value is the TOML
+    /// representation of what was set.
+    FrameworkConfig {
+        /// Framework that owns the config (e.g. `openclaw`).
+        framework: String,
+        /// Config key path.
+        key: String,
+    },
 }
 
 /// Framework-specific typed payload. Closed enum — there is no runtime
@@ -224,6 +258,9 @@ pub enum DriverPayload {
     /// OpenClaw driver payload.
     #[serde(rename = "openclaw")]
     OpenClaw(OpenClawClaim),
+    /// Hermes driver payload.
+    #[serde(rename = "hermes")]
+    Hermes(HermesClaim),
 }
 
 /// OpenClaw driver payload. Holds only [`ClaimResource::id`] references —
@@ -237,6 +274,26 @@ pub struct OpenClawClaim {
     /// Resource id of the registered plugin
     /// ([`ClaimResourceKind::FrameworkPlugin`]).
     pub plugin_resource: String,
+    /// Resource ids of delivered skill directories.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skill_resources: Vec<String>,
+    /// Resource ids of applied config key/value pairs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub config_resources: Vec<String>,
+}
+
+/// Hermes driver payload. Holds only [`ClaimResource::id`] references.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HermesClaim {
+    /// Resource id of the Hermes home directory
+    /// ([`ClaimResourceKind::ExternalPath`]).
+    pub home_resource: String,
+    /// Resource id of the installed plugin directory
+    /// ([`ClaimResourceKind::ExternalPath`]).
+    pub plugin_resource: String,
+    /// Resource ids of delivered skill directories.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skill_resources: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -273,6 +330,27 @@ pub enum ClaimValidationError {
         plugin_id: String,
         /// Why it was rejected.
         reason: String,
+    },
+    /// A config key in a [`ClaimResourceKind::FrameworkConfig`] resource
+    /// is empty or contains unsafe characters.
+    #[error("invalid config key in resource '{id}': {reason}")]
+    ConfigKey {
+        /// Offending resource id.
+        id: String,
+        /// Why it was rejected.
+        reason: String,
+    },
+    /// A resource declares a framework that differs from the claim's.
+    #[error(
+        "resource '{id}' declares framework '{resource_framework}' but claim targets '{claim_framework}'"
+    )]
+    FrameworkMismatch {
+        /// Offending resource id.
+        id: String,
+        /// Framework in the resource.
+        resource_framework: String,
+        /// Framework in the claim.
+        claim_framework: String,
     },
 }
 
@@ -372,6 +450,61 @@ pub fn validate_plugin_id(plugin_id: &str) -> Result<(), ClaimValidationError> {
     Ok(())
 }
 
+/// Reject a skill name that is empty, `.`/`..`, starts with `-`, or
+/// contains characters outside `[A-Za-z0-9._-]`. Same whitelist as
+/// [`validate_plugin_id`] — a skill name becomes a directory name under
+/// the framework's skill root, so it must be path-component-safe.
+pub fn validate_skill_name(name: &str) -> Result<(), super::AdapterError> {
+    let reject = |reason: String| {
+        Err(super::AdapterError::InvalidAdapterInput {
+            component: String::new(),
+            framework: String::new(),
+            reason: format!("invalid skill name '{name}': {reason}"),
+        })
+    };
+    if name.is_empty() {
+        return reject("must not be empty".to_string());
+    }
+    if name == "." || name == ".." {
+        return reject("must not be '.' or '..'".to_string());
+    }
+    if name.starts_with('-') {
+        return reject("must not start with '-'".to_string());
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
+    {
+        return reject(format!("contains disallowed character '{bad}'"));
+    }
+    Ok(())
+}
+
+/// Reject a config key that is empty or contains shell metacharacters.
+/// Allowed: printable ASCII minus `` ` `` `$` `;` `|` `&` `(` `)` `{`
+/// `}` `[` `]` `<` `>` `\` `!` `#` `~`. This prevents injection when
+/// the key is passed as a CLI argument to `config set`.
+pub fn validate_config_key(key: &str) -> Result<(), super::AdapterError> {
+    let reject = |reason: String| {
+        Err(super::AdapterError::InvalidAdapterInput {
+            component: String::new(),
+            framework: String::new(),
+            reason: format!("invalid config key '{key}': {reason}"),
+        })
+    };
+    if key.is_empty() {
+        return reject("must not be empty".to_string());
+    }
+    const BANNED: &[char] = &[
+        '`', '$', ';', '|', '&', '(', ')', '{', '}', '[', ']', '<', '>', '\\', '!', '#', '~', '\'',
+        '"', ' ', '\t', '\n', '\r',
+    ];
+    if let Some(bad) = key.chars().find(|c| BANNED.contains(c) || !c.is_ascii()) {
+        return reject(format!("contains disallowed character '{bad}'"));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -407,6 +540,8 @@ mod tests {
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "openclaw_state_dir".to_string(),
                 plugin_resource: "openclaw_plugin".to_string(),
+                skill_resources: Vec::new(),
+                config_resources: Vec::new(),
             }),
         }
     }
@@ -496,5 +631,190 @@ mod tests {
         };
         let err = claim.validate(&layout, &allowed).expect_err("must reject");
         assert!(matches!(err, ClaimValidationError::ExternalPath { .. }));
+    }
+
+    fn sample_hermes_claim() -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "agent-sec".to_string(),
+            framework: "hermes".to_string(),
+            plugin_id: Some("agent-sec".to_string()),
+            enabled_at: "2026-06-22T10:30:45Z".to_string(),
+            resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/agent-sec/hermes"),
+            bundle_digest: Some("sha256:def".to_string()),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: vec![
+                ClaimResource {
+                    id: "hermes_home".to_string(),
+                    purpose: "hermes_home".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.hermes"),
+                    },
+                },
+                ClaimResource {
+                    id: "hermes_plugin".to_string(),
+                    purpose: "hermes_plugin_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.hermes/plugins/agent-sec"),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::Hermes(HermesClaim {
+                home_resource: "hermes_home".to_string(),
+                plugin_resource: "hermes_plugin".to_string(),
+                skill_resources: Vec::new(),
+            }),
+        }
+    }
+
+    #[test]
+    fn hermes_claim_toml_round_trip() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            adapter_claims: Vec<AdapterClaim>,
+        }
+        let wrapper = Wrapper {
+            adapter_claims: vec![sample_hermes_claim()],
+        };
+        let text = toml::to_string_pretty(&wrapper).expect("serialize Hermes to TOML");
+        let parsed: Wrapper = toml::from_str(&text).expect("parse Hermes from TOML");
+        assert_eq!(wrapper, parsed, "Hermes round-trip mismatch; TOML:\n{text}");
+    }
+
+    #[test]
+    fn hermes_claim_json_round_trip() {
+        let claim = sample_hermes_claim();
+        let json = serde_json::to_string(&claim).expect("serialize Hermes JSON");
+        let parsed: AdapterClaim = serde_json::from_str(&json).expect("parse Hermes JSON");
+        assert_eq!(claim, parsed);
+    }
+
+    #[test]
+    fn framework_config_resource_validates() {
+        let layout = FsLayout::system(None);
+        let allowed = vec![PathBuf::from("/home/alice/.openclaw")];
+        let resource = ClaimResource {
+            id: "config_touch".to_string(),
+            purpose: "openclaw_config".to_string(),
+            kind: ClaimResourceKind::FrameworkConfig {
+                framework: "openclaw".to_string(),
+                key: "plugins.entries.sec.enabled".to_string(),
+            },
+        };
+        resource
+            .validate(&layout, &allowed)
+            .expect("config resource should pass");
+    }
+
+    #[test]
+    fn openclaw_claim_with_skills_and_config_round_trips() {
+        let claim = AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "sec-core".to_string(),
+            framework: "openclaw".to_string(),
+            plugin_id: Some("sec-core".to_string()),
+            enabled_at: "2026-06-22T12:00:00Z".to_string(),
+            resource_root: PathBuf::from("/data/adapters/sec-core/openclaw"),
+            bundle_digest: None,
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: vec![
+                ClaimResource {
+                    id: "state_dir".to_string(),
+                    purpose: "openclaw_state_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.openclaw"),
+                    },
+                },
+                ClaimResource {
+                    id: "plugin".to_string(),
+                    purpose: "openclaw_plugin".to_string(),
+                    kind: ClaimResourceKind::FrameworkPlugin {
+                        framework: "openclaw".to_string(),
+                        plugin_id: "sec-core".to_string(),
+                    },
+                },
+                ClaimResource {
+                    id: "skill_sec_audit".to_string(),
+                    purpose: "openclaw_skill".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.openclaw/skills/sec-audit"),
+                    },
+                },
+                ClaimResource {
+                    id: "config_enabled".to_string(),
+                    purpose: "openclaw_config".to_string(),
+                    kind: ClaimResourceKind::FrameworkConfig {
+                        framework: "openclaw".to_string(),
+                        key: "plugins.entries.sec-core.enabled".to_string(),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "state_dir".to_string(),
+                plugin_resource: "plugin".to_string(),
+                skill_resources: vec!["skill_sec_audit".to_string()],
+                config_resources: vec!["config_enabled".to_string()],
+            }),
+        };
+        let json = serde_json::to_string(&claim).expect("serialize");
+        let parsed: AdapterClaim = serde_json::from_str(&json).expect("parse");
+        assert_eq!(claim, parsed);
+    }
+
+    #[test]
+    fn validate_skill_name_accepts_safe_names() {
+        validate_skill_name("sec-audit").expect("dash");
+        validate_skill_name("cred_scan").expect("underscore");
+        validate_skill_name("skill.v2").expect("dot");
+        validate_skill_name("a1").expect("short");
+    }
+
+    #[test]
+    fn validate_skill_name_rejects_unsafe_names() {
+        assert!(validate_skill_name("").is_err(), "empty");
+        assert!(validate_skill_name("..").is_err(), "dotdot");
+        assert!(validate_skill_name(".").is_err(), "dot");
+        assert!(validate_skill_name("-rf").is_err(), "leading dash");
+        assert!(validate_skill_name("a/b").is_err(), "slash");
+        assert!(validate_skill_name("a b").is_err(), "space");
+        assert!(validate_skill_name("../x").is_err(), "traversal");
+    }
+
+    #[test]
+    fn validate_config_key_accepts_safe_keys() {
+        validate_config_key("plugins.entries.sec.enabled").expect("dotted path");
+        validate_config_key("foo.bar_baz-1").expect("mixed");
+    }
+
+    #[test]
+    fn validate_config_key_rejects_unsafe_keys() {
+        assert!(validate_config_key("").is_err(), "empty");
+        assert!(validate_config_key("a;b").is_err(), "semicolon");
+        assert!(validate_config_key("a$b").is_err(), "dollar");
+        assert!(validate_config_key("a`b").is_err(), "backtick");
+        assert!(validate_config_key("a b").is_err(), "space");
+        assert!(validate_config_key("a|b").is_err(), "pipe");
+    }
+
+    #[test]
+    fn framework_mismatch_rejected_by_claim_validate() {
+        let layout = FsLayout::system(None);
+        let allowed = vec![PathBuf::from("/home/alice/.openclaw")];
+        let mut claim = sample_claim();
+        claim.resources.push(ClaimResource {
+            id: "wrong_framework".to_string(),
+            purpose: "test".to_string(),
+            kind: ClaimResourceKind::FrameworkPlugin {
+                framework: "hermes".to_string(),
+                plugin_id: "tokenless".to_string(),
+            },
+        });
+        let err = claim.validate(&layout, &allowed).expect_err("must reject");
+        assert!(
+            matches!(err, ClaimValidationError::FrameworkMismatch { .. }),
+            "got {err:?}"
+        );
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -51,6 +51,17 @@ pub struct DriverCtx<'a> {
     /// Plugin id declared in the component's adapter manifest, if any.
     /// A driver may fall back to it when the bundle does not name one.
     pub declared_plugin_id: Option<String>,
+    /// Skill names declared in the component's adapter manifest. The
+    /// driver delivers these into the framework's skill directory.
+    pub declared_skills: Vec<String>,
+    /// Post-install config key/value pairs declared in the component's
+    /// adapter manifest. The driver applies these via the framework CLI.
+    pub declared_config: Vec<crate::manifest::AdapterConfigSetSpec>,
+    /// Bundle entry-point filename from the manifest (framework-specific
+    /// section preferred over generic `[adapters.bundle]`). The driver
+    /// should use this to locate the framework-native manifest inside
+    /// the resource root instead of hardcoding a filename.
+    pub declared_bundle_entry: Option<String>,
     /// True when the caller passed `--dry-run`; drivers must not mutate
     /// framework state in this mode (the Manager also guards this).
     pub dry_run: bool,
@@ -254,6 +265,36 @@ pub trait AdapterOps {
     /// A non-zero exit or a timeout is reported through [`CliOutput`], not
     /// as an error, so the driver decides how to interpret it.
     fn run_framework_cli(&self, cmd: FrameworkCommand) -> Result<CliOutput, AdapterError>;
+
+    /// Recursively copy a directory tree from `src` to `dst`. The Manager
+    /// validates that `dst` is under an allowed external root before
+    /// executing. `src` must be under the resource root or an allowed
+    /// root. Creates `dst` and any missing parents.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::Io`] on filesystem failure;
+    /// [`AdapterError::ClaimValidation`] if `dst` fails boundary check.
+    fn copy_tree(&self, src: &Path, dst: &Path) -> Result<(), AdapterError>;
+
+    /// Copy a single file from `src` to `dst`. Both paths are validated
+    /// against the allowed roots. Creates parent directories of `dst`.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::Io`] on filesystem failure;
+    /// [`AdapterError::ClaimValidation`] if either path fails boundary check.
+    fn copy_file(&self, src: &Path, dst: &Path) -> Result<(), AdapterError>;
+
+    /// Remove a directory tree rooted at `path`. The Manager validates
+    /// that `path` is under an allowed external root before executing.
+    /// Returns `Ok(false)` when the path does not exist (idempotent).
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::Io`] on filesystem failure;
+    /// [`AdapterError::ClaimValidation`] if `path` fails boundary check.
+    fn remove_tree(&self, path: &Path) -> Result<bool, AdapterError>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -1,0 +1,1028 @@
+//! Hermes framework driver.
+//!
+//! Hermes manages plugins and skills under `$HERMES_HOME` (default
+//! `~/.hermes`). `enable` places the plugin by copying the resource root
+//! into `$HERMES_HOME/plugins/<plugin_id>/` via
+//! [`AdapterOps::copy_tree`](super::driver::AdapterOps::copy_tree), then
+//! runs `hermes plugins enable <plugin_id>`. `disable` runs
+//! `hermes plugins disable <plugin_id>`, then removes the placed plugin
+//! directory and any delivered skill directories through
+//! [`AdapterOps::remove_tree`](super::driver::AdapterOps::remove_tree).
+//! Skill directories discovered under `<resource_root>/skills/` are
+//! copied into `$HERMES_HOME/skills/` during enable. Status uses the
+//! read-only `hermes plugins list`. All CLI and filesystem operations go
+//! through the Manager's [`AdapterOps`](super::driver::AdapterOps) —
+//! the driver never performs direct IO.
+//!
+//! The CLI env contract: `HERMES_BIN` overrides the executable (used by
+//! tests to point at a fake CLI); `HERMES_HOME` overrides the home
+//! directory.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+
+use super::AdapterError;
+use super::claim::{
+    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
+    DRIVER_SCHEMA_VERSION, DriverPayload, HermesClaim, validate_plugin_id,
+};
+use super::driver::{
+    AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
+    ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
+    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+};
+
+/// Default timeout for a Hermes CLI invocation.
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Resource ids used in Hermes receipts. Stable strings referenced from
+/// the [`HermesClaim`] payload and condition reports.
+const RES_HOME: &str = "hermes_home";
+const RES_PLUGIN: &str = "hermes_plugin";
+
+/// Hermes driver. Stateless; all per-operation context arrives via
+/// [`DriverCtx`].
+pub struct HermesDriver;
+
+impl HermesDriver {
+    /// Construct the driver.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HermesDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameworkDriver for HermesDriver {
+    fn name(&self) -> &'static str {
+        "hermes"
+    }
+
+    fn detect(&self, env: &HostEnv) -> DetectResult {
+        match find_binary_in_path(&hermes_bin()) {
+            Some(path) => DetectResult {
+                detected: true,
+                reason: format!("hermes CLI found at {}", path.display()),
+            },
+            None => {
+                // The CLI is what enable/disable need; a bare home dir is
+                // not sufficient. Report not-detected but mention the home
+                // so a user understands the framework is partially present.
+                let home_note = hermes_home(env.user_home.as_deref())
+                    .filter(|h| h.exists())
+                    .map(|h| format!(" (home {} exists but CLI is not on PATH)", h.display()))
+                    .unwrap_or_default();
+                DetectResult {
+                    detected: false,
+                    reason: format!("hermes CLI not found on PATH{home_note}"),
+                }
+            }
+        }
+    }
+
+    fn allowed_external_roots(&self, ctx: &DriverCtx) -> Vec<PathBuf> {
+        // The only external root Hermes writes is its own home dir.
+        hermes_home(ctx.user_home.as_deref()).into_iter().collect()
+    }
+
+    fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError> {
+        let root = &ctx.resource_root;
+        if !root.is_dir() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root does not exist or is not a directory".to_string(),
+            });
+        }
+        let is_empty = root
+            .read_dir()
+            .map_err(|source| AdapterError::Io {
+                path: root.clone(),
+                source,
+            })?
+            .next()
+            .is_none();
+        if is_empty {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root is empty".to_string(),
+            });
+        }
+
+        let plugin_id = match ctx.declared_plugin_id.clone().filter(|id| !id.is_empty()) {
+            Some(id) => Some(id),
+            None => read_plugin_manifest_id(root, ctx.declared_bundle_entry.as_deref())?
+                .or_else(|| Some(ctx.component.clone())),
+        };
+
+        Ok(AdapterBundle {
+            resource_root: root.clone(),
+            digest: digest_tree(root),
+            plugin_id,
+        })
+    }
+
+    fn plan_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<DriverPlan, AdapterError> {
+        let plugin_id = require_plugin_id(bundle)?;
+        validate_plugin_id(&plugin_id)?;
+        let home = require_home(ctx)?;
+        let enable_cmd = build_enable_cmd(&plugin_id);
+
+        let mut actions = vec![
+            format!(
+                "place hermes plugin '{plugin_id}' from {} to {}/plugins/{plugin_id}",
+                bundle.resource_root.display(),
+                home.display(),
+            ),
+            format!("enable hermes plugin '{plugin_id}'"),
+        ];
+
+        for skill in &ctx.declared_skills {
+            actions.push(format!(
+                "deliver skill '{skill}' to {}/skills/{skill}",
+                home.display()
+            ));
+        }
+
+        Ok(DriverPlan {
+            framework: self.name().to_string(),
+            component: ctx.component.clone(),
+            actions,
+            register_command: Some(display_command(&enable_cmd)),
+        })
+    }
+
+    fn prepare_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterClaim, AdapterError> {
+        let plugin_id = require_plugin_id(bundle)?;
+        validate_plugin_id(&plugin_id)?;
+        let home = require_home(ctx)?;
+
+        let mut resources = vec![
+            ClaimResource {
+                id: RES_HOME.to_string(),
+                purpose: "hermes_home".to_string(),
+                kind: ClaimResourceKind::ExternalPath { path: home.clone() },
+            },
+            ClaimResource {
+                id: RES_PLUGIN.to_string(),
+                purpose: "hermes_plugin_dir".to_string(),
+                kind: ClaimResourceKind::ExternalPath {
+                    path: home.join("plugins").join(&plugin_id),
+                },
+            },
+        ];
+
+        let mut skill_resource_ids = Vec::new();
+        for skill in &ctx.declared_skills {
+            let res_id = format!("hermes_skill_{skill}");
+            resources.push(ClaimResource {
+                id: res_id.clone(),
+                purpose: "hermes_skill".to_string(),
+                kind: ClaimResourceKind::ExternalPath {
+                    path: home.join("skills").join(skill),
+                },
+            });
+            skill_resource_ids.push(res_id);
+        }
+
+        Ok(AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: ctx.component.clone(),
+            framework: self.name().to_string(),
+            plugin_id: Some(plugin_id),
+            enabled_at: now_iso8601(),
+            resource_root: bundle.resource_root.clone(),
+            bundle_digest: bundle.digest.clone(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources,
+            driver_payload: DriverPayload::Hermes(HermesClaim {
+                home_resource: RES_HOME.to_string(),
+                plugin_resource: RES_PLUGIN.to_string(),
+                skill_resources: skill_resource_ids,
+            }),
+        })
+    }
+
+    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+        let plugin_id = claim_plugin_id(claim).ok_or_else(|| AdapterError::BundleInvalid {
+            root: claim.resource_root.clone(),
+            reason: "hermes receipt has no plugin id".to_string(),
+        })?;
+        validate_plugin_id(&plugin_id)?;
+        let home = require_home(ctx)?;
+
+        // 1. Place the plugin: copy the resource root into
+        //    $HERMES_HOME/plugins/<plugin_id>/, excluding the `skills/`
+        //    subtree (delivered separately to $HERMES_HOME/skills/).
+        let plugin_dest = home.join("plugins").join(&plugin_id);
+        copy_bundle_excluding_skills(&claim.resource_root, &plugin_dest, ctx)?;
+
+        // 2. Enable the placed plugin via the Hermes CLI.
+        let enable_cmd = build_enable_cmd(&plugin_id);
+        let program = enable_cmd.program.clone();
+        let output = ctx.ops.run_framework_cli(enable_cmd)?;
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
+                program,
+                reason: cli_failure_reason("plugins enable", &output),
+            });
+        }
+
+        // 3. Deliver skills through the Manager's controlled IO.
+        for skill in &ctx.declared_skills {
+            let src = claim.resource_root.join("skills").join(skill);
+            let dst = home.join("skills").join(skill);
+            ctx.ops.copy_tree(&src, &dst)?;
+        }
+
+        Ok(())
+    }
+
+    fn status(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterStatusReport, AdapterError> {
+        let mut conditions = Vec::new();
+
+        // 1. Framework detectable?
+        let detect = self.detect(&HostEnv {
+            user_home: ctx.user_home.clone(),
+        });
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::FrameworkDetected,
+            status: bool_status(detect.detected),
+            reason: Some(detect.reason.clone()),
+            resource: None,
+        });
+
+        // 2. Resource bundle still matches the enable-time digest?
+        conditions.push(self.bundle_match_condition(claim));
+
+        // 3. Plugin still registered? Requires the CLI for a read-only
+        //    `plugins list`.
+        let plugin_id = claim_plugin_id(claim);
+        let (plugin_cond, verify_cond, plugin_registered) = if !detect.detected {
+            (
+                AdapterCondition {
+                    kind: AdapterConditionKind::PluginRegistered,
+                    status: ConditionStatus::Unknown,
+                    reason: Some("framework not detected; cannot verify".to_string()),
+                    resource: plugin_id.as_ref().map(|_| ClaimResourceRef {
+                        id: RES_PLUGIN.to_string(),
+                    }),
+                },
+                AdapterCondition {
+                    kind: AdapterConditionKind::VerificationSupported,
+                    status: ConditionStatus::False,
+                    reason: Some("hermes CLI unavailable".to_string()),
+                    resource: None,
+                },
+                ConditionStatus::Unknown,
+            )
+        } else if let Some(pid) = &plugin_id {
+            self.plugin_registered_condition(pid, ctx)
+        } else {
+            (
+                AdapterCondition {
+                    kind: AdapterConditionKind::PluginRegistered,
+                    status: ConditionStatus::Unknown,
+                    reason: Some("receipt has no plugin id".to_string()),
+                    resource: None,
+                },
+                AdapterCondition {
+                    kind: AdapterConditionKind::VerificationSupported,
+                    status: ConditionStatus::True,
+                    reason: None,
+                    resource: None,
+                },
+                ConditionStatus::Unknown,
+            )
+        };
+        conditions.push(plugin_cond);
+        conditions.push(verify_cond);
+
+        let summary = summarize(claim.status, detect.detected, plugin_registered);
+        Ok(AdapterStatusReport {
+            summary,
+            conditions,
+        })
+    }
+
+    fn disable(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        let plugin_id = match claim_plugin_id(claim) {
+            Some(p) => p,
+            None => {
+                // No plugin recorded: nothing to unregister.
+                return Ok(DisableReport {
+                    cleanup_complete: true,
+                    messages: vec!["receipt records no plugin to unregister".to_string()],
+                });
+            }
+        };
+        validate_plugin_id(&plugin_id)?;
+
+        if find_binary_in_path(&hermes_bin()).is_none() {
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![
+                    "hermes CLI not found on PATH; receipt kept so cleanup can be retried"
+                        .to_string(),
+                ],
+            });
+        }
+
+        let mut messages = Vec::new();
+        let mut cleanup_complete = true;
+
+        let home = require_home(ctx)?;
+
+        // 1. Disable the plugin (ignore failure — might already be disabled).
+        let disable_cmd = build_disable_cmd(&plugin_id);
+        let _ = ctx.ops.run_framework_cli(disable_cmd);
+
+        // 2. Remove the placed plugin directory through controlled IO.
+        let plugin_dir = home.join("plugins").join(&plugin_id);
+        match ctx.ops.remove_tree(&plugin_dir) {
+            Ok(true) => messages.push(format!(
+                "removed hermes plugin directory {}",
+                plugin_dir.display()
+            )),
+            Ok(false) => messages.push(format!(
+                "hermes plugin directory {} already absent",
+                plugin_dir.display()
+            )),
+            Err(err) => {
+                cleanup_complete = false;
+                messages.push(format!(
+                    "failed to remove hermes plugin directory {}: {err}",
+                    plugin_dir.display()
+                ));
+            }
+        }
+
+        // 3. Remove skill directories through Manager IO.
+        if let DriverPayload::Hermes(ref hermes) = claim.driver_payload {
+            for skill_res_id in &hermes.skill_resources {
+                if let Some(resource) = claim.resource(skill_res_id) {
+                    if let ClaimResourceKind::ExternalPath { path } = &resource.kind {
+                        match ctx.ops.remove_tree(path) {
+                            Ok(true) => {
+                                messages.push(format!("removed skill dir {}", path.display()));
+                            }
+                            Ok(false) => {} // already gone
+                            Err(err) => {
+                                cleanup_complete = false;
+                                messages.push(format!(
+                                    "failed to remove skill dir {}: {err}",
+                                    path.display()
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(DisableReport {
+            cleanup_complete,
+            messages,
+        })
+    }
+}
+
+impl HermesDriver {
+    /// Build the `ResourceBundleMatches` condition by re-digesting the
+    /// resource root and comparing to the enable-time digest.
+    fn bundle_match_condition(&self, claim: &AdapterClaim) -> AdapterCondition {
+        let kind = AdapterConditionKind::ResourceBundleMatches;
+        match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
+            (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+                kind,
+                status: ConditionStatus::True,
+                reason: None,
+                resource: None,
+            },
+            (Some(_), Some(_)) => AdapterCondition {
+                kind,
+                status: ConditionStatus::False,
+                reason: Some("resource bundle changed since enable".to_string()),
+                resource: None,
+            },
+            _ => AdapterCondition {
+                kind,
+                status: ConditionStatus::Unknown,
+                reason: Some("no digest recorded or resource root unavailable".to_string()),
+                resource: None,
+            },
+        }
+    }
+
+    /// Run `hermes plugins list` and decide whether `plugin_id` is still
+    /// registered. Returns `(plugin_condition, verification_condition,
+    /// plugin_registered_status)`.
+    fn plugin_registered_condition(
+        &self,
+        plugin_id: &str,
+        ctx: &DriverCtx,
+    ) -> (AdapterCondition, AdapterCondition, ConditionStatus) {
+        let plugin_ref = Some(ClaimResourceRef {
+            id: RES_PLUGIN.to_string(),
+        });
+        let cmd = build_list_cmd();
+        match ctx.ops.run_framework_cli(cmd) {
+            Ok(output) if output.success() => {
+                let registered = list_contains_plugin(&output.stdout, plugin_id);
+                (
+                    AdapterCondition {
+                        kind: AdapterConditionKind::PluginRegistered,
+                        status: bool_status(registered),
+                        reason: (!registered)
+                            .then(|| "plugin not present in `plugins list`".to_string()),
+                        resource: plugin_ref,
+                    },
+                    AdapterCondition {
+                        kind: AdapterConditionKind::VerificationSupported,
+                        status: ConditionStatus::True,
+                        reason: None,
+                        resource: None,
+                    },
+                    bool_status(registered),
+                )
+            }
+            // The list probe ran but failed, or could not spawn: we cannot
+            // verify. Report Unknown, never a faked healthy/absent.
+            Ok(_) | Err(_) => (
+                AdapterCondition {
+                    kind: AdapterConditionKind::PluginRegistered,
+                    status: ConditionStatus::Unknown,
+                    reason: Some("`plugins list` did not return a usable result".to_string()),
+                    resource: plugin_ref,
+                },
+                AdapterCondition {
+                    kind: AdapterConditionKind::VerificationSupported,
+                    status: ConditionStatus::False,
+                    reason: Some("`plugins list` unavailable".to_string()),
+                    resource: None,
+                },
+                ConditionStatus::Unknown,
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no spawning) — unit-testable
+// ---------------------------------------------------------------------------
+
+/// `HERMES_BIN` override, else `hermes`.
+fn hermes_bin() -> String {
+    std::env::var("HERMES_BIN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "hermes".to_string())
+}
+
+/// Resolve the Hermes home directory: `HERMES_HOME`, else
+/// `<user_home>/.hermes`. Trailing slashes are trimmed.
+fn hermes_home(user_home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(h) = std::env::var_os("HERMES_HOME") {
+        let s = h.to_string_lossy();
+        let trimmed = s.trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    user_home.map(|h| h.join(".hermes"))
+}
+
+/// Build a bare Hermes command with the given args. Hermes has a simpler
+/// env contract than OpenClaw: no state-dir rewriting, no PATH prepend.
+fn base_cmd(args: Vec<String>) -> FrameworkCommand {
+    FrameworkCommand {
+        program: hermes_bin(),
+        args,
+        env_set: Vec::new(),
+        env_remove: Vec::new(),
+        path_prepend: Vec::new(),
+        timeout: CLI_TIMEOUT,
+    }
+}
+
+/// Build `hermes plugins enable <plugin_id>`.
+fn build_enable_cmd(plugin_id: &str) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugins".to_string(),
+        "enable".to_string(),
+        plugin_id.to_string(),
+    ])
+}
+
+/// Build `hermes plugins disable <plugin_id>`.
+fn build_disable_cmd(plugin_id: &str) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugins".to_string(),
+        "disable".to_string(),
+        plugin_id.to_string(),
+    ])
+}
+
+/// Build the read-only `hermes plugins list`.
+fn build_list_cmd() -> FrameworkCommand {
+    base_cmd(vec!["plugins".to_string(), "list".to_string()])
+}
+
+/// Plugin id declared by a Hermes-native manifest, when present.
+///
+/// When `declared_entry` is given, uses only that file; otherwise tries
+/// `hermes.plugin.json` then `hermes.manifest.yaml`. Falls back to `None`.
+///
+/// File format is determined by extension: `.yaml`/`.yml` are parsed with
+/// a simple line scan for `id: <value>`; `.json` (and the default
+/// fallback `hermes.plugin.json`) are parsed as JSON.
+fn read_plugin_manifest_id(
+    root: &Path,
+    declared_entry: Option<&str>,
+) -> Result<Option<String>, AdapterError> {
+    if let Some(entry) = declared_entry {
+        let lower = entry.to_ascii_lowercase();
+        if lower.ends_with(".yaml") || lower.ends_with(".yml") {
+            return read_yaml_id(root, entry);
+        }
+        return read_json_id(root, entry);
+    }
+
+    // No declared entry: try JSON then YAML fallback.
+    if let Some(id) = read_json_id(root, "hermes.plugin.json")? {
+        return Ok(Some(id));
+    }
+    read_yaml_id(root, "hermes.manifest.yaml")
+}
+
+/// Read the `id` field from a JSON manifest file.
+fn read_json_id(root: &Path, filename: &str) -> Result<Option<String>, AdapterError> {
+    #[derive(serde::Deserialize)]
+    struct PluginManifest {
+        id: Option<String>,
+    }
+
+    let path = root.join(filename);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(AdapterError::Io { path, source }),
+    };
+    let manifest: PluginManifest =
+        serde_json::from_slice(&bytes).map_err(|source| AdapterError::BundleInvalid {
+            root: root.to_path_buf(),
+            reason: format!(
+                "failed to parse {} as Hermes plugin manifest: {source}",
+                path.display()
+            ),
+        })?;
+    Ok(manifest.id.filter(|id| !id.is_empty()))
+}
+
+/// Read the `id` field from a YAML manifest via a minimal line scan.
+fn read_yaml_id(root: &Path, filename: &str) -> Result<Option<String>, AdapterError> {
+    let path = root.join(filename);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(AdapterError::Io { path, source }),
+    };
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("id:") {
+            let value = rest.trim().trim_matches('"').trim_matches('\'');
+            if !value.is_empty() {
+                return Ok(Some(value.to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Copy the bundle directory into the plugin destination, skipping the
+/// `skills/` subdirectory (delivered separately to `$HERMES_HOME/skills/`).
+/// All IO goes through `ctx.ops` so the Manager enforces path boundaries.
+fn copy_bundle_excluding_skills(
+    src: &Path,
+    dst: &Path,
+    ctx: &DriverCtx,
+) -> Result<(), AdapterError> {
+    let entries = std::fs::read_dir(src).map_err(|source| AdapterError::Io {
+        path: src.to_path_buf(),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| AdapterError::Io {
+            path: src.to_path_buf(),
+            source,
+        })?;
+        let name = entry.file_name();
+        if name == "skills" {
+            continue;
+        }
+        let src_child = entry.path();
+        let dst_child = dst.join(&name);
+        if src_child.is_dir() {
+            ctx.ops.copy_tree(&src_child, &dst_child)?;
+        } else {
+            ctx.ops.copy_file(&src_child, &dst_child)?;
+        }
+    }
+    Ok(())
+}
+
+/// Human-readable form of a command for dry-run/preview output. Display
+/// only — never parsed back into an argv.
+fn display_command(cmd: &FrameworkCommand) -> String {
+    let mut s = String::new();
+    for (k, v) in &cmd.env_set {
+        s.push_str(&format!("{k}={v} "));
+    }
+    s.push_str(&cmd.program);
+    for a in &cmd.args {
+        s.push(' ');
+        s.push_str(a);
+    }
+    s
+}
+
+/// True when `plugin_id` appears as a whole whitespace-delimited token on
+/// any line of `plugins list` output. Tolerant of decoration like
+/// `- agent-sec (v1.2)`.
+fn list_contains_plugin(stdout: &str, plugin_id: &str) -> bool {
+    stdout
+        .lines()
+        .any(|line| line.split_whitespace().any(|tok| tok == plugin_id))
+}
+
+/// Extract the validated plugin id from a claim's resources, falling back
+/// to the top-level `plugin_id` field.
+fn claim_plugin_id(claim: &AdapterClaim) -> Option<String> {
+    // Hermes uses ExternalPath for the plugin dir; the plugin id is in the
+    // top-level field.
+    claim.plugin_id.clone()
+}
+
+/// Plugin id from a bundle, or [`AdapterError::BundleInvalid`] when none
+/// is resolvable.
+fn require_plugin_id(bundle: &AdapterBundle) -> Result<String, AdapterError> {
+    bundle
+        .plugin_id
+        .clone()
+        .ok_or_else(|| AdapterError::BundleInvalid {
+            root: bundle.resource_root.clone(),
+            reason: "no plugin id declared in manifest and none discoverable".to_string(),
+        })
+}
+
+/// Hermes home, or [`AdapterError::FrameworkCli`] when `$HOME` is
+/// unresolvable (no `user_home`, no `HERMES_HOME`).
+fn require_home(ctx: &DriverCtx) -> Result<PathBuf, AdapterError> {
+    hermes_home(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
+        program: hermes_bin(),
+        reason: "cannot resolve Hermes home (no $HOME and no HERMES_HOME)".to_string(),
+    })
+}
+
+/// Compose a failure reason string from a non-success [`CliOutput`].
+fn cli_failure_reason(verb: &str, output: &super::driver::CliOutput) -> String {
+    if output.timed_out {
+        return format!("'{verb}' timed out");
+    }
+    let code = output
+        .status
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "killed".to_string());
+    let mut reason = format!("'{verb}' exited with {code}");
+    let stderr = output.stderr.trim();
+    if !stderr.is_empty() {
+        reason.push_str(": ");
+        reason.push_str(stderr);
+    }
+    reason
+}
+
+/// Map a bool to a [`ConditionStatus`] (`true` -> `True`, `false` -> `False`).
+fn bool_status(b: bool) -> ConditionStatus {
+    if b {
+        ConditionStatus::True
+    } else {
+        ConditionStatus::False
+    }
+}
+
+/// Roll the framework-detect and plugin-registration signals into a
+/// summary, honoring a `cleanup_failed` receipt.
+fn summarize(
+    claim_status: ClaimStatus,
+    framework_detected: bool,
+    plugin_registered: ConditionStatus,
+) -> AdapterSummary {
+    if claim_status == ClaimStatus::CleanupFailed {
+        return AdapterSummary::CleanupFailed;
+    }
+    if !framework_detected {
+        return AdapterSummary::Degraded;
+    }
+    match plugin_registered {
+        ConditionStatus::True => AdapterSummary::Healthy,
+        ConditionStatus::False => AdapterSummary::Degraded,
+        ConditionStatus::Unknown => AdapterSummary::Unknown,
+    }
+}
+
+/// SHA-256 digest of a directory tree, stable across runs: files are
+/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
+/// `None` on any IO error so callers fall back to `Unknown` rather than a
+/// wrong verdict.
+fn digest_tree(root: &Path) -> Option<String> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    collect_files(root, &mut files).ok()?;
+    files.sort();
+    let mut hasher = Sha256::new();
+    for path in &files {
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        let bytes = std::fs::read(path).ok()?;
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update([0u8]);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update([0u8]);
+        hasher.update(&bytes);
+    }
+    Some(format!("sha256:{:x}", hasher.finalize()))
+}
+
+/// Recursively collect regular-file paths under `dir`. Symlinks are not
+/// followed into directories (their link path is recorded as a file).
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            collect_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// ISO 8601 UTC timestamp, second precision.
+fn now_iso8601() -> String {
+    use chrono::{SecondsFormat, Utc};
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hermes_home_resolution() {
+        // SAFETY: test-only; env mutation is acceptable in serial tests.
+        unsafe {
+            // With env var set.
+            std::env::set_var("HERMES_HOME", "/opt/hermes");
+            assert_eq!(
+                hermes_home(Some(Path::new("/home/alice"))),
+                Some(PathBuf::from("/opt/hermes"))
+            );
+            // Trailing slashes are stripped.
+            std::env::set_var("HERMES_HOME", "/opt/hermes///");
+            assert_eq!(
+                hermes_home(Some(Path::new("/home/alice"))),
+                Some(PathBuf::from("/opt/hermes"))
+            );
+            // Empty env var falls back to user_home.
+            std::env::set_var("HERMES_HOME", "");
+            assert_eq!(
+                hermes_home(Some(Path::new("/home/alice"))),
+                Some(PathBuf::from("/home/alice/.hermes"))
+            );
+            // No env var, no user_home.
+            std::env::remove_var("HERMES_HOME");
+        }
+        assert_eq!(hermes_home(None), None);
+        // No env var, with user_home.
+        assert_eq!(
+            hermes_home(Some(Path::new("/home/bob"))),
+            Some(PathBuf::from("/home/bob/.hermes"))
+        );
+    }
+
+    #[test]
+    fn list_contains_plugin_matches_whole_token() {
+        assert!(list_contains_plugin("agent-sec\nother\n", "agent-sec"));
+        assert!(list_contains_plugin("- agent-sec (v1.2)\n", "agent-sec"));
+        assert!(!list_contains_plugin("agent-sec-extra\n", "agent-sec"));
+        assert!(!list_contains_plugin("", "agent-sec"));
+    }
+
+    #[test]
+    fn enable_cmd_shape() {
+        let cmd = build_enable_cmd("agent-sec");
+        assert_eq!(cmd.program, "hermes");
+        assert_eq!(cmd.args, vec!["plugins", "enable", "agent-sec"]);
+    }
+
+    #[test]
+    fn disable_cmd_shape() {
+        let cmd = build_disable_cmd("agent-sec");
+        assert_eq!(cmd.args, vec!["plugins", "disable", "agent-sec"]);
+    }
+
+    #[test]
+    fn summarize_prioritizes_cleanup_failed() {
+        assert_eq!(
+            summarize(ClaimStatus::CleanupFailed, true, ConditionStatus::True),
+            AdapterSummary::CleanupFailed
+        );
+    }
+
+    #[test]
+    fn summarize_healthy_only_when_detected_and_registered() {
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, true, ConditionStatus::True),
+            AdapterSummary::Healthy
+        );
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, false, ConditionStatus::True),
+            AdapterSummary::Degraded
+        );
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, true, ConditionStatus::False),
+            AdapterSummary::Degraded
+        );
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, true, ConditionStatus::Unknown),
+            AdapterSummary::Unknown
+        );
+    }
+
+    #[test]
+    fn digest_tree_is_stable_and_detects_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("a.txt"), b"hello").expect("write");
+        std::fs::create_dir(dir.path().join("sub")).expect("mkdir");
+        std::fs::write(dir.path().join("sub/b.txt"), b"world").expect("write");
+
+        let d1 = digest_tree(dir.path()).expect("digest");
+        let d2 = digest_tree(dir.path()).expect("digest again");
+        assert_eq!(d1, d2, "digest must be stable");
+
+        std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
+        let d3 = digest_tree(dir.path()).expect("digest after change");
+        assert_ne!(d1, d3, "digest must change when a file changes");
+    }
+
+    // -- review fix coverage: lazy plugin_id, YAML entry, skills allowlist --
+
+    use crate::adapter::claim::{DriverPayload, HermesClaim};
+    use crate::adapter::driver::{AdapterOps, CliOutput};
+
+    struct StubOps;
+
+    impl AdapterOps for StubOps {
+        fn run_framework_cli(&self, _: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+            unimplemented!()
+        }
+        fn copy_tree(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn copy_file(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn remove_tree(&self, _: &Path) -> Result<bool, AdapterError> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn declared_plugin_id_skips_manifest_parse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Invalid content that would fail if read_plugin_manifest_id parsed it.
+        std::fs::write(dir.path().join("hermes.plugin.json"), b"NOT JSON {{").expect("write");
+
+        let driver = HermesDriver::new();
+        let ops = StubOps;
+        let layout = anolisa_platform::fs_layout::FsLayout::user(PathBuf::from("/tmp/test-home-a"));
+        let ctx = DriverCtx {
+            component: "test-comp".to_string(),
+            framework: "hermes".to_string(),
+            layout: &layout,
+            resource_root: dir.path().to_path_buf(),
+            user_home: Some(PathBuf::from("/tmp/test-home-a")),
+            declared_plugin_id: Some("agent-sec".to_string()),
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            dry_run: true,
+            ops: &ops,
+        };
+
+        let bundle = driver
+            .read_bundle(&ctx)
+            .expect("must succeed without parsing manifest");
+        assert_eq!(bundle.plugin_id.as_deref(), Some("agent-sec"));
+    }
+
+    #[test]
+    fn yaml_bundle_entry_parses_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("hermes.manifest.yaml"),
+            "id: agent-sec\nname: Agent Security\n",
+        )
+        .expect("write");
+
+        let id = read_plugin_manifest_id(dir.path(), Some("hermes.manifest.yaml"))
+            .expect("parse must succeed")
+            .expect("id must be present");
+        assert_eq!(id, "agent-sec");
+    }
+
+    #[test]
+    fn only_declared_skills_are_planned_and_claimed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("skills/sec-audit")).expect("mkdir");
+        std::fs::create_dir_all(root.join("skills/undeclared-extra")).expect("mkdir");
+        std::fs::write(root.join("dummy.txt"), b"x").expect("write");
+
+        let driver = HermesDriver::new();
+        let ops = StubOps;
+        let layout = anolisa_platform::fs_layout::FsLayout::user(PathBuf::from("/tmp/test-home-c"));
+        let ctx = DriverCtx {
+            component: "test-comp".to_string(),
+            framework: "hermes".to_string(),
+            layout: &layout,
+            resource_root: root.to_path_buf(),
+            user_home: Some(PathBuf::from("/tmp/test-home-c")),
+            declared_plugin_id: Some("test-plugin".to_string()),
+            declared_skills: vec!["sec-audit".to_string()],
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            dry_run: true,
+            ops: &ops,
+        };
+
+        let bundle = AdapterBundle {
+            resource_root: root.to_path_buf(),
+            digest: None,
+            plugin_id: Some("test-plugin".to_string()),
+        };
+
+        let plan = driver.plan_enable(&bundle, &ctx).expect("plan_enable");
+        assert!(
+            plan.actions.iter().any(|a| a.contains("sec-audit")),
+            "declared skill must appear in plan"
+        );
+        assert!(
+            !plan.actions.iter().any(|a| a.contains("undeclared-extra")),
+            "undeclared skill must not appear in plan"
+        );
+
+        let claim = driver
+            .prepare_enable(&bundle, &ctx)
+            .expect("prepare_enable");
+        let skill_resources: Vec<&str> = claim
+            .resources
+            .iter()
+            .filter(|r| r.purpose == "hermes_skill")
+            .map(|r| r.id.as_str())
+            .collect();
+        assert_eq!(skill_resources, vec!["hermes_skill_sec-audit"]);
+        if let DriverPayload::Hermes(HermesClaim {
+            ref skill_resources,
+            ..
+        }) = claim.driver_payload
+        {
+            assert_eq!(skill_resources, &["hermes_skill_sec-audit"]);
+        } else {
+            panic!("expected Hermes driver payload");
+        }
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -16,7 +16,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -360,6 +360,39 @@ impl AdapterManager {
         }
 
         let declared_plugin_id = declared_plugin_id(&manifest, &framework);
+        let skills = declared_skills(&manifest, &framework);
+        let config = declared_config(&manifest, &framework);
+        let bundle_entry = declared_bundle_entry(&manifest, &framework);
+
+        for skill in &skills {
+            super::claim::validate_skill_name(skill).map_err(|mut err| {
+                if let AdapterError::InvalidAdapterInput {
+                    component: ref mut c,
+                    framework: ref mut f,
+                    ..
+                } = err
+                {
+                    *c = component.to_string();
+                    *f = framework.clone();
+                }
+                err
+            })?;
+        }
+        for cfg in &config {
+            super::claim::validate_config_key(&cfg.key).map_err(|mut err| {
+                if let AdapterError::InvalidAdapterInput {
+                    component: ref mut c,
+                    framework: ref mut f,
+                    ..
+                } = err
+                {
+                    *c = component.to_string();
+                    *f = framework.clone();
+                }
+                err
+            })?;
+        }
+
         let driver =
             self.registry
                 .get(&framework)
@@ -375,12 +408,43 @@ impl AdapterManager {
         )?;
 
         let label = format!("adapter enable {component} {framework}");
+        // Two-phase ManagerOps: first build a read-only ops (no allowed
+        // roots) to construct the DriverCtx needed for
+        // allowed_external_roots; then rebuild with the computed roots
+        // for the mutable phase.
+        let probe_ops = ManagerOps::new(
+            self.central_log(),
+            self.actor.clone(),
+            install_mode_str(self.layout.mode).to_string(),
+            component.to_string(),
+            label.clone(),
+            vec![resource_root.clone()],
+        );
+        let probe_ctx = DriverCtx {
+            component: component.to_string(),
+            framework: framework.clone(),
+            layout: &self.layout,
+            resource_root: resource_root.clone(),
+            user_home: self.user_home.clone(),
+            declared_plugin_id: declared_plugin_id.clone(),
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            dry_run,
+            ops: &probe_ops,
+        };
+        let mut allowed_roots = driver.allowed_external_roots(&probe_ctx);
+        allowed_roots.push(resource_root.clone());
+        drop(probe_ctx);
+        drop(probe_ops);
+
         let ops = ManagerOps::new(
             self.central_log(),
             self.actor.clone(),
             install_mode_str(self.layout.mode).to_string(),
             component.to_string(),
             label.clone(),
+            allowed_roots,
         );
         let ctx = DriverCtx {
             component: component.to_string(),
@@ -389,6 +453,9 @@ impl AdapterManager {
             resource_root: resource_root.clone(),
             user_home: self.user_home.clone(),
             declared_plugin_id,
+            declared_skills: skills,
+            declared_config: config,
+            declared_bundle_entry: bundle_entry,
             dry_run,
             ops: &ops,
         };
@@ -536,12 +603,39 @@ impl AdapterManager {
             .unwrap_or_else(|| claim.resource_root.clone());
 
         let label = format!("adapter disable {component} {framework}");
+        let probe_ops = ManagerOps::new(
+            self.central_log(),
+            self.actor.clone(),
+            install_mode_str(self.layout.mode).to_string(),
+            component.to_string(),
+            label.clone(),
+            vec![resource_root.clone()],
+        );
+        let probe_ctx = DriverCtx {
+            component: component.to_string(),
+            framework: framework.clone(),
+            layout: &self.layout,
+            resource_root: resource_root.clone(),
+            user_home: self.user_home.clone(),
+            declared_plugin_id: None,
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            dry_run: false,
+            ops: &probe_ops,
+        };
+        let mut allowed_roots = driver.allowed_external_roots(&probe_ctx);
+        allowed_roots.push(resource_root.clone());
+        drop(probe_ctx);
+        drop(probe_ops);
+
         let ops = ManagerOps::new(
             self.central_log(),
             self.actor.clone(),
             install_mode_str(self.layout.mode).to_string(),
             component.to_string(),
             label.clone(),
+            allowed_roots,
         );
         let ctx = DriverCtx {
             component: component.to_string(),
@@ -550,6 +644,9 @@ impl AdapterManager {
             resource_root,
             user_home: self.user_home.clone(),
             declared_plugin_id: None,
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
             dry_run: false,
             ops: &ops,
         };
@@ -630,6 +727,7 @@ impl AdapterManager {
                 install_mode_str(self.layout.mode).to_string(),
                 claim.component.clone(),
                 label,
+                vec![resource_root.clone()],
             );
             let ctx = DriverCtx {
                 component: claim.component.clone(),
@@ -638,6 +736,9 @@ impl AdapterManager {
                 resource_root,
                 user_home: self.user_home.clone(),
                 declared_plugin_id: None,
+                declared_skills: Vec::new(),
+                declared_config: Vec::new(),
+                declared_bundle_entry: None,
                 dry_run: false,
                 ops: &ops,
             };
@@ -959,6 +1060,10 @@ struct ManagerOps {
     component: String,
     /// Human-readable operation label for the log `command` field.
     label: String,
+    /// Roots that `copy_tree` / `remove_tree` destinations must fall
+    /// under. Populated from the driver's `allowed_external_roots` plus
+    /// the resource root.
+    allowed_roots: Vec<PathBuf>,
 }
 
 impl ManagerOps {
@@ -968,6 +1073,7 @@ impl ManagerOps {
         install_mode: String,
         component: String,
         label: String,
+        allowed_roots: Vec<PathBuf>,
     ) -> Self {
         Self {
             log,
@@ -975,6 +1081,7 @@ impl ManagerOps {
             install_mode,
             component,
             label,
+            allowed_roots,
         }
     }
 
@@ -1025,6 +1132,58 @@ impl AdapterOps for ManagerOps {
         let output = run_capture(&cmd)?;
         self.record(&cmd, &output);
         Ok(output)
+    }
+
+    fn copy_tree(&self, src: &Path, dst: &Path) -> Result<(), AdapterError> {
+        validate_ops_path(src, &self.allowed_roots)?;
+        validate_ops_path(dst, &self.allowed_roots)?;
+        reject_symlink(src)?;
+        if !src.is_dir() {
+            return Err(AdapterError::Io {
+                path: src.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "source directory does not exist",
+                ),
+            });
+        }
+        std::fs::create_dir_all(dst).map_err(|source| AdapterError::Io {
+            path: dst.to_path_buf(),
+            source,
+        })?;
+        copy_dir_recursive(src, dst).map_err(|source| AdapterError::Io {
+            path: dst.to_path_buf(),
+            source,
+        })
+    }
+
+    fn copy_file(&self, src: &Path, dst: &Path) -> Result<(), AdapterError> {
+        validate_ops_path(src, &self.allowed_roots)?;
+        validate_ops_path(dst, &self.allowed_roots)?;
+        reject_symlink(src)?;
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| AdapterError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        std::fs::copy(src, dst).map_err(|source| AdapterError::Io {
+            path: dst.to_path_buf(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    fn remove_tree(&self, path: &Path) -> Result<bool, AdapterError> {
+        validate_ops_path(path, &self.allowed_roots)?;
+        if !path.exists() {
+            return Ok(false);
+        }
+        std::fs::remove_dir_all(path).map_err(|source| AdapterError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Ok(true)
     }
 }
 
@@ -1103,6 +1262,68 @@ fn prepend_path(prepend: &[PathBuf]) -> std::ffi::OsString {
     // which our dirs do not; fall back to the prepend dirs alone.
     std::env::join_paths(&parts)
         .unwrap_or_else(|_| std::env::join_paths(prepend).unwrap_or_default())
+}
+
+/// Validate that `path` is under one of `allowed_roots` and contains no
+/// traversal segments. Used by `copy_tree` / `remove_tree` to enforce the
+/// Manager's IO boundary before any filesystem mutation.
+fn validate_ops_path(path: &Path, allowed_roots: &[PathBuf]) -> Result<(), AdapterError> {
+    use super::claim::validate_external_path;
+
+    validate_external_path(path, allowed_roots).map_err(|source| {
+        AdapterError::ClaimValidation(super::claim::ClaimValidationError::ExternalPath {
+            id: format!("ops:{}", path.display()),
+            source,
+        })
+    })
+}
+
+/// Reject a path that is a symlink. Used by `copy_file` and
+/// `copy_dir_recursive` to prevent following a symlink that escapes the
+/// allowed roots.
+fn reject_symlink(path: &Path) -> Result<(), AdapterError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => Err(AdapterError::Io {
+            path: path.to_path_buf(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "symlink rejected in adapter resource tree: {}",
+                    path.display()
+                ),
+            ),
+        }),
+        _ => Ok(()),
+    }
+}
+
+/// Recursively copy regular files and subdirectories from `src` into
+/// `dst`. Symlinks are rejected — a symlink inside the resource tree
+/// could point outside the allowed roots, bypassing the boundary check
+/// on the top-level `src` path.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        if ft.is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "symlink rejected in adapter resource tree: {}",
+                    entry.path().display()
+                ),
+            ));
+        }
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if ft.is_dir() {
+            std::fs::create_dir_all(&dst_path)?;
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
 }
 
 /// Drain a child pipe to EOF on its own thread, keeping at most `cap`
@@ -1215,6 +1436,92 @@ fn declared_plugin_id(manifest: &ComponentManifest, framework: &str) -> Option<S
         .map(str::trim)
         .filter(|plugin_id| !plugin_id.is_empty())
         .map(str::to_string)
+}
+
+/// Extract declared skills for a framework, checking the framework-specific
+/// section first (e.g. `adapters.openclaw.skills`) then falling back to
+/// the generic `adapters.skills`.
+fn declared_skills(manifest: &ComponentManifest, framework: &str) -> Vec<String> {
+    let adapter = manifest
+        .adapters
+        .iter()
+        .find(|a| a.framework.as_deref().map(str::trim) == Some(framework));
+    let adapter = match adapter {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    // Framework-specific section takes precedence.
+    match framework {
+        "openclaw" => {
+            if let Some(ref oc) = adapter.openclaw {
+                if !oc.skills.is_empty() {
+                    return oc.skills.clone();
+                }
+            }
+        }
+        "hermes" => {
+            if let Some(ref h) = adapter.hermes {
+                if !h.skills.is_empty() {
+                    return h.skills.clone();
+                }
+            }
+        }
+        _ => {}
+    }
+    adapter.skills.clone()
+}
+
+/// Extract declared config entries for a framework, checking the
+/// framework-specific section first then falling back to the generic one.
+fn declared_config(
+    manifest: &ComponentManifest,
+    framework: &str,
+) -> Vec<crate::manifest::AdapterConfigSetSpec> {
+    let adapter = manifest
+        .adapters
+        .iter()
+        .find(|a| a.framework.as_deref().map(str::trim) == Some(framework));
+    let adapter = match adapter {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    // Framework-specific section takes precedence.
+    if framework == "openclaw" {
+        if let Some(ref oc) = adapter.openclaw {
+            if !oc.config.is_empty() {
+                return oc.config.clone();
+            }
+        }
+    }
+    adapter.config.clone()
+}
+
+/// Extract the bundle entry-point from the manifest, checking the
+/// framework-specific section first then falling back to the generic
+/// `[adapters.bundle].entry`.
+fn declared_bundle_entry(manifest: &ComponentManifest, framework: &str) -> Option<String> {
+    let adapter = manifest
+        .adapters
+        .iter()
+        .find(|a| a.framework.as_deref().map(str::trim) == Some(framework))?;
+    match framework {
+        "openclaw" => {
+            if let Some(ref oc) = adapter.openclaw {
+                if let Some(ref entry) = oc.bundle.entry {
+                    return Some(entry.clone());
+                }
+            }
+        }
+        "hermes" => {
+            if let Some(ref h) = adapter.hermes {
+                if let Some(ref entry) = h.bundle.entry {
+                    return Some(entry.clone());
+                }
+            }
+        }
+        _ => {}
+    }
+    adapter.bundle.entry.clone()
 }
 
 /// A status report for a receipt that cannot be verified at all (e.g. no
@@ -1731,5 +2038,149 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
             entry.declared,
             "system component must be declared via system root"
         );
+    }
+
+    // -- copy_tree / remove_tree boundary ------------------------------------
+
+    #[test]
+    fn copy_tree_rejects_source_outside_allowed_roots() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let allowed = tmp.path().join("allowed");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(allowed.join("dst")).expect("mkdir");
+        std::fs::create_dir_all(&outside).expect("mkdir");
+        std::fs::write(outside.join("x.txt"), b"data").expect("write");
+
+        let ops = ManagerOps::new(
+            CentralLog::open(tmp.path().join("log.jsonl")),
+            "test".into(),
+            "user".into(),
+            "comp".into(),
+            "test".into(),
+            vec![allowed.clone()],
+        );
+        let err = ops
+            .copy_tree(&outside, &allowed.join("dst/target"))
+            .expect_err("source outside allowed roots must fail");
+        assert!(
+            matches!(err, AdapterError::ClaimValidation(_)),
+            "expected ClaimValidation, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn copy_tree_accepts_source_inside_allowed_roots() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let allowed = tmp.path().join("allowed");
+        let src = allowed.join("src");
+        let dst = allowed.join("dst");
+        std::fs::create_dir_all(&src).expect("mkdir src");
+        std::fs::write(src.join("f.txt"), b"ok").expect("write");
+
+        let ops = ManagerOps::new(
+            CentralLog::open(tmp.path().join("log.jsonl")),
+            "test".into(),
+            "user".into(),
+            "comp".into(),
+            "test".into(),
+            vec![allowed],
+        );
+        ops.copy_tree(&src, &dst)
+            .expect("source inside root must succeed");
+        assert!(dst.join("f.txt").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_rejects_symlink_inside_source() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let allowed = tmp.path().join("allowed");
+        let src = allowed.join("src");
+        let dst = allowed.join("dst");
+        std::fs::create_dir_all(&src).expect("mkdir src");
+        std::fs::write(src.join("ok.txt"), b"ok").expect("write");
+        std::os::unix::fs::symlink("/etc/passwd", src.join("link")).expect("symlink");
+
+        let ops = ManagerOps::new(
+            CentralLog::open(tmp.path().join("log.jsonl")),
+            "test".into(),
+            "user".into(),
+            "comp".into(),
+            "test".into(),
+            vec![allowed],
+        );
+        let err = ops
+            .copy_tree(&src, &dst)
+            .expect_err("symlink inside source must be rejected");
+        assert!(
+            matches!(err, AdapterError::Io { .. }),
+            "expected Io error, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("symlink rejected"),
+            "error should mention symlink: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_rejects_symlink_source_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = tmp.path().canonicalize().expect("canonicalize");
+        let allowed = base.join("allowed");
+        let real_dir = allowed.join("real");
+        std::fs::create_dir_all(&real_dir).expect("mkdir");
+        std::fs::write(real_dir.join("f.txt"), b"data").expect("write");
+        let link_dir = allowed.join("link_to_dir");
+        std::os::unix::fs::symlink(&real_dir, &link_dir).expect("symlink");
+
+        let ops = ManagerOps::new(
+            CentralLog::open(base.join("log.jsonl")),
+            "test".into(),
+            "user".into(),
+            "comp".into(),
+            "test".into(),
+            vec![allowed.clone()],
+        );
+        let err = ops
+            .copy_tree(&link_dir, &allowed.join("dst"))
+            .expect_err("symlink-to-dir source must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("symlink rejected"),
+            "error should mention symlink: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_file_rejects_symlink_source() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = tmp.path().canonicalize().expect("canonicalize tmp");
+        let allowed = base.join("allowed");
+        std::fs::create_dir_all(&allowed).expect("mkdir");
+        std::fs::write(allowed.join("real.txt"), b"ok").expect("write");
+        std::os::unix::fs::symlink("/etc/passwd", allowed.join("link.txt")).expect("symlink");
+
+        let ops = ManagerOps::new(
+            CentralLog::open(base.join("log.jsonl")),
+            "test".into(),
+            "user".into(),
+            "comp".into(),
+            "test".into(),
+            vec![allowed.clone()],
+        );
+        let err = ops
+            .copy_file(&allowed.join("link.txt"), &allowed.join("dst.txt"))
+            .expect_err("symlink source must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("symlink rejected") || msg.contains("boundary check"),
+            "error should reject symlink via boundary or explicit check: {msg}"
+        );
+
+        ops.copy_file(&allowed.join("real.txt"), &allowed.join("dst.txt"))
+            .expect("regular file must succeed");
+        assert!(allowed.join("dst.txt").is_file());
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -112,10 +112,14 @@ impl FrameworkDriver for OpenClawDriver {
             });
         }
 
+        let manifest_file = ctx
+            .declared_bundle_entry
+            .as_deref()
+            .unwrap_or("openclaw.plugin.json");
         let plugin_id = ctx
             .declared_plugin_id
             .clone()
-            .or(read_plugin_manifest_id(root)?)
+            .or(read_plugin_manifest_id(root, manifest_file)?)
             .or_else(|| Some(ctx.component.clone()));
 
         Ok(AdapterBundle {
@@ -134,13 +138,29 @@ impl FrameworkDriver for OpenClawDriver {
         validate_plugin_id(&plugin_id)?;
         let home = require_home(ctx)?;
         let cmd = build_install_cmd(&bundle.resource_root, &home, ctx.user_home.as_deref());
+        let mut actions = vec![format!(
+            "register openclaw plugin '{plugin_id}' from {}",
+            bundle.resource_root.display()
+        )];
+
+        for skill in &ctx.declared_skills {
+            actions.push(format!(
+                "deliver openclaw skill '{skill}' to {}/skills/{skill}",
+                home.display()
+            ));
+        }
+        for (i, cfg) in ctx.declared_config.iter().enumerate() {
+            actions.push(format!(
+                "set openclaw config [{i}] {} = {}",
+                cfg.key,
+                config_value_display(&cfg.value)
+            ));
+        }
+
         Ok(DriverPlan {
             framework: self.name().to_string(),
             component: ctx.component.clone(),
-            actions: vec![format!(
-                "register openclaw plugin '{plugin_id}' from {}",
-                bundle.resource_root.display()
-            )],
+            actions,
             register_command: Some(display_command(&cmd)),
         })
     }
@@ -154,7 +174,7 @@ impl FrameworkDriver for OpenClawDriver {
         validate_plugin_id(&plugin_id)?;
         let home = require_home(ctx)?;
 
-        let resources = vec![
+        let mut resources = vec![
             ClaimResource {
                 id: RES_STATE_DIR.to_string(),
                 purpose: "openclaw_state_dir".to_string(),
@@ -170,6 +190,33 @@ impl FrameworkDriver for OpenClawDriver {
             },
         ];
 
+        let mut skill_resources = Vec::new();
+        for skill in &ctx.declared_skills {
+            let res_id = format!("openclaw_skill_{skill}");
+            resources.push(ClaimResource {
+                id: res_id.clone(),
+                purpose: "openclaw_skill".to_string(),
+                kind: ClaimResourceKind::ExternalPath {
+                    path: home.join("skills").join(skill),
+                },
+            });
+            skill_resources.push(res_id);
+        }
+
+        let mut config_resources = Vec::new();
+        for (i, cfg) in ctx.declared_config.iter().enumerate() {
+            let res_id = format!("openclaw_config_{i}");
+            resources.push(ClaimResource {
+                id: res_id.clone(),
+                purpose: "openclaw_config".to_string(),
+                kind: ClaimResourceKind::FrameworkConfig {
+                    framework: self.name().to_string(),
+                    key: cfg.key.clone(),
+                },
+            });
+            config_resources.push(res_id);
+        }
+
         Ok(AdapterClaim {
             claim_schema: CLAIM_SCHEMA_VERSION,
             component: ctx.component.clone(),
@@ -184,6 +231,8 @@ impl FrameworkDriver for OpenClawDriver {
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: RES_STATE_DIR.to_string(),
                 plugin_resource: RES_PLUGIN.to_string(),
+                skill_resources,
+                config_resources,
             }),
         })
     }
@@ -196,17 +245,38 @@ impl FrameworkDriver for OpenClawDriver {
         validate_plugin_id(&plugin_id)?;
         let home = require_home(ctx)?;
 
+        // 1. Register the plugin.
         let cmd = build_install_cmd(&claim.resource_root, &home, ctx.user_home.as_deref());
         let program = cmd.program.clone();
         let output = ctx.ops.run_framework_cli(cmd)?;
-        if output.success() {
-            Ok(())
-        } else {
-            Err(AdapterError::FrameworkCli {
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
                 program,
                 reason: cli_failure_reason("plugins install", &output),
-            })
+            });
         }
+
+        // 2. Deliver skills through the Manager's controlled IO.
+        for skill in &ctx.declared_skills {
+            let src = ctx.resource_root.join("skills").join(skill);
+            let dst = home.join("skills").join(skill);
+            ctx.ops.copy_tree(&src, &dst)?;
+        }
+
+        // 3. Apply config entries via `openclaw config set <key> <value>`.
+        for cfg in &ctx.declared_config {
+            let cmd = build_config_set_cmd(&cfg.key, &cfg.value, &home, ctx.user_home.as_deref());
+            let program = cmd.program.clone();
+            let output = ctx.ops.run_framework_cli(cmd)?;
+            if !output.success() {
+                return Err(AdapterError::FrameworkCli {
+                    program,
+                    reason: cli_failure_reason("config set", &output),
+                });
+            }
+        }
+
+        Ok(())
     }
 
     fn status(
@@ -308,24 +378,59 @@ impl FrameworkDriver for OpenClawDriver {
         }
 
         let home = require_home(ctx)?;
+        let mut messages = Vec::new();
+        let mut cleanup_complete = true;
+
+        // 1. Unregister the plugin.
         let cmd = build_uninstall_cmd(&plugin_id, &home, ctx.user_home.as_deref());
         let output = ctx.ops.run_framework_cli(cmd)?;
         if output.success() {
-            Ok(DisableReport {
-                cleanup_complete: true,
-                messages: vec![format!("unregistered openclaw plugin '{plugin_id}'")],
-            })
+            messages.push(format!("unregistered openclaw plugin '{plugin_id}'"));
         } else {
             // Keep the receipt (Manager marks cleanup_failed) so disable can
             // be retried — do NOT delete anything else.
-            Ok(DisableReport {
+            return Ok(DisableReport {
                 cleanup_complete: false,
                 messages: vec![format!(
                     "openclaw plugin uninstall failed: {}",
                     cli_failure_reason("plugins uninstall", &output)
                 )],
-            })
+            });
         }
+
+        // 2. Remove delivered skill directories through Manager IO.
+        let skill_resources = claim_skill_resources(claim);
+        for skill_name in &skill_resources {
+            let skill_dir = home.join("skills").join(skill_name);
+            match ctx.ops.remove_tree(&skill_dir) {
+                Ok(true) => messages.push(format!(
+                    "removed openclaw skill dir {}",
+                    skill_dir.display()
+                )),
+                Ok(false) => {} // already gone, idempotent
+                Err(err) => {
+                    messages.push(format!(
+                        "failed to remove skill dir {}: {err}",
+                        skill_dir.display()
+                    ));
+                    cleanup_complete = false;
+                }
+            }
+        }
+
+        // 3. Config entries are NOT reversed on disable (framework-wide
+        //    config should persist).
+        let config_count = claim_config_count(claim);
+        if config_count > 0 {
+            messages.push(format!(
+                "{config_count} openclaw config entries left in place (not reversed on disable)"
+            ));
+        }
+
+        Ok(DisableReport {
+            cleanup_complete,
+            messages,
+        })
     }
 }
 
@@ -530,13 +635,13 @@ fn build_list_cmd(home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
 }
 
 /// Plugin id declared by the OpenClaw-native plugin manifest, when present.
-fn read_plugin_manifest_id(root: &Path) -> Result<Option<String>, AdapterError> {
+fn read_plugin_manifest_id(root: &Path, filename: &str) -> Result<Option<String>, AdapterError> {
     #[derive(serde::Deserialize)]
     struct PluginManifest {
         id: Option<String>,
     }
 
-    let path = root.join("openclaw.plugin.json");
+    let path = root.join(filename);
     let bytes = match std::fs::read(&path) {
         Ok(bytes) => bytes,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -701,6 +806,70 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Build `openclaw config set <key> <value>`.
+fn build_config_set_cmd(
+    key: &str,
+    value: &toml::Value,
+    home: &Path,
+    user_home: Option<&Path>,
+) -> FrameworkCommand {
+    base_cmd(
+        vec![
+            "config".to_string(),
+            "set".to_string(),
+            key.to_string(),
+            config_value_to_cli_string(value),
+        ],
+        home,
+        user_home,
+    )
+}
+
+/// Convert a TOML value to a string suitable for the `openclaw config set`
+/// CLI argument. Strings are passed bare (no quotes); other types use the
+/// TOML display representation.
+fn config_value_to_cli_string(value: &toml::Value) -> String {
+    match value {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Integer(i) => i.to_string(),
+        toml::Value::Float(f) => f.to_string(),
+        toml::Value::Boolean(b) => b.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Human-readable display of a config value for plan output.
+fn config_value_display(value: &toml::Value) -> String {
+    match value {
+        toml::Value::String(s) => format!("\"{s}\""),
+        other => other.to_string(),
+    }
+}
+
+/// Extract skill names from a claim's `skill_resources` by parsing the
+/// resource ids. Each id has the form `openclaw_skill_<name>`, and we
+/// extract `<name>` as the directory name under `<home>/skills/`.
+fn claim_skill_resources(claim: &AdapterClaim) -> Vec<String> {
+    let payload = match &claim.driver_payload {
+        DriverPayload::OpenClaw(oc) => oc,
+        _ => return Vec::new(),
+    };
+    payload
+        .skill_resources
+        .iter()
+        .filter_map(|id| id.strip_prefix("openclaw_skill_"))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Count config resources in a claim's OpenClaw payload.
+fn claim_config_count(claim: &AdapterClaim) -> usize {
+    match &claim.driver_payload {
+        DriverPayload::OpenClaw(oc) => oc.config_resources.len(),
+        _ => 0,
+    }
+}
+
 /// ISO 8601 UTC timestamp, second precision.
 fn now_iso8601() -> String {
     use chrono::{SecondsFormat, Utc};
@@ -771,7 +940,7 @@ mod tests {
         .expect("write manifest");
 
         assert_eq!(
-            read_plugin_manifest_id(dir.path()).expect("read"),
+            read_plugin_manifest_id(dir.path(), "openclaw.plugin.json").expect("read"),
             Some("tokenless".to_string())
         );
     }
@@ -818,5 +987,88 @@ mod tests {
         std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
         let d3 = digest_tree(dir.path()).expect("digest after change");
         assert_ne!(d1, d3, "digest must change when a file changes");
+    }
+
+    // -- config set cmd -------------------------------------------------
+
+    #[test]
+    fn config_set_cmd_string_value() {
+        let cmd = build_config_set_cmd(
+            "plugins.entries.sec.enabled",
+            &toml::Value::String("true".to_string()),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+        );
+        assert_eq!(cmd.program, "openclaw");
+        assert_eq!(
+            cmd.args,
+            vec!["config", "set", "plugins.entries.sec.enabled", "true"]
+        );
+    }
+
+    #[test]
+    fn config_set_cmd_boolean_value() {
+        let cmd = build_config_set_cmd(
+            "debug.enabled",
+            &toml::Value::Boolean(true),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+        );
+        assert_eq!(cmd.args, vec!["config", "set", "debug.enabled", "true"]);
+    }
+
+    #[test]
+    fn config_set_cmd_integer_value() {
+        let cmd = build_config_set_cmd(
+            "limits.max_plugins",
+            &toml::Value::Integer(42),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+        );
+        assert_eq!(cmd.args, vec!["config", "set", "limits.max_plugins", "42"]);
+    }
+
+    #[test]
+    fn config_value_to_cli_string_covers_types() {
+        assert_eq!(
+            config_value_to_cli_string(&toml::Value::String("hello".into())),
+            "hello"
+        );
+        assert_eq!(config_value_to_cli_string(&toml::Value::Integer(7)), "7");
+        assert_eq!(config_value_to_cli_string(&toml::Value::Float(2.5)), "2.5");
+        assert_eq!(
+            config_value_to_cli_string(&toml::Value::Boolean(false)),
+            "false"
+        );
+    }
+
+    // -- claim_skill_resources / claim_config_count ---------------------
+
+    #[test]
+    fn claim_skill_resources_extracts_names() {
+        let claim = AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "test".to_string(),
+            framework: "openclaw".to_string(),
+            plugin_id: None,
+            enabled_at: "2026-01-01T00:00:00Z".to_string(),
+            resource_root: PathBuf::from("/tmp"),
+            bundle_digest: None,
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: Vec::new(),
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "s".to_string(),
+                plugin_resource: "p".to_string(),
+                skill_resources: vec![
+                    "openclaw_skill_sec-audit".to_string(),
+                    "openclaw_skill_cred-scan".to_string(),
+                ],
+                config_resources: vec!["openclaw_config_0".to_string()],
+            }),
+        };
+        let skills = claim_skill_resources(&claim);
+        assert_eq!(skills, vec!["sec-audit", "cred-scan"]);
+        assert_eq!(claim_config_count(&claim), 1);
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
@@ -5,6 +5,7 @@
 //! no runtime plugin loading. MVP registers only the OpenClaw driver.
 
 use super::driver::FrameworkDriver;
+use super::hermes::HermesDriver;
 use super::openclaw::OpenClawDriver;
 
 /// Immutable collection of the built-in framework drivers.
@@ -16,7 +17,10 @@ impl DriverRegistry {
     /// Build the registry of all built-in drivers.
     pub fn builtin() -> Self {
         Self {
-            drivers: vec![Box::new(OpenClawDriver::new())],
+            drivers: vec![
+                Box::new(OpenClawDriver::new()),
+                Box::new(HermesDriver::new()),
+            ],
         }
     }
 
@@ -50,16 +54,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn builtin_registers_openclaw_only() {
+    fn builtin_registers_openclaw_and_hermes() {
         let reg = DriverRegistry::builtin();
         assert!(reg.contains("openclaw"));
-        assert!(!reg.contains("cosh"), "MVP ships OpenClaw only");
-        assert_eq!(reg.names(), vec!["openclaw"]);
+        assert!(reg.contains("hermes"));
+        assert!(!reg.contains("cosh"), "cosh driver not yet shipped");
+        assert_eq!(reg.names(), vec!["openclaw", "hermes"]);
     }
 
     #[test]
     fn get_unknown_framework_is_none() {
         let reg = DriverRegistry::builtin();
-        assert!(reg.get("hermes").is_none());
+        assert!(reg.get("qoder").is_none());
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -386,6 +386,23 @@ pub struct AdapterSpec {
     /// Framework-specific detection hints preserved as TOML values.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub detect: BTreeMap<String, toml::Value>,
+    /// Skill names this adapter delivers into the framework.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+    /// Post-install config key/value pairs the driver should apply.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub config: Vec<AdapterConfigSetSpec>,
+    /// Semver constraint on the target framework version, e.g. `">=1.2"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub framework_version_req: Option<String>,
+    /// OpenClaw-specific adapter configuration, when this adapter targets
+    /// the `openclaw` framework.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openclaw: Option<OpenClawAdapterSpec>,
+    /// Hermes-specific adapter configuration, when this adapter targets
+    /// the `hermes` framework.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hermes: Option<HermesAdapterSpec>,
 }
 
 /// Bundle description for an adapter resource directory. The driver uses
@@ -424,6 +441,61 @@ pub struct AdapterCompatSpec {
 impl AdapterCompatSpec {
     fn is_empty(&self) -> bool {
         self.driver_schema.is_none() && self.framework_version.is_none()
+    }
+}
+
+/// A post-install config key/value pair that the driver should apply to
+/// the framework's configuration. The driver interprets `key` as a
+/// framework-specific config path; `value` is the TOML value to set.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AdapterConfigSetSpec {
+    /// Framework-specific config key path.
+    pub key: String,
+    /// Value to set.
+    pub value: toml::Value,
+}
+
+/// OpenClaw-specific adapter configuration. When present on an
+/// `[[adapters]]` entry whose `framework = "openclaw"`, the driver uses
+/// these fields instead of the generic adapter-level ones.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct OpenClawAdapterSpec {
+    /// OpenClaw-specific bundle description (overrides generic
+    /// `[adapters.bundle]` when present).
+    #[serde(default, skip_serializing_if = "AdapterBundleSpec::is_empty")]
+    pub bundle: AdapterBundleSpec,
+    /// Skills delivered into OpenClaw's skill directory.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+    /// Post-install config key/value pairs for OpenClaw.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub config: Vec<AdapterConfigSetSpec>,
+}
+
+impl OpenClawAdapterSpec {
+    /// Whether no framework-specific data is present.
+    pub fn is_empty(&self) -> bool {
+        self.bundle.is_empty() && self.skills.is_empty() && self.config.is_empty()
+    }
+}
+
+/// Hermes-specific adapter configuration. When present on an
+/// `[[adapters]]` entry whose `framework = "hermes"`, the driver uses
+/// these fields instead of the generic adapter-level ones.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct HermesAdapterSpec {
+    /// Hermes-specific bundle description.
+    #[serde(default, skip_serializing_if = "AdapterBundleSpec::is_empty")]
+    pub bundle: AdapterBundleSpec,
+    /// Skills delivered into Hermes's skill directory.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+}
+
+impl HermesAdapterSpec {
+    /// Whether no framework-specific data is present.
+    pub fn is_empty(&self) -> bool {
+        self.bundle.is_empty() && self.skills.is_empty()
     }
 }
 
@@ -698,6 +770,16 @@ struct AdapterRaw {
     compat: AdapterCompatRaw,
     #[serde(default)]
     detect: BTreeMap<String, toml::Value>,
+    #[serde(default)]
+    skills: Vec<String>,
+    #[serde(default)]
+    config: Vec<AdapterConfigSetSpec>,
+    #[serde(default)]
+    framework_version_req: Option<String>,
+    #[serde(default)]
+    openclaw: Option<OpenClawAdapterSpec>,
+    #[serde(default)]
+    hermes: Option<HermesAdapterSpec>,
 }
 
 #[derive(Deserialize, Default)]
@@ -897,6 +979,11 @@ impl From<ComponentManifestRaw> for ComponentManifest {
                     framework_version: a.compat.framework_version,
                 },
                 detect: a.detect,
+                skills: a.skills,
+                config: a.config,
+                framework_version_req: a.framework_version_req,
+                openclaw: a.openclaw,
+                hermes: a.hermes,
             })
             .collect();
 
@@ -1905,5 +1992,247 @@ mod tests {
         )
         .expect("parse explicit empty");
         assert_eq!(explicit_empty.component.domain.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn adapter_skills_and_config_parse() {
+        let toml_text = r#"
+            [component]
+            name = "agent-sec-core"
+            version = "2.1.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            adapter_type = "plugin"
+            plugin_id = "agent-sec"
+            skills = ["sec-audit", "cred-scan"]
+            framework_version_req = ">=1.2"
+
+            [adapters.bundle]
+            entry = "openclaw.plugin.json"
+
+            [[adapters.config]]
+            key = "plugins.entries.agent-sec.hooks.allowConversationAccess"
+            value = true
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.adapters.len(), 1);
+        let a = &m.adapters[0];
+        assert_eq!(a.skills, vec!["sec-audit", "cred-scan"]);
+        assert_eq!(a.framework_version_req.as_deref(), Some(">=1.2"));
+        assert_eq!(a.config.len(), 1);
+        assert_eq!(
+            a.config[0].key,
+            "plugins.entries.agent-sec.hooks.allowConversationAccess"
+        );
+        assert_eq!(a.config[0].value, toml::Value::Boolean(true));
+    }
+
+    #[test]
+    fn adapter_openclaw_specific_section_parses() {
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.1.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            plugin_id = "sec-core"
+
+            [adapters.openclaw]
+            skills = ["sec-audit"]
+
+            [adapters.openclaw.bundle]
+            entry = "openclaw.plugin.json"
+
+            [[adapters.openclaw.config]]
+            key = "plugins.entries.sec-core.enabled"
+            value = true
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let a = &m.adapters[0];
+        let oc = a.openclaw.as_ref().expect("openclaw section");
+        assert_eq!(oc.skills, vec!["sec-audit"]);
+        assert_eq!(oc.bundle.entry.as_deref(), Some("openclaw.plugin.json"));
+        assert_eq!(oc.config.len(), 1);
+        assert_eq!(oc.config[0].key, "plugins.entries.sec-core.enabled");
+    }
+
+    #[test]
+    fn adapter_hermes_specific_section_parses() {
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.1.0"
+
+            [[adapters]]
+            framework = "hermes"
+            skills = ["sec-audit"]
+
+            [adapters.hermes]
+            skills = ["sec-audit"]
+
+            [adapters.hermes.bundle]
+            entry = "hermes.manifest.yaml"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let a = &m.adapters[0];
+        let h = a.hermes.as_ref().expect("hermes section");
+        assert_eq!(h.skills, vec!["sec-audit"]);
+        assert_eq!(h.bundle.entry.as_deref(), Some("hermes.manifest.yaml"));
+    }
+
+    #[test]
+    fn adapter_skills_config_round_trip() {
+        let toml_text = r#"
+            [component]
+            name = "roundtrip"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            plugin_id = "rt"
+            skills = ["skill-a", "skill-b"]
+            framework_version_req = ">=1.0"
+
+            [[adapters.config]]
+            key = "some.key"
+            value = "hello"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        let m2 = ComponentManifest::from_toml_str(&serialized).expect("re-parse");
+        assert_eq!(m.adapters[0].skills, m2.adapters[0].skills);
+        assert_eq!(m.adapters[0].config, m2.adapters[0].config);
+        assert_eq!(
+            m.adapters[0].framework_version_req,
+            m2.adapters[0].framework_version_req
+        );
+    }
+
+    #[test]
+    fn adapter_empty_skills_config_skip_serializing() {
+        let toml_text = r#"
+            [component]
+            name = "skiptest"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        assert!(
+            !serialized.contains("skills"),
+            "empty skills must be skipped: {serialized}"
+        );
+        assert!(
+            !serialized.contains("config"),
+            "empty config must be skipped: {serialized}"
+        );
+        assert!(
+            !serialized.contains("[openclaw]"),
+            "absent openclaw section must be skipped: {serialized}"
+        );
+        assert!(
+            !serialized.contains("[hermes]"),
+            "absent hermes section must be skipped: {serialized}"
+        );
+    }
+
+    #[test]
+    fn component_md_example_parses() {
+        let toml_text = r#"
+            schema_version = 1
+
+            [component]
+            name         = "agent-sec-core"
+            version      = "2.1.0"
+            display_name = "Agent Security Core"
+            owner        = "security-team"
+            license      = "Apache-2.0"
+            repository   = "https://github.com/example/agent-sec-core"
+            layer        = "runtime"
+            domain       = "security"
+
+            [component.contract]
+            schema_version      = "1"
+            min_anolisa_version = "0.6.0"
+
+            [[adapters]]
+            name         = "agent-sec-openclaw"
+            display_name = "Agent Sec (OpenClaw)"
+            framework    = "openclaw"
+            kind         = "first-party"
+            adapter_type = "plugin"
+            plugin_id    = "agent-sec"
+            skills       = ["sec-audit", "cred-scan"]
+            framework_version_req = ">=1.2"
+
+            [adapters.bundle]
+            entry = "openclaw.plugin.json"
+
+            [[adapters.config]]
+            key   = "plugins.entries.agent-sec.hooks.allowConversationAccess"
+            value = true
+
+            [[adapters]]
+            name         = "agent-sec-hermes"
+            display_name = "Agent Sec (hermes)"
+            framework    = "hermes"
+            kind         = "first-party"
+            skills       = ["sec-audit"]
+            framework_version_req = ">=0.4"
+
+            [adapters.bundle]
+            entry = "hermes.manifest.yaml"
+
+            [[adapters.config]]
+            key   = "security.conversation_access"
+            value = true
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse component.md example");
+        assert_eq!(m.adapters.len(), 2);
+
+        let oc = &m.adapters[0];
+        assert_eq!(oc.framework.as_deref(), Some("openclaw"));
+        assert_eq!(oc.plugin_id.as_deref(), Some("agent-sec"));
+        assert_eq!(oc.skills, vec!["sec-audit", "cred-scan"]);
+        assert_eq!(oc.bundle.entry.as_deref(), Some("openclaw.plugin.json"));
+        assert_eq!(oc.config.len(), 1);
+
+        let hm = &m.adapters[1];
+        assert_eq!(hm.framework.as_deref(), Some("hermes"));
+        assert_eq!(hm.skills, vec!["sec-audit"]);
+        assert_eq!(hm.bundle.entry.as_deref(), Some("hermes.manifest.yaml"));
+        assert_eq!(hm.config.len(), 1);
+    }
+
+    #[test]
+    fn existing_manifests_still_parse_after_schema_extension() {
+        let toml_text = r#"
+            [component]
+            name = "agentsight"
+            version = "0.2.0"
+            layer = "runtime"
+
+            [[adapters]]
+            framework = "openclaw"
+            kind = "third-party"
+            plugin_id = "agentsight-openclaw"
+            source = "adapters/agentsight/openclaw"
+            dest = "{datadir}/adapters/{component}/openclaw/"
+
+            [adapters.detect]
+            config_path = "~/.openclaw/config.toml"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let a = &m.adapters[0];
+        assert!(a.skills.is_empty());
+        assert!(a.config.is_empty());
+        assert!(a.framework_version_req.is_none());
+        assert!(a.openclaw.is_none());
+        assert!(a.hermes.is_none());
+        assert_eq!(a.plugin_id.as_deref(), Some("agentsight-openclaw"));
     }
 }

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -127,6 +127,10 @@ fn write_fake_openclaw(dir: &Path) -> PathBuf {
 sub="$1"; action="$2"; arg3="$3"
 reg="$OPENCLAW_STATE_DIR/registry"
 mkdir -p "$reg" 2>/dev/null
+if [ "$sub" = "config" ] && [ "$action" = "set" ]; then
+  echo "config set $arg3 $4"
+  exit 0
+fi
 if [ "$sub" != "plugins" ]; then echo "unknown subcommand: $sub" >&2; exit 2; fi
 case "$action" in
   install)


### PR DESCRIPTION
## Description

### Ship Note

This PR extends the ANOLISA adapter framework path for OpenClaw and Hermes.

What changed:

- Extended `component.toml` adapter schema with framework-specific sections:
  - `adapters.openclaw.bundle`
  - `adapters.openclaw.skills`
  - `adapters.openclaw.config`
  - `adapters.hermes.bundle`
  - `adapters.hermes.skills`
- Enhanced the OpenClaw driver to support:
  - plugin registration through the existing OpenClaw plugin flow;
  - skill delivery into the OpenClaw skills directory;
  - typed OpenClaw config set operations;
  - receipt resources for plugin, skill, and config claims.
- Added a built-in Hermes driver skeleton:
  - detects the Hermes CLI;
  - places plugin bundles under `$HERMES_HOME/plugins/<plugin_id>`;
  - runs `hermes plugins enable/disable`;
  - delivers declared skills into `$HERMES_HOME/skills`;
  - records Hermes-specific adapter receipts.
- Added Manager-owned adapter IO operations:
  - `copy_tree`
  - `copy_file`
  - `remove_tree`
- Hardened adapter IO boundaries:
  - source and destination paths are validated against allowed roots;
  - symlink sources are rejected for tree and file copy paths;
  - framework plugin/config receipt resources must match the claim framework.

Known limitations:

- Hermes support is a framework-driver foundation, not full real-machine E2E validation.
- `adapter scan` does not yet surface declared skill/config/bundle metadata; that remains follow-up work for #1040.
- Config rollback is not implemented; OpenClaw config entries are left in place on disable and reported in the disable output.
- Only OpenClaw and Hermes are covered. Cosh, Claude Code, Codex, Qoder CLI, and QwenCode remain future drivers.
- The manifest remains declarative; this PR does not add script execution, arbitrary argv, or a generic operation DSL.

## Related Issue

refs #1040
refs #1041

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --locked
```

Local validation reported 766 tests passing.
