### PR TITLE
feat(anolisa): tear down user-scope services on uninstall

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -2248,7 +2248,7 @@ fn resolve_manifest_contract(
         &resolution.component,
     )?);
 
-    let services = resolve_manifest_services(manifest, &resolution.component)?;
+    let services = resolve_manifest_services(manifest, &resolution.component, mode)?;
     let capabilities = resolve_manifest_capabilities(manifest, layout, &resolution.component)?;
 
     Ok((files, services, capabilities))
@@ -2265,7 +2265,26 @@ fn resolve_manifest_contract(
 fn resolve_manifest_services(
     manifest: &ComponentManifest,
     component: &str,
+    mode: &str,
 ) -> Result<Vec<ServiceRequest>, CliError> {
+    // The `%u` instance specifier resolves to the caller's login name, but
+    // only in a user-mode install where the unit is activated as that user.
+    // A system-mode install merely *places* a user-scope template for later
+    // per-user `systemctl --user enable`, so it leaves `%u` un-resolved
+    // (the bare template) rather than baking in root's name. Detect the user
+    // at most once, and only when a `%u` instance actually needs it.
+    let caller = if mode == "user"
+        && manifest
+            .install
+            .services
+            .iter()
+            .any(|s| s.instance.as_deref().is_some_and(|i| i.contains("%u")))
+    {
+        Some(anolisa_env::EnvService::detect().user)
+    } else {
+        None
+    };
+
     let mut requests = Vec::with_capacity(manifest.install.services.len());
     for spec in &manifest.install.services {
         if spec.unit.trim().is_empty() {
@@ -2279,7 +2298,12 @@ fn resolve_manifest_services(
         // Template unit (`name@.service`) + instance → `name@<instance>.service`.
         let unit = match &spec.instance {
             Some(instance) if spec.unit.contains("@.") => {
-                spec.unit.replacen("@.", &format!("@{instance}."), 1)
+                match resolve_service_instance(instance, caller.as_deref()) {
+                    Some(resolved) => spec.unit.replacen("@.", &format!("@{resolved}."), 1),
+                    // `%u` with no resolved user (system-mode place-only):
+                    // keep the bare template; per-user enable instantiates it.
+                    None => spec.unit.clone(),
+                }
             }
             _ => spec.unit.clone(),
         };
@@ -2291,6 +2315,21 @@ fn resolve_manifest_services(
         });
     }
     Ok(requests)
+}
+
+/// Resolve a systemd template instance, expanding the `%u` specifier to the
+/// caller's login name.
+///
+/// `%u` is a systemd specifier that systemd does *not* expand in the instance
+/// portion of a command-line unit name, so anolisa resolves it itself. Returns
+/// `None` when the instance uses `%u` but no caller name is available (a
+/// system-mode install that only places the template) — the caller then keeps
+/// the bare template. A literal instance is returned verbatim in every mode.
+fn resolve_service_instance(instance: &str, caller: Option<&str>) -> Option<String> {
+    if !instance.contains("%u") {
+        return Some(instance.to_string());
+    }
+    caller.map(|user| instance.replace("%u", user))
 }
 
 /// Render the manifest's `[install.files]` against the layout: expand
@@ -2767,11 +2806,6 @@ fn execute_raw(
         .collect();
     installed_paths.push(manifest_path.display().to_string());
 
-    let service_manager_label = match ctx.install_mode {
-        crate::context::InstallMode::System => "systemd",
-        crate::context::InstallMode::User => "systemd-user",
-    };
-
     // Migrate away legacy capability rows on this state write; surfaced
     // in the result warnings and audited in the central log below. A
     // state-save failure rolls the prune back with the rest of the write.
@@ -2816,10 +2850,14 @@ fn execute_raw(
             .iter()
             .map(|svc| ServiceRef {
                 name: svc.unit.clone(),
-                manager: service_manager_label.to_string(),
+                // Label follows the unit's scope, not install mode: a
+                // place-only user-scope unit in a system install is still
+                // `systemd-user`, keeping `manager` consistent with `scope`.
+                manager: svc.scope.manager_label().to_string(),
                 restartable: true,
                 // Reflect what the executor actually enabled this run.
                 enabled: service_run.enabled_units.contains(&svc.unit),
+                scope: svc.scope,
             })
             .collect(),
         health: Vec::new(),
@@ -4403,7 +4441,7 @@ sha256 = "{sha}"
     fn resolve_manifest_services_carries_spec_and_expands_instance() {
         let toml = service_manifest("anolisa-memory@.service", true, false, Some("alice"));
         let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
-        let reqs = resolve_manifest_services(&manifest, "agentsight").expect("resolve");
+        let reqs = resolve_manifest_services(&manifest, "agentsight", "system").expect("resolve");
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs[0].unit, "anolisa-memory@alice.service");
         assert!(reqs[0].enable);
@@ -4414,11 +4452,54 @@ sha256 = "{sha}"
     fn resolve_manifest_services_plain_unit_unchanged() {
         let toml = service_manifest("agentsight.service", true, true, None);
         let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
-        let reqs = resolve_manifest_services(&manifest, "agentsight").expect("resolve");
+        let reqs = resolve_manifest_services(&manifest, "agentsight", "system").expect("resolve");
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs[0].unit, "agentsight.service");
         assert!(reqs[0].enable && reqs[0].start);
         assert_eq!(reqs[0].scope, anolisa_core::ServiceScope::System);
+    }
+
+    #[test]
+    fn resolve_service_instance_expands_percent_u_only_with_a_caller() {
+        // `%u` resolves to the caller; a literal instance passes through in
+        // every mode; `%u` with no caller (system-mode place-only) stays None.
+        assert_eq!(
+            resolve_service_instance("%u", Some("alice")).as_deref(),
+            Some("alice")
+        );
+        assert_eq!(resolve_service_instance("%u", None), None);
+        assert_eq!(
+            resolve_service_instance("0", Some("alice")).as_deref(),
+            Some("0")
+        );
+        assert_eq!(resolve_service_instance("0", None).as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn resolve_manifest_services_resolves_percent_u_in_user_mode() {
+        let toml = service_manifest("anolisa-memory@.service", false, false, Some("%u"));
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let reqs = resolve_manifest_services(&manifest, "agent-memory", "user").expect("resolve");
+        // The exact name is the live login user, but `%u` must be gone and the
+        // template must be instantiated.
+        assert!(
+            !reqs[0].unit.contains("%u"),
+            "unit must not keep the literal specifier: {}",
+            reqs[0].unit
+        );
+        assert!(reqs[0].unit.starts_with("anolisa-memory@"));
+        assert!(reqs[0].unit.ends_with(".service"));
+        assert_ne!(reqs[0].unit, "anolisa-memory@.service");
+    }
+
+    #[test]
+    fn resolve_manifest_services_keeps_percent_u_template_in_system_mode() {
+        // System mode is place-only for user-scope templates: leave `%u`
+        // un-resolved so per-user `systemctl --user enable` instantiates it.
+        let toml = service_manifest("anolisa-memory@.service", false, false, Some("%u"));
+        let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
+        let reqs = resolve_manifest_services(&manifest, "agent-memory", "system").expect("resolve");
+        assert_eq!(reqs[0].unit, "anolisa-memory@.service");
     }
 
     /// Minimal-schema manifest with the given `[[component.hooks]]` entries

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -7,10 +7,12 @@
 //!      `INVALID_ARGUMENT`.
 //!   2. Collects the component's restartable service units.
 //!   3. If the set is empty → `INVALID_ARGUMENT` (nothing to restart).
-//!   4. Picks a [`anolisa_core::ServiceManager`] via `service::for_install_mode`.
-//!      Unsupported backends (user mode, non-Linux, container) short-circuit
-//!      with a `not_supported` outcome — caller sees a clear
-//!      "skipped" instead of a misleading success.
+//!   4. Routes each unit through the [`anolisa_core::ServiceManager`] for
+//!      its own scope — system units via `systemctl`, user units via
+//!      `systemctl --user` — the same per-scope partitioning uninstall uses.
+//!      A unit whose scope has no driver here (a user unit in a system-mode
+//!      restart, non-Linux, container) is a per-unit `not_supported` skip,
+//!      never mis-driven through another namespace.
 //!   5. Calls `restart_service(unit)` per unit. Per-unit failures are
 //!      collected as warnings on the outcome; a unit that systemctl
 //!      refuses does NOT abort the whole op.
@@ -24,7 +26,9 @@
 use clap::Parser;
 
 use anolisa_core::{
-    InstalledState, ObjectKind, ServiceState, service_for_install_mode as service_factory,
+    InstalledState, ObjectKind, ServiceManager, ServiceScope, ServiceState,
+    service_for_install_mode as service_factory,
+    user_service_for_install_mode as user_service_factory,
 };
 use anolisa_env::EnvService;
 
@@ -76,7 +80,7 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         .map(|svc| RestartUnit {
             component: args.component.clone(),
             unit: svc.name.clone(),
-            manager: svc.manager.clone(),
+            scope: svc.scope,
         })
         .collect();
 
@@ -91,64 +95,91 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
     }
 
     let env = EnvService::detect();
-    let manager = service_factory(install_mode, &env);
+    // Restart routes each unit through the manager for its own scope — the
+    // same per-scope partitioning uninstall uses. System units drive
+    // `systemctl`, user units drive `systemctl --user`, so a mixed-scope
+    // component never mis-drives a user unit through the system manager (or
+    // vice versa): a unit whose scope has no driver here is a per-unit
+    // `not_supported` skip rather than a wrong-namespace call.
+    let sys_manager = service_factory(install_mode, &env);
+    let user_manager = user_service_factory(install_mode, &env);
+
+    // Summary fields describe the set of scopes actually present. The op is
+    // "supported" if at least one unit's manager can drive it, and the label
+    // combines the distinct namespaces in play (just one for the common
+    // single-scope component).
+    let used_sys = units.iter().any(|u| u.scope == ServiceScope::System);
+    let used_user = units.iter().any(|u| u.scope == ServiceScope::User);
+    let supported =
+        (used_sys && sys_manager.supported()) || (used_user && user_manager.supported());
+    let manager_label = match (used_sys, used_user) {
+        (true, true) => format!("{}+{}", sys_manager.manager(), user_manager.manager()),
+        (true, false) => sys_manager.manager().to_string(),
+        (false, true) => user_manager.manager().to_string(),
+        // `units` is non-empty (checked above), so at least one scope is used.
+        (false, false) => unreachable!("restartable units present but no scope flagged"),
+    };
 
     let mut results: Vec<RestartResult> = Vec::with_capacity(units.len());
     let mut warnings: Vec<String> = Vec::new();
 
-    if !manager.supported() {
-        // Quiet skip: every unit reports `not_supported` so the caller
-        // sees the boundary explicitly rather than guessing.
-        let reason = manager
-            .unsupported_reason()
-            .unwrap_or("service manager not supported in this environment")
-            .to_string();
-        for u in &units {
+    for u in &units {
+        let manager: &dyn ServiceManager = match u.scope {
+            ServiceScope::System => sys_manager.as_ref(),
+            ServiceScope::User => user_manager.as_ref(),
+        };
+        if !manager.supported() {
+            // Quiet skip: this unit's scope has no driver here (a user unit
+            // in a system-mode restart, container, non-Linux). Reported
+            // `not_supported` per unit so the boundary is explicit and the
+            // unit is never mis-driven through another namespace.
+            let reason = manager
+                .unsupported_reason()
+                .unwrap_or("service manager not supported in this environment")
+                .to_string();
             results.push(RestartResult {
                 component: u.component.clone(),
                 unit: u.unit.clone(),
                 state: "not_supported".to_string(),
                 changed: false,
                 manager: manager.manager().to_string(),
-                message: reason.clone(),
+                message: reason,
             });
+            continue;
         }
-    } else {
-        for u in &units {
-            match manager.restart_service(&u.unit) {
-                Ok(outcome) => {
-                    results.push(RestartResult {
-                        component: u.component.clone(),
-                        unit: u.unit.clone(),
-                        state: outcome.state.as_str().to_string(),
-                        changed: outcome.changed,
-                        manager: outcome.manager,
-                        message: outcome.message,
-                    });
-                    if matches!(outcome.state, ServiceState::Failed | ServiceState::Unknown) {
-                        warnings.push(format!(
-                            "{}/{} reports state '{}' after restart",
-                            u.component,
-                            u.unit,
-                            outcome.state.as_str()
-                        ));
-                    }
-                }
-                Err(err) => {
-                    let msg = format!("{err}");
+        match manager.restart_service(&u.unit) {
+            Ok(outcome) => {
+                results.push(RestartResult {
+                    component: u.component.clone(),
+                    unit: u.unit.clone(),
+                    state: outcome.state.as_str().to_string(),
+                    changed: outcome.changed,
+                    manager: outcome.manager,
+                    message: outcome.message,
+                });
+                if matches!(outcome.state, ServiceState::Failed | ServiceState::Unknown) {
                     warnings.push(format!(
-                        "service restart skipped for {}/{}: {msg}",
-                        u.component, u.unit
+                        "{}/{} reports state '{}' after restart",
+                        u.component,
+                        u.unit,
+                        outcome.state.as_str()
                     ));
-                    results.push(RestartResult {
-                        component: u.component.clone(),
-                        unit: u.unit.clone(),
-                        state: "unknown".to_string(),
-                        changed: false,
-                        manager: manager.manager().to_string(),
-                        message: msg,
-                    });
                 }
+            }
+            Err(err) => {
+                let msg = format!("{err}");
+                warnings.push(format!(
+                    "service restart skipped for {}/{}: {msg}",
+                    u.component, u.unit
+                ));
+                results.push(RestartResult {
+                    component: u.component.clone(),
+                    unit: u.unit.clone(),
+                    state: "unknown".to_string(),
+                    changed: false,
+                    manager: manager.manager().to_string(),
+                    message: msg,
+                });
             }
         }
     }
@@ -157,8 +188,8 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         let payload = RestartPayload {
             component: args.component.clone(),
             install_mode: install_mode.to_string(),
-            manager: manager.manager().to_string(),
-            supported: manager.supported(),
+            manager: manager_label.clone(),
+            supported,
             units: results.clone(),
             warnings: warnings.clone(),
         };
@@ -168,8 +199,8 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
     if !ctx.quiet {
         render_human(
             &args.component,
-            manager.manager(),
-            manager.supported(),
+            &manager_label,
+            supported,
             &results,
             &warnings,
             ctx.no_color,
@@ -182,8 +213,7 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
 struct RestartUnit {
     component: String,
     unit: String,
-    #[allow(dead_code)]
-    manager: String,
+    scope: ServiceScope,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -472,21 +472,19 @@ fn update_raw_component(
 }
 
 fn raw_update_service_refs(
-    ctx: &CliContext,
     services: &[ServiceRequest],
     service_run: Option<&ServiceRunOutcome>,
 ) -> Vec<ServiceRef> {
-    let manager = match ctx.install_mode {
-        crate::context::InstallMode::System => "systemd",
-        crate::context::InstallMode::User => "systemd-user",
-    };
     services
         .iter()
         .map(|svc| ServiceRef {
             name: svc.unit.clone(),
-            manager: manager.to_string(),
+            // Label follows the unit's scope (not install mode), consistent
+            // with install so `manager` never disagrees with `scope`.
+            manager: svc.scope.manager_label().to_string(),
             restartable: true,
             enabled: service_run.is_some_and(|run| run.enabled_units.contains(&svc.unit)),
+            scope: svc.scope,
         })
         .collect()
 }
@@ -796,7 +794,7 @@ fn execute_raw_update(
     // Service activation happens after this durable state write, so the first
     // save records the service declarations with conservative `enabled=false`;
     // a best-effort second save below backfills the actual enable result.
-    obj.services = raw_update_service_refs(ctx, &services, None);
+    obj.services = raw_update_service_refs(&services, None);
     obj.status = ObjectStatus::Installed;
     obj.health = Vec::new();
     obj.external_modified_files = Vec::new();
@@ -869,7 +867,7 @@ fn execute_raw_update(
     let mut activation_state_warnings = Vec::new();
     if !services.is_empty() {
         if let Some(obj) = state.find_object_mut(ObjectKind::Component, component) {
-            obj.services = raw_update_service_refs(ctx, &services, Some(&service_run));
+            obj.services = raw_update_service_refs(&services, Some(&service_run));
             if let Err(err) = state.save(&state_path) {
                 activation_state_warnings.push(format!(
                     "failed to persist service activation result after update: {err}"
@@ -1746,15 +1744,6 @@ mod tests {
 
     #[test]
     fn raw_update_service_refs_are_conservative_until_activation_runs() {
-        let ctx = CliContext {
-            install_mode: InstallMode::System,
-            prefix: None,
-            json: false,
-            dry_run: false,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        };
         let services = vec![ServiceRequest {
             unit: "agentsight.service".to_string(),
             scope: anolisa_core::ServiceScope::System,
@@ -1762,7 +1751,7 @@ mod tests {
             start: true,
         }];
 
-        let before_activation = raw_update_service_refs(&ctx, &services, None);
+        let before_activation = raw_update_service_refs(&services, None);
         assert!(!before_activation[0].enabled);
 
         let run = ServiceRunOutcome {
@@ -1770,8 +1759,33 @@ mod tests {
             started_units: Vec::new(),
             warnings: Vec::new(),
         };
-        let after_activation = raw_update_service_refs(&ctx, &services, Some(&run));
+        let after_activation = raw_update_service_refs(&services, Some(&run));
         assert!(after_activation[0].enabled);
+    }
+
+    #[test]
+    fn raw_update_service_refs_manager_label_follows_scope() {
+        // The persisted `manager` label is derived from each unit's scope,
+        // not install mode, so it never disagrees with `scope`.
+        let services = vec![
+            ServiceRequest {
+                unit: "agentsight.service".to_string(),
+                scope: anolisa_core::ServiceScope::System,
+                enable: false,
+                start: false,
+            },
+            ServiceRequest {
+                unit: "anolisa-memory@alice.service".to_string(),
+                scope: anolisa_core::ServiceScope::User,
+                enable: false,
+                start: false,
+            },
+        ];
+        let refs = raw_update_service_refs(&services, None);
+        assert_eq!(refs[0].manager, "systemd");
+        assert_eq!(refs[0].scope, anolisa_core::ServiceScope::System);
+        assert_eq!(refs[1].manager, "systemd-user");
+        assert_eq!(refs[1].scope, anolisa_core::ServiceScope::User);
     }
 
     #[test]
@@ -2664,6 +2678,7 @@ sha256 = "{sha}"
                 manager: "systemd".to_string(),
                 restartable: true,
                 enabled: false,
+                scope: ServiceScope::System,
             }];
             state.save(&path).expect("save poisoned state");
         }

--- a/src/anolisa/crates/anolisa-core/src/lifecycle.rs
+++ b/src/anolisa/crates/anolisa-core/src/lifecycle.rs
@@ -69,6 +69,7 @@ use anolisa_platform::fs_layout::FsLayout;
 use crate::central_log::{CentralLog, CentralLogError, LogKind, LogRecord, LogStatus, Severity};
 use crate::hooks::{HookSpec, run_hooks};
 use crate::lock::{InstallLock, LockError};
+use crate::manifest::ServiceScope;
 use crate::service;
 use crate::state::{
     ExternalModifiedFile, FileOwner as StateFileOwner, InstalledObject, InstalledState, ObjectKind,
@@ -209,6 +210,10 @@ pub struct ServiceAction {
     pub name: String,
     /// Planned behavior for the unit.
     pub action: ServiceActionKind,
+    /// Manager scope, carried from the installed `ServiceRef` so the
+    /// uninstall executor can drive user units via `systemctl --user`.
+    #[serde(default)]
+    pub scope: ServiceScope,
     /// Explanation when a service action is skipped or deferred.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
@@ -426,12 +431,61 @@ fn plan_services(services: &[ServiceRef]) -> Vec<ServiceAction> {
         .map(|s| ServiceAction {
             name: s.name.clone(),
             action: ServiceActionKind::Stop,
+            scope: s.scope,
             reason: Some(
-                "stops and disables via systemd in system mode; skipped on user/non-linux/container hosts"
+                "stops and disables via systemd; user-scope units via `systemctl --user`; skipped on non-linux/container hosts"
                     .to_string(),
             ),
         })
         .collect()
+}
+
+/// Run `daemon-reload` for one scope after its unit files were removed, record
+/// the audit line, and return a warning string on failure.
+///
+/// Best-effort: a `NotSupported` manager (non-linux / container / wrong mode)
+/// is a quiet skip returning `None`, and a reload error warns without failing
+/// uninstall. `component` labels the audit record.
+fn reload_after_unit_removal(
+    manager: &dyn service::ServiceManager,
+    central: &CentralLog,
+    component: &str,
+    operation_id: &str,
+    actor: &str,
+    install_mode: &str,
+) -> Option<String> {
+    if !manager.supported() {
+        return None;
+    }
+    match manager.daemon_reload() {
+        Ok(_) => {
+            service::record_service_op(
+                Some(central),
+                service::ServiceOp::DaemonReload,
+                component,
+                "",
+                operation_id,
+                actor,
+                install_mode,
+                None,
+            );
+            None
+        }
+        Err(err) => {
+            let msg = format!("daemon-reload after unit removal failed: {err}");
+            service::record_service_op(
+                Some(central),
+                service::ServiceOp::DaemonReload,
+                component,
+                "",
+                operation_id,
+                actor,
+                install_mode,
+                Some(&msg),
+            );
+            Some(msg)
+        }
+    }
 }
 
 /// Configuration fragments to drop on `Purge`. Today we only purge the
@@ -930,24 +984,42 @@ fn execute_uninstall_or_purge(
     // fail uninstall — they surface on `LifecycleOutcome.warnings`.
     let mut warnings_pre_delete: Vec<String> = pre_uninstall.warnings;
     {
-        let mut units: Vec<(String, String)> = Vec::new();
+        // Partition by scope: system units stop/disable via `systemctl`, user
+        // units via `systemctl --user`. Each scope is driven by its matching
+        // factory so a user-mode uninstall tears down per-user units and a
+        // system-mode uninstall leaves them (place-only, mirroring install).
+        let mut sys_units: Vec<(String, String)> = Vec::new();
+        let mut user_units: Vec<(String, String)> = Vec::new();
         for c in &live_plan.components {
             for s in &c.services {
-                units.push((c.name.clone(), s.name.clone()));
+                match s.scope {
+                    ServiceScope::User => user_units.push((c.name.clone(), s.name.clone())),
+                    ServiceScope::System => sys_units.push((c.name.clone(), s.name.clone())),
+                }
             }
         }
-        if !units.is_empty() {
+        if !sys_units.is_empty() || !user_units.is_empty() {
             let env = EnvService::detect();
-            let manager = service::for_install_mode(install_mode, &env);
-            let deactivation = service::deactivate_services(
-                manager.as_ref(),
-                &units,
-                Some(&central),
-                &operation_id,
-                actor,
-                install_mode,
-            );
-            warnings_pre_delete.extend(deactivation.warnings);
+            for (units, manager) in [
+                (sys_units, service::for_install_mode(install_mode, &env)),
+                (
+                    user_units,
+                    service::user_service_for_install_mode(install_mode, &env),
+                ),
+            ] {
+                if units.is_empty() {
+                    continue;
+                }
+                let deactivation = service::deactivate_services(
+                    manager.as_ref(),
+                    &units,
+                    Some(&central),
+                    &operation_id,
+                    actor,
+                    install_mode,
+                );
+                warnings_pre_delete.extend(deactivation.warnings);
+            }
         }
     }
 
@@ -1386,46 +1458,41 @@ fn execute_uninstall_or_purge(
     // manager drops the now-deleted units from its database (the
     // uninstall-side mirror of the install reload — without it systemd keeps
     // a stale unit until the next manual reload). Best-effort: a failed
-    // reload only warns. Runs only when the component declared service units
-    // (whose files were just removed) on a host that drives systemd.
-    //
-    // A user-mode install places (and reloads) its units under the user
-    // manager, so the post-removal reload selects the user-scope factory in
-    // user mode — `for_install_mode("user")` is unsupported and would skip
-    // the `systemctl --user daemon-reload` the removed `~/.config/systemd/user`
-    // units need. (Per-unit user-scope stop/disable in a *system*-mode
-    // uninstall still waits on `ServiceRef` recording scope.)
-    if live_plan.components.iter().any(|c| !c.services.is_empty()) {
-        let env = EnvService::detect();
-        let manager = if install_mode == "user" {
-            service::user_service_for_install_mode(install_mode, &env)
-        } else {
-            service::for_install_mode(install_mode, &env)
-        };
-        if manager.supported() {
-            match manager.daemon_reload() {
-                Ok(_) => service::record_service_op(
-                    Some(&central),
-                    service::ServiceOp::DaemonReload,
+    // reload only warns. Reload each scope that had units removed through its
+    // own manager, so a user-scope teardown issues `systemctl --user
+    // daemon-reload` and a system-scope one issues the plain reload.
+    {
+        let has_sys = live_plan
+            .components
+            .iter()
+            .any(|c| c.services.iter().any(|s| s.scope == ServiceScope::System));
+        let has_user = live_plan
+            .components
+            .iter()
+            .any(|c| c.services.iter().any(|s| s.scope == ServiceScope::User));
+        if has_sys || has_user {
+            let env = EnvService::detect();
+            if has_sys {
+                if let Some(msg) = reload_after_unit_removal(
+                    service::for_install_mode(install_mode, &env).as_ref(),
+                    &central,
                     target_name,
-                    "",
                     &operation_id,
                     actor,
                     install_mode,
-                    None,
-                ),
-                Err(err) => {
-                    let msg = format!("daemon-reload after unit removal failed: {err}");
-                    service::record_service_op(
-                        Some(&central),
-                        service::ServiceOp::DaemonReload,
-                        target_name,
-                        "",
-                        &operation_id,
-                        actor,
-                        install_mode,
-                        Some(&msg),
-                    );
+                ) {
+                    combined.push(msg);
+                }
+            }
+            if has_user {
+                if let Some(msg) = reload_after_unit_removal(
+                    service::user_service_for_install_mode(install_mode, &env).as_ref(),
+                    &central,
+                    target_name,
+                    &operation_id,
+                    actor,
+                    install_mode,
+                ) {
                     combined.push(msg);
                 }
             }
@@ -1956,6 +2023,7 @@ mod tests {
                 manager: "systemd".to_string(),
                 restartable: true,
                 enabled: false,
+                scope: ServiceScope::System,
             }],
             health: Vec::new(),
         });
@@ -2140,6 +2208,118 @@ mod tests {
             "no service units declared — must not daemon-reload: {lines:?}",
         );
         assert!(!owned_path.exists(), "owned file should be removed");
+    }
+
+    #[test]
+    fn plan_services_carries_scope_from_service_ref() {
+        let refs = vec![
+            ServiceRef {
+                name: "agentsight.service".to_string(),
+                manager: "systemd".to_string(),
+                restartable: true,
+                enabled: true,
+                scope: ServiceScope::System,
+            },
+            ServiceRef {
+                name: "anolisa-memory@alice.service".to_string(),
+                manager: "systemd-user".to_string(),
+                restartable: false,
+                enabled: false,
+                scope: ServiceScope::User,
+            },
+        ];
+        let actions = plan_services(&refs);
+        assert!(matches!(actions[0].scope, ServiceScope::System));
+        assert!(matches!(actions[1].scope, ServiceScope::User));
+    }
+
+    /// A `scope = user` unit removed under a **system-mode** uninstall is
+    /// place-only: the user manager is `NotSupported` (mirroring install,
+    /// where a system-mode install only places per-user templates), so
+    /// teardown is a recorded skip with no `systemctl --user daemon-reload`,
+    /// while the owned files are still removed.
+    #[test]
+    #[cfg(unix)]
+    fn uninstall_user_scope_service_in_system_mode_is_place_only() {
+        let root = tempdir().expect("tempdir");
+        let layout = fixture_layout(root.path());
+        std_fs::create_dir_all(&layout.bin_dir).unwrap();
+        let owned_path = layout.bin_dir.join("anolisa-memory");
+        std_fs::write(&owned_path, b"owned").unwrap();
+
+        std_fs::create_dir_all(&layout.state_dir).expect("mkdir state");
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "agent-memory".to_string(),
+            version: "0.1.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("file:///fake".to_string()),
+            raw_package: None,
+            install_backend: Some("raw".to_string()),
+            ownership: None,
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: Some("op-prior".to_string()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: vec![OwnedFile {
+                path: owned_path.clone(),
+                owner: StateFileOwner::Anolisa,
+                sha256: Some("0".repeat(64)),
+            }],
+            external_modified_files: Vec::new(),
+            services: vec![ServiceRef {
+                name: "anolisa-memory@%u.service".to_string(),
+                manager: "systemd-user".to_string(),
+                restartable: false,
+                enabled: false,
+                scope: ServiceScope::User,
+            }],
+            health: Vec::new(),
+        });
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed state save");
+
+        let hooks = ResolvedLifecycleHooks {
+            pre_uninstall: Vec::new(),
+            post_uninstall: Vec::new(),
+        };
+        let plan = LifecyclePlan::for_component_uninstall(
+            "agent-memory",
+            &InstalledState::load(&layout.state_dir.join("installed.toml")).unwrap(),
+        );
+        execute_plan(&plan, &layout, "tester", "system", &hooks).expect("uninstall ok");
+
+        let lines = read_log_lines(&layout.central_log);
+        assert!(
+            !lines.iter().any(|l| {
+                l.get("command").and_then(|v| v.as_str()) == Some("service:daemon-reload")
+            }),
+            "user-scope teardown in system mode must not daemon-reload: {lines:?}",
+        );
+        let stop = lines
+            .iter()
+            .find(|l| l.get("command").and_then(|v| v.as_str()) == Some("service:stop"))
+            .expect("user unit stop must be recorded");
+        let msg = stop.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            msg.contains("anolisa-memory@%u.service"),
+            "stop record must target the user unit: {msg}",
+        );
+        assert!(
+            msg.contains("skipped"),
+            "system-mode user teardown is a recorded skip, not a drive: {msg}",
+        );
+        assert!(
+            !owned_path.exists(),
+            "owned unit file should still be removed"
+        );
     }
 
     /// ws-ckpt semantics: a **non-strict** pre_uninstall hook that fails

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -302,6 +302,19 @@ pub enum ServiceScope {
     User,
 }
 
+impl ServiceScope {
+    /// systemd manager namespace recorded as `ServiceRef.manager` and shown
+    /// in diagnostics: `systemd` for system units, `systemd-user` for user
+    /// units (driven by `systemctl --user`). Single source of truth so the
+    /// persisted label can never disagree with a unit's scope.
+    pub fn manager_label(self) -> &'static str {
+        match self {
+            Self::System => "systemd",
+            Self::User => "systemd-user",
+        }
+    }
+}
+
 /// systemd unit lifecycle declaration from `[[component.services]]`.
 ///
 /// Drives `enable`/`start` on install and `stop`/`disable` on uninstall.

--- a/src/anolisa/crates/anolisa-core/src/service.rs
+++ b/src/anolisa/crates/anolisa-core/src/service.rs
@@ -438,14 +438,11 @@ impl Default for SystemdServiceManager {
 
 impl ServiceManager for SystemdServiceManager {
     fn manager(&self) -> &str {
-        // Report the scope in the label so central-log and probe outcomes
-        // match install state, which records `systemd-user` for user mode.
-        // A user-scoped instance drives `systemctl --user`, so it is a
-        // distinct manager namespace from the system one.
-        match self.scope {
-            ServiceScope::System => "systemd",
-            ServiceScope::User => "systemd-user",
-        }
+        // Report the scope in the label (a user-scoped instance drives
+        // `systemctl --user`, a distinct namespace). Shared with the install
+        // state writers via `ServiceScope::manager_label` so the running
+        // manager and the persisted `ServiceRef.manager` never diverge.
+        self.scope.manager_label()
     }
     fn supported(&self) -> bool {
         true

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -19,6 +19,7 @@ use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::adapter::claim::AdapterClaim;
+use crate::manifest::ServiceScope;
 
 /// Current `installed.toml` schema version. Bump on incompatible changes.
 /// When bumped, [`InstalledState::load`] must migrate older on-disk versions
@@ -231,6 +232,12 @@ pub struct ServiceRef {
     /// Desired enabled-on-boot state when a manager supports it.
     #[serde(default)]
     pub enabled: bool,
+    /// Manager scope: `system` units are driven by `systemctl`, `user`
+    /// units by `systemctl --user`. Persisted so uninstall can pick the
+    /// right manager. State files written before this field deserialize as
+    /// [`ServiceScope::System`].
+    #[serde(default)]
+    pub scope: ServiceScope,
 }
 
 /// Last-known health probe result for an object.
@@ -722,6 +729,23 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn service_ref_scope_defaults_to_system_when_absent() {
+        // State files written before `scope` existed must load as System so
+        // uninstall keeps driving them through the (root) system manager.
+        let legacy: ServiceRef = toml::from_str(
+            "name = \"agentsight.service\"\nmanager = \"systemd\"\nrestartable = true\nenabled = true\n",
+        )
+        .expect("legacy ServiceRef parses");
+        assert_eq!(legacy.scope, ServiceScope::System);
+
+        let user: ServiceRef = toml::from_str(
+            "name = \"anolisa-memory@alice.service\"\nmanager = \"systemd-user\"\nscope = \"user\"\n",
+        )
+        .expect("user-scope ServiceRef parses");
+        assert_eq!(user.scope, ServiceScope::User);
+    }
+
     fn sample_object(kind: ObjectKind, name: &str, version: &str) -> InstalledObject {
         InstalledObject {
             kind,
@@ -752,6 +776,7 @@ mod tests {
                 manager: "systemd".to_string(),
                 restartable: true,
                 enabled: true,
+                scope: ServiceScope::System,
             }],
             health: vec![HealthEntry {
                 name: "binary".to_string(),


### PR DESCRIPTION
## Description

Completes user-scope service lifecycle under #1070, on top of #1100 (user-scope activation + a scope-aware uninstall reload by install mode). This PR persists each unit's scope and routes uninstall teardown per scope: a **user-mode** uninstall stops/disables/reloads user-scope services through `systemctl --user`, while a **system-mode** uninstall keeps user-scope units place-only — symmetric with install, where root has no single target user to activate them for.

Three parts:
1. **`%u` instance resolution** — a template service with `instance = "%u"` (e.g. agent-memory's `anolisa-memory@.service`) now resolves `%u` to the caller's login name in a user-mode install → `anolisa-memory@<user>.service`. `%u` is a systemd specifier that systemd does *not* expand in a command-line instance name, so anolisa resolves it itself. A system-mode install is place-only and keeps the bare template for per-user `systemctl --user enable`.
2. **Scope persisted in state** — `ServiceRef` gains a `scope` field (`#[serde(default)]` → `system`, so pre-existing `installed.toml` loads unchanged). Install and update record the unit's scope, `anolisa restart` routes by it (an all-user-scope component restarts via `systemctl --user`), and the persisted `manager` label is derived from scope (`systemd` / `systemd-user`) so it never disagrees with `scope`.
3. **Per-scope uninstall teardown** — the uninstall executor partitions removed units by scope: system units stop/disable + `daemon-reload` via `systemctl`, user units via `systemctl --user`. The user factory is only supported in a user-mode uninstall, so a user-scope unit removed in a system-mode uninstall is a place-only skip (mirroring install).

## Design Note

`ServiceRef.scope` uses `#[serde(default)]` (→ `ServiceScope::System`), so no migration step is needed — older state files deserialize as system-scope, correct for everything installed before this change. The resolved unit name (`anolisa-memory@<user>.service` in user mode, the bare template in system mode) is what gets persisted, so uninstall reconstructs the same name from state.

`%u` resolution is keyed on install mode, not just the presence of the specifier: a user-mode install activates the unit as the caller, so it bakes in the login name; a system-mode install only places the template (root has no single target user), so it leaves `%u` un-resolved for per-user enable. The username is detected once (via `EnvService`) and only when a `%u` instance needs it.

`ServiceAction` carries the scope from `ServiceRef` into the lifecycle plan; `execute_plan` partitions removed units by scope and drives each through its matching factory (`for_install_mode` for system, `user_service_for_install_mode` for user), for both stop/disable and the post-removal `daemon-reload`. The user factory is unsupported outside a user-mode install, so system-mode user-scope teardown is a recorded skip rather than a mis-drive through the system manager. `deactivate_services` keeps its single-manager signature — the executor calls it once per non-empty scope.

The persisted `manager` label and the running `SystemdServiceManager::manager()` both come from a single `ServiceScope::manager_label()`, so state and live diagnostics can't diverge.

## Ship Note

- **Completes the user-scope teardown deferred in #1100**: this PR threads scope through state so a user-mode uninstall stops/disables/reloads user-scope services via `systemctl --user`, and a system-mode uninstall cleanly skips them (place-only) instead of mis-driving them through the system manager. System-scope units are unaffected.
- **No production behavior change today**: agent-memory still declares `enable = false` / `start = false`, so nothing auto-activates; this completes the plumbing + tests so a future `enable = true` user-scope service works end-to-end (place → activate → tear down).
- Per-unit teardown is a quiet skip where the relevant manager is `NotSupported` (container / non-Linux / a user-scope unit in a system-mode uninstall).

## Test

- Unit (install): `resolve_service_instance` — `%u` → caller when a name is available, `None` (place-only) when not; a literal instance passes through. `resolve_manifest_services` resolves `%u` in user mode and keeps the bare template in system mode.
- Unit (state/update): a `ServiceRef` written without a `scope` field deserializes as `system`; an explicit `scope = "user"` round-trips; `raw_update_service_refs` labels `manager` from each unit's scope (`systemd` / `systemd-user`).
- Unit (lifecycle): `plan_services` carries scope into `ServiceAction`; a user-scope service in a system-mode uninstall is place-only (recorded stop/disable skip, no `service:daemon-reload`) while owned files are still removed.
- Full gate: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`. One pre-existing platform test (`systemd::tests::unimplemented_unit_operations_return_errors_instead_of_panicking`) fails on the dev host only because `agentsight.service` is installed there; it fails identically on clean `main` and is unrelated to this change.

Closes #1070
