### PR TITLE
fix(anolisa): persist adapter contract provenance

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -59,12 +59,24 @@ pub fn installed_component_manifest_path(
     component: &str,
     command: &str,
 ) -> Result<PathBuf, CliError> {
+    Ok(
+        installed_component_manifest_dir(layout, component, command)?
+            .join(INSTALLED_COMPONENT_MANIFEST_FILE),
+    )
+}
+
+/// Directory for the component manifest saved as part of an installed
+/// component's local state.
+pub fn installed_component_manifest_dir(
+    layout: &FsLayout,
+    component: &str,
+    command: &str,
+) -> Result<PathBuf, CliError> {
     validate_component_path_segment(component, command)?;
     Ok(layout
         .state_dir
         .join(INSTALLED_COMPONENT_MANIFESTS_SUBDIR)
-        .join(component)
-        .join(INSTALLED_COMPONENT_MANIFEST_FILE))
+        .join(component))
 }
 
 fn validate_component_path_segment(component: &str, command: &str) -> Result<(), CliError> {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -5,9 +5,10 @@
 //! `missing` case from `anolisa status`), or whenever the operator wants ANOLISA
 //! to stop tracking a component, `forget` removes the `installed.toml` object
 //! and records the operation. It performs **no** package operation — no
-//! `dnf remove`, no `rpm -e` — and deletes no files. An observed/managed RPM
-//! stays installed in rpmdb; a raw component's owned files stay on disk (use
-//! `anolisa uninstall` to remove those).
+//! `dnf remove`, no `rpm -e` — and leaves package/component files on disk. It
+//! only removes ANOLISA-owned state metadata for the forgotten component. An
+//! observed/managed RPM stays installed in rpmdb; a raw component's owned files
+//! stay on disk (use `anolisa uninstall` to remove those).
 
 use chrono::{SecondsFormat, Utc};
 use clap::Parser;
@@ -118,9 +119,9 @@ pub fn handle(args: ForgetArgs, ctx: &CliContext) -> Result<(), CliError> {
     Ok(())
 }
 
-/// Remove the component's state object under the install lock and append an
-/// audit record. No package operation, no file deletion. Returns the operation
-/// id.
+/// Remove the component's state object and local manifest snapshot under the
+/// install lock, then append an audit record. No package/component files are
+/// removed. Returns the operation id.
 fn persist_forget(
     ctx: &CliContext,
     component: &str,
@@ -165,6 +166,7 @@ fn persist_forget(
             ),
         })?;
     let ownership_label = removed.effective_ownership().label();
+    remove_component_manifest_snapshot(&layout, component, command)?;
 
     let now = now_iso8601();
     let lock_ts = Utc::now();
@@ -215,6 +217,25 @@ fn persist_forget(
     }
 
     Ok((operation_id, ownership_label))
+}
+
+fn remove_component_manifest_snapshot(
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    component: &str,
+    command: &str,
+) -> Result<(), CliError> {
+    let dir = common::installed_component_manifest_dir(layout, component, command)?;
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "failed to remove component manifest snapshot at {}: {err}",
+                dir.display()
+            ),
+        }),
+    }
 }
 
 /// Human/JSON renderer for a forget result.
@@ -378,6 +399,19 @@ mod tests {
         InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
     }
 
+    fn seed_manifest_snapshot(ctx: &CliContext, component: &str) -> PathBuf {
+        let layout = common::resolve_layout(ctx);
+        let snapshot = common::installed_component_manifest_path(&layout, component, COMMAND)
+            .expect("snapshot path");
+        let dir = snapshot.parent().expect("snapshot dir").to_path_buf();
+        std::fs::create_dir_all(&dir).expect("mkdir snapshot dir");
+        std::fs::write(&snapshot, "component snapshot").expect("write snapshot");
+        let provenance =
+            anolisa_platform::fs_layout::FsLayout::provenance_path_for_snapshot(&snapshot);
+        std::fs::write(provenance, "schema_version = 1\n").expect("write provenance");
+        dir
+    }
+
     /// forget drops the state object and records the operation; no package
     /// operation is involved (there is no package query/transaction at all).
     #[test]
@@ -393,6 +427,7 @@ mod tests {
             )],
             Vec::new(),
         );
+        let snapshot_dir = seed_manifest_snapshot(&c, "copilot-shell");
 
         handle(
             ForgetArgs {
@@ -415,6 +450,10 @@ mod tests {
                 .iter()
                 .any(|o| o.command == "forget copilot-shell"),
             "an operation record must be appended",
+        );
+        assert!(
+            !snapshot_dir.exists(),
+            "component manifest snapshot dir must be removed",
         );
     }
 
@@ -520,6 +559,7 @@ mod tests {
             )],
             Vec::new(),
         );
+        let snapshot_dir = seed_manifest_snapshot(&c, "copilot-shell");
         handle(
             ForgetArgs {
                 component: "copilot-shell".to_string(),
@@ -532,6 +572,10 @@ mod tests {
                 .find_object(ObjectKind::Component, "copilot-shell")
                 .is_some(),
             "dry-run must not remove the state object",
+        );
+        assert!(
+            snapshot_dir.exists(),
+            "dry-run must not remove the manifest snapshot dir",
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -3285,12 +3285,16 @@ fn snapshot_datadir_contract(layout: &FsLayout, component: &str, command: &str) 
     }
 
     let mut content: Option<String> = None;
+    let mut found_source: Option<PathBuf> = None;
+    let mut found_root: Option<PathBuf> = None;
     let mut searched: Vec<PathBuf> = Vec::new();
     for root in &roots {
         let source = FsLayout::component_contract_path(root, component);
         match std::fs::read_to_string(&source) {
             Ok(c) => {
                 content = Some(c);
+                found_source = Some(source);
+                found_root = Some(root.clone());
                 break;
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -3332,6 +3336,27 @@ fn snapshot_datadir_contract(layout: &FsLayout, component: &str, command: &str) 
         );
         eprintln!("warning: {msg}");
         warnings.push(msg);
+        return warnings;
+    }
+
+    // Best-effort provenance sidecar so adapter operations can resolve
+    // {datadir} without content-matching against scoped datadir roots.
+    if let (Some(source_path), Some(datadir_root)) = (found_source, found_root) {
+        use anolisa_core::adapter::contract::{
+            ContractProvenance, ContractSourceKind, write_snapshot_provenance,
+        };
+        let provenance = ContractProvenance {
+            schema_version: 1,
+            source_kind: ContractSourceKind::Datadir,
+            source_path,
+            datadir_root,
+        };
+        if let Err(err) = write_snapshot_provenance(&dest, &provenance) {
+            let msg =
+                format!("failed to write contract provenance for component '{component}': {err}");
+            eprintln!("warning: {msg}");
+            warnings.push(msg);
+        }
     }
 
     warnings
@@ -6550,6 +6575,47 @@ scope = "@anolisa"
         assert_eq!(
             content, contract,
             "snapshot must be a verbatim copy of the FHS package contract"
+        );
+    }
+
+    /// Scenario A: snapshot_datadir_contract writes provenance sidecar.
+    #[test]
+    fn snapshot_datadir_contract_writes_provenance() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        let contract = component_manifest_toml("sec-core", "1.0.0", &["system"]);
+        seed_datadir_contract(&layout, "sec-core", &contract);
+
+        let warnings = snapshot_datadir_contract(&layout, "sec-core", COMMAND);
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+
+        let snapshot = common::installed_component_manifest_path(&layout, "sec-core", COMMAND)
+            .expect("snapshot path");
+        assert!(snapshot.exists(), "component.toml snapshot must exist");
+
+        let prov_path =
+            anolisa_platform::fs_layout::FsLayout::provenance_path_for_snapshot(&snapshot);
+        assert!(
+            prov_path.exists(),
+            "provenance.toml must exist alongside snapshot"
+        );
+
+        let prov: anolisa_core::adapter::contract::ContractProvenance =
+            toml::from_str(&std::fs::read_to_string(&prov_path).expect("read prov"))
+                .expect("parse prov");
+        assert_eq!(prov.schema_version, 1);
+        assert_eq!(
+            prov.source_kind,
+            anolisa_core::adapter::contract::ContractSourceKind::Datadir,
+        );
+        assert_eq!(prov.datadir_root, layout.datadir);
+        assert_eq!(
+            prov.source_path,
+            anolisa_platform::fs_layout::FsLayout::component_contract_path(
+                &layout.datadir,
+                "sec-core"
+            ),
         );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -620,6 +620,7 @@ fn uninstall_rpm_component(
                 "component '{component}' disappeared from state during uninstall; nothing removed"
             ),
         })?;
+    remove_component_manifest_snapshot(&layout, component, command)?;
 
     let now = now_iso8601();
     let lock_ts = Utc::now();
@@ -699,6 +700,25 @@ fn uninstall_rpm_component(
     };
     render_uninstall_rpm(ctx, &payload);
     Ok(())
+}
+
+fn remove_component_manifest_snapshot(
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    component: &str,
+    command: &str,
+) -> Result<(), CliError> {
+    let dir = common::installed_component_manifest_dir(layout, component, command)?;
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "failed to remove component manifest snapshot at {}: {err}",
+                dir.display()
+            ),
+        }),
+    }
 }
 
 /// Build the actionable "rpm/dnf tooling missing" error for the RPM uninstall
@@ -1675,6 +1695,19 @@ mod tests {
         InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
     }
 
+    fn seed_manifest_snapshot(ctx: &CliContext, component: &str) -> PathBuf {
+        let layout = common::resolve_layout(ctx);
+        let snapshot = common::installed_component_manifest_path(&layout, component, COMMAND)
+            .expect("snapshot path");
+        let dir = snapshot.parent().expect("snapshot dir").to_path_buf();
+        std::fs::create_dir_all(&dir).expect("mkdir snapshot dir");
+        std::fs::write(&snapshot, "component snapshot").expect("write snapshot");
+        let provenance =
+            anolisa_platform::fs_layout::FsLayout::provenance_path_for_snapshot(&snapshot);
+        std::fs::write(provenance, "schema_version = 1\n").expect("write provenance");
+        dir
+    }
+
     fn args_rm(component: &str) -> UninstallArgs {
         UninstallArgs {
             component: component.to_string(),
@@ -1727,6 +1760,7 @@ mod tests {
             )],
             Vec::new(),
         );
+        let snapshot_dir = seed_manifest_snapshot(&c, "copilot-shell");
         let rpm = FakeRpm::present("anolisa-copilot-shell");
         run(args("copilot-shell", false), &c, &rpm, true).expect("uninstall ok");
 
@@ -1748,6 +1782,10 @@ mod tests {
                 .iter()
                 .any(|o| o.command == "uninstall copilot-shell"),
             "an operation record must be appended",
+        );
+        assert!(
+            !snapshot_dir.exists(),
+            "component manifest snapshot dir must be removed",
         );
     }
 
@@ -1934,6 +1972,7 @@ mod tests {
             )],
             Vec::new(),
         );
+        let snapshot_dir = seed_manifest_snapshot(&c, "copilot-shell");
         let rpm = FakeRpm::present("anolisa-copilot-shell");
         run(args_rm("copilot-shell"), &c, &rpm, true).expect("dry-run ok");
 
@@ -1943,6 +1982,10 @@ mod tests {
                 .find_object(ObjectKind::Component, "copilot-shell")
                 .is_some(),
             "dry-run must not drop the state record",
+        );
+        assert!(
+            snapshot_dir.exists(),
+            "dry-run must not remove the manifest snapshot dir",
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/src/adapter/contract.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/contract.rs
@@ -14,9 +14,108 @@
 
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::manifest::{ComponentManifest, ManifestError};
+
+// ---------------------------------------------------------------------------
+// Provenance
+// ---------------------------------------------------------------------------
+
+/// How a contract snapshot was originally sourced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractSourceKind {
+    /// Sourced from a `{datadir}/components/<component>/component.toml`.
+    Datadir,
+}
+
+/// Provenance sidecar for a state-snapshotted component contract.
+///
+/// Written alongside `component.toml` during install/adopt so that later
+/// adapter operations can resolve `{datadir}` without content-matching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractProvenance {
+    /// Sidecar schema version (currently `1`).
+    pub schema_version: u32,
+    /// How the contract was obtained.
+    pub source_kind: ContractSourceKind,
+    /// Absolute path of the original contract file.
+    pub source_path: PathBuf,
+    /// The datadir root that `source_path` lives under.
+    pub datadir_root: PathBuf,
+}
+
+/// Read the provenance sidecar for a snapshot at `snapshot_path`.
+///
+/// Returns `None` when the file is absent or unparseable — callers
+/// must fall back to content matching.
+pub fn read_snapshot_provenance(snapshot_path: &Path) -> Option<ContractProvenance> {
+    let provenance_path = FsLayout::provenance_path_for_snapshot(snapshot_path);
+    let content = std::fs::read_to_string(&provenance_path).ok()?;
+    toml::from_str(&content).ok()
+}
+
+/// Write a provenance sidecar alongside the snapshot at `snapshot_path`.
+pub fn write_snapshot_provenance(
+    snapshot_path: &Path,
+    provenance: &ContractProvenance,
+) -> Result<(), std::io::Error> {
+    let provenance_path = FsLayout::provenance_path_for_snapshot(snapshot_path);
+    let content = toml::to_string_pretty(provenance).map_err(std::io::Error::other)?;
+    std::fs::write(provenance_path, content)
+}
+
+/// Determine the effective datadir root for a resolved contract.
+///
+/// - If `contract_path` is a direct datadir hit (lives under one of
+///   `scoped_datadir_roots`), returns that root directly.
+/// - If `contract_path` is a state snapshot, tries provenance first: reads
+///   `provenance.toml` and uses its `datadir_root` if the source path is
+///   consistent and the root is in `scoped_datadir_roots`.
+/// - Falls back to content matching: compares the snapshot content against
+///   each scoped datadir contract and returns the first match.
+/// - Returns `None` when no root can be determined.
+pub fn infer_contract_datadir_root(
+    component: &str,
+    contract_path: &Path,
+    scoped_datadir_roots: &[PathBuf],
+) -> Option<PathBuf> {
+    // Direct datadir hit.
+    if let Some(root) = scoped_datadir_roots
+        .iter()
+        .find(|root| FsLayout::component_contract_path(root, component) == contract_path)
+        .cloned()
+    {
+        return Some(root);
+    }
+
+    // Snapshot hit — try provenance sidecar.
+    if let Some(prov) = read_snapshot_provenance(contract_path) {
+        if prov.source_kind == ContractSourceKind::Datadir
+            && scoped_datadir_roots.contains(&prov.datadir_root)
+            && FsLayout::component_contract_path(&prov.datadir_root, component) == prov.source_path
+        {
+            return Some(prov.datadir_root);
+        }
+    }
+
+    // Fallback: content match against scoped datadir contracts.
+    let snapshot_content = std::fs::read(contract_path).ok()?;
+    scoped_datadir_roots
+        .iter()
+        .find(|root| {
+            let candidate = FsLayout::component_contract_path(root, component);
+            std::fs::read(candidate).is_ok_and(|content| content == snapshot_content)
+        })
+        .cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Resolved contract with source
+// ---------------------------------------------------------------------------
 
 /// A resolved component contract plus the concrete file that supplied it.
 #[derive(Debug, Clone)]
@@ -319,5 +418,200 @@ layer = "runtime"
         let manifest = resolve_component_contract("mycomp", &[state], &[data1, data2])
             .expect("should resolve from data2");
         assert_eq!(manifest.component.name, "mycomp");
+    }
+
+    // -- provenance read/write ----------------------------------------------
+
+    #[test]
+    fn write_then_read_provenance_roundtrip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        write_snapshot(&state, "mycomp", &valid_toml("mycomp"));
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "mycomp");
+
+        let prov = ContractProvenance {
+            schema_version: 1,
+            source_kind: ContractSourceKind::Datadir,
+            source_path: PathBuf::from("/usr/share/anolisa/components/mycomp/component.toml"),
+            datadir_root: PathBuf::from("/usr/share/anolisa"),
+        };
+        write_snapshot_provenance(&snapshot_path, &prov).expect("write provenance");
+
+        let read_back = read_snapshot_provenance(&snapshot_path).expect("read provenance");
+        assert_eq!(read_back.schema_version, 1);
+        assert_eq!(read_back.source_kind, ContractSourceKind::Datadir);
+        assert_eq!(read_back.datadir_root, PathBuf::from("/usr/share/anolisa"));
+    }
+
+    #[test]
+    fn read_provenance_returns_none_when_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        write_snapshot(&state, "mycomp", &valid_toml("mycomp"));
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "mycomp");
+
+        assert!(read_snapshot_provenance(&snapshot_path).is_none());
+    }
+
+    #[test]
+    fn read_provenance_returns_none_on_invalid_toml() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        write_snapshot(&state, "mycomp", &valid_toml("mycomp"));
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "mycomp");
+
+        let bad_path = FsLayout::provenance_path_for_snapshot(&snapshot_path);
+        fs::write(&bad_path, "not valid {{{toml").expect("write bad");
+        assert!(read_snapshot_provenance(&snapshot_path).is_none());
+    }
+
+    // -- infer_contract_datadir_root ----------------------------------------
+
+    /// Scenario B: provenance guides resolution when two datadir roots have
+    /// identical contracts.
+    #[test]
+    fn provenance_selects_correct_datadir_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let local_data = tmp.path().join("local_data");
+        let pkg_data = tmp.path().join("pkg_data");
+
+        let contract = valid_toml("sec-core");
+        write_snapshot(&state, "sec-core", &contract);
+        write_datadir(&local_data, "sec-core", &contract);
+        write_datadir(&pkg_data, "sec-core", &contract);
+
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "sec-core");
+        let prov = ContractProvenance {
+            schema_version: 1,
+            source_kind: ContractSourceKind::Datadir,
+            source_path: FsLayout::component_contract_path(&pkg_data, "sec-core"),
+            datadir_root: pkg_data.clone(),
+        };
+        write_snapshot_provenance(&snapshot_path, &prov).expect("write prov");
+
+        let root = infer_contract_datadir_root(
+            "sec-core",
+            &snapshot_path,
+            &[local_data.clone(), pkg_data.clone()],
+        );
+        assert_eq!(
+            root.as_ref(),
+            Some(&pkg_data),
+            "provenance must select pkg_data, not local_data"
+        );
+    }
+
+    /// Scenario C: no provenance falls back to content matching.
+    #[test]
+    fn backward_compat_content_match_without_provenance() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        let contract = valid_toml("sec-core");
+        write_snapshot(&state, "sec-core", &contract);
+        write_datadir(&data, "sec-core", &contract);
+
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "sec-core");
+
+        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        assert_eq!(
+            root.as_ref(),
+            Some(&data),
+            "content matching fallback must find the datadir root"
+        );
+    }
+
+    /// Scenario D: provenance datadir_root not in scoped roots.
+    #[test]
+    fn invalid_provenance_falls_back_to_content_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        let contract = valid_toml("sec-core");
+        write_snapshot(&state, "sec-core", &contract);
+        write_datadir(&data, "sec-core", &contract);
+
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "sec-core");
+        let prov = ContractProvenance {
+            schema_version: 1,
+            source_kind: ContractSourceKind::Datadir,
+            source_path: PathBuf::from("/gone/components/sec-core/component.toml"),
+            datadir_root: PathBuf::from("/gone"),
+        };
+        write_snapshot_provenance(&snapshot_path, &prov).expect("write prov");
+
+        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        assert_eq!(
+            root.as_ref(),
+            Some(&data),
+            "invalid provenance must fall back to content match"
+        );
+    }
+
+    /// Scenario D variant: malformed provenance TOML.
+    #[test]
+    fn malformed_provenance_toml_falls_back_to_content_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        let contract = valid_toml("sec-core");
+        write_snapshot(&state, "sec-core", &contract);
+        write_datadir(&data, "sec-core", &contract);
+
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "sec-core");
+        let bad = FsLayout::provenance_path_for_snapshot(&snapshot_path);
+        fs::write(&bad, "this is not valid toml [[[").expect("write bad");
+
+        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        assert_eq!(
+            root.as_ref(),
+            Some(&data),
+            "malformed provenance must fall back to content match"
+        );
+    }
+
+    /// Scenario D variant: provenance source_path inconsistent with root.
+    #[test]
+    fn inconsistent_provenance_source_path_falls_back() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = tmp.path().join("state");
+        let data = tmp.path().join("data");
+
+        let contract = valid_toml("sec-core");
+        write_snapshot(&state, "sec-core", &contract);
+        write_datadir(&data, "sec-core", &contract);
+
+        let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "sec-core");
+        let prov = ContractProvenance {
+            schema_version: 1,
+            source_kind: ContractSourceKind::Datadir,
+            source_path: PathBuf::from("/some/other/component.toml"),
+            datadir_root: data.clone(),
+        };
+        write_snapshot_provenance(&snapshot_path, &prov).expect("write prov");
+
+        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        assert_eq!(
+            root.as_ref(),
+            Some(&data),
+            "inconsistent source_path must fall back to content match"
+        );
+    }
+
+    /// Direct datadir hit returns that root without provenance.
+    #[test]
+    fn direct_datadir_hit_returns_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data = tmp.path().join("data");
+
+        write_datadir(&data, "mycomp", &valid_toml("mycomp"));
+        let datadir_path = FsLayout::component_contract_path(&data, "mycomp");
+
+        let root = infer_contract_datadir_root("mycomp", &datadir_path, &[data.clone()]);
+        assert_eq!(root.as_ref(), Some(&data));
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -1690,32 +1690,16 @@ fn is_adapter_visible_status(status: ObjectStatus) -> bool {
 
 /// Return the datadir root that supplied a resolved component contract.
 ///
-/// Direct datadir hits are identified by path. State snapshots do not yet
-/// persist explicit source metadata, so for snapshot hits we match the
-/// snapshot content against scoped datadir contracts. This preserves the
-/// normal install/adopt behavior where the snapshot is a verbatim copy of
-/// a datadir contract, without adding state-schema surface.
+/// Delegates to [`super::contract::infer_contract_datadir_root`] which
+/// checks provenance first (written during install/adopt), then falls
+/// back to content matching for snapshots created before provenance was
+/// introduced.
 fn contract_datadir_root_from_source(
     component: &str,
     contract_path: &Path,
     scoped_datadir_roots: &[PathBuf],
 ) -> Option<PathBuf> {
-    if let Some(root) = scoped_datadir_roots
-        .iter()
-        .find(|root| FsLayout::component_contract_path(root, component) == contract_path)
-        .cloned()
-    {
-        return Some(root);
-    }
-
-    let snapshot_content = std::fs::read(contract_path).ok()?;
-    scoped_datadir_roots
-        .iter()
-        .find(|root| {
-            let candidate = FsLayout::component_contract_path(root, component);
-            std::fs::read(candidate).is_ok_and(|content| content == snapshot_content)
-        })
-        .cloned()
+    super::contract::infer_contract_datadir_root(component, contract_path, scoped_datadir_roots)
 }
 
 fn declared_plugin_id(manifest: &ComponentManifest, framework: &str) -> Option<String> {
@@ -3597,5 +3581,159 @@ source = "{{datadir}}/skills/code-scanner/"
         )
         .expect("resolve skills");
         assert_eq!(skills[0].source.as_ref(), Some(&skill_source));
+    }
+
+    // -- provenance-guided contract datadir root ----------------------------
+
+    /// Provenance selects the correct datadir root when two roots have
+    /// identical contracts (Scenario B). Without provenance, the first
+    /// content match wins (local_datadir) which would be wrong.
+    #[test]
+    fn provenance_selects_correct_datadir_for_absolute_dest_skill_sources() {
+        use crate::adapter::contract::{
+            ContractProvenance, ContractSourceKind, write_snapshot_provenance,
+        };
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("var/lib/anolisa");
+        let local_datadir = tmp.path().join("usr/local/share/anolisa");
+        let pkg_datadir = tmp.path().join("usr/share/anolisa");
+        let abs_dest = tmp.path().join("opt/agent-sec/openclaw-plugin");
+
+        seed_installed_state(&state_dir, "sec-core", ObjectStatus::Adopted);
+
+        let contract = format!(
+            r#"
+[component]
+name = "sec-core"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "sec-core"
+dest = "{}"
+
+[[adapters.openclaw.skills]]
+name = "code-scanner"
+source = "{{datadir}}/skills/code-scanner/"
+"#,
+            abs_dest.display()
+        );
+
+        // Both datadirs have identical contracts — content match alone
+        // would pick local_datadir (first in list), but provenance
+        // points to pkg_datadir.
+        write_contract_with_content(&local_datadir, "sec-core", &contract);
+        write_contract_with_content(&pkg_datadir, "sec-core", &contract);
+
+        let snapshot = FsLayout::component_manifest_snapshot_path(&state_dir, "sec-core");
+        std::fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir");
+        std::fs::write(&snapshot, &contract).expect("write snapshot");
+
+        let prov = ContractProvenance {
+            schema_version: 1,
+            source_kind: ContractSourceKind::Datadir,
+            source_path: FsLayout::component_contract_path(&pkg_datadir, "sec-core"),
+            datadir_root: pkg_datadir.clone(),
+        };
+        write_snapshot_provenance(&snapshot, &prov).expect("write prov");
+
+        std::fs::create_dir_all(&abs_dest).expect("mkdir abs_dest");
+        std::fs::write(abs_dest.join("openclaw.plugin.json"), b"{}").expect("write plugin");
+
+        let skill_source = pkg_datadir.join("skills").join("code-scanner");
+        std::fs::create_dir_all(&skill_source).expect("mkdir skill source");
+        std::fs::write(skill_source.join("manifest.json"), b"{}").expect("write skill");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(
+            layout.clone(),
+            Some(tmp.path().to_path_buf()),
+            "test".into(),
+        );
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.clone(),
+            contract_datadir_roots: vec![local_datadir.clone(), pkg_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![local_datadir.clone(), pkg_datadir.clone()];
+
+        let state = InstalledState::load(&state_dir.join("installed.toml")).expect("load state");
+        let (manifest, scoped_roots, contract_datadir_root) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        assert_eq!(
+            contract_datadir_root.as_ref(),
+            Some(&pkg_datadir),
+            "provenance must select pkg_datadir, not local_datadir"
+        );
+
+        let (resource_root, effective_datadir) = manager
+            .resolve_resource_root(
+                "sec-core",
+                "openclaw",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+            )
+            .expect("resolve resource root");
+        assert_eq!(resource_root, abs_dest);
+        assert_eq!(effective_datadir, pkg_datadir);
+
+        let skill_specs = declared_skills(&manifest, "openclaw");
+        let skills = resolve_skill_sources(
+            skill_specs,
+            &layout,
+            &effective_datadir,
+            "sec-core",
+            "openclaw",
+            &resource_root,
+        )
+        .expect("resolve skills");
+        assert_eq!(
+            skills[0].source.as_ref(),
+            Some(&skill_source),
+            "skill source must resolve to pkg_datadir, not local_datadir"
+        );
+    }
+
+    /// Without provenance, snapshot content match still works (Scenario C).
+    #[test]
+    fn snapshot_without_provenance_falls_back_to_content_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let pkg_datadir = tmp.path().join("pkg_data");
+
+        seed_installed_state(&state_dir, "sec-core", ObjectStatus::Adopted);
+
+        let contract = valid_contract_toml("sec-core");
+        write_contract(&pkg_datadir, "sec-core");
+
+        let snapshot = FsLayout::component_manifest_snapshot_path(&state_dir, "sec-core");
+        std::fs::create_dir_all(snapshot.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&snapshot, contract).expect("write snapshot");
+        // Deliberately no provenance.toml.
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager =
+            AdapterManager::new(layout, Some(tmp.path().to_path_buf()), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.clone(),
+            contract_datadir_roots: vec![pkg_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![pkg_datadir.clone()];
+
+        let state = InstalledState::load(&state_dir.join("installed.toml")).expect("load state");
+        let (_manifest, _scoped_roots, contract_datadir_root) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        assert_eq!(
+            contract_datadir_root.as_ref(),
+            Some(&pkg_datadir),
+            "content matching must find pkg_datadir"
+        );
     }
 }

--- a/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
+++ b/src/anolisa/crates/anolisa-platform/src/fs_layout.rs
@@ -30,6 +30,8 @@ const COMPONENT_MANIFESTS_SUBDIR: &str = "component-manifests";
 /// Filename used for both the package-owned component contract and the
 /// runtime state snapshot.
 const COMPONENT_MANIFEST_FILE: &str = "component.toml";
+/// Sidecar provenance file written alongside a contract snapshot.
+const PROVENANCE_FILE: &str = "provenance.toml";
 /// Audit-log file name written under `log_dir`.
 const CENTRAL_LOG_NAME: &str = "central.jsonl";
 /// Lock file name written under `state_dir`.
@@ -369,6 +371,21 @@ impl FsLayout {
             .join(COMPONENT_MANIFESTS_SUBDIR)
             .join(component)
             .join(COMPONENT_MANIFEST_FILE)
+    }
+
+    /// Provenance sidecar path for a state snapshot under an arbitrary
+    /// state root. Lives alongside the snapshot `component.toml`.
+    pub fn component_manifest_provenance_path(state_root: &Path, component: &str) -> PathBuf {
+        state_root
+            .join(COMPONENT_MANIFESTS_SUBDIR)
+            .join(component)
+            .join(PROVENANCE_FILE)
+    }
+
+    /// Provenance sidecar path derived from an existing snapshot path.
+    /// Replaces the filename with `provenance.toml`.
+    pub fn provenance_path_for_snapshot(snapshot_path: &Path) -> PathBuf {
+        snapshot_path.with_file_name(PROVENANCE_FILE)
     }
 }
 


### PR DESCRIPTION
## Description

Persists provenance for component contract snapshots so adapter `{datadir}`
expansion can use the original contract source.

This is a follow-up to #1105. Snapshot-backed adapter resolution now prefers
the recorded datadir root before falling back to content matching for older
snapshots.

### Ship Note

What changed:
- `install` / `adopt` snapshot writes best-effort `provenance.toml`.
- Adapter resolution uses provenance for snapshot-backed contracts.
- Old snapshots without provenance keep the content-match fallback.

Known limitations:
- Only `source_kind = "datadir"` is supported for now.
- Provenance write failure is a warning and does not fail install/adopt.

## Related Issue

closes #1119

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/anolisa
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p anolisa-core --locked -- adapter
cargo test -p anolisa-cli --locked -- install
cargo test -p anolisa-cli --locked -- adapter
cargo doc --workspace --no-deps
```

## Additional Notes

Follow-up to #1105. The fallback remains for snapshots created before
provenance existed.
