### PR TITLE
feat(skillfs): support Hermes layout compatibility

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -256,9 +256,15 @@ enum Commands {
         /// Skill directory layout mode.
         ///
         /// `flat` (default): each top-level directory under SOURCE is a
-        /// skill with SKILL.md. `hermes`: SOURCE is a Hermes hub
-        /// workspace with management paths (.hub, .bundled_manifest)
-        /// and categorized skills (category/skill/SKILL.md).
+        /// skill containing SKILL.md. `hermes`: SOURCE is a Hermes hub
+        /// workspace — management paths (.hub, .bundled_manifest,
+        /// .no-bundled-skills) are passthrough; skills live at
+        /// category/skill/SKILL.md.
+        ///
+        /// Hermes mode is a discovery compatibility layer. It does not
+        /// provide activation, fallback, security runtime, or daemon
+        /// notify for nested skills. Incompatible with --security,
+        /// --activation-mode, --notify-socket, and --control-socket.
         #[arg(long, value_name = "MODE", help_heading = help_text::HEADING_MOUNT)]
         skill_layout: Option<String>,
     },
@@ -658,6 +664,24 @@ async fn cmd_mount(
                 _ => skillfs_fuse::SkillLayout::Flat,
             }),
     };
+
+    // Hermes layout is a discovery/filesystem compatibility mode.
+    // H1 does not implement nested skill activation, notify, or
+    // security runtime, so reject those combinations at startup.
+    if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
+        if security {
+            return Err("--skill-layout hermes is incompatible with --security \
+                 (hermes mode is a discovery compatibility layer; \
+                 nested skill activation is not yet implemented)"
+                .into());
+        }
+        if notify_socket.is_some() {
+            return Err("--skill-layout hermes is incompatible with --notify-socket".into());
+        }
+        if control_socket.is_some() {
+            return Err("--skill-layout hermes is incompatible with --control-socket".into());
+        }
+    }
 
     // Parse reload mode: CLI flag (if present) overrides config file.
     let reload_mode = match activation_reload_mode_raw.as_deref() {

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -664,30 +664,6 @@ async fn cmd_mount(
             }),
     };
 
-    // Hermes layout compatibility gates.
-    //
-    // H2 allows hermes + --security + --activation-mode file so nested
-    // skill leaves can participate in activation-file mode and notify.
-    // --decision-command and --control-socket remain incompatible because
-    // the external protocols do not accept slash-containing skill ids.
-    if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
-        if let Some(ref cmd) = decision_command {
-            return Err(format!(
-                "--skill-layout hermes is incompatible with \
-                 --decision-command '{}' (the external decision protocol \
-                 does not accept slash-containing skill ids)",
-                cmd
-            )
-            .into());
-        }
-        if control_socket.is_some() {
-            return Err("--skill-layout hermes is incompatible with \
-                 --control-socket (control socket skill-name validation \
-                 does not accept nested ids)"
-                .into());
-        }
-    }
-
     // Parse reload mode: CLI flag (if present) overrides config file.
     let reload_mode = match activation_reload_mode_raw.as_deref() {
         Some(raw) => ReloadMode::parse(raw).ok_or_else(|| {
@@ -749,6 +725,19 @@ async fn cmd_mount(
         }
         None => None,
     };
+
+    // Hermes + decision-command gate (post config merge).
+    //
+    // The external decision protocol does not accept slash-containing
+    // skill ids, so hermes nested skills cannot use --decision-command.
+    // This gate runs after both CLI and config-file values are merged.
+    if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) && parsed_decision_command.is_some()
+    {
+        return Err("--skill-layout hermes is incompatible with \
+                 --decision-command (the external decision protocol \
+                 does not accept slash-containing skill ids)"
+            .into());
+    }
 
     // Activation source validation:
     //   --security + --decision-command           => scan -> resolve path
@@ -1687,6 +1676,17 @@ async fn cmd_mount(
             .into());
         }
         _ => {}
+    }
+
+    // Hermes + control-socket gate (post config merge).
+    //
+    // Control socket skill-name validation does not accept nested ids.
+    // This gate runs after both CLI and config-file values are merged.
+    if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) && control_socket.is_some() {
+        return Err("--skill-layout hermes is incompatible with \
+                 --control-socket (control socket skill-name validation \
+                 does not accept nested ids)"
+            .into());
     }
 
     // Build ControlSocketConfig when both are set.

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -252,6 +252,15 @@ enum Commands {
         /// `SO_PEERCRED`) must match this value.
         #[arg(long, value_name = "GID", help_heading = help_text::HEADING_TRUSTED_PEER)]
         trusted_peer_gid: Option<u32>,
+
+        /// Skill directory layout mode.
+        ///
+        /// `flat` (default): each top-level directory under SOURCE is a
+        /// skill with SKILL.md. `hermes`: SOURCE is a Hermes hub
+        /// workspace with management paths (.hub, .bundled_manifest)
+        /// and categorized skills (category/skill/SKILL.md).
+        #[arg(long, value_name = "MODE", help_heading = help_text::HEADING_MOUNT)]
+        skill_layout: Option<String>,
     },
 
     /// Generate or update skillfs-views.toml from a skill directory
@@ -417,6 +426,7 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
             trusted_peer_exe,
             trusted_peer_uid,
             trusted_peer_gid,
+            skill_layout,
         } => {
             if managed {
                 // Managed mode: spawn a detached supervisor and return once
@@ -457,6 +467,7 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
                 trusted_peer_exe,
                 trusted_peer_uid,
                 trusted_peer_gid,
+                skill_layout,
             )
             .await;
             sls_ops::log_command("mount", start, err_reason(&result));
@@ -607,6 +618,7 @@ async fn cmd_mount(
     trusted_peer_exe: Option<PathBuf>,
     trusted_peer_uid: Option<u32>,
     trusted_peer_gid: Option<u32>,
+    skill_layout_raw: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(source = %source.display(), mountpoint = %mountpoint.display(), security_mode, "mounting SkillFS");
 
@@ -629,6 +641,22 @@ async fn cmd_mount(
             .as_ref()
             .map(|c| c.activation_mode())
             .unwrap_or_default(),
+    };
+
+    // Parse skill layout: CLI flag overrides config file.
+    let skill_layout = match skill_layout_raw.as_deref() {
+        Some("flat") => Some(skillfs_fuse::SkillLayout::Flat),
+        Some("hermes") => Some(skillfs_fuse::SkillLayout::Hermes),
+        Some(other) => {
+            return Err(format!("invalid --skill-layout '{other}'; allowed: flat, hermes").into());
+        }
+        None => file_config
+            .as_ref()
+            .and_then(|c| c.skills_layout())
+            .map(|s| match s {
+                "hermes" => skillfs_fuse::SkillLayout::Hermes,
+                _ => skillfs_fuse::SkillLayout::Flat,
+            }),
     };
 
     // Parse reload mode: CLI flag (if present) overrides config file.
@@ -2118,6 +2146,7 @@ async fn cmd_mount(
                 pending_install_controller,
                 post_publish_controller,
                 runtime_metrics: Some(mount_runtime_metrics),
+                skill_layout,
             },
         )
     });

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -255,11 +255,13 @@ enum Commands {
 
         /// Skill directory layout mode.
         ///
-        /// `flat` (default): each top-level directory under SOURCE is a
-        /// skill containing SKILL.md. `hermes`: SOURCE is a Hermes hub
-        /// workspace — management paths (.hub, .bundled_manifest,
-        /// .no-bundled-skills) are passthrough; skills live at
-        /// category/skill/SKILL.md.
+        /// `auto` (default): detect Hermes from source-root markers
+        /// (`.bundled_manifest` or `.hub/`), otherwise flat. `flat`: each
+        /// top-level directory under SOURCE is a skill containing
+        /// SKILL.md. `hermes`: SOURCE is a Hermes hub workspace —
+        /// management paths (.hub, .bundled_manifest, .no-bundled-skills)
+        /// are passthrough; skills live at category/skill/SKILL.md (and
+        /// top-level skill/SKILL.md).
         ///
         /// Hermes mode supports --security --activation-mode file
         /// for nested skill activation and notify. Incompatible with
@@ -648,20 +650,22 @@ async fn cmd_mount(
             .unwrap_or_default(),
     };
 
-    // Parse skill layout: CLI flag overrides config file.
-    let skill_layout = match skill_layout_raw.as_deref() {
+    // Parse skill layout: CLI flag overrides config file; the default is
+    // `auto`, which conservatively detects Hermes from source-root markers
+    // (`.bundled_manifest` / `.hub/`) and otherwise falls back to flat.
+    // Explicit `flat` / `hermes` always win over detection.
+    let layout_intent = skill_layout_raw
+        .as_deref()
+        .or_else(|| file_config.as_ref().and_then(|c| c.skills_layout()));
+    let skill_layout = match layout_intent {
         Some("flat") => Some(skillfs_fuse::SkillLayout::Flat),
         Some("hermes") => Some(skillfs_fuse::SkillLayout::Hermes),
+        Some("auto") | None => Some(skillfs_fuse::detect_skill_layout(&source)),
         Some(other) => {
-            return Err(format!("invalid --skill-layout '{other}'; allowed: flat, hermes").into());
+            return Err(
+                format!("invalid --skill-layout '{other}'; allowed: auto, flat, hermes").into(),
+            );
         }
-        None => file_config
-            .as_ref()
-            .and_then(|c| c.skills_layout())
-            .map(|s| match s {
-                "hermes" => skillfs_fuse::SkillLayout::Hermes,
-                _ => skillfs_fuse::SkillLayout::Flat,
-            }),
     };
 
     // Parse reload mode: CLI flag (if present) overrides config file.
@@ -1295,7 +1299,7 @@ async fn cmd_mount(
         // missing activation files map to hidden (fail-safe).
         let resolver = ActiveSkillResolver::new(source.clone());
         let skill_names: Vec<String> = if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
-            skillfs_fuse::security::enumerate_hermes_skill_leaves(&daemon_root)
+            skillfs_fuse::security::enumerate_hermes_skill_ids(&daemon_root)
         } else {
             shared_store
                 .read()
@@ -1907,7 +1911,7 @@ async fn cmd_mount(
     let reconcile_skill_names: Option<Vec<String>> =
         if activation_mode == ActivationMode::File && notify_controller.is_some() {
             let names: Vec<String> = if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
-                skillfs_fuse::security::enumerate_hermes_skill_leaves(&daemon_root)
+                skillfs_fuse::security::enumerate_hermes_skill_ids(&daemon_root)
             } else {
                 shared_store
                     .read()

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -261,10 +261,9 @@ enum Commands {
         /// .no-bundled-skills) are passthrough; skills live at
         /// category/skill/SKILL.md.
         ///
-        /// Hermes mode is a discovery compatibility layer. It does not
-        /// provide activation, fallback, security runtime, or daemon
-        /// notify for nested skills. Incompatible with --security,
-        /// --activation-mode, --notify-socket, and --control-socket.
+        /// Hermes mode supports --security --activation-mode file
+        /// for nested skill activation and notify. Incompatible with
+        /// --decision-command and --control-socket.
         #[arg(long, value_name = "MODE", help_heading = help_text::HEADING_MOUNT)]
         skill_layout: Option<String>,
     },
@@ -665,21 +664,27 @@ async fn cmd_mount(
             }),
     };
 
-    // Hermes layout is a discovery/filesystem compatibility mode.
-    // H1 does not implement nested skill activation, notify, or
-    // security runtime, so reject those combinations at startup.
+    // Hermes layout compatibility gates.
+    //
+    // H2 allows hermes + --security + --activation-mode file so nested
+    // skill leaves can participate in activation-file mode and notify.
+    // --decision-command and --control-socket remain incompatible because
+    // the external protocols do not accept slash-containing skill ids.
     if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
-        if security {
-            return Err("--skill-layout hermes is incompatible with --security \
-                 (hermes mode is a discovery compatibility layer; \
-                 nested skill activation is not yet implemented)"
-                .into());
-        }
-        if notify_socket.is_some() {
-            return Err("--skill-layout hermes is incompatible with --notify-socket".into());
+        if let Some(ref cmd) = decision_command {
+            return Err(format!(
+                "--skill-layout hermes is incompatible with \
+                 --decision-command '{}' (the external decision protocol \
+                 does not accept slash-containing skill ids)",
+                cmd
+            )
+            .into());
         }
         if control_socket.is_some() {
-            return Err("--skill-layout hermes is incompatible with --control-socket".into());
+            return Err("--skill-layout hermes is incompatible with \
+                 --control-socket (control socket skill-name validation \
+                 does not accept nested ids)"
+                .into());
         }
     }
 
@@ -1290,103 +1295,109 @@ async fn cmd_mount(
     // transport, or `check`/`certify`. Skill-discover is exempt from
     // the gate inside SkillFS itself, so we deliberately do not
     // run scan/resolve on it.
-    let active_resolver: Option<Arc<ActiveSkillResolver>> =
-        if security && activation_mode == ActivationMode::File {
-            // A1: Activation File Consumer bootstrap.
-            //
-            // When `--activation-mode file` is set, SkillFS reads
-            // `<skill_dir>/.skill-meta/activation.json` for every loaded
-            // skill at startup and populates the resolver. Invalid or
-            // missing activation files map to hidden (fail-safe).
-            let resolver = ActiveSkillResolver::new(source.clone());
-            let skill_names: Vec<String> = shared_store
+    let active_resolver: Option<Arc<ActiveSkillResolver>> = if security
+        && activation_mode == ActivationMode::File
+    {
+        // A1: Activation File Consumer bootstrap.
+        //
+        // When `--activation-mode file` is set, SkillFS reads
+        // `<skill_dir>/.skill-meta/activation.json` for every loaded
+        // skill at startup and populates the resolver. Invalid or
+        // missing activation files map to hidden (fail-safe).
+        let resolver = ActiveSkillResolver::new(source.clone());
+        let skill_names: Vec<String> = if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
+            skillfs_fuse::security::enumerate_hermes_skill_leaves(&daemon_root)
+        } else {
+            shared_store
                 .read()
                 .list()
                 .iter()
                 .filter(|n| **n != "skill-discover")
                 .map(|s| s.to_string())
-                .collect();
-            info!(
-                count = skill_names.len(),
-                activation_mode = %activation_mode,
-                "activation: loading activation files for skill mapping"
-            );
-            let results = bootstrap_activation(daemon_root.as_path(), &skill_names, &resolver);
-            for (name, outcome) in &results {
-                match outcome {
+                .collect()
+        };
+        info!(
+            count = skill_names.len(),
+            activation_mode = %activation_mode,
+            layout = ?skill_layout,
+            "activation: loading activation files for skill mapping"
+        );
+        let results = bootstrap_activation(daemon_root.as_path(), &skill_names, &resolver);
+        for (name, outcome) in &results {
+            match outcome {
+                Ok(target) => {
+                    info!(
+                        skill = %name,
+                        target = %target.as_label(),
+                        "activation file loaded"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        skill = %name,
+                        error = %e,
+                        "activation file invalid or missing; skill hidden (fail-safe)"
+                    );
+                }
+            }
+        }
+        Some(Arc::new(resolver))
+    } else if security && parsed_decision_command.is_some() {
+        // D1.3.1 active-mapping bootstrap (decision-command path).
+        let cmd = parsed_decision_command
+            .as_ref()
+            .expect("decision_command presence checked above")
+            .clone();
+        let adapter: Arc<dyn LedgerAdapter> = Arc::new(CliLedgerAdapter::new(cmd.clone()));
+        let resolver = ActiveSkillResolver::new(source.clone());
+        let skill_names: Vec<String> = shared_store
+            .read()
+            .list()
+            .iter()
+            .filter(|n| **n != "skill-discover")
+            .map(|s| s.to_string())
+            .collect();
+        info!(
+            count = skill_names.len(),
+            program = %cmd.program().display(),
+            "security: resolving active skill mapping via scan -> resolve"
+        );
+        for name in &skill_names {
+            let skill_dir = source.join(name);
+            if let Err(e) = adapter.scan(&skill_dir) {
+                warn!(
+                    skill = %name,
+                    error = %e,
+                    "decision-command scan failed; skill will be hidden (no activation)"
+                );
+                continue;
+            }
+            match adapter.resolve(&skill_dir) {
+                Ok(result) => match resolver.set_from_resolve_for_expected(name, &result) {
                     Ok(target) => {
                         info!(
                             skill = %name,
                             target = %target.as_label(),
-                            "activation file loaded"
+                            "decision-command resolve installed"
                         );
                     }
-                    Err(e) => {
-                        warn!(
-                            skill = %name,
-                            error = %e,
-                            "activation file invalid or missing; skill hidden (fail-safe)"
-                        );
-                    }
-                }
-            }
-            Some(Arc::new(resolver))
-        } else if security && parsed_decision_command.is_some() {
-            // D1.3.1 active-mapping bootstrap (decision-command path).
-            let cmd = parsed_decision_command
-                .as_ref()
-                .expect("decision_command presence checked above")
-                .clone();
-            let adapter: Arc<dyn LedgerAdapter> = Arc::new(CliLedgerAdapter::new(cmd.clone()));
-            let resolver = ActiveSkillResolver::new(source.clone());
-            let skill_names: Vec<String> = shared_store
-                .read()
-                .list()
-                .iter()
-                .filter(|n| **n != "skill-discover")
-                .map(|s| s.to_string())
-                .collect();
-            info!(
-                count = skill_names.len(),
-                program = %cmd.program().display(),
-                "security: resolving active skill mapping via scan -> resolve"
-            );
-            for name in &skill_names {
-                let skill_dir = source.join(name);
-                if let Err(e) = adapter.scan(&skill_dir) {
-                    warn!(
-                        skill = %name,
-                        error = %e,
-                        "decision-command scan failed; skill will be hidden (no activation)"
-                    );
-                    continue;
-                }
-                match adapter.resolve(&skill_dir) {
-                    Ok(result) => match resolver.set_from_resolve_for_expected(name, &result) {
-                        Ok(target) => {
-                            info!(
-                                skill = %name,
-                                target = %target.as_label(),
-                                "decision-command resolve installed"
-                            );
-                        }
-                        Err(e) => warn!(
-                            skill = %name,
-                            error = %e,
-                            "could not install resolve target; skill will be hidden (no activation)"
-                        ),
-                    },
                     Err(e) => warn!(
                         skill = %name,
                         error = %e,
-                        "decision-command resolve failed; skill will be hidden (no activation)"
+                        "could not install resolve target; skill will be hidden (no activation)"
                     ),
-                }
+                },
+                Err(e) => warn!(
+                    skill = %name,
+                    error = %e,
+                    "decision-command resolve failed; skill will be hidden (no activation)"
+                ),
             }
-            Some(Arc::new(resolver))
-        } else {
-            None
-        };
+        }
+        Some(Arc::new(resolver))
+    } else {
+        None
+    };
 
     // D1.3.1 refresh controller bootstrap.
     //
@@ -1895,13 +1906,17 @@ async fn cmd_mount(
     let reconcile_notify = notify_controller.clone();
     let reconcile_skill_names: Option<Vec<String>> =
         if activation_mode == ActivationMode::File && notify_controller.is_some() {
-            let names: Vec<String> = shared_store
-                .read()
-                .list()
-                .iter()
-                .filter(|n| **n != "skill-discover")
-                .map(|s| s.to_string())
-                .collect();
+            let names: Vec<String> = if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
+                skillfs_fuse::security::enumerate_hermes_skill_leaves(&daemon_root)
+            } else {
+                shared_store
+                    .read()
+                    .list()
+                    .iter()
+                    .filter(|n| **n != "skill-discover")
+                    .map(|s| s.to_string())
+                    .collect()
+            };
             Some(names)
         } else {
             None

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -1769,3 +1769,89 @@ fn control_socket_created_and_accepts_ping() {
         eprintln!("SKIP: control socket not created (FUSE mount likely unavailable)");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Hermes layout + security mutual exclusion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hermes_layout_with_security_fails_startup() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--skill-layout",
+            "hermes",
+            "--security",
+            "--activation-mode",
+            "file",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "hermes + security must fail startup");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("incompatible"),
+        "error must mention incompatibility: {stderr}"
+    );
+}
+
+#[test]
+fn hermes_layout_with_notify_socket_fails_startup() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--skill-layout",
+            "hermes",
+            "--notify-socket",
+            "/tmp/nonexistent.sock",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(
+        !out.status.success(),
+        "hermes + notify-socket must fail startup"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("incompatible"),
+        "error must mention incompatibility: {stderr}"
+    );
+}
+
+#[test]
+fn hermes_layout_without_security_passes_gate() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let mut child = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--skill-layout",
+            "hermes",
+            "--foreground",
+        ])
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    // Wait briefly — if the incompatibility gate fires it exits
+    // immediately; if it passes the gate it either starts FUSE or
+    // fails later on FUSE availability.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let _ = child.kill();
+    let output = child.wait_with_output().expect("wait");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("incompatible"),
+        "hermes without security must not trigger incompatibility gate: {stderr}"
+    );
+}

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -1771,11 +1771,78 @@ fn control_socket_created_and_accepts_ping() {
 }
 
 // ---------------------------------------------------------------------------
-// Hermes layout + security mutual exclusion
+// Hermes layout + security gates (H2)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn hermes_layout_with_security_fails_startup() {
+fn hermes_security_activation_file_passes_gate() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let mut child = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--skill-layout",
+            "hermes",
+            "--security",
+            "--activation-mode",
+            "file",
+            "--foreground",
+        ])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let _ = child.kill();
+    let output = child.wait_with_output().expect("wait");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        !combined.contains("incompatible"),
+        "hermes + security + activation-mode file must pass gate: {combined}"
+    );
+}
+
+#[test]
+fn hermes_decision_command_rejected() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--skill-layout",
+            "hermes",
+            "--security",
+            "--decision-command",
+            "echo",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(
+        !out.status.success(),
+        "hermes + decision-command must fail startup"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("incompatible"),
+        "error must mention incompatibility: {combined}"
+    );
+}
+
+#[test]
+fn hermes_control_socket_rejected() {
     let source = empty_source();
     let mount = tempfile::tempdir().expect("mount tempdir");
     let out = Command::new(bin_path())
@@ -1788,41 +1855,25 @@ fn hermes_layout_with_security_fails_startup() {
             "--security",
             "--activation-mode",
             "file",
-        ])
-        .output()
-        .expect("invoke skillfs");
-    assert!(!out.status.success(), "hermes + security must fail startup");
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("incompatible"),
-        "error must mention incompatibility: {stderr}"
-    );
-}
-
-#[test]
-fn hermes_layout_with_notify_socket_fails_startup() {
-    let source = empty_source();
-    let mount = tempfile::tempdir().expect("mount tempdir");
-    let out = Command::new(bin_path())
-        .args([
-            "mount",
-            source.path().to_str().unwrap(),
-            mount.path().to_str().unwrap(),
-            "--skill-layout",
-            "hermes",
-            "--notify-socket",
-            "/tmp/nonexistent.sock",
+            "--control-socket",
+            "/tmp/test-hermes.sock",
+            "--trusted-peer-exe",
+            bin_path(),
         ])
         .output()
         .expect("invoke skillfs");
     assert!(
         !out.status.success(),
-        "hermes + notify-socket must fail startup"
+        "hermes + control-socket must fail startup"
     );
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
     assert!(
-        stderr.contains("incompatible"),
-        "error must mention incompatibility: {stderr}"
+        combined.contains("incompatible"),
+        "error must mention incompatibility: {combined}"
     );
 }
 
@@ -1843,9 +1894,6 @@ fn hermes_layout_without_security_passes_gate() {
         .spawn()
         .expect("spawn skillfs");
 
-    // Wait briefly — if the incompatibility gate fires it exits
-    // immediately; if it passes the gate it either starts FUSE or
-    // fails later on FUSE availability.
     std::thread::sleep(std::time::Duration::from_secs(2));
     let _ = child.kill();
     let output = child.wait_with_output().expect("wait");

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -1903,3 +1903,98 @@ fn hermes_layout_without_security_passes_gate() {
         "hermes without security must not trigger incompatibility gate: {stderr}"
     );
 }
+
+#[test]
+fn hermes_config_decision_command_rejected() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let config_dir = tempfile::tempdir().expect("config dir");
+    let config_path = config_dir.path().join("security.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[skills]
+layout = "hermes"
+
+[decision]
+command = "agent-sec-cli skill-ledger"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--config",
+            config_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(
+        !out.status.success(),
+        "hermes (config) + decision-command (config) must fail"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("incompatible"),
+        "config-sourced hermes + decision-command must be rejected: {combined}"
+    );
+}
+
+#[test]
+fn hermes_config_control_socket_rejected() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let config_dir = tempfile::tempdir().expect("config dir");
+    let config_path = config_dir.path().join("security.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+[skills]
+layout = "hermes"
+
+[activation]
+mode = "file"
+
+[control_socket]
+path = "/tmp/test-hermes-config.sock"
+trusted_peer_exe = "{}"
+"#,
+            bin_path()
+        ),
+    )
+    .unwrap();
+
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--config",
+            config_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(
+        !out.status.success(),
+        "hermes (config) + control-socket (config) must fail"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("incompatible"),
+        "config-sourced hermes + control-socket must be rejected: {combined}"
+    );
+}

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -8,7 +8,7 @@ use tracing::{debug, warn};
 use super::super::SkillFs;
 use super::super::read_resolution::ReadResolution;
 use crate::attr::dir_entry_file_type;
-use crate::path::{PathType, is_skill_discover_path, parse_path};
+use crate::path::{PathType, is_skill_discover_path};
 use crate::security::{
     SKILL_META_DIR, inbox::INBOX_DIR_NAME, lifecycle::is_reserved_lifecycle_name,
 };
@@ -30,9 +30,42 @@ impl SkillFs {
             }
         };
 
-        let entries: Vec<(u64, FileType, String)> =
-            match parse_path(Path::new(&path), self.in_place) {
-                PathType::Root => {
+        let entries: Vec<(u64, FileType, String)> = match self.parse_fuse_path(Path::new(&path)) {
+            PathType::Root => {
+                let inbox_ino = self
+                    .inodes
+                    .lookup_by_path("/.skillfs-inbox")
+                    .unwrap_or_else(|| {
+                        self.inodes
+                            .allocate("/.skillfs-inbox", FileType::Directory, FUSE_ROOT_ID)
+                    });
+                vec![
+                    (FUSE_ROOT_ID, FileType::Directory, ".".to_string()),
+                    (FUSE_ROOT_ID, FileType::Directory, "..".to_string()),
+                    (
+                        self.inodes.lookup_by_path("/skills").unwrap_or(2),
+                        FileType::Directory,
+                        "skills".to_string(),
+                    ),
+                    (inbox_ino, FileType::Directory, INBOX_DIR_NAME.to_string()),
+                ]
+            }
+            PathType::SkillsDir if self.skill_layout == crate::path::SkillLayout::Hermes => {
+                let skills_dir_ino = self.skills_dir_ino();
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (FUSE_ROOT_ID, FileType::Directory, "..".to_string()),
+                ];
+                if let Ok(dir_iter) = std::fs::read_dir(self.source_base()) {
+                    for entry in dir_iter.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        let kind = dir_entry_file_type(&entry);
+                        let entry_path = self.skill_inode_path(&name);
+                        let entry_ino = self.inodes.readdir_ino(&entry_path);
+                        entries.push((entry_ino, kind, name));
+                    }
+                }
+                if self.in_place {
                     let inbox_ino = self
                         .inodes
                         .lookup_by_path("/.skillfs-inbox")
@@ -40,109 +73,144 @@ impl SkillFs {
                             self.inodes.allocate(
                                 "/.skillfs-inbox",
                                 FileType::Directory,
-                                FUSE_ROOT_ID,
+                                skills_dir_ino,
                             )
                         });
-                    vec![
-                        (FUSE_ROOT_ID, FileType::Directory, ".".to_string()),
-                        (FUSE_ROOT_ID, FileType::Directory, "..".to_string()),
-                        (
-                            self.inodes.lookup_by_path("/skills").unwrap_or(2),
-                            FileType::Directory,
-                            "skills".to_string(),
-                        ),
-                        (inbox_ino, FileType::Directory, INBOX_DIR_NAME.to_string()),
-                    ]
+                    entries.push((inbox_ino, FileType::Directory, INBOX_DIR_NAME.to_string()));
                 }
-                PathType::SkillsDir => {
-                    let mut skill_names = self.primary_skill_names();
-                    // S3: lifecycle namespaces never appear in ordinary
-                    // `/skills` listings. The store loader already skips
-                    // hidden top-level directories, but defend in depth here
-                    // in case a placeholder lands in the store via mkdir
-                    // before the S3 mkdir gate fires.
-                    skill_names.retain(|n| !is_reserved_lifecycle_name(n));
-                    // I2: staging roots are installer-private workspaces,
-                    // not skills. Hide them from the /skills listing.
-                    if let Some(ref matcher) = self.staging_matcher {
-                        skill_names.retain(|n| !matcher.is_staging_root(n));
-                    }
-                    // Pending installs are hidden from discovery until
-                    // completeness check passes and activation exists.
-                    if self.pending_install_controller.is_some() {
-                        skill_names.retain(|n| !self.is_pending_install(n));
-                    }
-                    // D1.1: mirror the opendir filter so the dynamic
-                    // fallback path also hides ledger-hidden skills.
-                    if self.active_resolver.is_some() {
-                        skill_names.retain(|n| {
-                            n == "skill-discover"
-                                || !matches!(self.resolve_skill_read(n), ReadResolution::Hidden)
-                        });
-                    }
-                    let skills_dir_ino = self.skills_dir_ino();
+                entries
+            }
+            PathType::SkillsDir => {
+                let mut skill_names = self.primary_skill_names();
+                // S3: lifecycle namespaces never appear in ordinary
+                // `/skills` listings. The store loader already skips
+                // hidden top-level directories, but defend in depth here
+                // in case a placeholder lands in the store via mkdir
+                // before the S3 mkdir gate fires.
+                skill_names.retain(|n| !is_reserved_lifecycle_name(n));
+                // I2: staging roots are installer-private workspaces,
+                // not skills. Hide them from the /skills listing.
+                if let Some(ref matcher) = self.staging_matcher {
+                    skill_names.retain(|n| !matcher.is_staging_root(n));
+                }
+                // Pending installs are hidden from discovery until
+                // completeness check passes and activation exists.
+                if self.pending_install_controller.is_some() {
+                    skill_names.retain(|n| !self.is_pending_install(n));
+                }
+                // D1.1: mirror the opendir filter so the dynamic
+                // fallback path also hides ledger-hidden skills.
+                if self.active_resolver.is_some() {
+                    skill_names.retain(|n| {
+                        n == "skill-discover"
+                            || !matches!(self.resolve_skill_read(n), ReadResolution::Hidden)
+                    });
+                }
+                let skills_dir_ino = self.skills_dir_ino();
 
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (FUSE_ROOT_ID, FileType::Directory, "..".to_string()),
+                ];
+
+                for name in &skill_names {
+                    let skill_path = self.skill_inode_path(name);
+                    let skill_ino = self.inodes.readdir_ino(&skill_path);
+                    entries.push((skill_ino, FileType::Directory, name.clone()));
+                }
+
+                if !skill_names.iter().any(|n| n == "skill-discover") {
+                    let discover_path = self.skill_inode_path("skill-discover");
+                    let discover_ino = self.inodes.readdir_ino(&discover_path);
+                    entries.push((
+                        discover_ino,
+                        FileType::Directory,
+                        "skill-discover".to_string(),
+                    ));
+                }
+
+                // L1: in in-place mode, the FUSE root IS the skills
+                // directory, so the inbox appears here. In normal
+                // mode the inbox lives under `/` and is exposed by
+                // the `Root` branch above; this gate avoids
+                // double-listing it when readdir descends into
+                // `/skills`.
+                if self.in_place {
+                    let inbox_ino = self
+                        .inodes
+                        .lookup_by_path("/.skillfs-inbox")
+                        .unwrap_or_else(|| {
+                            self.inodes.allocate(
+                                "/.skillfs-inbox",
+                                FileType::Directory,
+                                skills_dir_ino,
+                            )
+                        });
+                    entries.push((inbox_ino, FileType::Directory, INBOX_DIR_NAME.to_string()));
+                }
+
+                entries
+            }
+            PathType::SkillDir { skill_name } => {
+                // I2: staging roots bypass the active resolver and
+                // enumerate physical entries directly — no compiled
+                // SKILL.md virtual entry, no skill-discover virtual
+                // entries.  Pending installs use the same bypass.
+                if self.is_staging_skill_root(&skill_name) || self.is_pending_install(&skill_name) {
+                    let show_meta = self.should_show_skill_meta_in_listing(&skill_name, req);
+                    let parent_ino = self.skills_dir_ino();
                     let mut entries: Vec<(u64, FileType, String)> = vec![
                         (ino, FileType::Directory, ".".to_string()),
-                        (FUSE_ROOT_ID, FileType::Directory, "..".to_string()),
+                        (parent_ino, FileType::Directory, "..".to_string()),
+                    ];
+                    let phys_dir = self.source_base().join(&skill_name);
+                    if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                        for entry in dir_iter.flatten() {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            if name == SKILL_META_DIR && !show_meta {
+                                continue;
+                            }
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = format!("{}/{}", path, name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                    }
+                    entries
+                } else {
+                    // D1.1: ledger-hidden skills do not list anything.
+                    // I4: grace does NOT bypass readdir — the skill stays
+                    // hidden from directory listing. Grace only allows
+                    // exact-path traversal (lookup/getattr) so the
+                    // installer can reach whitelisted files.
+                    if matches!(self.resolve_skill_read(&skill_name), ReadResolution::Hidden) {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    let parent_ino = self.skills_dir_ino();
+                    let mut entries: Vec<(u64, FileType, String)> = vec![
+                        (ino, FileType::Directory, ".".to_string()),
+                        (parent_ino, FileType::Directory, "..".to_string()),
                     ];
 
-                    for name in &skill_names {
-                        let skill_path = self.skill_inode_path(name);
-                        let skill_ino = self.inodes.readdir_ino(&skill_path);
-                        entries.push((skill_ino, FileType::Directory, name.clone()));
-                    }
+                    let md_path = format!("{}/SKILL.md", path);
+                    let md_ino = self.inodes.readdir_ino(&md_path);
+                    entries.push((md_ino, FileType::RegularFile, "SKILL.md".to_string()));
 
-                    if !skill_names.iter().any(|n| n == "skill-discover") {
-                        let discover_path = self.skill_inode_path("skill-discover");
-                        let discover_ino = self.inodes.readdir_ino(&discover_path);
-                        entries.push((
-                            discover_ino,
-                            FileType::Directory,
-                            "skill-discover".to_string(),
-                        ));
-                    }
-
-                    // L1: in in-place mode, the FUSE root IS the skills
-                    // directory, so the inbox appears here. In normal
-                    // mode the inbox lives under `/` and is exposed by
-                    // the `Root` branch above; this gate avoids
-                    // double-listing it when readdir descends into
-                    // `/skills`.
-                    if self.in_place {
-                        let inbox_ino = self
-                            .inodes
-                            .lookup_by_path("/.skillfs-inbox")
-                            .unwrap_or_else(|| {
-                                self.inodes.allocate(
-                                    "/.skillfs-inbox",
-                                    FileType::Directory,
-                                    skills_dir_ino,
-                                )
-                            });
-                        entries.push((inbox_ino, FileType::Directory, INBOX_DIR_NAME.to_string()));
-                    }
-
-                    entries
-                }
-                PathType::SkillDir { skill_name } => {
-                    // I2: staging roots bypass the active resolver and
-                    // enumerate physical entries directly — no compiled
-                    // SKILL.md virtual entry, no skill-discover virtual
-                    // entries.  Pending installs use the same bypass.
-                    if self.is_staging_skill_root(&skill_name)
-                        || self.is_pending_install(&skill_name)
-                    {
+                    if skill_name != "skill-discover" {
                         let show_meta = self.should_show_skill_meta_in_listing(&skill_name, req);
-                        let parent_ino = self.skills_dir_ino();
-                        let mut entries: Vec<(u64, FileType, String)> = vec![
-                            (ino, FileType::Directory, ".".to_string()),
-                            (parent_ino, FileType::Directory, "..".to_string()),
-                        ];
-                        let phys_dir = self.source_base().join(&skill_name);
+                        // D1.1: fallback skills enumerate from the
+                        // snapshot tree; current and no-resolver skills
+                        // enumerate from the live source.
+                        let phys_dir = self
+                            .skill_read_dir(&skill_name)
+                            .unwrap_or_else(|| self.skill_physical_dir(&skill_name));
                         if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
                             for entry in dir_iter.flatten() {
                                 let name = entry.file_name().to_string_lossy().to_string();
+                                if name == "SKILL.md" {
+                                    continue;
+                                }
                                 if name == SKILL_META_DIR && !show_meta {
                                     continue;
                                 }
@@ -152,242 +220,313 @@ impl SkillFs {
                                 entries.push((entry_ino, kind, name));
                             }
                         }
-                        entries
-                    } else {
-                        // D1.1: ledger-hidden skills do not list anything.
-                        // I4: grace does NOT bypass readdir — the skill stays
-                        // hidden from directory listing. Grace only allows
-                        // exact-path traversal (lookup/getattr) so the
-                        // installer can reach whitelisted files.
-                        if matches!(self.resolve_skill_read(&skill_name), ReadResolution::Hidden) {
-                            reply.error(libc::ENOENT);
-                            return;
-                        }
-                        let parent_ino = self.skills_dir_ino();
+                    }
+
+                    entries
+                }
+            }
+            PathType::Passthrough {
+                skill_name,
+                relative_path,
+            } => {
+                let pt = PathType::Passthrough {
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&pt, req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let phys_dir = self.skill_physical_dir(&skill_name).join(&relative_path);
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
                         let mut entries: Vec<(u64, FileType, String)> = vec![
                             (ino, FileType::Directory, ".".to_string()),
                             (parent_ino, FileType::Directory, "..".to_string()),
                         ];
-
-                        // Only synthesize the virtual SKILL.md when the
-                        // manifest is actually readable (physical file
-                        // present in the resolved read dir, or the always
-                        // -virtual skill-discover). A newly-created empty
-                        // skill dir has none yet and must list as empty.
-                        if self.skill_md_listable(&skill_name) {
-                            let md_path = format!("{}/SKILL.md", path);
-                            let md_ino = self.inodes.readdir_ino(&md_path);
-                            entries.push((md_ino, FileType::RegularFile, "SKILL.md".to_string()));
-                        }
-
-                        if skill_name != "skill-discover" {
-                            let show_meta =
-                                self.should_show_skill_meta_in_listing(&skill_name, req);
-                            // D1.1: fallback skills enumerate from the
-                            // snapshot tree; current and no-resolver skills
-                            // enumerate from the live source.
-                            let phys_dir = self
-                                .skill_read_dir(&skill_name)
-                                .unwrap_or_else(|| self.skill_physical_dir(&skill_name));
-                            if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
-                                for entry in dir_iter.flatten() {
-                                    let name = entry.file_name().to_string_lossy().to_string();
-                                    if name == "SKILL.md" {
-                                        continue;
-                                    }
-                                    if name == SKILL_META_DIR && !show_meta {
-                                        continue;
-                                    }
-                                    let kind = dir_entry_file_type(&entry);
-                                    let entry_path = format!("{}/{}", path, name);
-                                    let entry_ino = self.inodes.readdir_ino(&entry_path);
-                                    entries.push((entry_ino, kind, name));
-                                }
+                        if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                            for entry in dir_iter.flatten() {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let kind = dir_entry_file_type(&entry);
+                                let entry_path = format!("{}/{}", path, name);
+                                let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                entries.push((entry_ino, kind, name));
                             }
                         }
-
+                        entries
+                    }
+                    None => {
+                        // I2: staging roots use the physical source dir
+                        // directly, bypassing the active resolver.
+                        // Pending installs use the same bypass.
+                        let skill_dir = if self.is_staging_skill_root(&skill_name)
+                            || self.is_pending_install(&skill_name)
+                        {
+                            self.source_base().join(&skill_name)
+                        } else {
+                            match self.skill_read_dir(&skill_name) {
+                                Some(d) => d,
+                                None => {
+                                    reply.error(libc::ENOENT);
+                                    return;
+                                }
+                            }
+                        };
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
+                        let phys_dir = skill_dir.join(&relative_path);
+                        let mut entries: Vec<(u64, FileType, String)> = vec![
+                            (ino, FileType::Directory, ".".to_string()),
+                            (parent_ino, FileType::Directory, "..".to_string()),
+                        ];
+                        if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                            for entry in dir_iter.flatten() {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let kind = dir_entry_file_type(&entry);
+                                let entry_path = format!("{}/{}", path, name);
+                                let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                entries.push((entry_ino, kind, name));
+                            }
+                        }
                         entries
                     }
                 }
-                PathType::Passthrough {
-                    skill_name,
-                    relative_path,
-                } => {
-                    let pt = PathType::Passthrough {
-                        skill_name: skill_name.clone(),
-                        relative_path: relative_path.clone(),
-                    };
-                    match self.is_trusted_skill_meta_access(&pt, req) {
-                        Some(false) => {
-                            reply.error(libc::ENOENT);
-                            return;
+            }
+            PathType::InboxDir => {
+                let parent_ino = FUSE_ROOT_ID;
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                if let Ok(dir_iter) = std::fs::read_dir(self.source_base()) {
+                    for entry in dir_iter.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        if !Self::is_inbox_skill_name_allowed(&name) {
+                            continue;
                         }
-                        Some(true) => {
-                            let phys_dir =
-                                self.skill_physical_dir(&skill_name).join(&relative_path);
-                            let parent_ino = {
-                                let parent_path = Path::new(&path)
-                                    .parent()
-                                    .map(|p| p.to_string_lossy().to_string())
-                                    .unwrap_or_default();
-                                self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
-                            };
-                            let mut entries: Vec<(u64, FileType, String)> = vec![
-                                (ino, FileType::Directory, ".".to_string()),
-                                (parent_ino, FileType::Directory, "..".to_string()),
-                            ];
-                            if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
-                                for entry in dir_iter.flatten() {
-                                    let name = entry.file_name().to_string_lossy().to_string();
-                                    let kind = dir_entry_file_type(&entry);
-                                    let entry_path = format!("{}/{}", path, name);
-                                    let entry_ino = self.inodes.readdir_ino(&entry_path);
-                                    entries.push((entry_ino, kind, name));
-                                }
-                            }
-                            entries
+                        let meta = match entry.metadata() {
+                            Ok(m) => m,
+                            Err(_) => continue,
+                        };
+                        if !meta.is_dir() {
+                            continue;
                         }
-                        None => {
-                            // I2: staging roots use the physical source dir
-                            // directly, bypassing the active resolver.
-                            // Pending installs use the same bypass.
-                            let skill_dir = if self.is_staging_skill_root(&skill_name)
-                                || self.is_pending_install(&skill_name)
-                            {
-                                self.source_base().join(&skill_name)
-                            } else {
-                                match self.skill_read_dir(&skill_name) {
-                                    Some(d) => d,
-                                    None => {
-                                        reply.error(libc::ENOENT);
-                                        return;
-                                    }
-                                }
-                            };
-                            let parent_ino = {
-                                let parent_path = Path::new(&path)
-                                    .parent()
-                                    .map(|p| p.to_string_lossy().to_string())
-                                    .unwrap_or_default();
-                                self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
-                            };
-                            let phys_dir = skill_dir.join(&relative_path);
-                            let mut entries: Vec<(u64, FileType, String)> = vec![
-                                (ino, FileType::Directory, ".".to_string()),
-                                (parent_ino, FileType::Directory, "..".to_string()),
-                            ];
-                            if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
-                                for entry in dir_iter.flatten() {
-                                    let name = entry.file_name().to_string_lossy().to_string();
-                                    let kind = dir_entry_file_type(&entry);
-                                    let entry_path = format!("{}/{}", path, name);
-                                    let entry_ino = self.inodes.readdir_ino(&entry_path);
-                                    entries.push((entry_ino, kind, name));
-                                }
-                            }
-                            entries
-                        }
+                        let entry_path = format!("/.skillfs-inbox/{}", name);
+                        let entry_ino = self.inodes.readdir_ino(&entry_path);
+                        entries.push((entry_ino, FileType::Directory, name));
                     }
                 }
-                PathType::InboxDir => {
-                    let parent_ino = FUSE_ROOT_ID;
-                    let mut entries: Vec<(u64, FileType, String)> = vec![
-                        (ino, FileType::Directory, ".".to_string()),
-                        (parent_ino, FileType::Directory, "..".to_string()),
-                    ];
-                    if let Ok(dir_iter) = std::fs::read_dir(self.source_base()) {
-                        for entry in dir_iter.flatten() {
-                            let name = entry.file_name().to_string_lossy().to_string();
-                            if !Self::is_inbox_skill_name_allowed(&name) {
-                                continue;
-                            }
-                            let meta = match entry.metadata() {
-                                Ok(m) => m,
-                                Err(_) => continue,
-                            };
-                            if !meta.is_dir() {
-                                continue;
-                            }
-                            let entry_path = format!("/.skillfs-inbox/{}", name);
-                            let entry_ino = self.inodes.readdir_ino(&entry_path);
-                            entries.push((entry_ino, FileType::Directory, name));
-                        }
-                    }
-                    entries
-                }
-                PathType::InboxSkillDir { skill_name } => {
-                    if !Self::is_inbox_skill_name_allowed(&skill_name) {
-                        reply.error(libc::ENOENT);
-                        return;
-                    }
-                    let parent_ino = self
-                        .inodes
-                        .lookup_by_path("/.skillfs-inbox")
-                        .unwrap_or(FUSE_ROOT_ID);
-                    let phys_dir = self.inbox_skill_dir(&skill_name);
-                    let mut entries: Vec<(u64, FileType, String)> = vec![
-                        (ino, FileType::Directory, ".".to_string()),
-                        (parent_ino, FileType::Directory, "..".to_string()),
-                    ];
-                    match std::fs::read_dir(&phys_dir) {
-                        Ok(dir_iter) => {
-                            for entry in dir_iter.flatten() {
-                                let name = entry.file_name().to_string_lossy().to_string();
-                                let kind = dir_entry_file_type(&entry);
-                                let entry_path = format!("{}/{}", path, name);
-                                let entry_ino = self.inodes.readdir_ino(&entry_path);
-                                entries.push((entry_ino, kind, name));
-                            }
-                        }
-                        Err(e) => {
-                            reply.error(errno(&e));
-                            return;
-                        }
-                    }
-                    entries
-                }
-                PathType::InboxPassthrough {
-                    skill_name,
-                    relative_path,
-                } => {
-                    if !Self::is_inbox_skill_name_allowed(&skill_name) {
-                        reply.error(libc::ENOENT);
-                        return;
-                    }
-                    let phys_dir = self.inbox_skill_dir(&skill_name).join(&relative_path);
-                    let parent_ino = {
-                        let parent_path = Path::new(&path)
-                            .parent()
-                            .map(|p| p.to_string_lossy().to_string())
-                            .unwrap_or_default();
-                        self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
-                    };
-                    let mut entries: Vec<(u64, FileType, String)> = vec![
-                        (ino, FileType::Directory, ".".to_string()),
-                        (parent_ino, FileType::Directory, "..".to_string()),
-                    ];
-                    match std::fs::read_dir(&phys_dir) {
-                        Ok(dir_iter) => {
-                            for entry in dir_iter.flatten() {
-                                let name = entry.file_name().to_string_lossy().to_string();
-                                let kind = dir_entry_file_type(&entry);
-                                let entry_path = format!("{}/{}", path, name);
-                                let entry_ino = self.inodes.readdir_ino(&entry_path);
-                                entries.push((entry_ino, kind, name));
-                            }
-                        }
-                        Err(e) => {
-                            reply.error(errno(&e));
-                            return;
-                        }
-                    }
-                    entries
-                }
-                _ => {
-                    reply.error(libc::ENOTDIR);
+                entries
+            }
+            PathType::InboxSkillDir { skill_name } => {
+                if !Self::is_inbox_skill_name_allowed(&skill_name) {
+                    reply.error(libc::ENOENT);
                     return;
                 }
-            };
+                let parent_ino = self
+                    .inodes
+                    .lookup_by_path("/.skillfs-inbox")
+                    .unwrap_or(FUSE_ROOT_ID);
+                let phys_dir = self.inbox_skill_dir(&skill_name);
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                match std::fs::read_dir(&phys_dir) {
+                    Ok(dir_iter) => {
+                        for entry in dir_iter.flatten() {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = format!("{}/{}", path, name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                    }
+                    Err(e) => {
+                        reply.error(errno(&e));
+                        return;
+                    }
+                }
+                entries
+            }
+            PathType::InboxPassthrough {
+                skill_name,
+                relative_path,
+            } => {
+                if !Self::is_inbox_skill_name_allowed(&skill_name) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let phys_dir = self.inbox_skill_dir(&skill_name).join(&relative_path);
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                match std::fs::read_dir(&phys_dir) {
+                    Ok(dir_iter) => {
+                        for entry in dir_iter.flatten() {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = format!("{}/{}", path, name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                    }
+                    Err(e) => {
+                        reply.error(errno(&e));
+                        return;
+                    }
+                }
+                entries
+            }
+            PathType::HermesMeta { name: meta_name } => {
+                let phys_dir = self.source_base().join(&meta_name);
+                let parent_ino = self.skills_dir_ino();
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                    for entry in dir_iter.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        let kind = dir_entry_file_type(&entry);
+                        let entry_path = format!("{}/{}", path, name);
+                        let entry_ino = self.inodes.readdir_ino(&entry_path);
+                        entries.push((entry_ino, kind, name));
+                    }
+                }
+                entries
+            }
+            PathType::HermesMetaChild {
+                name: meta_name,
+                relative_path,
+            } => {
+                let phys_dir = self.source_base().join(&meta_name).join(&relative_path);
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                    for entry in dir_iter.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        let kind = dir_entry_file_type(&entry);
+                        let entry_path = format!("{}/{}", path, name);
+                        let entry_ino = self.inodes.readdir_ino(&entry_path);
+                        entries.push((entry_ino, kind, name));
+                    }
+                }
+                entries
+            }
+            PathType::CategoryDir { category } => {
+                let phys_dir = self.source_base().join(&category);
+                let parent_ino = self.skills_dir_ino();
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                    for entry in dir_iter.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        if !entry.path().is_dir() {
+                            continue;
+                        }
+                        let entry_path = format!("{}/{}", path, name);
+                        let entry_ino = self.inodes.readdir_ino(&entry_path);
+                        entries.push((entry_ino, FileType::Directory, name));
+                    }
+                }
+                entries
+            }
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => {
+                let phys_dir = self.source_base().join(&category).join(&skill_name);
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                    for entry in dir_iter.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        let kind = dir_entry_file_type(&entry);
+                        let entry_path = format!("{}/{}", path, name);
+                        let entry_ino = self.inodes.readdir_ino(&entry_path);
+                        entries.push((entry_ino, kind, name));
+                    }
+                }
+                entries
+            }
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => {
+                let phys_dir = self
+                    .source_base()
+                    .join(&category)
+                    .join(&skill_name)
+                    .join(&relative_path);
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                    for entry in dir_iter.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        let kind = dir_entry_file_type(&entry);
+                        let entry_path = format!("{}/{}", path, name);
+                        let entry_ino = self.inodes.readdir_ino(&entry_path);
+                        entries.push((entry_ino, kind, name));
+                    }
+                }
+                entries
+            }
+            _ => {
+                reply.error(libc::ENOTDIR);
+                return;
+            }
+        };
 
         for (i, (entry_ino, kind, name)) in entries.iter().enumerate().skip(offset as usize) {
             if reply.add(*entry_ino, (i + 1) as i64, *kind, name.as_str()) {
@@ -409,7 +548,7 @@ impl SkillFs {
             None => return reply.error(libc::ENOENT),
         };
 
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         let (entries, dir_file) = match path_type {
             PathType::Root => {
@@ -433,6 +572,42 @@ impl SkillFs {
                     ],
                     None,
                 )
+            }
+            PathType::SkillsDir if self.skill_layout == crate::path::SkillLayout::Hermes => {
+                let skills_dir_ino = self.skills_dir_ino();
+                let mut entries = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (FUSE_ROOT_ID, FileType::Directory, "..".to_string()),
+                ];
+                let dir_file = match std::fs::read_dir(self.source_base()) {
+                    Ok(dir_iter) => {
+                        let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                        phys_entries.sort_by_key(|e| e.file_name());
+                        for entry in phys_entries {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = self.skill_inode_path(&name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                        std::fs::File::open(self.source_base()).ok()
+                    }
+                    Err(e) => return reply.error(errno(&e)),
+                };
+                if self.in_place {
+                    let inbox_ino = self
+                        .inodes
+                        .lookup_by_path("/.skillfs-inbox")
+                        .unwrap_or_else(|| {
+                            self.inodes.allocate(
+                                "/.skillfs-inbox",
+                                FileType::Directory,
+                                skills_dir_ino,
+                            )
+                        });
+                    entries.push((inbox_ino, FileType::Directory, INBOX_DIR_NAME.to_string()));
+                }
+                (entries, dir_file)
             }
             PathType::SkillsDir => {
                 let mut skill_names = self.primary_skill_names();
@@ -787,8 +962,81 @@ impl SkillFs {
                 };
                 (entries, dir_file)
             }
+            PathType::HermesMeta { name: meta_name }
+            | PathType::HermesMetaChild {
+                name: meta_name, ..
+            }
+            | PathType::CategoryDir {
+                category: meta_name,
+            } => {
+                let phys_dir = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let _ = meta_name;
+                let mut entries = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                let dir_file = match std::fs::read_dir(&phys_dir) {
+                    Ok(dir_iter) => {
+                        let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                        phys_entries.sort_by_key(|e| e.file_name());
+                        for entry in phys_entries {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = format!("{}/{}", path, name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                        std::fs::File::open(&phys_dir).ok()
+                    }
+                    Err(e) => return reply.error(errno(&e)),
+                };
+                (entries, dir_file)
+            }
+            PathType::NestedSkillDir { .. } | PathType::NestedPassthrough { .. } => {
+                let phys_dir = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let mut entries = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                let dir_file = match std::fs::read_dir(&phys_dir) {
+                    Ok(dir_iter) => {
+                        let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                        phys_entries.sort_by_key(|e| e.file_name());
+                        for entry in phys_entries {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = format!("{}/{}", path, name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                        std::fs::File::open(&phys_dir).ok()
+                    }
+                    Err(e) => return reply.error(errno(&e)),
+                };
+                (entries, dir_file)
+            }
             _ => {
-                // SkillMd, Invalid — not a directory
+                // SkillMd, NestedSkillMd, Invalid — not a directory
                 return reply.error(libc::ENOTDIR);
             }
         };
@@ -859,7 +1107,7 @@ impl SkillFs {
             None => return reply.error(libc::ENOENT),
         };
 
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         match path_type {
             PathType::Root | PathType::SkillsDir | PathType::InboxDir => {
@@ -918,7 +1166,35 @@ impl SkillFs {
                     Err(e) => reply.error(errno(&e)),
                 }
             }
-            PathType::SkillMd { .. } => {
+            PathType::HermesMeta { .. }
+            | PathType::HermesMetaChild { .. }
+            | PathType::CategoryDir { .. }
+            | PathType::NestedSkillDir { .. }
+            | PathType::NestedPassthrough { .. } => {
+                let dir_path = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
+                match std::fs::metadata(&dir_path) {
+                    Ok(m) if m.is_dir() => match std::fs::File::open(&dir_path) {
+                        Ok(dir_file) => {
+                            let result = if datasync {
+                                dir_file.sync_data()
+                            } else {
+                                dir_file.sync_all()
+                            };
+                            match result {
+                                Ok(()) => reply.ok(),
+                                Err(e) => reply.error(errno(&e)),
+                            }
+                        }
+                        Err(e) => reply.error(errno(&e)),
+                    },
+                    Ok(_) => reply.error(libc::ENOTDIR),
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::SkillMd { .. } | PathType::NestedSkillMd { .. } => {
                 reply.error(libc::ENOTDIR);
             }
             PathType::Invalid => {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -417,10 +417,14 @@ impl SkillFs {
                 entries
             }
             PathType::HermesMetaChild {
-                name: meta_name,
+                name: dir_name,
+                relative_path,
+            }
+            | PathType::CategoryPassthrough {
+                name: dir_name,
                 relative_path,
             } => {
-                let phys_dir = self.source_base().join(&meta_name).join(&relative_path);
+                let phys_dir = self.source_base().join(&dir_name).join(&relative_path);
                 let parent_ino = {
                     let parent_path = Path::new(&path)
                         .parent()
@@ -454,31 +458,32 @@ impl SkillFs {
                 if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
                     for entry in dir_iter.flatten() {
                         let name = entry.file_name().to_string_lossy().to_string();
-                        if !entry.path().is_dir() {
-                            continue;
-                        }
-                        // H3: staging roots inside category are hidden
-                        // from listing.
-                        if self.is_staging_skill_root(&name) {
-                            continue;
-                        }
-                        let nested_id = Self::hermes_skill_id(category, &name);
-                        // H3: pending installs hidden from listing.
-                        if self.is_pending_install(&nested_id) {
-                            continue;
-                        }
-                        if has_resolver {
-                            let is_skill_leaf = entry.path().join("SKILL.md").exists();
-                            if is_skill_leaf {
+                        let is_dir = entry.path().is_dir();
+                        // Activation gating applies only to real nested
+                        // skill leaves (directories with SKILL.md). Plain
+                        // files/dirs under the category are passthrough and
+                        // are always listed with their true file type.
+                        if is_dir {
+                            // H3: staging roots inside category are hidden.
+                            if self.is_staging_skill_root(&name) {
+                                continue;
+                            }
+                            let nested_id = Self::hermes_skill_id(category, &name);
+                            // H3: pending installs hidden from listing.
+                            if self.is_pending_install(&nested_id) {
+                                continue;
+                            }
+                            if has_resolver && entry.path().join("SKILL.md").exists() {
                                 let resolution = self.resolve_hermes_nested_read(category, &name);
                                 if matches!(resolution, ReadResolution::Hidden) {
                                     continue;
                                 }
                             }
                         }
+                        let kind = dir_entry_file_type(&entry);
                         let entry_path = format!("{}/{}", path, name);
                         let entry_ino = self.inodes.readdir_ino(&entry_path);
-                        entries.push((entry_ino, FileType::Directory, name));
+                        entries.push((entry_ino, kind, name));
                     }
                 }
                 entries
@@ -1054,7 +1059,9 @@ impl SkillFs {
                 };
                 (entries, dir_file)
             }
-            PathType::HermesMeta { .. } | PathType::HermesMetaChild { .. } => {
+            PathType::HermesMeta { .. }
+            | PathType::HermesMetaChild { .. }
+            | PathType::CategoryPassthrough { .. } => {
                 let phys_dir = match self.resolve_physical_path(&path) {
                     Some(p) => p,
                     None => return reply.error(libc::ENOENT),
@@ -1412,6 +1419,7 @@ impl SkillFs {
             }
             PathType::HermesMeta { .. }
             | PathType::HermesMetaChild { .. }
+            | PathType::CategoryPassthrough { .. }
             | PathType::CategoryDir { .. }
             | PathType::NestedSkillDir { .. }
             | PathType::NestedPassthrough { .. } => {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -499,6 +499,8 @@ impl SkillFs {
                     reply.error(libc::ENOENT);
                     return;
                 }
+                let show_meta =
+                    self.should_show_skill_meta_in_nested_listing(category, skill_name, req);
                 let phys_dir = self
                     .hermes_nested_skill_read_dir(category, skill_name)
                     .unwrap_or_else(|| self.source_base().join(category).join(skill_name));
@@ -516,6 +518,9 @@ impl SkillFs {
                 if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
                     for entry in dir_iter.flatten() {
                         let name = entry.file_name().to_string_lossy().to_string();
+                        if name == SKILL_META_DIR && !show_meta {
+                            continue;
+                        }
                         let kind = dir_entry_file_type(&entry);
                         let entry_path = format!("{}/{}", path, name);
                         let entry_ino = self.inodes.readdir_ino(&entry_path);
@@ -529,46 +534,85 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
-                let nested_id = Self::hermes_skill_id(category, skill_name);
-                if !self.is_staging_skill_root(&nested_id)
-                    && !self.is_pending_install(&nested_id)
-                    && matches!(
-                        self.resolve_hermes_nested_read(category, skill_name),
-                        ReadResolution::Hidden
-                    )
-                {
-                    reply.error(libc::ENOENT);
-                    return;
-                }
-                let phys_dir = match self.resolve_hermes_nested_read(category, skill_name) {
-                    ReadResolution::Snapshot { dir, .. } => dir.join(relative_path),
-                    _ => self
-                        .source_base()
-                        .join(category)
-                        .join(skill_name)
-                        .join(relative_path),
+                let npt = PathType::NestedPassthrough {
+                    category: category.clone(),
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
                 };
-                let parent_ino = {
-                    let parent_path = Path::new(&path)
-                        .parent()
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
-                };
-                let mut entries: Vec<(u64, FileType, String)> = vec![
-                    (ino, FileType::Directory, ".".to_string()),
-                    (parent_ino, FileType::Directory, "..".to_string()),
-                ];
-                if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
-                    for entry in dir_iter.flatten() {
-                        let name = entry.file_name().to_string_lossy().to_string();
-                        let kind = dir_entry_file_type(&entry);
-                        let entry_path = format!("{}/{}", path, name);
-                        let entry_ino = self.inodes.readdir_ino(&entry_path);
-                        entries.push((entry_ino, kind, name));
+                match self.is_trusted_skill_meta_access(&npt, req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let phys_dir = self
+                            .hermes_skill_physical_dir(category, skill_name)
+                            .join(relative_path);
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
+                        let mut entries: Vec<(u64, FileType, String)> = vec![
+                            (ino, FileType::Directory, ".".to_string()),
+                            (parent_ino, FileType::Directory, "..".to_string()),
+                        ];
+                        if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                            for entry in dir_iter.flatten() {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let kind = dir_entry_file_type(&entry);
+                                let entry_path = format!("{}/{}", path, name);
+                                let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                entries.push((entry_ino, kind, name));
+                            }
+                        }
+                        entries
+                    }
+                    None => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        if !self.is_staging_skill_root(&nested_id)
+                            && !self.is_pending_install(&nested_id)
+                            && matches!(
+                                self.resolve_hermes_nested_read(category, skill_name),
+                                ReadResolution::Hidden
+                            )
+                        {
+                            reply.error(libc::ENOENT);
+                            return;
+                        }
+                        let phys_dir = match self.resolve_hermes_nested_read(category, skill_name) {
+                            ReadResolution::Snapshot { dir, .. } => dir.join(relative_path),
+                            _ => self
+                                .source_base()
+                                .join(category)
+                                .join(skill_name)
+                                .join(relative_path),
+                        };
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
+                        let mut entries: Vec<(u64, FileType, String)> = vec![
+                            (ino, FileType::Directory, ".".to_string()),
+                            (parent_ino, FileType::Directory, "..".to_string()),
+                        ];
+                        if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                            for entry in dir_iter.flatten() {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let kind = dir_entry_file_type(&entry);
+                                let entry_path = format!("{}/{}", path, name);
+                                let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                entries.push((entry_ino, kind, name));
+                            }
+                        }
+                        entries
                     }
                 }
-                entries
             }
             _ => {
                 reply.error(libc::ENOTDIR);
@@ -1109,6 +1153,8 @@ impl SkillFs {
                 {
                     return reply.error(libc::ENOENT);
                 }
+                let show_meta =
+                    self.should_show_skill_meta_in_nested_listing(category, skill_name, _req);
                 let phys_dir = self
                     .hermes_nested_skill_read_dir(category, skill_name)
                     .unwrap_or_else(|| self.hermes_skill_physical_dir(category, skill_name));
@@ -1129,6 +1175,9 @@ impl SkillFs {
                         phys_entries.sort_by_key(|e| e.file_name());
                         for entry in phys_entries {
                             let name = entry.file_name().to_string_lossy().to_string();
+                            if name == SKILL_META_DIR && !show_meta {
+                                continue;
+                            }
                             let kind = dir_entry_file_type(&entry);
                             let entry_path = format!("{}/{}", path, name);
                             let entry_ino = self.inodes.readdir_ino(&entry_path);
@@ -1145,51 +1194,90 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
-                let nested_id = Self::hermes_skill_id(category, skill_name);
-                if !self.is_staging_skill_root(&nested_id)
-                    && !self.is_pending_install(&nested_id)
-                    && matches!(
-                        self.resolve_hermes_nested_read(category, skill_name),
-                        ReadResolution::Hidden
-                    )
-                {
-                    return reply.error(libc::ENOENT);
-                }
-                let phys_dir = match self.resolve_hermes_nested_read(category, skill_name) {
-                    ReadResolution::Snapshot { dir, .. } => dir.join(relative_path),
-                    _ => self
-                        .source_base()
-                        .join(category)
-                        .join(skill_name)
-                        .join(relative_path),
+                let npt = PathType::NestedPassthrough {
+                    category: category.clone(),
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
                 };
-                let parent_ino = {
-                    let parent_path = Path::new(&path)
-                        .parent()
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
-                };
-                let mut entries = vec![
-                    (ino, FileType::Directory, ".".to_string()),
-                    (parent_ino, FileType::Directory, "..".to_string()),
-                ];
-                let dir_file = match std::fs::read_dir(&phys_dir) {
-                    Ok(dir_iter) => {
-                        let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
-                        phys_entries.sort_by_key(|e| e.file_name());
-                        for entry in phys_entries {
-                            let name = entry.file_name().to_string_lossy().to_string();
-                            let kind = dir_entry_file_type(&entry);
-                            let entry_path = format!("{}/{}", path, name);
-                            let entry_ino = self.inodes.readdir_ino(&entry_path);
-                            entries.push((entry_ino, kind, name));
+                match self.is_trusted_skill_meta_access(&npt, _req) {
+                    Some(false) => return reply.error(libc::ENOENT),
+                    Some(true) => {
+                        let phys_dir = self
+                            .hermes_skill_physical_dir(category, skill_name)
+                            .join(relative_path);
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
+                        let mut entries = vec![
+                            (ino, FileType::Directory, ".".to_string()),
+                            (parent_ino, FileType::Directory, "..".to_string()),
+                        ];
+                        if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
+                            let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                            phys_entries.sort_by_key(|e| e.file_name());
+                            for entry in phys_entries {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let kind = dir_entry_file_type(&entry);
+                                let entry_path = format!("{}/{}", path, name);
+                                let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                entries.push((entry_ino, kind, name));
+                            }
                         }
-                        std::fs::File::open(&phys_dir).ok()
+                        let dir_file = std::fs::File::open(&phys_dir).ok();
+                        (entries, dir_file)
                     }
-                    Err(e) => return reply.error(errno(&e)),
-                };
-                (entries, dir_file)
+                    None => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        if !self.is_staging_skill_root(&nested_id)
+                            && !self.is_pending_install(&nested_id)
+                            && matches!(
+                                self.resolve_hermes_nested_read(category, skill_name),
+                                ReadResolution::Hidden
+                            )
+                        {
+                            return reply.error(libc::ENOENT);
+                        }
+                        let phys_dir = match self.resolve_hermes_nested_read(category, skill_name) {
+                            ReadResolution::Snapshot { dir, .. } => dir.join(relative_path),
+                            _ => self
+                                .source_base()
+                                .join(category)
+                                .join(skill_name)
+                                .join(relative_path),
+                        };
+                        let parent_ino = {
+                            let parent_path = Path::new(&path)
+                                .parent()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .unwrap_or_default();
+                            self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                        };
+                        let mut entries = vec![
+                            (ino, FileType::Directory, ".".to_string()),
+                            (parent_ino, FileType::Directory, "..".to_string()),
+                        ];
+                        let dir_file = match std::fs::read_dir(&phys_dir) {
+                            Ok(dir_iter) => {
+                                let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                                phys_entries.sort_by_key(|e| e.file_name());
+                                for entry in phys_entries {
+                                    let name = entry.file_name().to_string_lossy().to_string();
+                                    let kind = dir_entry_file_type(&entry);
+                                    let entry_path = format!("{}/{}", path, name);
+                                    let entry_ino = self.inodes.readdir_ino(&entry_path);
+                                    entries.push((entry_ino, kind, name));
+                                }
+                                std::fs::File::open(&phys_dir).ok()
+                            }
+                            Err(e) => return reply.error(errno(&e)),
+                        };
+                        (entries, dir_file)
+                    }
+                }
             }
             _ => {
                 // SkillMd, NestedSkillMd, Invalid — not a directory

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -457,6 +457,16 @@ impl SkillFs {
                         if !entry.path().is_dir() {
                             continue;
                         }
+                        // H3: staging roots inside category are hidden
+                        // from listing.
+                        if self.is_staging_skill_root(&name) {
+                            continue;
+                        }
+                        let nested_id = Self::hermes_skill_id(category, &name);
+                        // H3: pending installs hidden from listing.
+                        if self.is_pending_install(&nested_id) {
+                            continue;
+                        }
                         if has_resolver {
                             let is_skill_leaf = entry.path().join("SKILL.md").exists();
                             if is_skill_leaf {
@@ -477,10 +487,15 @@ impl SkillFs {
                 ref category,
                 ref skill_name,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    ReadResolution::Hidden
-                ) {
+                // H3: staging and pending install bypass for nested skills.
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id)
+                    && !self.is_pending_install(&nested_id)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }
@@ -514,10 +529,14 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    ReadResolution::Hidden
-                ) {
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id)
+                    && !self.is_pending_install(&nested_id)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }
@@ -1047,6 +1066,14 @@ impl SkillFs {
                         phys_entries.sort_by_key(|e| e.file_name());
                         for entry in phys_entries {
                             let name = entry.file_name().to_string_lossy().to_string();
+                            // H3: staging roots inside category hidden from listing.
+                            if entry.path().is_dir() && self.is_staging_skill_root(&name) {
+                                continue;
+                            }
+                            let nested_id = Self::hermes_skill_id(category, &name);
+                            if self.is_pending_install(&nested_id) {
+                                continue;
+                            }
                             if has_resolver && entry.path().is_dir() {
                                 let is_skill_leaf = entry.path().join("SKILL.md").exists();
                                 if is_skill_leaf {
@@ -1072,10 +1099,14 @@ impl SkillFs {
                 ref category,
                 ref skill_name,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    ReadResolution::Hidden
-                ) {
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id)
+                    && !self.is_pending_install(&nested_id)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        ReadResolution::Hidden
+                    )
+                {
                     return reply.error(libc::ENOENT);
                 }
                 let phys_dir = self
@@ -1114,10 +1145,14 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    ReadResolution::Hidden
-                ) {
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id)
+                    && !self.is_pending_install(&nested_id)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        ReadResolution::Hidden
+                    )
+                {
                     return reply.error(libc::ENOENT);
                 }
                 let phys_dir = match self.resolve_hermes_nested_read(category, skill_name) {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -443,9 +443,10 @@ impl SkillFs {
                 }
                 entries
             }
-            PathType::CategoryDir { category } => {
-                let phys_dir = self.source_base().join(&category);
+            PathType::CategoryDir { ref category } => {
+                let phys_dir = self.source_base().join(category);
                 let parent_ino = self.skills_dir_ino();
+                let has_resolver = self.active_resolver.is_some();
                 let mut entries: Vec<(u64, FileType, String)> = vec![
                     (ino, FileType::Directory, ".".to_string()),
                     (parent_ino, FileType::Directory, "..".to_string()),
@@ -456,6 +457,15 @@ impl SkillFs {
                         if !entry.path().is_dir() {
                             continue;
                         }
+                        if has_resolver {
+                            let is_skill_leaf = entry.path().join("SKILL.md").exists();
+                            if is_skill_leaf {
+                                let resolution = self.resolve_hermes_nested_read(category, &name);
+                                if matches!(resolution, ReadResolution::Hidden) {
+                                    continue;
+                                }
+                            }
+                        }
                         let entry_path = format!("{}/{}", path, name);
                         let entry_ino = self.inodes.readdir_ino(&entry_path);
                         entries.push((entry_ino, FileType::Directory, name));
@@ -464,10 +474,19 @@ impl SkillFs {
                 entries
             }
             PathType::NestedSkillDir {
-                category,
-                skill_name,
+                ref category,
+                ref skill_name,
             } => {
-                let phys_dir = self.source_base().join(&category).join(&skill_name);
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let phys_dir = self
+                    .hermes_nested_skill_read_dir(category, skill_name)
+                    .unwrap_or_else(|| self.source_base().join(category).join(skill_name));
                 let parent_ino = {
                     let parent_path = Path::new(&path)
                         .parent()
@@ -491,15 +510,25 @@ impl SkillFs {
                 entries
             }
             PathType::NestedPassthrough {
-                category,
-                skill_name,
-                relative_path,
+                ref category,
+                ref skill_name,
+                ref relative_path,
             } => {
-                let phys_dir = self
-                    .source_base()
-                    .join(&category)
-                    .join(&skill_name)
-                    .join(&relative_path);
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let phys_dir = match self.resolve_hermes_nested_read(category, skill_name) {
+                    ReadResolution::Snapshot { dir, .. } => dir.join(relative_path),
+                    _ => self
+                        .source_base()
+                        .join(category)
+                        .join(skill_name)
+                        .join(relative_path),
+                };
                 let parent_ino = {
                     let parent_path = Path::new(&path)
                         .parent()
@@ -962,13 +991,7 @@ impl SkillFs {
                 };
                 (entries, dir_file)
             }
-            PathType::HermesMeta { name: meta_name }
-            | PathType::HermesMetaChild {
-                name: meta_name, ..
-            }
-            | PathType::CategoryDir {
-                category: meta_name,
-            } => {
+            PathType::HermesMeta { .. } | PathType::HermesMetaChild { .. } => {
                 let phys_dir = match self.resolve_physical_path(&path) {
                     Some(p) => p,
                     None => return reply.error(libc::ENOENT),
@@ -980,7 +1003,6 @@ impl SkillFs {
                         .unwrap_or_default();
                     self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
                 };
-                let _ = meta_name;
                 let mut entries = vec![
                     (ino, FileType::Directory, ".".to_string()),
                     (parent_ino, FileType::Directory, "..".to_string()),
@@ -1002,10 +1024,109 @@ impl SkillFs {
                 };
                 (entries, dir_file)
             }
-            PathType::NestedSkillDir { .. } | PathType::NestedPassthrough { .. } => {
+            PathType::CategoryDir { ref category } => {
                 let phys_dir = match self.resolve_physical_path(&path) {
                     Some(p) => p,
                     None => return reply.error(libc::ENOENT),
+                };
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let mut entries = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                let has_resolver = self.active_resolver.is_some();
+                let dir_file = match std::fs::read_dir(&phys_dir) {
+                    Ok(dir_iter) => {
+                        let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                        phys_entries.sort_by_key(|e| e.file_name());
+                        for entry in phys_entries {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            if has_resolver && entry.path().is_dir() {
+                                let is_skill_leaf = entry.path().join("SKILL.md").exists();
+                                if is_skill_leaf {
+                                    let resolution =
+                                        self.resolve_hermes_nested_read(category, &name);
+                                    if matches!(resolution, ReadResolution::Hidden) {
+                                        continue;
+                                    }
+                                }
+                            }
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = format!("{}/{}", path, name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                        std::fs::File::open(&phys_dir).ok()
+                    }
+                    Err(e) => return reply.error(errno(&e)),
+                };
+                (entries, dir_file)
+            }
+            PathType::NestedSkillDir {
+                ref category,
+                ref skill_name,
+            } => {
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    ReadResolution::Hidden
+                ) {
+                    return reply.error(libc::ENOENT);
+                }
+                let phys_dir = self
+                    .hermes_nested_skill_read_dir(category, skill_name)
+                    .unwrap_or_else(|| self.hermes_skill_physical_dir(category, skill_name));
+                let parent_ino = {
+                    let parent_path = Path::new(&path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    self.inodes.lookup_by_path(&parent_path).unwrap_or(ino)
+                };
+                let mut entries = vec![
+                    (ino, FileType::Directory, ".".to_string()),
+                    (parent_ino, FileType::Directory, "..".to_string()),
+                ];
+                let dir_file = match std::fs::read_dir(&phys_dir) {
+                    Ok(dir_iter) => {
+                        let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
+                        phys_entries.sort_by_key(|e| e.file_name());
+                        for entry in phys_entries {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            let kind = dir_entry_file_type(&entry);
+                            let entry_path = format!("{}/{}", path, name);
+                            let entry_ino = self.inodes.readdir_ino(&entry_path);
+                            entries.push((entry_ino, kind, name));
+                        }
+                        std::fs::File::open(&phys_dir).ok()
+                    }
+                    Err(e) => return reply.error(errno(&e)),
+                };
+                (entries, dir_file)
+            }
+            PathType::NestedPassthrough {
+                ref category,
+                ref skill_name,
+                ref relative_path,
+            } => {
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    ReadResolution::Hidden
+                ) {
+                    return reply.error(libc::ENOENT);
+                }
+                let phys_dir = match self.resolve_hermes_nested_read(category, skill_name) {
+                    ReadResolution::Snapshot { dir, .. } => dir.join(relative_path),
+                    _ => self
+                        .source_base()
+                        .join(category)
+                        .join(skill_name)
+                        .join(relative_path),
                 };
                 let parent_ino = {
                     let parent_path = Path::new(&path)

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
@@ -8,7 +8,7 @@ use tracing::{debug, warn};
 
 use super::super::SkillFs;
 use crate::attr::file_attr_from_metadata;
-use crate::path::{PathType, is_skill_discover_path, parse_path};
+use crate::path::{PathType, is_skill_discover_path};
 use crate::security::{
     self, SkillEvent, SkillEventAction, SkillEventKind, lifecycle::is_reserved_lifecycle_name,
 };
@@ -23,7 +23,7 @@ impl SkillFs {
             None => return reply.error(libc::ENOENT),
         };
 
-        match parse_path(Path::new(&path), self.in_place) {
+        match self.parse_fuse_path(Path::new(&path)) {
             // Virtual directories are never symlinks; readlink on a
             // non-symlink returns EINVAL on Linux.
             PathType::Root
@@ -140,6 +140,36 @@ impl SkillFs {
                     }
                 }
             }
+            PathType::HermesMeta { .. }
+            | PathType::CategoryDir { .. }
+            | PathType::NestedSkillDir { .. } => {
+                reply.error(libc::EINVAL);
+            }
+            PathType::HermesMetaChild {
+                name,
+                relative_path,
+            }
+            | PathType::NestedPassthrough {
+                category: name,
+                skill_name: _,
+                relative_path,
+            } => {
+                let physical = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
+                let _ = (&name, &relative_path);
+                match std::fs::read_link(&physical) {
+                    Ok(target) => {
+                        use std::os::unix::ffi::OsStrExt;
+                        reply.data(target.as_os_str().as_bytes());
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::NestedSkillMd { .. } => {
+                reply.error(libc::EINVAL);
+            }
             PathType::Invalid => {
                 self.emit_event(
                     SkillEvent::new(SkillEventKind::Readlink)
@@ -166,7 +196,7 @@ impl SkillFs {
                 return;
             }
         };
-        let path_type = parse_path(Path::new(&path_str), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path_str));
         let target_str = target.display().to_string();
 
         // Only Passthrough leaves under an ordinary skill may host a new
@@ -439,7 +469,7 @@ impl SkillFs {
                 return;
             }
         };
-        let new_path_type = parse_path(Path::new(&new_path_str), self.in_place);
+        let new_path_type = self.parse_fuse_path(Path::new(&new_path_str));
 
         // Resolve the source FUSE path from its inode. Without a path
         // mapping we cannot reason about same-skill / cross-skill — the
@@ -460,7 +490,7 @@ impl SkillFs {
                 return;
             }
         };
-        let source_path_type = parse_path(Path::new(&source_path_str), self.in_place);
+        let source_path_type = self.parse_fuse_path(Path::new(&source_path_str));
 
         // Destination must be a passthrough leaf.
         let (dst_skill, dst_rel) = match &new_path_type {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
@@ -149,6 +149,10 @@ impl SkillFs {
                 name,
                 relative_path,
             }
+            | PathType::CategoryPassthrough {
+                name,
+                relative_path,
+            }
             | PathType::NestedPassthrough {
                 category: name,
                 skill_name: _,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -385,6 +385,10 @@ impl SkillFs {
             PathType::HermesMetaChild {
                 name,
                 relative_path,
+            }
+            | PathType::CategoryPassthrough {
+                name,
+                relative_path,
             } => {
                 let physical = self.source_base().join(&name).join(&relative_path);
                 match std::fs::symlink_metadata(&physical) {
@@ -852,6 +856,10 @@ impl SkillFs {
             PathType::HermesMetaChild {
                 name,
                 relative_path,
+            }
+            | PathType::CategoryPassthrough {
+                name,
+                relative_path,
             } => {
                 let physical = self.source_base().join(&name).join(&relative_path);
                 match std::fs::symlink_metadata(&physical) {
@@ -1215,6 +1223,7 @@ impl SkillFs {
             }
             PathType::HermesMeta { .. }
             | PathType::HermesMetaChild { .. }
+            | PathType::CategoryPassthrough { .. }
             | PathType::CategoryDir { .. } => {
                 let physical = match self.resolve_physical_path(&path) {
                     Some(p) => p,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use super::super::SkillFs;
 use super::super::read_resolution::ReadResolution;
 use crate::attr::{file_attr_from_metadata, file_attr_from_stat};
-use crate::path::{PathType, is_skill_discover_path, parse_path};
+use crate::path::{PathType, is_skill_discover_path};
 use crate::security::{SkillEventKind, lifecycle::is_reserved_lifecycle_name};
 use crate::sys::{errno, fstatat_leaf};
 
@@ -39,7 +39,7 @@ impl SkillFs {
         };
         let path = Path::new(&path_str);
 
-        match parse_path(path, self.in_place) {
+        match self.parse_fuse_path(path) {
             PathType::Root => {
                 let attr = self.dir_attr();
                 self.inodes.remember(FUSE_ROOT_ID);
@@ -369,6 +369,105 @@ impl SkillFs {
                     Err(e) => reply.error(errno(&e)),
                 }
             }
+            PathType::HermesMeta { name } => {
+                let physical = self.source_base().join(&name);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        let ino = self.inodes.allocate(&path_str, attr.kind, parent);
+                        self.inodes.remember(ino);
+                        attr.ino = ino;
+                        reply.entry(&Duration::from_secs(1), &attr, 0);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::HermesMetaChild {
+                name,
+                relative_path,
+            } => {
+                let physical = self.source_base().join(&name).join(&relative_path);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        let ino = self.inodes.allocate(&path_str, attr.kind, parent);
+                        self.inodes.remember(ino);
+                        attr.ino = ino;
+                        reply.entry(&Duration::from_secs(1), &attr, 0);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::CategoryDir { category } => {
+                let physical = self.source_base().join(&category);
+                if physical.is_dir() {
+                    let ino = self.inodes.allocate(&path_str, FileType::Directory, parent);
+                    self.inodes.remember(ino);
+                    let mut attr = self.dir_attr();
+                    attr.ino = ino;
+                    reply.entry(&Duration::from_secs(1), &attr, 0);
+                } else {
+                    reply.error(libc::ENOENT);
+                }
+            }
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => {
+                let physical = self.source_base().join(&category).join(&skill_name);
+                if physical.is_dir() {
+                    let ino = self.inodes.allocate(&path_str, FileType::Directory, parent);
+                    self.inodes.remember(ino);
+                    let mut attr = self.dir_attr();
+                    attr.ino = ino;
+                    reply.entry(&Duration::from_secs(1), &attr, 0);
+                } else {
+                    reply.error(libc::ENOENT);
+                }
+            }
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } => {
+                let physical = self
+                    .source_base()
+                    .join(&category)
+                    .join(&skill_name)
+                    .join("SKILL.md");
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        let ino = self
+                            .inodes
+                            .allocate(&path_str, FileType::RegularFile, parent);
+                        self.inodes.remember(ino);
+                        attr.ino = ino;
+                        reply.entry(&Duration::from_secs(1), &attr, 0);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => {
+                let physical = self
+                    .source_base()
+                    .join(&category)
+                    .join(&skill_name)
+                    .join(&relative_path);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        let ino = self.inodes.allocate(&path_str, attr.kind, parent);
+                        self.inodes.remember(ino);
+                        attr.ino = ino;
+                        reply.entry(&Duration::from_secs(1), &attr, 0);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
             PathType::Invalid => reply.error(libc::ENOENT),
         }
     }
@@ -426,7 +525,7 @@ impl SkillFs {
             }
         };
 
-        match parse_path(Path::new(&path), self.in_place) {
+        match self.parse_fuse_path(Path::new(&path)) {
             PathType::Root | PathType::SkillsDir => {
                 reply.attr(&Duration::from_secs(1), &self.dir_attr());
             }
@@ -636,6 +735,93 @@ impl SkillFs {
                     Err(e) => reply.error(errno(&e)),
                 }
             }
+            PathType::HermesMeta { name } => {
+                let physical = self.source_base().join(&name);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        attr.ino = ino;
+                        reply.attr(&Duration::from_secs(1), &attr);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::HermesMetaChild {
+                name,
+                relative_path,
+            } => {
+                let physical = self.source_base().join(&name).join(&relative_path);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        attr.ino = ino;
+                        reply.attr(&Duration::from_secs(1), &attr);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::CategoryDir { category } => {
+                let physical = self.source_base().join(&category);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        attr.ino = ino;
+                        reply.attr(&Duration::from_secs(1), &attr);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => {
+                let physical = self.source_base().join(&category).join(&skill_name);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        attr.ino = ino;
+                        reply.attr(&Duration::from_secs(1), &attr);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } => {
+                let physical = self
+                    .source_base()
+                    .join(&category)
+                    .join(&skill_name)
+                    .join("SKILL.md");
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        attr.ino = ino;
+                        reply.attr(&Duration::from_secs(1), &attr);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => {
+                let physical = self
+                    .source_base()
+                    .join(&category)
+                    .join(&skill_name)
+                    .join(&relative_path);
+                match std::fs::symlink_metadata(&physical) {
+                    Ok(meta) => {
+                        let mut attr = file_attr_from_metadata(&meta);
+                        attr.ino = ino;
+                        reply.attr(&Duration::from_secs(1), &attr);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
             PathType::Invalid => reply.error(libc::ENOENT),
         }
     }
@@ -682,7 +868,7 @@ impl SkillFs {
             None => return reply.error(libc::ENOENT),
         };
 
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         match path_type {
             PathType::Root | PathType::SkillsDir | PathType::InboxDir => {
@@ -831,6 +1017,34 @@ impl SkillFs {
                     } else {
                         reply.error(result);
                     }
+                }
+            }
+            PathType::HermesMeta { .. }
+            | PathType::HermesMetaChild { .. }
+            | PathType::CategoryDir { .. } => {
+                let physical = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
+                let result = self.check_physical_access_result(&physical, mask, req);
+                if result == 0 {
+                    reply.ok();
+                } else {
+                    reply.error(result);
+                }
+            }
+            PathType::NestedSkillDir { .. }
+            | PathType::NestedSkillMd { .. }
+            | PathType::NestedPassthrough { .. } => {
+                let physical = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
+                let result = self.check_physical_access_result(&physical, mask, req);
+                if result == 0 {
+                    reply.ok();
+                } else {
+                    reply.error(result);
                 }
             }
             PathType::Invalid => {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -446,37 +446,64 @@ impl SkillFs {
                 ref skill_name,
             } => {
                 let nested_id = Self::hermes_skill_id(category, skill_name);
-                if !self.is_staging_skill_root(&nested_id)
-                    && !self.is_pending_install(&nested_id)
-                    && matches!(
-                        self.resolve_hermes_nested_read(category, skill_name),
-                        crate::fs::read_resolution::ReadResolution::Hidden
-                    )
-                {
-                    reply.error(libc::ENOENT);
-                    return;
-                }
-                let physical = match self.resolve_hermes_nested_read(category, skill_name) {
-                    crate::fs::read_resolution::ReadResolution::Snapshot { dir, .. } => {
-                        dir.join("SKILL.md")
-                    }
-                    _ => self
+                // Staging / pending nested SKILL.md is a raw physical file.
+                if self.is_staging_skill_root(&nested_id) || self.is_pending_install(&nested_id) {
+                    let physical = self
                         .source_base()
                         .join(category)
                         .join(skill_name)
-                        .join("SKILL.md"),
-                };
-                match std::fs::symlink_metadata(&physical) {
-                    Ok(meta) => {
-                        let mut attr = file_attr_from_metadata(&meta);
+                        .join("SKILL.md");
+                    match std::fs::symlink_metadata(&physical) {
+                        Ok(meta) => {
+                            let ino =
+                                self.inodes
+                                    .allocate(&path_str, FileType::RegularFile, parent);
+                            self.inodes.remember(ino);
+                            let mut attr = file_attr_from_metadata(&meta);
+                            attr.ino = ino;
+                            reply.entry(&Duration::from_secs(1), &attr, 0);
+                        }
+                        Err(e) => reply.error(errno(&e)),
+                    }
+                    return;
+                }
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                // Size must match the compiled payload the kernel will see
+                // on `read`; take mtime/type from the physical SKILL.md but
+                // project the compiled length over the raw size.
+                match self.compiled_hermes_nested_skill_md(category, skill_name) {
+                    Some(compiled) => {
+                        let md_phys = self
+                            .hermes_nested_skill_read_dir(category, skill_name)
+                            .map(|d| d.join("SKILL.md"))
+                            .unwrap_or_else(|| {
+                                self.source_base()
+                                    .join(category)
+                                    .join(skill_name)
+                                    .join("SKILL.md")
+                            });
                         let ino = self
                             .inodes
                             .allocate(&path_str, FileType::RegularFile, parent);
                         self.inodes.remember(ino);
+                        let mut attr = match std::fs::metadata(&md_phys) {
+                            Ok(meta) => {
+                                let mut a = file_attr_from_metadata(&meta);
+                                a.size = compiled.len() as u64;
+                                a
+                            }
+                            Err(_) => self.virtual_file_attr(compiled.len() as u64),
+                        };
                         attr.ino = ino;
                         reply.entry(&Duration::from_secs(1), &attr, 0);
                     }
-                    Err(e) => reply.error(errno(&e)),
+                    None => reply.error(libc::ENOENT),
                 }
             }
             PathType::NestedPassthrough {
@@ -879,33 +906,53 @@ impl SkillFs {
                 ref skill_name,
             } => {
                 let nid = Self::hermes_skill_id(category, skill_name);
-                if !self.is_staging_skill_root(&nid)
-                    && !self.is_pending_install(&nid)
-                    && matches!(
-                        self.resolve_hermes_nested_read(category, skill_name),
-                        crate::fs::read_resolution::ReadResolution::Hidden
-                    )
-                {
-                    reply.error(libc::ENOENT);
-                    return;
-                }
-                let physical = match self.resolve_hermes_nested_read(category, skill_name) {
-                    crate::fs::read_resolution::ReadResolution::Snapshot { dir, .. } => {
-                        dir.join("SKILL.md")
-                    }
-                    _ => self
+                // Staging / pending nested SKILL.md is a raw physical file.
+                if self.is_staging_skill_root(&nid) || self.is_pending_install(&nid) {
+                    let physical = self
                         .source_base()
                         .join(category)
                         .join(skill_name)
-                        .join("SKILL.md"),
-                };
-                match std::fs::symlink_metadata(&physical) {
-                    Ok(meta) => {
-                        let mut attr = file_attr_from_metadata(&meta);
+                        .join("SKILL.md");
+                    match std::fs::metadata(&physical) {
+                        Ok(meta) => {
+                            let mut attr = file_attr_from_metadata(&meta);
+                            attr.ino = ino;
+                            reply.attr(&Duration::from_secs(1), &attr);
+                        }
+                        Err(e) => reply.error(errno(&e)),
+                    }
+                    return;
+                }
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                match self.compiled_hermes_nested_skill_md(category, skill_name) {
+                    Some(compiled) => {
+                        let md_phys = self
+                            .hermes_nested_skill_read_dir(category, skill_name)
+                            .map(|d| d.join("SKILL.md"))
+                            .unwrap_or_else(|| {
+                                self.source_base()
+                                    .join(category)
+                                    .join(skill_name)
+                                    .join("SKILL.md")
+                            });
+                        let mut attr = match std::fs::metadata(&md_phys) {
+                            Ok(meta) => {
+                                let mut a = file_attr_from_metadata(&meta);
+                                a.size = compiled.len() as u64;
+                                a
+                            }
+                            Err(_) => self.virtual_file_attr(compiled.len() as u64),
+                        };
                         attr.ino = ino;
                         reply.attr(&Duration::from_secs(1), &attr);
                     }
-                    Err(e) => reply.error(errno(&e)),
+                    None => reply.error(libc::ENOENT),
                 }
             }
             PathType::NestedPassthrough {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -423,6 +423,7 @@ impl SkillFs {
                         self.resolve_hermes_nested_read(category, skill_name),
                         crate::fs::read_resolution::ReadResolution::Hidden
                     )
+                    && !self.evaluate_trusted_writer(_req).is_allowed()
                 {
                     reply.error(libc::ENOENT);
                     return;
@@ -483,6 +484,34 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
+                let npt = PathType::NestedPassthrough {
+                    category: category.clone(),
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&npt, _req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let physical_path = self
+                            .hermes_skill_physical_dir(category, skill_name)
+                            .join(relative_path);
+                        match std::fs::symlink_metadata(&physical_path) {
+                            Ok(meta) => {
+                                let mut attr = file_attr_from_metadata(&meta);
+                                let ino = self.inodes.allocate(&path_str, attr.kind, parent);
+                                self.inodes.remember(ino);
+                                attr.ino = ino;
+                                reply.entry(&Duration::from_secs(1), &attr, 0);
+                            }
+                            Err(e) => reply.error(errno(&e)),
+                        }
+                        return;
+                    }
+                    None => {}
+                }
                 let nested_id_lu = Self::hermes_skill_id(category, skill_name);
                 if !self.is_staging_skill_root(&nested_id_lu)
                     && !self.is_pending_install(&nested_id_lu)
@@ -884,6 +913,32 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
+                let npt = PathType::NestedPassthrough {
+                    category: category.clone(),
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&npt, _req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let physical_path = self
+                            .hermes_skill_physical_dir(category, skill_name)
+                            .join(relative_path);
+                        match std::fs::symlink_metadata(&physical_path) {
+                            Ok(meta) => {
+                                let mut attr = file_attr_from_metadata(&meta);
+                                attr.ino = ino;
+                                reply.attr(&Duration::from_secs(1), &attr);
+                            }
+                            Err(e) => reply.error(errno(&e)),
+                        }
+                        return;
+                    }
+                    None => {}
+                }
                 let nid = Self::hermes_skill_id(category, skill_name);
                 if !self.is_staging_skill_root(&nid)
                     && !self.is_pending_install(&nid)
@@ -1125,9 +1180,58 @@ impl SkillFs {
                     reply.error(result);
                 }
             }
-            PathType::NestedSkillDir { .. }
-            | PathType::NestedSkillMd { .. }
-            | PathType::NestedPassthrough { .. } => {
+            PathType::NestedSkillDir { .. } | PathType::NestedSkillMd { .. } => {
+                let physical = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
+                let result = self.check_physical_access_result(&physical, mask, req);
+                if result == 0 {
+                    reply.ok();
+                } else {
+                    reply.error(result);
+                }
+            }
+            PathType::NestedPassthrough {
+                ref category,
+                ref skill_name,
+                ref relative_path,
+            } => {
+                let npt = PathType::NestedPassthrough {
+                    category: category.clone(),
+                    skill_name: skill_name.clone(),
+                    relative_path: relative_path.clone(),
+                };
+                match self.is_trusted_skill_meta_access(&npt, req) {
+                    Some(false) => {
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                    Some(true) => {
+                        let file_path = self
+                            .hermes_skill_physical_dir(category, skill_name)
+                            .join(relative_path);
+                        let result = self.check_physical_access_result(&file_path, mask, req);
+                        if result == 0 {
+                            reply.ok();
+                        } else {
+                            reply.error(result);
+                        }
+                        return;
+                    }
+                    None => {}
+                }
+                if (mask & libc::W_OK) != 0 {
+                    if let Some(errno) = self.enforce_skill_meta(
+                        &npt,
+                        SkillEventKind::Metadata,
+                        req,
+                        Some(format!("access mask=0x{:x}", mask)),
+                    ) {
+                        reply.error(errno);
+                        return;
+                    }
+                }
                 let physical = match self.resolve_physical_path(&path) {
                     Some(p) => p,
                     None => return reply.error(libc::ENOENT),

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -411,10 +411,19 @@ impl SkillFs {
                 }
             }
             PathType::NestedSkillDir {
-                category,
-                skill_name,
+                ref category,
+                ref skill_name,
             } => {
-                let physical = self.source_base().join(&category).join(&skill_name);
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let physical = self
+                    .hermes_nested_skill_read_dir(category, skill_name)
+                    .unwrap_or_else(|| self.source_base().join(category).join(skill_name));
                 if physical.is_dir() {
                     let ino = self.inodes.allocate(&path_str, FileType::Directory, parent);
                     self.inodes.remember(ino);
@@ -426,14 +435,26 @@ impl SkillFs {
                 }
             }
             PathType::NestedSkillMd {
-                category,
-                skill_name,
+                ref category,
+                ref skill_name,
             } => {
-                let physical = self
-                    .source_base()
-                    .join(&category)
-                    .join(&skill_name)
-                    .join("SKILL.md");
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let physical = match self.resolve_hermes_nested_read(category, skill_name) {
+                    crate::fs::read_resolution::ReadResolution::Snapshot { dir, .. } => {
+                        dir.join("SKILL.md")
+                    }
+                    _ => self
+                        .source_base()
+                        .join(category)
+                        .join(skill_name)
+                        .join("SKILL.md"),
+                };
                 match std::fs::symlink_metadata(&physical) {
                     Ok(meta) => {
                         let mut attr = file_attr_from_metadata(&meta);
@@ -448,15 +469,27 @@ impl SkillFs {
                 }
             }
             PathType::NestedPassthrough {
-                category,
-                skill_name,
-                relative_path,
+                ref category,
+                ref skill_name,
+                ref relative_path,
             } => {
-                let physical = self
-                    .source_base()
-                    .join(&category)
-                    .join(&skill_name)
-                    .join(&relative_path);
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let physical = match self.resolve_hermes_nested_read(category, skill_name) {
+                    crate::fs::read_resolution::ReadResolution::Snapshot { dir, .. } => {
+                        dir.join(relative_path)
+                    }
+                    _ => self
+                        .source_base()
+                        .join(category)
+                        .join(skill_name)
+                        .join(relative_path),
+                };
                 match std::fs::symlink_metadata(&physical) {
                     Ok(meta) => {
                         let mut attr = file_attr_from_metadata(&meta);
@@ -772,10 +805,19 @@ impl SkillFs {
                 }
             }
             PathType::NestedSkillDir {
-                category,
-                skill_name,
+                ref category,
+                ref skill_name,
             } => {
-                let physical = self.source_base().join(&category).join(&skill_name);
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let physical = self
+                    .hermes_nested_skill_read_dir(category, skill_name)
+                    .unwrap_or_else(|| self.source_base().join(category).join(skill_name));
                 match std::fs::symlink_metadata(&physical) {
                     Ok(meta) => {
                         let mut attr = file_attr_from_metadata(&meta);
@@ -786,14 +828,26 @@ impl SkillFs {
                 }
             }
             PathType::NestedSkillMd {
-                category,
-                skill_name,
+                ref category,
+                ref skill_name,
             } => {
-                let physical = self
-                    .source_base()
-                    .join(&category)
-                    .join(&skill_name)
-                    .join("SKILL.md");
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let physical = match self.resolve_hermes_nested_read(category, skill_name) {
+                    crate::fs::read_resolution::ReadResolution::Snapshot { dir, .. } => {
+                        dir.join("SKILL.md")
+                    }
+                    _ => self
+                        .source_base()
+                        .join(category)
+                        .join(skill_name)
+                        .join("SKILL.md"),
+                };
                 match std::fs::symlink_metadata(&physical) {
                     Ok(meta) => {
                         let mut attr = file_attr_from_metadata(&meta);
@@ -804,15 +858,27 @@ impl SkillFs {
                 }
             }
             PathType::NestedPassthrough {
-                category,
-                skill_name,
-                relative_path,
+                ref category,
+                ref skill_name,
+                ref relative_path,
             } => {
-                let physical = self
-                    .source_base()
-                    .join(&category)
-                    .join(&skill_name)
-                    .join(&relative_path);
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    crate::fs::read_resolution::ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                let physical = match self.resolve_hermes_nested_read(category, skill_name) {
+                    crate::fs::read_resolution::ReadResolution::Snapshot { dir, .. } => {
+                        dir.join(relative_path)
+                    }
+                    _ => self
+                        .source_base()
+                        .join(category)
+                        .join(skill_name)
+                        .join(relative_path),
+                };
                 match std::fs::symlink_metadata(&physical) {
                     Ok(meta) => {
                         let mut attr = file_attr_from_metadata(&meta);

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -414,10 +414,16 @@ impl SkillFs {
                 ref category,
                 ref skill_name,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
+                // H3: staging and pending install bypass for nested
+                // skill lookup.
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id)
+                    && !self.is_pending_install(&nested_id)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        crate::fs::read_resolution::ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }
@@ -438,10 +444,14 @@ impl SkillFs {
                 ref category,
                 ref skill_name,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id)
+                    && !self.is_pending_install(&nested_id)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        crate::fs::read_resolution::ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }
@@ -473,10 +483,14 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
+                let nested_id_lu = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id_lu)
+                    && !self.is_pending_install(&nested_id_lu)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        crate::fs::read_resolution::ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }
@@ -808,10 +822,14 @@ impl SkillFs {
                 ref category,
                 ref skill_name,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
+                let nid = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nid)
+                    && !self.is_pending_install(&nid)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        crate::fs::read_resolution::ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }
@@ -831,10 +849,14 @@ impl SkillFs {
                 ref category,
                 ref skill_name,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
+                let nid = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nid)
+                    && !self.is_pending_install(&nid)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        crate::fs::read_resolution::ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }
@@ -862,10 +884,14 @@ impl SkillFs {
                 ref skill_name,
                 ref relative_path,
             } => {
-                if matches!(
-                    self.resolve_hermes_nested_read(category, skill_name),
-                    crate::fs::read_resolution::ReadResolution::Hidden
-                ) {
+                let nid = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nid)
+                    && !self.is_pending_install(&nid)
+                    && matches!(
+                        self.resolve_hermes_nested_read(category, skill_name),
+                        crate::fs::read_resolution::ReadResolution::Hidden
+                    )
+                {
                     reply.error(libc::ENOENT);
                     return;
                 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
@@ -71,15 +71,27 @@ impl SkillFs {
             return;
         }
 
-        // I4: reject mkdir on hidden skills unless the path matches
-        // the post-publish grace whitelist. SkillDir mkdir is not gated
-        // — creating a new skill directory is the start of an install.
-        if let PathType::Passthrough {
-            ref skill_name,
-            ref relative_path,
-        } = path_type
+        // I4/H3: reject mkdir on hidden skills unless the path
+        // matches the post-publish grace whitelist. SkillDir /
+        // NestedSkillDir mkdir is not gated — creating a new skill
+        // directory is the start of an install.
         {
-            if self.should_reject_hidden_write(skill_name, Some(relative_path)) {
+            let reject = match &path_type {
+                PathType::Passthrough {
+                    skill_name,
+                    relative_path,
+                } => self.should_reject_hidden_write(skill_name, Some(relative_path)),
+                PathType::NestedPassthrough {
+                    category,
+                    skill_name,
+                    relative_path,
+                } => {
+                    let nid = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nid, Some(relative_path))
+                }
+                _ => false,
+            };
+            if reject {
                 reply.error(libc::ENOENT);
                 return;
             }
@@ -279,13 +291,31 @@ impl SkillFs {
             return;
         }
 
-        // I4: reject unlink on hidden skills unless grace-allowed.
-        if let PathType::Passthrough {
-            ref skill_name,
-            ref relative_path,
-        } = path_type
+        // I4/H3: reject unlink on hidden skills unless grace-allowed.
         {
-            if self.should_reject_hidden_write(skill_name, Some(relative_path)) {
+            let reject = match &path_type {
+                PathType::Passthrough {
+                    skill_name,
+                    relative_path,
+                } => self.should_reject_hidden_write(skill_name, Some(relative_path)),
+                PathType::NestedPassthrough {
+                    category,
+                    skill_name,
+                    relative_path,
+                } => {
+                    let nid = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nid, Some(relative_path))
+                }
+                PathType::NestedSkillMd {
+                    category,
+                    skill_name,
+                } => {
+                    let nid = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nid, Some(Path::new("SKILL.md")))
+                }
+                _ => false,
+            };
+            if reject {
                 reply.error(libc::ENOENT);
                 return;
             }
@@ -444,13 +474,24 @@ impl SkillFs {
             return;
         }
 
-        // I4: reject rmdir on hidden skills unless grace-allowed.
-        if let PathType::Passthrough {
-            ref skill_name,
-            ref relative_path,
-        } = path_type
+        // I4/H3: reject rmdir on hidden skills unless grace-allowed.
         {
-            if self.should_reject_hidden_write(skill_name, Some(relative_path)) {
+            let reject = match &path_type {
+                PathType::Passthrough {
+                    skill_name,
+                    relative_path,
+                } => self.should_reject_hidden_write(skill_name, Some(relative_path)),
+                PathType::NestedPassthrough {
+                    category,
+                    skill_name,
+                    relative_path,
+                } => {
+                    let nid = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nid, Some(relative_path))
+                }
+                _ => false,
+            };
+            if reject {
                 reply.error(libc::ENOENT);
                 return;
             }
@@ -727,26 +768,45 @@ impl SkillFs {
             return;
         }
 
-        // I4: reject renames on hidden skills unless both sides match
-        // the post-publish grace whitelist.
+        // I4/H3: reject renames on hidden skills unless both sides
+        // match the post-publish grace whitelist.
         for pt in [&old_path_type, &new_path_type] {
-            let (skill_name, rel) = match pt {
+            let reject = match pt {
                 PathType::Passthrough {
                     skill_name,
                     relative_path,
-                } => (skill_name.as_str(), relative_path.as_path()),
-                PathType::SkillMd { skill_name } => (skill_name.as_str(), Path::new("SKILL.md")),
-                _ => continue,
+                } => self.should_reject_hidden_write(skill_name, Some(relative_path)),
+                PathType::SkillMd { skill_name } => {
+                    self.should_reject_hidden_write(skill_name, Some(Path::new("SKILL.md")))
+                }
+                PathType::NestedPassthrough {
+                    category,
+                    skill_name,
+                    relative_path,
+                } => {
+                    let nested_id = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nested_id, Some(relative_path))
+                }
+                PathType::NestedSkillMd {
+                    category,
+                    skill_name,
+                } => {
+                    let nested_id = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nested_id, Some(Path::new("SKILL.md")))
+                }
+                _ => false,
             };
-            if self.should_reject_hidden_write(skill_name, Some(rel)) {
+            if reject {
                 reply.error(libc::ENOENT);
                 return;
             }
         }
 
-        // I2: staging-to-skill rename validation. When a staging root is
-        // renamed to a top-level skill directory, validate the target name
+        // I2/H3: staging-to-skill rename validation. When a staging root
+        // is renamed to a skill directory, validate the target name
         // against sensitive namespaces and invalid skill name shapes.
+        // Flat layout: SkillDir → SkillDir.
+        // Hermes layout: NestedSkillDir → NestedSkillDir (same category).
         let is_staging_rename = if let Some(ref matcher) = self.staging_matcher {
             match (&old_path_type, &new_path_type) {
                 (
@@ -763,6 +823,41 @@ impl SkillFs {
                             old = %old_path,
                             new = %new_path,
                             "rename: rejecting staging rename to invalid target"
+                        );
+                        self.emit_event(
+                            SkillEvent::new(SkillEventKind::Rename)
+                                .with_optional_skill_name(event_skill.clone())
+                                .with_optional_relative_path(event_relative.clone())
+                                .with_action(SkillEventAction::Rejected)
+                                .with_errno(libc::EACCES)
+                                .with_caller(req.uid(), req.gid())
+                                .with_detail(format!(
+                                    "class=invalid_staging_rename_target old={} new={}",
+                                    old_path, new_path
+                                )),
+                        );
+                        reply.error(libc::EACCES);
+                        return;
+                    }
+                    true
+                }
+                // H3: Hermes intra-category staging rename.
+                (
+                    PathType::NestedSkillDir {
+                        category: old_cat,
+                        skill_name: old_skill,
+                    },
+                    PathType::NestedSkillDir {
+                        category: new_cat,
+                        skill_name: new_skill,
+                    },
+                ) if old_cat == new_cat && matcher.is_staging_root(old_skill) => {
+                    if !crate::security::install::is_valid_staging_rename_target(new_skill, matcher)
+                    {
+                        warn!(
+                            old = %old_path,
+                            new = %new_path,
+                            "rename: rejecting Hermes staging rename to invalid target"
                         );
                         self.emit_event(
                             SkillEvent::new(SkillEventKind::Rename)
@@ -926,22 +1021,30 @@ impl SkillFs {
                     }
                 }
 
-                // I2: staging-to-skill rename triggers exactly one
+                // I2/H3: staging-to-skill rename triggers exactly one
                 // rename mutation notify (non-blocking enqueue).
                 // The generic old/new observe pair below is skipped for
                 // staging renames.
                 if is_staging_rename {
-                    if let PathType::SkillDir {
-                        skill_name: new_name,
-                    } = &new_type
-                    {
+                    let notify_id = match &new_type {
+                        PathType::SkillDir {
+                            skill_name: new_name,
+                        } => Some(new_name.clone()),
+                        // H3: Hermes intra-category staging rename.
+                        PathType::NestedSkillDir {
+                            category,
+                            skill_name,
+                        } => Some(Self::hermes_skill_id(category, skill_name)),
+                        _ => None,
+                    };
+                    if let Some(ref id) = notify_id {
                         if let Some(ref staging_ctrl) = self.staging_controller {
-                            staging_ctrl.emit_staging_rename_notify(new_name);
+                            staging_ctrl.emit_staging_rename_notify(id);
                         }
                         // I4: start post-publish grace session after staging rename.
                         if let Some(ref pp_ctrl) = self.post_publish_controller {
                             pp_ctrl.start_session(
-                                new_name,
+                                id,
                                 crate::security::PostPublishSessionKind::StagingRename,
                             );
                         }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
@@ -9,7 +9,7 @@ use skillfs_core::parser;
 use tracing::{debug, info, warn};
 
 use super::super::SkillFs;
-use crate::path::{PathType, parse_path};
+use crate::path::PathType;
 use crate::security::{MutationKind, SkillEvent, SkillEventAction, SkillEventKind};
 use crate::sync::SyncEvent;
 use crate::sys::{errno, mkdirat_leaf, rename_noreplace, renameat2_leaf, unlinkat_leaf};
@@ -31,7 +31,7 @@ impl SkillFs {
                 return;
             }
         };
-        let path_type = parse_path(Path::new(&path_str), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path_str));
 
         // L1: the inbox virtual root is always present — refuse to
         // shadow it with a real directory. The inbox-skill case lands
@@ -232,7 +232,7 @@ impl SkillFs {
                 return;
             }
         };
-        let path_type = parse_path(Path::new(&path_str), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path_str));
         let (skill_name_for_event, relative_for_event) = match &path_type {
             PathType::Passthrough {
                 skill_name,
@@ -383,7 +383,7 @@ impl SkillFs {
                 return;
             }
         };
-        let path_type = parse_path(Path::new(&path_str), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path_str));
 
         // S3: refuse to rmdir a reserved lifecycle namespace or any
         // directory beneath one. The gate fires before any physical
@@ -543,8 +543,8 @@ impl SkillFs {
                 return;
             }
         };
-        let old_path_type = parse_path(Path::new(&old_path), self.in_place);
-        let new_path_type = parse_path(Path::new(&new_path), self.in_place);
+        let old_path_type = self.parse_fuse_path(Path::new(&old_path));
+        let new_path_type = self.parse_fuse_path(Path::new(&new_path));
         let (event_skill, event_relative) = match &old_path_type {
             PathType::Passthrough {
                 skill_name,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
@@ -85,10 +85,11 @@ impl SkillFs {
                     category,
                     skill_name,
                     relative_path,
-                } => {
-                    let nid = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nid, Some(relative_path))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(relative_path),
+                ),
                 _ => false,
             };
             if reject {
@@ -302,17 +303,19 @@ impl SkillFs {
                     category,
                     skill_name,
                     relative_path,
-                } => {
-                    let nid = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nid, Some(relative_path))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(relative_path),
+                ),
                 PathType::NestedSkillMd {
                     category,
                     skill_name,
-                } => {
-                    let nid = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nid, Some(Path::new("SKILL.md")))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(Path::new("SKILL.md")),
+                ),
                 _ => false,
             };
             if reject {
@@ -485,10 +488,11 @@ impl SkillFs {
                     category,
                     skill_name,
                     relative_path,
-                } => {
-                    let nid = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nid, Some(relative_path))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(relative_path),
+                ),
                 _ => false,
             };
             if reject {
@@ -783,17 +787,19 @@ impl SkillFs {
                     category,
                     skill_name,
                     relative_path,
-                } => {
-                    let nested_id = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nested_id, Some(relative_path))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(relative_path),
+                ),
                 PathType::NestedSkillMd {
                     category,
                     skill_name,
-                } => {
-                    let nested_id = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nested_id, Some(Path::new("SKILL.md")))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(Path::new("SKILL.md")),
+                ),
                 _ => false,
             };
             if reject {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
@@ -1079,6 +1079,28 @@ impl SkillFs {
                     PathType::InboxSkillDir { skill_name } => {
                         Some((skill_name.clone(), None, true))
                     }
+                    // H3: Hermes nested paths.
+                    PathType::NestedSkillMd {
+                        category,
+                        skill_name,
+                    } => Some((
+                        Self::hermes_skill_id(category, skill_name),
+                        Some(PathBuf::from("SKILL.md")),
+                        false,
+                    )),
+                    PathType::NestedPassthrough {
+                        category,
+                        skill_name,
+                        relative_path,
+                    } => Some((
+                        Self::hermes_skill_id(category, skill_name),
+                        Some(relative_path.clone()),
+                        false,
+                    )),
+                    PathType::NestedSkillDir {
+                        category,
+                        skill_name,
+                    } => Some((Self::hermes_skill_id(category, skill_name), None, false)),
                     _ => None,
                 };
                 let new_skill_path = match &new_type {
@@ -1097,6 +1119,27 @@ impl SkillFs {
                     PathType::InboxSkillDir { skill_name } => {
                         Some((skill_name.clone(), None, true))
                     }
+                    PathType::NestedSkillMd {
+                        category,
+                        skill_name,
+                    } => Some((
+                        Self::hermes_skill_id(category, skill_name),
+                        Some(PathBuf::from("SKILL.md")),
+                        false,
+                    )),
+                    PathType::NestedPassthrough {
+                        category,
+                        skill_name,
+                        relative_path,
+                    } => Some((
+                        Self::hermes_skill_id(category, skill_name),
+                        Some(relative_path.clone()),
+                        false,
+                    )),
+                    PathType::NestedSkillDir {
+                        category,
+                        skill_name,
+                    } => Some((Self::hermes_skill_id(category, skill_name), None, false)),
                     _ => None,
                 };
                 let observe_pair = |fs: &Self, skill: &str, rel: Option<&Path>, is_inbox: bool| {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
@@ -207,6 +207,25 @@ impl SkillFs {
                             MutationKind::Mkdir,
                         );
                     }
+                    PathType::NestedSkillDir {
+                        category,
+                        skill_name,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(&nested_id, None, MutationKind::Mkdir);
+                    }
+                    PathType::NestedPassthrough {
+                        category,
+                        skill_name,
+                        relative_path,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(relative_path.as_path()),
+                            MutationKind::Mkdir,
+                        );
+                    }
                     _ => {}
                 }
 
@@ -343,6 +362,29 @@ impl SkillFs {
                         relative_path.as_path(),
                         MutationKind::Unlink,
                     ),
+                    PathType::NestedSkillMd {
+                        category,
+                        skill_name,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(Path::new("SKILL.md")),
+                            MutationKind::Unlink,
+                        );
+                    }
+                    PathType::NestedPassthrough {
+                        category,
+                        skill_name,
+                        relative_path,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(relative_path.as_path()),
+                            MutationKind::Unlink,
+                        );
+                    }
                     _ => {}
                 }
                 self.emit_event(
@@ -486,6 +528,25 @@ impl SkillFs {
                         relative_path.as_path(),
                         MutationKind::Rmdir,
                     ),
+                    PathType::NestedSkillDir {
+                        category,
+                        skill_name,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(&nested_id, None, MutationKind::Rmdir);
+                    }
+                    PathType::NestedPassthrough {
+                        category,
+                        skill_name,
+                        relative_path,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(relative_path.as_path()),
+                            MutationKind::Rmdir,
+                        );
+                    }
                     _ => {}
                 }
                 reply.ok();

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -9,7 +9,7 @@ use tracing::{debug, warn};
 use super::super::SkillFs;
 use super::super::read_resolution::ReadResolution;
 use crate::handles::open_options_from_flags;
-use crate::path::{PathType, is_skill_discover_path, parse_path};
+use crate::path::{PathType, is_skill_discover_path};
 use crate::security::{SkillEventAction, SkillEventKind};
 use crate::sync::SyncEvent;
 use crate::sys::{errno, openat_leaf};
@@ -56,7 +56,7 @@ impl SkillFs {
             }
         };
 
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         // Read events are high-volume so we emit only on failure to keep the
         // audit stream useful without flooding it with per-syscall successes.
@@ -115,7 +115,12 @@ impl SkillFs {
                     }
                 }
             }
-            PathType::Passthrough { .. } | PathType::InboxPassthrough { .. } => {
+            PathType::Passthrough { .. }
+            | PathType::InboxPassthrough { .. }
+            | PathType::HermesMeta { .. }
+            | PathType::HermesMetaChild { .. }
+            | PathType::NestedSkillMd { .. }
+            | PathType::NestedPassthrough { .. } => {
                 // Use fd-backed read via handle
                 let result = self.handles.with_handle(fh, |entry| {
                     if let Some(ref file) = entry.file {
@@ -202,7 +207,7 @@ impl SkillFs {
             }
         };
 
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
         let access_mode = flags & libc::O_ACCMODE;
         let is_write = access_mode == libc::O_WRONLY || access_mode == libc::O_RDWR;
 
@@ -232,6 +237,17 @@ impl SkillFs {
             PathType::InboxPassthrough { skill_name, .. } => {
                 if !Self::is_inbox_skill_name_allowed(skill_name) {
                     reply.error(libc::ENOENT);
+                    return;
+                }
+            }
+            PathType::CategoryDir { .. } | PathType::NestedSkillDir { .. } => {
+                reply.error(libc::EISDIR);
+                return;
+            }
+            PathType::HermesMeta { name } => {
+                let physical = self.source_base().join(name);
+                if physical.is_dir() {
+                    reply.error(libc::EISDIR);
                     return;
                 }
             }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -240,7 +240,21 @@ impl SkillFs {
                     return;
                 }
             }
-            PathType::CategoryDir { .. } | PathType::NestedSkillDir { .. } => {
+            PathType::CategoryDir { .. } => {
+                reply.error(libc::EISDIR);
+                return;
+            }
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => {
+                if matches!(
+                    self.resolve_hermes_nested_read(category, skill_name),
+                    ReadResolution::Hidden
+                ) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
                 reply.error(libc::EISDIR);
                 return;
             }
@@ -450,6 +464,30 @@ impl SkillFs {
                     }
                 }
             }
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            }
+            | PathType::NestedPassthrough {
+                category,
+                skill_name,
+                ..
+            } => match self.resolve_hermes_nested_read(category, skill_name) {
+                ReadResolution::Hidden => {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                ReadResolution::Snapshot { dir, .. } if !is_mutating_open => match &path_type {
+                    PathType::NestedSkillMd { .. } => {
+                        physical = dir.join("SKILL.md");
+                    }
+                    PathType::NestedPassthrough { relative_path, .. } => {
+                        physical = dir.join(relative_path);
+                    }
+                    _ => {}
+                },
+                _ => {}
+            },
             _ => {}
         }
 

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -472,22 +472,42 @@ impl SkillFs {
                 category,
                 skill_name,
                 ..
-            } => match self.resolve_hermes_nested_read(category, skill_name) {
-                ReadResolution::Hidden => {
-                    reply.error(libc::ENOENT);
-                    return;
+            } => {
+                // H3: staging and pending install bypass for nested skills.
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                if !self.is_staging_skill_root(&nested_id) && !self.is_pending_install(&nested_id) {
+                    let grace_rel = match &path_type {
+                        PathType::NestedPassthrough { relative_path, .. } => {
+                            Some(relative_path.as_path())
+                        }
+                        PathType::NestedSkillMd { .. } => Some(Path::new("SKILL.md")),
+                        _ => None,
+                    };
+                    match self.resolve_hermes_nested_read(category, skill_name) {
+                        ReadResolution::Hidden
+                            if !self.is_post_publish_grace_allowed(&nested_id, grace_rel) =>
+                        {
+                            reply.error(libc::ENOENT);
+                            return;
+                        }
+                        ReadResolution::Hidden => {
+                            // H3: grace bypass — let the open proceed against source.
+                        }
+                        ReadResolution::Snapshot { dir, .. } if !is_mutating_open => {
+                            match &path_type {
+                                PathType::NestedSkillMd { .. } => {
+                                    physical = dir.join("SKILL.md");
+                                }
+                                PathType::NestedPassthrough { relative_path, .. } => {
+                                    physical = dir.join(relative_path);
+                                }
+                                _ => {}
+                            }
+                        }
+                        _ => {}
+                    }
                 }
-                ReadResolution::Snapshot { dir, .. } if !is_mutating_open => match &path_type {
-                    PathType::NestedSkillMd { .. } => {
-                        physical = dir.join("SKILL.md");
-                    }
-                    PathType::NestedPassthrough { relative_path, .. } => {
-                        physical = dir.join(relative_path);
-                    }
-                    _ => {}
-                },
-                _ => {}
-            },
+            }
             _ => {}
         }
 

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -176,6 +176,7 @@ impl SkillFs {
             | PathType::InboxPassthrough { .. }
             | PathType::HermesMeta { .. }
             | PathType::HermesMetaChild { .. }
+            | PathType::CategoryPassthrough { .. }
             | PathType::NestedPassthrough { .. } => {
                 // Use fd-backed read via handle
                 let result = self.handles.with_handle(fh, |entry| {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -302,6 +302,14 @@ impl SkillFs {
                         ref skill_name,
                         ref relative_path,
                     } => Some(self.inbox_skill_dir(skill_name).join(relative_path)),
+                    PathType::NestedPassthrough {
+                        ref category,
+                        ref skill_name,
+                        ref relative_path,
+                    } => Some(
+                        self.hermes_skill_physical_dir(category, skill_name)
+                            .join(relative_path),
+                    ),
                     _ => None,
                 };
                 if let Some(physical) = physical {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -115,11 +115,67 @@ impl SkillFs {
                     }
                 }
             }
+            PathType::NestedSkillMd {
+                ref category,
+                ref skill_name,
+            } if self.is_staging_skill_root(&Self::hermes_skill_id(category, skill_name))
+                || self.is_pending_install(&Self::hermes_skill_id(category, skill_name)) =>
+            {
+                // Staging / pending nested SKILL.md is served raw from the
+                // physical handle, mirroring the flat SkillMd behavior.
+                let result = self.handles.with_handle(fh, |entry| {
+                    if let Some(ref file) = entry.file {
+                        let mut buf = vec![0u8; size as usize];
+                        match file.read_at(&mut buf, offset as u64) {
+                            Ok(n) => Ok(buf[..n].to_vec()),
+                            Err(e) => Err(errno(&e)),
+                        }
+                    } else {
+                        Err(libc::EBADF)
+                    }
+                });
+                match result {
+                    Some(Ok(data)) => {
+                        reply.data(&data);
+                        return;
+                    }
+                    Some(Err(e)) => {
+                        reply.error(e);
+                        return;
+                    }
+                    None => {
+                        reply.error(libc::EBADF);
+                        return;
+                    }
+                }
+            }
+            PathType::NestedSkillMd {
+                ref category,
+                ref skill_name,
+            } => {
+                // Nested SKILL.md is compiled just like the flat SkillMd:
+                // frontmatter is stripped and env placeholders resolved, so
+                // the agent-visible content matches the flat contract.
+                match self.compiled_hermes_nested_skill_md(category, skill_name) {
+                    Some(c) => c,
+                    None => {
+                        self.emit_op_event(
+                            req,
+                            &path_type,
+                            SkillEventKind::Read,
+                            SkillEventAction::Failed,
+                            Some(libc::ENOENT),
+                            None,
+                        );
+                        reply.error(libc::ENOENT);
+                        return;
+                    }
+                }
+            }
             PathType::Passthrough { .. }
             | PathType::InboxPassthrough { .. }
             | PathType::HermesMeta { .. }
             | PathType::HermesMetaChild { .. }
-            | PathType::NestedSkillMd { .. }
             | PathType::NestedPassthrough { .. } => {
                 // Use fd-backed read via handle
                 let result = self.handles.with_handle(fh, |entry| {
@@ -650,6 +706,88 @@ impl SkillFs {
                 let fh = self
                     .handles
                     .allocate(ino, flags, None, pinned_target.clone());
+                self.emit_op_event(
+                    req,
+                    &path_type,
+                    SkillEventKind::Open,
+                    SkillEventAction::Allowed,
+                    None,
+                    None,
+                );
+                reply.opened(fh, 0);
+            }
+            return;
+        }
+
+        // Nested SKILL.md: virtual compiled read, physical write. Mirrors
+        // the flat SkillMd handling so nested skills strip frontmatter on
+        // read while writes still target the live source file.
+        if let PathType::NestedSkillMd {
+            ref category,
+            ref skill_name,
+        } = path_type
+        {
+            let nested_id = Self::hermes_skill_id(category, skill_name);
+            let is_trunc = (flags & libc::O_TRUNC) != 0;
+
+            if is_trunc {
+                if let Err(e) = std::fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(&physical)
+                {
+                    warn!(op = "open", ?physical, error = %e, "nested SKILL.md O_TRUNC failed");
+                    reply.error(errno(&e));
+                    return;
+                }
+                self.observe_mutation(
+                    &nested_id,
+                    Some(Path::new("SKILL.md")),
+                    crate::security::MutationKind::SetattrTruncate,
+                );
+            }
+
+            if is_write {
+                match open_options_from_flags(flags).open(&physical) {
+                    Ok(file) => {
+                        let fh = self.handles.allocate(ino, flags, Some(file), None);
+                        self.emit_op_event(
+                            req,
+                            &path_type,
+                            SkillEventKind::Open,
+                            SkillEventAction::Allowed,
+                            None,
+                            None,
+                        );
+                        reply.opened(fh, 0);
+                    }
+                    Err(e) => {
+                        warn!(op = "open", ?physical, error = %e, "open failed");
+                        let err = errno(&e);
+                        self.emit_op_event(
+                            req,
+                            &path_type,
+                            SkillEventKind::Open,
+                            SkillEventAction::Failed,
+                            Some(err),
+                            None,
+                        );
+                        reply.error(err);
+                    }
+                }
+            } else if self.is_staging_skill_root(&nested_id) || self.is_pending_install(&nested_id)
+            {
+                // Staging / pending nested SKILL.md is served raw.
+                match open_options_from_flags(flags).open(&physical) {
+                    Ok(file) => {
+                        let fh = self.handles.allocate(ino, flags, Some(file), None);
+                        reply.opened(fh, 0);
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            } else {
+                // Read-only: compiled content served virtually, no fd.
+                let fh = self.handles.allocate(ino, flags, None, None);
                 self.emit_op_event(
                     req,
                     &path_type,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 use super::super::SkillFs;
 use crate::attr::{file_attr_from_metadata, file_attr_from_stat};
 use crate::handles::open_options_from_flags;
-use crate::path::{PathType, is_skill_discover_path, parse_path};
+use crate::path::{PathType, is_skill_discover_path};
 use crate::security::{MutationKind, SkillEventAction, SkillEventKind};
 use crate::sync::SyncEvent;
 use crate::sys::{errno, fstatat_leaf, openat_leaf};
@@ -69,7 +69,7 @@ impl SkillFs {
             }
         };
 
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         // skill-discover namespace is always read-only
         match &path_type {
@@ -234,7 +234,7 @@ impl SkillFs {
                 return;
             }
         };
-        let path_type = parse_path(Path::new(&path_str), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path_str));
 
         // L1: the inbox virtual root is a directory; refuse to shadow it
         // with a regular file (e.g. a stray `touch /.skillfs-inbox` from
@@ -519,7 +519,7 @@ impl SkillFs {
                 return;
             }
         };
-        let path_type = parse_path(Path::new(&path_str), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path_str));
 
         // T2 mknod policy: FIFO is the only special file SkillFS creates.
         // Sockets, block/char devices, and any other S_IFMT bit are
@@ -704,7 +704,7 @@ impl SkillFs {
             }
         };
 
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         // Determine whether any mutation is requested.
         let has_mutation = size.is_some()
@@ -817,6 +817,14 @@ impl SkillFs {
                 }
                 // Fall through to physical mutation; lifecycle and
                 // `.skill-meta` gates run below.
+            }
+            PathType::HermesMeta { .. }
+            | PathType::HermesMetaChild { .. }
+            | PathType::CategoryDir { .. }
+            | PathType::NestedSkillDir { .. }
+            | PathType::NestedSkillMd { .. }
+            | PathType::NestedPassthrough { .. } => {
+                // Hermes paths fall through to physical mutation.
             }
             PathType::Invalid => {
                 reply.error(libc::ENOENT);

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -181,6 +181,29 @@ impl SkillFs {
                         relative_path.as_path(),
                         MutationKind::Write,
                     ),
+                    PathType::NestedSkillMd {
+                        category,
+                        skill_name,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(Path::new("SKILL.md")),
+                            MutationKind::Write,
+                        );
+                    }
+                    PathType::NestedPassthrough {
+                        category,
+                        skill_name,
+                        relative_path,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(relative_path.as_path()),
+                            MutationKind::Write,
+                        );
+                    }
                     _ => {}
                 }
                 self.emit_op_event(
@@ -474,6 +497,29 @@ impl SkillFs {
                         relative_path.as_path(),
                         MutationKind::Create,
                     ),
+                    PathType::NestedSkillMd {
+                        category,
+                        skill_name,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(Path::new("SKILL.md")),
+                            MutationKind::Create,
+                        );
+                    }
+                    PathType::NestedPassthrough {
+                        category,
+                        skill_name,
+                        relative_path,
+                    } => {
+                        let nested_id = Self::hermes_skill_id(category, skill_name);
+                        self.observe_mutation(
+                            &nested_id,
+                            Some(relative_path.as_path()),
+                            MutationKind::Create,
+                        );
+                    }
                     _ => {}
                 }
 
@@ -648,16 +694,30 @@ impl SkillFs {
                 a
             }
         };
-        if let PathType::Passthrough {
-            skill_name,
-            relative_path,
-        } = &path_type
-        {
-            self.observe_mutation(
+        match &path_type {
+            PathType::Passthrough {
                 skill_name,
-                Some(relative_path.as_path()),
-                MutationKind::Create,
-            );
+                relative_path,
+            } => {
+                self.observe_mutation(
+                    skill_name,
+                    Some(relative_path.as_path()),
+                    MutationKind::Create,
+                );
+            }
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => {
+                let nested_id = Self::hermes_skill_id(category, skill_name);
+                self.observe_mutation(
+                    &nested_id,
+                    Some(relative_path.as_path()),
+                    MutationKind::Create,
+                );
+            }
+            _ => {}
         }
         self.emit_op_event(
             req,
@@ -939,6 +999,29 @@ impl SkillFs {
                             relative_path.as_path(),
                             MutationKind::SetattrTruncate,
                         ),
+                        PathType::NestedSkillMd {
+                            category,
+                            skill_name,
+                        } => {
+                            let nested_id = Self::hermes_skill_id(category, skill_name);
+                            self.observe_mutation(
+                                &nested_id,
+                                Some(Path::new("SKILL.md")),
+                                MutationKind::SetattrTruncate,
+                            );
+                        }
+                        PathType::NestedPassthrough {
+                            category,
+                            skill_name,
+                            relative_path,
+                        } => {
+                            let nested_id = Self::hermes_skill_id(category, skill_name);
+                            self.observe_mutation(
+                                &nested_id,
+                                Some(relative_path.as_path()),
+                                MutationKind::SetattrTruncate,
+                            );
+                        }
                         _ => {}
                     }
                 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -351,17 +351,19 @@ impl SkillFs {
                     category,
                     skill_name,
                     relative_path,
-                } => {
-                    let nid = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nid, Some(relative_path))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(relative_path),
+                ),
                 PathType::NestedSkillMd {
                     category,
                     skill_name,
-                } => {
-                    let nid = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nid, Some(Path::new("SKILL.md")))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(Path::new("SKILL.md")),
+                ),
                 _ => false,
             };
             if reject {
@@ -951,17 +953,19 @@ impl SkillFs {
                     category,
                     skill_name,
                     relative_path,
-                } => {
-                    let nested_id = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nested_id, Some(relative_path))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(relative_path),
+                ),
                 PathType::NestedSkillMd {
                     category,
                     skill_name,
-                } => {
-                    let nested_id = Self::hermes_skill_id(category, skill_name);
-                    self.should_reject_hidden_write(&nested_id, Some(Path::new("SKILL.md")))
-                }
+                } => self.should_reject_hermes_nested_hidden_write(
+                    category,
+                    skill_name,
+                    Some(Path::new("SKILL.md")),
+                ),
                 _ => false,
             };
             if reject {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -898,6 +898,7 @@ impl SkillFs {
             }
             PathType::HermesMeta { .. }
             | PathType::HermesMetaChild { .. }
+            | PathType::CategoryPassthrough { .. }
             | PathType::CategoryDir { .. }
             | PathType::NestedSkillDir { .. }
             | PathType::NestedSkillMd { .. }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -339,14 +339,32 @@ impl SkillFs {
             return;
         }
 
-        // I4: reject create on hidden skills unless the path matches
-        // the post-publish grace whitelist.
-        if let PathType::Passthrough {
-            ref skill_name,
-            ref relative_path,
-        } = path_type
+        // I4/H3: reject create on hidden skills unless the path
+        // matches the post-publish grace whitelist.
         {
-            if self.should_reject_hidden_write(skill_name, Some(relative_path)) {
+            let reject = match &path_type {
+                PathType::Passthrough {
+                    skill_name,
+                    relative_path,
+                } => self.should_reject_hidden_write(skill_name, Some(relative_path)),
+                PathType::NestedPassthrough {
+                    category,
+                    skill_name,
+                    relative_path,
+                } => {
+                    let nid = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nid, Some(relative_path))
+                }
+                PathType::NestedSkillMd {
+                    category,
+                    skill_name,
+                } => {
+                    let nid = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nid, Some(Path::new("SKILL.md")))
+                }
+                _ => false,
+            };
+            if reject {
                 reply.error(libc::ENOENT);
                 return;
             }
@@ -917,18 +935,35 @@ impl SkillFs {
             }
         }
 
-        // I4: reject setattr mutations on hidden skills unless
+        // I4/H3: reject setattr mutations on hidden skills unless
         // the path matches the post-publish grace whitelist.
         if has_mutation {
-            let (skill_name, rel) = match &path_type {
+            let reject = match &path_type {
                 PathType::Passthrough {
                     skill_name,
                     relative_path,
-                } => (skill_name.as_str(), relative_path.as_path()),
-                PathType::SkillMd { skill_name } => (skill_name.as_str(), Path::new("SKILL.md")),
-                _ => ("", Path::new("")),
+                } => self.should_reject_hidden_write(skill_name, Some(relative_path)),
+                PathType::SkillMd { skill_name } => {
+                    self.should_reject_hidden_write(skill_name, Some(Path::new("SKILL.md")))
+                }
+                PathType::NestedPassthrough {
+                    category,
+                    skill_name,
+                    relative_path,
+                } => {
+                    let nested_id = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nested_id, Some(relative_path))
+                }
+                PathType::NestedSkillMd {
+                    category,
+                    skill_name,
+                } => {
+                    let nested_id = Self::hermes_skill_id(category, skill_name);
+                    self.should_reject_hidden_write(&nested_id, Some(Path::new("SKILL.md")))
+                }
+                _ => false,
             };
-            if !skill_name.is_empty() && self.should_reject_hidden_write(skill_name, Some(rel)) {
+            if reject {
                 reply.error(libc::ENOENT);
                 return;
             }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/xattr.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/xattr.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use fuser::{ReplyEmpty, ReplyXattr, Request};
 
 use super::super::SkillFs;
-use crate::path::parse_path;
 use crate::security::{SkillEventAction, SkillEventKind};
 use crate::xattr::{
     XattrNamespace, filter_user_xattr_list, path_type_supports_xattr_passthrough, xattr_lget,
@@ -25,7 +24,7 @@ impl SkillFs {
             Some(p) => p,
             None => return reply.error(libc::ENOENT),
         };
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         if !path_type_supports_xattr_passthrough(&path_type) {
             return reply.error(libc::EOPNOTSUPP);
@@ -69,7 +68,7 @@ impl SkillFs {
             Some(p) => p,
             None => return reply.error(libc::ENOENT),
         };
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         if !path_type_supports_xattr_passthrough(&path_type) {
             return reply.error(libc::EOPNOTSUPP);
@@ -115,7 +114,7 @@ impl SkillFs {
             Some(p) => p,
             None => return reply.error(libc::ENOENT),
         };
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         if !path_type_supports_xattr_passthrough(&path_type) {
             self.emit_xattr_event(
@@ -206,7 +205,7 @@ impl SkillFs {
             Some(p) => p,
             None => return reply.error(libc::ENOENT),
         };
-        let path_type = parse_path(Path::new(&path), self.in_place);
+        let path_type = self.parse_fuse_path(Path::new(&path));
 
         if !path_type_supports_xattr_passthrough(&path_type) {
             self.emit_xattr_event(

--- a/src/skillfs/crates/skillfs-fuse/src/fs/events.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/events.rs
@@ -137,6 +137,25 @@ impl SkillFs {
             PathType::SkillDir { skill_name } | PathType::InboxSkillDir { skill_name } => {
                 (Some(skill_name.clone()), None)
             }
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => (Some(Self::hermes_skill_id(category, skill_name)), None),
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } => (
+                Some(Self::hermes_skill_id(category, skill_name)),
+                Some(PathBuf::from("SKILL.md")),
+            ),
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => (
+                Some(Self::hermes_skill_id(category, skill_name)),
+                Some(relative_path.clone()),
+            ),
             _ => (None, None),
         };
         let mut event = SkillEvent::new(kind)
@@ -181,6 +200,25 @@ impl SkillFs {
                 (Some(skill_name.clone()), Some(PathBuf::from("SKILL.md")))
             }
             PathType::SkillDir { skill_name } => (Some(skill_name.clone()), None),
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => (Some(Self::hermes_skill_id(category, skill_name)), None),
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } => (
+                Some(Self::hermes_skill_id(category, skill_name)),
+                Some(PathBuf::from("SKILL.md")),
+            ),
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => (
+                Some(Self::hermes_skill_id(category, skill_name)),
+                Some(relative_path.clone()),
+            ),
             _ => (None, None),
         };
         let display_name = name.to_string_lossy();

--- a/src/skillfs/crates/skillfs-fuse/src/fs/events.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/events.rs
@@ -31,10 +31,16 @@ impl SkillFs {
         relative_path: Option<&Path>,
         kind: MutationKind,
     ) {
-        // I2: staging roots bypass normal refresh/notify.
+        // I2/H3: staging roots bypass normal refresh/notify.
         if let Some(ref matcher) = self.staging_matcher {
             if matcher.is_staging_root(skill_name) {
                 return;
+            }
+            // H3: Hermes nested ID — check the leaf component.
+            if let Some(leaf) = skill_name.split('/').next_back() {
+                if leaf != skill_name && matcher.is_staging_root(leaf) {
+                    return;
+                }
             }
         }
         // Pending install: if a pending_install_controller is attached,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -458,6 +458,27 @@ impl SkillFs {
                 skill_name: category,
                 relative_path: std::path::Path::new(&skill_name).join(relative_path),
             },
+            // A plain *file* directly under a category (e.g.
+            // `apple/README.md`) is lexically labelled `NestedSkillDir`
+            // even though it is not a directory. Rewrite it to
+            // `CategoryPassthrough` so `lookup`/`open`/`read` treat it as an
+            // ordinary passthrough file instead of a (broken) skill dir.
+            //
+            // Non-skill *directories* (`apple/docs`) and their descendants
+            // are intentionally NOT reclassified: they stay
+            // `NestedSkillDir` / `NestedPassthrough` and are ungated via
+            // `resolve_hermes_nested_read`. This keeps brand-new install /
+            // staging directories (which have no `SKILL.md` yet) on the
+            // nested-skill code path the installer machinery depends on.
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } if self.hermes_category_child_is_file(&category, &skill_name) => {
+                PathType::CategoryPassthrough {
+                    name: category,
+                    relative_path: std::path::PathBuf::from(skill_name),
+                }
+            }
             other => other,
         }
     }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -18,6 +18,7 @@ use tracing::{info, warn};
 
 use crate::handles::HandleManager;
 use crate::inode::InodeManager;
+use crate::path::SkillLayout;
 use crate::security::{
     ActiveSkillResolver, InstallerStagingController, NoopEventSink, NotifyController,
     PendingInstallController, PostPublishGraceController, ProcessIdentityResolver,
@@ -55,6 +56,8 @@ pub struct SkillFs {
     source_dirfd: Option<std::fs::File>,
     /// Whether we are mounted in-place (source == mountpoint).
     in_place: bool,
+    /// Skill directory layout mode (flat or hermes).
+    skill_layout: SkillLayout,
     /// Channel to send sync events to the background sync worker.
     sync_tx: Option<std::sync::mpsc::Sender<SyncEvent>>,
     /// Skill Security policy. The S1 default is
@@ -180,6 +183,7 @@ impl SkillFs {
             views_config,
             source_dirfd,
             in_place,
+            skill_layout: SkillLayout::Flat,
             sync_tx: Some(sync_tx),
             policy: Arc::new(SkillMetaProtectionPolicy),
             event_sink: Arc::new(NoopEventSink),
@@ -395,6 +399,16 @@ impl SkillFs {
         if let Some(s) = &self.runtime_metrics {
             s.record_policy_denied();
         }
+    }
+
+    pub fn with_skill_layout(mut self, layout: SkillLayout) -> Self {
+        self.skill_layout = layout;
+        self
+    }
+
+    /// Parse a FUSE path using this filesystem's layout and in-place mode.
+    pub(super) fn parse_fuse_path(&self, path: &std::path::Path) -> crate::path::PathType {
+        crate::path::parse_path_with_layout(path, self.in_place, self.skill_layout)
     }
 
     fn virtual_file_attr(&self, size: u64) -> FileAttr {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -407,8 +407,59 @@ impl SkillFs {
     }
 
     /// Parse a FUSE path using this filesystem's layout and in-place mode.
+    ///
+    /// For [`SkillLayout::Hermes`] the lexical parser cannot tell a
+    /// top-level skill (`skill/SKILL.md`) from a category container
+    /// (`category/skill/SKILL.md`) — it classifies every top-level entry
+    /// as a category. Real Hermes workspaces mix both, so this wrapper
+    /// probes the physical source and rewrites a top-level skill and its
+    /// descendants back into the flat [`PathType`] variants
+    /// (`SkillDir` / `SkillMd` / `Passthrough`) that the flat code paths
+    /// already handle. Categorized nested skills are left untouched.
     pub(super) fn parse_fuse_path(&self, path: &std::path::Path) -> crate::path::PathType {
-        crate::path::parse_path_with_layout(path, self.in_place, self.skill_layout)
+        use crate::path::PathType;
+        let parsed = crate::path::parse_path_with_layout(path, self.in_place, self.skill_layout);
+        if self.skill_layout != SkillLayout::Hermes {
+            return parsed;
+        }
+        match parsed {
+            PathType::CategoryDir { category } if self.hermes_is_top_level_skill(&category) => {
+                PathType::SkillDir {
+                    skill_name: category,
+                }
+            }
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } if self.hermes_is_top_level_skill(&category) => {
+                if skill_name == "SKILL.md" {
+                    PathType::SkillMd {
+                        skill_name: category,
+                    }
+                } else {
+                    PathType::Passthrough {
+                        skill_name: category,
+                        relative_path: std::path::PathBuf::from(skill_name),
+                    }
+                }
+            }
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } if self.hermes_is_top_level_skill(&category) => PathType::Passthrough {
+                skill_name: category,
+                relative_path: std::path::Path::new(&skill_name).join("SKILL.md"),
+            },
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } if self.hermes_is_top_level_skill(&category) => PathType::Passthrough {
+                skill_name: category,
+                relative_path: std::path::Path::new(&skill_name).join(relative_path),
+            },
+            other => other,
+        }
     }
 
     fn virtual_file_attr(&self, size: u64) -> FileAttr {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use fuser::FUSE_ROOT_ID;
 
 use super::SkillFs;
-use crate::path::{PathType, is_skill_discover_path, parse_path};
+use crate::path::{PathType, is_skill_discover_path};
 use crate::security::{
     inbox::{is_inbox_dir_name, is_valid_inbox_skill_name},
     lifecycle::is_reserved_lifecycle_name,
@@ -157,7 +157,7 @@ impl SkillFs {
     /// Uses `source_base()` (which goes through `/proc/self/fd/{n}` in
     /// in-place mode) so that all I/O bypasses the FUSE layer.
     pub(super) fn resolve_physical_path(&self, fuse_path: &str) -> Option<PathBuf> {
-        match parse_path(Path::new(fuse_path), self.in_place) {
+        match self.parse_fuse_path(Path::new(fuse_path)) {
             PathType::SkillDir { skill_name } => Some(self.source_base().join(&skill_name)),
             PathType::SkillMd { skill_name } => {
                 Some(self.source_base().join(&skill_name).join("SKILL.md"))
@@ -175,6 +175,35 @@ impl SkillFs {
                 skill_name,
                 relative_path,
             } => Some(self.source_base().join(&skill_name).join(&relative_path)),
+            PathType::HermesMeta { name } => Some(self.source_base().join(&name)),
+            PathType::HermesMetaChild {
+                name,
+                relative_path,
+            } => Some(self.source_base().join(&name).join(&relative_path)),
+            PathType::CategoryDir { category } => Some(self.source_base().join(&category)),
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => Some(self.source_base().join(&category).join(&skill_name)),
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } => Some(
+                self.source_base()
+                    .join(&category)
+                    .join(&skill_name)
+                    .join("SKILL.md"),
+            ),
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => Some(
+                self.source_base()
+                    .join(&category)
+                    .join(&skill_name)
+                    .join(&relative_path),
+            ),
             _ => None,
         }
     }
@@ -203,7 +232,11 @@ impl SkillFs {
             Some(s) => s.to_string(),
             None => return Err(libc::EINVAL),
         };
-        let parent_physical = match parse_path(parent_fuse, self.in_place) {
+        let parent_physical = match crate::path::parse_path_with_layout(
+            parent_fuse,
+            self.in_place,
+            self.skill_layout,
+        ) {
             PathType::SkillDir { skill_name } | PathType::InboxSkillDir { skill_name } => {
                 self.source_base().join(&skill_name)
             }
@@ -218,6 +251,33 @@ impl SkillFs {
                 skill_name,
                 relative_path,
             } => self.source_base().join(&skill_name).join(&relative_path),
+            PathType::HermesMeta { name } => self.source_base().join(&name),
+            PathType::HermesMetaChild {
+                name,
+                relative_path,
+            } => self.source_base().join(&name).join(&relative_path),
+            PathType::CategoryDir { category } => self.source_base().join(&category),
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            } => self.source_base().join(&category).join(&skill_name),
+            PathType::NestedSkillMd {
+                category,
+                skill_name,
+            } => self
+                .source_base()
+                .join(&category)
+                .join(&skill_name)
+                .join("SKILL.md"),
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => self
+                .source_base()
+                .join(&category)
+                .join(&skill_name)
+                .join(&relative_path),
             PathType::SkillsDir | PathType::Root | PathType::InboxDir => self.source_base(),
             PathType::Invalid => return Err(libc::ENOTDIR),
         };

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -358,4 +358,31 @@ impl SkillFs {
     pub(super) fn hermes_skill_physical_dir(&self, category: &str, skill_name: &str) -> PathBuf {
         self.source_base().join(category).join(skill_name)
     }
+
+    /// Whether `<category>/<skill_name>` is a real Hermes nested skill
+    /// leaf — i.e. a directory that physically contains `SKILL.md`.
+    ///
+    /// The Hermes parser is purely lexical and classifies *every*
+    /// second-level entry as a nested skill, but only directories with a
+    /// `SKILL.md` are actual skills. Plain files/dirs under a category
+    /// (e.g. `apple/docs/readme.txt`) are category passthrough and must
+    /// never enter activation gating. The probe hits the physical source
+    /// via `source_base()` so it bypasses the FUSE over-mount in in-place
+    /// mode.
+    pub(super) fn hermes_nested_is_skill(&self, category: &str, skill_name: &str) -> bool {
+        self.hermes_skill_physical_dir(category, skill_name)
+            .join("SKILL.md")
+            .exists()
+    }
+
+    /// Whether `<name>` is a real top-level Hermes skill — i.e. a
+    /// directory directly under the source root that physically contains
+    /// `SKILL.md`. Real Hermes workspaces mix top-level skills
+    /// (`skill/SKILL.md`) with categorized nested skills
+    /// (`category/skill/SKILL.md`); the lexical parser classifies every
+    /// top-level entry as a category container, so callers reclassify a
+    /// top-level skill back into the flat skill path types.
+    pub(super) fn hermes_is_top_level_skill(&self, name: &str) -> bool {
+        self.source_base().join(name).join("SKILL.md").exists()
+    }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -179,6 +179,10 @@ impl SkillFs {
             PathType::HermesMetaChild {
                 name,
                 relative_path,
+            }
+            | PathType::CategoryPassthrough {
+                name,
+                relative_path,
             } => Some(self.source_base().join(&name).join(&relative_path)),
             PathType::CategoryDir { category } => Some(self.source_base().join(&category)),
             PathType::NestedSkillDir {
@@ -253,6 +257,10 @@ impl SkillFs {
             } => self.source_base().join(&skill_name).join(&relative_path),
             PathType::HermesMeta { name } => self.source_base().join(&name),
             PathType::HermesMetaChild {
+                name,
+                relative_path,
+            }
+            | PathType::CategoryPassthrough {
                 name,
                 relative_path,
             } => self.source_base().join(&name).join(&relative_path),
@@ -373,6 +381,20 @@ impl SkillFs {
         self.hermes_skill_physical_dir(category, skill_name)
             .join("SKILL.md")
             .exists()
+    }
+
+    /// Whether the direct category child `<category>/<name>` physically
+    /// exists and is NOT a directory (a plain file or symlink).
+    ///
+    /// A skill is always a directory, so a non-directory child under a
+    /// category (e.g. `apple/README.md`) can never be a nested skill and
+    /// must be served as ordinary passthrough. A missing child returns
+    /// `false` so it stays on the nested-skill path (surfacing `ENOENT`
+    /// via the normal directory checks rather than being mis-served).
+    pub(super) fn hermes_category_child_is_file(&self, category: &str, name: &str) -> bool {
+        std::fs::symlink_metadata(self.source_base().join(category).join(name))
+            .map(|m| !m.is_dir())
+            .unwrap_or(false)
     }
 
     /// Whether `<name>` is a real top-level Hermes skill — i.e. a

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -288,9 +288,18 @@ impl SkillFs {
     }
 
     pub(super) fn is_staging_skill_root(&self, skill_name: &str) -> bool {
-        self.staging_matcher
-            .as_ref()
-            .is_some_and(|m| m.is_staging_root(skill_name))
+        self.staging_matcher.as_ref().is_some_and(|m| {
+            if m.is_staging_root(skill_name) {
+                return true;
+            }
+            // H3: Hermes nested ID — check the leaf component.
+            if let Some(leaf) = skill_name.split('/').next_back() {
+                if leaf != skill_name {
+                    return m.is_staging_root(leaf);
+                }
+            }
+            false
+        })
     }
 
     pub(super) fn is_pending_install(&self, skill_name: &str) -> bool {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -339,4 +339,14 @@ impl SkillFs {
             None => ctrl.has_active_session(skill_name),
         }
     }
+
+    /// Canonical Hermes skill id: `"category/skill"`.
+    pub(super) fn hermes_skill_id(category: &str, skill_name: &str) -> String {
+        format!("{}/{}", category, skill_name)
+    }
+
+    /// Physical source dir for a Hermes nested skill leaf.
+    pub(super) fn hermes_skill_physical_dir(&self, category: &str, skill_name: &str) -> PathBuf {
+        self.source_base().join(category).join(skill_name)
+    }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -342,6 +342,38 @@ impl SkillFs {
         !self.is_post_publish_grace_allowed(skill_name, relative_path)
     }
 
+    /// Hidden-write gate for a Hermes nested path (`category/skill/...`).
+    ///
+    /// Mirrors [`Self::should_reject_hidden_write`] but resolves through
+    /// [`Self::resolve_hermes_nested_read`] so it honors nested-skill
+    /// activation. Crucially, non-skill category children (a directory
+    /// without `SKILL.md`, e.g. `apple/docs`) are plain passthrough and are
+    /// never rejected — otherwise the flat resolver would treat the synthetic
+    /// id `apple/docs` as an unknown (hidden) skill and block creating new
+    /// files like `apple/docs/new.txt` while still allowing reads/appends.
+    pub(super) fn should_reject_hermes_nested_hidden_write(
+        &self,
+        category: &str,
+        skill_name: &str,
+        relative_path: Option<&std::path::Path>,
+    ) -> bool {
+        use crate::fs::read_resolution::ReadResolution;
+        if !self.hermes_nested_is_skill(category, skill_name) {
+            return false;
+        }
+        if !matches!(
+            self.resolve_hermes_nested_read(category, skill_name),
+            ReadResolution::Hidden
+        ) {
+            return false;
+        }
+        let nid = Self::hermes_skill_id(category, skill_name);
+        if self.is_staging_skill_root(&nid) || self.is_pending_install(&nid) {
+            return false;
+        }
+        !self.is_post_publish_grace_allowed(&nid, relative_path)
+    }
+
     pub(super) fn is_post_publish_grace_allowed(
         &self,
         skill_name: &str,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
@@ -58,6 +58,7 @@ impl SkillFs {
         req: &Request,
         detail: Option<String>,
     ) -> Option<i32> {
+        let nested_id;
         let (skill_name, relative_path) = match path_type {
             PathType::Passthrough {
                 skill_name,
@@ -67,10 +68,14 @@ impl SkillFs {
                 skill_name,
                 relative_path,
             } => (skill_name.as_str(), relative_path.as_path()),
-            // Only Passthrough / InboxPassthrough paths can land inside
-            // `.skill-meta`. Other path classes (Root, SkillsDir,
-            // SkillDir, SkillMd, InboxDir, InboxSkillDir, Invalid) are
-            // excluded by construction.
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => {
+                nested_id = Self::hermes_skill_id(category, skill_name);
+                (nested_id.as_str(), relative_path.as_path())
+            }
             _ => return None,
         };
 
@@ -379,7 +384,8 @@ impl SkillFs {
     ) -> Option<bool> {
         let relative_path = match path_type {
             PathType::Passthrough { relative_path, .. }
-            | PathType::InboxPassthrough { relative_path, .. } => relative_path.as_path(),
+            | PathType::InboxPassthrough { relative_path, .. }
+            | PathType::NestedPassthrough { relative_path, .. } => relative_path.as_path(),
             _ => return None,
         };
         if !is_skill_meta_path(relative_path) {
@@ -395,6 +401,21 @@ impl SkillFs {
         req: &Request,
     ) -> bool {
         let probe = PathType::Passthrough {
+            skill_name: skill_name.to_string(),
+            relative_path: std::path::PathBuf::from(crate::security::SKILL_META_DIR),
+        };
+        self.is_trusted_skill_meta_access(&probe, req) == Some(true)
+    }
+
+    /// Whether `.skill-meta` should appear in a `NestedSkillDir` listing.
+    pub(super) fn should_show_skill_meta_in_nested_listing(
+        &self,
+        category: &str,
+        skill_name: &str,
+        req: &Request,
+    ) -> bool {
+        let probe = PathType::NestedPassthrough {
+            category: category.to_string(),
             skill_name: skill_name.to_string(),
             relative_path: std::path::PathBuf::from(crate::security::SKILL_META_DIR),
         };

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -225,6 +225,14 @@ impl SkillFs {
         category: &str,
         skill_name: &str,
     ) -> ReadResolution {
+        // Non-skill children of a category (no `SKILL.md`) are plain
+        // passthrough — they are never gated by activation. Without this,
+        // an attached resolver has no entry for `category/child` and
+        // would (incorrectly) map the child to `Hidden`, making files
+        // like `apple/docs/readme.txt` disappear from the mount.
+        if !self.hermes_nested_is_skill(category, skill_name) {
+            return ReadResolution::Source;
+        }
         let nested_id = Self::hermes_skill_id(category, skill_name);
         let resolver = match self.active_resolver.as_ref() {
             Some(r) => r,
@@ -245,7 +253,6 @@ impl SkillFs {
     }
 
     /// Compiled SKILL.md for a Hermes nested skill.
-    #[allow(dead_code)]
     pub(super) fn compiled_hermes_nested_skill_md(
         &self,
         category: &str,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -225,11 +225,14 @@ impl SkillFs {
         category: &str,
         skill_name: &str,
     ) -> ReadResolution {
-        // Non-skill children of a category (no `SKILL.md`) are plain
-        // passthrough — they are never gated by activation. Without this,
-        // an attached resolver has no entry for `category/child` and
-        // would (incorrectly) map the child to `Hidden`, making files
-        // like `apple/docs/readme.txt` disappear from the mount.
+        // Non-skill children of a category (a directory without `SKILL.md`,
+        // e.g. `apple/docs`) are plain passthrough — never gated by
+        // activation. Without this, an attached resolver has no entry for
+        // `category/child` and would (incorrectly) map it to `Hidden`,
+        // hiding files like `apple/docs/readme.txt`. Category-child *files*
+        // are reclassified to `CategoryPassthrough` earlier and never reach
+        // here; this guard covers the directory case (including brand-new
+        // install/staging dirs that have no `SKILL.md` yet).
         if !self.hermes_nested_is_skill(category, skill_name) {
             return ReadResolution::Source;
         }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -216,4 +216,64 @@ impl SkillFs {
             Err(_) => snapshot_dir.to_path_buf(),
         }
     }
+
+    /// Resolve read for a Hermes nested skill leaf.
+    ///
+    /// Consults the active_resolver with `"category/skill"`.
+    pub(super) fn resolve_hermes_nested_read(
+        &self,
+        category: &str,
+        skill_name: &str,
+    ) -> ReadResolution {
+        let nested_id = Self::hermes_skill_id(category, skill_name);
+        let resolver = match self.active_resolver.as_ref() {
+            Some(r) => r,
+            None => return ReadResolution::Source,
+        };
+        match resolver.get(&nested_id) {
+            None => ReadResolution::Hidden,
+            Some(ActiveTarget::Hidden { .. }) => ReadResolution::Hidden,
+            Some(ActiveTarget::Current { .. }) => ReadResolution::Source,
+            Some(ActiveTarget::Snapshot {
+                snapshot_dir,
+                version,
+            }) => {
+                let dir = self.snapshot_read_dir(&nested_id, &snapshot_dir);
+                ReadResolution::Snapshot { dir, version }
+            }
+        }
+    }
+
+    /// Compiled SKILL.md for a Hermes nested skill.
+    #[allow(dead_code)]
+    pub(super) fn compiled_hermes_nested_skill_md(
+        &self,
+        category: &str,
+        skill_name: &str,
+    ) -> Option<String> {
+        let physical_path = match self.resolve_hermes_nested_read(category, skill_name) {
+            ReadResolution::Hidden => return None,
+            ReadResolution::Source => self
+                .source_base()
+                .join(category)
+                .join(skill_name)
+                .join("SKILL.md"),
+            ReadResolution::Snapshot { dir, .. } => dir.join("SKILL.md"),
+        };
+        let raw = std::fs::read_to_string(&physical_path).ok()?;
+        Some(compiler::compile(&raw, &self.env_profile))
+    }
+
+    /// Physical read dir for a Hermes nested skill.
+    pub(super) fn hermes_nested_skill_read_dir(
+        &self,
+        category: &str,
+        skill_name: &str,
+    ) -> Option<PathBuf> {
+        match self.resolve_hermes_nested_read(category, skill_name) {
+            ReadResolution::Hidden => None,
+            ReadResolution::Source => Some(self.source_base().join(category).join(skill_name)),
+            ReadResolution::Snapshot { dir, .. } => Some(dir),
+        }
+    }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/lib.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/lib.rs
@@ -20,13 +20,14 @@ mod fs;
 mod handles;
 mod inode;
 mod mount;
-mod path;
+pub mod path;
 mod sync;
 mod sys;
 mod xattr;
 
 pub use fs::SkillFs;
 pub use mount::{MountConfig, mount_background_configured, mount_configured};
+pub use path::SkillLayout;
 
 #[allow(deprecated)]
 pub use mount::{

--- a/src/skillfs/crates/skillfs-fuse/src/lib.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/lib.rs
@@ -27,7 +27,7 @@ mod xattr;
 
 pub use fs::SkillFs;
 pub use mount::{MountConfig, mount_background_configured, mount_configured};
-pub use path::SkillLayout;
+pub use path::{SkillLayout, detect_skill_layout};
 
 #[allow(deprecated)]
 pub use mount::{

--- a/src/skillfs/crates/skillfs-fuse/src/mount.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/mount.rs
@@ -289,7 +289,7 @@ pub fn mount(
 ) -> Result<(), FuseError> {
     mount_inner(
         mountpoint, source, store, options, in_place, None, None, None, None, None, None, None,
-        None, None, None, None, None,
+        None, None, None, None, None, None,
     )
 }
 
@@ -319,7 +319,7 @@ pub fn mount_with_security(
 ) -> Result<(), FuseError> {
     mount_inner(
         mountpoint, source, store, options, in_place, event_sink, policy, None, None, None, None,
-        None, None, None, None, None, None,
+        None, None, None, None, None, None, None,
     )
 }
 
@@ -354,6 +354,7 @@ pub fn mount_with_security_and_active_resolver(
         event_sink,
         policy,
         active_resolver,
+        None,
         None,
         None,
         None,
@@ -406,6 +407,7 @@ pub fn mount_with_security_active_resolver_and_demo_refresh(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -448,6 +450,7 @@ pub fn mount_with_security_active_resolver_demo_refresh_and_trusted_writer(
         refresh_controller,
         None,
         trusted_writer,
+        None,
         None,
         None,
         None,
@@ -613,6 +616,7 @@ pub fn mount_background_with_security_active_resolver_demo_refresh_and_trusted_w
             refresh_controller,
             None,
             trusted_writer,
+            None,
             None,
             None,
             None,

--- a/src/skillfs/crates/skillfs-fuse/src/mount.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/mount.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use skillfs_core::SharedSkillStore;
 use tracing::{error, info, warn};
 
+use crate::path::SkillLayout;
 use crate::security::{
     ActiveSkillResolver, InstallerStagingController, NotifyController, PendingInstallController,
     PostPublishGraceController, QuietTimeoutController, RefreshController, RuntimeMetricsSink,
@@ -37,6 +38,7 @@ pub struct MountConfig {
     /// Best-effort runtime metric delta sink. When `Some`, agent-visible skill
     /// opens and security/policy decisions emit `runtime_metric` JSONL records.
     pub runtime_metrics: Option<Arc<RuntimeMetricsSink>>,
+    pub skill_layout: Option<SkillLayout>,
 }
 
 /// Mount the SkillFS FUSE filesystem (blocking) with a unified
@@ -67,6 +69,7 @@ pub fn mount_configured(
         config.pending_install_controller,
         config.post_publish_controller,
         config.runtime_metrics,
+        config.skill_layout,
     )
 }
 
@@ -104,6 +107,7 @@ pub fn mount_background_configured(
             config.pending_install_controller,
             config.post_publish_controller,
             config.runtime_metrics,
+            config.skill_layout,
         ) {
             error!(error = %e, "background mount failed");
         }
@@ -140,6 +144,7 @@ fn mount_inner(
     pending_install_controller: Option<Arc<PendingInstallController>>,
     post_publish_controller: Option<Arc<PostPublishGraceController>>,
     runtime_metrics: Option<Arc<RuntimeMetricsSink>>,
+    skill_layout: Option<SkillLayout>,
 ) -> Result<(), FuseError> {
     info!(mountpoint = %mountpoint.display(), source = %source.display(), in_place, "mounting SkillFS");
 
@@ -238,6 +243,9 @@ fn mount_inner(
     }
     if let Some(s) = runtime_metrics {
         fs = fs.with_runtime_metrics(s);
+    }
+    if let Some(layout) = skill_layout {
+        fs = fs.with_skill_layout(layout);
     }
     info!("starting FUSE filesystem");
 

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -17,11 +17,24 @@ pub enum SkillLayout {
     /// Traditional flat layout: `{source}/{skill}/SKILL.md`.
     #[default]
     Flat,
-    /// Hermes hub workspace layout.
+    /// Hermes hub workspace layout (H1: discovery compatibility).
     ///
     /// Management paths (`.hub/`, `.bundled_manifest`,
     /// `.no-bundled-skills`) are passthrough. Skills live at
     /// `{source}/{category}/{skill}/SKILL.md`.
+    ///
+    /// **H1 scope:** filesystem visibility and POSIX traversal only.
+    /// Nested skills are served as raw physical passthrough — no
+    /// compiled SKILL.md, no activation/fallback/hidden gating, no
+    /// daemon notify on mutation. Incompatible with `--security`,
+    /// `--activation-mode file`, `--notify-socket`, and
+    /// `--control-socket` at startup.
+    ///
+    /// **Parser model:** purely lexical. Every non-management
+    /// top-level entry is classified as `CategoryDir`; every second-
+    /// level entry as `NestedSkillDir`. The parser does not probe
+    /// for `SKILL.md` — a subdirectory without `SKILL.md` is still
+    /// a valid `NestedSkillDir` for POSIX traversal purposes.
     Hermes,
 }
 

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -17,18 +17,18 @@ pub enum SkillLayout {
     /// Traditional flat layout: `{source}/{skill}/SKILL.md`.
     #[default]
     Flat,
-    /// Hermes hub workspace layout (H1: discovery compatibility).
+    /// Hermes hub workspace layout.
     ///
     /// Management paths (`.hub/`, `.bundled_manifest`,
-    /// `.no-bundled-skills`) are passthrough. Skills live at
+    /// `.no-bundled-skills`) are passthrough — no notify, no
+    /// activation gating. Skills live at
     /// `{source}/{category}/{skill}/SKILL.md`.
     ///
-    /// **H1 scope:** filesystem visibility and POSIX traversal only.
-    /// Nested skills are served as raw physical passthrough — no
-    /// compiled SKILL.md, no activation/fallback/hidden gating, no
-    /// daemon notify on mutation. Incompatible with `--security`,
-    /// `--activation-mode file`, `--notify-socket`, and
-    /// `--control-socket` at startup.
+    /// Supports `--activation-mode file` (current / fallback /
+    /// hidden), `--notify-socket` mutation events, and installer
+    /// transactions (staging rename, pending install, quiet timeout,
+    /// post-publish grace). Incompatible with `--decision-command`
+    /// and `--control-socket` (rejected at startup).
     ///
     /// **Parser model:** purely lexical. Every non-management
     /// top-level entry is classified as `CategoryDir`; every second-

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -104,6 +104,22 @@ pub enum PathType {
     /// Category container directory in Hermes layout
     /// (e.g. `apple/`). Not a skill.
     CategoryDir { category: String },
+    /// Physical passthrough of a non-skill child directly under a Hermes
+    /// category (e.g. `apple/README.md` or `apple/docs/readme.txt`).
+    ///
+    /// The lexical parser cannot tell a real nested skill leaf from a
+    /// plain file/dir that happens to live under a category, so
+    /// [`crate::fs::SkillFs::parse_fuse_path`] probes the source for
+    /// `SKILL.md` and rewrites non-skill children into this variant.
+    /// `name` is the category component and `relative_path` is everything
+    /// below it, so the physical path is `source/name/relative_path` —
+    /// identical in shape to [`PathType::HermesMetaChild`], which is why
+    /// the two share callback handling. These paths carry no skill
+    /// semantics: no compilation, no activation gating, no notify.
+    CategoryPassthrough {
+        name: String,
+        relative_path: PathBuf,
+    },
     /// Nested skill directory in Hermes layout
     /// (e.g. `apple/apple-notes/`).
     NestedSkillDir {

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -11,9 +11,30 @@ use std::path::{Path, PathBuf};
 
 use crate::security::inbox::is_inbox_dir_name;
 
+/// Skill directory layout mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkillLayout {
+    /// Traditional flat layout: `{source}/{skill}/SKILL.md`.
+    #[default]
+    Flat,
+    /// Hermes hub workspace layout.
+    ///
+    /// Management paths (`.hub/`, `.bundled_manifest`,
+    /// `.no-bundled-skills`) are passthrough. Skills live at
+    /// `{source}/{category}/{skill}/SKILL.md`.
+    Hermes,
+}
+
+/// Well-known Hermes management paths that must be passthrough.
+const HERMES_MANAGEMENT_PATHS: &[&str] = &[".hub", ".bundled_manifest", ".no-bundled-skills"];
+
+pub fn is_hermes_management_path(name: &str) -> bool {
+    HERMES_MANAGEMENT_PATHS.contains(&name)
+}
+
 /// Types of paths in the SkillFS filesystem.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum PathType {
+pub enum PathType {
     /// Root directory (/)
     Root,
     /// Skills directory (/skills)
@@ -43,6 +64,37 @@ pub(crate) enum PathType {
         skill_name: String,
         relative_path: PathBuf,
     },
+    /// Hermes management top-level entry (`.hub`, `.bundled_manifest`,
+    /// `.no-bundled-skills`). Physical passthrough, not a skill.
+    HermesMeta { name: String },
+    /// Child path under a Hermes management entry
+    /// (e.g. `.hub/some/file`).
+    HermesMetaChild {
+        name: String,
+        relative_path: PathBuf,
+    },
+    /// Category container directory in Hermes layout
+    /// (e.g. `apple/`). Not a skill.
+    CategoryDir { category: String },
+    /// Nested skill directory in Hermes layout
+    /// (e.g. `apple/apple-notes/`).
+    NestedSkillDir {
+        category: String,
+        skill_name: String,
+    },
+    /// SKILL.md under a nested skill in Hermes layout
+    /// (e.g. `apple/apple-notes/SKILL.md`).
+    NestedSkillMd {
+        category: String,
+        skill_name: String,
+    },
+    /// Passthrough path under a nested skill in Hermes layout
+    /// (e.g. `apple/apple-notes/scripts/run.sh`).
+    NestedPassthrough {
+        category: String,
+        skill_name: String,
+        relative_path: PathBuf,
+    },
     /// Unknown/invalid path
     Invalid,
 }
@@ -51,7 +103,7 @@ pub(crate) enum PathType {
 ///
 /// When `in_place` is true the FUSE root IS the skills directory, so
 /// paths have no `/skills/` prefix: `/{skill}`, `/{skill}/SKILL.md`, etc.
-pub(crate) fn parse_path(path: &Path, in_place: bool) -> PathType {
+pub fn parse_path(path: &Path, in_place: bool) -> PathType {
     let components: Vec<_> = path.components().collect();
 
     // Try the L1 inbox namespace first in both modes. The inbox root is a
@@ -126,6 +178,124 @@ pub(crate) fn parse_path(path: &Path, in_place: bool) -> PathType {
             }
             _ => PathType::Invalid,
         }
+    }
+}
+
+/// Parse a path with an explicit layout mode.
+///
+/// Delegates to [`parse_path`] for [`SkillLayout::Flat`]. For
+/// [`SkillLayout::Hermes`] the in-place arm recognises management paths,
+/// category directories, and nested skill directories.
+pub fn parse_path_with_layout(path: &Path, in_place: bool, layout: SkillLayout) -> PathType {
+    if layout == SkillLayout::Flat {
+        return parse_path(path, in_place);
+    }
+
+    let components: Vec<_> = path.components().collect();
+
+    // Inbox namespace: same in every layout.
+    if components.len() >= 2 {
+        let second = components[1].as_os_str().to_string_lossy();
+        if is_inbox_dir_name(&second) {
+            return parse_inbox_components(&components);
+        }
+    }
+
+    if in_place {
+        parse_hermes_in_place(&components)
+    } else {
+        // Normal (non-in-place) Hermes: skills live under /skills/.
+        // The /skills/ prefix is stripped and the remainder is parsed as
+        // Hermes layout.
+        match components.as_slice() {
+            [] => PathType::Root,
+            [root] if root.as_os_str() == "/" => PathType::Root,
+            [_, skills] if skills.as_os_str() == "skills" => PathType::SkillsDir,
+            [_, skills, rest @ ..] if skills.as_os_str() == "skills" => {
+                // Synthesise a fake in-place component slice: ["/", rest...]
+                let mut synth: Vec<std::path::Component<'_>> = Vec::with_capacity(rest.len() + 1);
+                synth.push(components[0]); // "/"
+                synth.extend_from_slice(rest);
+                parse_hermes_in_place(&synth)
+            }
+            _ => PathType::Invalid,
+        }
+    }
+}
+
+/// Hermes in-place path classification. The root is the skills
+/// directory; top-level entries are either management paths or category
+/// directories.
+fn parse_hermes_in_place(components: &[std::path::Component<'_>]) -> PathType {
+    match components {
+        [] => PathType::SkillsDir,
+        [root] if root.as_os_str() == "/" => PathType::SkillsDir,
+        [_, first] => {
+            let name = first.as_os_str().to_string_lossy().to_string();
+            if is_hermes_management_path(&name) {
+                PathType::HermesMeta { name }
+            } else {
+                PathType::CategoryDir { category: name }
+            }
+        }
+        [_, first, second] => {
+            let first_name = first.as_os_str().to_string_lossy().to_string();
+            if is_hermes_management_path(&first_name) {
+                return PathType::HermesMetaChild {
+                    name: first_name,
+                    relative_path: PathBuf::from(second.as_os_str()),
+                };
+            }
+            let second_name = second.as_os_str().to_string_lossy().to_string();
+            PathType::NestedSkillDir {
+                category: first_name,
+                skill_name: second_name,
+            }
+        }
+        [_, first, second, third] => {
+            let first_name = first.as_os_str().to_string_lossy().to_string();
+            if is_hermes_management_path(&first_name) {
+                let relative_path: PathBuf =
+                    components[2..].iter().map(|c| c.as_os_str()).collect();
+                return PathType::HermesMetaChild {
+                    name: first_name,
+                    relative_path,
+                };
+            }
+            let second_name = second.as_os_str().to_string_lossy().to_string();
+            let third_name = third.as_os_str().to_string_lossy();
+            if third_name == "SKILL.md" {
+                PathType::NestedSkillMd {
+                    category: first_name,
+                    skill_name: second_name,
+                }
+            } else {
+                PathType::NestedPassthrough {
+                    category: first_name,
+                    skill_name: second_name,
+                    relative_path: PathBuf::from(third.as_os_str()),
+                }
+            }
+        }
+        [_, first, second, rest @ ..] => {
+            let first_name = first.as_os_str().to_string_lossy().to_string();
+            if is_hermes_management_path(&first_name) {
+                let relative_path: PathBuf =
+                    components[2..].iter().map(|c| c.as_os_str()).collect();
+                return PathType::HermesMetaChild {
+                    name: first_name,
+                    relative_path,
+                };
+            }
+            let second_name = second.as_os_str().to_string_lossy().to_string();
+            let relative_path: PathBuf = rest.iter().map(|c| c.as_os_str()).collect();
+            PathType::NestedPassthrough {
+                category: first_name,
+                skill_name: second_name,
+                relative_path,
+            }
+        }
+        _ => PathType::Invalid,
     }
 }
 

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -45,6 +45,21 @@ pub fn is_hermes_management_path(name: &str) -> bool {
     HERMES_MANAGEMENT_PATHS.contains(&name)
 }
 
+/// Conservatively auto-detect the skill layout for a source root.
+///
+/// A source is Hermes only when it carries an unambiguous Hermes hub
+/// marker: a `.bundled_manifest` file or a `.hub/` directory. Everything
+/// else — including a bare `.no-bundled-skills` sentinel, which a flat
+/// workspace can also carry — is treated as [`SkillLayout::Flat`]. This
+/// keeps the default safe: a normal flat tree is never misread as Hermes.
+pub fn detect_skill_layout(source: &Path) -> SkillLayout {
+    if source.join(".bundled_manifest").exists() || source.join(".hub").is_dir() {
+        SkillLayout::Hermes
+    } else {
+        SkillLayout::Flat
+    }
+}
+
 /// Types of paths in the SkillFS filesystem.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PathType {

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -118,8 +118,8 @@ pub mod trusted_writer;
 pub use activation::{
     ACTIVATION_FILE, ACTIVATION_SCHEMA_VERSION, ACTIVATION_XATTR, ActivationError, ActivationMode,
     ActivationRecord, XattrReadOutcome, bootstrap_activation, classify_xattr_errno,
-    fail_safe_hidden, load_activation, load_activation_prefer_xattr, read_activation_xattr,
-    resolve_activation,
+    enumerate_hermes_skill_leaves, fail_safe_hidden, load_activation, load_activation_prefer_xattr,
+    read_activation_xattr, resolve_activation,
 };
 pub use activation_reload::{
     ActivationFreshness, ActivationReloadController, DEFAULT_RELOAD_INTERVAL_MS,

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -118,8 +118,9 @@ pub mod trusted_writer;
 pub use activation::{
     ACTIVATION_FILE, ACTIVATION_SCHEMA_VERSION, ACTIVATION_XATTR, ActivationError, ActivationMode,
     ActivationRecord, XattrReadOutcome, bootstrap_activation, classify_xattr_errno,
-    enumerate_hermes_skill_leaves, fail_safe_hidden, load_activation, load_activation_prefer_xattr,
-    read_activation_xattr, resolve_activation,
+    enumerate_hermes_skill_ids, enumerate_hermes_skill_leaves, enumerate_hermes_top_level_skills,
+    fail_safe_hidden, load_activation, load_activation_prefer_xattr, read_activation_xattr,
+    resolve_activation,
 };
 pub use activation_reload::{
     ActivationFreshness, ActivationReloadController, DEFAULT_RELOAD_INTERVAL_MS,

--- a/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
@@ -642,6 +642,49 @@ pub fn enumerate_hermes_skill_leaves(source_root: &Path) -> Vec<String> {
     leaves
 }
 
+/// Enumerate top-level Hermes skills under `source_root`.
+///
+/// A top-level skill is a non-management directory directly under the
+/// source root that contains its own `SKILL.md`. Real Hermes workspaces
+/// mix these flat skills with categorized nested skills, so activation
+/// discovery must cover both.
+pub fn enumerate_hermes_top_level_skills(source_root: &Path) -> Vec<String> {
+    use crate::path::is_hermes_management_path;
+
+    let mut skills = Vec::new();
+    let entries = match std::fs::read_dir(source_root) {
+        Ok(e) => e,
+        Err(_) => return skills,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if is_hermes_management_path(&name) || name.starts_with('.') {
+            continue;
+        }
+        if !entry.path().is_dir() {
+            continue;
+        }
+        if entry.path().join("SKILL.md").exists() {
+            skills.push(name);
+        }
+    }
+    skills
+}
+
+/// Enumerate every activatable Hermes skill id under `source_root`:
+/// top-level skills (`skill`) and categorized nested skills
+/// (`category/skill`).
+///
+/// This mirrors exactly what the FUSE mount treats as a skill — top-level
+/// directories with `SKILL.md` become flat skills, and second-level
+/// directories with `SKILL.md` become nested skills — so activation
+/// bootstrap consumes the same set the mount exposes and cannot diverge.
+pub fn enumerate_hermes_skill_ids(source_root: &Path) -> Vec<String> {
+    let mut ids = enumerate_hermes_top_level_skills(source_root);
+    ids.extend(enumerate_hermes_skill_leaves(source_root));
+    ids
+}
+
 /// Load activation state for every skill in `skill_names` and install
 /// into the given resolver. Errors are non-fatal: each failing skill is
 /// mapped to hidden with a diagnostic log line.

--- a/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
@@ -625,6 +625,14 @@ pub fn enumerate_hermes_skill_leaves(source_root: &Path) -> Vec<String> {
         if !entry.path().is_dir() {
             continue;
         }
+        // A first-level directory that carries its own SKILL.md is a
+        // top-level skill, not a category. The mount serves it (and its
+        // whole subtree) as a flat skill, so descending into it here would
+        // register `skill/subdir` as a phantom nested skill and diverge
+        // from mount discovery.
+        if entry.path().join("SKILL.md").exists() {
+            continue;
+        }
         let cat_entries = match std::fs::read_dir(entry.path()) {
             Ok(e) => e,
             Err(_) => continue,

--- a/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
@@ -604,6 +604,44 @@ impl std::fmt::Display for ActivationMode {
 // Startup bootstrap
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Enumerate Hermes nested skill leaves under `source_root`.
+///
+/// Walks the source root physically: first-level dirs are categories
+/// (skipping management paths), second-level dirs with `SKILL.md` are
+/// skill leaves. Returns skill ids as `"category/skill"`.
+pub fn enumerate_hermes_skill_leaves(source_root: &Path) -> Vec<String> {
+    use crate::path::is_hermes_management_path;
+
+    let mut leaves = Vec::new();
+    let entries = match std::fs::read_dir(source_root) {
+        Ok(e) => e,
+        Err(_) => return leaves,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if is_hermes_management_path(&name) || name.starts_with('.') {
+            continue;
+        }
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let cat_entries = match std::fs::read_dir(entry.path()) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for child in cat_entries.flatten() {
+            let child_name = child.file_name().to_string_lossy().to_string();
+            if !child.path().is_dir() {
+                continue;
+            }
+            if child.path().join("SKILL.md").exists() {
+                leaves.push(format!("{}/{}", name, child_name));
+            }
+        }
+    }
+    leaves
+}
+
 /// Load activation state for every skill in `skill_names` and install
 /// into the given resolver. Errors are non-fatal: each failing skill is
 /// mapped to hidden with a diagnostic log line.

--- a/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
@@ -1002,6 +1002,95 @@ mod tests {
     }
 
     // ─────────────────────────────────────────────────────────────────────
+    // enumerate_hermes_skill_leaves + bootstrap_activation with nested ids
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn enumerate_hermes_skill_leaves_finds_nested_skills() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Management paths — should be skipped.
+        std::fs::create_dir_all(root.join(".hub")).unwrap();
+        std::fs::write(root.join(".bundled_manifest"), "").unwrap();
+
+        // Category with two skill leaves.
+        let notes = root.join("apple/apple-notes");
+        std::fs::create_dir_all(&notes).unwrap();
+        std::fs::write(notes.join("SKILL.md"), "---\nname: n\n---\n").unwrap();
+
+        let music = root.join("apple/apple-music");
+        std::fs::create_dir_all(&music).unwrap();
+        std::fs::write(music.join("SKILL.md"), "---\nname: m\n---\n").unwrap();
+
+        // Non-skill subdir (no SKILL.md) — should be skipped.
+        std::fs::create_dir_all(root.join("apple/docs")).unwrap();
+
+        // Dot-prefixed dir — should be skipped.
+        std::fs::create_dir_all(root.join(".git/objects")).unwrap();
+
+        let mut leaves = enumerate_hermes_skill_leaves(root);
+        leaves.sort();
+        assert_eq!(
+            leaves,
+            vec!["apple/apple-music", "apple/apple-notes"],
+            "must enumerate only dirs with SKILL.md, got: {:?}",
+            leaves
+        );
+    }
+
+    #[test]
+    fn bootstrap_activation_with_hermes_nested_id() {
+        use super::super::active::ActiveSkillResolver;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Create a nested skill with a valid activation file.
+        let skill = root.join("apple/apple-notes");
+        std::fs::create_dir_all(skill.join(".skill-meta/versions/v000001.snapshot")).unwrap();
+        std::fs::write(
+            skill.join(".skill-meta/activation.json"),
+            r#"{"schemaVersion": 1, "target": ".skill-meta/versions/v000001.snapshot"}"#,
+        )
+        .unwrap();
+
+        // Create another nested skill with hidden activation.
+        let hidden = root.join("apple/apple-music");
+        std::fs::create_dir_all(hidden.join(".skill-meta")).unwrap();
+        std::fs::write(
+            hidden.join(".skill-meta/activation.json"),
+            r#"{"schemaVersion": 1, "target": null}"#,
+        )
+        .unwrap();
+
+        let resolver = ActiveSkillResolver::new(root);
+        let names = vec![
+            "apple/apple-notes".to_string(),
+            "apple/apple-music".to_string(),
+        ];
+        let results = bootstrap_activation(root, &names, &resolver);
+
+        assert!(results[0].1.is_ok(), "apple/apple-notes must load");
+        assert!(results[1].1.is_ok(), "apple/apple-music must load");
+
+        assert!(
+            matches!(
+                resolver.get("apple/apple-notes"),
+                Some(ActiveTarget::Snapshot { .. })
+            ),
+            "apple/apple-notes must be snapshot"
+        );
+        assert!(
+            matches!(
+                resolver.get("apple/apple-music"),
+                Some(ActiveTarget::Hidden { .. })
+            ),
+            "apple/apple-music must be hidden"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
     // A2: load_activation_prefer_xattr
     // ─────────────────────────────────────────────────────────────────────
 

--- a/src/skillfs/crates/skillfs-fuse/src/security/config.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/config.rs
@@ -360,12 +360,12 @@ impl SecurityConfig {
         }
         if let Some(value) = self.skills.as_ref().and_then(|s| s.layout.as_deref()) {
             match value {
-                "flat" | "hermes" => {}
+                "auto" | "flat" | "hermes" => {}
                 other => {
                     return Err(ConfigError::InvalidValue {
                         field: "skills.layout",
                         value: other.to_string(),
-                        allowed: "flat, hermes",
+                        allowed: "auto, flat, hermes",
                     });
                 }
             }
@@ -1671,6 +1671,27 @@ post_publish_write_patterns = [".openclaw/**"]
         let cfg: SecurityConfig = toml::from_str("").unwrap();
         assert!(cfg.post_publish_grace_ms().is_none());
         assert!(cfg.post_publish_write_patterns().is_none());
+    }
+
+    #[test]
+    fn skills_layout_accepts_auto_flat_hermes() {
+        let dir = tempfile::tempdir().unwrap();
+        for value in ["auto", "flat", "hermes"] {
+            let path = dir.path().join(format!("{value}.toml"));
+            std::fs::write(&path, format!("[skills]\nlayout = \"{value}\"\n")).unwrap();
+            let cfg = SecurityConfig::load(&path)
+                .unwrap_or_else(|e| panic!("layout '{value}' must validate: {e}"));
+            assert_eq!(cfg.skills_layout(), Some(value));
+        }
+    }
+
+    #[test]
+    fn skills_layout_rejects_unknown_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "[skills]\nlayout = \"categorized\"\n").unwrap();
+        let result = SecurityConfig::load(&path);
+        assert!(matches!(result, Err(ConfigError::InvalidValue { .. })));
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/security/config.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/config.rs
@@ -29,6 +29,13 @@ pub struct SecurityConfig {
     pub ledger: Option<LedgerSection>,
     pub install: Option<InstallSection>,
     pub control_socket: Option<ControlSocketSection>,
+    pub skills: Option<SkillsSection>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillsSection {
+    pub layout: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -351,6 +358,18 @@ impl SecurityConfig {
                 }
             }
         }
+        if let Some(value) = self.skills.as_ref().and_then(|s| s.layout.as_deref()) {
+            match value {
+                "flat" | "hermes" => {}
+                other => {
+                    return Err(ConfigError::InvalidValue {
+                        field: "skills.layout",
+                        value: other.to_string(),
+                        allowed: "flat, hermes",
+                    });
+                }
+            }
+        }
         if let Some(ref cs) = self.control_socket {
             let has_path = cs
                 .path
@@ -562,6 +581,13 @@ impl SecurityConfig {
             .as_ref()
             .and_then(|i| i.post_publish_write_patterns.as_deref())
             .filter(|p| !p.is_empty())
+    }
+
+    pub fn skills_layout(&self) -> Option<&str> {
+        self.skills
+            .as_ref()
+            .and_then(|s| s.layout.as_deref())
+            .filter(|s| !s.trim().is_empty())
     }
 
     /// Validate that the backing root is configured and accessible when

--- a/src/skillfs/crates/skillfs-fuse/tests/common/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/common/mod.rs
@@ -160,10 +160,31 @@ impl MountFixture {
         Self::mount_now(MountMode::InPlace, source, None)
     }
 
+    /// Mount in in-place mode with Hermes layout.
+    pub fn in_place_hermes<F: FnOnce(&Path)>(seed: F) -> Self {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        Self::mount_now_with_layout(
+            MountMode::InPlace,
+            source,
+            None,
+            Some(skillfs_fuse::SkillLayout::Hermes),
+        )
+    }
+
     fn mount_now(
         mode: MountMode,
         source: tempfile::TempDir,
         mountpoint: Option<tempfile::TempDir>,
+    ) -> Self {
+        Self::mount_now_with_layout(mode, source, mountpoint, None)
+    }
+
+    fn mount_now_with_layout(
+        mode: MountMode,
+        source: tempfile::TempDir,
+        mountpoint: Option<tempfile::TempDir>,
+        skill_layout: Option<skillfs_fuse::SkillLayout>,
     ) -> Self {
         let mut store = SkillStore::new();
         store.load_from_directory(source.path(), &ParseConfig::default());
@@ -176,13 +197,18 @@ impl MountFixture {
         };
         let in_place = matches!(mode, MountMode::InPlace);
 
+        let config = MountConfig {
+            skill_layout,
+            ..MountConfig::default()
+        };
+
         let handle = mount_background_configured(
             &mp_path,
             source.path(),
             shared,
             MountOptions::default(),
             in_place,
-            MountConfig::default(),
+            config,
         )
         .expect("mount_background_configured");
 

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -910,6 +910,16 @@ fn hermes_non_skill_subdir_accessible_with_resolver() {
         "category readme"
     );
 
+    // Creating a NEW file inside a non-skill category subdir must succeed:
+    // it is plain passthrough, not a hidden skill, so the write-path
+    // hidden-write gate must not reject it.
+    std::fs::write(mp.join("apple/docs/new.txt"), "created via mount")
+        .expect("create apple/docs/new.txt with resolver");
+    assert_eq!(
+        std::fs::read_to_string(mp.join("apple/docs/new.txt")).expect("read back new.txt"),
+        "created via mount"
+    );
+
     // apple/ listing must still contain the non-skill children.
     let entries = list_dir_names(&mp.join("apple"));
     assert!(

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -1,0 +1,263 @@
+//! Integration tests for the Hermes skill layout mode.
+
+mod common;
+
+use std::path::Path;
+
+use common::{MountFixture, create_skill_dir, list_dir_names};
+
+fn seed_hermes_workspace(dir: &Path) {
+    std::fs::create_dir_all(dir.join(".hub")).unwrap();
+    std::fs::write(dir.join(".hub/config.json"), r#"{"version": 1}"#).unwrap();
+    std::fs::write(dir.join(".bundled_manifest"), "manifest-content").unwrap();
+    std::fs::write(dir.join(".no-bundled-skills"), "").unwrap();
+
+    let apple_notes = dir.join("apple/apple-notes");
+    std::fs::create_dir_all(&apple_notes).unwrap();
+    std::fs::write(
+        apple_notes.join("SKILL.md"),
+        "---\nname: apple-notes\ndescription: notes\n---\nApple Notes skill body.\n",
+    )
+    .unwrap();
+
+    let apple_music = dir.join("apple/apple-music");
+    std::fs::create_dir_all(&apple_music).unwrap();
+    std::fs::write(
+        apple_music.join("SKILL.md"),
+        "---\nname: apple-music\ndescription: music\n---\n",
+    )
+    .unwrap();
+}
+
+// -----------------------------------------------------------------------
+// 1. Flat mode behavior unchanged
+// -----------------------------------------------------------------------
+
+#[test]
+fn flat_mode_in_place_unchanged() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place(|dir| {
+        create_skill_dir(dir, "my-skill");
+    });
+
+    let md_path = fix.mountpoint().join("my-skill/SKILL.md");
+    let content = std::fs::read_to_string(&md_path).expect("read SKILL.md");
+    assert!(
+        content.contains("my-skill"),
+        "flat in-place SKILL.md should be readable"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 2. Hermes mode management path passthrough
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_management_path_stat() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+    });
+
+    let hub = fix.mountpoint().join(".hub");
+    let meta = std::fs::metadata(&hub).expect("stat .hub");
+    assert!(meta.is_dir(), ".hub must be a directory");
+}
+
+#[test]
+fn hermes_management_path_readdir() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+    });
+
+    let hub = fix.mountpoint().join(".hub");
+    let entries = list_dir_names(&hub);
+    assert!(
+        entries.contains(&"config.json".to_string()),
+        ".hub readdir should contain config.json, got: {:?}",
+        entries
+    );
+}
+
+#[test]
+fn hermes_management_path_mkdir_eexist() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+    });
+
+    let hub = fix.mountpoint().join(".hub");
+    assert!(hub.exists(), "stat .hub should succeed first");
+    let err = std::fs::create_dir(&hub).expect_err("mkdir .hub should fail");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::EEXIST),
+        "mkdir existing .hub must return EEXIST, got: {}",
+        err
+    );
+}
+
+// -----------------------------------------------------------------------
+// 3. Hermes mode manifest passthrough
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_manifest_stat_and_read() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+    });
+
+    let manifest = fix.mountpoint().join(".bundled_manifest");
+    let meta = std::fs::metadata(&manifest).expect("stat .bundled_manifest");
+    assert!(meta.is_file(), ".bundled_manifest must be a regular file");
+
+    let content = std::fs::read_to_string(&manifest).expect("read .bundled_manifest");
+    assert_eq!(content, "manifest-content");
+}
+
+// -----------------------------------------------------------------------
+// 4. Hermes mode category dir is container
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_category_dir_readdir() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+    });
+
+    let apple = fix.mountpoint().join("apple");
+    let entries = list_dir_names(&apple);
+    assert!(
+        entries.contains(&"apple-notes".to_string()),
+        "apple/ readdir should contain apple-notes, got: {:?}",
+        entries
+    );
+    assert!(
+        entries.contains(&"apple-music".to_string()),
+        "apple/ readdir should contain apple-music, got: {:?}",
+        entries
+    );
+}
+
+// -----------------------------------------------------------------------
+// 5. Hermes mode nested skill leaf readable
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_skill_md_readable() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+    });
+
+    let md = fix.mountpoint().join("apple/apple-notes/SKILL.md");
+    let content = std::fs::read_to_string(&md).expect("read nested SKILL.md");
+    assert!(
+        content.contains("Apple Notes skill body"),
+        "nested SKILL.md should be readable with correct content"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 6. Management path changes do not trigger notify
+//    (path classification unit test — management paths produce HermesMeta
+//     which mutate callbacks skip for observe_mutation)
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_path_classification_management() {
+    use skillfs_fuse::path::{
+        PathType, SkillLayout, is_hermes_management_path, parse_path_with_layout,
+    };
+
+    assert!(is_hermes_management_path(".hub"));
+    assert!(is_hermes_management_path(".bundled_manifest"));
+    assert!(is_hermes_management_path(".no-bundled-skills"));
+    assert!(!is_hermes_management_path("apple"));
+
+    let pt = parse_path_with_layout(Path::new("/.hub"), true, SkillLayout::Hermes);
+    assert!(
+        matches!(pt, PathType::HermesMeta { ref name } if name == ".hub"),
+        "expected HermesMeta, got: {:?}",
+        pt
+    );
+
+    let pt = parse_path_with_layout(Path::new("/.hub/config.json"), true, SkillLayout::Hermes);
+    assert!(
+        matches!(pt, PathType::HermesMetaChild { ref name, .. } if name == ".hub"),
+        "expected HermesMetaChild, got: {:?}",
+        pt
+    );
+
+    let pt = parse_path_with_layout(Path::new("/apple"), true, SkillLayout::Hermes);
+    assert!(
+        matches!(pt, PathType::CategoryDir { ref category } if category == "apple"),
+        "expected CategoryDir, got: {:?}",
+        pt
+    );
+}
+
+// -----------------------------------------------------------------------
+// 7. Nested skill source-relative path preserved
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_skill_path_preserved() {
+    use skillfs_fuse::path::{PathType, SkillLayout, parse_path_with_layout};
+
+    let pt = parse_path_with_layout(Path::new("/apple/apple-notes"), true, SkillLayout::Hermes);
+    match pt {
+        PathType::NestedSkillDir {
+            category,
+            skill_name,
+        } => {
+            assert_eq!(category, "apple");
+            assert_eq!(skill_name, "apple-notes");
+        }
+        other => panic!("expected NestedSkillDir, got: {:?}", other),
+    }
+
+    let pt = parse_path_with_layout(
+        Path::new("/apple/apple-notes/SKILL.md"),
+        true,
+        SkillLayout::Hermes,
+    );
+    match pt {
+        PathType::NestedSkillMd {
+            category,
+            skill_name,
+        } => {
+            assert_eq!(category, "apple");
+            assert_eq!(skill_name, "apple-notes");
+        }
+        other => panic!("expected NestedSkillMd, got: {:?}", other),
+    }
+
+    let pt = parse_path_with_layout(
+        Path::new("/apple/apple-notes/scripts/run.sh"),
+        true,
+        SkillLayout::Hermes,
+    );
+    match pt {
+        PathType::NestedPassthrough {
+            category,
+            skill_name,
+            relative_path,
+        } => {
+            assert_eq!(category, "apple");
+            assert_eq!(skill_name, "apple-notes");
+            assert_eq!(relative_path, std::path::PathBuf::from("scripts/run.sh"));
+        }
+        other => panic!("expected NestedPassthrough, got: {:?}", other),
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -329,6 +329,297 @@ fn hermes_management_path_write_no_notify() {
 }
 
 // -----------------------------------------------------------------------
+// 10. Hermes activation current — nested skill is readable
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_activation_current() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{ActiveSkillResolver, ActiveTarget};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let resolver = ActiveSkillResolver::new(source.path());
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Current {
+            source_dir: source.path().join("apple/apple-notes"),
+        },
+    );
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let config = MountConfig {
+        active_resolver: Some(Arc::new(resolver)),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let md = mountpoint.path().join("apple/apple-notes/SKILL.md");
+    let content = std::fs::read_to_string(&md).expect("read nested SKILL.md");
+    assert!(
+        content.contains("Apple Notes skill body"),
+        "current activation must serve live source: {content}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 11. Hermes activation fallback — reads from snapshot
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_activation_fallback() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{ActiveSkillResolver, ActiveTarget};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let snap_dir = source
+        .path()
+        .join("apple/apple-notes/.skill-meta/versions/v000001.snapshot");
+    std::fs::create_dir_all(&snap_dir).unwrap();
+    std::fs::write(
+        snap_dir.join("SKILL.md"),
+        "---\nname: apple-notes\ndescription: snapshot\n---\nSnapshot body.\n",
+    )
+    .unwrap();
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let resolver = ActiveSkillResolver::new(source.path());
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Snapshot {
+            snapshot_dir: snap_dir.clone(),
+            version: "v000001.snapshot".to_string(),
+        },
+    );
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let config = MountConfig {
+        active_resolver: Some(Arc::new(resolver)),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let md = mountpoint.path().join("apple/apple-notes/SKILL.md");
+    let content = std::fs::read_to_string(&md).expect("read nested SKILL.md");
+    assert!(
+        content.contains("Snapshot body"),
+        "fallback activation must serve snapshot: {content}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 12. Hermes activation hidden — ENOENT on leaf, category stays visible
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_activation_hidden() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{ActiveSkillResolver, ActiveTarget};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let resolver = ActiveSkillResolver::new(source.path());
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Hidden {
+            reason: "test hidden".to_string(),
+        },
+    );
+    resolver.set(
+        "apple/apple-music",
+        ActiveTarget::Current {
+            source_dir: source.path().join("apple/apple-music"),
+        },
+    );
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let config = MountConfig {
+        active_resolver: Some(Arc::new(resolver)),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mp = mountpoint.path();
+
+    // Category dir itself must still be accessible.
+    let apple = mp.join("apple");
+    assert!(
+        apple.is_dir(),
+        "category dir must remain visible even with hidden children"
+    );
+
+    // Hidden leaf must return ENOENT.
+    let notes = mp.join("apple/apple-notes");
+    let err = std::fs::metadata(&notes).expect_err("hidden skill must return ENOENT");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ENOENT),
+        "hidden nested skill lookup must return ENOENT, got: {err}"
+    );
+
+    // Category listing must omit hidden children.
+    let entries = list_dir_names(&apple);
+    assert!(
+        !entries.contains(&"apple-notes".to_string()),
+        "hidden skill must be omitted from category listing, got: {:?}",
+        entries
+    );
+
+    // Visible child must still appear.
+    assert!(
+        entries.contains(&"apple-music".to_string()),
+        "visible skill must appear in category listing, got: {:?}",
+        entries
+    );
+}
+
+// -----------------------------------------------------------------------
+// 13. Hermes nested SKILL.md write triggers notify
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_write_triggers_notify() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{InMemoryNotifyClient, NotifyController};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let mountpoint = tempfile::tempdir().unwrap();
+
+    let notify_client = Arc::new(InMemoryNotifyClient::new());
+    let notify_ctrl = NotifyController::new(
+        notify_client.clone(),
+        source.path().to_path_buf(),
+        Duration::from_millis(50),
+        5000,
+    );
+
+    let config = MountConfig {
+        notify_controller: Some(notify_ctrl.clone()),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mp = mountpoint.path();
+
+    // Write to a nested SKILL.md.
+    std::fs::write(
+        mp.join("apple/apple-notes/SKILL.md"),
+        "---\nname: apple-notes\ndescription: updated\n---\nUpdated.\n",
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+    notify_ctrl.flush_for_testing();
+
+    let events = notify_client.events();
+    assert!(
+        !events.is_empty(),
+        "nested SKILL.md write must trigger notify"
+    );
+
+    let event = &events[0];
+    assert_eq!(
+        event.skill_name, "apple/apple-notes",
+        "skillName must be category/skill"
+    );
+    assert!(
+        event.skill_dir.ends_with("/apple/apple-notes"),
+        "skillDir must end with /apple/apple-notes, got: {}",
+        event.skill_dir
+    );
+    assert!(
+        event.paths.contains(&"SKILL.md".to_string()),
+        "paths must contain SKILL.md, got: {:?}",
+        event.paths
+    );
+}
+
+// -----------------------------------------------------------------------
 // 9. Non-skill subdirectory under category is accessible
 // -----------------------------------------------------------------------
 

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -620,6 +620,101 @@ fn hermes_nested_write_triggers_notify() {
 }
 
 // -----------------------------------------------------------------------
+// H3-14. Management path writes produce zero notify even with
+//        staging + pending install controllers attached.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_management_no_notify_with_install_controllers() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{
+        ActiveSkillResolver, ActiveTarget, InMemoryNotifyClient, InstallerStagingController,
+        NotifyController, PendingInstallController, StagingConfig, StagingMatcher, StagingPattern,
+    };
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let mountpoint = tempfile::tempdir().unwrap();
+
+    let notify_client = Arc::new(InMemoryNotifyClient::new());
+    let notify_ctrl = NotifyController::new(
+        notify_client.clone(),
+        source.path().to_path_buf(),
+        Duration::from_millis(50),
+        5000,
+    );
+
+    let staging_config = StagingConfig {
+        patterns: vec![StagingPattern::PrefixStar(
+            ".openclaw-install-stage-".to_string(),
+        )],
+        ..StagingConfig::default()
+    };
+    let matcher = Arc::new(StagingMatcher::new(staging_config));
+    let staging_ctrl = InstallerStagingController::new(matcher.clone(), notify_ctrl.clone());
+
+    let resolver = Arc::new(ActiveSkillResolver::new(source.path()));
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Current {
+            source_dir: source.path().join("apple/apple-notes"),
+        },
+    );
+
+    let pending_ctrl = PendingInstallController::new(
+        notify_ctrl.clone(),
+        Duration::from_millis(200),
+        source.path().to_path_buf(),
+    );
+
+    let config = MountConfig {
+        notify_controller: Some(notify_ctrl.clone()),
+        staging_matcher: Some(matcher),
+        staging_controller: Some(staging_ctrl),
+        active_resolver: Some(resolver),
+        pending_install_controller: Some(pending_ctrl.clone()),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mp = mountpoint.path();
+
+    std::fs::write(mp.join(".hub/new-file.json"), r#"{"test": true}"#).unwrap();
+    std::fs::write(mp.join(".bundled_manifest"), "updated-manifest").unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+    pending_ctrl.flush_for_testing();
+    notify_ctrl.flush_for_testing();
+    assert!(
+        notify_client.is_empty(),
+        "management path writes must not trigger notify even with \
+         staging+pending controllers, got {} events",
+        notify_client.len()
+    );
+}
+
+// -----------------------------------------------------------------------
 // 9. Non-skill subdirectory under category is accessible
 // -----------------------------------------------------------------------
 

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -799,6 +799,8 @@ fn hermes_non_skill_subdir_accessible() {
         let docs = dir.join("apple/docs");
         std::fs::create_dir_all(&docs).unwrap();
         std::fs::write(docs.join("readme.txt"), "documentation").unwrap();
+        // A file living directly under the category (not in a subdir).
+        std::fs::write(dir.join("apple/README.md"), "category readme").unwrap();
     });
 
     let docs = fix.mountpoint().join("apple/docs");
@@ -808,6 +810,22 @@ fn hermes_non_skill_subdir_accessible() {
     let readme = fix.mountpoint().join("apple/docs/readme.txt");
     let content = std::fs::read_to_string(&readme).expect("read readme.txt");
     assert_eq!(content, "documentation");
+
+    // A plain file directly under the category must not be a ghost entry:
+    // it must appear in the listing, stat as a file, and read back.
+    let entries = list_dir_names(&fix.mountpoint().join("apple"));
+    assert!(
+        entries.contains(&"README.md".to_string()),
+        "category direct-child file must be listed, got: {:?}",
+        entries
+    );
+    let cat_file = fix.mountpoint().join("apple/README.md");
+    let file_meta = std::fs::metadata(&cat_file).expect("stat apple/README.md");
+    assert!(file_meta.is_file(), "apple/README.md must stat as a file");
+    assert_eq!(
+        std::fs::read_to_string(&cat_file).expect("read apple/README.md"),
+        "category readme"
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -830,6 +848,7 @@ fn hermes_non_skill_subdir_accessible_with_resolver() {
     let docs = source.path().join("apple/docs");
     std::fs::create_dir_all(&docs).unwrap();
     std::fs::write(docs.join("readme.txt"), "documentation").unwrap();
+    std::fs::write(source.path().join("apple/README.md"), "category readme").unwrap();
 
     let mut store = SkillStore::new();
     store.load_from_directory(source.path(), &ParseConfig::default());
@@ -881,11 +900,26 @@ fn hermes_non_skill_subdir_accessible_with_resolver() {
         .expect("read apple/docs/readme.txt with resolver");
     assert_eq!(content, "documentation");
 
-    // apple/ listing must still contain the non-skill child.
+    // A category direct-child file must also stay accessible with a
+    // resolver attached (it must not be gated as a nested skill).
+    let cat_file = mp.join("apple/README.md");
+    let file_meta = std::fs::metadata(&cat_file).expect("stat apple/README.md with resolver");
+    assert!(file_meta.is_file(), "apple/README.md must stat as a file");
+    assert_eq!(
+        std::fs::read_to_string(&cat_file).expect("read apple/README.md with resolver"),
+        "category readme"
+    );
+
+    // apple/ listing must still contain the non-skill children.
     let entries = list_dir_names(&mp.join("apple"));
     assert!(
         entries.contains(&"docs".to_string()),
         "non-skill child must remain listed under its category, got: {:?}",
+        entries
+    );
+    assert!(
+        entries.contains(&"README.md".to_string()),
+        "category direct-child file must remain listed, got: {:?}",
         entries
     );
 }
@@ -1297,6 +1331,11 @@ fn hermes_enumerate_skill_ids_matches_mixed_layout() {
         "---\nname: weather\n---\n",
     )
     .unwrap();
+    // A subdir under the top-level skill that itself contains a SKILL.md
+    // file. The mount treats this as a passthrough of the `weather` skill,
+    // NOT a nested skill, so enumeration must not register `weather/scripts`.
+    std::fs::create_dir_all(dir.path().join("weather/scripts")).unwrap();
+    std::fs::write(dir.path().join("weather/scripts/SKILL.md"), "decoy").unwrap();
     // Non-skill category child must be excluded.
     std::fs::create_dir_all(dir.path().join("apple/docs")).unwrap();
     std::fs::write(dir.path().join("apple/docs/readme.txt"), "x").unwrap();
@@ -1310,7 +1349,8 @@ fn hermes_enumerate_skill_ids_matches_mixed_layout() {
             "apple/apple-notes".to_string(),
             "weather".to_string(),
         ],
-        "enumeration must cover top-level and nested skills, excluding non-skill children"
+        "enumeration must cover top-level and nested skills, excluding non-skill \
+         children and top-level skill subtrees"
     );
 }
 

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -620,6 +620,78 @@ fn hermes_nested_write_triggers_notify() {
 }
 
 // -----------------------------------------------------------------------
+// H3-15. Hermes nested file rename triggers notify
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_file_rename_triggers_notify() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{InMemoryNotifyClient, NotifyController};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+    std::fs::write(source.path().join("apple/apple-notes/old.txt"), "rename-me").unwrap();
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let mountpoint = tempfile::tempdir().unwrap();
+
+    let notify_client = Arc::new(InMemoryNotifyClient::new());
+    let notify_ctrl = NotifyController::new(
+        notify_client.clone(),
+        source.path().to_path_buf(),
+        Duration::from_millis(50),
+        5000,
+    );
+
+    let config = MountConfig {
+        notify_controller: Some(notify_ctrl.clone()),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mp = mountpoint.path();
+
+    std::fs::rename(
+        mp.join("apple/apple-notes/old.txt"),
+        mp.join("apple/apple-notes/new.txt"),
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+    notify_ctrl.flush_for_testing();
+
+    let events = notify_client.events();
+    let rename_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.skill_name == "apple/apple-notes" && e.event_kind == "rename")
+        .collect();
+    assert!(
+        !rename_events.is_empty(),
+        "nested file rename must trigger notify for apple/apple-notes, got: {:?}",
+        events
+    );
+}
+
+// -----------------------------------------------------------------------
 // H3-14. Management path writes produce zero notify even with
 //        staging + pending install controllers attached.
 // -----------------------------------------------------------------------

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -3,6 +3,8 @@
 mod common;
 
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
 
 use common::{MountFixture, create_skill_dir, list_dir_names};
 
@@ -260,4 +262,92 @@ fn hermes_nested_skill_path_preserved() {
         }
         other => panic!("expected NestedPassthrough, got: {:?}", other),
     }
+}
+
+// -----------------------------------------------------------------------
+// 8. Management path writes do not trigger notify
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_management_path_write_no_notify() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{InMemoryNotifyClient, NotifyController};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let mountpoint = tempfile::tempdir().unwrap();
+
+    let notify_client = Arc::new(InMemoryNotifyClient::new());
+    let notify_ctrl = NotifyController::new(
+        notify_client.clone(),
+        source.path().to_path_buf(),
+        Duration::from_millis(50),
+        5000,
+    );
+
+    let config = MountConfig {
+        notify_controller: Some(notify_ctrl.clone()),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mp = mountpoint.path();
+
+    // Write to a management path — should NOT trigger notify.
+    std::fs::write(mp.join(".hub/new-file.json"), r#"{"test": true}"#).unwrap();
+    std::fs::write(mp.join(".bundled_manifest"), "updated-manifest").unwrap();
+
+    // Wait and check no notify was produced.
+    std::thread::sleep(Duration::from_millis(300));
+    notify_ctrl.flush_for_testing();
+    assert!(
+        notify_client.is_empty(),
+        "management path writes must not trigger notify, got {} events",
+        notify_client.len()
+    );
+}
+
+// -----------------------------------------------------------------------
+// 9. Non-skill subdirectory under category is accessible
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_non_skill_subdir_accessible() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+        let docs = dir.join("apple/docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        std::fs::write(docs.join("readme.txt"), "documentation").unwrap();
+    });
+
+    let docs = fix.mountpoint().join("apple/docs");
+    let meta = std::fs::metadata(&docs).expect("stat apple/docs");
+    assert!(meta.is_dir(), "non-skill subdir must be a directory");
+
+    let readme = fix.mountpoint().join("apple/docs/readme.txt");
+    let content = std::fs::read_to_string(&readme).expect("read readme.txt");
+    assert_eq!(content, "documentation");
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -809,3 +809,524 @@ fn hermes_non_skill_subdir_accessible() {
     let content = std::fs::read_to_string(&readme).expect("read readme.txt");
     assert_eq!(content, "documentation");
 }
+
+// -----------------------------------------------------------------------
+// 9b. Non-skill category child stays accessible even with an active
+//     resolver attached (regression: non-skill children were classified
+//     as nested skills and mapped to Hidden by the resolver).
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_non_skill_subdir_accessible_with_resolver() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{ActiveSkillResolver, ActiveTarget};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+    let docs = source.path().join("apple/docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(docs.join("readme.txt"), "documentation").unwrap();
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    // Resolver knows only the real nested skills — nothing for apple/docs.
+    let resolver = ActiveSkillResolver::new(source.path());
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Current {
+            source_dir: source.path().join("apple/apple-notes"),
+        },
+    );
+    resolver.set(
+        "apple/apple-music",
+        ActiveTarget::Current {
+            source_dir: source.path().join("apple/apple-music"),
+        },
+    );
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let config = MountConfig {
+        active_resolver: Some(Arc::new(resolver)),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mp = mountpoint.path();
+
+    // The non-skill directory and its file must remain accessible — they
+    // are category passthrough, never subject to activation gating.
+    let docs_meta =
+        std::fs::metadata(mp.join("apple/docs")).expect("stat apple/docs with resolver");
+    assert!(docs_meta.is_dir(), "apple/docs must remain a directory");
+
+    let content = std::fs::read_to_string(mp.join("apple/docs/readme.txt"))
+        .expect("read apple/docs/readme.txt with resolver");
+    assert_eq!(content, "documentation");
+
+    // apple/ listing must still contain the non-skill child.
+    let entries = list_dir_names(&mp.join("apple"));
+    assert!(
+        entries.contains(&"docs".to_string()),
+        "non-skill child must remain listed under its category, got: {:?}",
+        entries
+    );
+}
+
+// -----------------------------------------------------------------------
+// 14. Nested SKILL.md is compiled (directives stripped), not raw fd
+//     passthrough, and its stat size matches the compiled payload.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_skill_md_is_compiled_not_raw() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+        // Replace the nested SKILL.md with one carrying a conditional
+        // directive. The compiler always strips `<!-- @if ... -->` marker
+        // lines regardless of branch, so a raw passthrough read would leak
+        // them while a compiled read must not.
+        std::fs::write(
+            dir.join("apple/apple-notes/SKILL.md"),
+            "---\nname: apple-notes\ndescription: notes\n---\n\
+             <!-- @if os == linux -->\nlinux-only line\n<!-- @endif -->\n\
+             Apple Notes skill body.\n",
+        )
+        .unwrap();
+    });
+
+    let md = fix.mountpoint().join("apple/apple-notes/SKILL.md");
+    let content = std::fs::read_to_string(&md).expect("read nested SKILL.md");
+
+    assert!(
+        !content.contains("<!-- @if"),
+        "nested SKILL.md must be compiled (directive markers stripped), got: {content}"
+    );
+    assert!(
+        !content.contains("@endif"),
+        "compiled output must not contain directive markers, got: {content}"
+    );
+    assert!(
+        content.contains("Apple Notes skill body"),
+        "compiled body must be preserved, got: {content}"
+    );
+
+    // lookup/getattr size must match the compiled bytes served on read.
+    let meta = std::fs::metadata(&md).expect("stat nested SKILL.md");
+    assert_eq!(
+        meta.len() as usize,
+        content.len(),
+        "stat size must equal compiled content length"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 15. Nested SKILL.md served from a fallback snapshot is also compiled.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_skill_md_snapshot_is_compiled() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{ActiveSkillResolver, ActiveTarget};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let snap_dir = source
+        .path()
+        .join("apple/apple-notes/.skill-meta/versions/v000001.snapshot");
+    std::fs::create_dir_all(&snap_dir).unwrap();
+    std::fs::write(
+        snap_dir.join("SKILL.md"),
+        "---\nname: apple-notes\ndescription: snapshot\n---\n\
+         <!-- @if os == linux -->\nsnap-linux\n<!-- @endif -->\nSnapshot body.\n",
+    )
+    .unwrap();
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let resolver = ActiveSkillResolver::new(source.path());
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Snapshot {
+            snapshot_dir: snap_dir.clone(),
+            version: "v000001.snapshot".to_string(),
+        },
+    );
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let config = MountConfig {
+        active_resolver: Some(Arc::new(resolver)),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let md = mountpoint.path().join("apple/apple-notes/SKILL.md");
+    let content = std::fs::read_to_string(&md).expect("read nested SKILL.md");
+    assert!(
+        content.contains("Snapshot body"),
+        "snapshot content must be served, got: {content}"
+    );
+    assert!(
+        !content.contains("<!-- @if"),
+        "snapshot nested SKILL.md must be compiled, got: {content}"
+    );
+    let meta = std::fs::metadata(&md).expect("stat nested SKILL.md");
+    assert_eq!(
+        meta.len() as usize,
+        content.len(),
+        "snapshot stat size must equal compiled content length"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 16. Nested SKILL.md write is audited and attributed to category/skill.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_write_audit_attribution() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{InMemoryEventSink, SkillEventKind, SkillEventSink};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let sink = Arc::new(InMemoryEventSink::new());
+    let mountpoint = tempfile::tempdir().unwrap();
+    let config = MountConfig {
+        event_sink: Some(sink.clone() as Arc<dyn SkillEventSink>),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    std::fs::write(
+        mountpoint.path().join("apple/apple-notes/SKILL.md"),
+        "---\nname: apple-notes\ndescription: updated\n---\nUpdated.\n",
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(150));
+
+    let events = sink.events();
+    let attributed: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.skill_name.as_deref() == Some("apple/apple-notes")
+                && matches!(e.kind, SkillEventKind::Open | SkillEventKind::Write)
+        })
+        .collect();
+    assert!(
+        !attributed.is_empty(),
+        "nested SKILL.md write must emit audit events attributed to \
+         'apple/apple-notes', got: {:?}",
+        events
+            .iter()
+            .map(|e| (e.kind, e.skill_name.clone(), e.relative_path.clone()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        attributed
+            .iter()
+            .any(|e| e.relative_path.as_deref() == Some(std::path::Path::new("SKILL.md"))),
+        "audit event relative_path must be SKILL.md, got: {:?}",
+        attributed
+            .iter()
+            .map(|e| e.relative_path.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+// -----------------------------------------------------------------------
+// 17. Nested passthrough xattr set is audited and attributed to
+//     category/skill with the correct relative path.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_nested_xattr_audit_attribution() {
+    skip_if_no_fuse!();
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+    use skillfs_fuse::security::{InMemoryEventSink, SkillEventKind, SkillEventSink};
+    use skillfs_fuse::{MountConfig, MountOptions, SkillLayout, mount_background_configured};
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+    std::fs::write(
+        source.path().join("apple/apple-notes/notes.txt"),
+        "note body",
+    )
+    .unwrap();
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let sink = Arc::new(InMemoryEventSink::new());
+    let mountpoint = tempfile::tempdir().unwrap();
+    let config = MountConfig {
+        event_sink: Some(sink.clone() as Arc<dyn SkillEventSink>),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let _handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Attempt to set a user.* xattr through the mount. The FUSE side emits
+    // the audit event whether the underlying filesystem accepts the xattr
+    // or not, so the assertion holds regardless of tmpfs xattr support.
+    let target = mountpoint.path().join("apple/apple-notes/notes.txt");
+    set_user_xattr(&target, "user.skillfs.test", b"1");
+
+    std::thread::sleep(Duration::from_millis(150));
+
+    let events = sink.events();
+    let attributed: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            e.kind == SkillEventKind::Metadata
+                && e.skill_name.as_deref() == Some("apple/apple-notes")
+        })
+        .collect();
+    assert!(
+        !attributed.is_empty(),
+        "nested xattr set must emit a Metadata event attributed to \
+         'apple/apple-notes', got: {:?}",
+        events
+            .iter()
+            .map(|e| (e.kind, e.skill_name.clone(), e.relative_path.clone()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        attributed
+            .iter()
+            .any(|e| e.relative_path.as_deref() == Some(std::path::Path::new("notes.txt"))),
+        "xattr audit relative_path must be notes.txt, got: {:?}",
+        attributed
+            .iter()
+            .map(|e| e.relative_path.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+// -----------------------------------------------------------------------
+// 18. Mixed layout: top-level skill and nested skill coexist.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_mixed_layout_top_level_and_nested() {
+    skip_if_no_fuse!();
+
+    let fix = MountFixture::in_place_hermes(|dir| {
+        seed_hermes_workspace(dir);
+        // A top-level skill living directly under the source root.
+        let weather = dir.join("weather");
+        std::fs::create_dir_all(&weather).unwrap();
+        std::fs::write(
+            weather.join("SKILL.md"),
+            "---\nname: weather\ndescription: top-level\n---\n\
+             <!-- @if os == linux -->\nw-linux\n<!-- @endif -->\nWeather body.\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(weather.join("scripts")).unwrap();
+        std::fs::write(weather.join("scripts/run.sh"), "#!/bin/sh\necho hi\n").unwrap();
+    });
+
+    let mp = fix.mountpoint();
+
+    // Root listing exposes both the top-level skill and the category.
+    let root_entries = list_dir_names(mp);
+    assert!(
+        root_entries.contains(&"weather".to_string()),
+        "root must list top-level skill 'weather', got: {:?}",
+        root_entries
+    );
+    assert!(
+        root_entries.contains(&"apple".to_string()),
+        "root must list category 'apple', got: {:?}",
+        root_entries
+    );
+
+    // Top-level skill SKILL.md is compiled (behaves like a flat skill).
+    let top_md = std::fs::read_to_string(mp.join("weather/SKILL.md"))
+        .expect("read top-level skill SKILL.md");
+    assert!(
+        !top_md.contains("<!-- @if"),
+        "top-level skill SKILL.md must be compiled, got: {top_md}"
+    );
+    assert!(top_md.contains("Weather body"));
+
+    // Top-level skill passthrough file is readable.
+    let script = std::fs::read_to_string(mp.join("weather/scripts/run.sh"))
+        .expect("read top-level skill passthrough");
+    assert_eq!(script, "#!/bin/sh\necho hi\n");
+
+    // Nested skill still works alongside the top-level skill.
+    let nested_md = std::fs::read_to_string(mp.join("apple/apple-notes/SKILL.md"))
+        .expect("read nested SKILL.md");
+    assert!(nested_md.contains("Apple Notes skill body"));
+}
+
+// -----------------------------------------------------------------------
+// 19. Conservative layout auto-detection.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_layout_auto_detection() {
+    use skillfs_fuse::{SkillLayout, detect_skill_layout};
+
+    // Bundled manifest marker => Hermes.
+    let hermes_manifest = tempfile::tempdir().unwrap();
+    std::fs::write(hermes_manifest.path().join(".bundled_manifest"), "x").unwrap();
+    assert_eq!(
+        detect_skill_layout(hermes_manifest.path()),
+        SkillLayout::Hermes,
+        ".bundled_manifest must select Hermes"
+    );
+
+    // .hub directory marker => Hermes.
+    let hermes_hub = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(hermes_hub.path().join(".hub")).unwrap();
+    assert_eq!(
+        detect_skill_layout(hermes_hub.path()),
+        SkillLayout::Hermes,
+        ".hub/ must select Hermes"
+    );
+
+    // A bare .no-bundled-skills sentinel is NOT a strong marker => Flat.
+    let flat_sentinel = tempfile::tempdir().unwrap();
+    std::fs::write(flat_sentinel.path().join(".no-bundled-skills"), "").unwrap();
+    create_skill_dir(flat_sentinel.path(), "my-skill");
+    assert_eq!(
+        detect_skill_layout(flat_sentinel.path()),
+        SkillLayout::Flat,
+        ".no-bundled-skills alone must NOT select Hermes"
+    );
+
+    // A plain flat workspace => Flat.
+    let flat = tempfile::tempdir().unwrap();
+    create_skill_dir(flat.path(), "my-skill");
+    assert_eq!(
+        detect_skill_layout(flat.path()),
+        SkillLayout::Flat,
+        "plain workspace must be Flat"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 20. Activation enumeration matches mount discovery for mixed layouts.
+// -----------------------------------------------------------------------
+
+#[test]
+fn hermes_enumerate_skill_ids_matches_mixed_layout() {
+    use skillfs_fuse::security::enumerate_hermes_skill_ids;
+
+    let dir = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(dir.path());
+    // Top-level skill.
+    std::fs::create_dir_all(dir.path().join("weather")).unwrap();
+    std::fs::write(
+        dir.path().join("weather/SKILL.md"),
+        "---\nname: weather\n---\n",
+    )
+    .unwrap();
+    // Non-skill category child must be excluded.
+    std::fs::create_dir_all(dir.path().join("apple/docs")).unwrap();
+    std::fs::write(dir.path().join("apple/docs/readme.txt"), "x").unwrap();
+
+    let mut ids = enumerate_hermes_skill_ids(dir.path());
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "apple/apple-music".to_string(),
+            "apple/apple-notes".to_string(),
+            "weather".to_string(),
+        ],
+        "enumeration must cover top-level and nested skills, excluding non-skill children"
+    );
+}
+
+/// Set a `user.*` xattr on `path` via libc (best-effort; the test only
+/// needs the FUSE callback to fire so the return value is ignored).
+fn set_user_xattr(path: &Path, name: &str, value: &[u8]) {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+    let c_name = std::ffi::CString::new(name).unwrap();
+    unsafe {
+        libc::lsetxattr(
+            c_path.as_ptr(),
+            c_name.as_ptr(),
+            value.as_ptr() as *const libc::c_void,
+            value.len(),
+            0,
+        );
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
@@ -2469,7 +2469,6 @@ fn post_publish_grace_direct_pending_complete_triggers_session() {
         .args(["-u", &mountpoint.path().to_string_lossy()])
         .output();
 }
-
 // ─────────────────────────────────────────────────────────────────────────────
 // I4: Post-publish grace fallback snapshot tests
 //
@@ -2757,4 +2756,594 @@ fn post_publish_grace_fallback_skill_md_not_opened_via_grace() {
         "SKILL.md must come from snapshot, not physical source: {}",
         content
     );
+}
+// ─────────────────────────────────────────────────────────────────────────────
+// H3: Hermes installer compatibility tests
+//
+// Tests for installer transactions under Hermes layout mode: staging dirs
+// inside categories, direct-write pending install with nested skill IDs,
+// post-publish grace for nested skills, and management path noise regression.
+// ─────────────────────────────────────────────────────────────────────────────
+
+use skillfs_fuse::SkillLayout;
+
+fn seed_hermes_workspace(dir: &Path) {
+    std::fs::create_dir_all(dir.join(".hub")).unwrap();
+    std::fs::write(dir.join(".hub/config.json"), r#"{"version": 1}"#).unwrap();
+    std::fs::write(dir.join(".bundled_manifest"), "manifest-content").unwrap();
+
+    let apple_notes = dir.join("apple/apple-notes");
+    std::fs::create_dir_all(&apple_notes).unwrap();
+    std::fs::write(
+        apple_notes.join("SKILL.md"),
+        "---\nname: apple-notes\ndescription: notes\n---\n",
+    )
+    .unwrap();
+}
+
+struct HermesStagingFixture {
+    #[allow(dead_code)]
+    source: tempfile::TempDir,
+    mountpoint: tempfile::TempDir,
+    handle: Option<MountHandle>,
+    notify_client: Arc<InMemoryNotifyClient>,
+    notify_controller: Arc<NotifyController>,
+    #[allow(dead_code)]
+    staging_controller: Arc<InstallerStagingController>,
+}
+
+impl HermesStagingFixture {
+    fn new(seed: impl FnOnce(&Path)) -> Self {
+        let source = tempfile::tempdir().unwrap();
+        seed(source.path());
+
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+        let mountpoint = tempfile::tempdir().unwrap();
+        let notify_client = Arc::new(InMemoryNotifyClient::new());
+
+        let notify_ctrl = NotifyController::new(
+            notify_client.clone(),
+            source.path().to_path_buf(),
+            Duration::from_millis(50),
+            5000,
+        );
+
+        let staging_config = StagingConfig {
+            patterns: vec![StagingPattern::PrefixStar(
+                ".openclaw-install-stage-".to_string(),
+            )],
+            ..StagingConfig::default()
+        };
+        let matcher = Arc::new(StagingMatcher::new(staging_config));
+        let staging_ctrl = InstallerStagingController::new(matcher.clone(), notify_ctrl.clone());
+
+        let config = MountConfig {
+            notify_controller: Some(notify_ctrl.clone()),
+            staging_matcher: Some(matcher),
+            staging_controller: Some(staging_ctrl.clone()),
+            skill_layout: Some(SkillLayout::Hermes),
+            ..MountConfig::default()
+        };
+
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            shared,
+            MountOptions::default(),
+            true,
+            config,
+        )
+        .unwrap();
+
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            source,
+            mountpoint,
+            handle: Some(handle),
+            notify_client,
+            notify_controller: notify_ctrl,
+            staging_controller: staging_ctrl,
+        }
+    }
+
+    fn mp(&self) -> &Path {
+        self.mountpoint.path()
+    }
+
+    fn wait_for_notify(&self, expected: usize) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            self.notify_controller.flush_for_testing();
+            if self.notify_client.len() >= expected {
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for {} notify events, got {}",
+                    expected,
+                    self.notify_client.len()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for HermesStagingFixture {
+    fn drop(&mut self) {
+        self.notify_controller.shutdown();
+        if let Some(handle) = self.handle.take() {
+            drop(handle);
+        }
+        let mp = self.mountpoint.path().to_path_buf();
+        std::thread::sleep(Duration::from_millis(150));
+        let _ = std::process::Command::new("fusermount3")
+            .args(["-u", &mp.to_string_lossy()])
+            .output();
+    }
+}
+
+#[test]
+fn hermes_staging_writes_no_notify() {
+    skip_if_no_fuse!();
+
+    let fix = HermesStagingFixture::new(|src| {
+        seed_hermes_workspace(src);
+    });
+
+    let staging = fix.mp().join("apple/.openclaw-install-stage-new");
+    std::fs::create_dir(&staging).unwrap();
+    std::fs::write(
+        staging.join("SKILL.md"),
+        "---\nname: new-skill\ndescription: test\n---\n",
+    )
+    .unwrap();
+    std::fs::write(staging.join("data.txt"), "payload").unwrap();
+
+    std::thread::sleep(Duration::from_millis(500));
+    fix.notify_controller.flush_for_testing();
+
+    let staging_events: Vec<_> = fix
+        .notify_client
+        .events()
+        .iter()
+        .filter(|e| e.skill_name.contains(".openclaw-install-stage-"))
+        .cloned()
+        .collect();
+    assert!(
+        staging_events.is_empty(),
+        "Hermes staging writes must not trigger any notify: {:?}",
+        staging_events
+    );
+}
+
+#[test]
+fn hermes_staging_rename_triggers_notify() {
+    skip_if_no_fuse!();
+
+    let fix = HermesStagingFixture::new(|src| {
+        seed_hermes_workspace(src);
+    });
+
+    let staging = fix.mp().join("apple/.openclaw-install-stage-beta");
+    std::fs::create_dir(&staging).unwrap();
+    std::fs::write(
+        staging.join("SKILL.md"),
+        "---\nname: beta\ndescription: installed\n---\n",
+    )
+    .unwrap();
+
+    let final_path = fix.mp().join("apple/beta");
+    std::fs::rename(&staging, &final_path).unwrap();
+
+    fix.wait_for_notify(1);
+
+    let events = fix.notify_client.events();
+    let rename_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.skill_name == "apple/beta" && e.event_kind == "rename")
+        .collect();
+    assert_eq!(
+        rename_events.len(),
+        1,
+        "expected one rename notify for apple/beta, got: {:?}",
+        events
+    );
+    assert!(
+        rename_events[0].skill_dir.ends_with("/apple/beta"),
+        "skillDir must end with /apple/beta, got: {}",
+        rename_events[0].skill_dir
+    );
+
+    let staging_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.skill_name.contains(".openclaw-install-stage-"))
+        .collect();
+    assert!(
+        staging_events.is_empty(),
+        "no staging name events must exist: {:?}",
+        staging_events
+    );
+}
+
+#[test]
+fn hermes_staging_hidden_from_category_listing() {
+    skip_if_no_fuse!();
+
+    let fix = HermesStagingFixture::new(|src| {
+        seed_hermes_workspace(src);
+        let staging = src.join("apple/.openclaw-install-stage-gamma");
+        std::fs::create_dir_all(&staging).unwrap();
+        std::fs::write(staging.join("SKILL.md"), "---\nname: gamma\n---\n").unwrap();
+    });
+
+    let entries = common::list_dir_names(&fix.mp().join("apple"));
+    assert!(
+        entries.contains(&"apple-notes".to_string()),
+        "existing skill must be visible: {:?}",
+        entries
+    );
+    assert!(
+        !entries.contains(&".openclaw-install-stage-gamma".to_string()),
+        "staging root must NOT appear in category listing: {:?}",
+        entries
+    );
+}
+
+#[test]
+fn hermes_staging_exact_path_accessible() {
+    skip_if_no_fuse!();
+
+    let fix = HermesStagingFixture::new(|src| {
+        seed_hermes_workspace(src);
+        let staging = src.join("apple/.openclaw-install-stage-delta");
+        std::fs::create_dir_all(&staging).unwrap();
+        std::fs::write(staging.join("data.txt"), "payload").unwrap();
+    });
+
+    let staging = fix.mp().join("apple/.openclaw-install-stage-delta");
+    let meta = std::fs::metadata(&staging);
+    assert!(
+        meta.is_ok(),
+        "staging root must be accessible via exact path"
+    );
+    assert!(meta.unwrap().is_dir());
+
+    let data = std::fs::read_to_string(staging.join("data.txt")).unwrap();
+    assert_eq!(data, "payload");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H3: Hermes pending install tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct HermesPendingFixture {
+    #[allow(dead_code)]
+    source: tempfile::TempDir,
+    mountpoint: tempfile::TempDir,
+    handle: Option<MountHandle>,
+    notify_client: Arc<InMemoryNotifyClient>,
+    notify_controller: Arc<NotifyController>,
+    pending_controller: Arc<PendingInstallController>,
+    #[allow(dead_code)]
+    resolver: Arc<ActiveSkillResolver>,
+}
+
+impl HermesPendingFixture {
+    fn new(pending_timeout_ms: u64, seed: impl FnOnce(&Path)) -> Self {
+        let source = tempfile::tempdir().unwrap();
+        seed(source.path());
+
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+        let mountpoint = tempfile::tempdir().unwrap();
+        let notify_client = Arc::new(InMemoryNotifyClient::new());
+
+        let notify_ctrl = NotifyController::new(
+            notify_client.clone(),
+            source.path().to_path_buf(),
+            Duration::from_millis(50),
+            5000,
+        );
+
+        let resolver = Arc::new(ActiveSkillResolver::new(source.path()));
+        resolver.set(
+            "apple/apple-notes",
+            ActiveTarget::Current {
+                source_dir: source.path().join("apple/apple-notes"),
+            },
+        );
+
+        let pending_ctrl = PendingInstallController::new(
+            notify_ctrl.clone(),
+            Duration::from_millis(pending_timeout_ms),
+            source.path().to_path_buf(),
+        );
+
+        let config = MountConfig {
+            notify_controller: Some(notify_ctrl.clone()),
+            active_resolver: Some(resolver.clone()),
+            pending_install_controller: Some(pending_ctrl.clone()),
+            skill_layout: Some(SkillLayout::Hermes),
+            ..MountConfig::default()
+        };
+
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            shared,
+            MountOptions::default(),
+            true,
+            config,
+        )
+        .unwrap();
+
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            source,
+            mountpoint,
+            handle: Some(handle),
+            notify_client,
+            notify_controller: notify_ctrl,
+            pending_controller: pending_ctrl,
+            resolver,
+        }
+    }
+
+    fn mp(&self) -> &Path {
+        self.mountpoint.path()
+    }
+}
+
+impl Drop for HermesPendingFixture {
+    fn drop(&mut self) {
+        self.pending_controller.shutdown();
+        self.notify_controller.shutdown();
+        if let Some(handle) = self.handle.take() {
+            drop(handle);
+        }
+        let mp = self.mountpoint.path().to_path_buf();
+        std::thread::sleep(Duration::from_millis(150));
+        let _ = std::process::Command::new("fusermount3")
+            .args(["-u", &mp.to_string_lossy()])
+            .output();
+    }
+}
+
+#[test]
+fn hermes_pending_complete_notifies() {
+    skip_if_no_fuse!();
+
+    let fix = HermesPendingFixture::new(200, |src| {
+        seed_hermes_workspace(src);
+    });
+
+    let new_skill = fix.mp().join("apple/new-skill");
+    std::fs::create_dir(&new_skill).unwrap();
+    std::fs::write(
+        new_skill.join("SKILL.md"),
+        "---\nname: new-skill\ndescription: test\n---\n",
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(400));
+    fix.pending_controller.flush_for_testing();
+    fix.notify_controller.flush_for_testing();
+
+    let events = fix.notify_client.events();
+    let new_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.skill_name == "apple/new-skill")
+        .collect();
+    assert_eq!(
+        new_events.len(),
+        1,
+        "complete Hermes pending install must trigger one notify: {:?}",
+        events
+    );
+}
+
+#[test]
+fn hermes_pending_incomplete_no_notify() {
+    skip_if_no_fuse!();
+
+    let fix = HermesPendingFixture::new(150, |src| {
+        seed_hermes_workspace(src);
+    });
+
+    let new_skill = fix.mp().join("apple/incomplete");
+    std::fs::create_dir(&new_skill).unwrap();
+    std::fs::write(new_skill.join("data.txt"), "no SKILL.md").unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+    fix.pending_controller.flush_for_testing();
+    fix.notify_controller.flush_for_testing();
+
+    let events = fix.notify_client.events();
+    let inc_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.skill_name == "apple/incomplete")
+        .collect();
+    assert!(
+        inc_events.is_empty(),
+        "incomplete Hermes pending install must not notify: {:?}",
+        inc_events
+    );
+}
+
+#[test]
+fn hermes_pending_hidden_from_category_listing() {
+    skip_if_no_fuse!();
+
+    let fix = HermesPendingFixture::new(5000, |src| {
+        seed_hermes_workspace(src);
+    });
+
+    let new_skill = fix.mp().join("apple/pending-hidden");
+    std::fs::create_dir(&new_skill).unwrap();
+
+    let entries = common::list_dir_names(&fix.mp().join("apple"));
+    assert!(
+        entries.contains(&"apple-notes".to_string()),
+        "existing skill must be visible: {:?}",
+        entries
+    );
+    assert!(
+        !entries.contains(&"pending-hidden".to_string()),
+        "pending skill must NOT appear in category listing: {:?}",
+        entries
+    );
+}
+
+#[test]
+fn hermes_pending_exact_path_accessible() {
+    skip_if_no_fuse!();
+
+    let fix = HermesPendingFixture::new(5000, |src| {
+        seed_hermes_workspace(src);
+    });
+
+    let new_skill = fix.mp().join("apple/pending-access");
+    std::fs::create_dir(&new_skill).unwrap();
+
+    let meta = std::fs::metadata(&new_skill);
+    assert!(
+        meta.is_ok(),
+        "pending nested skill must be accessible via exact path"
+    );
+    assert!(meta.unwrap().is_dir());
+
+    std::fs::write(new_skill.join("data.txt"), "test").unwrap();
+    let content = std::fs::read_to_string(new_skill.join("data.txt")).unwrap();
+    assert_eq!(content, "test");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H3: Hermes post-publish grace tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn hermes_post_publish_grace_allows_whitelisted() {
+    skip_if_no_fuse!();
+
+    use skillfs_fuse::security::PostPublishWritePattern;
+
+    let source = tempfile::tempdir().unwrap();
+    seed_hermes_workspace(source.path());
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(source.path(), &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let notify_client = Arc::new(InMemoryNotifyClient::new());
+
+    let notify_ctrl = NotifyController::new(
+        notify_client.clone(),
+        source.path().to_path_buf(),
+        Duration::from_millis(50),
+        5000,
+    );
+
+    let staging_config = StagingConfig {
+        patterns: vec![StagingPattern::PrefixStar(
+            ".openclaw-install-stage-".to_string(),
+        )],
+        ..StagingConfig::default()
+    };
+    let matcher = Arc::new(StagingMatcher::new(staging_config));
+    let staging_ctrl = InstallerStagingController::new(matcher.clone(), notify_ctrl.clone());
+
+    let resolver = Arc::new(ActiveSkillResolver::new(source.path()));
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Current {
+            source_dir: source.path().join("apple/apple-notes"),
+        },
+    );
+
+    let pp_patterns = vec![PostPublishWritePattern::PrefixRecursive(
+        ".openclaw".to_string(),
+    )];
+    let pp_ctrl = PostPublishGraceController::new(Duration::from_millis(5000), pp_patterns);
+
+    let config = MountConfig {
+        notify_controller: Some(notify_ctrl.clone()),
+        staging_matcher: Some(matcher),
+        staging_controller: Some(staging_ctrl),
+        active_resolver: Some(resolver),
+        post_publish_controller: Some(pp_ctrl.clone()),
+        skill_layout: Some(SkillLayout::Hermes),
+        ..MountConfig::default()
+    };
+
+    let handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        shared,
+        MountOptions::default(),
+        true,
+        config,
+    )
+    .unwrap();
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mp = mountpoint.path();
+
+    let staging = mp.join("apple/.openclaw-install-stage-grace");
+    std::fs::create_dir(&staging).unwrap();
+    std::fs::write(
+        staging.join("SKILL.md"),
+        "---\nname: grace-test\ndescription: test\n---\n",
+    )
+    .unwrap();
+    let final_path = mp.join("apple/grace-test");
+    std::fs::rename(&staging, &final_path).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        notify_ctrl.flush_for_testing();
+        if !notify_client.is_empty() {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for rename notify, events: {:?}",
+                notify_client.events()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // Grace: whitelisted .openclaw/** write must succeed.
+    std::fs::create_dir(final_path.join(".openclaw")).unwrap();
+    let result = std::fs::write(final_path.join(".openclaw/metadata.tmp"), "installer-data");
+    assert!(
+        result.is_ok(),
+        "whitelisted .openclaw/** write must succeed during grace: {:?}",
+        result.err()
+    );
+
+    // Non-whitelisted write must fail.
+    let result = std::fs::create_dir(final_path.join("other-dir"));
+    assert!(
+        result.is_err(),
+        "non-whitelisted path must be rejected during grace"
+    );
+
+    pp_ctrl.shutdown();
+    notify_ctrl.shutdown();
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(150));
+    let _ = std::process::Command::new("fusermount3")
+        .args(["-u", &mountpoint.path().to_string_lossy()])
+        .output();
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/trusted_skill_meta_view_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/trusted_skill_meta_view_tests.rs
@@ -19,8 +19,12 @@ use std::time::Duration;
 
 use parking_lot::RwLock;
 use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
-use skillfs_fuse::security::{ActiveSkillResolver, LedgerResolveResult, TrustedWriterConfig};
-use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
+use skillfs_fuse::security::{
+    ActiveSkillResolver, ActiveTarget, LedgerResolveResult, TrustedWriterConfig,
+};
+use skillfs_fuse::{
+    MountConfig, MountHandle, MountOptions, SkillLayout, mount_background_configured,
+};
 
 #[path = "common/mod.rs"]
 mod common;
@@ -640,5 +644,359 @@ fn untrusted_parent_listing_still_hides_skill_meta() {
     assert!(
         !listing.contains(&".skill-meta".to_string()),
         "untrusted caller must NOT see .skill-meta, got {listing:?}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hermes nested .skill-meta tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn seed_hermes_with_meta(source: &Path, category: &str, skill: &str) {
+    let skill_dir = source.join(category).join(skill);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        format!("---\nname: {skill}\ndescription: test\n---\n{skill} body.\n"),
+    )
+    .unwrap();
+    let meta = skill_dir.join(".skill-meta");
+    std::fs::create_dir_all(&meta).unwrap();
+    std::fs::write(
+        meta.join("manifest.json"),
+        format!("{{\"skill\":\"{category}/{skill}\",\"live\":true}}\n"),
+    )
+    .unwrap();
+}
+
+#[allow(dead_code)]
+struct HermesMetaViewFixture {
+    source: tempfile::TempDir,
+    mountpoint: tempfile::TempDir,
+    handle: Option<MountHandle>,
+}
+
+impl HermesMetaViewFixture {
+    fn new<S, R>(seed: S, trusted_writer: Option<TrustedWriterConfig>, resolver_builder: R) -> Self
+    where
+        S: FnOnce(&Path),
+        R: FnOnce(&Path) -> Option<Arc<ActiveSkillResolver>>,
+    {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let resolver = resolver_builder(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+
+        let store = fixture_store(source.path());
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            store,
+            MountOptions::default(),
+            true,
+            MountConfig {
+                trusted_writer,
+                active_resolver: resolver,
+                skill_layout: Some(SkillLayout::Hermes),
+                ..MountConfig::default()
+            },
+        )
+        .expect("mount_background_configured");
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            source,
+            mountpoint,
+            handle: Some(handle),
+        }
+    }
+
+    fn nested_skill_dir(&self, category: &str, skill: &str) -> PathBuf {
+        self.mountpoint.path().join(category).join(skill)
+    }
+
+    fn nested_skill_meta(&self, category: &str, skill: &str) -> PathBuf {
+        self.nested_skill_dir(category, skill).join(".skill-meta")
+    }
+}
+
+impl Drop for HermesMetaViewFixture {
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            drop(h);
+        }
+        let mp = self.mountpoint.path().to_path_buf();
+        std::thread::sleep(Duration::from_millis(150));
+        let _ = std::process::Command::new("fusermount3")
+            .args(["-u", &mp.to_string_lossy()])
+            .output();
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H1. Untrusted readdir of category/skill hides .skill-meta
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn hermes_untrusted_readdir_hides_skill_meta() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = HermesMetaViewFixture::new(
+        |src| seed_hermes_with_meta(src, "apple", "apple-notes"),
+        None,
+        |_| None,
+    );
+    let listing = sorted_dir(&fx.nested_skill_dir("apple", "apple-notes"));
+    assert!(
+        listing.contains(&"SKILL.md".to_string()),
+        "SKILL.md must be visible, got {listing:?}"
+    );
+    assert!(
+        !listing.contains(&".skill-meta".to_string()),
+        ".skill-meta must be hidden from untrusted readdir, got {listing:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H2. Untrusted exact path metadata/read for category/skill/.skill-meta/...
+//     returns ENOENT
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn hermes_untrusted_exact_skill_meta_denied() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = HermesMetaViewFixture::new(
+        |src| seed_hermes_with_meta(src, "apple", "apple-notes"),
+        None,
+        |_| None,
+    );
+    let meta_dir = fx.nested_skill_meta("apple", "apple-notes");
+    let err = std::fs::metadata(&meta_dir).expect_err("untrusted .skill-meta lookup must fail");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    let manifest = meta_dir.join("manifest.json");
+    let err =
+        std::fs::read(&manifest).expect_err("untrusted .skill-meta/manifest.json read must fail");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H3. Trusted read-only open/stat of category/skill/.skill-meta/... succeeds
+//     and reads live source even when the skill is fallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn hermes_trusted_reads_live_skill_meta() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = HermesMetaViewFixture::new(
+        |src| {
+            seed_hermes_with_meta(src, "apple", "apple-notes");
+            std::fs::create_dir_all(src.join("apple/apple-notes/scripts")).unwrap();
+            std::fs::write(
+                src.join("apple/apple-notes/scripts/run.sh"),
+                "#!/bin/sh\necho live\n",
+            )
+            .unwrap();
+            write_snapshot(
+                src,
+                "apple/apple-notes",
+                "v000001.snapshot",
+                "---\nname: apple-notes\ndescription: snapshot\n---\n",
+                &[("scripts/run.sh", "#!/bin/sh\necho snapshot\n")],
+            );
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |src_root| {
+            let snap_dir = src_root.join("apple/apple-notes/.skill-meta/versions/v000001.snapshot");
+            let r = ActiveSkillResolver::new(src_root);
+            r.set(
+                "apple/apple-notes",
+                ActiveTarget::Snapshot {
+                    snapshot_dir: snap_dir,
+                    version: "v000001.snapshot".to_string(),
+                },
+            );
+            Some(Arc::new(r))
+        },
+    );
+    let manifest = std::fs::read_to_string(
+        fx.nested_skill_meta("apple", "apple-notes")
+            .join("manifest.json"),
+    )
+    .expect("trusted .skill-meta must be readable even in fallback");
+    assert!(
+        manifest.contains("\"live\":true"),
+        ".skill-meta must come from live source, got: {manifest}"
+    );
+    let script = std::fs::read_to_string(
+        fx.nested_skill_dir("apple", "apple-notes")
+            .join("scripts/run.sh"),
+    )
+    .expect("regular file should be readable");
+    assert!(
+        script.contains("echo snapshot"),
+        "regular file must come from snapshot, got: {script}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H4. Trusted hidden nested skill can read live .skill-meta but cannot read
+//     ordinary hidden files
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn hermes_trusted_hidden_meta_no_ordinary_files() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = HermesMetaViewFixture::new(
+        |src| {
+            seed_hermes_with_meta(src, "apple", "apple-notes");
+            std::fs::write(
+                src.join("apple/apple-notes/private.txt"),
+                "secret content\n",
+            )
+            .unwrap();
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root);
+            r.set(
+                "apple/apple-notes",
+                ActiveTarget::Hidden {
+                    reason: "no trusted version available".to_string(),
+                },
+            );
+            Some(Arc::new(r))
+        },
+    );
+    let manifest = std::fs::read_to_string(
+        fx.nested_skill_meta("apple", "apple-notes")
+            .join("manifest.json"),
+    )
+    .expect("trusted .skill-meta must be readable on hidden nested skill");
+    assert!(manifest.contains("\"live\":true"));
+    let err = std::fs::read_to_string(
+        fx.nested_skill_dir("apple", "apple-notes")
+            .join("private.txt"),
+    )
+    .expect_err("hidden nested skill regular file must remain inaccessible");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H5. Untrusted write/create under nested .skill-meta is rejected
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn hermes_untrusted_write_nested_skill_meta_rejected() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = HermesMetaViewFixture::new(
+        |src| seed_hermes_with_meta(src, "apple", "apple-notes"),
+        None,
+        |_| None,
+    );
+    let manifest = fx
+        .nested_skill_meta("apple", "apple-notes")
+        .join("manifest.json");
+    let err = std::fs::write(&manifest, b"overwritten\n")
+        .expect_err("untrusted write to nested .skill-meta must be denied");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H6. Trusted mutating open/create under nested .skill-meta goes through
+//     enforce_skill_meta and preserves existing audit/policy semantics
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn hermes_trusted_mutating_open_goes_through_policy() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = HermesMetaViewFixture::new(
+        |src| seed_hermes_with_meta(src, "apple", "apple-notes"),
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |_| None,
+    );
+    let manifest = fx
+        .nested_skill_meta("apple", "apple-notes")
+        .join("manifest.json");
+    let _content = std::fs::read_to_string(&manifest).expect("trusted read must succeed");
+    std::fs::write(&manifest, b"{\"updated\":true}\n")
+        .expect("trusted writer write must succeed through policy gate");
+    let updated = std::fs::read_to_string(&manifest).expect("re-read after write");
+    assert!(
+        updated.contains("\"updated\":true"),
+        "write must have landed, got: {updated}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H7. Symlink/hardlink under nested .skill-meta remains rejected even for
+//     trusted writer, matching flat behavior
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn hermes_trusted_meta_symlink_hardlink_rejected() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let comm = self_comm();
+    let fx = HermesMetaViewFixture::new(
+        |src| {
+            seed_hermes_with_meta(src, "apple", "apple-notes");
+            std::fs::write(src.join("apple/apple-notes/regular.txt"), b"normal\n").unwrap();
+        },
+        Some(TrustedWriterConfig::with_process_name(comm)),
+        |_| None,
+    );
+    let _manifest = std::fs::read_to_string(
+        fx.nested_skill_meta("apple", "apple-notes")
+            .join("manifest.json"),
+    )
+    .expect("trusted read must work");
+    let link_path = fx
+        .nested_skill_meta("apple", "apple-notes")
+        .join("link-to-regular");
+    let err = std::os::unix::fs::symlink("../regular.txt", &link_path)
+        .expect_err("symlink inside nested .skill-meta must be denied");
+    // Nested paths are rejected at the link-type gate (EROFS) since
+    // symlink_impl only accepts flat Passthrough targets.
+    assert!(
+        err.raw_os_error() == Some(libc::EACCES) || err.raw_os_error() == Some(libc::EROFS),
+        "expected EACCES or EROFS, got {err:?}"
+    );
+    let dst = fx
+        .nested_skill_dir("apple", "apple-notes")
+        .join("manifest-copy.json");
+    let err = std::fs::hard_link(
+        fx.nested_skill_meta("apple", "apple-notes")
+            .join("manifest.json"),
+        &dst,
+    )
+    .expect_err("hardlink from nested .skill-meta must be denied");
+    assert!(
+        err.raw_os_error() == Some(libc::EACCES) || err.raw_os_error() == Some(libc::EROFS),
+        "expected EACCES or EROFS, got {err:?}"
     );
 }


### PR DESCRIPTION
## Summary

Add Hermes layout compatibility for SkillFS.

This lets SkillFS operate on a Hermes-style skill workspace where the root is
both a skill hub and a management workspace. Hermes management paths remain
pass-through, category directories remain containers, and real skills are
handled as nested `category/skill` leaves.

## Ship Note

This PR adds:

- `--skill-layout hermes` / `[skills].layout = "hermes"`.
- Pass-through handling for Hermes management paths:
  - `.hub/`
  - `.bundled_manifest`
  - `.no-bundled-skills`
- Category container support for paths like `apple/`.
- Nested skill support for paths like `apple/apple-notes/SKILL.md`.
- Activation-file support for nested skill ids using `category/skill`.
- Notify support for nested skill mutations.
- Installer compatibility for Hermes/OpenClaw-style flows:
  - staging writes are suppressed;
  - staging rename emits a normal `rename` mutation;
  - direct-write installs enter pending state;
  - quiet timeout emits a normal mutation after the skill is complete;
  - post-publish grace can allow whitelisted installer metadata writes.

## Behavior / Compatibility

Default behavior is unchanged. The default layout remains flat.

Hermes layout is opt-in:

```sh
--skill-layout hermes