### PR TITLE
feat(ci): prefer specific issue component matches

### DIFF
--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -124,10 +124,15 @@ jobs:
               }
             }
             
-            // 3. Title keyword fallback (from labelMap keys + common aliases)
+            // 3. Title keyword fallback.
+            //
+            // Match longer component keys first so a specific scope like
+            // "skillfs" is not captured by the shorter "skill" scope.
             if (!componentLabel) {
               const t = title.toLowerCase();
-              for (const [short, label] of Object.entries(labelMap)) {
+              const titleMatches = Object.entries(labelMap)
+                .sort(([a], [b]) => b.length - a.length);
+              for (const [short, label] of titleMatches) {
                 if (t.includes(short)) { componentLabel = label; labelSource = `title keyword: "${short}"`; break; }
               }
               if (componentLabel) {


### PR DESCRIPTION
## Summary

Fix issue triage fallback matching so specific component scopes are matched
before shorter overlapping scopes.

## What Changed

- Sort issue title fallback component keys by descending length before matching.
- Prevent titles containing `skillfs` from being captured by the shorter `skill`
  scope.

## Why

Issue #1115 was a SkillFS issue, but the automation matched `skill` before
`skillfs`, which added `component:skill`, assigned the wrong maintainer, and
prefixed the title with `[skill]`.

## Validation

- Verified locally that `SkillFS: ...` resolves to `component:skillfs`.
- Verified locally that `Skill: ...` still resolves to `component:skill`.
