### PR TITLE
feat(cosh): add anolisa component contract

### DIFF
--- a/src/copilot-shell/component.toml
+++ b/src/copilot-shell/component.toml
@@ -1,0 +1,28 @@
+manifest_version = 2
+anolisa_min_version = "0.1.0"
+
+[component]
+name = "cosh"
+version = "2.5.0"
+layer = "runtime"
+domain = "tools"
+description = "Copilot shell launcher and deterministic CLI gateway"
+stability = "experimental"
+
+[install]
+modes = ["system"]
+
+[backends.rpm]
+package = "copilot-shell"
+
+[environment]
+requires_os = "linux"
+requires_arch = ["x86_64", "aarch64"]
+
+[dependencies]
+runtime = ["node>=20"]
+
+[[health_checks]]
+name = "launcher"
+kind = "command"
+command = "{bindir}/cosh --version"

--- a/src/copilot-shell/copilot-shell.spec.in
+++ b/src/copilot-shell/copilot-shell.spec.in
@@ -15,6 +15,7 @@ Requires:       nodejs >= 20
 Requires(post):	  lua
 Requires(postun): lua
 Provides:       %{_bindir}/co %{_bindir}/copilot %{_bindir}/cosh
+Provides:       anolisa-component(cosh)
 
 %description
 Copilot Shell - Entrance to AI-native OS.
@@ -30,12 +31,15 @@ make build
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot} PREFIX=%{_prefix}
+install -d %{buildroot}%{_datadir}/anolisa/components/cosh
+install -m 0644 component.toml %{buildroot}%{_datadir}/anolisa/components/cosh/component.toml
 
 %files
 %license %{_docdir}/%{name}/LICENSE
 %doc %{_docdir}/%{name}/README.md
 %{_prefix}/lib/%{name}
 %{_datadir}/%{name}
+%{_datadir}/anolisa/components/cosh/component.toml
 %{_bindir}/co
 %{_bindir}/copilot
 %{_bindir}/cosh


### PR DESCRIPTION
## Description

Adds a minimal ANOLISA component contract for the `copilot-shell` RPM so cosh
can be adopted and inspected by anolisa without declaring any adapter behavior.

The RPM now installs `component.toml` under the package datadir contract path
and exposes `anolisa-component(cosh)` as a virtual provide.

### Ship Note

What changed:
- Added `src/copilot-shell/component.toml` for the cosh runtime component.
- Updated the RPM spec to install the contract under `/usr/share/anolisa`.
- Added `Provides: anolisa-component(cosh)` for package discovery.

Known limitations:
- This contract is intentionally adopt/status only.
- No cosh adapter, skill, or framework integration is declared.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
cd src/anolisa
cargo test -p anolisa-core --locked manifest --quiet
```

Also validated:
- `src/copilot-shell/component.toml` parses as TOML.
- `rpmspec -P` expands the updated spec with the new contract path.

## Additional Notes

The existing spec changelog emits a date warning under `rpmspec -P`; this PR
does not change that changelog entry.
