### PR TITLE
feat(sight): add anolisa component contract

### DIFF
--- a/src/agentsight/agentsight.spec.in
+++ b/src/agentsight/agentsight.spec.in
@@ -17,6 +17,7 @@ BuildRequires:  perl-core
 # Runtime dependencies
 # Requires for eBPF components
 Requires:       elfutils-libelf
+Provides:       anolisa-component(agentsight)
 
 %description
 AgentSight is an eBPF-based AI Agent observability tool that provides zero-intrusion 
@@ -34,10 +35,12 @@ rm -rf $RPM_BUILD_ROOT
 install -d -m 0755 %{buildroot}/usr/local/bin
 install -d -m 0755 %{buildroot}%{_unitdir}
 install -d -m 0755 %{buildroot}%{_docdir}/agentsight
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/components/agentsight
 
 install -p -m 0755 agentsight %{buildroot}/usr/local/bin/
 install -p -m 0755 agentsight-start %{buildroot}/usr/local/bin/
 install -p -m 0644 agentsight.service %{buildroot}%{_unitdir}/
+install -p -m 0644 component.toml %{buildroot}%{_datadir}/anolisa/components/agentsight/component.toml
 install -p -m 0644 README.md %{buildroot}%{_docdir}/agentsight/
 install -p -m 0644 README_CN.md %{buildroot}%{_docdir}/agentsight/
 install -p -m 0644 LICENSE %{buildroot}%{_docdir}/agentsight/
@@ -56,6 +59,7 @@ install -p -m 0644 LICENSE %{buildroot}%{_docdir}/agentsight/
 %attr(0755,root,root) /usr/local/bin/agentsight
 %attr(0755,root,root) /usr/local/bin/agentsight-start
 %{_unitdir}/agentsight.service
+%{_datadir}/anolisa/components/agentsight/component.toml
 %doc %{_docdir}/agentsight/README.md
 %doc %{_docdir}/agentsight/README_CN.md
 %license %{_docdir}/agentsight/LICENSE

--- a/src/agentsight/component.toml
+++ b/src/agentsight/component.toml
@@ -1,0 +1,33 @@
+manifest_version = 2
+anolisa_min_version = "0.1.0"
+
+[component]
+name = "agentsight"
+version = "0.6.1"
+layer = "runtime"
+domain = "observability"
+description = "eBPF-based AI agent observability tool"
+stability = "experimental"
+
+[install]
+modes = ["system"]
+
+[backends.rpm]
+package = "agentsight"
+
+[environment]
+requires_os = "linux"
+requires_arch = ["x86_64"]
+requires_kernel = ">=5.8"
+
+[environment.requires_env]
+btf_available = "true"
+capability = "CAP_BPF"
+
+[dependencies]
+runtime = ["elfutils-libelf"]
+
+[[health_checks]]
+name = "binary"
+kind = "command"
+command = "{bindir}/agentsight --version"

--- a/src/agentsight/scripts/rpm-build.sh
+++ b/src/agentsight/scripts/rpm-build.sh
@@ -17,7 +17,8 @@
 #   1. Build frontend (npm install && npm run build:embed)
 #   2. Build Rust binary (cargo build --release)
 #   3. Create a tarball: agentsight-<version>.tar.gz
-#   4. The tarball contains: agentsight, agentsight-start, agentsight.service, README.md, README_CN.md, LICENSE
+#   4. The tarball contains: agentsight, agentsight-start, agentsight.service,
+#      component.toml, README.md, README_CN.md, LICENSE
 # =============================================================================
 
 set -e
@@ -52,7 +53,8 @@ The script will:
     1. Build frontend (npm install && npm run build:embed)
     2. Build Rust binary (cargo build --release)
     3. Create a tarball: agentsight-<version>.tar.gz
-    4. The tarball contains: agentsight, agentsight-start, agentsight.service, README.md, README_CN.md, LICENSE
+    4. The tarball contains: agentsight, agentsight-start, agentsight.service,
+       component.toml, README.md, README_CN.md, LICENSE
 
 Example:
     $(basename "$0")                    # Build with default version
@@ -142,6 +144,7 @@ mkdir -p "$TARBALL_DIR"
 cp "target/release/agentsight" "$TARBALL_DIR/"
 cp "$PROJECT_ROOT/scripts/agentsight-start.sh" "$TARBALL_DIR/agentsight-start"
 cp "$PROJECT_ROOT/scripts/agentsight.service" "$TARBALL_DIR/"
+cp "$PROJECT_ROOT/component.toml" "$TARBALL_DIR/"
 cp "$PROJECT_ROOT/README.md" "$TARBALL_DIR/"
 cp "$PROJECT_ROOT/README_CN.md" "$TARBALL_DIR/"
 cp "$PROJECT_ROOT/LICENSE" "$TARBALL_DIR/"


### PR DESCRIPTION
 ## Description

  Adds a minimal ANOLISA component contract for the `agentsight` RPM so AgentSight
  can be installed, adopted, inspected, and checked by anolisa through the RPM
  backend.

  The RPM now installs `component.toml` under the package datadir contract path
  and exposes `anolisa-component(agentsight)` as a virtual provide.

  ### Ship Note

  What changed:
  - Added `src/agentsight/component.toml` for the AgentSight runtime component.
  - Updated the RPM spec to install the contract under `/usr/share/anolisa`.
  - Added `Provides: anolisa-component(agentsight)` for package discovery.
  - Updated the RPM source tarball script to include `component.toml`.

  ## Related Issue

  N/A

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional change)
  - [ ] Performance improvement
  - [ ] CI/CD or build changes

  ## Scope

  - [ ] `cosh` (copilot-shell)
  - [ ] `sec-core` (agent-sec-core)
  - [ ] `skill` (os-skills)
  - [x] `sight` (agentsight)
  - [ ] `tokenless` (tokenless)
  - [ ] `ckpt` (ws-ckpt)
  - [ ] `memory` (agent-memory)
  - [ ] `anolisa` (anolisa-cli)
  - [ ] `skillfs` (SkillFS)
  - [ ] Multiple / Project-wide

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [x] My code follows the project's code style
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have updated the documentation accordingly
  - [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and
  `cargo test --locked` pass
  - [] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

  ## Testing

  ```bash
  python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("src/agentsight/
  component.toml").read_text())'
  bash -n src/agentsight/scripts/rpm-build.sh
  rpmspec -P <(sed 's/@VERSION@/0.6.1/g' src/agentsight/agentsight.spec.in)
  git diff --check

  Also validated on a clean remote environment:

  - Built a real AgentSight RPM containing:
      - Provides: anolisa-component(agentsight)
      - /usr/share/anolisa/components/agentsight/component.toml

  - Verified anolisa install agentsight --backend rpm --package agentsight --json
    using a temporary local dnf repo.

  - Verified anolisa adopt agentsight --package agentsight --json after installing
    the RPM outside ANOLISA.

  - Verified anolisa status agentsight --json and
    anolisa doctor agentsight --json for both install and adopt scenarios.