### PR TITLE
feat(anolisa): add raw-backend runtime dependency preflight

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -44,9 +44,10 @@ use anolisa_core::state::{
     ObjectStatus, OperationRecord, OwnedFile, Ownership, RpmMetadata, ServiceRef,
 };
 use anolisa_core::{
-    ArtifactType, CapabilityRequest, ComponentManifest, DistributionEntry, DistributionIndex,
-    FileKind, HookPhase, HookSpec, ResolveQuery, ServiceActivation, ServiceManager, ServiceRequest,
-    ServiceRunOutcome, ServiceScope, apply_capabilities, apply_services,
+    ArtifactType, CapabilityRequest, ComponentManifest, DependencyKind, DependencyResolution,
+    DependencyResolver, DependencyStatus, DistributionEntry, DistributionIndex, FileKind,
+    HookPhase, HookSpec, ResolveQuery, ResolverEnv, ServiceActivation, ServiceManager,
+    ServiceRequest, ServiceRunOutcome, ServiceScope, apply_capabilities, apply_services,
     capability_for_install_mode, deactivate_services, expand_layout_placeholders,
     resolve_manifest_hooks, run_hooks, service_for_install_mode, user_service_for_install_mode,
 };
@@ -123,6 +124,58 @@ struct InstallPreview {
     files: Vec<ResolvedInstallFile>,
     services: Vec<ServiceRequest>,
     capabilities: Vec<CapabilityRequest>,
+    /// Runtime-dependency preflight outcomes. Empty when the artifact was not
+    /// downloaded (file/service details unavailable) or the component declares
+    /// none.
+    dependencies: Vec<DependencyResolution>,
+}
+
+/// Project detected host facts onto the slice the dependency resolver needs.
+fn resolver_env_from_facts(facts: &anolisa_env::EnvFacts) -> ResolverEnv {
+    ResolverEnv {
+        kernel: facts.kernel.clone(),
+        // `os_id` (raw `/etc/os-release` ID) maps to the coarse rpm/deb family;
+        // the legacy `EnvFacts::pkg_base` is Anolis-specific and unsuitable here.
+        pkg_base: facts
+            .os_id
+            .as_deref()
+            .and_then(anolisa_env::pkg_base_from_id),
+        btf: facts.btf,
+        cap_bpf: facts.cap_bpf,
+    }
+}
+
+/// Runtime-dependency preflight shared by the fresh-install (`execute_raw`) and
+/// update (`execute_raw_update`) paths. Probes every declared dependency
+/// through the system resolver and returns the satisfied plan's (soft)
+/// warnings, or an error listing every miss so the caller can refuse **before
+/// touching the host**. Empty `runtime_deps` is a no-op. The RPM backend never
+/// calls this — dnf owns its `Requires`, so a dependency is never resolved
+/// twice. Pure probe: never mutates.
+pub(crate) fn run_runtime_preflight(
+    manifest: &ComponentManifest,
+    env: &anolisa_env::EnvFacts,
+    command: &str,
+) -> Result<Vec<String>, CliError> {
+    if manifest.runtime_deps.is_empty() {
+        return Ok(Vec::new());
+    }
+    let plan = DependencyResolver::system()
+        .resolve(&manifest.runtime_deps, &resolver_env_from_facts(env))
+        .map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("invalid runtime dependency declaration: {err}"),
+        })?;
+    if !plan.is_satisfied() {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "missing runtime dependencies; no files were changed:\n  {}",
+                plan.unsatisfied_lines().join("\n  ")
+            ),
+        });
+    }
+    Ok(plan.warnings)
 }
 
 /// Execution input after the artifact has been verified and its install
@@ -180,8 +233,75 @@ struct InstallPlanPayload {
     /// Human-readable `path: cap,cap` lines for the capabilities install
     /// would apply. Rendered for `--dry-run`; setcap is never run here.
     capabilities: Vec<String>,
+    /// Runtime-dependency preflight rows the real install would enforce.
+    /// Reported only; `--dry-run` never fails on a missing dependency.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dependencies: Vec<DependencyPlanRow>,
     dry_run: bool,
     warnings: Vec<String>,
+}
+
+/// Flat preflight status for the dry-run wire. Projects the data-carrying
+/// [`DependencyStatus`] onto a serializable tag; its payload moves to
+/// [`DependencyPlanRow::note`].
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+enum DependencyPlanStatus {
+    Resolved,
+    Unresolved,
+    Unresolvable,
+}
+
+impl DependencyPlanStatus {
+    /// Display spelling, matching the serde representation.
+    fn as_str(self) -> &'static str {
+        match self {
+            DependencyPlanStatus::Resolved => "resolved",
+            DependencyPlanStatus::Unresolved => "unresolved",
+            DependencyPlanStatus::Unresolvable => "unresolvable",
+        }
+    }
+}
+
+/// One dependency row in the `--dry-run` plan, mirroring a
+/// [`DependencyResolution`] onto the wire.
+#[derive(Serialize)]
+struct DependencyPlanRow {
+    /// Logical dependency name.
+    name: String,
+    /// Dependency kind; serializes kebab-case (e.g. `system-package`).
+    kind: DependencyKind,
+    /// Preflight outcome.
+    status: DependencyPlanStatus,
+    /// Remediation command (`unresolved`) or reason (`unresolvable`); absent
+    /// when resolved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+    /// Optional human note (e.g. an unverified version constraint).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+impl DependencyPlanRow {
+    /// Project a resolver outcome onto the dry-run wire row.
+    fn from_resolution(r: &DependencyResolution) -> Self {
+        let (status, note) = match &r.status {
+            DependencyStatus::Resolved => (DependencyPlanStatus::Resolved, None),
+            DependencyStatus::Unresolved { remediation } => {
+                (DependencyPlanStatus::Unresolved, Some(remediation.clone()))
+            }
+            DependencyStatus::Unresolvable { reason } => {
+                (DependencyPlanStatus::Unresolvable, Some(reason.clone()))
+            }
+        };
+        DependencyPlanRow {
+            name: r.name.clone(),
+            kind: r.kind,
+            status,
+            note,
+            detail: r.detail.clone(),
+        }
+    }
 }
 
 /// Wire shape for a completed install.
@@ -1926,6 +2046,7 @@ fn build_install_preview(
             files: Vec::new(),
             services: Vec::new(),
             capabilities: Vec::new(),
+            dependencies: Vec::new(),
         });
     };
 
@@ -1947,12 +2068,43 @@ fn build_install_preview(
         Err(err) => return Err(err),
     };
 
+    let dependencies = preview_dependencies(&contract.manifest, &mut resolution);
+
     Ok(InstallPreview {
         resolution,
         files,
         services,
         capabilities,
+        dependencies,
     })
+}
+
+/// Run the runtime-dependency preflight for `--dry-run` (read-only). Reports
+/// per-dependency status without ever failing the preview: a missing dependency
+/// is informational here, and a declaration error degrades to a warning rather
+/// than aborting the plan.
+fn preview_dependencies(
+    manifest: &ComponentManifest,
+    resolution: &mut RawResolution,
+) -> Vec<DependencyResolution> {
+    if manifest.runtime_deps.is_empty() {
+        return Vec::new();
+    }
+    let env = anolisa_env::EnvService::detect();
+    match DependencyResolver::system()
+        .resolve(&manifest.runtime_deps, &resolver_env_from_facts(&env))
+    {
+        Ok(plan) => {
+            resolution.warnings.extend(plan.warnings);
+            plan.resolutions
+        }
+        Err(err) => {
+            resolution
+                .warnings
+                .push(format!("dependency preflight skipped: {err}"));
+            Vec::new()
+        }
+    }
 }
 
 pub(crate) fn prepare_raw_execution(
@@ -2621,6 +2773,18 @@ fn execute_raw(
             command: command.to_string(),
             reason: format!("failed to parse component manifest for hook resolution: {err}"),
         })?;
+
+    // Runtime-dependency preflight — probe declared dependencies while the lock
+    // is held but before any filesystem mutation, so a missing dependency fails
+    // fast with a remediation instead of a service that silently dies after a
+    // "successful" install. The RPM backend never reaches here (dnf resolves its
+    // `Requires`), so a dependency is never resolved twice. Host facts are
+    // detected once and reused for the capability step below.
+    let env = anolisa_env::EnvService::detect();
+    resolution
+        .warnings
+        .extend(run_runtime_preflight(&manifest, &env, command)?);
+
     let hooks = resolve_install_hooks(&manifest, layout, &resolution.component)?;
     let log = CentralLog::open(layout.central_log.clone());
 
@@ -2671,8 +2835,8 @@ fn execute_raw(
     // A required (non-optional) failure aborts: roll back files + manifest
     // while the lock is still held and before any state is persisted, so no
     // half-installed component survives. Optional failures degrade to
-    // warnings. Reuses the `log` handle opened before file layout.
-    let env = anolisa_env::EnvService::detect();
+    // warnings. Reuses the `log` handle opened before file layout and the
+    // `env` facts detected for the dependency preflight above.
     let cap_manager = capability_for_install_mode(ctx.install_mode.as_str(), &env);
     let cap_outcome = apply_capabilities(
         cap_manager.as_ref(),
@@ -3039,6 +3203,11 @@ fn render_plan(ctx: &CliContext, preview: &InstallPreview) -> Result<(), CliErro
             .iter()
             .map(|c| format!("{}: {}", c.path.display(), c.caps.join(",")))
             .collect(),
+        dependencies: preview
+            .dependencies
+            .iter()
+            .map(DependencyPlanRow::from_resolution)
+            .collect(),
         dry_run: true,
         warnings: resolved.warnings.clone(),
     };
@@ -3088,6 +3257,19 @@ fn render_plan(ctx: &CliContext, preview: &InstallPreview) -> Result<(), CliErro
         println!("{}", color.header("capabilities (applied on install):"));
         for c in &payload.capabilities {
             println!("  - {c}");
+        }
+    }
+    if !payload.dependencies.is_empty() {
+        println!("{}", color.header("dependencies (preflight):"));
+        for d in &payload.dependencies {
+            let (kind, status) = (d.kind.as_str(), d.status.as_str());
+            match &d.note {
+                Some(note) => println!("  - {} [{kind}]: {status} — {note}", d.name),
+                None => println!("  - {} [{kind}]: {status}", d.name),
+            }
+            if let Some(detail) = &d.detail {
+                println!("      {detail}");
+            }
         }
     }
     render_warnings(&payload.warnings, &color);
@@ -3442,6 +3624,59 @@ mod tests {
             repo: None,
             package: None,
         }
+    }
+
+    #[test]
+    fn dependency_plan_row_projects_each_status() {
+        let resolved = DependencyResolution {
+            name: "btrfs-progs".to_string(),
+            kind: DependencyKind::SystemPackage,
+            status: DependencyStatus::Resolved,
+            detail: None,
+        };
+        let row = DependencyPlanRow::from_resolution(&resolved);
+        assert!(matches!(row.kind, DependencyKind::SystemPackage));
+        assert_eq!(row.status.as_str(), "resolved");
+        assert!(row.note.is_none());
+
+        let missing = DependencyResolution {
+            name: "btrfs-progs".to_string(),
+            kind: DependencyKind::SystemPackage,
+            status: DependencyStatus::Unresolved {
+                remediation: "sudo dnf install btrfs-progs".to_string(),
+            },
+            detail: None,
+        };
+        let row = DependencyPlanRow::from_resolution(&missing);
+        assert_eq!(row.status.as_str(), "unresolved");
+        assert_eq!(row.note.as_deref(), Some("sudo dnf install btrfs-progs"));
+
+        let cap = DependencyResolution {
+            name: "btrfs".to_string(),
+            kind: DependencyKind::PlatformCapability,
+            status: DependencyStatus::Unresolvable {
+                reason: "requires kernel >= 5.4, host is 3.10".to_string(),
+            },
+            detail: None,
+        };
+        let row = DependencyPlanRow::from_resolution(&cap);
+        assert_eq!(row.status.as_str(), "unresolvable");
+        assert!(row.note.unwrap().contains("kernel >= 5.4"));
+    }
+
+    #[test]
+    fn dependency_plan_row_serializes_kind_and_status_kebab_case() {
+        // The enum-typed `kind`/`status` must reach the wire as kebab-case so
+        // the JSON contract is unchanged by using enums instead of strings.
+        let row = DependencyPlanRow::from_resolution(&DependencyResolution {
+            name: "btrfs-progs".to_string(),
+            kind: DependencyKind::SystemPackage,
+            status: DependencyStatus::Resolved,
+            detail: None,
+        });
+        let json = serde_json::to_string(&row).expect("serialize");
+        assert!(json.contains("\"kind\":\"system-package\""), "{json}");
+        assert!(json.contains("\"status\":\"resolved\""), "{json}");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -48,9 +48,9 @@ use anolisa_core::transaction::{
     TransactionStepStatus,
 };
 use anolisa_core::{
-    CapabilityRunOutcome, ServiceActivation, ServiceRequest, ServiceRunOutcome, ServiceScope,
-    apply_capabilities, apply_services, capability_for_install_mode, service_for_install_mode,
-    user_service_for_install_mode,
+    CapabilityRunOutcome, ComponentManifest, ServiceActivation, ServiceRequest, ServiceRunOutcome,
+    ServiceScope, apply_capabilities, apply_services, capability_for_install_mode,
+    service_for_install_mode, user_service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
@@ -61,7 +61,8 @@ use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use super::install::{
     PreparedInstall, artifact_type_wire, available_raw_versions, prepare_raw_execution,
-    resolve_raw, resolve_raw_inputs_for_component, write_installed_component_manifest,
+    resolve_raw, resolve_raw_inputs_for_component, run_runtime_preflight,
+    write_installed_component_manifest,
 };
 use crate::color::Palette;
 use crate::commands::common;
@@ -586,6 +587,21 @@ fn execute_raw_update(
     let artifact_url = resolution.artifact_url.clone();
     let artifact_type = artifact_type_wire(&resolution.entry.artifact_type);
 
+    // Runtime-dependency preflight — a newer artifact may declare dependencies
+    // the installed version did not; replacing files on a host that misses them
+    // would strand the component exactly like a fresh install. Probe before the
+    // first filesystem mutation (Phase 1 backup/remove below) and before the
+    // transaction opens, so a miss aborts with nothing touched. RPM never here.
+    let preflight_warnings = {
+        let manifest =
+            ComponentManifest::from_toml_str(&manifest_toml).map_err(|err| CliError::Runtime {
+                command: command.to_string(),
+                reason: format!("failed to parse component manifest for preflight: {err}"),
+            })?;
+        let env = anolisa_env::EnvService::detect();
+        run_runtime_preflight(&manifest, &env, command)?
+    };
+
     let state_path = layout.state_dir.join("installed.toml");
     let journal_dir = layout.state_dir.join("journal");
     let mut tx = Transaction::begin("update", state_path.clone(), &journal_dir).map_err(|err| {
@@ -886,6 +902,7 @@ fn execute_raw_update(
     let mut execution_warnings = cap_warnings;
     execution_warnings.extend(service_run.warnings);
     execution_warnings.extend(activation_state_warnings);
+    execution_warnings.extend(preflight_warnings);
     let mut all_warnings = warnings.to_vec();
     all_warnings.extend(execution_warnings.clone());
     let record = LogRecord {
@@ -2653,6 +2670,66 @@ sha256 = "{sha}"
                 .as_deref(),
             Some("0.2.0"),
             "refused downgrade must not change the recorded version"
+        );
+    }
+
+    /// A newer artifact that declares a dependency the host lacks must be
+    /// refused before any file is touched: the raw update path runs the same
+    /// runtime preflight as a fresh install. Regression for the update path
+    /// previously bypassing the resolver entirely.
+    #[test]
+    fn raw_update_refuses_when_new_artifact_adds_unmet_dependency() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().join("sys"), InstallMode::System, false);
+        let old_body: &[u8] = b"installed 0.1.0\n";
+        seed_installed_raw(&c, "foo", "0.1.0", old_body);
+
+        // v2's contract adds a system-package whose probe can never succeed, so
+        // the preflight fails on every host.
+        let deps = r#"
+[[component.dependencies]]
+name = "absent-tool"
+kind = "system-package"
+probe = "anolisa-nonexistent-probe-xyz --version"
+packages = { rpm = "absent-tool", deb = "absent-tool" }
+"#;
+        let manifest = format!("{}{}", raw_manifest("foo", "0.2.0"), deps);
+        let new_body: &[u8] = b"#!/bin/sh\necho foo v2\n";
+        let artifact = tar_gz(&[
+            (".anolisa/component.toml", manifest.as_bytes()),
+            ("bin/foo", new_body),
+        ]);
+        publish_raw_repo(
+            &tmp.path().join("repo"),
+            &common::resolve_layout(&c),
+            "foo",
+            "0.2.0",
+            &artifact,
+        );
+
+        let err = update_raw_component("foo", "raw", "0.1.0", None, &c, "update foo")
+            .expect_err("update must refuse when the new artifact adds an unmet dependency");
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("missing runtime dependencies"),
+            "error must come from the runtime preflight, got: {}",
+            err.reason()
+        );
+
+        // Preflight runs before Phase 1, so nothing was touched.
+        let layout = common::resolve_layout(&c);
+        assert_eq!(
+            std::fs::read(layout.bin_dir.join("foo")).expect("read bin"),
+            old_body,
+            "refused update must not touch the old binary"
+        );
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "foo")
+                .map(|o| o.version.clone())
+                .as_deref(),
+            Some("0.1.0"),
+            "refused update must not change the recorded version"
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -1987,6 +1987,7 @@ mod tests {
             backends: ManifestBackends::default(),
             env_requirements: EnvRequirements::default(),
             dependencies: DependenciesSpec::default(),
+            runtime_deps: Vec::new(),
             features: Vec::new(),
             adapters: vec![AdapterSpec {
                 framework: Some("openclaw".to_string()),

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod path_safety;
 pub mod process;
 pub mod register;
 pub mod registry;
+pub mod resolver;
 pub mod sandbox_manifest;
 pub mod self_update;
 pub mod service;
@@ -79,7 +80,8 @@ pub use lifecycle::{
 };
 pub use lock::{InstallLock, LockError};
 pub use manifest::{
-    AdapterSpec, ComponentManifest, DistributionSelector, FileKind, HealthSpec, ServiceScope,
+    AdapterSpec, ComponentManifest, DependencyKind, DistributionSelector, FileKind, HealthSpec,
+    PackageNames, RuntimeDependency, ServiceScope,
 };
 pub use metadata::MetadataClient;
 pub use register::{
@@ -89,6 +91,10 @@ pub use register::{
 pub use registry::{
     FetchFailure, FetchedMeta, HttpFetch, IndexFreshness, Registry, RegistryClient, RegistryConfig,
     RegistryError, UreqFetch,
+};
+pub use resolver::{
+    DependencyResolution, DependencyResolver, DependencyStatus, ResolutionPlan, ResolverEnv,
+    ResolverError,
 };
 pub use self_update::{
     ReleaseArtifact, ReleaseManifest, SelfUpdateError, SelfUpdateOutcome, check_and_update,

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -58,6 +58,15 @@ pub struct ComponentManifest {
     /// (e.g. resolver only follows `components`, doctor only checks
     /// `runtime`).
     pub dependencies: DependenciesSpec,
+    /// Structured `[[component.dependencies]]` entries the raw backend
+    /// preflights before laying files. Distinct from the flat
+    /// [`dependencies`](Self::dependencies): each entry carries a
+    /// [`DependencyKind`] and probe/remediation metadata so the resolver can
+    /// fail fast on a missing runtime dependency instead of letting a service
+    /// silently die after install. Empty for components with no declared
+    /// runtime dependencies.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_deps: Vec<RuntimeDependency>,
     /// Feature toggles exposed by this component manifest.
     pub features: Vec<FeatureSpec>,
     /// `[[adapters]]` declarations preserved verbatim. The component schema
@@ -454,6 +463,100 @@ impl DependenciesSpec {
     }
 }
 
+/// Resolution bucket for a [`RuntimeDependency`]. The kind decides what the
+/// preflight does when the dependency is missing — the strategy is dispatched
+/// by bucket, never hard-coded per dependency name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DependencyKind {
+    /// A language interpreter/runtime (e.g. Node). Vendored into the
+    /// component's isolated prefix; never touches the user's global install.
+    LanguageRuntime,
+    /// A system package installed by the host package manager (e.g.
+    /// `btrfs-progs`). Shared infrastructure: the preflight reports the install
+    /// command but never removes it on uninstall.
+    SystemPackage,
+    /// A kernel/platform capability that no package manager can install (e.g.
+    /// in-kernel btrfs support, eBPF BTF / `CAP_BPF`). Check-only; a miss is
+    /// fatal with a kernel/capability requirement.
+    PlatformCapability,
+}
+
+impl DependencyKind {
+    /// Wire/display spelling (kebab-case), matching the serde representation.
+    /// Shared by the resolver and CLI so labels never drift from the schema.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DependencyKind::LanguageRuntime => "language-runtime",
+            DependencyKind::SystemPackage => "system-package",
+            DependencyKind::PlatformCapability => "platform-capability",
+        }
+    }
+}
+
+/// Per-package-format names for a [`DependencyKind::SystemPackage`].
+///
+/// The same logical dependency is often packaged under different names across
+/// distributions; this maps the package name by format (`rpm` → dnf, `deb` →
+/// apt). An absent entry for the host's format falls back to the dependency's
+/// [`name`](RuntimeDependency::name).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PackageNames {
+    /// Package name on `rpm`-based hosts (dnf).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpm: Option<String>,
+    /// Package name on `deb`-based hosts (apt).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deb: Option<String>,
+}
+
+impl PackageNames {
+    /// Whether no package-name mapping is present (used by `skip_serializing_if`
+    /// so dependencies without an explicit map round-trip cleanly).
+    pub fn is_empty(&self) -> bool {
+        self.rpm.is_none() && self.deb.is_none()
+    }
+}
+
+/// One structured `[[component.dependencies]]` entry from the artifact
+/// contract.
+///
+/// Drives the raw-backend preflight ([`crate::resolver`]): each entry is probed
+/// before any filesystem mutation, and a miss is reported with a
+/// kind-appropriate remediation. The RPM backend ignores these — dnf resolves
+/// `Requires` instead — so the same dependency is never resolved twice.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeDependency {
+    /// Logical dependency identifier (e.g. `btrfs-progs`, `node`).
+    pub name: String,
+    /// Resolution bucket; see [`DependencyKind`].
+    pub kind: DependencyKind,
+    /// Optional version constraint (e.g. `>=20`). Presence-first: an
+    /// unparseable constraint or probed version does not fail the preflight.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Command whose success means the dependency is satisfied (e.g.
+    /// `btrfs version`). Absent system packages fall back to a native
+    /// package-manager query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probe: Option<String>,
+    /// Distribution-source identifier for a [`DependencyKind::LanguageRuntime`]
+    /// (surfaced in the manual-install hint while vendoring is unimplemented).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Per-format package names for a [`DependencyKind::SystemPackage`].
+    #[serde(default, skip_serializing_if = "PackageNames::is_empty")]
+    pub packages: PackageNames,
+    /// Built-in capability check identifier for a
+    /// [`DependencyKind::PlatformCapability`] (e.g. `btrfs`, `btf`, `cap_bpf`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check: Option<String>,
+    /// Minimum kernel version for a [`DependencyKind::PlatformCapability`]
+    /// (e.g. `5.4`). The one hard version gate in the preflight.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_kernel: Option<String>,
+}
+
 /// One `[[adapters]]` entry. We keep every field the loader can parse so
 /// later tooling (adapter registry, doctor, build planner) does not have
 /// to re-read the TOML. `detect` is captured as a free-form map because
@@ -790,6 +893,13 @@ struct ComponentMetaRaw {
     // directly into the internally-tagged `CheckSpec` (`type = "..."`).
     #[serde(default)]
     health_check: Option<CheckSpec>,
+    // `[[component.dependencies]]` — structured runtime dependency entries, a
+    // sibling of `[component.layout]`. Nested under `[component]`, so it never
+    // collides with the top-level `[dependencies]` parsed into
+    // `ComponentManifestRaw::dependencies`. RuntimeDependency deserializes
+    // directly: `name` + `kind` are required, the rest defaults.
+    #[serde(default)]
+    dependencies: Vec<RuntimeDependency>,
 }
 
 #[derive(Deserialize, Default)]
@@ -1043,6 +1153,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             capabilities: component_capabilities,
             hooks: component_hooks,
             health_check,
+            dependencies: component_runtime_deps,
         } = raw.component;
 
         let component = ComponentMeta {
@@ -1170,6 +1281,13 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             components: raw.dependencies.components,
         };
 
+        // Drop nameless entries, mirroring the empty-unit/empty-script filters
+        // applied to services and hooks above.
+        let runtime_deps = component_runtime_deps
+            .into_iter()
+            .filter(|d| !d.name.is_empty())
+            .collect();
+
         let features = raw
             .features
             .into_iter()
@@ -1241,6 +1359,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             backends: raw.backends,
             env_requirements,
             dependencies,
+            runtime_deps,
             features,
             adapters,
             health_check,
@@ -2005,6 +2124,136 @@ mod tests {
         assert_eq!(m.dependencies.build, vec!["rust>=1.91", "clang>=14"]);
         assert_eq!(m.dependencies.runtime, vec!["kernel-headers"]);
         assert_eq!(m.dependencies.components, vec!["sec-core"]);
+    }
+
+    #[test]
+    fn runtime_deps_parse_system_package_with_packages_map() {
+        let toml_text = r#"
+            [component]
+            name = "ws-ckpt"
+            version = "0.3.3"
+
+            [[component.dependencies]]
+            name = "btrfs-progs"
+            kind = "system-package"
+            probe = "btrfs version"
+            packages = { rpm = "btrfs-progs", deb = "btrfs-progs" }
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.runtime_deps.len(), 1);
+        let d = &m.runtime_deps[0];
+        assert_eq!(d.name, "btrfs-progs");
+        assert_eq!(d.kind, DependencyKind::SystemPackage);
+        assert_eq!(d.probe.as_deref(), Some("btrfs version"));
+        assert_eq!(d.packages.rpm.as_deref(), Some("btrfs-progs"));
+        assert_eq!(d.packages.deb.as_deref(), Some("btrfs-progs"));
+    }
+
+    #[test]
+    fn runtime_deps_parse_platform_capability_check_and_min_kernel() {
+        let toml_text = r#"
+            [component]
+            name = "ws-ckpt"
+            version = "0.3.3"
+
+            [[component.dependencies]]
+            name = "btrfs"
+            kind = "platform-capability"
+            check = "btrfs"
+            min_kernel = "5.4"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.runtime_deps.len(), 1);
+        let d = &m.runtime_deps[0];
+        assert_eq!(d.kind, DependencyKind::PlatformCapability);
+        assert_eq!(d.check.as_deref(), Some("btrfs"));
+        assert_eq!(d.min_kernel.as_deref(), Some("5.4"));
+        assert!(d.packages.is_empty());
+    }
+
+    #[test]
+    fn runtime_deps_parse_language_runtime_with_version_and_source() {
+        let toml_text = r#"
+            [component]
+            name = "cosh"
+            version = "1.0.0"
+
+            [[component.dependencies]]
+            name = "node"
+            kind = "language-runtime"
+            version = ">=20"
+            probe = "node --version"
+            source = "nodejs-official"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let d = &m.runtime_deps[0];
+        assert_eq!(d.kind, DependencyKind::LanguageRuntime);
+        assert_eq!(d.version.as_deref(), Some(">=20"));
+        assert_eq!(d.source.as_deref(), Some("nodejs-official"));
+    }
+
+    #[test]
+    fn runtime_deps_kind_kebab_case_roundtrip() {
+        // The wire spelling is kebab-case; serializing back must preserve it so
+        // a contract round-trips byte-stably.
+        let dep = RuntimeDependency {
+            name: "node".into(),
+            kind: DependencyKind::LanguageRuntime,
+            version: None,
+            probe: None,
+            source: None,
+            packages: PackageNames::default(),
+            check: None,
+            min_kernel: None,
+        };
+        let text = toml::to_string(&dep).expect("serialize");
+        assert!(
+            text.contains("kind = \"language-runtime\""),
+            "kebab-case kind expected, got: {text}"
+        );
+    }
+
+    #[test]
+    fn runtime_deps_distinct_from_flat_dependencies() {
+        // The structured `[[component.dependencies]]` and the flat top-level
+        // `[dependencies]` are independent fields at different TOML paths; a
+        // manifest may carry both without either shadowing the other.
+        let toml_text = r#"
+            [component]
+            name = "ws-ckpt"
+            version = "0.3.3"
+
+            [dependencies]
+            runtime = ["legacy-flat"]
+
+            [[component.dependencies]]
+            name = "btrfs-progs"
+            kind = "system-package"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.dependencies.runtime, vec!["legacy-flat"]);
+        assert_eq!(m.runtime_deps.len(), 1);
+        assert_eq!(m.runtime_deps[0].name, "btrfs-progs");
+    }
+
+    #[test]
+    fn runtime_deps_empty_name_entry_dropped() {
+        let toml_text = r#"
+            [component]
+            name = "ws-ckpt"
+            version = "0.3.3"
+
+            [[component.dependencies]]
+            name = ""
+            kind = "system-package"
+
+            [[component.dependencies]]
+            name = "btrfs-progs"
+            kind = "system-package"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        assert_eq!(m.runtime_deps.len(), 1);
+        assert_eq!(m.runtime_deps[0].name, "btrfs-progs");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/resolver.rs
+++ b/src/anolisa/crates/anolisa-core/src/resolver.rs
@@ -1,0 +1,855 @@
+//! Raw-backend runtime-dependency preflight.
+//!
+//! Before the raw backend lays any files, it probes each declared
+//! [`RuntimeDependency`] and fails fast on a miss — turning "install succeeded,
+//! service silently dead" into a clear remediation. The RPM backend never runs
+//! this: dnf resolves `Requires` instead, so a dependency is never resolved
+//! twice. Check-only by design: the resolver reports what to install but never
+//! mutates the host.
+
+use crate::manifest::{DependencyKind, RuntimeDependency};
+use anolisa_platform::command::{CommandRunner, SystemCommandRunner};
+
+/// Host facts the preflight needs, decoupled from `anolisa_env::EnvFacts` so
+/// callers (and tests) supply only the relevant slice.
+#[derive(Debug, Clone, Default)]
+pub struct ResolverEnv {
+    /// Kernel release (`uname -r`), e.g. `5.10.134-007.ali5000`. Gates
+    /// `min_kernel` declarations.
+    pub kernel: Option<String>,
+    /// Coarse package-base family (`"rpm"` / `"deb"`) used for remediation
+    /// commands and native package queries. `None` → unsupported package
+    /// manager.
+    pub pkg_base: Option<String>,
+    /// Whether kernel BTF is available (`/sys/kernel/btf/vmlinux`).
+    pub btf: Option<bool>,
+    /// Whether `CAP_BPF` is available.
+    pub cap_bpf: Option<bool>,
+}
+
+/// Outcome of probing one dependency.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencyStatus {
+    /// Present, and any verifiable version constraint is satisfied.
+    Resolved,
+    /// Missing but installable: carries the command the user should run.
+    Unresolved {
+        /// Remediation command or instruction (e.g. `sudo dnf install
+        /// btrfs-progs`).
+        remediation: String,
+    },
+    /// Missing and not installable by any package manager (kernel/capability):
+    /// the install cannot proceed on this host.
+    Unresolvable {
+        /// Why the host cannot satisfy this dependency.
+        reason: String,
+    },
+}
+
+/// Per-dependency preflight result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyResolution {
+    /// Logical dependency name.
+    pub name: String,
+    /// Resolution bucket the dependency was dispatched through.
+    pub kind: DependencyKind,
+    /// Probe outcome.
+    pub status: DependencyStatus,
+    /// Optional human note (e.g. "version not verified against '>=20'").
+    pub detail: Option<String>,
+}
+
+/// Aggregate preflight result over all declared dependencies.
+#[derive(Debug, Clone, Default)]
+pub struct ResolutionPlan {
+    /// One entry per declared dependency, in declaration order.
+    pub resolutions: Vec<DependencyResolution>,
+    /// Non-fatal notes collected during resolution.
+    pub warnings: Vec<String>,
+}
+
+impl ResolutionPlan {
+    /// Whether every dependency resolved. `false` if any is `Unresolved` or
+    /// `Unresolvable` — the install must not proceed.
+    pub fn is_satisfied(&self) -> bool {
+        self.resolutions
+            .iter()
+            .all(|r| matches!(r.status, DependencyStatus::Resolved))
+    }
+
+    /// One line per unsatisfied dependency, for a single fail-fast message
+    /// listing every miss at once.
+    pub fn unsatisfied_lines(&self) -> Vec<String> {
+        self.resolutions
+            .iter()
+            .filter_map(|r| match &r.status {
+                DependencyStatus::Resolved => None,
+                DependencyStatus::Unresolved { remediation } => {
+                    Some(format!("{} [{}]: {remediation}", r.name, r.kind.as_str()))
+                }
+                DependencyStatus::Unresolvable { reason } => {
+                    Some(format!("{} [{}]: {reason}", r.name, r.kind.as_str()))
+                }
+            })
+            .collect()
+    }
+}
+
+/// Failure that means the contract itself is wrong. Never raised for a merely
+/// missing dependency — that is a [`DependencyStatus`], not an error.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolverError {
+    /// A `platform-capability` dependency named a `check` the resolver does not
+    /// implement.
+    #[error("dependency '{name}' has unknown platform-capability check '{check}'")]
+    UnknownCheck {
+        /// Dependency name.
+        name: String,
+        /// The unrecognized check identifier.
+        check: String,
+    },
+}
+
+/// Probes declared runtime dependencies against the host. Generic over the
+/// command runner so tests inject a fake; the default runs real commands.
+pub struct DependencyResolver<R: CommandRunner = SystemCommandRunner> {
+    runner: R,
+}
+
+impl DependencyResolver<SystemCommandRunner> {
+    /// Build a resolver that runs real host commands.
+    pub fn system() -> Self {
+        Self {
+            runner: SystemCommandRunner,
+        }
+    }
+}
+
+impl<R: CommandRunner> DependencyResolver<R> {
+    /// Build a resolver backed by a custom runner (primarily for tests).
+    pub fn with_runner(runner: R) -> Self {
+        Self { runner }
+    }
+
+    /// Probe every dependency and aggregate the outcome. Never mutates the host.
+    ///
+    /// # Errors
+    /// Returns [`ResolverError`] only when a dependency declaration is itself
+    /// invalid (e.g. an unknown platform-capability `check`); a missing
+    /// dependency is reported as a [`DependencyStatus`], not an error.
+    pub fn resolve(
+        &self,
+        deps: &[RuntimeDependency],
+        env: &ResolverEnv,
+    ) -> Result<ResolutionPlan, ResolverError> {
+        let mut plan = ResolutionPlan::default();
+        for dep in deps {
+            let (status, detail) = match dep.kind {
+                DependencyKind::SystemPackage => self.resolve_system_package(dep, env),
+                DependencyKind::LanguageRuntime => self.resolve_language_runtime(dep),
+                DependencyKind::PlatformCapability => resolve_platform_capability(dep, env)?,
+            };
+            plan.resolutions.push(DependencyResolution {
+                name: dep.name.clone(),
+                kind: dep.kind,
+                status,
+                detail,
+            });
+        }
+        Ok(plan)
+    }
+
+    /// System package: present → resolved; missing → remediation command for
+    /// the host package manager. Presence-first (no version gate in MVP).
+    fn resolve_system_package(
+        &self,
+        dep: &RuntimeDependency,
+        env: &ResolverEnv,
+    ) -> (DependencyStatus, Option<String>) {
+        let present = match &dep.probe {
+            Some(probe) => matches!(self.run_probe(probe), ProbeOutcome::Present { .. }),
+            None => self.native_package_present(dep, env),
+        };
+        if present {
+            return (DependencyStatus::Resolved, None);
+        }
+        (
+            DependencyStatus::Unresolved {
+                remediation: system_package_remediation(dep, env),
+            },
+            None,
+        )
+    }
+
+    /// Language runtime: probe presence, then a presence-first version check.
+    /// Missing → manual-install hint (no vendoring in MVP).
+    fn resolve_language_runtime(
+        &self,
+        dep: &RuntimeDependency,
+    ) -> (DependencyStatus, Option<String>) {
+        let probe = dep
+            .probe
+            .clone()
+            .unwrap_or_else(|| format!("{} --version", dep.name));
+        let ProbeOutcome::Present { stdout } = self.run_probe(&probe) else {
+            return (
+                DependencyStatus::Unresolved {
+                    remediation: language_runtime_hint(dep),
+                },
+                None,
+            );
+        };
+        match version_verdict(dep.version.as_deref(), &stdout) {
+            VersionVerdict::Ok => (DependencyStatus::Resolved, None),
+            VersionVerdict::NotVerified => (
+                DependencyStatus::Resolved,
+                dep.version
+                    .as_deref()
+                    .map(|v| format!("version not verified against '{v}'")),
+            ),
+            VersionVerdict::Mismatch { found } => (
+                DependencyStatus::Unresolved {
+                    remediation: language_runtime_hint(dep),
+                },
+                Some(format!(
+                    "found {found}, need {}",
+                    dep.version.as_deref().unwrap_or("")
+                )),
+            ),
+        }
+    }
+
+    /// Run a `program arg arg` probe string. Present iff the command spawns and
+    /// exits 0; a spawn failure (missing binary) counts as absent.
+    fn run_probe(&self, probe: &str) -> ProbeOutcome {
+        let mut parts = probe.split_whitespace();
+        let Some(program) = parts.next() else {
+            return ProbeOutcome::Absent;
+        };
+        let args: Vec<&str> = parts.collect();
+        match self.runner.run(program, &args) {
+            Ok(out) if out.code == Some(0) => ProbeOutcome::Present { stdout: out.stdout },
+            _ => ProbeOutcome::Absent,
+        }
+    }
+
+    /// Native presence query when a system package has no explicit probe:
+    /// `rpm -q` / `dpkg -s`. Unknown package manager → treated as absent (the
+    /// remediation then reports the unsupported manager).
+    fn native_package_present(&self, dep: &RuntimeDependency, env: &ResolverEnv) -> bool {
+        let (program, args): (&str, [&str; 2]) = match env.pkg_base.as_deref() {
+            Some("rpm") => (
+                "rpm",
+                ["-q", dep.packages.rpm.as_deref().unwrap_or(&dep.name)],
+            ),
+            Some("deb") => (
+                "dpkg",
+                ["-s", dep.packages.deb.as_deref().unwrap_or(&dep.name)],
+            ),
+            _ => return false,
+        };
+        matches!(self.runner.run(program, &args), Ok(out) if out.code == Some(0))
+    }
+}
+
+/// Probe result, carrying stdout for an optional version parse.
+enum ProbeOutcome {
+    Present { stdout: String },
+    Absent,
+}
+
+/// Platform capability: gate `min_kernel` first, then evaluate the built-in
+/// `check`. Never installs; a miss is `Unresolvable`.
+fn resolve_platform_capability(
+    dep: &RuntimeDependency,
+    env: &ResolverEnv,
+) -> Result<(DependencyStatus, Option<String>), ResolverError> {
+    if let Some(min) = &dep.min_kernel {
+        match kernel_satisfies(env.kernel.as_deref(), min) {
+            KernelCheck::Satisfied => {}
+            KernelCheck::Below { have } => {
+                return Ok((
+                    DependencyStatus::Unresolvable {
+                        reason: format!("requires kernel >= {min}, host is {have}"),
+                    },
+                    None,
+                ));
+            }
+            KernelCheck::Unknown => {
+                return Ok((
+                    DependencyStatus::Unresolvable {
+                        reason: format!(
+                            "requires kernel >= {min}, but the host kernel could not be determined"
+                        ),
+                    },
+                    None,
+                ));
+            }
+        }
+    }
+
+    if let Some(check) = &dep.check {
+        let result = evaluate_check(check, env).ok_or_else(|| ResolverError::UnknownCheck {
+            name: dep.name.clone(),
+            check: check.clone(),
+        })?;
+        return Ok(match result {
+            CheckResult::Supported => (DependencyStatus::Resolved, None),
+            CheckResult::Unsupported { reason } => {
+                (DependencyStatus::Unresolvable { reason }, None)
+            }
+        });
+    }
+
+    // A min_kernel-only declaration that passed the gate has nothing left to
+    // verify.
+    Ok((DependencyStatus::Resolved, None))
+}
+
+/// Remediation command for a missing system package, by host package format.
+fn system_package_remediation(dep: &RuntimeDependency, env: &ResolverEnv) -> String {
+    match env.pkg_base.as_deref() {
+        Some("rpm") => format!(
+            "sudo dnf install {}",
+            dep.packages.rpm.as_deref().unwrap_or(&dep.name)
+        ),
+        Some("deb") => format!(
+            "sudo apt install {}",
+            dep.packages.deb.as_deref().unwrap_or(&dep.name)
+        ),
+        _ => format!(
+            "unsupported package manager — install '{}' with the host package manager",
+            dep.name
+        ),
+    }
+}
+
+/// Manual-install hint for a missing language runtime (vendoring is a later
+/// phase, so MVP only tells the user what to install).
+fn language_runtime_hint(dep: &RuntimeDependency) -> String {
+    let version = dep
+        .version
+        .as_deref()
+        .map(|v| format!(" {v}"))
+        .unwrap_or_default();
+    let source = dep
+        .source
+        .as_deref()
+        .map(|s| format!(" (source: {s})"))
+        .unwrap_or_default();
+    format!("install {}{version} manually{source}", dep.name)
+}
+
+/// Result of a built-in platform-capability check.
+enum CheckResult {
+    Supported,
+    Unsupported { reason: String },
+}
+
+/// Dispatch a built-in `check` identifier. `None` → unknown identifier (a
+/// contract bug the caller turns into [`ResolverError::UnknownCheck`]). The set
+/// is intentionally small; extend it deliberately.
+fn evaluate_check(check: &str, env: &ResolverEnv) -> Option<CheckResult> {
+    match check {
+        "btf" => Some(bool_fact(env.btf, "kernel BTF (/sys/kernel/btf/vmlinux)")),
+        "cap_bpf" => Some(bool_fact(env.cap_bpf, "CAP_BPF capability")),
+        "btrfs" => Some(btrfs_supported()),
+        _ => None,
+    }
+}
+
+/// Map an `Option<bool>` env fact to a check result. `None` is conservative —
+/// "could not determine" fails the preflight, since the bug we're fixing is a
+/// silent miss.
+fn bool_fact(fact: Option<bool>, label: &str) -> CheckResult {
+    match fact {
+        Some(true) => CheckResult::Supported,
+        Some(false) => CheckResult::Unsupported {
+            reason: format!("{label} is not available on this host"),
+        },
+        None => CheckResult::Unsupported {
+            reason: format!("{label} could not be determined on this host"),
+        },
+    }
+}
+
+/// Whether the running kernel supports btrfs, read from `/proc/filesystems`.
+fn btrfs_supported() -> CheckResult {
+    match std::fs::read_to_string("/proc/filesystems") {
+        Ok(contents) if fs_supported(&contents, "btrfs") => CheckResult::Supported,
+        Ok(_) => CheckResult::Unsupported {
+            reason: "btrfs is not supported by the running kernel (absent from /proc/filesystems)"
+                .to_string(),
+        },
+        Err(_) => CheckResult::Unsupported {
+            reason: "could not read /proc/filesystems to verify btrfs support".to_string(),
+        },
+    }
+}
+
+/// Whether `proc_filesystems` content lists `fs`. Each line is `nodev\t<fs>` or
+/// `\t<fs>`; the filesystem name is the trailing token.
+fn fs_supported(proc_filesystems: &str, fs: &str) -> bool {
+    proc_filesystems
+        .lines()
+        .any(|line| line.split_whitespace().last() == Some(fs))
+}
+
+/// Result of comparing the host kernel against a `min_kernel` requirement.
+enum KernelCheck {
+    Satisfied,
+    Below { have: String },
+    Unknown,
+}
+
+/// Compare the host kernel release against a minimum. Either side unparseable
+/// → `Unknown` (conservative: the preflight then refuses rather than guessing).
+fn kernel_satisfies(have: Option<&str>, min: &str) -> KernelCheck {
+    let Some(have_raw) = have else {
+        return KernelCheck::Unknown;
+    };
+    match (parse_kernel(have_raw), parse_kernel(min)) {
+        (Some(have_v), Some(min_v)) if have_v >= min_v => KernelCheck::Satisfied,
+        (Some(_), Some(_)) => KernelCheck::Below {
+            have: have_raw.to_string(),
+        },
+        _ => KernelCheck::Unknown,
+    }
+}
+
+/// Parse a kernel release's leading `MAJOR.MINOR[.PATCH]` into a semver
+/// `Version`, ignoring any `-suffix`: `5.10.134-007.ali5000` → `5.10.134`,
+/// `5.4` → `5.4.0`.
+fn parse_kernel(s: &str) -> Option<semver::Version> {
+    let head = s.split('-').next()?.trim();
+    let mut parts = head.split('.');
+    let major = leading_u64(parts.next()?)?;
+    let minor = parts.next().and_then(leading_u64).unwrap_or(0);
+    let patch = parts.next().and_then(leading_u64).unwrap_or(0);
+    Some(semver::Version::new(major, minor, patch))
+}
+
+/// Leading run of ASCII digits parsed as `u64` (`"134"` from `"134abc"`).
+fn leading_u64(s: &str) -> Option<u64> {
+    let digits: String = s
+        .trim()
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
+/// Outcome of a presence-first version check.
+enum VersionVerdict {
+    /// No constraint, or constraint satisfied.
+    Ok,
+    /// Constraint set but unverifiable (either side unparseable). Not a failure.
+    NotVerified,
+    /// Constraint set, a version was found, and it does not satisfy.
+    Mismatch { found: String },
+}
+
+/// Presence-first version check: only a confidently-parsed mismatch fails;
+/// anything ambiguous is `NotVerified` (never silently downgraded).
+fn version_verdict(constraint: Option<&str>, stdout: &str) -> VersionVerdict {
+    let Some(constraint) = constraint else {
+        return VersionVerdict::Ok;
+    };
+    let Ok(req) = semver::VersionReq::parse(constraint) else {
+        return VersionVerdict::NotVerified;
+    };
+    let Some(found) = extract_semver(stdout) else {
+        return VersionVerdict::NotVerified;
+    };
+    if req.matches(&found) {
+        VersionVerdict::Ok
+    } else {
+        VersionVerdict::Mismatch {
+            found: found.to_string(),
+        }
+    }
+}
+
+/// First whitespace-delimited token in `stdout` that parses as semver
+/// (tolerating a leading `v`): `node --version` → `v20.3.1` → `20.3.1`.
+fn extract_semver(stdout: &str) -> Option<semver::Version> {
+    stdout.split_whitespace().find_map(|tok| {
+        let t = tok.strip_prefix('v').unwrap_or(tok);
+        semver::Version::parse(t).ok()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anolisa_platform::command::CommandOutput;
+    use std::collections::HashMap;
+    use std::io;
+
+    /// Canned outcome for one program under the fake runner.
+    enum Fake {
+        Ok(CommandOutput),
+        Spawn(io::ErrorKind),
+    }
+
+    /// Maps a program name to a canned result. An unmapped program spawns
+    /// `NotFound`, mirroring a missing binary on the host.
+    #[derive(Default)]
+    struct FakeRunner {
+        map: HashMap<String, Fake>,
+    }
+
+    impl FakeRunner {
+        fn ok(mut self, program: &str, code: i32, stdout: &str) -> Self {
+            self.map.insert(
+                program.to_string(),
+                Fake::Ok(CommandOutput {
+                    code: Some(code),
+                    stdout: stdout.to_string(),
+                    stderr: String::new(),
+                }),
+            );
+            self
+        }
+        fn missing(mut self, program: &str) -> Self {
+            self.map
+                .insert(program.to_string(), Fake::Spawn(io::ErrorKind::NotFound));
+            self
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, program: &str, _args: &[&str]) -> io::Result<CommandOutput> {
+            match self.map.get(program) {
+                Some(Fake::Ok(out)) => Ok(out.clone()),
+                Some(Fake::Spawn(kind)) => Err(io::Error::new(*kind, "fake spawn failure")),
+                None => Err(io::Error::new(io::ErrorKind::NotFound, "missing binary")),
+            }
+        }
+    }
+
+    fn dep(name: &str, kind: DependencyKind) -> RuntimeDependency {
+        RuntimeDependency {
+            name: name.to_string(),
+            kind,
+            version: None,
+            probe: None,
+            source: None,
+            packages: crate::manifest::PackageNames::default(),
+            check: None,
+            min_kernel: None,
+        }
+    }
+
+    fn rpm_env() -> ResolverEnv {
+        ResolverEnv {
+            pkg_base: Some("rpm".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn resolve_one(
+        runner: FakeRunner,
+        d: RuntimeDependency,
+        env: &ResolverEnv,
+    ) -> DependencyResolution {
+        let plan = DependencyResolver::with_runner(runner)
+            .resolve(&[d], env)
+            .expect("resolve");
+        plan.resolutions.into_iter().next().expect("one resolution")
+    }
+
+    #[test]
+    fn system_package_present_is_resolved() {
+        let mut d = dep("btrfs-progs", DependencyKind::SystemPackage);
+        d.probe = Some("btrfs version".to_string());
+        // Only the probe binary is faked — if native `rpm -q` were used instead,
+        // it would be missing and the dep would be unresolved. Resolving proves
+        // the explicit probe is preferred.
+        let r = resolve_one(
+            FakeRunner::default().ok("btrfs", 0, "btrfs-progs v6.6"),
+            d,
+            &rpm_env(),
+        );
+        assert_eq!(r.status, DependencyStatus::Resolved);
+    }
+
+    #[test]
+    fn system_package_missing_rpm_remediation() {
+        let mut d = dep("btrfs-progs", DependencyKind::SystemPackage);
+        d.probe = Some("btrfs version".to_string());
+        d.packages.rpm = Some("btrfs-progs".to_string());
+        let r = resolve_one(FakeRunner::default().missing("btrfs"), d, &rpm_env());
+        assert_eq!(
+            r.status,
+            DependencyStatus::Unresolved {
+                remediation: "sudo dnf install btrfs-progs".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn system_package_missing_deb_remediation() {
+        let mut d = dep("btrfs-progs", DependencyKind::SystemPackage);
+        d.probe = Some("btrfs version".to_string());
+        d.packages.deb = Some("btrfs-progs".to_string());
+        let env = ResolverEnv {
+            pkg_base: Some("deb".to_string()),
+            ..Default::default()
+        };
+        let r = resolve_one(FakeRunner::default().missing("btrfs"), d, &env);
+        assert_eq!(
+            r.status,
+            DependencyStatus::Unresolved {
+                remediation: "sudo apt install btrfs-progs".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn system_package_unknown_pkg_base_manual_hint() {
+        let mut d = dep("btrfs-progs", DependencyKind::SystemPackage);
+        d.probe = Some("btrfs version".to_string());
+        let env = ResolverEnv::default(); // pkg_base = None
+        let r = resolve_one(FakeRunner::default().missing("btrfs"), d, &env);
+        match r.status {
+            DependencyStatus::Unresolved { remediation } => {
+                assert!(
+                    remediation.contains("unsupported package manager"),
+                    "{remediation}"
+                );
+            }
+            other => panic!("expected unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn system_package_native_query_present_when_no_probe() {
+        let d = dep("btrfs-progs", DependencyKind::SystemPackage);
+        // No probe → native `rpm -q` path; exit 0 means installed.
+        let r = resolve_one(FakeRunner::default().ok("rpm", 0, ""), d, &rpm_env());
+        assert_eq!(r.status, DependencyStatus::Resolved);
+    }
+
+    #[test]
+    fn system_package_native_query_absent_when_no_probe() {
+        let d = dep("btrfs-progs", DependencyKind::SystemPackage);
+        let r = resolve_one(FakeRunner::default().ok("rpm", 1, ""), d, &rpm_env());
+        assert!(matches!(r.status, DependencyStatus::Unresolved { .. }));
+    }
+
+    #[test]
+    fn platform_capability_min_kernel_below_is_unresolvable() {
+        let mut d = dep("btrfs", DependencyKind::PlatformCapability);
+        d.min_kernel = Some("5.4".to_string());
+        let env = ResolverEnv {
+            kernel: Some("3.10.0-1160.el7".to_string()),
+            ..Default::default()
+        };
+        let r = resolve_one(FakeRunner::default(), d, &env);
+        match r.status {
+            DependencyStatus::Unresolvable { reason } => {
+                assert!(reason.contains("requires kernel >= 5.4"), "{reason}");
+            }
+            other => panic!("expected unresolvable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn platform_capability_min_kernel_satisfied_is_resolved() {
+        let mut d = dep("btrfs", DependencyKind::PlatformCapability);
+        d.min_kernel = Some("5.4".to_string());
+        let env = ResolverEnv {
+            kernel: Some("5.10.134-007.ali5000.al8.x86_64".to_string()),
+            ..Default::default()
+        };
+        let r = resolve_one(FakeRunner::default(), d, &env);
+        assert_eq!(r.status, DependencyStatus::Resolved);
+    }
+
+    #[test]
+    fn platform_capability_min_kernel_unknown_host_is_unresolvable() {
+        let mut d = dep("btrfs", DependencyKind::PlatformCapability);
+        d.min_kernel = Some("5.4".to_string());
+        let env = ResolverEnv::default(); // kernel = None
+        let r = resolve_one(FakeRunner::default(), d, &env);
+        assert!(matches!(r.status, DependencyStatus::Unresolvable { .. }));
+    }
+
+    #[test]
+    fn platform_capability_btf_supported_and_missing() {
+        let mut d = dep("ebpf", DependencyKind::PlatformCapability);
+        d.check = Some("btf".to_string());
+        let yes = ResolverEnv {
+            btf: Some(true),
+            ..Default::default()
+        };
+        let no = ResolverEnv {
+            btf: Some(false),
+            ..Default::default()
+        };
+        let none = ResolverEnv {
+            btf: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_one(FakeRunner::default(), d.clone(), &yes).status,
+            DependencyStatus::Resolved
+        );
+        assert!(matches!(
+            resolve_one(FakeRunner::default(), d.clone(), &no).status,
+            DependencyStatus::Unresolvable { .. }
+        ));
+        assert!(matches!(
+            resolve_one(FakeRunner::default(), d, &none).status,
+            DependencyStatus::Unresolvable { .. }
+        ));
+    }
+
+    #[test]
+    fn platform_capability_unknown_check_is_error() {
+        let mut d = dep("frob", DependencyKind::PlatformCapability);
+        d.check = Some("frobnicate".to_string());
+        let err = DependencyResolver::with_runner(FakeRunner::default())
+            .resolve(&[d], &ResolverEnv::default())
+            .expect_err("unknown check must error");
+        assert!(matches!(err, ResolverError::UnknownCheck { .. }));
+    }
+
+    #[test]
+    fn language_runtime_present_satisfies_version() {
+        let mut d = dep("node", DependencyKind::LanguageRuntime);
+        d.version = Some(">=20".to_string());
+        let r = resolve_one(
+            FakeRunner::default().ok("node", 0, "v20.3.1"),
+            d,
+            &ResolverEnv::default(),
+        );
+        assert_eq!(r.status, DependencyStatus::Resolved);
+    }
+
+    #[test]
+    fn language_runtime_version_mismatch_is_unresolved() {
+        let mut d = dep("node", DependencyKind::LanguageRuntime);
+        d.version = Some(">=20".to_string());
+        let r = resolve_one(
+            FakeRunner::default().ok("node", 0, "v18.19.0"),
+            d,
+            &ResolverEnv::default(),
+        );
+        assert!(matches!(r.status, DependencyStatus::Unresolved { .. }));
+        assert!(r.detail.unwrap().contains("found 18.19.0"));
+    }
+
+    #[test]
+    fn language_runtime_missing_reports_manual_hint_no_install_cmd() {
+        let mut d = dep("node", DependencyKind::LanguageRuntime);
+        d.version = Some(">=20".to_string());
+        d.source = Some("nodejs-official".to_string());
+        let r = resolve_one(
+            FakeRunner::default().missing("node"),
+            d,
+            &ResolverEnv::default(),
+        );
+        match r.status {
+            DependencyStatus::Unresolved { remediation } => {
+                assert!(
+                    remediation.contains("install node >=20 manually"),
+                    "{remediation}"
+                );
+                assert!(remediation.contains("nodejs-official"), "{remediation}");
+                // No package-manager install is issued for a language runtime.
+                assert!(
+                    !remediation.contains("dnf") && !remediation.contains("apt"),
+                    "{remediation}"
+                );
+            }
+            other => panic!("expected unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn language_runtime_unparseable_version_does_not_fail() {
+        let mut d = dep("node", DependencyKind::LanguageRuntime);
+        d.version = Some("latest".to_string()); // not a semver req
+        let r = resolve_one(
+            FakeRunner::default().ok("node", 0, "v20.3.1"),
+            d,
+            &ResolverEnv::default(),
+        );
+        assert_eq!(r.status, DependencyStatus::Resolved);
+        assert!(r.detail.unwrap().contains("not verified"));
+    }
+
+    #[test]
+    fn aggregate_fails_and_lists_all_missing() {
+        let mut present = dep("present-pkg", DependencyKind::SystemPackage);
+        present.probe = Some("present-tool x".to_string());
+        let mut missing = dep("btrfs-progs", DependencyKind::SystemPackage);
+        missing.probe = Some("btrfs version".to_string());
+        missing.packages.rpm = Some("btrfs-progs".to_string());
+        let mut cap = dep("btrfs", DependencyKind::PlatformCapability);
+        cap.min_kernel = Some("5.4".to_string());
+
+        let env = ResolverEnv {
+            pkg_base: Some("rpm".to_string()),
+            kernel: Some("3.10.0-1160".to_string()),
+            ..Default::default()
+        };
+        let plan = DependencyResolver::with_runner(
+            FakeRunner::default()
+                .ok("present-tool", 0, "ok")
+                .missing("btrfs"),
+        )
+        .resolve(&[present, missing, cap], &env)
+        .expect("resolve");
+
+        assert!(!plan.is_satisfied());
+        let lines = plan.unsatisfied_lines();
+        assert_eq!(lines.len(), 2, "both misses listed: {lines:?}");
+        assert!(lines.iter().any(|l| l.contains("btrfs-progs")));
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("btrfs [platform-capability]"))
+        );
+    }
+
+    #[test]
+    fn aggregate_all_present_is_satisfied() {
+        let mut a = dep("a", DependencyKind::SystemPackage);
+        a.probe = Some("a v".to_string());
+        let mut b = dep("b", DependencyKind::PlatformCapability);
+        b.check = Some("btf".to_string());
+        let env = ResolverEnv {
+            btf: Some(true),
+            ..Default::default()
+        };
+        let plan = DependencyResolver::with_runner(FakeRunner::default().ok("a", 0, "1"))
+            .resolve(&[a, b], &env)
+            .expect("resolve");
+        assert!(plan.is_satisfied());
+        assert!(plan.unsatisfied_lines().is_empty());
+    }
+
+    #[test]
+    fn fs_supported_matches_trailing_token() {
+        let procfs = "nodev\tsysfs\nnodev\ttmpfs\n\text4\n\tbtrfs\n";
+        assert!(fs_supported(procfs, "btrfs"));
+        assert!(fs_supported(procfs, "ext4"));
+        assert!(!fs_supported(procfs, "xfs"));
+    }
+
+    #[test]
+    fn parse_kernel_handles_vendor_suffixes() {
+        assert_eq!(
+            parse_kernel("5.10.134-007.ali5000.al8.x86_64"),
+            Some(semver::Version::new(5, 10, 134))
+        );
+        assert_eq!(parse_kernel("5.4"), Some(semver::Version::new(5, 4, 0)));
+        assert_eq!(
+            parse_kernel("3.10.0-1160.el7"),
+            Some(semver::Version::new(3, 10, 0))
+        );
+    }
+}


### PR DESCRIPTION
## Description

The raw install backend is an HTTPS GET + untar with no package manager, so RPM `Requires` never runs on a raw install. A missing runtime dependency surfaces only as a service that silently dies after a "successful" install — e.g. `install ws-ckpt --backend raw` on a host without `btrfs-progs` reports success, enables/starts the unit, then the service fails at runtime with `wrong fs type` and no dependency warning anywhere.

Add a preflight that probes declared dependencies while the install lock is held but before any filesystem mutation, and fails fast with per-dependency remediation instead of installing a dead component.

Behavior:
- Three dependency kinds via a `DependencyKind` enum, each with its own missing-dep policy:
  - `system-package` → remediation `<dnf|apt> install <name>` (name picked per host package family); **reported, not auto-installed**.
  - `platform-capability` → kernel-capability check (`btf` / `cap_bpf` / `btrfs` + `min_kernel`); **never installable**, fails fast.
  - `language-runtime` → manual install hint (node; **no vendoring yet**).
- Probes run under the install lock, before the first filesystem mutation; every miss is aggregated and reported in one shot.
- `install --dry-run` renders a read-only preflight section and never fails.
- The RPM backend never reaches the resolver (dnf owns its `Requires`), so a dependency is never resolved twice.

## Design Note

- **Schema lives on the artifact contract** (`.anolisa/component.toml`), as a structured `[[component.dependencies]]` array (`runtime_deps`), distinct from the flat `[dependencies]` spec. The contract is what the raw backend actually executes (it already drives layout / capabilities / services / hooks) and travels inside the tarball; the bundled `manifests/runtime/*.toml` are catalog/planning artifacts and schema-sensitive, so they are left untouched.
- **platform-capability is a first-class kind, not a degenerate package.** agentsight's BTF / kernel-5.8 and ws-ckpt's btrfs kernel support cannot be installed by any package manager (`kernel-headers` is a package; "kernel built with BTF/btrfs" is not). A two-way split would misclassify these into the package bucket and fail; the third kind makes "check-only, never installable" explicit.
- **Resolver (anolisa-core) never mutates.** It probes each dependency through an injectable `CommandRunner` (fake runner → unit-testable without a real host), maps each kind to its policy, and aggregates every miss. `execute_raw` calls it before the first mutation and refuses on any miss; `--dry-run` runs the same probe read-only.

## Ship Note

- **Check + report only.** Auto-installing system packages (`dnf`/`apt`) and language-runtime vendoring are both deferred to later phases — this PR only turns a silent runtime death into an actionable pre-install error.
- doctor/status's missing post-hoc runtime-dep check (doctor is `NOT_IMPLEMENTED`, status only checks file integrity) is an orthogonal gap, tracked separately and out of scope here.
- No general cross-distro package-name database: only the rpm/deb names actually used by current components are mapped. Target package managers are alinux (dnf) and Ubuntu (apt); anything else is reported unsupported rather than guessed.
- The btrfs platform-capability check reads `/proc/filesystems` — it verifies btrfs is **currently exposed by the running kernel**, not that the module could be loaded on demand. On a modular kernel where btrfs is not yet loaded this conservatively reports the capability as missing (a deliberate false-negative: the preflight would rather over-report a miss than let a real one through). A stronger probe (`modprobe -n btrfs` / module availability) is deferred.

## Test

- **Unit (manifest):** `[[component.dependencies]]` parsing for all three kinds (kebab-case tags), covering `version` / `probe` / `source` / `packages` / `check` / `min_kernel`.
- **Unit (resolver):** per-kind probing via a fake `CommandRunner` — system-package remediation picks the rpm vs deb name per host family; platform-capability honors `min_kernel` + `btf` / `cap_bpf` / `btrfs`; language-runtime emits the manual hint; version-constraint verdicts; multiple misses aggregated in one pass; resolver never mutates.
- **Unit (install/CLI):** `execute_raw` refuses before the first filesystem mutation; `--dry-run` renders the preflight section, never fails, and writes nothing; the RPM backend bypasses the resolver entirely.
- **Full gate green:** `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.
- **Real-host:** on a host missing the declared deps, `install <comp> --backend raw` now fails fast listing the misses (previously reported success, then the service died); re-running once the deps are present proceeds; `--dry-run` shows the preflight without touching anything.

close #1117
