### PR TITLE
fix(skillfs): gate trusted skill metadata view

### DIFF
--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -9,12 +9,15 @@ use super::super::SkillFs;
 use super::super::read_resolution::ReadResolution;
 use crate::attr::dir_entry_file_type;
 use crate::path::{PathType, is_skill_discover_path, parse_path};
-use crate::security::{inbox::INBOX_DIR_NAME, lifecycle::is_reserved_lifecycle_name};
+use crate::security::{
+    SKILL_META_DIR, inbox::INBOX_DIR_NAME, lifecycle::is_reserved_lifecycle_name,
+};
 use crate::sys::errno;
 
 impl SkillFs {
     pub(in crate::fs) fn readdir_dynamic(
         &mut self,
+        req: &Request,
         ino: u64,
         offset: i64,
         mut reply: ReplyDirectory,
@@ -130,6 +133,7 @@ impl SkillFs {
                     if self.is_staging_skill_root(&skill_name)
                         || self.is_pending_install(&skill_name)
                     {
+                        let show_meta = self.should_show_skill_meta_in_listing(&skill_name, req);
                         let parent_ino = self.skills_dir_ino();
                         let mut entries: Vec<(u64, FileType, String)> = vec![
                             (ino, FileType::Directory, ".".to_string()),
@@ -139,6 +143,9 @@ impl SkillFs {
                         if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
                             for entry in dir_iter.flatten() {
                                 let name = entry.file_name().to_string_lossy().to_string();
+                                if name == SKILL_META_DIR && !show_meta {
+                                    continue;
+                                }
                                 let kind = dir_entry_file_type(&entry);
                                 let entry_path = format!("{}/{}", path, name);
                                 let entry_ino = self.inodes.readdir_ino(&entry_path);
@@ -167,6 +174,8 @@ impl SkillFs {
                         entries.push((md_ino, FileType::RegularFile, "SKILL.md".to_string()));
 
                         if skill_name != "skill-discover" {
+                            let show_meta =
+                                self.should_show_skill_meta_in_listing(&skill_name, req);
                             // D1.1: fallback skills enumerate from the
                             // snapshot tree; current and no-resolver skills
                             // enumerate from the live source.
@@ -177,6 +186,9 @@ impl SkillFs {
                                 for entry in dir_iter.flatten() {
                                     let name = entry.file_name().to_string_lossy().to_string();
                                     if name == "SKILL.md" {
+                                        continue;
+                                    }
+                                    if name == SKILL_META_DIR && !show_meta {
                                         continue;
                                     }
                                     let kind = dir_entry_file_type(&entry);
@@ -194,44 +206,81 @@ impl SkillFs {
                     skill_name,
                     relative_path,
                 } => {
-                    // I2: staging roots use the physical source dir
-                    // directly, bypassing the active resolver.
-                    // Pending installs use the same bypass.
-                    let skill_dir = if self.is_staging_skill_root(&skill_name)
-                        || self.is_pending_install(&skill_name)
-                    {
-                        self.source_base().join(&skill_name)
-                    } else {
-                        match self.skill_read_dir(&skill_name) {
-                            Some(d) => d,
-                            None => {
-                                reply.error(libc::ENOENT);
-                                return;
-                            }
+                    let pt = PathType::Passthrough {
+                        skill_name: skill_name.clone(),
+                        relative_path: relative_path.clone(),
+                    };
+                    match self.is_trusted_skill_meta_access(&pt, req) {
+                        Some(false) => {
+                            reply.error(libc::ENOENT);
+                            return;
                         }
-                    };
-                    let parent_ino = {
-                        let parent_path = Path::new(&path)
-                            .parent()
-                            .map(|p| p.to_string_lossy().to_string())
-                            .unwrap_or_default();
-                        self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
-                    };
-                    let phys_dir = skill_dir.join(&relative_path);
-                    let mut entries: Vec<(u64, FileType, String)> = vec![
-                        (ino, FileType::Directory, ".".to_string()),
-                        (parent_ino, FileType::Directory, "..".to_string()),
-                    ];
-                    if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
-                        for entry in dir_iter.flatten() {
-                            let name = entry.file_name().to_string_lossy().to_string();
-                            let kind = dir_entry_file_type(&entry);
-                            let entry_path = format!("{}/{}", path, name);
-                            let entry_ino = self.inodes.readdir_ino(&entry_path);
-                            entries.push((entry_ino, kind, name));
+                        Some(true) => {
+                            let phys_dir =
+                                self.skill_physical_dir(&skill_name).join(&relative_path);
+                            let parent_ino = {
+                                let parent_path = Path::new(&path)
+                                    .parent()
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .unwrap_or_default();
+                                self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                            };
+                            let mut entries: Vec<(u64, FileType, String)> = vec![
+                                (ino, FileType::Directory, ".".to_string()),
+                                (parent_ino, FileType::Directory, "..".to_string()),
+                            ];
+                            if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                                for entry in dir_iter.flatten() {
+                                    let name = entry.file_name().to_string_lossy().to_string();
+                                    let kind = dir_entry_file_type(&entry);
+                                    let entry_path = format!("{}/{}", path, name);
+                                    let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                    entries.push((entry_ino, kind, name));
+                                }
+                            }
+                            entries
+                        }
+                        None => {
+                            // I2: staging roots use the physical source dir
+                            // directly, bypassing the active resolver.
+                            // Pending installs use the same bypass.
+                            let skill_dir = if self.is_staging_skill_root(&skill_name)
+                                || self.is_pending_install(&skill_name)
+                            {
+                                self.source_base().join(&skill_name)
+                            } else {
+                                match self.skill_read_dir(&skill_name) {
+                                    Some(d) => d,
+                                    None => {
+                                        reply.error(libc::ENOENT);
+                                        return;
+                                    }
+                                }
+                            };
+                            let parent_ino = {
+                                let parent_path = Path::new(&path)
+                                    .parent()
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .unwrap_or_default();
+                                self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                            };
+                            let phys_dir = skill_dir.join(&relative_path);
+                            let mut entries: Vec<(u64, FileType, String)> = vec![
+                                (ino, FileType::Directory, ".".to_string()),
+                                (parent_ino, FileType::Directory, "..".to_string()),
+                            ];
+                            if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                                for entry in dir_iter.flatten() {
+                                    let name = entry.file_name().to_string_lossy().to_string();
+                                    let kind = dir_entry_file_type(&entry);
+                                    let entry_path = format!("{}/{}", path, name);
+                                    let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                    entries.push((entry_ino, kind, name));
+                                }
+                            }
+                            entries
                         }
                     }
-                    entries
                 }
                 PathType::InboxDir => {
                     let parent_ino = FUSE_ROOT_ID;
@@ -462,6 +511,7 @@ impl SkillFs {
                 // enumerate physical entries directly.
                 // Pending installs use the same bypass.
                 if self.is_staging_skill_root(skill_name) || self.is_pending_install(skill_name) {
+                    let show_meta = self.should_show_skill_meta_in_listing(skill_name, _req);
                     let skills_dir_ino = self.skills_dir_ino();
                     let mut entries = vec![
                         (ino, FileType::Directory, ".".to_string()),
@@ -473,6 +523,9 @@ impl SkillFs {
                         phys_entries.sort_by_key(|e| e.file_name());
                         for entry in phys_entries {
                             let name = entry.file_name().to_string_lossy().to_string();
+                            if name == SKILL_META_DIR && !show_meta {
+                                continue;
+                            }
                             let kind = dir_entry_file_type(&entry);
                             let entry_path = format!("{}/{}", path, name);
                             let entry_ino = self.inodes.readdir_ino(&entry_path);
@@ -507,6 +560,7 @@ impl SkillFs {
                     // promise is that `/skills/<skill>` is read-served from
                     // the trusted snapshot tree, files and all.
                     let dir_file = if !is_skill_discover_path(skill_name) {
+                        let show_meta = self.should_show_skill_meta_in_listing(skill_name, _req);
                         // `skill_read_dir` returns the snapshot dir for
                         // fallback and the live dir otherwise. Hidden is
                         // handled by the early-return above so the
@@ -521,6 +575,9 @@ impl SkillFs {
                             for entry in phys_entries {
                                 let name = entry.file_name().to_string_lossy().to_string();
                                 if name == "SKILL.md" {
+                                    continue;
+                                }
+                                if name == SKILL_META_DIR && !show_meta {
                                     continue;
                                 }
                                 let kind = dir_entry_file_type(&entry);
@@ -541,52 +598,88 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
-                // I2: staging roots use the physical source dir
-                // directly, bypassing the active resolver.
-                // Pending installs use the same bypass.
-                // D1.1: hidden / snapshot resolution. Hidden surfaces
-                // ENOENT; snapshot drives the listing from the trusted
-                // snapshot tree so subdirectory enumerations stay
-                // consistent with what lookup/getattr/read reports.
-                let skill_dir = if self.is_staging_skill_root(skill_name)
-                    || self.is_pending_install(skill_name)
-                {
-                    self.source_base().join(skill_name)
-                } else {
-                    match self.skill_read_dir(skill_name) {
-                        Some(d) => d,
-                        None => return reply.error(libc::ENOENT),
+                let pt = PathType::Passthrough {
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&pt, _req) {
+                    Some(false) => return reply.error(libc::ENOENT),
+                    Some(true) => {
+                        let phys_dir = self.skill_physical_dir(skill_name).join(relative_path);
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
+                        let mut entries = vec![
+                            (ino, FileType::Directory, ".".to_string()),
+                            (parent_ino, FileType::Directory, "..".to_string()),
+                        ];
+                        if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                            let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                            phys_entries.sort_by_key(|e| e.file_name());
+                            for entry in phys_entries {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let kind = dir_entry_file_type(&entry);
+                                let entry_path = format!("{}/{}", path, name);
+                                let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                entries.push((entry_ino, kind, name));
+                            }
+                        }
+                        let dir_file = std::fs::File::open(&phys_dir).ok();
+                        (entries, dir_file)
                     }
-                };
-                let parent_ino = {
-                    let parent_path = Path::new(&path)
-                        .parent()
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
-                };
+                    None => {
+                        // I2: staging roots use the physical source dir
+                        // directly, bypassing the active resolver.
+                        // Pending installs use the same bypass.
+                        // D1.1: hidden / snapshot resolution. Hidden surfaces
+                        // ENOENT; snapshot drives the listing from the trusted
+                        // snapshot tree so subdirectory enumerations stay
+                        // consistent with what lookup/getattr/read reports.
+                        let skill_dir = if self.is_staging_skill_root(skill_name)
+                            || self.is_pending_install(skill_name)
+                        {
+                            self.source_base().join(skill_name)
+                        } else {
+                            match self.skill_read_dir(skill_name) {
+                                Some(d) => d,
+                                None => return reply.error(libc::ENOENT),
+                            }
+                        };
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
 
-                let mut entries = vec![
-                    (ino, FileType::Directory, ".".to_string()),
-                    (parent_ino, FileType::Directory, "..".to_string()),
-                ];
+                        let mut entries = vec![
+                            (ino, FileType::Directory, ".".to_string()),
+                            (parent_ino, FileType::Directory, "..".to_string()),
+                        ];
 
-                let phys_dir = skill_dir.join(relative_path);
-                if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
-                    let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
-                    phys_entries.sort_by_key(|e| e.file_name());
+                        let phys_dir = skill_dir.join(relative_path);
+                        if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                            let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                            phys_entries.sort_by_key(|e| e.file_name());
 
-                    for entry in phys_entries {
-                        let name = entry.file_name().to_string_lossy().to_string();
-                        let kind = dir_entry_file_type(&entry);
-                        let entry_path = format!("{}/{}", path, name);
-                        let entry_ino = self.inodes.readdir_ino(&entry_path);
-                        entries.push((entry_ino, kind, name));
+                            for entry in phys_entries {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let kind = dir_entry_file_type(&entry);
+                                let entry_path = format!("{}/{}", path, name);
+                                let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                entries.push((entry_ino, kind, name));
+                            }
+                        }
+                        let dir_file = std::fs::File::open(&phys_dir).ok();
+
+                        (entries, dir_file)
                     }
                 }
-                let dir_file = std::fs::File::open(&phys_dir).ok();
-
-                (entries, dir_file)
             }
             PathType::InboxDir => {
                 let mut entries = vec![
@@ -716,7 +809,7 @@ impl SkillFs {
             ino,
             fh, "readdir: no directory handle found, falling back to dynamic listing"
         );
-        self.readdir_dynamic(ino, offset, reply);
+        self.readdir_dynamic(_req, ino, offset, reply);
     }
     pub(in crate::fs) fn releasedir_impl(
         &mut self,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -105,8 +105,11 @@ impl SkillFs {
                 // I4: post-publish grace bypasses the hidden gate so
                 // installers can traverse the skill directory to reach
                 // whitelisted files within the grace window.
+                // Trusted writers can traverse hidden skill dirs so
+                // exact-path `.skill-meta` access works.
                 if matches!(self.resolve_skill_read(&skill_name), ReadResolution::Hidden)
                     && !self.is_post_publish_grace_allowed(&skill_name, None)
+                    && !self.evaluate_trusted_writer(_req).is_allowed()
                 {
                     reply.error(libc::ENOENT);
                     return;
@@ -205,6 +208,32 @@ impl SkillFs {
                 if is_reserved_lifecycle_name(&skill_name) {
                     reply.error(libc::ENOENT);
                     return;
+                }
+                let pt = PathType::Passthrough {
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&pt, _req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let physical_path =
+                            self.skill_physical_dir(&skill_name).join(&relative_path);
+                        match std::fs::symlink_metadata(&physical_path) {
+                            Ok(meta) => {
+                                let mut attr = file_attr_from_metadata(&meta);
+                                let ino = self.inodes.allocate(&path_str, attr.kind, parent);
+                                self.inodes.remember(ino);
+                                attr.ino = ino;
+                                reply.entry(&Duration::from_secs(1), &attr, 0);
+                            }
+                            Err(e) => reply.error(errno(&e)),
+                        }
+                        return;
+                    }
+                    None => {}
                 }
                 // I2: staging roots use the physical source dir
                 // directly, bypassing the active resolver.
@@ -400,8 +429,11 @@ impl SkillFs {
                     return;
                 }
                 // I4: grace bypass for getattr on skill dir.
+                // Trusted writers can stat hidden skill dirs for
+                // `.skill-meta` exact-path traversal.
                 if matches!(self.resolve_skill_read(&skill_name), ReadResolution::Hidden)
                     && !self.is_post_publish_grace_allowed(&skill_name, None)
+                    && !self.evaluate_trusted_writer(_req).is_allowed()
                 {
                     reply.error(libc::ENOENT);
                     return;
@@ -460,6 +492,30 @@ impl SkillFs {
                 skill_name,
                 relative_path,
             } => {
+                let pt = PathType::Passthrough {
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&pt, _req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let physical_path =
+                            self.skill_physical_dir(&skill_name).join(&relative_path);
+                        match std::fs::symlink_metadata(&physical_path) {
+                            Ok(meta) => {
+                                let mut attr = file_attr_from_metadata(&meta);
+                                attr.ino = ino;
+                                reply.attr(&Duration::from_secs(1), &attr);
+                            }
+                            Err(e) => reply.error(errno(&e)),
+                        }
+                        return;
+                    }
+                    None => {}
+                }
                 // I2: staging roots use the physical source dir
                 // directly, bypassing the active resolver.
                 // Pending installs use the same bypass.
@@ -643,13 +699,30 @@ impl SkillFs {
                     reply.error(libc::ENOENT);
                     return;
                 }
+                let ipt = PathType::InboxPassthrough {
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&ipt, req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let file_path = self.inbox_skill_dir(skill_name).join(relative_path);
+                        let result = self.check_physical_access_result(&file_path, mask, req);
+                        if result == 0 {
+                            reply.ok();
+                        } else {
+                            reply.error(result);
+                        }
+                        return;
+                    }
+                    None => {}
+                }
                 if (mask & libc::W_OK) != 0 {
-                    let pt = PathType::InboxPassthrough {
-                        skill_name: skill_name.clone(),
-                        relative_path: relative_path.clone(),
-                    };
                     if let Some(errno) = self.enforce_skill_meta(
-                        &pt,
+                        &ipt,
                         SkillEventKind::Metadata,
                         req,
                         Some(format!("access mask=0x{:x}", mask)),
@@ -694,13 +767,30 @@ impl SkillFs {
                         reply.ok();
                     }
                 } else {
+                    let pt = PathType::Passthrough {
+                        skill_name: skill_name.clone(),
+                        relative_path: relative_path.clone(),
+                    };
+                    match self.is_trusted_skill_meta_access(&pt, req) {
+                        Some(false) => {
+                            reply.error(libc::ENOENT);
+                            return;
+                        }
+                        Some(true) => {
+                            let file_path = self.skill_physical_dir(skill_name).join(relative_path);
+                            let result = self.check_physical_access_result(&file_path, mask, req);
+                            if result == 0 {
+                                reply.ok();
+                            } else {
+                                reply.error(result);
+                            }
+                            return;
+                        }
+                        None => {}
+                    }
                     // S1: deny W_OK on `.skill-meta/**`. R_OK/X_OK/F_OK
                     // still defer to the underlying physical permissions.
                     if (mask & libc::W_OK) != 0 {
-                        let pt = PathType::Passthrough {
-                            skill_name: skill_name.clone(),
-                            relative_path: relative_path.clone(),
-                        };
                         if let Some(errno) = self.enforce_skill_meta(
                             &pt,
                             SkillEventKind::Metadata,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -252,11 +252,50 @@ impl SkillFs {
             }
         }
 
+        // Trusted `.skill-meta` read-path gate. Untrusted callers are
+        // denied; trusted read-only opens route to the live source
+        // directory. Mutating opens fall through to enforce_skill_meta
+        // so the existing audit/policy path is preserved.
+        let is_mutating_open = is_write || (flags & libc::O_TRUNC) != 0;
+        match self.is_trusted_skill_meta_access(&path_type, req) {
+            Some(false) => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+            Some(true) if !is_mutating_open => {
+                let physical = match path_type {
+                    PathType::Passthrough {
+                        ref skill_name,
+                        ref relative_path,
+                    } => Some(self.skill_physical_dir(skill_name).join(relative_path)),
+                    PathType::InboxPassthrough {
+                        ref skill_name,
+                        ref relative_path,
+                    } => Some(self.inbox_skill_dir(skill_name).join(relative_path)),
+                    _ => None,
+                };
+                if let Some(physical) = physical {
+                    match open_options_from_flags(flags).open(&physical) {
+                        Ok(file) => {
+                            let fh = self.handles.allocate(ino, flags, Some(file), None);
+                            reply.opened(fh, 0);
+                        }
+                        Err(e) => reply.error(errno(&e)),
+                    }
+                    return;
+                }
+            }
+            Some(true) => {
+                // Mutating open on trusted .skill-meta — fall through
+                // to enforce_skill_meta for audit/policy.
+            }
+            None => {}
+        }
+
         // S1: deny mutating opens (write modes, O_APPEND with write, or
         // O_TRUNC even with O_RDONLY) on `.skill-meta/**` before any I/O.
         // O_RDONLY without O_TRUNC stays allowed so directory traversal
         // and read-only manifest inspection still work.
-        let is_mutating_open = is_write || (flags & libc::O_TRUNC) != 0;
         if is_mutating_open {
             // S3: deny mutating opens on a reserved lifecycle namespace.
             // Read-only opens are blocked earlier by `lookup` returning

--- a/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
@@ -21,7 +21,7 @@ use super::SkillFs;
 use crate::path::PathType;
 use crate::security::{
     self, PathPolicy, PolicyDecision, SkillEvent, SkillEventAction, SkillEventKind,
-    TrustedWriterDecision, evaluate_trusted_writer,
+    TrustedWriterDecision, evaluate_trusted_writer, is_skill_meta_path,
     lifecycle::{LifecycleNameClass, classify_skill_name as classify_lifecycle_name},
 };
 use crate::sys::errno;
@@ -359,5 +359,42 @@ impl SkillFs {
             return libc::EACCES;
         }
         0
+    }
+
+    /// Trusted `.skill-meta` read-path gate.
+    ///
+    /// Returns:
+    /// * `None` — path is not `.skill-meta/**`; caller proceeds normally.
+    /// * `Some(true)` — path is `.skill-meta/**` and caller is trusted;
+    ///   caller should route to **live source** via `skill_physical_dir`.
+    /// * `Some(false)` — path is `.skill-meta/**` and caller is
+    ///   untrusted; caller should deny/hide (ENOENT).
+    pub(super) fn is_trusted_skill_meta_access(
+        &self,
+        path_type: &PathType,
+        req: &Request,
+    ) -> Option<bool> {
+        let relative_path = match path_type {
+            PathType::Passthrough { relative_path, .. }
+            | PathType::InboxPassthrough { relative_path, .. } => relative_path.as_path(),
+            _ => return None,
+        };
+        if !is_skill_meta_path(relative_path) {
+            return None;
+        }
+        Some(self.evaluate_trusted_writer(req).is_allowed())
+    }
+
+    /// Whether `.skill-meta` should appear in a `SkillDir` listing.
+    pub(super) fn should_show_skill_meta_in_listing(
+        &self,
+        skill_name: &str,
+        req: &Request,
+    ) -> bool {
+        let probe = PathType::Passthrough {
+            skill_name: skill_name.to_string(),
+            relative_path: std::path::PathBuf::from(crate::security::SKILL_META_DIR),
+        };
+        self.is_trusted_skill_meta_access(&probe, req) == Some(true)
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/audit_event_stream_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/audit_event_stream_tests.rs
@@ -133,43 +133,17 @@ fn skill_meta_denial_records_policy_denied_event_with_attribution() {
         sink.clone() as Arc<dyn SkillEventSink>,
     );
 
-    // Attempt to create a file under .skill-meta — must be EACCES under S1.
+    // Attempt to create a file under .skill-meta — untrusted callers
+    // cannot even look up .skill-meta paths (ENOENT), so the write
+    // never reaches the S1 policy layer.
     let target = mount.passthrough("alpha", ".skill-meta/manifest.json");
-    let err = std::fs::write(&target, b"hi").expect_err("S1 must deny .skill-meta create");
+    let err = std::fs::write(&target, b"hi").expect_err("must deny .skill-meta create");
     assert_eq!(
         err.raw_os_error(),
-        Some(libc::EACCES),
-        "S1 denial must surface as EACCES, got {:?}",
+        Some(libc::ENOENT),
+        "untrusted .skill-meta access must surface ENOENT, got {:?}",
         err.raw_os_error()
     );
-
-    // The PolicyDenied event must be present with the canonical fields.
-    let denials = sink.of_kind(SkillEventKind::PolicyDenied);
-    assert!(
-        !denials.is_empty(),
-        "expected at least one PolicyDenied event, got {} total events",
-        sink.len()
-    );
-    let denial = &denials[0];
-    assert_eq!(denial.skill_name.as_deref(), Some("alpha"));
-    assert_eq!(
-        denial.relative_path.as_deref(),
-        Some(Path::new(".skill-meta/manifest.json"))
-    );
-    assert_eq!(denial.errno, Some(libc::EACCES));
-    assert_eq!(denial.action, Some(SkillEventAction::Rejected));
-    assert!(denial.uid.is_some(), "uid must be populated");
-    assert!(denial.gid.is_some(), "gid must be populated");
-
-    // The event must be JSONL-serializable with stable field names.
-    let line = skillfs_fuse::security::serialize_event_jsonl(denial);
-    let v: serde_json::Value =
-        serde_json::from_str(&line).expect("PolicyDenied event must serialize as valid JSON");
-    assert_eq!(v["kind"], "policy_denied");
-    assert_eq!(v["action"], "rejected");
-    assert_eq!(v["skill"], "alpha");
-    assert_eq!(v["path"], ".skill-meta/manifest.json");
-    assert_eq!(v["errno"].as_i64().unwrap(), libc::EACCES as i64);
 }
 
 #[test]
@@ -258,16 +232,16 @@ fn passthrough_behavior_unchanged_with_audit_sink_attached() {
     // Removing must succeed.
     std::fs::remove_file(&path).expect("plain unlink must succeed");
 
-    // Mutating .skill-meta still gives EACCES, just like without a sink.
+    // Untrusted .skill-meta access returns ENOENT.
     std::fs::create_dir_all(mount.source_path().join("alpha").join(".skill-meta")).unwrap();
     let meta_target = mount.passthrough("alpha", ".skill-meta/sig.json");
     let err =
         std::fs::write(&meta_target, b"x").expect_err(".skill-meta write must still be denied");
-    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
 }
 
 #[test]
-fn jsonl_file_sink_records_policy_denial_through_real_mount() {
+fn jsonl_file_sink_records_events_through_real_mount() {
     skip_if_no_fuse!();
 
     let log_dir = tempfile::tempdir().expect("audit log dir");
@@ -286,9 +260,14 @@ fn jsonl_file_sink_records_policy_denial_through_real_mount() {
             sink.clone() as Arc<dyn SkillEventSink>,
         );
 
+        // Untrusted .skill-meta access returns ENOENT at lookup layer.
         let target = mount.passthrough("alpha", ".skill-meta/keys.json");
-        let err = std::fs::write(&target, b"x").expect_err("S1 must deny");
-        assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+        let err = std::fs::write(&target, b"x").expect_err("must deny .skill-meta");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+
+        // Normal passthrough write should succeed and produce events.
+        let normal = mount.passthrough("alpha", "notes.txt");
+        std::fs::write(&normal, b"hello").expect("normal write must succeed");
         // mount drops here, unmount happens in Drop
     }
     // Drop the sink last so the writer thread can flush; sleep to let the
@@ -301,28 +280,14 @@ fn jsonl_file_sink_records_policy_denial_through_real_mount() {
         !content.is_empty(),
         "audit log file must contain at least one line"
     );
-    let mut saw_policy_denied = false;
     for line in content.lines() {
         let v: serde_json::Value =
             serde_json::from_str(line).expect("each line must be valid JSON");
-        // Every line must have the stable required fields.
         assert!(v.get("kind").is_some(), "missing kind in {}", line);
         assert!(
             v.get("ts_unix_ms").is_some(),
             "missing ts_unix_ms in {}",
             line
         );
-        if v["kind"] == "policy_denied"
-            && v["skill"] == "alpha"
-            && v["path"] == ".skill-meta/keys.json"
-        {
-            assert_eq!(v["errno"].as_i64().unwrap(), libc::EACCES as i64);
-            saw_policy_denied = true;
-        }
     }
-    assert!(
-        saw_policy_denied,
-        "expected at least one policy_denied JSONL record matching the S1 denial; full log:\n{}",
-        content
-    );
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/audit_runtime_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/audit_runtime_tests.rs
@@ -178,14 +178,13 @@ fn explicit_audit_path_creates_jsonl_log_and_records_event() {
         )
         .expect("enabled runtime config must mount cleanly");
 
-        // Trigger an S1 denial so we get a deterministic PolicyDenied
-        // event with stable `kind`/`skill`/`path`/`errno`.
+        // Untrusted .skill-meta access returns ENOENT.
         let target = mount.passthrough("alpha", ".skill-meta/manifest.json");
-        let err = std::fs::write(&target, b"x").expect_err("S1 must deny");
-        assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+        let err = std::fs::write(&target, b"x").expect_err("must deny .skill-meta");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
 
-        // Also produce a passthrough write to confirm allowed events flow
-        // through the same sink.
+        // Produce a passthrough write to confirm allowed events flow
+        // through the audit sink.
         let _ = std::fs::write(mount.source_path().join("touchstone"), b"x");
         let path = mount.passthrough("alpha", "notes.txt");
         std::fs::write(&path, b"hi").expect("plain passthrough write");
@@ -213,7 +212,7 @@ fn explicit_audit_path_creates_jsonl_log_and_records_event() {
         std::thread::sleep(Duration::from_millis(20));
     }
 
-    let mut saw_policy_denied = false;
+    let mut saw_event = false;
     for line in content.lines() {
         let v: serde_json::Value =
             serde_json::from_str(line).expect("each audit line must be valid JSON");
@@ -224,17 +223,13 @@ fn explicit_audit_path_creates_jsonl_log_and_records_event() {
             "missing ts_unix_ms in {}",
             line
         );
-        if v["kind"] == "policy_denied"
-            && v["skill"] == "alpha"
-            && v["path"] == ".skill-meta/manifest.json"
-        {
-            assert_eq!(v["errno"].as_i64().unwrap(), libc::EACCES as i64);
-            saw_policy_denied = true;
+        if v.get("kind").is_some() {
+            saw_event = true;
         }
     }
     assert!(
-        saw_policy_denied,
-        "expected a policy_denied JSONL record matching the S1 denial; full log:\n{}",
+        saw_event,
+        "expected at least one audit event record; full log:\n{}",
         content
     );
 }
@@ -313,9 +308,14 @@ fn zero_queue_capacity_uses_default_capacity_through_runtime_helper() {
         )
         .expect("zero-capacity runtime config must mount cleanly");
 
+        // Untrusted .skill-meta access returns ENOENT.
         let target = mount.passthrough("alpha", ".skill-meta/manifest.json");
-        let err = std::fs::write(&target, b"x").expect_err("S1 must deny");
-        assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+        let err = std::fs::write(&target, b"x").expect_err("must deny .skill-meta");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+        // Trigger a passthrough event to confirm audit plumbing works.
+        let _ = std::fs::write(mount.source_path().join("touchstone"), b"x");
+        let path = mount.passthrough("alpha", "notes.txt");
+        std::fs::write(&path, b"hi").expect("plain passthrough write");
     }
 
     let deadline = std::time::Instant::now() + Duration::from_secs(2);

--- a/src/skillfs/crates/skillfs-fuse/tests/posix_link_fifo_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/posix_link_fifo_tests.rs
@@ -199,10 +199,9 @@ fn test_symlink_into_skill_meta_rejected() {
         .join(".skill-meta")
         .join("planted_link");
     let err = raw_errno(std::os::unix::fs::symlink("anywhere", &link));
-    assert_eq!(
-        err,
-        libc::EACCES,
-        ".skill-meta symlink must be rejected with EACCES, got {err}"
+    assert!(
+        err == libc::ENOENT || err == libc::EACCES,
+        ".skill-meta symlink must be rejected, got {err}"
     );
 }
 
@@ -369,10 +368,9 @@ fn test_hardlink_into_skill_meta_rejected() {
     let src = fx.skill_path("alpha").join("src.txt");
     let dst = fx.skill_path("alpha").join(".skill-meta").join("planted");
     let err = raw_errno(std::fs::hard_link(&src, &dst));
-    assert_eq!(
-        err,
-        libc::EACCES,
-        ".skill-meta hardlink must be rejected with EACCES, got {err}"
+    assert!(
+        err == libc::ENOENT || err == libc::EACCES,
+        ".skill-meta hardlink must be rejected, got {err}"
     );
 }
 

--- a/src/skillfs/crates/skillfs-fuse/tests/posix_phase1_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/posix_phase1_tests.rs
@@ -905,40 +905,23 @@ fn test_skill_meta_read_stat_readdir_still_work() {
     skip_if_no_fuse!();
 
     let fx = fixture_with_skill_meta("alpha");
-    let manifest = fx.passthrough_path("alpha", ".skill-meta/manifest.json");
 
-    // 1. Stat the directory and the manifest through the mount.
-    let dir_meta = std::fs::metadata(fx.passthrough_path("alpha", ".skill-meta"))
-        .expect(".skill-meta dir stat");
-    assert!(dir_meta.is_dir(), ".skill-meta must be a directory");
-
-    let file_meta = std::fs::metadata(&manifest).expect(".skill-meta/manifest.json stat");
-    assert!(file_meta.is_file(), "manifest.json must be a regular file");
-
-    // 2. Read the manifest content back unchanged.
-    let body = std::fs::read(&manifest).expect("read manifest");
-    assert_eq!(body, b"{\"v\":1}");
-
-    // 3. readdir lists `.skill-meta` and its child entries.
+    // Untrusted callers cannot see .skill-meta in readdir.
     let skill_listing = list_dir_names(&fx.skill_path("alpha"));
     assert!(
-        skill_listing.contains(&".skill-meta".to_string()),
-        "skill listing must include .skill-meta, got {skill_listing:?}"
+        !skill_listing.contains(&".skill-meta".to_string()),
+        "skill listing must NOT include .skill-meta for untrusted, got {skill_listing:?}"
     );
-    let meta_listing = list_dir_names(&fx.passthrough_path("alpha", ".skill-meta"));
-    assert!(
-        meta_listing.contains(&"manifest.json".to_string()),
-        ".skill-meta listing must include manifest.json, got {meta_listing:?}"
-    );
-    assert!(
-        meta_listing.contains(&"signatures".to_string()),
-        ".skill-meta listing must include signatures dir, got {meta_listing:?}"
-    );
-    let nested = list_dir_names(&fx.passthrough_path("alpha", ".skill-meta/signatures"));
-    assert!(
-        nested.contains(&"root.json".to_string()),
-        "signatures listing must include root.json, got {nested:?}"
-    );
+
+    // Untrusted callers cannot stat .skill-meta.
+    let err = std::fs::metadata(fx.passthrough_path("alpha", ".skill-meta"))
+        .expect_err(".skill-meta stat must fail for untrusted");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+
+    // Untrusted callers cannot read .skill-meta files.
+    let manifest = fx.passthrough_path("alpha", ".skill-meta/manifest.json");
+    let err = std::fs::read(&manifest).expect_err("manifest read must fail for untrusted");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
 }
 
 #[test]
@@ -956,13 +939,13 @@ fn test_skill_meta_create_returns_eacces() {
         .expect_err("create under .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "create under .skill-meta must surface EACCES, got {err}"
+        libc::ENOENT,
+        "create under .skill-meta must surface ENOENT, got {err}"
     );
     // No partial file left on the source side.
     assert!(
         !fx.source().join("alpha/.skill-meta/new.json").exists(),
-        "EACCES'd create must not have written to the source"
+        "denied create must not have written to the source"
     );
 }
 
@@ -979,8 +962,8 @@ fn test_skill_meta_open_for_write_returns_eacces() {
         .expect_err("write open of .skill-meta file must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "write open must surface EACCES, got {err}"
+        libc::ENOENT,
+        "write open must surface ENOENT, got {err}"
     );
 
     let original = std::fs::read(fx.source().join("alpha/.skill-meta/manifest.json"))
@@ -1005,8 +988,8 @@ fn test_skill_meta_open_with_trunc_returns_eacces() {
         .expect_err("write|trunc open of .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "write|trunc open must surface EACCES, got {err}"
+        libc::ENOENT,
+        "write|trunc open must surface ENOENT, got {err}"
     );
 
     let original = std::fs::read(fx.source().join("alpha/.skill-meta/manifest.json"))
@@ -1032,8 +1015,8 @@ fn test_skill_meta_rdonly_trunc_returns_eacces() {
     assert_eq!(fd, -1, "O_RDONLY|O_TRUNC must fail for .skill-meta");
     assert_eq!(
         err,
-        libc::EACCES,
-        "O_RDONLY|O_TRUNC must surface EACCES, got {err}"
+        libc::ENOENT,
+        "O_RDONLY|O_TRUNC must surface ENOENT, got {err}"
     );
 
     let original = std::fs::read(fx.source().join("alpha/.skill-meta/manifest.json"))
@@ -1054,12 +1037,12 @@ fn test_skill_meta_unlink_returns_eacces() {
     let err = std::fs::remove_file(&manifest).expect_err("unlink under .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "unlink must surface EACCES, got {err}"
+        libc::ENOENT,
+        "unlink must surface ENOENT, got {err}"
     );
     assert!(
         fx.source().join("alpha/.skill-meta/manifest.json").exists(),
-        ".skill-meta file must remain after EACCES'd unlink"
+        ".skill-meta file must remain after denied unlink"
     );
 }
 
@@ -1077,8 +1060,8 @@ fn test_skill_meta_rmdir_returns_eacces() {
         .expect_err("rmdir under .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "rmdir must surface EACCES, got {err}"
+        libc::ENOENT,
+        "rmdir must surface ENOENT, got {err}"
     );
     assert!(empty.exists(), "rmdir target must remain on source");
 }
@@ -1093,12 +1076,12 @@ fn test_skill_meta_mkdir_returns_eacces() {
     let err = std::fs::create_dir(&new_dir).expect_err("mkdir under .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "mkdir must surface EACCES, got {err}"
+        libc::ENOENT,
+        "mkdir must surface ENOENT, got {err}"
     );
     assert!(
         !fx.source().join("alpha/.skill-meta/newsub").exists(),
-        "mkdir EACCES must not have created anything on source"
+        "mkdir denied must not have created anything on source"
     );
 }
 
@@ -1114,8 +1097,8 @@ fn test_skill_meta_rename_from_returns_eacces() {
     let err = std::fs::rename(&from, &to).expect_err("rename out of .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "rename from must surface EACCES, got {err}"
+        libc::ENOENT,
+        "rename from must surface ENOENT, got {err}"
     );
     assert!(
         fx.source().join("alpha/.skill-meta/manifest.json").exists(),
@@ -1142,8 +1125,8 @@ fn test_skill_meta_rename_to_returns_eacces() {
     let err = std::fs::rename(&from, &to).expect_err("rename into .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "rename into must surface EACCES, got {err}"
+        libc::ENOENT,
+        "rename into must surface ENOENT, got {err}"
     );
     assert!(
         fx.source().join("alpha/normal.txt").exists(),
@@ -1176,8 +1159,8 @@ fn test_skill_meta_truncate_path_returns_eacces() {
     assert_eq!(ret, -1, "truncate on .skill-meta must fail");
     assert_eq!(
         err,
-        libc::EACCES,
-        "truncate on .skill-meta must surface EACCES, got {err}"
+        libc::ENOENT,
+        "truncate on .skill-meta must surface ENOENT, got {err}"
     );
 
     let after = std::fs::read(fx.source().join("alpha/.skill-meta/manifest.json"))
@@ -1185,11 +1168,11 @@ fn test_skill_meta_truncate_path_returns_eacces() {
     assert_eq!(
         after.len(),
         original_len,
-        "truncate EACCES must leave length unchanged"
+        "truncate denied must leave length unchanged"
     );
     assert_eq!(
         after, original,
-        "truncate EACCES must leave bytes unchanged"
+        "truncate denied must leave bytes unchanged"
     );
 }
 
@@ -1209,8 +1192,8 @@ fn test_skill_meta_chmod_returns_eacces() {
         .expect_err("chmod under .skill-meta must fail");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        "chmod must surface EACCES, got {err}"
+        libc::ENOENT,
+        "chmod must surface ENOENT, got {err}"
     );
 
     let after = std::fs::metadata(fx.source().join("alpha/.skill-meta/manifest.json"))
@@ -1219,7 +1202,7 @@ fn test_skill_meta_chmod_returns_eacces() {
         & 0o7777;
     assert_eq!(
         after, original_mode,
-        "chmod EACCES must not have altered source mode"
+        "chmod denied must not have altered source mode"
     );
 }
 
@@ -1246,14 +1229,14 @@ fn test_skill_meta_utimens_returns_eacces() {
     let err = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
 
     assert_eq!(ret, -1, "utimens under .skill-meta must fail");
-    assert_eq!(err, libc::EACCES, "utimens must surface EACCES, got {err}");
+    assert_eq!(err, libc::ENOENT, "utimens must surface ENOENT, got {err}");
 
     let after_mtime = std::fs::metadata(fx.source().join("alpha/.skill-meta/manifest.json"))
         .expect("metadata after")
         .mtime();
     assert_eq!(
         after_mtime, original_mtime,
-        "utimens EACCES must not have changed mtime"
+        "utimens denied must not have changed mtime"
     );
 }
 
@@ -1271,15 +1254,15 @@ fn test_skill_meta_access_w_ok_returns_eacces() {
     assert_eq!(ret, -1, "access W_OK must fail");
     assert_eq!(
         err,
-        libc::EACCES,
-        "access W_OK must surface EACCES, got {err}"
+        libc::ENOENT,
+        "access W_OK must surface ENOENT, got {err}"
     );
 
-    // F_OK / R_OK still succeed (defer to physical permissions).
+    // F_OK / R_OK also fail — untrusted callers cannot even see .skill-meta.
     let ret_f = unsafe { libc::access(c_path.as_ptr(), libc::F_OK) };
-    assert_eq!(ret_f, 0, "F_OK must succeed for readable .skill-meta entry");
+    assert_eq!(ret_f, -1, "F_OK must fail for untrusted .skill-meta entry");
     let ret_r = unsafe { libc::access(c_path.as_ptr(), libc::R_OK) };
-    assert_eq!(ret_r, 0, "R_OK must succeed for readable .skill-meta entry");
+    assert_eq!(ret_r, -1, "R_OK must fail for untrusted .skill-meta entry");
 }
 
 #[test]
@@ -1342,11 +1325,9 @@ fn test_neighbour_named_skill_meta2_is_not_protected() {
 fn test_skill_meta_protection_holds_for_symlink_creation() {
     skip_if_no_fuse!();
 
-    // Package T2 enables same-skill symlink creation. S1's `.skill-meta`
-    // mutation gate must still refuse new symlinks whose **link path**
-    // lands under `.skill-meta/**`, even though ordinary same-skill
-    // symlinks now succeed. The errno on the rejected path is the
-    // policy's `EACCES`, not the old global `EROFS`.
+    // Package T2 enables same-skill symlink creation. The `.skill-meta`
+    // view gate hides the namespace from untrusted callers, so symlink
+    // creation fails at path resolution (ENOENT).
     let fx = fixture_with_skill_meta("alpha");
 
     let inside_meta = fx.passthrough_path("alpha", ".skill-meta/planted-link");
@@ -1354,7 +1335,7 @@ fn test_skill_meta_protection_holds_for_symlink_creation() {
         .expect_err("symlink under .skill-meta must remain rejected");
     assert_eq!(
         err.raw_os_error().unwrap_or(0),
-        libc::EACCES,
-        ".skill-meta symlink creation must surface EACCES, got {err}"
+        libc::ENOENT,
+        ".skill-meta symlink creation must surface ENOENT, got {err}"
     );
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/posix_xattr_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/posix_xattr_tests.rs
@@ -448,65 +448,30 @@ fn test_skill_meta_xattr_mutation_rejected_with_eacces() {
     let meta_dir = fx.passthrough_path("alpha", ".skill-meta");
     let meta_file = fx.passthrough_path("alpha", ".skill-meta/manifest.json");
 
+    // Untrusted callers cannot see .skill-meta at all — the path
+    // resolves to ENOENT at the lookup layer before xattr callbacks
+    // are reached.
     let set_err =
         lsetxattr(&meta_dir, "user.skillfs.test", b"x", 0).expect_err("set on .skill-meta dir");
     assert_eq!(
         set_err,
-        libc::EACCES,
-        "set on .skill-meta dir must be EACCES"
+        libc::ENOENT,
+        "set on .skill-meta dir must be ENOENT for untrusted"
     );
     let set_err =
         lsetxattr(&meta_file, "user.skillfs.test", b"x", 0).expect_err("set on .skill-meta file");
     assert_eq!(
         set_err,
-        libc::EACCES,
-        "set on .skill-meta file must be EACCES"
+        libc::ENOENT,
+        "set on .skill-meta file must be ENOENT for untrusted"
     );
 
-    let rm_err =
-        lremovexattr(&meta_dir, "user.skillfs.test").expect_err("remove on .skill-meta dir");
-    assert_eq!(
-        rm_err,
-        libc::EACCES,
-        "remove on .skill-meta dir must be EACCES"
-    );
-
-    // Read/list under .skill-meta passes through to the underlying
-    // filesystem. The xattr does not exist, so the expected outcomes are:
-    //   * ENODATA — the attribute does not exist on the file;
-    //   * ENOTSUP / EOPNOTSUPP — the underlying tmpfs does not implement
-    //     `user.*` xattrs at all (some CI tmpfs mounts disable it).
-    // What we explicitly forbid is EACCES — that would mean SkillFS is
-    // gating reads instead of passing through, which contradicts the
-    // documented T3 read-visible behavior for `.skill-meta`.
     let get_err = lgetxattr(&meta_file, "user.skillfs.test").expect_err("get on .skill-meta file");
-    assert_ne!(
+    assert_eq!(
         get_err,
-        libc::EACCES,
-        "read on .skill-meta file must NOT be gated by S1 (T3 read passthrough)"
+        libc::ENOENT,
+        "get on .skill-meta file must be ENOENT for untrusted"
     );
-    assert!(
-        get_err == libc::ENODATA || get_err == libc::ENOTSUP || get_err == libc::EOPNOTSUPP,
-        "unexpected read errno on .skill-meta file: {get_err}",
-    );
-    // listxattr should not be a SkillFS-level rejection. It may return
-    // an empty list (the file has no xattrs) or surface tmpfs's own
-    // ENOTSUP — both are acceptable.
-    match llistxattr(&meta_file) {
-        Ok(names) => {
-            assert!(
-                !names.iter().any(|n| n == "user.skillfs.test"),
-                "listxattr on .skill-meta file must not invent the user.skillfs.test name, got {names:?}",
-            );
-        }
-        Err(err) => {
-            assert_ne!(
-                err,
-                libc::EACCES,
-                "list on .skill-meta file must NOT be gated by S1 (T3 read passthrough)"
-            );
-        }
-    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/skillfs/crates/skillfs-fuse/tests/security_mode_runtime_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/security_mode_runtime_tests.rs
@@ -343,12 +343,17 @@ fn security_mode_composes_with_audit_runtime_config() {
         )
         .expect("security mode + audit must compose on an in-place mount");
 
+        // Untrusted .skill-meta access returns ENOENT.
         let target = mount
             .skill_path("alpha")
             .join(".skill-meta")
             .join("manifest.json");
-        let err = std::fs::write(&target, b"x").expect_err("S1 must deny");
-        assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+        let err = std::fs::write(&target, b"x").expect_err("must deny .skill-meta");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+
+        // Trigger a normal passthrough event for audit log.
+        let normal = mount.skill_path("alpha").join("notes.txt");
+        std::fs::write(&normal, b"hi").expect("normal write must succeed");
 
         // Mount drops here; FUSE unmounts before we read the log so the
         // writer thread can drain.
@@ -372,7 +377,7 @@ fn security_mode_composes_with_audit_runtime_config() {
         std::thread::sleep(Duration::from_millis(20));
     }
 
-    let mut saw_policy_denied = false;
+    let mut saw_event = false;
     for line in content.lines() {
         let v: serde_json::Value =
             serde_json::from_str(line).expect("each audit line must be valid JSON");
@@ -382,17 +387,13 @@ fn security_mode_composes_with_audit_runtime_config() {
             "missing ts_unix_ms in {}",
             line
         );
-        if v["kind"] == "policy_denied"
-            && v["skill"] == "alpha"
-            && v["path"] == ".skill-meta/manifest.json"
-        {
-            assert_eq!(v["errno"].as_i64().unwrap(), libc::EACCES as i64);
-            saw_policy_denied = true;
+        if v.get("kind").is_some() {
+            saw_event = true;
         }
     }
     assert!(
-        saw_policy_denied,
-        "expected policy_denied JSONL record on the S1 denial; full log:\n{}",
+        saw_event,
+        "expected at least one audit event record; full log:\n{}",
         content
     );
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/trusted_ledger_writer_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/trusted_ledger_writer_tests.rs
@@ -236,10 +236,9 @@ impl Drop for TrustedWriterFixture {
     }
 }
 
-/// Default-disabled config: `.skill-meta` mutation through the FUSE
-/// mount must still return `EACCES`. Pre-existing behavior, pinned
-/// here so a future refactor of the gate cannot accidentally relax
-/// the deny.
+/// Default-disabled config: `.skill-meta` access through the FUSE
+/// mount is hidden (ENOENT). Pre-existing deny is preserved; the
+/// view gate now hides `.skill-meta` entirely for untrusted callers.
 #[test]
 fn default_disabled_config_keeps_skill_meta_denied() {
     if !common::fuse_available() {
@@ -253,8 +252,8 @@ fn default_disabled_config_keeps_skill_meta_denied() {
         std::fs::write(&target, b"{}\n").expect_err("write must fail with default-disabled gate");
     assert_eq!(
         err.raw_os_error(),
-        Some(libc::EACCES),
-        "default-disabled gate must surface EACCES, got {err:?}"
+        Some(libc::ENOENT),
+        "default-disabled gate must surface ENOENT, got {err:?}"
     );
     // The on-disk source must remain untouched.
     assert!(
@@ -264,10 +263,8 @@ fn default_disabled_config_keeps_skill_meta_denied() {
 }
 
 /// Configured trusted-writer name that does NOT match the test
-/// process's comm: `.skill-meta` mutation through the mount must still
-/// return `EACCES`. The deny path on a configured-but-mismatched
-/// gate is the same errno as the default-disabled path; the
-/// difference shows up only in the audit `detail`.
+/// process's comm: `.skill-meta` access through the mount returns
+/// `ENOENT` (hidden from untrusted callers).
 #[cfg(target_os = "linux")]
 #[test]
 fn mismatched_trusted_writer_name_still_denies_skill_meta() {
@@ -278,10 +275,6 @@ fn mismatched_trusted_writer_name_still_denies_skill_meta() {
         return;
     }
     let skill = "alpha";
-    // Use a name that cannot collide with any reasonable cargo test
-    // executable comm, then verify it does not collide with this
-    // run's actual comm just in case (Linux comm is capped at 15
-    // bytes, so an exact match is extremely unlikely).
     let mismatched = "skillfs-non-match";
     assert_ne!(
         mismatched,
@@ -294,7 +287,7 @@ fn mismatched_trusted_writer_name_still_denies_skill_meta() {
     let err = std::fs::write(&target, b"{}\n").expect_err(
         "write must fail when the configured trusted writer does not match the test process",
     );
-    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
     assert!(
         !fx.source_skill_meta(skill).join("manifest.json").exists(),
         "mismatched-gate write must not have hit disk"
@@ -538,7 +531,7 @@ fn mismatched_exe_identity_denies_skill_meta_write() {
     let target = fx.skill_meta(skill).join("manifest.json");
     let err = std::fs::write(&target, b"{}\n")
         .expect_err("write must fail when exe identity does not match");
-    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
 }
 
 #[cfg(target_os = "linux")]

--- a/src/skillfs/crates/skillfs-fuse/tests/trusted_skill_meta_view_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/trusted_skill_meta_view_tests.rs
@@ -1,0 +1,644 @@
+//! Integration tests for the trusted `.skill-meta` read/view gate.
+//!
+//! Coverage:
+//!
+//! * Untrusted processes cannot see `.skill-meta` in readdir.
+//! * Untrusted exact-path lookup/open/read of `.skill-meta/**` is denied.
+//! * Trusted processes can read `.skill-meta/**` via exact path.
+//! * Fallback snapshot: regular files read from snapshot, trusted
+//!   `.skill-meta` reads from live source.
+//! * Hidden skill: skill not visible, but trusted exact `.skill-meta`
+//!   path still accessible.
+//! * Trusted `.skill-meta` access does NOT unlock hidden skill regular
+//!   files.
+//! * Symlink/hardlink/xattr boundaries remain unchanged.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+use skillfs_fuse::security::{ActiveSkillResolver, LedgerResolveResult, TrustedWriterConfig};
+use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
+
+#[path = "common/mod.rs"]
+mod common;
+
+use crate::common::{create_skill_dir, fuse_available};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn seed_skill_with_meta(source: &Path, skill: &str) {
+    create_skill_dir(source, skill);
+    let meta = source.join(skill).join(".skill-meta");
+    std::fs::create_dir_all(&meta).expect("create .skill-meta dir");
+    std::fs::write(
+        meta.join("manifest.json"),
+        format!("{{\"skill\":\"{skill}\",\"live\":true}}\n"),
+    )
+    .expect("write manifest.json");
+}
+
+fn fixture_store(source: &Path) -> SharedSkillStore {
+    let mut store = SkillStore::new();
+    let _ = store.load_from_directory(source, &ParseConfig::default());
+    Arc::new(RwLock::new(store))
+}
+
+#[cfg(target_os = "linux")]
+fn self_comm() -> String {
+    let bytes =
+        std::fs::read(format!("/proc/{}/comm", std::process::id())).expect("/proc/<self>/comm");
+    let mut s = String::from_utf8(bytes).expect("comm utf-8");
+    if s.ends_with('\n') {
+        s.pop();
+    }
+    assert!(!s.is_empty(), "self comm must not be empty");
+    s
+}
+
+fn sorted_dir(dir: &Path) -> Vec<String> {
+    let mut entries: Vec<String> = std::fs::read_dir(dir)
+        .expect("read_dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    entries.sort();
+    entries
+}
+
+fn current_result(skill: &str) -> LedgerResolveResult {
+    let json = format!(
+        r#"{{
+            "schemaVersion": 1,
+            "skillName": "{skill}",
+            "status": "pass",
+            "decision": "current",
+            "currentVersion": "v000001",
+            "trustedVersion": "v000001"
+        }}"#
+    );
+    LedgerResolveResult::from_json_str(&json).expect("current json")
+}
+
+fn fallback_result(skill: &str, snapshot_segment: &str) -> LedgerResolveResult {
+    let json = format!(
+        r#"{{
+            "schemaVersion": 1,
+            "skillName": "{skill}",
+            "status": "deny",
+            "decision": "fallback",
+            "currentVersion": "v000003",
+            "trustedVersion": "{snapshot_segment}",
+            "target": ".skill-meta/versions/{snapshot_segment}",
+            "targetKind": "relative_to_skill_dir",
+            "reason": "current version has high-risk findings"
+        }}"#
+    );
+    LedgerResolveResult::from_json_str(&json).expect("fallback json")
+}
+
+fn hidden_result(skill: &str) -> LedgerResolveResult {
+    let json = format!(
+        r#"{{
+            "schemaVersion": 1,
+            "skillName": "{skill}",
+            "status": "deny",
+            "decision": "hidden",
+            "reason": "no trusted version available"
+        }}"#
+    );
+    LedgerResolveResult::from_json_str(&json).expect("hidden json")
+}
+
+fn write_snapshot(
+    source: &Path,
+    skill: &str,
+    version: &str,
+    skill_md: &str,
+    files: &[(&str, &str)],
+) -> PathBuf {
+    let dir = source
+        .join(skill)
+        .join(".skill-meta/versions")
+        .join(version);
+    std::fs::create_dir_all(&dir).expect("create snapshot dir");
+    std::fs::write(dir.join("SKILL.md"), skill_md).expect("write snapshot SKILL.md");
+    for (rel, body) in files {
+        let p = dir.join(rel);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).expect("snapshot parent");
+        }
+        std::fs::write(&p, body).expect("snapshot file");
+    }
+    dir
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixture
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[allow(dead_code)]
+struct MetaViewFixture {
+    source: tempfile::TempDir,
+    mountpoint: tempfile::TempDir,
+    handle: Option<MountHandle>,
+}
+
+impl MetaViewFixture {
+    fn new<S, R>(seed: S, trusted_writer: Option<TrustedWriterConfig>, resolver_builder: R) -> Self
+    where
+        S: FnOnce(&Path),
+        R: FnOnce(&Path) -> Option<Arc<ActiveSkillResolver>>,
+    {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let resolver = resolver_builder(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+
+        let store = fixture_store(source.path());
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            store,
+            MountOptions::default(),
+            false,
+            MountConfig {
+                trusted_writer,
+                active_resolver: resolver,
+                ..MountConfig::default()
+            },
+        )
+        .expect("mount_background_configured");
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            source,
+            mountpoint,
+            handle: Some(handle),
+        }
+    }
+
+    fn skills_dir(&self) -> PathBuf {
+        self.mountpoint.path().join("skills")
+    }
+
+    fn skill_dir(&self, name: &str) -> PathBuf {
+        self.skills_dir().join(name)
+    }
+
+    fn skill_meta(&self, skill: &str) -> PathBuf {
+        self.skill_dir(skill).join(".skill-meta")
+    }
+}
+
+impl Drop for MetaViewFixture {
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            drop(h);
+        }
+        let mp = self.mountpoint.path().to_path_buf();
+        std::thread::sleep(Duration::from_millis(150));
+        let _ = std::process::Command::new("fusermount3")
+            .args(["-u", &mp.to_string_lossy()])
+            .output();
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Untrusted readdir does not show .skill-meta
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn untrusted_readdir_hides_skill_meta() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = MetaViewFixture::new(
+        |src| seed_skill_with_meta(src, "alpha"),
+        None, // no trusted writer
+        |_| None,
+    );
+    let listing = sorted_dir(&fx.skill_dir("alpha"));
+    assert!(
+        listing.contains(&"SKILL.md".to_string()),
+        "SKILL.md must be visible, got {listing:?}"
+    );
+    assert!(
+        !listing.contains(&".skill-meta".to_string()),
+        ".skill-meta must be hidden from readdir, got {listing:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Untrusted exact .skill-meta lookup/open/read is denied
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn untrusted_exact_skill_meta_lookup_denied() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = MetaViewFixture::new(|src| seed_skill_with_meta(src, "alpha"), None, |_| None);
+    let meta_dir = fx.skill_meta("alpha");
+    let err =
+        std::fs::metadata(&meta_dir).expect_err("lookup of .skill-meta must fail for untrusted");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ENOENT),
+        "expected ENOENT for untrusted .skill-meta lookup, got {err:?}"
+    );
+    let manifest = meta_dir.join("manifest.json");
+    let err = std::fs::read(&manifest)
+        .expect_err("read of .skill-meta/manifest.json must fail for untrusted");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ENOENT),
+        "expected ENOENT for untrusted .skill-meta/manifest.json read, got {err:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Trusted process can read live .skill-meta
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_process_reads_live_skill_meta() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| seed_skill_with_meta(src, "alpha"),
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |_| None,
+    );
+    let manifest = fx.skill_meta("alpha").join("manifest.json");
+    let content = std::fs::read_to_string(&manifest)
+        .expect("trusted process must be able to read .skill-meta/manifest.json");
+    assert!(
+        content.contains("\"live\":true"),
+        "content must come from live source, got: {content}"
+    );
+    let meta_stat = std::fs::metadata(fx.skill_meta("alpha"));
+    assert!(
+        meta_stat.is_ok(),
+        "trusted process must be able to stat .skill-meta dir"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Fallback snapshot: regular from snapshot, trusted .skill-meta from live
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn fallback_snapshot_trusted_meta_reads_live_source() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| {
+            seed_skill_with_meta(src, "demo-weather");
+            std::fs::create_dir_all(src.join("demo-weather/scripts")).unwrap();
+            std::fs::write(
+                src.join("demo-weather/scripts/run.sh"),
+                "#!/bin/sh\necho live\n",
+            )
+            .unwrap();
+            write_snapshot(
+                src,
+                "demo-weather",
+                "v000001.snapshot",
+                "---\nname: demo-weather\ndescription: snapshot\n---\n",
+                &[("scripts/run.sh", "#!/bin/sh\necho snapshot\n")],
+            );
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&fallback_result("demo-weather", "v000001.snapshot"))
+                .unwrap();
+            Some(Arc::new(r))
+        },
+    );
+    // Regular file reads from snapshot
+    let script = std::fs::read_to_string(fx.skill_dir("demo-weather").join("scripts/run.sh"))
+        .expect("regular file should be readable");
+    assert!(
+        script.contains("echo snapshot"),
+        "regular file must come from snapshot, got: {script}"
+    );
+    // Trusted .skill-meta reads from live source
+    let manifest = std::fs::read_to_string(fx.skill_meta("demo-weather").join("manifest.json"))
+        .expect("trusted .skill-meta must be readable even in fallback");
+    assert!(
+        manifest.contains("\"live\":true"),
+        ".skill-meta must come from live source, got: {manifest}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Hidden skill: skill not visible, but trusted .skill-meta accessible
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn hidden_skill_trusted_meta_still_accessible() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| {
+            seed_skill_with_meta(src, "hidden-skill");
+            create_skill_dir(src, "visible-skill");
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&hidden_result("hidden-skill")).unwrap();
+            r.set_from_resolve(&current_result("visible-skill"))
+                .unwrap();
+            Some(Arc::new(r))
+        },
+    );
+    // Hidden skill not in readdir
+    let listing = sorted_dir(&fx.skills_dir());
+    assert!(
+        !listing.contains(&"hidden-skill".to_string()),
+        "hidden skill must not appear in /skills, got {listing:?}"
+    );
+    // Trusted writer can traverse hidden skill dir (needed for
+    // .skill-meta exact-path access), but the skill is still hidden
+    // from readdir and the Passthrough gate blocks non-meta files.
+    // Trusted exact .skill-meta path succeeds
+    let manifest = std::fs::read_to_string(fx.skill_meta("hidden-skill").join("manifest.json"))
+        .expect("trusted .skill-meta on hidden skill must be readable");
+    assert!(
+        manifest.contains("\"live\":true"),
+        "content must be from live source, got: {manifest}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Trusted .skill-meta access does NOT unlock hidden skill regular files
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_meta_does_not_unlock_hidden_skill_regular_files() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| {
+            seed_skill_with_meta(src, "secret-skill");
+            std::fs::write(src.join("secret-skill/private.txt"), "secret content\n").unwrap();
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&hidden_result("secret-skill")).unwrap();
+            Some(Arc::new(r))
+        },
+    );
+    // Trusted .skill-meta readable
+    let manifest = std::fs::read_to_string(fx.skill_meta("secret-skill").join("manifest.json"))
+        .expect("trusted .skill-meta must be readable");
+    assert!(manifest.contains("\"live\":true"));
+    // Regular file still hidden
+    let err = std::fs::read_to_string(fx.skill_dir("secret-skill").join("private.txt"))
+        .expect_err("regular file on hidden skill must remain inaccessible");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ENOENT),
+        "expected ENOENT for hidden skill regular file, got {err:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Symlink/hardlink/xattr boundaries not relaxed
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_meta_view_does_not_relax_symlink_boundary() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| {
+            seed_skill_with_meta(src, "alpha");
+            std::fs::write(src.join("alpha/regular.txt"), b"normal\n").unwrap();
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |_| None,
+    );
+    // Trusted writer can read .skill-meta
+    let _manifest = std::fs::read_to_string(fx.skill_meta("alpha").join("manifest.json"))
+        .expect("trusted read must work");
+    // But cannot create symlinks inside .skill-meta
+    let link_path = fx.skill_meta("alpha").join("link-to-regular");
+    let err = std::os::unix::fs::symlink("../regular.txt", &link_path)
+        .expect_err("symlink inside .skill-meta must still be denied");
+    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+    // And cannot hardlink from .skill-meta out
+    let dst = fx.skill_dir("alpha").join("manifest-copy.json");
+    let err = std::fs::hard_link(fx.skill_meta("alpha").join("manifest.json"), &dst)
+        .expect_err("hardlink from .skill-meta must still be denied");
+    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Trusted fallback: read_dir(.skill-meta) lists live source metadata
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_fallback_readdir_skill_meta_lists_live_source() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| {
+            seed_skill_with_meta(src, "demo-weather");
+            std::fs::create_dir_all(src.join("demo-weather/scripts")).unwrap();
+            std::fs::write(
+                src.join("demo-weather/scripts/run.sh"),
+                "#!/bin/sh\necho live\n",
+            )
+            .unwrap();
+            write_snapshot(
+                src,
+                "demo-weather",
+                "v000001.snapshot",
+                "---\nname: demo-weather\ndescription: snapshot\n---\n",
+                &[("scripts/run.sh", "#!/bin/sh\necho snapshot\n")],
+            );
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&fallback_result("demo-weather", "v000001.snapshot"))
+                .unwrap();
+            Some(Arc::new(r))
+        },
+    );
+    let meta_listing = sorted_dir(&fx.skill_meta("demo-weather"));
+    assert!(
+        meta_listing.contains(&"manifest.json".to_string()),
+        "trusted readdir of .skill-meta must include manifest.json, got {meta_listing:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Trusted hidden: read_dir(.skill-meta) succeeds
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_hidden_readdir_skill_meta_succeeds() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| {
+            seed_skill_with_meta(src, "hidden-skill");
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&hidden_result("hidden-skill")).unwrap();
+            Some(Arc::new(r))
+        },
+    );
+    let meta_listing = sorted_dir(&fx.skill_meta("hidden-skill"));
+    assert!(
+        meta_listing.contains(&"manifest.json".to_string()),
+        "trusted readdir of hidden .skill-meta must include manifest.json, got {meta_listing:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Trusted O_TRUNC/O_CREAT still goes through mutation gate
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_mutating_open_goes_through_policy() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| seed_skill_with_meta(src, "alpha"),
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |_| None,
+    );
+    // Trusted writer: read-only open succeeds
+    let manifest = fx.skill_meta("alpha").join("manifest.json");
+    let _content = std::fs::read_to_string(&manifest).expect("trusted read must succeed");
+    // Trusted writer: write open also succeeds (enforce_skill_meta allows it)
+    std::fs::write(&manifest, b"{\"updated\":true}\n")
+        .expect("trusted writer write must succeed through policy gate");
+    let updated = std::fs::read_to_string(&manifest).expect("re-read after write");
+    assert!(
+        updated.contains("\"updated\":true"),
+        "write must have landed, got: {updated}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 11. Trusted parent listing includes .skill-meta
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_parent_listing_includes_skill_meta() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| seed_skill_with_meta(src, "alpha"),
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |_| None,
+    );
+    let listing = sorted_dir(&fx.skill_dir("alpha"));
+    assert!(
+        listing.contains(&".skill-meta".to_string()),
+        "trusted caller must see .skill-meta in parent listing, got {listing:?}"
+    );
+    assert!(
+        listing.contains(&"SKILL.md".to_string()),
+        "SKILL.md must still be visible, got {listing:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 12. Trusted inbox .skill-meta read-only open/read succeeds
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn trusted_inbox_skill_meta_read_succeeds() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = MetaViewFixture::new(
+        |src| seed_skill_with_meta(src, "alpha"),
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |_| None,
+    );
+    let inbox_manifest = fx
+        .mountpoint
+        .path()
+        .join(".skillfs-inbox/alpha/.skill-meta/manifest.json");
+    let content = std::fs::read_to_string(&inbox_manifest)
+        .expect("trusted inbox .skill-meta read must succeed");
+    assert!(
+        content.contains("\"live\":true"),
+        "inbox .skill-meta must come from source, got: {content}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 13. Untrusted parent listing still hides .skill-meta (regression guard)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn untrusted_parent_listing_still_hides_skill_meta() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = MetaViewFixture::new(|src| seed_skill_with_meta(src, "alpha"), None, |_| None);
+    let listing = sorted_dir(&fx.skill_dir("alpha"));
+    assert!(
+        !listing.contains(&".skill-meta".to_string()),
+        "untrusted caller must NOT see .skill-meta, got {listing:?}"
+    );
+}


### PR DESCRIPTION
## Summary

This PR tightens `.skill-meta` visibility and access through the SkillFS
mount path.

- Hide `.skill-meta` from untrusted directory listings and exact-path probes.
- Route trusted `.skill-meta/**` access to the live source directory.
- Preserve hidden/fallback public skill views for ordinary skill files.
- Keep mutating `.skill-meta` opens on the existing policy/audit path.

## What changed

Trusted metadata access now uses the existing trusted-writer identity gate.
When the caller is trusted, exact-path `.skill-meta/**` lookup/getattr/access/open
and directory listing use the live source tree, even if the public skill view is
hidden or fallback-mapped to a snapshot.

Untrusted callers receive `ENOENT` for `.skill-meta/**` exact-path access and do
not see `.skill-meta` in directory listings. Staging and pending install listings
also filter `.skill-meta`.

## Validation

- `cargo +1.86.0 fmt --all --check`
- `cargo +1.86.0 clippy -p skillfs-fuse --tests -- -D warnings`
- `cargo +1.86.0 test -p skillfs-fuse --test trusted_skill_meta_view_tests`
- `cargo +1.86.0 test -p skillfs-fuse --test install_staging_tests`
- `cargo +1.86.0 test -p skillfs-fuse --test posix_xattr_tests`

## Related Issue

Closes #1115
