### PR TITLE
feat(anolisa): activate user-scope services and reload units on uninstall

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -46,9 +46,9 @@ use anolisa_core::state::{
 use anolisa_core::{
     ArtifactType, CapabilityRequest, ComponentManifest, DistributionEntry, DistributionIndex,
     FileKind, HookPhase, HookSpec, ResolveQuery, ServiceActivation, ServiceManager, ServiceRequest,
-    ServiceRunOutcome, apply_capabilities, apply_services, capability_for_install_mode,
-    deactivate_services, expand_layout_placeholders, resolve_manifest_hooks, run_hooks,
-    service_for_install_mode,
+    ServiceRunOutcome, ServiceScope, apply_capabilities, apply_services,
+    capability_for_install_mode, deactivate_services, expand_layout_placeholders,
+    resolve_manifest_hooks, run_hooks, service_for_install_mode, user_service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
@@ -2681,12 +2681,23 @@ fn execute_raw(
     }
 
     // Capabilities done; bring declared services up (issue order: setcap →
-    // service enable/start). The manager gates itself to system + Linux +
-    // non-container; user-scope units and unsupported hosts are quiet skips.
-    // Activation is best-effort — a failed enable/start is a warning, not an
-    // abort: the component's files are installed and an operator can fix the
-    // unit out of band. Reuse the env + log opened for the capability step.
-    let service_manager = service_for_install_mode(ctx.install_mode.as_str(), &env);
+    // service enable/start). Activation is best-effort — a failed enable/start
+    // is a warning, not an abort: the component's files are installed and an
+    // operator can fix the unit out of band. Reuse the env + log opened for
+    // the capability step.
+    //
+    // A contract's services are single-scope in practice (a component is
+    // either a system daemon or a per-user service). Pick the matching
+    // backend: an all-user-scope set drives `systemctl --user` (and only in a
+    // user-mode install); otherwise the system backend. A request the chosen
+    // backend does not handle (a hypothetical mixed-scope contract) is skipped
+    // by `apply_services` via `handles_scope`, so this never mis-drives.
+    let service_manager: Box<dyn ServiceManager> =
+        if !services.is_empty() && services.iter().all(|s| s.scope == ServiceScope::User) {
+            user_service_for_install_mode(ctx.install_mode.as_str(), &env)
+        } else {
+            service_for_install_mode(ctx.install_mode.as_str(), &env)
+        };
     let service_run = apply_services(
         service_manager.as_ref(),
         &services,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -48,8 +48,9 @@ use anolisa_core::transaction::{
     TransactionStepStatus,
 };
 use anolisa_core::{
-    CapabilityRunOutcome, ServiceActivation, ServiceRequest, ServiceRunOutcome, apply_capabilities,
-    apply_services, capability_for_install_mode, service_for_install_mode,
+    CapabilityRunOutcome, ServiceActivation, ServiceRequest, ServiceRunOutcome, ServiceScope,
+    apply_capabilities, apply_services, capability_for_install_mode, service_for_install_mode,
+    user_service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
@@ -844,9 +845,18 @@ fn execute_raw_update(
 
     // Upgrade restarts (not just starts) so the new binary is loaded.
     // Best-effort: failures warn, never roll back, because the component
-    // record and new files are already committed.
+    // record and new files are already committed. Pick the scope-matched
+    // backend like install does: a purely user-scope contract restarts
+    // through `systemctl --user`, so a user service is actually reloaded onto
+    // the new binary instead of being left running on the replaced files.
+    let service_manager =
+        if !services.is_empty() && services.iter().all(|s| s.scope == ServiceScope::User) {
+            user_service_for_install_mode(ctx.install_mode.as_str(), &env)
+        } else {
+            service_for_install_mode(ctx.install_mode.as_str(), &env)
+        };
     let service_run = apply_services(
-        service_for_install_mode(ctx.install_mode.as_str(), &env).as_ref(),
+        service_manager.as_ref(),
         &services,
         ServiceActivation::Restart,
         Some(&log),

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -98,7 +98,7 @@ pub use service::{
     DeactivationOutcome, FakeServiceManager, NotSupportedServiceManager, ServiceActivation,
     ServiceError, ServiceManager, ServiceOp, ServiceOutcome, ServiceRequest, ServiceRunOutcome,
     ServiceState, SystemdServiceManager, apply_services, deactivate_services,
-    for_install_mode as service_for_install_mode,
+    for_install_mode as service_for_install_mode, user_service_for_install_mode,
 };
 pub use state::{
     BackupRecord, ExternalModifiedFile, FileOwner, HealthEntry, InstallMode, InstalledObject,

--- a/src/anolisa/crates/anolisa-core/src/lifecycle.rs
+++ b/src/anolisa/crates/anolisa-core/src/lifecycle.rs
@@ -1381,6 +1381,57 @@ fn execute_uninstall_or_purge(
         ));
         combined.push(msg);
     }
+
+    // Step 8.5 — daemon-reload AFTER the owned unit files are gone, so the
+    // manager drops the now-deleted units from its database (the
+    // uninstall-side mirror of the install reload — without it systemd keeps
+    // a stale unit until the next manual reload). Best-effort: a failed
+    // reload only warns. Runs only when the component declared service units
+    // (whose files were just removed) on a host that drives systemd.
+    //
+    // A user-mode install places (and reloads) its units under the user
+    // manager, so the post-removal reload selects the user-scope factory in
+    // user mode — `for_install_mode("user")` is unsupported and would skip
+    // the `systemctl --user daemon-reload` the removed `~/.config/systemd/user`
+    // units need. (Per-unit user-scope stop/disable in a *system*-mode
+    // uninstall still waits on `ServiceRef` recording scope.)
+    if live_plan.components.iter().any(|c| !c.services.is_empty()) {
+        let env = EnvService::detect();
+        let manager = if install_mode == "user" {
+            service::user_service_for_install_mode(install_mode, &env)
+        } else {
+            service::for_install_mode(install_mode, &env)
+        };
+        if manager.supported() {
+            match manager.daemon_reload() {
+                Ok(_) => service::record_service_op(
+                    Some(&central),
+                    service::ServiceOp::DaemonReload,
+                    target_name,
+                    "",
+                    &operation_id,
+                    actor,
+                    install_mode,
+                    None,
+                ),
+                Err(err) => {
+                    let msg = format!("daemon-reload after unit removal failed: {err}");
+                    service::record_service_op(
+                        Some(&central),
+                        service::ServiceOp::DaemonReload,
+                        target_name,
+                        "",
+                        &operation_id,
+                        actor,
+                        install_mode,
+                        Some(&msg),
+                    );
+                    combined.push(msg);
+                }
+            }
+        }
+    }
+
     let warnings = combined;
 
     // Best-effort cleanup of backups on the success path.
@@ -2023,6 +2074,72 @@ mod tests {
                 Some("agentsight"),
             );
         }
+    }
+
+    /// The uninstall-side daemon-reload is gated on the component actually
+    /// declaring service units: a component with none must never emit a
+    /// `service:daemon-reload` record — the manager is not even built, so
+    /// the gate also keeps the no-service uninstall free of systemctl.
+    #[test]
+    #[cfg(unix)]
+    fn uninstall_without_services_does_not_daemon_reload() {
+        let root = tempdir().expect("tempdir");
+        let layout = fixture_layout(root.path());
+        std_fs::create_dir_all(&layout.bin_dir).unwrap();
+        let owned_path = layout.bin_dir.join("os-skills-marker");
+        std_fs::write(&owned_path, b"owned").unwrap();
+
+        std_fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "os-skills".to_string(),
+            version: "0.2.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("file:///fake".to_string()),
+            raw_package: None,
+            install_backend: Some("raw".to_string()),
+            ownership: None,
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: vec![OwnedFile {
+                path: owned_path.clone(),
+                owner: StateFileOwner::Anolisa,
+                sha256: Some("0".repeat(64)),
+            }],
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+        });
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state save");
+
+        let hooks = ResolvedLifecycleHooks {
+            pre_uninstall: Vec::new(),
+            post_uninstall: Vec::new(),
+        };
+        let plan = LifecyclePlan::for_component_uninstall(
+            "os-skills",
+            &InstalledState::load(&layout.state_dir.join("installed.toml")).unwrap(),
+        );
+        execute_plan(&plan, &layout, "tester", "system", &hooks).expect("uninstall ok");
+
+        let lines = read_log_lines(&layout.central_log);
+        assert!(
+            !lines.iter().any(|l| {
+                l.get("command").and_then(|v| v.as_str()) == Some("service:daemon-reload")
+            }),
+            "no service units declared — must not daemon-reload: {lines:?}",
+        );
+        assert!(!owned_path.exists(), "owned file should be removed");
     }
 
     /// ws-ckpt semantics: a **non-strict** pre_uninstall hook that fails

--- a/src/anolisa/crates/anolisa-core/src/service.rs
+++ b/src/anolisa/crates/anolisa-core/src/service.rs
@@ -5,13 +5,15 @@
 //! systemctl status on `anolisa restart`. This module wraps the minimum
 //! amount of `systemctl` we need without a dbus dependency.
 //!
-//! The trait surface is small on purpose. Any platform that does not
-//! match the alpha factory rules — non-Linux, install_mode == "user",
-//! container runtime detected — gets a [`NotSupportedServiceManager`]
-//! whose ops succeed with `state: NotSupported, supported: false,
-//! changed: false`. Callers treat that as a quiet skip rather than a
-//! warning, so the lifecycle on macOS / inside CI containers / under
-//! user-mode installs stays a no-op for services.
+//! The trait surface is small on purpose. A non-Linux host or a detected
+//! container runtime gets a [`NotSupportedServiceManager`] whose ops
+//! succeed with `state: NotSupported, supported: false, changed: false`;
+//! callers treat that as a quiet skip rather than a warning. Install mode
+//! selects the *scope* instead of disabling services outright: system mode
+//! drives system units via `systemctl`, user mode drives the caller's user
+//! units via `systemctl --user`. A manager only acts on requests of its
+//! own scope (see [`ServiceManager::handles_scope`]); a request for the
+//! other scope is a documented skip.
 //!
 //! `FakeServiceManager` is the executor used by `service.rs`'s own unit
 //! tests and by integration tests that need to assert which ops the
@@ -160,6 +162,16 @@ pub trait ServiceManager: Send + Sync {
         None
     }
 
+    /// Whether this manager drives units of `scope`. A systemd backend is
+    /// bound to a single scope by install mode — `systemctl` for
+    /// [`ServiceScope::System`], `systemctl --user` for
+    /// [`ServiceScope::User`] — and orchestrators skip any request whose
+    /// scope it does not handle. Default `true` for scope-agnostic
+    /// backends (the not-supported skip and the test fake's default).
+    fn handles_scope(&self, _scope: ServiceScope) -> bool {
+        true
+    }
+
     /// Reload the manager's unit database so a freshly-installed unit file
     /// becomes loadable (`systemctl daemon-reload`). Default is a no-op
     /// for backends that don't drive systemd; override only where a real
@@ -191,9 +203,13 @@ pub trait ServiceManager: Send + Sync {
     fn disable_service(&self, unit: &str) -> Result<ServiceOutcome, ServiceError>;
 }
 
-/// Pick a backend for the current host + install mode. Linux + system
-/// mode + no container → real `systemctl` driver; everything else →
-/// quiet skip.
+/// Pick the **system-scope** backend for the current host + install mode.
+/// Linux + system mode + no container → real `systemctl` driver;
+/// everything else (non-Linux, user mode, container) → quiet skip. This is
+/// the manager used to enable/stop system units and to probe systemd
+/// health checks, so user mode is deliberately unsupported here — a
+/// user-mode install cannot manage system units. User-scope activation has
+/// its own factory, [`user_service_for_install_mode`].
 pub fn for_install_mode(install_mode: &str, env: &EnvFacts) -> Box<dyn ServiceManager> {
     if env.os != "linux" {
         return Box::new(NotSupportedServiceManager::new(format!(
@@ -212,6 +228,40 @@ pub fn for_install_mode(install_mode: &str, env: &EnvFacts) -> Box<dyn ServiceMa
         )));
     }
     Box::new(SystemdServiceManager::new())
+}
+
+/// Pick the **user-scope** backend (`systemctl --user`) for activating user
+/// units. Unlike [`for_install_mode`], user units are auto-activated only in
+/// a **user**-mode install: that install runs as the owning user with their
+/// session bus, so `systemctl --user enable/start` targets the right
+/// manager. A system-mode install *places* a user unit (under
+/// `{userunitdir}`) for all users but leaves activation to the user — root
+/// has no single target user session — so it is a quiet skip here.
+///
+/// Linux + user mode + no container → user-scope `systemctl --user` driver;
+/// everything else → quiet skip.
+pub fn user_service_for_install_mode(
+    install_mode: &str,
+    env: &EnvFacts,
+) -> Box<dyn ServiceManager> {
+    if env.os != "linux" {
+        return Box::new(NotSupportedServiceManager::new(format!(
+            "user-scope service manager unsupported on os '{}'",
+            env.os,
+        )));
+    }
+    if install_mode != "user" {
+        return Box::new(NotSupportedServiceManager::new(format!(
+            "user-scope service not auto-activated in install_mode='{install_mode}' — \
+             unit is placed; enable per-user with `systemctl --user enable`",
+        )));
+    }
+    if let Some(rt) = env.container.as_deref() {
+        return Box::new(NotSupportedServiceManager::new(format!(
+            "container runtime '{rt}' detected — refusing to drive systemctl --user from inside a container",
+        )));
+    }
+    Box::new(SystemdServiceManager::with_scope(ServiceScope::User))
 }
 
 /// Quiet-skip backend. Every op succeeds with `state: NotSupported`.
@@ -272,18 +322,41 @@ impl ServiceManager for NotSupportedServiceManager {
 /// downgrade them to warnings.
 pub struct SystemdServiceManager {
     binary: PathBuf,
+    /// System vs user manager. A user-scoped instance prefixes every
+    /// invocation with `--user`, so ops target the caller's `systemd
+    /// --user` instance instead of the system manager. Set from install
+    /// mode by [`for_install_mode`].
+    scope: ServiceScope,
 }
 
 impl SystemdServiceManager {
-    /// Build a manager that invokes `systemctl` from `PATH`.
+    /// Build a **system**-scope manager that invokes `systemctl` from
+    /// `PATH`.
     pub fn new() -> Self {
+        Self::with_scope(ServiceScope::System)
+    }
+
+    /// Build a manager bound to `scope`. A [`ServiceScope::User`] manager
+    /// prefixes every `systemctl` call with `--user`.
+    pub fn with_scope(scope: ServiceScope) -> Self {
         Self {
             binary: PathBuf::from("systemctl"),
+            scope,
         }
     }
 
-    fn probe_state(&self, unit: &str) -> Result<ServiceState, ServiceError> {
+    /// `systemctl` command seeded with `--user` when this manager is
+    /// user-scoped, so probe / op / reload all target the right manager.
+    fn command(&self) -> Command {
         let mut cmd = Command::new(&self.binary);
+        if self.scope == ServiceScope::User {
+            cmd.arg("--user");
+        }
+        cmd
+    }
+
+    fn probe_state(&self, unit: &str) -> Result<ServiceState, ServiceError> {
+        let mut cmd = self.command();
         cmd.arg("is-active").arg(unit);
         let output = cmd
             .output()
@@ -308,7 +381,7 @@ impl SystemdServiceManager {
         let prior = self.probe_state(unit)?;
         if matches!(op, ServiceOp::Probe) {
             return Ok(ServiceOutcome {
-                manager: "systemd".to_string(),
+                manager: self.manager().to_string(),
                 unit: unit.to_string(),
                 op,
                 state: prior,
@@ -317,7 +390,7 @@ impl SystemdServiceManager {
                 message: format!("systemctl is-active reported {}", prior.as_str()),
             });
         }
-        let mut cmd = Command::new(&self.binary);
+        let mut cmd = self.command();
         cmd.arg(op.as_str()).arg(unit);
         let output = cmd
             .output()
@@ -341,7 +414,7 @@ impl SystemdServiceManager {
             ServiceOp::Probe | ServiceOp::DaemonReload => false,
         };
         Ok(ServiceOutcome {
-            manager: "systemd".to_string(),
+            manager: self.manager().to_string(),
             unit: unit.to_string(),
             op,
             state: post,
@@ -365,13 +438,23 @@ impl Default for SystemdServiceManager {
 
 impl ServiceManager for SystemdServiceManager {
     fn manager(&self) -> &str {
-        "systemd"
+        // Report the scope in the label so central-log and probe outcomes
+        // match install state, which records `systemd-user` for user mode.
+        // A user-scoped instance drives `systemctl --user`, so it is a
+        // distinct manager namespace from the system one.
+        match self.scope {
+            ServiceScope::System => "systemd",
+            ServiceScope::User => "systemd-user",
+        }
     }
     fn supported(&self) -> bool {
         true
     }
+    fn handles_scope(&self, scope: ServiceScope) -> bool {
+        self.scope == scope
+    }
     fn daemon_reload(&self) -> Result<ServiceOutcome, ServiceError> {
-        let mut cmd = Command::new(&self.binary);
+        let mut cmd = self.command();
         cmd.arg("daemon-reload");
         let output = cmd
             .output()
@@ -387,7 +470,7 @@ impl ServiceManager for SystemdServiceManager {
             });
         }
         Ok(ServiceOutcome {
-            manager: "systemd".to_string(),
+            manager: self.manager().to_string(),
             unit: String::new(),
             op: ServiceOp::DaemonReload,
             // daemon-reload doesn't target a unit, so there is no post-state.
@@ -423,21 +506,33 @@ impl ServiceManager for SystemdServiceManager {
 pub struct FakeServiceManager {
     manager_name: String,
     supported: bool,
+    /// Scope this fake claims to drive (see [`ServiceManager::handles_scope`]).
+    /// Defaults to [`ServiceScope::System`] so existing system-mode tests
+    /// drive their requests and user-scope requests are skipped.
+    scope: ServiceScope,
     state: Mutex<ServiceState>,
     calls: Mutex<Vec<(ServiceOp, String)>>,
     fail_ops: Mutex<HashSet<(ServiceOp, String)>>,
 }
 
 impl FakeServiceManager {
-    /// Build a supported fake manager with an initially inactive unit
-    /// state and no injected failures.
+    /// Build a supported, **system**-scope fake manager with an initially
+    /// inactive unit state and no injected failures.
     pub fn new() -> Self {
         Self {
             manager_name: "fake".to_string(),
             supported: true,
+            scope: ServiceScope::System,
             state: Mutex::new(ServiceState::Inactive),
             calls: Mutex::new(Vec::new()),
             fail_ops: Mutex::new(HashSet::new()),
+        }
+    }
+    /// Build a fake bound to `scope`, for exercising user-scope routing.
+    pub fn with_scope(scope: ServiceScope) -> Self {
+        Self {
+            scope,
+            ..Self::new()
         }
     }
     /// Snapshot of every call recorded so far, in dispatch order.
@@ -506,6 +601,9 @@ impl ServiceManager for FakeServiceManager {
     }
     fn supported(&self) -> bool {
         self.supported
+    }
+    fn handles_scope(&self, scope: ServiceScope) -> bool {
+        self.scope == scope
     }
     fn daemon_reload(&self) -> Result<ServiceOutcome, ServiceError> {
         self.record(ServiceOp::DaemonReload, "")
@@ -705,8 +803,10 @@ pub struct ServiceRunOutcome {
 ///
 /// Skips, in priority order, each producing a documented `Info` audit line
 /// and no warning:
-/// - `scope == user`: user-scope activation is not yet supported.
-/// - `!manager.supported()`: non-Linux, user mode, or container host.
+/// - `!manager.supported()`: non-Linux or container host.
+/// - `!manager.handles_scope(req.scope)`: the request's scope is not the
+///   one this install mode drives (e.g. a user-scope unit in a system
+///   install) — the unit is placed but not activated here.
 #[allow(clippy::too_many_arguments)]
 pub fn apply_services(
     manager: &dyn ServiceManager,
@@ -723,13 +823,13 @@ pub fn apply_services(
     // Freshly-installed unit files aren't loadable until the manager reloads
     // its database, so a unit placed this run would otherwise fail `start`
     // with "not found". Reload once up-front when we'll actually drive
-    // systemd: a supported backend with at least one system-scope unit to
-    // act on. User-scope units are skipped in the loop below, so no
-    // `systemctl --user daemon-reload` is attempted here.
+    // systemd: a supported backend with at least one request whose scope it
+    // handles. A user-scope manager reloads via `systemctl --user`; requests
+    // of the scope it does not handle are skipped in the loop below.
     if manager.supported()
         && requests
             .iter()
-            .any(|req| req.scope != ServiceScope::User && (req.enable || req.start))
+            .any(|req| manager.handles_scope(req.scope) && (req.enable || req.start))
     {
         match manager.daemon_reload() {
             Ok(_) => record_service_op(
@@ -770,21 +870,6 @@ pub fn apply_services(
             ServiceOp::Start
         };
 
-        if req.scope == ServiceScope::User {
-            record_service_op_unsupported(
-                log,
-                primary_op,
-                component,
-                &req.unit,
-                operation_id,
-                actor,
-                install_mode,
-                manager.manager(),
-                Some("user-scope service activation not yet supported"),
-            );
-            continue;
-        }
-
         if !manager.supported() {
             record_service_op_unsupported(
                 log,
@@ -796,6 +881,35 @@ pub fn apply_services(
                 install_mode,
                 manager.manager(),
                 manager.unsupported_reason(),
+            );
+            continue;
+        }
+
+        // The manager is bound to one scope by install mode. A unit of the
+        // other scope is placed but not activated here: a user-scope unit in
+        // a system install is left for `systemctl --user enable`; a
+        // system-scope unit in a user install needs a system-mode install.
+        if !manager.handles_scope(req.scope) {
+            let reason = match req.scope {
+                ServiceScope::User => {
+                    "user-scope service not activated in this install mode — \
+                     unit placed; enable per-user with `systemctl --user enable`"
+                }
+                ServiceScope::System => {
+                    "system-scope service not activated in user install mode — \
+                     needs a system-mode install"
+                }
+            };
+            record_service_op_unsupported(
+                log,
+                primary_op,
+                component,
+                &req.unit,
+                operation_id,
+                actor,
+                install_mode,
+                manager.manager(),
+                Some(reason),
             );
             continue;
         }
@@ -1099,14 +1213,47 @@ mod tests {
         let m = for_install_mode("system", &fake_env("linux", None));
         assert_eq!(m.manager(), "systemd");
         assert!(m.supported());
+        // System mode drives system units, not user units.
+        assert!(m.handles_scope(ServiceScope::System));
+        assert!(!m.handles_scope(ServiceScope::User));
     }
 
     #[test]
     fn factory_skips_user_install_mode_on_linux() {
+        // The system-scope factory stays unsupported in user mode: a
+        // user-mode install cannot manage system units (this also keeps
+        // systemd health checks degrading to not_supported in user mode).
         let m = for_install_mode("user", &fake_env("linux", None));
         assert!(!m.supported());
         assert_eq!(m.manager(), "not-supported");
         assert!(m.unsupported_reason().unwrap().contains("install_mode"));
+    }
+
+    #[test]
+    fn user_factory_drives_user_scope_only_in_user_mode() {
+        // The user-scope factory drives `systemctl --user` in user mode,
+        // handling only user-scope requests, and labels itself `systemd-user`
+        // so diagnostics distinguish it from the system manager.
+        let m = user_service_for_install_mode("user", &fake_env("linux", None));
+        assert!(m.supported());
+        assert_eq!(m.manager(), "systemd-user");
+        assert!(m.handles_scope(ServiceScope::User));
+        assert!(!m.handles_scope(ServiceScope::System));
+    }
+
+    #[test]
+    fn user_factory_skips_system_mode_as_place_only() {
+        // System mode places the user unit but does not auto-activate it.
+        let m = user_service_for_install_mode("system", &fake_env("linux", None));
+        assert!(!m.supported());
+        assert!(m.unsupported_reason().unwrap().contains("placed"));
+    }
+
+    #[test]
+    fn user_factory_skips_inside_containers() {
+        let m = user_service_for_install_mode("user", &fake_env("linux", Some("docker")));
+        assert!(!m.supported());
+        assert!(m.unsupported_reason().unwrap().contains("docker"));
     }
 
     #[test]
@@ -1500,7 +1647,10 @@ mod tests {
     }
 
     #[test]
-    fn apply_services_user_scope_is_skipped_without_touching_manager() {
+    fn apply_services_user_scope_is_skipped_by_a_system_manager() {
+        // Default fake is system-scope (mirrors a system-mode install). A
+        // user-scope request is not handled, so the manager is never called
+        // — not even a daemon-reload, which only precedes work it handles.
         let m = FakeServiceManager::new();
         let reqs = vec![ServiceRequest {
             unit: "anolisa-memory@alice.service".to_string(),
@@ -1518,11 +1668,48 @@ mod tests {
             "cli",
             "system",
         );
-        // user-scope activation is out of scope: the manager is never called
-        // — not even a daemon-reload, which only precedes system-scope work.
         assert!(m.calls().is_empty());
         assert!(out.enabled_units.is_empty());
         assert!(out.started_units.is_empty());
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn apply_services_drives_user_scope_when_manager_handles_it() {
+        // A user-scope manager (user-mode install) drives a user-scope unit:
+        // reload precedes enable+start, all recorded against it.
+        let m = FakeServiceManager::with_scope(ServiceScope::User);
+        let reqs = vec![ServiceRequest {
+            unit: "anolisa-memory@alice.service".to_string(),
+            scope: ServiceScope::User,
+            enable: true,
+            start: true,
+        }];
+        let out = apply_services(
+            &m,
+            &reqs,
+            ServiceActivation::Start,
+            None,
+            "comp",
+            "op1",
+            "cli",
+            "user",
+        );
+        let calls = m.calls();
+        assert_eq!(calls[0], (ServiceOp::DaemonReload, String::new()));
+        assert!(calls.contains(&(
+            ServiceOp::Enable,
+            "anolisa-memory@alice.service".to_string()
+        )));
+        assert!(calls.contains(&(ServiceOp::Start, "anolisa-memory@alice.service".to_string())));
+        assert_eq!(
+            out.enabled_units,
+            vec!["anolisa-memory@alice.service".to_string()]
+        );
+        assert_eq!(
+            out.started_units,
+            vec!["anolisa-memory@alice.service".to_string()]
+        );
         assert!(out.warnings.is_empty());
     }
 


### PR DESCRIPTION
## Description

Completes the two install-operations follow-ups tracked under #1070, on top of the declarative service/capability/hook executor (#1080) and unit placement (#1089):

1. **User-scope service activation** — `scope=user` units (e.g. agent-memory's `anolisa-memory@.service`) are now *activated* via `systemctl --user`, not merely placed. A user-mode install drives the caller's `systemctl --user enable/start`, and a raw `update` restarts them the same way; a system-mode install still only places the unit (root has no single target-user session) and leaves per-user `systemctl --user enable` to the user.
2. **Uninstall-side daemon-reload** — after a component's owned unit files are removed, the manager runs `daemon-reload` so systemd drops the now-deleted units (the mirror of the install-side reload from #1089). A user-mode uninstall issues `systemctl --user daemon-reload`. Requested by the #1089 review.

Behavior:
- `SystemdServiceManager` carries a scope; a user-scoped instance prefixes every `systemctl` call with `--user` and labels itself `systemd-user`, so central-log records and `ServiceOutcome.manager` (enable/start/restart/reload) match the `systemd-user` label install state already writes for user mode.
- New `user_service_for_install_mode` factory drives `systemctl --user` only in a user-mode install (Linux, no container); otherwise a quiet skip.
- Both **install** and **update** pick the scope-matched backend by the requests' scope, so a user-scope service is enabled/started on install and *restarted* on update via `systemctl --user` rather than left running on the replaced binary.
- `ServiceManager::handles_scope` routes each request to the backend that drives its scope; a request the chosen backend does not handle (a mixed-scope contract) is a documented skip, never mis-driven.
- The uninstall reload runs only when the component declared service units and the host drives systemd; it selects the user-scope factory in a user-mode uninstall (`systemctl --user daemon-reload`) and the system factory otherwise.

## Design Note

User-scope activation gets its **own** factory rather than making `for_install_mode` scope-aware, because `for_install_mode` is also the factory the **status/health** path uses to probe `kind = "systemd"` checks — and it relies on user mode being *unsupported* so a system-service health check degrades to `not_supported` instead of probing a system unit from a user-mode install. Flipping `for_install_mode("user")` to drive `systemctl --user` regressed that path. So `for_install_mode` stays the system-scope factory (user mode → unsupported), and user-scope work goes through `user_service_for_install_mode`, called by the install/update executors and the uninstall reload.

`apply_services` / `deactivate_services` keep their single-manager signatures; the install/update executors pick the system or user backend by the requests' scope (a contract's services are single-scope in practice). `handles_scope` — defaulted `true`, overridden by the systemd and fake backends — is the safety net that skips any off-scope request.

The uninstall reload runs after the file-removal loop and before `post_uninstall` hooks, and is best-effort (a failed reload only warns). It selects the user-scope factory when `install_mode == "user"` so the removed `~/.config/systemd/user` units get a `systemctl --user daemon-reload`, and the system factory otherwise.

## Ship Note

- **No production behavior change today**: the only user-scope component, agent-memory, declares `enable = false` / `start = false`, so nothing auto-activates. This adds the capability + tests and lands the unit where `systemctl --user enable` can find it (via `{userunitdir}`, #1089).
- **Per-unit user-scope stop/disable on uninstall is intentionally out of scope**: the persisted `ServiceRef` does not record a unit's scope, so uninstall drives the system manager for stop/disable. The post-removal *reload* is already scope-aware by install mode (a user-mode uninstall runs `systemctl --user daemon-reload`), but threading scope through state — so a system-mode uninstall can stop/disable per-unit user services — is a separate follow-up.
- The uninstall reload is a quiet skip on container / non-Linux / user-mode-without-session hosts.

## Test

- Unit (service): `user_service_for_install_mode` support matrix — drives `--user` only in user mode (labeled `systemd-user`), skips system mode (place-only) and containers; `for_install_mode` stays unsupported in user mode (keeps systemd health checks degrading). `apply_services` drives a user-scope unit when the backend handles its scope (reload → enable → start) and skips it under a system backend without touching it.
- Unit (lifecycle): a no-service uninstall never emits a `service:daemon-reload` record (the gate) and still removes owned files.
- Existing `apply_services` / `deactivate_services` and status-health tests unchanged and green.
- Full gate: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`. One pre-existing platform test (`systemd::tests::unimplemented_unit_operations_return_errors_instead_of_panicking`) fails on the dev host only because `agentsight.service` happens to be installed there; it fails identically on clean `main` and is unrelated to this change.

Refs #1070
