### PR TITLE
feat(skillfs): add RPM packaging support

### DIFF
--- a/.github/actions/package-source/action.yaml
+++ b/.github/actions/package-source/action.yaml
@@ -53,6 +53,7 @@ runs:
           os-skills)      SRC_DIR="src/os-skills" ;;
           ws-ckpt)        SRC_DIR="src/ws-ckpt" ;;
           agent-memory)   SRC_DIR="src/agent-memory" ;;
+          skillfs)        SRC_DIR="src/skillfs" ;;
           *)
             echo "ERROR: Unknown component: $COMPONENT"
             exit 1

--- a/.github/workflows/_rpm-build.yaml
+++ b/.github/workflows/_rpm-build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       component:
-        description: "Component to build (copilot-shell, agent-sec-core, agentsight, os-skills, tokenless, ws-ckpt, agent-memory)"
+        description: "Component to build (copilot-shell, agent-sec-core, agentsight, os-skills, tokenless, ws-ckpt, agent-memory, skillfs)"
         required: true
         type: string
       version:
@@ -68,6 +68,9 @@ jobs:
               # journald fan-out feature.
               dnf install -y rust cargo cmake systemd-devel
               ;;
+            skillfs)
+              dnf install -y rust cargo gcc make pkgconfig fuse3-devel
+              ;;
             os-skills)
               # noarch, no extra build deps
               ;;
@@ -80,6 +83,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: '1.93.0'
+
+      - name: "Setup Rust toolchain (skillfs)"
+        if: inputs.component == 'skillfs'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.86.0'
 
       - name: "Setup Python + uv (agent-sec-core)"
         if: inputs.component == 'agent-sec-core'

--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -35,6 +35,7 @@ jobs:
       tokenless-version: ${{ steps.tokenless.outputs.version }}
       ws-ckpt-version: ${{ steps.ws-ckpt.outputs.version }}
       agent-memory-version: ${{ steps.agent-memory.outputs.version }}
+      skillfs-version: ${{ steps.skillfs.outputs.version }}
       image-version: ${{ steps.image.outputs.version }}
       image-version-tag: ${{ steps.image.outputs.version_tag }}
     steps:
@@ -106,6 +107,12 @@ jobs:
         with:
           tag-match: "memory/v*"
 
+      - name: "Version: skillfs"
+        id: skillfs
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-match: "skillfs/v*"
+
       - name: Summary
         run: |
           echo "## Component Versions" >> $GITHUB_STEP_SUMMARY
@@ -118,6 +125,7 @@ jobs:
           echo "| tokenless | \`${{ steps.tokenless.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| ws-ckpt | \`${{ steps.ws-ckpt.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| agent-memory | \`${{ steps.agent-memory.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| skillfs | \`${{ steps.skillfs.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **image** | \`${{ steps.image.outputs.version }}\` (tag: \`${{ steps.image.outputs.version_tag }}\`) |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -217,6 +225,29 @@ jobs:
         with:
           component: agent-memory
           version: ${{ needs.versions.outputs.agent-memory-version }}
+          artifact-suffix: ".nightly"
+          retention-days: "7"
+
+  package-skillfs:
+    name: "Package: skillfs"
+    runs-on: [self-hosted, ubuntu]
+    needs: versions
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/package-source
+        with:
+          component: skillfs
+          version: ${{ needs.versions.outputs.skillfs-version }}
+          artifact-suffix: ".nightly"
+          retention-days: "7"
+
+      - name: Package vendor archive
+        uses: ./.github/actions/package-vendor
+        with:
+          component: skillfs
+          version: ${{ needs.versions.outputs.skillfs-version }}
           artifact-suffix: ".nightly"
           retention-days: "7"
 
@@ -365,6 +396,21 @@ jobs:
       vendor-artifact: "agent-memory-${{ needs.versions.outputs.agent-memory-version }}.nightly-vendor"
       artifact-suffix: ".nightly"
 
+  rpm-skillfs:
+    name: "RPM: skillfs (${{ matrix.arch }})"
+    needs: [versions, package-skillfs]
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    uses: ./.github/workflows/_rpm-build.yaml
+    with:
+      component: skillfs
+      version: ${{ needs.versions.outputs.skillfs-version }}
+      arch: ${{ matrix.arch }}
+      source-artifact: "skillfs-${{ needs.versions.outputs.skillfs-version }}.nightly"
+      vendor-artifact: "skillfs-${{ needs.versions.outputs.skillfs-version }}.nightly-vendor"
+      artifact-suffix: ".nightly"
+
   # ===========================================================================
   # Job 4: Build and push Docker image
   # ===========================================================================
@@ -379,6 +425,7 @@ jobs:
       - rpm-tokenless
       - rpm-ws-ckpt
       - rpm-agent-memory
+      - rpm-skillfs
       # TODO: uncomment when agentsight is integrated
       # - rpm-sight
     steps:
@@ -485,6 +532,7 @@ jobs:
           echo "| tokenless | \`${{ needs.versions.outputs.tokenless-version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| ws-ckpt | \`${{ needs.versions.outputs.ws-ckpt-version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| agent-memory | \`${{ needs.versions.outputs.agent-memory-version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| skillfs | \`${{ needs.versions.outputs.skillfs-version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Images" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.GHCR_IMAGE }}:${IMAGE_TAG}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -21,6 +21,7 @@ on:
           - tokenless
           - ws-ckpt
           - agent-memory
+          - skillfs
       version:
         description: 'Version (e.g. 2.1.0, without v prefix)'
         required: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
       - 'tokenless/v*'
       - 'ckpt/v*'
       - 'memory/v*'
+      - 'skillfs/v*'
 
 permissions:
   contents: write
@@ -49,6 +50,7 @@ jobs:
             tokenless) COMPONENT="tokenless" ;;
             ckpt)     COMPONENT="ws-ckpt" ;;
             memory)   COMPONENT="agent-memory" ;;
+            skillfs)  COMPONENT="skillfs" ;;
             *)
               echo "Unknown scope: $SCOPE"
               exit 1
@@ -146,6 +148,7 @@ jobs:
             tokenless)      PREFIX="tokenless/v" ;;
             ws-ckpt)        PREFIX="ckpt/v" ;;
             agent-memory)   PREFIX="memory/v" ;;
+            skillfs)        PREFIX="skillfs/v" ;;
           esac
 
           PREV_TAG=$(git tag --list "${PREFIX}*" --sort=-version:refname | grep -v "^${TAG}$" | head -1)

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -5,7 +5,7 @@
 #   ./scripts/rpm-build.sh <package>        Build a single package
 #   ./scripts/rpm-build.sh all              Build all packages
 #
-# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory
+# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory, skillfs
 #
 # Environment variables:
 #   VERSION    Override version for .spec.in templates (default: auto-detect)
@@ -26,6 +26,7 @@ SKILLS_DIR="${ROOT_DIR}/src/os-skills"
 SIGHT_DIR="${ROOT_DIR}/src/agentsight"
 TOKEN_DIR="${ROOT_DIR}/src/tokenless"
 MEM_DIR="${ROOT_DIR}/src/agent-memory"
+SKILLFS_DIR="${ROOT_DIR}/src/skillfs"
 SANDBOX_PKG_DIR="${ROOT_DIR}/src/anolisa/packaging/sandbox"
 
 # gVisor upstream release (overridable via env). Format: YYYYMMDD
@@ -604,6 +605,85 @@ build_agent_memory() {
 }
 
 # =============================================================================
+# skillfs
+# =============================================================================
+build_skillfs() {
+    log "=========================================="
+    log "Building RPM: skillfs"
+    log "=========================================="
+
+    local spec_in="${SKILLFS_DIR}/skillfs.spec.in"
+    if [ ! -f "$spec_in" ]; then
+        err "Spec template not found: $spec_in"
+        return 1
+    fi
+
+    local version="${VERSION:-}"
+    if [ -z "$version" ]; then
+        version=$(grep -m1 '^version = ' "${SKILLFS_DIR}/Cargo.toml" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || true)
+    fi
+    if [ -z "$version" ]; then
+        version=$(grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+' "$spec_in" | head -1)
+    fi
+    if [ -z "$version" ]; then
+        err "Cannot determine skillfs version. Set VERSION env or ensure Cargo.toml/spec exists."
+        return 1
+    fi
+
+    local pkg_name
+    pkg_name=$(parse_spec_name "$spec_in")
+    local tarball_name="${pkg_name}-${version}.tar.gz"
+    local vendor_tarball_name="${pkg_name}-${version}-vendor.tar.gz"
+    local spec_file
+    spec_file=$(process_spec_template "$spec_in" "$version")
+
+    log "Step 1/3: Creating source tarball ${tarball_name}..."
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
+    mkdir -p "$pkg_dir"
+
+    tar -cf - -C "$SKILLFS_DIR" \
+        --exclude='target' \
+        --exclude='vendor' \
+        --exclude='.cargo' \
+        . | tar -xf - -C "$pkg_dir"
+
+    if [ -L "${pkg_dir}/LICENSE" ] && [ -f "${ROOT_DIR}/LICENSE" ]; then
+        rm -f "${pkg_dir}/LICENSE"
+        cp -p "${ROOT_DIR}/LICENSE" "${pkg_dir}/LICENSE"
+    fi
+
+    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
+    rm -rf "$tmp_dir"
+
+    log "Step 2/3: Creating vendor tarball ${vendor_tarball_name}..."
+    local vendor_tmp
+    vendor_tmp=$(mktemp -d)
+    mkdir -p "${vendor_tmp}/.cargo"
+    (
+        cd "$SKILLFS_DIR"
+        cargo vendor --locked "${vendor_tmp}/vendor" >/dev/null
+    )
+    cat > "${vendor_tmp}/.cargo/config.toml" <<'EOF'
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+    tar -czf "${BUILD_DIR}/SOURCES/${vendor_tarball_name}" -C "$vendor_tmp" vendor .cargo
+    rm -rf "$vendor_tmp"
+
+    log "Step 3/3: Running rpmbuild..."
+    "$RPMBUILD" -ba --nodeps \
+        --define "_topdir ${BUILD_DIR}" \
+        "$spec_file"
+
+    ok "skillfs RPM built successfully"
+}
+
+# =============================================================================
 # sandbox: shared helpers
 # =============================================================================
 
@@ -875,13 +955,14 @@ usage() {
     echo "  agentsight                Build agentsight RPM"
     echo "  tokenless                 Build tokenless RPM"
     echo "  agent-memory              Build agent-memory RPM"
+    echo "  skillfs                   Build skillfs RPM"
     echo "  gvisor-runsc              Build gvisor-runsc RPM (sandbox)"
     echo "  containerd-shim-runsc-v1  Build containerd-shim-runsc-v1 RPM (sandbox)"
     echo "  atelet                    Build atelet RPM (sandbox, placeholder)"
     echo "  ateom-gvisor              Build ateom-gvisor RPM (sandbox, placeholder)"
     echo "  sandbox-all               Build all 4 sandbox RPMs"
     echo "  sandbox-repo              Generate yum/dnf repo metadata (createrepo_c) for sandbox RPMs"
-    echo "  all                       Build all RPM packages (legacy 6 only)"
+    echo "  all                       Build all primary RPM packages"
     echo ""
     echo "Environment variables:"
     echo "  VERSION                   Override version for .spec.in templates"
@@ -928,6 +1009,9 @@ case "$TARGET" in
     agent-memory)
         build_agent_memory
         ;;
+    skillfs)
+        build_skillfs
+        ;;
     gvisor-runsc)
         build_gvisor_runsc
         ;;
@@ -953,6 +1037,7 @@ case "$TARGET" in
         build_agentsight
         build_tokenless
         build_agent_memory
+        build_skillfs
         ;;
     *)
         err "Unknown package: $TARGET"

--- a/src/skillfs/skillfs.spec.in
+++ b/src/skillfs/skillfs.spec.in
@@ -1,0 +1,58 @@
+%global         rustflags -C opt-level=3 -C codegen-units=1
+%global         debug_package %{nil}
+%global         _localbindir /usr/local/bin
+
+Name:           skillfs
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        AI agent skill management via virtual filesystem
+
+License:        Apache-2.0
+URL:            https://github.com/alibaba/anolisa
+Source0:        %{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.gz
+
+# Cargo.toml specifies rust-version = "1.86", edition = "2024".
+BuildRequires:  rust >= 1.86
+BuildRequires:  cargo
+# Required by Rust crates with C build scripts and fuser/libfuse bindings.
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  pkgconfig(fuse3)
+
+Requires:       fuse3
+Requires:       fuse3-libs%{?_isa}
+
+%description
+SkillFS is a FUSE-based filesystem that exposes AI agent skills through
+filesystem views, while preserving ordinary POSIX passthrough behavior and
+SkillFS-specific security boundaries.
+
+%prep
+%setup -q -a 1 -n %{name}-%{version}
+
+%build
+export RUSTFLAGS="%{rustflags}"
+cargo build --release --workspace --locked --offline
+
+%install
+rm -rf %{buildroot}
+
+install -d -m 0755 %{buildroot}%{_localbindir}
+install -p -m 0755 target/release/skillfs %{buildroot}%{_localbindir}/skillfs
+
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/runtime/skills/skillfs
+cp -rp docs/skills/skillfs-mount/. \
+    %{buildroot}%{_datadir}/anolisa/runtime/skills/skillfs/
+
+%files
+%license LICENSE
+%doc README.md CHANGELOG.md
+%attr(0755,root,root) %{_localbindir}/skillfs
+%dir %{_datadir}/anolisa/runtime
+%dir %{_datadir}/anolisa/runtime/skills
+%{_datadir}/anolisa/runtime/skills/skillfs/
+
+%changelog
+* Wed Jun 24 2026 Kongche <kongche.jbw@alibaba-inc.com> - 0.2.0-1
+- Package SkillFS from the ANOLISA monorepo.


### PR DESCRIPTION
## Summary

Add RPM packaging support for SkillFS in the ANOLISA monorepo.

This PR adds:
- `src/skillfs/skillfs.spec.in`
- `skillfs` support in package-source
- `skillfs/v*` release tag support
- release-preview component support
- nightly source/vendor/RPM build wiring
- local `scripts/rpm-build.sh skillfs` support

## Packaging Behavior

SkillFS follows the existing ws-ckpt style where applicable:

- Source archive: `skillfs-${version}.tar.gz`
- Vendor archive: `skillfs-${version}-vendor.tar.gz`
- Offline build: `cargo build --release --workspace --locked --offline`
- Binary install path: `/usr/local/bin/skillfs`
- Runtime skill install path: `/usr/share/anolisa/runtime/skills/skillfs/`

SkillFS differs from ws-ckpt because `src/skillfs` itself is the Cargo
workspace root, so the spec builds from the archive root rather than `cd src`.

## Validation

- [x] `bash -n scripts/rpm-build.sh`
- [x] `git diff --check`
- [x] YAML parse for updated workflows/actions
- [x] `cargo vendor --locked` to a temporary directory
- [x] Source archive layout preview includes:
  - `skillfs.spec.in`
  - `LICENSE`
  - `docs/skills/skillfs-mount/SKILL.md`
