### PR TITLE
feat(skill): add OpenClaw bootstrap guidance

### DIFF
--- a/src/os-skills/ai/install-openclaw/SKILL.md
+++ b/src/os-skills/ai/install-openclaw/SKILL.md
@@ -7,7 +7,7 @@ description: Install and configure OpenClaw non-interactively with Alibaba Cloud
 
 Use this skill to turn a user's one-sentence request into a complete local OpenClaw setup. The normal path is one script command: resolve the Alibaba Cloud Model Studio plan, validate the API key/Base URL/model combination with the official `anthropic-messages` endpoint shape, install Node.js/npm/OpenClaw when needed, write config, install/restart the local gateway service, and verify `openclaw gateway health`.
 
-Do not use `openclaw onboard` unless the user explicitly asks for interactive setup. Do not configure DingTalk unless the user provides DingTalk credentials or asks for DingTalk access.
+Do not execute `openclaw onboard` unless the user explicitly asks for interactive setup or asks to skip first-run BOOTSTRAP onboarding. After setup, always tell the user they can run `openclaw onboard --skip-bootstrap` if they want the first real task to run without the introductory BOOTSTRAP flow. Do not configure DingTalk unless the user provides DingTalk credentials or asks for DingTalk access.
 
 ## Billing
 
@@ -134,6 +134,7 @@ python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_op
 - Starts OpenClaw through `openclaw gateway install` and `openclaw gateway restart` unless `--skip-gateway` is passed.
 - If the gateway port is occupied by OpenClaw, it clears that stale listener. If the port is occupied by another process, it stops and prints the process details for the user to decide.
 - **Auto-installs the tokenless OpenClaw plugin** after OpenClaw is installed, for token usage tracking and response compression. Pass `--skip-tokenless` to opt out.
+- Prints first-run BOOTSTRAP guidance by default. Tell the user `openclaw onboard --skip-bootstrap` keeps the first real task from being interrupted by OpenClaw's introductory `BOOTSTRAP.md` flow, and that they can still adjust `IDENTITY.md`, `USER.md`, and `SOUL.md` later under the OpenClaw workspace.
 
 ## Verify
 

--- a/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
+++ b/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
@@ -1101,6 +1101,16 @@ def print_summary(metadata, args):
     print("  openclaw status")
     print('  openclaw agent --message "hello" --agent main')
     print("  # If agent output says EMBEDDED FALLBACK, approve the local device or fix gateway.")
+    print("\nFirst real task tip:")
+    print("  openclaw onboard --skip-bootstrap")
+    print(
+        "  # Run this if you want first real tasks to start without the "
+        "BOOTSTRAP.md introduction flow interrupting them."
+    )
+    print(
+        "  # You can still fill in or adjust IDENTITY.md, USER.md, and SOUL.md later "
+        "under the OpenClaw workspace."
+    )
     if args.dingtalk_client_id and args.dingtalk_client_secret:
         print("  openclaw channels status --probe")
 


### PR DESCRIPTION
## Description

Add first-run BOOTSTRAP guidance to the `install-openclaw` skill.

After installation, the script now prints `openclaw onboard --skip-bootstrap`
as a default tip for users who want their first real task to start without
being interrupted by OpenClaw's introductory `BOOTSTRAP.md` flow.

The skill documentation is also updated to tell agents to surface this guidance,
while avoiding automatic `openclaw onboard` execution unless the user explicitly
asks for it. Users can still fill in or adjust `IDENTITY.md`, `USER.md`, and
`SOUL.md` later under the OpenClaw workspace.

## Related Issue

no-issue: small skill UX guidance update

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [x] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [x] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
python3 -m py_compile src/os-skills/ai/install-openclaw/scripts/install_openclaw.py

python3 src/os-skills/ai/install-openclaw/scripts/install_openclaw.py \
  --billing payg \
  --api-key test-key \
  --skip-install-openclaw \
  --skip-gateway \
  --skip-preflight \
  --config /tmp/openclaw-bootstrap-guidance.json
```

Verified that the install summary prints the new first-real-task tip:

```text
openclaw onboard --skip-bootstrap
```