### PR TITLE
feat(anolisa): place declarative systemd units via {unitdir}/{userunitdir}

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -380,6 +380,13 @@ pub fn expand_layout_placeholders(
     replacements.insert("log_dir", &layout.log_dir);
     replacements.insert("cachedir", &layout.cache_dir);
     replacements.insert("cache_dir", &layout.cache_dir);
+    // systemd unit search dirs: `{unitdir}` for system-scope units,
+    // `{userunitdir}` for user-scope template units. Both are mode-aware
+    // via the layout (see `FsLayout::systemd_user_unit_dir`).
+    replacements.insert("unitdir", &layout.systemd_unit_dir);
+    replacements.insert("unit_dir", &layout.systemd_unit_dir);
+    replacements.insert("userunitdir", &layout.systemd_user_unit_dir);
+    replacements.insert("user_unit_dir", &layout.systemd_user_unit_dir);
 
     let mut result = template.to_string();
     let mut search_from = 0;
@@ -617,6 +624,41 @@ mod tests {
         let r2 = expand_layout_placeholders("{lib_dir}/plugin.so", &layout, &[]).unwrap();
         assert_eq!(r1, r2);
         assert_eq!(r1, PathBuf::from("/usr/local/lib/anolisa/plugin.so"));
+    }
+
+    #[test]
+    fn expand_unitdir_system() {
+        // System-scope units resolve under the system unit search dir.
+        let layout = test_layout();
+        let r1 = expand_layout_placeholders("{unitdir}/agentsight.service", &layout, &[]).unwrap();
+        let r2 = expand_layout_placeholders("{unit_dir}/agentsight.service", &layout, &[]).unwrap();
+        assert_eq!(r1, r2);
+        assert_eq!(
+            r1,
+            PathBuf::from("/usr/local/lib/systemd/system/agentsight.service")
+        );
+    }
+
+    #[test]
+    fn expand_userunitdir_system_vs_user() {
+        // User-scope template units resolve under the *user* unit dir: the
+        // system-wide one in system mode, the per-user one in user mode.
+        let sys = FsLayout::system(None);
+        let r =
+            expand_layout_placeholders("{userunitdir}/anolisa-memory@.service", &sys, &[]).unwrap();
+        assert_eq!(
+            r,
+            PathBuf::from("/usr/local/lib/systemd/user/anolisa-memory@.service")
+        );
+
+        let user =
+            FsLayout::user_with_overrides(PathBuf::from("/tmp/h"), None, None, None, None, None);
+        let r2 = expand_layout_placeholders("{user_unit_dir}/anolisa-memory@.service", &user, &[])
+            .unwrap();
+        assert_eq!(
+            r2,
+            PathBuf::from("/tmp/h/.config/systemd/user/anolisa-memory@.service")
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/path_safety.rs
+++ b/src/anolisa/crates/anolisa-core/src/path_safety.rs
@@ -57,6 +57,14 @@ pub fn lexical_roots(layout: &FsLayout) -> Vec<&Path> {
         layout.datadir.as_path(),
         layout.log_dir.as_path(),
         layout.cache_dir.as_path(),
+        // systemd unit dirs are owned so contracts can place units via
+        // `{unitdir}`/`{userunitdir}` and uninstall removes them again.
+        // In system mode these sit outside the `/usr/local/share/anolisa`
+        // tree (`/usr/local/lib/systemd/{system,user}`); in user mode the
+        // user-unit dir (`~/.config/systemd/user`) is outside `etc_dir`
+        // (`~/.config/anolisa`) — so both must be listed explicitly.
+        layout.systemd_unit_dir.as_path(),
+        layout.systemd_user_unit_dir.as_path(),
     ]
 }
 
@@ -152,6 +160,23 @@ mod tests {
         std::fs::create_dir_all(&layout.bin_dir).unwrap();
         let dest = layout.bin_dir.join("agentsight");
         validate_owned_path(&layout, &dest).expect("clean path must accept");
+    }
+
+    #[test]
+    fn accepts_unit_targets_under_systemd_dirs() {
+        // `{unitdir}`/`{userunitdir}` targets must be owned so contracts can
+        // place (and uninstall can remove) systemd units.
+        let tmp = tempdir().unwrap();
+        let layout = fixture(tmp.path());
+        std::fs::create_dir_all(&layout.systemd_unit_dir).unwrap();
+        std::fs::create_dir_all(&layout.systemd_user_unit_dir).unwrap();
+        validate_owned_path(&layout, &layout.systemd_unit_dir.join("agentsight.service"))
+            .expect("system unit target must accept");
+        validate_owned_path(
+            &layout,
+            &layout.systemd_user_unit_dir.join("anolisa-memory@.service"),
+        )
+        .expect("user unit target must accept");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/service.rs
+++ b/src/anolisa/crates/anolisa-core/src/service.rs
@@ -42,6 +42,10 @@ pub enum ServiceOp {
     Enable,
     /// Disable service startup.
     Disable,
+    /// Reload the manager's unit database (`systemctl daemon-reload`).
+    /// Not tied to a specific unit; run once after new unit files land so
+    /// they become loadable.
+    DaemonReload,
 }
 
 impl ServiceOp {
@@ -54,6 +58,7 @@ impl ServiceOp {
             Self::Restart => "restart",
             Self::Enable => "enable",
             Self::Disable => "disable",
+            Self::DaemonReload => "daemon-reload",
         }
     }
 }
@@ -153,6 +158,23 @@ pub trait ServiceManager: Send + Sync {
     /// Reason text when `supported() == false`. `None` for active backends.
     fn unsupported_reason(&self) -> Option<&str> {
         None
+    }
+
+    /// Reload the manager's unit database so a freshly-installed unit file
+    /// becomes loadable (`systemctl daemon-reload`). Default is a no-op
+    /// for backends that don't drive systemd; override only where a real
+    /// reload applies. Not tied to a unit, so the returned outcome's
+    /// `unit` is empty.
+    fn daemon_reload(&self) -> Result<ServiceOutcome, ServiceError> {
+        Ok(ServiceOutcome {
+            manager: self.manager().to_string(),
+            unit: String::new(),
+            op: ServiceOp::DaemonReload,
+            state: ServiceState::NotSupported,
+            supported: false,
+            changed: false,
+            message: "daemon-reload skipped: manager does not drive systemd".to_string(),
+        })
     }
 
     /// Probe the service without attempting mutation.
@@ -316,7 +338,7 @@ impl SystemdServiceManager {
             ServiceOp::Stop => prior == ServiceState::Active && post != ServiceState::Active,
             ServiceOp::Restart => true,
             ServiceOp::Enable | ServiceOp::Disable => true,
-            ServiceOp::Probe => false,
+            ServiceOp::Probe | ServiceOp::DaemonReload => false,
         };
         Ok(ServiceOutcome {
             manager: "systemd".to_string(),
@@ -347,6 +369,33 @@ impl ServiceManager for SystemdServiceManager {
     }
     fn supported(&self) -> bool {
         true
+    }
+    fn daemon_reload(&self) -> Result<ServiceOutcome, ServiceError> {
+        let mut cmd = Command::new(&self.binary);
+        cmd.arg("daemon-reload");
+        let output = cmd
+            .output()
+            .map_err(|source| ServiceError::Spawn { source })?;
+        if !output.status.success() {
+            let code = output.status.code().unwrap_or(-1);
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(ServiceError::NonZeroExit {
+                op: "daemon-reload".to_string(),
+                unit: String::new(),
+                code,
+                stderr,
+            });
+        }
+        Ok(ServiceOutcome {
+            manager: "systemd".to_string(),
+            unit: String::new(),
+            op: ServiceOp::DaemonReload,
+            // daemon-reload doesn't target a unit, so there is no post-state.
+            state: ServiceState::Unknown,
+            supported: true,
+            changed: true,
+            message: "systemctl daemon-reload ok".to_string(),
+        })
     }
     fn probe_service(&self, unit: &str) -> Result<ServiceOutcome, ServiceError> {
         self.run_op(ServiceOp::Probe, unit)
@@ -457,6 +506,9 @@ impl ServiceManager for FakeServiceManager {
     }
     fn supported(&self) -> bool {
         self.supported
+    }
+    fn daemon_reload(&self) -> Result<ServiceOutcome, ServiceError> {
+        self.record(ServiceOp::DaemonReload, "")
     }
     fn probe_service(&self, unit: &str) -> Result<ServiceOutcome, ServiceError> {
         self.record(ServiceOp::Probe, unit)
@@ -667,6 +719,48 @@ pub fn apply_services(
     install_mode: &str,
 ) -> ServiceRunOutcome {
     let mut outcome = ServiceRunOutcome::default();
+
+    // Freshly-installed unit files aren't loadable until the manager reloads
+    // its database, so a unit placed this run would otherwise fail `start`
+    // with "not found". Reload once up-front when we'll actually drive
+    // systemd: a supported backend with at least one system-scope unit to
+    // act on. User-scope units are skipped in the loop below, so no
+    // `systemctl --user daemon-reload` is attempted here.
+    if manager.supported()
+        && requests
+            .iter()
+            .any(|req| req.scope != ServiceScope::User && (req.enable || req.start))
+    {
+        match manager.daemon_reload() {
+            Ok(_) => record_service_op(
+                log,
+                ServiceOp::DaemonReload,
+                component,
+                "",
+                operation_id,
+                actor,
+                install_mode,
+                None,
+            ),
+            Err(err) => {
+                let msg = err.to_string();
+                record_service_op(
+                    log,
+                    ServiceOp::DaemonReload,
+                    component,
+                    "",
+                    operation_id,
+                    actor,
+                    install_mode,
+                    Some(&msg),
+                );
+                outcome
+                    .warnings
+                    .push(format!("daemon-reload failed: {msg}"));
+            }
+        }
+    }
+
     for req in requests {
         // Representative op for skip records: prefer the first op we would
         // have run so the audit line names a meaningful action.
@@ -1250,6 +1344,7 @@ mod tests {
         assert_eq!(
             m.calls(),
             vec![
+                (ServiceOp::DaemonReload, "".to_string()),
                 (ServiceOp::Enable, "a.service".to_string()),
                 (ServiceOp::Start, "a.service".to_string()),
             ]
@@ -1273,7 +1368,13 @@ mod tests {
             "cli",
             "system",
         );
-        assert_eq!(m.calls(), vec![(ServiceOp::Start, "a.service".to_string())]);
+        assert_eq!(
+            m.calls(),
+            vec![
+                (ServiceOp::DaemonReload, "".to_string()),
+                (ServiceOp::Start, "a.service".to_string()),
+            ]
+        );
         assert!(out.enabled_units.is_empty());
         assert_eq!(out.started_units, vec!["a.service".to_string()]);
     }
@@ -1294,7 +1395,10 @@ mod tests {
         );
         assert_eq!(
             m.calls(),
-            vec![(ServiceOp::Enable, "a.service".to_string())]
+            vec![
+                (ServiceOp::DaemonReload, "".to_string()),
+                (ServiceOp::Enable, "a.service".to_string()),
+            ]
         );
         assert_eq!(out.enabled_units, vec!["a.service".to_string()]);
         assert!(out.started_units.is_empty());
@@ -1316,7 +1420,10 @@ mod tests {
         );
         assert_eq!(
             m.calls(),
-            vec![(ServiceOp::Restart, "a.service".to_string())]
+            vec![
+                (ServiceOp::DaemonReload, "".to_string()),
+                (ServiceOp::Restart, "a.service".to_string()),
+            ]
         );
         assert_eq!(out.started_units, vec!["a.service".to_string()]);
     }
@@ -1340,6 +1447,7 @@ mod tests {
         assert_eq!(
             m.calls(),
             vec![
+                (ServiceOp::DaemonReload, "".to_string()),
                 (ServiceOp::Enable, "a.service".to_string()),
                 (ServiceOp::Start, "a.service".to_string()),
             ]
@@ -1410,11 +1518,42 @@ mod tests {
             "cli",
             "system",
         );
-        // user-scope activation is out of scope: the manager is never called.
+        // user-scope activation is out of scope: the manager is never called
+        // — not even a daemon-reload, which only precedes system-scope work.
         assert!(m.calls().is_empty());
         assert!(out.enabled_units.is_empty());
         assert!(out.started_units.is_empty());
         assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn apply_services_daemon_reload_failure_warns_but_still_activates() {
+        let m = FakeServiceManager::new();
+        m.fail(ServiceOp::DaemonReload, "");
+        let reqs = vec![svc_req("a.service", true, true)];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "system",
+        );
+        // Reload is attempted first and fails, but activation continues.
+        assert_eq!(
+            m.calls(),
+            vec![
+                (ServiceOp::DaemonReload, "".to_string()),
+                (ServiceOp::Enable, "a.service".to_string()),
+                (ServiceOp::Start, "a.service".to_string()),
+            ]
+        );
+        assert_eq!(out.enabled_units, vec!["a.service".to_string()]);
+        assert_eq!(out.started_units, vec!["a.service".to_string()]);
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("daemon-reload"));
     }
 
     #[test]
@@ -1444,11 +1583,17 @@ mod tests {
             .filter(|l| !l.trim().is_empty())
             .map(|l| serde_json::from_str(l).expect("parse line"))
             .collect();
-        assert_eq!(lines.len(), 2, "one record per attempted op");
+        assert_eq!(
+            lines.len(),
+            3,
+            "one record per attempted op: daemon-reload, enable, start"
+        );
 
+        // A new unit file landed this run, so a daemon-reload precedes
+        // activation — recorded as an Info audit line.
         assert_eq!(
             lines[0].get("command").and_then(|v| v.as_str()),
-            Some("service:enable"),
+            Some("service:daemon-reload"),
         );
         assert_eq!(
             lines[0].get("severity").and_then(|v| v.as_str()),
@@ -1456,14 +1601,22 @@ mod tests {
         );
         assert_eq!(
             lines[1].get("command").and_then(|v| v.as_str()),
-            Some("service:start"),
+            Some("service:enable"),
         );
         assert_eq!(
             lines[1].get("severity").and_then(|v| v.as_str()),
+            Some("info"),
+        );
+        assert_eq!(
+            lines[2].get("command").and_then(|v| v.as_str()),
+            Some("service:start"),
+        );
+        assert_eq!(
+            lines[2].get("severity").and_then(|v| v.as_str()),
             Some("warn"),
             "a failed start must be Warn so audit pipelines can grep",
         );
-        let msg = lines[1]
+        let msg = lines[2]
             .get("message")
             .and_then(|v| v.as_str())
             .unwrap_or("");

--- a/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
+++ b/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
@@ -58,6 +58,12 @@ mod fhs {
     pub const LOG: &str = "/var/log/anolisa";
     pub const RUNTIME: &str = "/run/anolisa";
     pub const SYSTEMD_UNITS: &str = "/usr/local/lib/systemd/system";
+    /// System-wide *user* unit search dir. Per-user template units
+    /// (`foo@.service` driven by `systemctl --user`) install here so every
+    /// user's manager can find them — the `/usr/local` analogue of the
+    /// distro `/usr/lib/systemd/user`. Distinct from [`SYSTEMD_UNITS`],
+    /// which holds system-manager units.
+    pub const SYSTEMD_USER_UNITS: &str = "/usr/local/lib/systemd/user";
 }
 
 // ---- User-mode (file-hierarchy(7)) leaf names ---------------------------
@@ -145,8 +151,16 @@ pub struct FsLayout {
     pub runtime_dir: PathBuf,
     /// Catalog overlay directory for this install mode.
     pub manifests_overlay: PathBuf,
-    /// Distribution-specific systemd unit search directory.
+    /// Distribution-specific systemd *system* unit search directory.
+    /// Targets system-scope units (`{unitdir}` placeholder).
     pub systemd_unit_dir: PathBuf,
+    /// Systemd *user* unit search directory (`{userunitdir}` placeholder).
+    /// Targets user-scope template units. In system mode this is the
+    /// system-wide user-unit dir (`/usr/local/lib/systemd/user`); in user
+    /// mode it coincides with [`systemd_unit_dir`](Self::systemd_unit_dir)
+    /// at `~/.config/systemd/user`, since a user install has no
+    /// system-manager units.
+    pub systemd_user_unit_dir: PathBuf,
 }
 
 impl FsLayout {
@@ -183,6 +197,7 @@ impl FsLayout {
             runtime_dir: rebase(fhs::RUNTIME),
             manifests_overlay,
             systemd_unit_dir: rebase(fhs::SYSTEMD_UNITS),
+            systemd_user_unit_dir: rebase(fhs::SYSTEMD_USER_UNITS),
             prefix,
         }
     }
@@ -260,7 +275,10 @@ impl FsLayout {
             .unwrap_or_else(|| state_dir.join(fh_user::RUNTIME_FALLBACK_SUB));
 
         let manifests_overlay = etc_dir.join(OVERLAY_NAME);
+        // A user install has no system-manager units, so the system and
+        // user unit dirs coincide at `~/.config/systemd/user`.
         let systemd_unit_dir = config.join(fh_user::SYSTEMD_USER_SUB);
+        let systemd_user_unit_dir = systemd_unit_dir.clone();
 
         Self {
             mode: InstallMode::User,
@@ -281,6 +299,7 @@ impl FsLayout {
             runtime_dir,
             manifests_overlay,
             systemd_unit_dir,
+            systemd_user_unit_dir,
         }
     }
 
@@ -409,6 +428,10 @@ mod tests {
             PathBuf::from("/usr/local/lib/systemd/system")
         );
         assert_eq!(
+            layout.systemd_user_unit_dir,
+            PathBuf::from("/usr/local/lib/systemd/user")
+        );
+        assert_eq!(
             layout.central_log,
             PathBuf::from("/var/log/anolisa/central.jsonl")
         );
@@ -451,6 +474,10 @@ mod tests {
         assert_eq!(
             layout.systemd_unit_dir,
             PathBuf::from("/opt/x/usr/local/lib/systemd/system")
+        );
+        assert_eq!(
+            layout.systemd_user_unit_dir,
+            PathBuf::from("/opt/x/usr/local/lib/systemd/user")
         );
     }
 
@@ -505,6 +532,11 @@ mod tests {
             layout.systemd_unit_dir,
             PathBuf::from("/tmp/h/.config/systemd/user")
         );
+        // User mode has no system-manager units: both unit dirs coincide.
+        assert_eq!(
+            layout.systemd_user_unit_dir,
+            PathBuf::from("/tmp/h/.config/systemd/user")
+        );
     }
 
     #[test]
@@ -526,6 +558,10 @@ mod tests {
         assert_eq!(layout.lock_file, PathBuf::from("/state/anolisa/lock"));
         assert_eq!(layout.runtime_dir, PathBuf::from("/run/user/1000/anolisa"));
         assert_eq!(layout.systemd_unit_dir, PathBuf::from("/conf/systemd/user"));
+        assert_eq!(
+            layout.systemd_user_unit_dir,
+            PathBuf::from("/conf/systemd/user")
+        );
         // bin/lib/libexec are HOME-rooted regardless of the data-root
         // override: file-hierarchy(7) places them under ~/.local/bin and
         // ~/.local/lib, decoupled from the data root.


### PR DESCRIPTION
## Description

The raw backend parses `[[component.services]]` and runs `systemctl enable/start <unit>`, but the unit file was laid under `{datadir}` (e.g. `/usr/local/share/anolisa/agentsight/agentsight.service`). systemd resolves units by name against its search path, so activation failed with `Unit file ... does not exist` and degraded to a warning. This exposes the systemd unit search directories as layout placeholders so contracts place units where systemd looks, and reloads the unit database before activation.

Behavior:
- `{unitdir}` in a layout target → the **system** unit dir: `/usr/local/lib/systemd/system` (system mode), `~/.config/systemd/user` (user mode).
- `{userunitdir}` → the **user** unit dir: `/usr/local/lib/systemd/user` in system mode (system-wide — every user's `systemctl --user` can find it, the `/usr/local` analogue of `/usr/lib/systemd/user`), `~/.config/systemd/user` in user mode.
- Snake-case aliases `{unit_dir}` / `{user_unit_dir}` are accepted, matching the existing `{lib_dir}`/`{etc_dir}` style.
- A unit installed this run is `systemctl daemon-reload`-ed once before enable/start, so a freshly-placed unit is loadable and `start` no longer fails with "not found".
- Unit targets are owned: uninstall removes them with the rest of the manifest.

## Design Note

`FsLayout::systemd_unit_dir` already existed; this adds a sibling `systemd_user_unit_dir` (new `fhs::SYSTEMD_USER_UNITS = /usr/local/lib/systemd/user`; user mode reuses `~/.config/systemd/user`, since a user install has no system-manager units). Both map through the same `expand_layout_placeholders` that already renders layout files, adapters, capabilities, and hook scripts, so the layout renderer picks up the new placeholders with no call-site change.

`path_safety::lexical_roots` gains both unit dirs. This is required in both modes, not just system: in user mode `~/.config/systemd/user` lives **outside** the anolisa `etc_dir` (`~/.config/anolisa`), and in system mode `/usr/local/lib/systemd/{system,user}` are outside the `/usr/local/share/anolisa` tree — without listing them the owned-path boundary check rejects unit targets as `External`. Adding them as owned roots is also what lets uninstall remove the placed unit.

`ServiceManager::daemon_reload` is a defaulted no-op overridden only by the systemd backend (`systemctl daemon-reload`); the not-supported and fake managers inherit the no-op. `apply_services` invokes it once, before the per-unit loop, only when the backend is supported and at least one **system-scope** unit will actually be enabled/started. User-scope units are skipped in the loop, so no `systemctl --user daemon-reload` is attempted. Reload failure is best-effort (collected as a warning), consistent with enable/start.

## Ship Note

- Placeholders resolve mode-aware via the layout. Placing a system-scope unit under `{unitdir}` in a *user*-mode install lands it in `~/.config/systemd/user` — harmless, since the service manager is `NotSupported` in user mode and never activates it.
- User-scope **auto**-activation is still unsupported: `apply_services` records a documented skip for `scope=user` units. `{userunitdir}` fixes unit *placement* only — the template unit lands where `systemctl --user enable <unit>` can find it and a future user-scope executor can drive it — but this PR does not enable/start user-scope services.
- `expand_layout_placeholders` still hard-fails on a genuinely unknown placeholder (`UnknownPlaceholder`), so a contract using `{unitdir}` requires a CLI that knows it. Gating that with a clean `min_anolisa_version` message is left to the release that bumps the version; this change keeps the workspace at 0.1.13.
- Uninstall-side `daemon-reload` (after the unit file is removed) is not added here; this PR targets the install-side activation failure.

## Test

- Unit (fs_layout): `systemd_user_unit_dir` resolves to `/usr/local/lib/systemd/user` (system mode, incl. custom prefix) and `~/.config/systemd/user` (user mode, incl. explicit XDG overrides).
- Unit (adapter): `{unitdir}`/`{unit_dir}` → the system unit path; `{userunitdir}`/`{user_unit_dir}` → system-wide vs per-user user-unit path.
- Unit (path_safety): `validate_owned_path` accepts targets under both unit dirs.
- Unit (service): existing `apply_services` ordering tests updated to expect the leading `daemon-reload`; new test that a failed reload warns but still enable/starts; a user-scope-only request triggers no reload (manager untouched); central-log audit emits the `service:daemon-reload` Info line.
- Full gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- Real-host dry-run (system mode): component contracts declaring services resolve their unit to `/usr/local/lib/systemd/system/agentsight.service`, `/usr/local/lib/systemd/system/ws-ckpt.service`, and `/usr/local/lib/systemd/user/anolisa-memory@.service` — no expansion or owned-path rejection, capabilities and services planned with no warnings.

Refs #1070
