### PR TITLE
feat(anolisa): restart RPM-backed component services

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -1,36 +1,48 @@
-//! `anolisa restart <component>` — restart owned service units.
+//! `anolisa restart <component>` — restart a component's systemd service units.
 //!
-//! Best-effort restart of every `services[]` entry on the component
-//! where `restartable = true`. The handler:
+//! Brings a component's services up (`systemctl restart` starts a stopped
+//! unit), routing each through the [`anolisa_core::ServiceManager`] for its
+//! scope. The handler:
 //!
 //!   1. Loads `installed.toml` and locates the component. Unknown →
 //!      `INVALID_ARGUMENT`.
-//!   2. Collects the component's restartable service units.
-//!   3. If the set is empty → `INVALID_ARGUMENT` (nothing to restart).
-//!   4. Routes each unit through the [`anolisa_core::ServiceManager`] for
-//!      its own scope — system units via `systemctl`, user units via
-//!      `systemctl --user` — the same per-scope partitioning uninstall uses.
-//!      A unit whose scope has no driver here (a user unit in a system-mode
-//!      restart, non-Linux, container) is a per-unit `not_supported` skip,
-//!      never mis-driven through another namespace.
-//!   5. Calls `restart_service(unit)` per unit. Per-unit failures are
-//!      collected as warnings on the outcome; a unit that systemctl
-//!      refuses does NOT abort the whole op.
+//!   2. Collects the component's restartable `.service` units, by backend:
+//!      - **raw** installs: the recorded `ServiceRef`s — ANOLISA drove the
+//!        activation, so state is the source of truth;
+//!      - **RPM** installs (rpm-observed / rpm-managed): live `rpm -ql`
+//!        discovery, because the RPM path records no services and the package
+//!        owns the unit files. Template (`foo@.service`) units cannot be
+//!        expanded here — instances are runtime/user state, not package files —
+//!        so they degrade to a per-user guidance note instead of a restart.
+//!   3. Empty set splits two ways: a component that ships no service units at
+//!      all → `INVALID_ARGUMENT`; one that ships only templates restart cannot
+//!      expand → exit 0 with per-user guidance (the package is fine, the
+//!      operator just has to pick an instance).
+//!   4. Reloads each in-play scope's unit database once (best-effort), so a
+//!      freshly-placed unit (a place-only install, or an RPM whose `%post` did
+//!      not reload) is loadable before restart.
+//!   5. Routes each unit through the manager for its own scope — system units
+//!      via `systemctl`, user units via `systemctl --user`. A unit whose scope
+//!      has no driver here (a user unit in a system-mode restart, non-Linux,
+//!      container) is a per-unit `not_supported` skip, never mis-driven through
+//!      another namespace.
+//!   6. Calls `restart_service(unit)` per unit. Per-unit failures are collected
+//!      as warnings; a unit systemctl refuses does NOT abort the whole op.
 //!
-//! Restart is intentionally lock-free: it does not mutate
-//! `installed.toml` and it is safe to run concurrently with other
-//! ANOLISA invocations. If we later add a "record last_restart_at"
-//! field on `ServiceRef`, this handler will need to take the install
-//! lock around the state write.
+//! Restart is intentionally lock-free: it does not mutate `installed.toml` and
+//! is safe to run concurrently with other ANOLISA invocations.
 
 use clap::Parser;
 
 use anolisa_core::{
-    InstalledState, ObjectKind, ServiceManager, ServiceScope, ServiceState,
+    InstalledObject, InstalledState, ObjectKind, ServiceManager, ServiceScope, ServiceState,
     service_for_install_mode as service_factory,
     user_service_for_install_mode as user_service_factory,
 };
 use anolisa_env::EnvService;
+use anolisa_platform::command::CommandRunner;
+use anolisa_platform::pkg_query::PackageQueryError;
+use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::Palette;
 use crate::commands::common;
@@ -70,28 +82,27 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
             ),
         })?;
 
-    // A service with `restartable = false` (one-shot setup unit, timer,
-    // etc.) is silently filtered out here — the manifest opts that unit
-    // out of `restart` semantics explicitly.
-    let units: Vec<RestartUnit> = comp
-        .services
-        .iter()
-        .filter(|svc| svc.restartable)
-        .map(|svc| RestartUnit {
-            component: args.component.clone(),
-            unit: svc.name.clone(),
-            scope: svc.scope,
-        })
-        .collect();
+    // Units come from the component's recorded ServiceRefs (raw installs, where
+    // ANOLISA drove activation) or from live `rpm -ql` discovery (RPM installs,
+    // which record no services). Discovery may also return notes — e.g. a
+    // template unit it cannot expand in this tier — which seed `warnings`.
+    let (units, mut warnings) = collect_restart_units(comp, &args.component)?;
 
     if units.is_empty() {
-        return Err(CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "component '{}' has no restartable service units (no `services[]` with `restartable = true`)",
-                args.component
-            ),
-        });
+        if warnings.is_empty() {
+            // Ships no service units at all → nothing to restart, a usage error.
+            return Err(CliError::InvalidArgument {
+                command,
+                reason: format!(
+                    "component '{}' has no restartable systemd service units",
+                    args.component
+                ),
+            });
+        }
+        // Ships only template units whose instances are per-user runtime state
+        // restart cannot choose. Not an error: the package is fine,
+        // so exit 0 and surface the per-user guidance already collected.
+        return render_guidance_only(&args.component, install_mode, warnings, ctx);
     }
 
     let env = EnvService::detect();
@@ -120,8 +131,22 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         (false, false) => unreachable!("restartable units present but no scope flagged"),
     };
 
+    // Freshly-placed units (a place-only install, or an RPM whose %post did not
+    // reload the manager) aren't loadable until the manager reloads its unit
+    // database, so restart would otherwise fail "unit not found". Reload once
+    // per in-play scope, best-effort — a reload failure only adds a warning.
+    if used_sys && sys_manager.supported() {
+        if let Err(err) = sys_manager.daemon_reload() {
+            warnings.push(format!("daemon-reload (system scope) failed: {err}"));
+        }
+    }
+    if used_user && user_manager.supported() {
+        if let Err(err) = user_manager.daemon_reload() {
+            warnings.push(format!("daemon-reload (user scope) failed: {err}"));
+        }
+    }
+
     let mut results: Vec<RestartResult> = Vec::with_capacity(units.len());
-    let mut warnings: Vec<String> = Vec::new();
 
     for u in &units {
         let manager: &dyn ServiceManager = match u.scope {
@@ -209,6 +234,229 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Absolute directories systemd searches for **system** unit files. A `.service`
+/// placed directly in one of these is a system-scope unit.
+const SYSTEM_UNIT_DIRS: &[&str] = &[
+    "/usr/lib/systemd/system",
+    "/usr/local/lib/systemd/system",
+    "/etc/systemd/system",
+    "/run/systemd/system",
+];
+
+/// Absolute directories systemd searches for **user** unit files (driven via
+/// `systemctl --user`).
+const USER_UNIT_DIRS: &[&str] = &[
+    "/usr/lib/systemd/user",
+    "/usr/local/lib/systemd/user",
+    "/etc/systemd/user",
+];
+
+/// Collect a component's restartable units plus any discovery notes.
+///
+/// The unit source is the component's backend: raw installs read the recorded
+/// `ServiceRef`s (ANOLISA owns activation); RPM installs discover live from
+/// `rpm -ql` (the package owns the unit files and state records no services).
+/// Returned notes (e.g. for un-expandable templates) are surfaced to the user.
+fn collect_restart_units(
+    comp: &InstalledObject,
+    component: &str,
+) -> Result<(Vec<RestartUnit>, Vec<String>), CliError> {
+    if comp.effective_ownership().is_rpm() {
+        discover_rpm_units(comp, component, &RpmPackageQuery::system())
+    } else {
+        // Raw: the recorded ServiceRefs (restartable is hardcoded true today;
+        // the filter keeps the door open for an explicit opt-out later).
+        let units = comp
+            .services
+            .iter()
+            .filter(|svc| svc.restartable)
+            .map(|svc| RestartUnit {
+                component: component.to_string(),
+                unit: svc.name.clone(),
+                scope: svc.scope,
+            })
+            .collect();
+        Ok((units, Vec::new()))
+    }
+}
+
+/// Discover an RPM component's `.service` units from its file manifest.
+///
+/// `rpm -ql <pkg>` lists every owned path; [`classify_unit_files`] keeps the
+/// `.service` files sitting directly in a systemd unit directory and infers
+/// scope from that directory. Plain units become [`RestartUnit`]s; template
+/// (`foo@.service`) units cannot be expanded here (their instances are runtime
+/// state, not package files), so each yields a per-user guidance note instead.
+///
+/// Generic over the [`RpmPackageQuery`] runner so tests can inject a fake
+/// `rpm -ql` listing; production passes [`RpmPackageQuery::system`].
+///
+/// # Errors
+/// `Runtime` when the component records no RPM package name (refresh with
+/// `repair`), or when `rpm -ql` fails (e.g. the recorded package vanished).
+fn discover_rpm_units<R: CommandRunner>(
+    comp: &InstalledObject,
+    component: &str,
+    query: &RpmPackageQuery<R>,
+) -> Result<(Vec<RestartUnit>, Vec<String>), CliError> {
+    let command = format!("restart {component}");
+    let package = comp
+        .rpm_metadata
+        .as_ref()
+        .map(|m| m.package_name.as_str())
+        .ok_or_else(|| CliError::Runtime {
+            command: command.clone(),
+            reason: format!(
+                "component '{component}' is RPM-backed but its state records no package name; run `anolisa repair {component}` to refresh rpm metadata"
+            ),
+        })?;
+
+    let paths = match query.list_files(package) {
+        Ok(paths) => paths,
+        // Tooling gone: match the rpm/dnf-missing handling repair/update/uninstall
+        // use, so an RPM-backed restart fails with the same actionable message
+        // rather than a generic "command not found".
+        Err(PackageQueryError::CommandMissing { .. }) => {
+            return Err(rpm_tooling_missing_error(&command));
+        }
+        Err(err) => {
+            return Err(CliError::Runtime {
+                command,
+                reason: format!("could not list files for RPM package '{package}': {err}"),
+            });
+        }
+    };
+
+    let mut units = Vec::new();
+    let mut notes = Vec::new();
+    for (unit, scope) in classify_unit_files(&paths) {
+        if is_template_unit(&unit) {
+            notes.push(template_guidance(&unit, scope));
+            continue;
+        }
+        units.push(RestartUnit {
+            component: component.to_string(),
+            unit,
+            scope,
+        });
+    }
+    Ok((units, notes))
+}
+
+/// Warn-and-exit error when `rpm`/`dnf` is absent: an RPM-backed component
+/// cannot be restarted without the package manager to enumerate its units.
+/// Mirrors the sibling helpers in `repair`/`update`/`uninstall` so the
+/// tooling-missing message is uniform across tier-1 commands.
+fn rpm_tooling_missing_error(command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: "rpm/dnf not found: cannot restart an RPM-backed component without the package manager. Install rpm/dnf and retry".to_string(),
+    }
+}
+
+/// Stable `manager` label for a guidance-only result. No manager is engaged
+/// (the component ships only templates), so the wire field carries a sentinel
+/// rather than an empty string — `""` would be ambiguous between "no manager"
+/// and a missing field, whereas `none` reads clearly alongside the normal
+/// `systemd` / `systemd-user` / `not-supported` labels.
+const GUIDANCE_MANAGER: &str = "none";
+
+/// Build the payload for a guidance-only outcome: no units, the
+/// per-user guidance as warnings, the [`GUIDANCE_MANAGER`] sentinel, and
+/// `supported = true` (the command completed; the package is healthy).
+fn guidance_only_payload(
+    component: &str,
+    install_mode: &str,
+    warnings: Vec<String>,
+) -> RestartPayload {
+    RestartPayload {
+        component: component.to_string(),
+        install_mode: install_mode.to_string(),
+        manager: GUIDANCE_MANAGER.to_string(),
+        supported: true,
+        units: Vec::new(),
+        warnings,
+    }
+}
+
+/// Successful guidance-only outcome: the component ships only
+/// template units restart cannot expand, so there is nothing to drive but the
+/// package is healthy. Exits 0 with the per-user guidance as warnings.
+fn render_guidance_only(
+    component: &str,
+    install_mode: &str,
+    warnings: Vec<String>,
+    ctx: &CliContext,
+) -> Result<(), CliError> {
+    if ctx.json {
+        let payload = guidance_only_payload(component, install_mode, warnings);
+        return render_json(COMMAND, &payload);
+    }
+    if !ctx.quiet {
+        let color = Palette::new(ctx.no_color);
+        println!(
+            "{} {} {}",
+            color.command("restart"),
+            component,
+            color.warn("no instances to restart")
+        );
+        for w in &warnings {
+            eprintln!("{} {}", color.warn("guidance:"), w);
+        }
+    }
+    Ok(())
+}
+
+/// Keep the `.service` files that sit **directly** in a known systemd unit
+/// directory, pairing each with the scope its directory implies.
+///
+/// Requiring a direct parent match rejects `*.target.wants/foo.service` enable
+/// symlinks and `foo.service.d/` drop-ins, leaving only canonical unit files.
+fn classify_unit_files(paths: &[String]) -> Vec<(String, ServiceScope)> {
+    let mut out = Vec::new();
+    for path in paths {
+        let path = path.trim();
+        if !path.ends_with(".service") {
+            continue;
+        }
+        let Some((dir, file)) = path.rsplit_once('/') else {
+            continue;
+        };
+        let scope = if SYSTEM_UNIT_DIRS.contains(&dir) {
+            ServiceScope::System
+        } else if USER_UNIT_DIRS.contains(&dir) {
+            ServiceScope::User
+        } else {
+            continue;
+        };
+        out.push((file.to_string(), scope));
+    }
+    out
+}
+
+/// A systemd template unit names its instance after `@` and has no instance
+/// before `.service` (e.g. `anolisa-memory@.service`).
+fn is_template_unit(unit: &str) -> bool {
+    unit.ends_with("@.service")
+}
+
+/// Per-user guidance for a template unit restart cannot expand.
+///
+/// A bare template is not restartable (`systemctl restart foo@.service` fails);
+/// the operator must pick an instance. For user-scope templates that also means
+/// running as the target user, plus linger to survive logout.
+fn template_guidance(unit: &str, scope: ServiceScope) -> String {
+    let base = unit.trim_end_matches("@.service");
+    match scope {
+        ServiceScope::User => format!(
+            "{unit} is a per-user template; restart cannot expand its instances — enable one as the target user: `systemctl --user enable --now {base}@<user>.service` (and `loginctl enable-linger <user>` to keep it running after logout)"
+        ),
+        ServiceScope::System => format!(
+            "{unit} is a systemd template; restart cannot pick an instance — start a concrete one with `systemctl start {base}@<instance>.service`"
+        ),
+    }
+}
+
 #[derive(Debug)]
 struct RestartUnit {
     component: String,
@@ -284,6 +532,8 @@ mod tests {
     use super::*;
 
     use crate::context::InstallMode;
+    use anolisa_core::{ObjectStatus, Ownership, RpmMetadata};
+    use anolisa_platform::command::CommandOutput;
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -296,6 +546,67 @@ mod tests {
             verbose: false,
             quiet: true,
             no_color: true,
+        }
+    }
+
+    /// Fake `CommandRunner` returning a canned `rpm -ql` listing (or a spawn
+    /// error), so the RPM discovery path is exercised without a real `rpm`.
+    struct FakeRpm {
+        stdout: String,
+        code: Option<i32>,
+        spawn_err: Option<std::io::ErrorKind>,
+    }
+
+    impl CommandRunner for FakeRpm {
+        fn run(&self, _program: &str, _args: &[&str]) -> std::io::Result<CommandOutput> {
+            if let Some(kind) = self.spawn_err {
+                return Err(std::io::Error::new(kind, "fake spawn failure"));
+            }
+            Ok(CommandOutput {
+                code: self.code,
+                stdout: self.stdout.clone(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn fake_query(listing: &str) -> RpmPackageQuery<FakeRpm> {
+        RpmPackageQuery::with_runner(FakeRpm {
+            stdout: listing.to_string(),
+            code: Some(0),
+            spawn_err: None,
+        })
+    }
+
+    /// An rpm-observed component object; `package = None` omits rpm metadata.
+    fn rpm_component(name: &str, package: Option<&str>) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: name.to_string(),
+            version: "1.0.0-1".to_string(),
+            status: ObjectStatus::Adopted,
+            manifest_digest: None,
+            distribution_source: None,
+            raw_package: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmObserved),
+            rpm_metadata: package.map(|p| RpmMetadata {
+                package_name: p.to_string(),
+                evr: Some("1.0.0-1".to_string()),
+                arch: Some("x86_64".to_string()),
+                source_repo: Some("@System".to_string()),
+            }),
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: false,
+            adopted: true,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
         }
     }
 
@@ -314,6 +625,164 @@ mod tests {
         assert!(
             err.reason().contains("not installed"),
             "reason must mention 'not installed': {}",
+            err.reason()
+        );
+    }
+
+    #[test]
+    fn classify_unit_files_keeps_direct_service_units_with_scope() {
+        let paths = vec![
+            // not a unit
+            "/usr/local/bin/agentsight".to_string(),
+            // system units in the canonical and FHS-local dirs
+            "/usr/lib/systemd/system/agentsight.service".to_string(),
+            "/usr/local/lib/systemd/system/ws-ckpt.service".to_string(),
+            // user-scope template
+            "/usr/lib/systemd/user/anolisa-memory@.service".to_string(),
+            // enable symlink in a .wants subdir — not a canonical unit file
+            "/etc/systemd/system/multi-user.target.wants/x.service".to_string(),
+            // drop-in (.conf, not .service)
+            "/usr/lib/systemd/system/foo.service.d/override.conf".to_string(),
+            // non-.service unit type
+            "/usr/lib/systemd/system/foo.socket".to_string(),
+            // .service outside any known unit dir
+            "/opt/random/bar.service".to_string(),
+        ];
+        assert_eq!(
+            classify_unit_files(&paths),
+            vec![
+                ("agentsight.service".to_string(), ServiceScope::System),
+                ("ws-ckpt.service".to_string(), ServiceScope::System),
+                ("anolisa-memory@.service".to_string(), ServiceScope::User),
+            ]
+        );
+    }
+
+    #[test]
+    fn is_template_unit_matches_only_bare_template() {
+        assert!(is_template_unit("anolisa-memory@.service"));
+        assert!(!is_template_unit("agentsight.service"));
+        // A concrete instance is restartable directly, so it is not a template.
+        assert!(!is_template_unit("anolisa-memory@alice.service"));
+    }
+
+    #[test]
+    fn template_guidance_user_mentions_instance_and_linger() {
+        let msg = template_guidance("anolisa-memory@.service", ServiceScope::User);
+        assert!(msg.contains("anolisa-memory@<user>.service"), "{msg}");
+        assert!(msg.contains("--user"), "{msg}");
+        assert!(msg.contains("enable-linger"), "{msg}");
+    }
+
+    #[test]
+    fn template_guidance_system_mentions_instance_not_user_bus() {
+        let msg = template_guidance("getty@.service", ServiceScope::System);
+        assert!(msg.contains("getty@<instance>.service"), "{msg}");
+        assert!(!msg.contains("--user"), "{msg}");
+    }
+
+    #[test]
+    fn rpm_tooling_missing_error_mentions_restart_and_tooling() {
+        // P3: rpm/dnf absent must surface the same actionable message the other
+        // tier-1 commands use, not a bare "command not found".
+        let err = rpm_tooling_missing_error("restart agent-memory");
+        assert!(
+            err.reason().contains("rpm/dnf not found"),
+            "{}",
+            err.reason()
+        );
+        assert!(err.reason().contains("restart"), "{}", err.reason());
+    }
+
+    #[test]
+    fn guidance_only_template_component_succeeds_not_errors() {
+        // A component whose only units are templates is NOT an error — the
+        // guidance-only path returns Ok with the per-user guidance.
+        let ctx = ctx_with_prefix(InstallMode::System, None);
+        let warnings = vec![template_guidance(
+            "anolisa-memory@.service",
+            ServiceScope::User,
+        )];
+        let res = render_guidance_only("agent-memory", "system", warnings, &ctx);
+        assert!(
+            res.is_ok(),
+            "templates-only restart must succeed, got {res:?}"
+        );
+    }
+
+    #[test]
+    fn guidance_only_payload_uses_stable_manager_label() {
+        // Wire semantics: guidance-only carries a stable `none` sentinel (not an
+        // empty string), no units, the guidance as warnings, and supported=true.
+        let warnings = vec![template_guidance(
+            "anolisa-memory@.service",
+            ServiceScope::User,
+        )];
+        let payload = guidance_only_payload("agent-memory", "system", warnings);
+        assert_eq!(payload.manager, "none");
+        assert!(payload.supported);
+        assert!(payload.units.is_empty());
+        assert_eq!(payload.warnings.len(), 1);
+        assert!(
+            payload.warnings[0].contains("--user"),
+            "{}",
+            payload.warnings[0]
+        );
+    }
+
+    #[test]
+    fn discover_rpm_units_splits_plain_units_and_templates() {
+        // End-to-end over a fake `rpm -ql`: a plain system .service becomes a
+        // restartable unit; a user template degrades to a per-user note; bins
+        // and docs are ignored.
+        let listing = [
+            "/usr/local/bin/agent-memory",
+            "/usr/lib/systemd/system/agentsight.service",
+            "/usr/lib/systemd/user/anolisa-memory@.service",
+            "/usr/share/doc/agent-memory/README",
+        ]
+        .join("\n");
+        let comp = rpm_component("agent-memory", Some("agent-memory"));
+        let (units, notes) =
+            discover_rpm_units(&comp, "agent-memory", &fake_query(&listing)).expect("discovery ok");
+
+        assert_eq!(units.len(), 1, "one plain unit expected: {units:?}");
+        assert_eq!(units[0].unit, "agentsight.service");
+        assert_eq!(units[0].scope, ServiceScope::System);
+        assert_eq!(units[0].component, "agent-memory");
+
+        assert_eq!(notes.len(), 1, "one template note expected: {notes:?}");
+        assert!(
+            notes[0].contains("anolisa-memory@<user>.service") && notes[0].contains("--user"),
+            "{}",
+            notes[0]
+        );
+    }
+
+    #[test]
+    fn discover_rpm_units_without_package_name_errors() {
+        // RPM-backed but state lost the package name → actionable repair hint.
+        let comp = rpm_component("agent-memory", None);
+        let err = discover_rpm_units(&comp, "agent-memory", &fake_query(""))
+            .expect_err("missing package name must error");
+        assert!(err.reason().contains("repair"), "{}", err.reason());
+    }
+
+    #[test]
+    fn discover_rpm_units_tooling_missing_maps_to_actionable_error() {
+        // `rpm` absent (spawn NotFound) → the uniform rpm/dnf-not-found message,
+        // not a generic "command not found".
+        let comp = rpm_component("agent-memory", Some("agent-memory"));
+        let query = RpmPackageQuery::with_runner(FakeRpm {
+            stdout: String::new(),
+            code: None,
+            spawn_err: Some(std::io::ErrorKind::NotFound),
+        });
+        let err = discover_rpm_units(&comp, "agent-memory", &query)
+            .expect_err("missing rpm tooling must error");
+        assert!(
+            err.reason().contains("rpm/dnf not found"),
+            "{}",
             err.reason()
         );
     }

--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -62,6 +62,52 @@ impl<R: CommandRunner> RpmPackageQuery<R> {
     pub fn with_runner(runner: R) -> Self {
         Self { runner }
     }
+
+    /// List the absolute file paths an installed package owns (`rpm -q --list`).
+    ///
+    /// Used to discover the systemd unit files an RPM placed, so `anolisa
+    /// restart` can drive the services a package owns even though the RPM
+    /// install path records no `services` in state. Paths are returned verbatim
+    /// (one per `rpm` output line, blank lines dropped); the caller classifies
+    /// which are units and in which scope — this layer keeps no systemd
+    /// knowledge. Not on [`PackageQuery`]: keeping it inherent avoids touching
+    /// the trait's many fake implementations.
+    ///
+    /// # Errors
+    /// - [`PackageQueryError::CommandMissing`] when `rpm` is absent.
+    /// - [`PackageQueryError::QueryFailed`] on a non-zero exit. This includes
+    ///   "package is not installed", which for a state-tracked component is
+    ///   drift the caller should surface rather than silently treat as
+    ///   "no units".
+    pub fn list_files(&self, package: &str) -> Result<Vec<String>, PackageQueryError> {
+        let out = self
+            .runner
+            .run(RPM, &["-q", "--list", package])
+            .map_err(|e| map_spawn_error(e, RPM))?;
+
+        if out.code != Some(0) {
+            // rpm writes "is not installed" to stdout and hard errors to stderr;
+            // surface whichever is non-empty so the caller sees the real cause.
+            let detail = if out.stderr.trim().is_empty() {
+                out.stdout.clone()
+            } else {
+                out.stderr.clone()
+            };
+            return Err(PackageQueryError::QueryFailed {
+                command: RPM.to_string(),
+                code: out.code,
+                stderr: detail,
+            });
+        }
+
+        Ok(out
+            .stdout
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect())
+    }
 }
 
 impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
@@ -359,6 +405,19 @@ mod tests {
                 assert_eq!(
                     args[4], expected_package,
                     "rpm capability argument must be last: {args:?}"
+                );
+            }
+            // `rpm -q --list <pkg>` (list_files)
+            RPM if args.get(1) == Some(&"--list") => {
+                assert_eq!(
+                    args.len(),
+                    3,
+                    "rpm list needs [-q, --list, <pkg>]: {args:?}"
+                );
+                assert_eq!(args[0], "-q");
+                assert_eq!(
+                    args[2], expected_package,
+                    "rpm package argument must be last: {args:?}"
                 );
             }
             // `rpm -q --qf <fmt> <pkg>` (query_installed)
@@ -731,6 +790,59 @@ mod tests {
         assert!(matches!(
             err,
             PackageQueryError::QueryFailed { command, .. } if command == RPM
+        ));
+    }
+
+    #[test]
+    fn list_files_returns_paths() {
+        // Mixed manifest: a binary, a system unit, and a blank line. The blank
+        // line is dropped; every real path is returned verbatim (the caller,
+        // not this layer, decides which are units).
+        let manifest = "/usr/local/bin/agentsight\n\
+                        /usr/lib/systemd/system/agentsight.service\n\
+                        \n";
+        let q = query_with_rpm("agentsight", ok_out(Some(0), manifest, ""));
+        let files = q.list_files("agentsight").unwrap();
+        assert_eq!(
+            files,
+            vec![
+                "/usr/local/bin/agentsight".to_string(),
+                "/usr/lib/systemd/system/agentsight.service".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_files_not_installed_maps_to_error() {
+        // `rpm -ql` on an absent package exits non-zero with the notice on
+        // stdout; for a tracked component that is drift, so it must surface as
+        // an error (carrying the stdout detail), not an empty file list.
+        let q = query_with_rpm(
+            "ghost",
+            ok_out(Some(1), "package ghost is not installed", ""),
+        );
+        let err = q.list_files("ghost").unwrap_err();
+        match err {
+            PackageQueryError::QueryFailed {
+                command, stderr, ..
+            } => {
+                assert_eq!(command, RPM);
+                assert!(
+                    stderr.contains("not installed"),
+                    "detail should carry the rpm notice: {stderr}"
+                );
+            }
+            other => panic!("expected QueryFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_files_command_missing_maps_to_error() {
+        let q = query_with_rpm("x", FakeOutcome::Err(io::ErrorKind::NotFound));
+        let err = q.list_files("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageQueryError::CommandMissing { command } if command == RPM
         ));
     }
 }


### PR DESCRIPTION
## Description

`anolisa restart <component>` previously did nothing for RPM-installed components: the RPM install/adopt paths record no services in ANOLISA state, so the `ServiceRef`-driven restart had nothing to act on. Restart now sources units by backend — raw installs from the recorded `ServiceRef`s (unchanged), RPM installs from a live `rpm -ql` discovery.

Behavior:
- RPM component → discover units from `rpm -ql`, keep the `.service` files sitting **directly** in a systemd unit search directory, infer system/user scope from that directory, daemon-reload the in-play scopes, then `systemctl restart` each.
- Covers agentsight (preset-only, not auto-started at install) and ws-ckpt.
- Template units (`foo@.service`, e.g. agent-memory's user-scope template) cannot be expanded from package files — their instances are runtime/user state — so they exit 0 with a per-user guidance message (`systemctl --user enable --now …` + linger) instead of erroring.
- No service units at all → `INVALID_ARGUMENT`.
- `rpm`/`dnf` missing → the same actionable "rpm/dnf not found" message the other tier-1 commands use, not a bare "command not found".
- Restart stays lock-free, idempotent, and only `systemctl restart` (never `enable`), matching the raw path.

## Design Note

- `RpmPackageQuery::list_files` (the `rpm -ql` wrapper) is an **inherent** method, not on the `PackageQuery` trait: the trait has ~10 fake implementations and a new trait method would churn all of them. It returns raw paths with no systemd knowledge, because `anolisa-platform` does not depend on `anolisa-core` where `ServiceScope` lives; classification into `(unit, scope)` happens in the CLI layer (`classify_unit_files`).
- "package not installed" from `rpm -ql` maps to `QueryFailed`, **not** an empty list: for a state-tracked component that is drift the caller should surface, not silently treat as "no units".
- Guidance-only outcomes carry a stable `manager: "none"` sentinel rather than an empty string, keeping the JSON field unambiguous alongside the normal `systemd` / `systemd-user` labels.
- daemon-reload runs **before** restart so a freshly-placed unit (a place-only install, or an RPM whose `%post` did not reload the manager) is loadable.

## Ship Note

- **Template instance expansion is out of scope.** Restart degrades a template to per-user guidance rather than enumerating and restarting its live instances. The only current target is agent-memory's intentionally opt-in user service, whose RPM ships no ANOLISA contract, so the systemd-enumeration tier has no present beneficiary; deferred to a follow-up.
- Discovery takes only `.service` files (no `.socket` / `.timer`) and does not pick a "main unit" among several — no current component ships a socket/timer or ≥2 services, so this is headroom, not a gap.

## Test

- **Unit (rpm_query):** `list_files` returns trimmed paths; not-installed → `QueryFailed`; missing `rpm` → `CommandMissing`; call-contract asserts `rpm -q --list <pkg>`.
- **Unit (restart):** `classify_unit_files` keeps only direct-child `.service` units with the right scope (rejects `.wants` symlinks, `.service.d` drop-ins, sockets, unknown dirs); template detection; per-user vs system guidance text; tooling-missing message; guidance-only returns `Ok` with the stable `none` label; end-to-end `discover_rpm_units` over a fake `rpm -ql` listing (plain unit → restartable, template → note) plus the missing-package-name and missing-tooling error paths.
- **Full gate green:** `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- **Real-host end-to-end** (Alibaba Cloud Linux 4, freshly-built CLI). Each scenario checked service/state before and after and was cleaned up afterward:
  - **rpm-managed, stopped → started** — `install agentsight --backend rpm` (preset-only → `inactive`/`disabled`) → `restart` discovers `agentsight.service` from `rpm -ql`, daemon-reloads, `systemctl restart` → `is-active` = `active`, `changed=true`.
  - **rpm-observed (adopt)** — `dnf install agentsight` + `adopt agentsight` → `ownership=rpm_observed` → `restart` → `active` (the other half of `is_rpm()`).
  - **rpm-managed, already-running → bounced** — `install ws-ckpt` (its btrfs-loop backend self-starts the daemon) → `restart` → `MainPID` changes, `state=active`, `changed=true`.
  - **raw-managed (ServiceRef path)** — `install agentsight --backend raw` (place-only → `inactive`) → `restart` drives the recorded `ServiceRef` → `active`, confirming no regression in the existing path.
  - **template (user-scope)** — `install agent-memory` → `restart` exits 0 with `manager: "none"`, empty `units`, and the per-user guidance warning.
  - **no service units** — `install tokenless` (ships no `.service`) → `restart` → `INVALID_ARGUMENT`, exit 2.
  - **component not installed** — `restart <unknown>` → `INVALID_ARGUMENT` ("not installed"), exit 2.
  - **rpm tooling missing** — `restart` an rpm-backed component with `rpm` hidden from `PATH` → the shared "rpm/dnf not found" message, exit 1.

close #1118 