### PR TITLE
fix(anolisa): discover package-managed component contracts

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -247,12 +247,24 @@ pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
     let env = anolisa_env::EnvService::detect();
     let mut manager = AdapterManager::new(layout.clone(), Some(env.home), env.user);
 
+    // Two independent datadir-discovery mechanisms are layered here:
+    //
+    //   packaged_datadir_root()  — runtime probe: env override → exe-sibling
+    //                              `../share/anolisa/` → layout.datadir.
+    //                              Discovers wherever the *running binary's*
+    //                              packaged tree actually lives on disk.
+    //
+    //   layout.package_datadir() — FHS constant: `/usr/share/anolisa` (rebased
+    //                              under prefix). Always present in system mode
+    //                              so RPM-installed contracts are found even
+    //                              when the binary is at `/usr/local/bin/`.
+    //
+    // Both are added (deduped by push_primary_datadir_root / contains-check)
+    // because they cover different scenarios: the exe-sibling probe handles
+    // relocated installs; the FHS constant handles cross-install-method
+    // discovery (raw binary + RPM components).
+
     if ctx.install_mode == InstallMode::User {
-        // In user mode, the primary visible root is the user layout (set
-        // by `new`).  Add a system visible root so user-mode CLI can
-        // enable adapters for system-installed components.  The system
-        // root pairs with the system datadir + packaged datadir, which
-        // may differ (RPM uses /usr/share, CLI installs to /usr/local/share).
         let system_layout = FsLayout::system(ctx.prefix.clone());
         let mut system_datadirs = vec![system_layout.datadir.clone()];
         if let Some(packaged) = packaged::packaged_datadir_root(&system_layout)
@@ -260,19 +272,23 @@ pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
         {
             system_datadirs.push(packaged);
         }
+        if let Some(pkg_dd) = system_layout.package_datadir()
+            && !system_datadirs.contains(&pkg_dd)
+        {
+            system_datadirs.push(pkg_dd);
+        }
         manager.push_visible_root(VisibleRoot {
             state_dir: system_layout.state_dir,
             contract_datadir_roots: system_datadirs,
         });
     } else {
-        // In system mode, the primary visible root uses `layout.datadir`.
-        // If the packaged datadir differs (exe-sibling vs install prefix),
-        // add it to the primary root's contract datadirs so RPM-installed
-        // contracts at /usr/share/... are found.
         if let Some(packaged) = packaged::packaged_datadir_root(&layout)
             && packaged != layout.datadir
         {
             manager.push_primary_datadir_root(packaged);
+        }
+        if let Some(pkg_dd) = layout.package_datadir() {
+            manager.push_primary_datadir_root(pkg_dd);
         }
     }
 
@@ -282,6 +298,104 @@ pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Verify that `package_datadir()` is wired into the system-mode
+    /// manager: an RPM-installed contract under `{prefix}/usr/share/anolisa`
+    /// must be discoverable via scan when the primary datadir is
+    /// `{prefix}/usr/local/share/anolisa`.
+    ///
+    /// This exercises the same wiring path as `build_adapter_manager()`
+    /// for system mode without needing a full `CliContext`.
+    #[test]
+    fn system_mode_wiring_discovers_package_datadir_contract() {
+        use anolisa_core::adapter::manager::AdapterManager;
+        use anolisa_core::state::{
+            InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership, SubscriptionScope,
+        };
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix));
+
+        // Simulate the system-mode wiring from build_adapter_manager().
+        let mut manager = AdapterManager::new(
+            layout.clone(),
+            Some(tmp.path().to_path_buf()),
+            "test".into(),
+        );
+        if let Some(pkg_dd) = layout.package_datadir() {
+            manager.push_primary_datadir_root(pkg_dd);
+        }
+
+        // Seed state: sec-core adopted.
+        let state_dir = &layout.state_dir;
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "sec-core".to_string(),
+            version: "0.1.0".to_string(),
+            status: ObjectStatus::Adopted,
+            manifest_digest: None,
+            distribution_source: None,
+            raw_package: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmObserved),
+            rpm_metadata: None,
+            installed_at: "2026-06-23T00:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: false,
+            adopted: true,
+            subscription_scope: SubscriptionScope::None,
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        std::fs::create_dir_all(state_dir).expect("mkdir state");
+        state
+            .save(&state_dir.join("installed.toml"))
+            .expect("save state");
+
+        // Write contract under the package datadir (NOT local datadir).
+        let package_datadir = layout.package_datadir().expect("package_datadir");
+        let contract_dir = package_datadir.join("components").join("sec-core");
+        std::fs::create_dir_all(&contract_dir).expect("mkdir contract");
+        std::fs::write(
+            contract_dir.join("component.toml"),
+            r#"
+[component]
+name = "sec-core"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "sec-core"
+dest = "{datadir}/adapters/sec-core/openclaw/"
+"#,
+        )
+        .expect("write contract");
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw");
+        assert!(
+            entry.is_some_and(|e| e.declared),
+            "system-mode wiring must discover contract under package_datadir; \
+             entries: {:?}, warnings: {:?}",
+            report
+                .entries
+                .iter()
+                .map(|e| (&e.component, &e.framework, e.declared))
+                .collect::<Vec<_>>(),
+            report.warnings,
+        );
+    }
 
     /// `object_status_str` must cover every variant of `ObjectStatus` and
     /// produce the exact wire vocabulary the spec promises. If a new variant

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -2862,13 +2862,19 @@ fn snapshot_datadir_contract(layout: &FsLayout, component: &str, command: &str) 
     let mut warnings: Vec<String> = Vec::new();
 
     // Build the set of datadir roots to search, deduped, in priority
-    // order.  packaged_datadir_root already covers env override →
-    // exe-sibling → layout.datadir, but its last probe is is_dir()
-    // gated.  We always include layout.datadir as the final fallback
-    // so the path appears in the "not found" warning.
+    // order. packaged_datadir_root covers env override → exe-sibling →
+    // layout.datadir, while package_datadir covers the FHS RPM/DEB root
+    // (`/usr/share/anolisa`, rebased under prefix). Always include
+    // layout.datadir as the final fallback so the path appears in the
+    // "not found" warning.
     let mut roots: Vec<PathBuf> = Vec::new();
     if let Some(packaged) = crate::packaged::packaged_datadir_root(layout) {
         roots.push(packaged);
+    }
+    if let Some(package_datadir) = layout.package_datadir()
+        && !roots.iter().any(|r| r == &package_datadir)
+    {
+        roots.push(package_datadir);
     }
     if !roots.iter().any(|r| r == &layout.datadir) {
         roots.push(layout.datadir.clone());
@@ -5361,6 +5367,56 @@ scope = "@anolisa"
         assert_eq!(
             content, contract,
             "snapshot must be a verbatim copy of the packaged contract"
+        );
+    }
+
+    /// Regression: RPM contracts live in the FHS package datadir
+    /// (`/usr/share/anolisa`, rebased under prefix), which is distinct
+    /// from the raw/system install datadir (`/usr/local/share/anolisa`).
+    #[test]
+    fn adopt_snapshots_fhs_package_datadir_contract() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let tmp = tempdir().expect("tempdir");
+        let prefix = tmp.path().join("sys");
+        let ctx = ctx_with_prefix(false, Some(prefix));
+        let layout = common::resolve_layout(&ctx);
+
+        let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
+        let package_datadir = layout.package_datadir().expect("package datadir");
+        let contract_dir = package_datadir.join("components").join("copilot-shell");
+        std::fs::create_dir_all(&contract_dir).expect("mkdir package contract");
+        std::fs::write(contract_dir.join("component.toml"), &contract)
+            .expect("write package contract");
+
+        assert_ne!(
+            package_datadir, layout.datadir,
+            "test requires package datadir to differ from raw install datadir"
+        );
+
+        let q = FakeQuery {
+            installed: vec![(
+                "anolisa-copilot-shell".to_string(),
+                pkg_info("anolisa-copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+            )],
+            origins: vec![("anolisa-copilot-shell".to_string(), "@System".to_string())],
+            ..Default::default()
+        };
+        let outcome =
+            handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
+                .expect("adopt ok");
+
+        assert_eq!(outcome, InstallOutcome::Adopted);
+
+        let snapshot = common::installed_component_manifest_path(&layout, "copilot-shell", COMMAND)
+            .expect("snapshot path");
+        assert!(
+            snapshot.exists(),
+            "adopt must snapshot from FHS package datadir to {snapshot:?}"
+        );
+        let content = std::fs::read_to_string(&snapshot).expect("read snapshot");
+        assert_eq!(
+            content, contract,
+            "snapshot must be a verbatim copy of the FHS package contract"
         );
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -2735,6 +2735,164 @@ source = "{datadir}/skills/code-scanner/"
         );
     }
 
+    /// System-mode manager discovers a package contract under the FHS
+    /// `/usr/share/anolisa` tree (simulated via temp dirs) when
+    /// `package_datadir` is added to `contract_datadir_roots`.
+    #[test]
+    fn system_manager_discovers_package_contract_under_usr_share() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let local_datadir = tmp.path().join("usr/local/share/anolisa");
+        let package_datadir = tmp.path().join("usr/share/anolisa");
+        let state_dir = tmp.path().join("var/lib/anolisa");
+
+        seed_installed_state(&state_dir, "sec-core", ObjectStatus::Adopted);
+
+        // Contract lives under the package datadir (simulates RPM install).
+        write_contract(&package_datadir, "sec-core");
+
+        // Adapter resource directory under the package datadir.
+        let adapter_root = package_datadir
+            .join("adapters")
+            .join("sec-core")
+            .join("openclaw");
+        std::fs::create_dir_all(&adapter_root).expect("mkdir adapter");
+        std::fs::write(adapter_root.join("plugin.json"), b"{}").expect("write");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager =
+            AdapterManager::new(layout, Some(tmp.path().to_path_buf()), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.clone(),
+            contract_datadir_roots: vec![local_datadir.clone(), package_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![local_datadir, package_datadir.clone()];
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw")
+            .expect("sec-core/openclaw should be discovered from package datadir");
+        assert!(
+            entry.declared,
+            "contract from package datadir must be declared"
+        );
+        assert!(
+            entry.resource_root.is_some(),
+            "resource root must be found under package datadir"
+        );
+
+        // Verify resolve_resource_root returns the package datadir path.
+        let state = InstalledState::load(&state_dir.join("installed.toml")).expect("load state");
+        let (manifest, scoped_roots) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        let (resource_root, effective_datadir) = manager
+            .resolve_resource_root("sec-core", "openclaw", &manifest, &scoped_roots)
+            .expect("resolve resource root");
+        assert_eq!(
+            effective_datadir, package_datadir,
+            "effective datadir must be the package datadir"
+        );
+        assert!(
+            resource_root.starts_with(&package_datadir),
+            "resource root must be under the package datadir"
+        );
+    }
+
+    /// When a contract from the package datadir declares `dest` and
+    /// skill `source` using `{datadir}`, the placeholder must expand to
+    /// the package datadir — not the local-install datadir.
+    #[test]
+    fn package_contract_datadir_expands_skill_source() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let local_datadir = tmp.path().join("usr/local/share/anolisa");
+        let package_datadir = tmp.path().join("usr/share/anolisa");
+        let state_dir = tmp.path().join("var/lib/anolisa");
+
+        seed_installed_state(&state_dir, "sec-core", ObjectStatus::Adopted);
+
+        let contract = r#"
+[component]
+name = "sec-core"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "sec-core"
+dest = "{datadir}/adapters/sec-core/openclaw/"
+
+[[adapters.openclaw.skills]]
+name = "code-scanner"
+source = "{datadir}/skills/code-scanner/"
+"#;
+        write_contract_with_content(&package_datadir, "sec-core", contract);
+
+        // Create the adapter and skill directories under the package datadir.
+        let adapter_root = package_datadir
+            .join("adapters")
+            .join("sec-core")
+            .join("openclaw");
+        std::fs::create_dir_all(&adapter_root).expect("mkdir adapter");
+        std::fs::write(adapter_root.join("plugin.json"), b"{}").expect("write");
+        let skill_source = package_datadir.join("skills").join("code-scanner");
+        std::fs::create_dir_all(&skill_source).expect("mkdir skill source");
+        std::fs::write(skill_source.join("manifest.json"), b"{}").expect("write skill");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(
+            layout.clone(),
+            Some(tmp.path().to_path_buf()),
+            "test".into(),
+        );
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.clone(),
+            contract_datadir_roots: vec![local_datadir, package_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![package_datadir.clone()];
+
+        let state = InstalledState::load(&state_dir.join("installed.toml")).expect("load state");
+        let (manifest, scoped_roots) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+
+        // resource root must be under the package datadir.
+        let (resource_root, effective_datadir) = manager
+            .resolve_resource_root("sec-core", "openclaw", &manifest, &scoped_roots)
+            .expect("resolve resource root");
+        assert_eq!(
+            resource_root, adapter_root,
+            "resource root must be the package datadir adapter path"
+        );
+        assert_eq!(
+            effective_datadir, package_datadir,
+            "effective datadir must be the package datadir"
+        );
+
+        // skill source must also resolve under the package datadir.
+        let skill_specs = declared_skills(&manifest, "openclaw");
+        let skills = resolve_skill_sources(
+            skill_specs,
+            &layout,
+            &effective_datadir,
+            "sec-core",
+            "openclaw",
+            &resource_root,
+        )
+        .expect("resolve skills");
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "code-scanner");
+        assert_eq!(
+            skills[0].source.as_ref(),
+            Some(&skill_source),
+            "skill source {{datadir}} must expand to the package datadir"
+        );
+    }
+
     /// User-mode scan includes system-installed component via system
     /// visible root (contract resolved from system datadir).
     #[test]

--- a/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
+++ b/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
@@ -48,6 +48,10 @@ mod fhs {
     pub const LIB: &str = "/usr/local/lib/anolisa";
     pub const LIBEXEC: &str = "/usr/local/libexec/anolisa";
     pub const DATADIR: &str = "/usr/local/share/anolisa";
+    /// FHS package-managed read-only datadir. RPM/DEB packages install
+    /// component contracts and adapter resources here, separate from the
+    /// `/usr/local` tree used by raw/tar installs.
+    pub const PACKAGE_DATADIR: &str = "/usr/share/anolisa";
     pub const ETC: &str = "/etc/anolisa";
     pub const STATE: &str = "/var/lib/anolisa";
     pub const CACHE: &str = "/var/cache/anolisa";
@@ -298,6 +302,32 @@ impl FsLayout {
     /// first, falling back to the package-owned contract when absent.
     pub fn snapshot_path(&self, component: &str) -> PathBuf {
         Self::component_manifest_snapshot_path(&self.state_dir, component)
+    }
+
+    /// FHS package-managed read-only datadir (`/usr/share/anolisa`),
+    /// rebased under the same prefix as the rest of the system layout.
+    ///
+    /// RPM/DEB packages install component contracts and adapter resources
+    /// under this path. It is separate from [`Self::datadir`]
+    /// (`/usr/local/share/anolisa`) because FHS reserves `/usr/local` for
+    /// locally-installed software and `/usr/share` for
+    /// distribution-packaged read-only data.
+    ///
+    /// Returns `None` in user mode (user-mode installs never consult the
+    /// FHS package tree) or when the result would equal `self.datadir`
+    /// (a custom prefix can collapse the two).
+    pub fn package_datadir(&self) -> Option<PathBuf> {
+        match self.mode {
+            InstallMode::System => {
+                let path = rebase_under(&self.prefix, fhs::PACKAGE_DATADIR);
+                if path != self.datadir {
+                    Some(path)
+                } else {
+                    None
+                }
+            }
+            InstallMode::User => None,
+        }
     }
 
     /// Package-owned component contract path under an arbitrary datadir root.
@@ -642,6 +672,73 @@ mod tests {
             PathBuf::from(
                 "/tmp/h/.local/state/anolisa/component-manifests/os-skills/component.toml"
             )
+        );
+    }
+
+    // ---- package_datadir ----------------------------------------------------
+
+    #[test]
+    fn system_layout_keeps_local_datadir() {
+        let layout = FsLayout::system(None);
+        assert_eq!(
+            layout.datadir,
+            PathBuf::from("/usr/local/share/anolisa"),
+            "system datadir must remain /usr/local/share/anolisa for raw/tar installs"
+        );
+        let pkg = layout.package_datadir();
+        assert_eq!(
+            pkg,
+            Some(PathBuf::from("/usr/share/anolisa")),
+            "package_datadir must be /usr/share/anolisa, distinct from datadir"
+        );
+        assert_ne!(
+            layout.datadir,
+            pkg.unwrap(),
+            "package_datadir must not equal the primary datadir"
+        );
+    }
+
+    #[test]
+    fn package_datadir_respects_prefix() {
+        let layout = FsLayout::system(Some(PathBuf::from("/opt/x")));
+        assert_eq!(
+            layout.datadir,
+            PathBuf::from("/opt/x/usr/local/share/anolisa")
+        );
+        assert_eq!(
+            layout.package_datadir(),
+            Some(PathBuf::from("/opt/x/usr/share/anolisa"))
+        );
+    }
+
+    #[test]
+    fn package_datadir_is_none_for_user_mode() {
+        let layout = user_no_overrides("/tmp/h");
+        assert_eq!(
+            layout.package_datadir(),
+            None,
+            "user mode must not expose a package_datadir"
+        );
+    }
+
+    #[test]
+    fn package_contract_does_not_change_raw_install_target() {
+        let layout = FsLayout::system(None);
+        assert_eq!(
+            layout.datadir,
+            PathBuf::from("/usr/local/share/anolisa"),
+            "raw/system install datadir must remain /usr/local/share/anolisa"
+        );
+        assert_eq!(
+            layout.contract_path("sec-core"),
+            PathBuf::from("/usr/local/share/anolisa/components/sec-core/component.toml"),
+            "contract_path must derive from the primary (local-install) datadir"
+        );
+        let pkg = layout.package_datadir().unwrap();
+        assert_eq!(
+            FsLayout::component_contract_path(&pkg, "sec-core"),
+            PathBuf::from("/usr/share/anolisa/components/sec-core/component.toml"),
+            "package contract path must be under /usr/share/anolisa"
         );
     }
 


### PR DESCRIPTION
## Description

### Ship Note

This PR aligns ANOLISA adapter contract discovery with RPM/FHS package layout while keeping raw/system install paths unchanged.

What changed:
- Added a package-managed datadir root: `/usr/share/anolisa`.
- Kept the primary system/raw install datadir as `/usr/local/share/anolisa`.
- Wired package datadir discovery into adapter manager visible roots.
- `component.toml` contracts under `/usr/share/anolisa/components/<component>/component.toml` can now be discovered.
- Adapter `dest` and skill `source` placeholders expand from the datadir root that owns the discovered contract.

Known limitations:
- `/usr/share/anolisa` is used as a read-only discovery root; this PR does not make ANOLISA write raw install files there.
- sec-core RPM packaging is not changed in this PR.
- DEB or distro-specific alternate package paths are not added yet.

## Related Issue

closes #1063

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/anolisa
cargo fmt --all -- --check
cargo test -p anolisa-platform --locked --quiet
cargo test -p anolisa-core --locked adapter --quiet
cargo test -p anolisa-cli --locked adapter --quiet
cargo clippy --workspace --all-targets -- -D warnings
cargo doc --workspace --no-deps
```

Results:
- `anolisa-platform`: 58 passed
- `anolisa-core` adapter tests: 137 passed
- `anolisa-cli` adapter tests: 23 passed
- workspace clippy: clean
- workspace docs: no new warnings

## Additional Notes

This PR separates raw/tar install layout from RPM/package-managed contract discovery. `/usr/local/share/anolisa` remains the writable system install datadir, while `/usr/share/anolisa` is added as a package contract/resource discovery root.
