### PR TITLE
feat(skill): add anolisa component contract

### DIFF
--- a/src/os-skills/Makefile
+++ b/src/os-skills/Makefile
@@ -14,6 +14,7 @@ ifeq ($(INSTALL_PROFILE),system)
 SKILLS_DIR ?= $(DATADIR)/anolisa/skills
 endif
 ADAPTER_DIR ?= $(DATADIR)/anolisa/adapters/os-skills
+COMPONENT_DIR ?= $(DATADIR)/anolisa/components/os-skills
 
 .PHONY: build install uninstall clean help
 
@@ -30,6 +31,8 @@ install:
 	done
 	install -d -m 0755 "$(DESTDIR)$(ADAPTER_DIR)"
 	install -p -m 0644 adapters/adapter-manifest.json "$(DESTDIR)$(ADAPTER_DIR)/manifest.json"
+	install -d -m 0755 "$(DESTDIR)$(COMPONENT_DIR)"
+	install -p -m 0644 component.toml "$(DESTDIR)$(COMPONENT_DIR)/component.toml"
 	install -d -m 0755 "$(DESTDIR)$(ADAPTER_DIR)/openclaw/scripts"
 	install -p -m 0755 adapters/openclaw/scripts/detect.sh "$(DESTDIR)$(ADAPTER_DIR)/openclaw/scripts/"
 	install -p -m 0755 adapters/openclaw/scripts/install.sh "$(DESTDIR)$(ADAPTER_DIR)/openclaw/scripts/"
@@ -47,6 +50,7 @@ uninstall:
 		rm -rf "$(DESTDIR)$(SKILLS_DIR)/$$skill_name"; \
 	done
 	rm -rf "$(DESTDIR)$(ADAPTER_DIR)"
+	rm -rf "$(DESTDIR)$(COMPONENT_DIR)"
 
 clean:
 	@true

--- a/src/os-skills/component.toml
+++ b/src/os-skills/component.toml
@@ -1,0 +1,241 @@
+manifest_version = 2
+anolisa_min_version = "0.1.15"
+
+[component]
+name = "os-skills"
+version = "0.1.0"
+layer = "runtime"
+domain = "tools"
+description = "Curated OS Skill library for agent runtimes"
+
+[install]
+modes = ["system"]
+
+[backends.rpm]
+package = "os-skills"
+
+[[adapters]]
+framework = "openclaw"
+name = "os-skills-openclaw"
+display_name = "OS Skills for OpenClaw"
+adapter_type = "skill_bundle"
+trust = "first-party"
+dest = "{datadir}/skills"
+detect = { binary = "openclaw" }
+
+[[adapters.openclaw.skills]]
+name = "qwenpaw-usage"
+source = "{datadir}/skills/qwenpaw-usage/"
+
+[[adapters.openclaw.skills]]
+name = "install-claude-code"
+source = "{datadir}/skills/install-claude-code/"
+
+[[adapters.openclaw.skills]]
+name = "install-qwenpaw"
+source = "{datadir}/skills/install-qwenpaw/"
+
+[[adapters.openclaw.skills]]
+name = "install-hermes"
+source = "{datadir}/skills/install-hermes/"
+
+[[adapters.openclaw.skills]]
+name = "install-openclaw"
+source = "{datadir}/skills/install-openclaw/"
+
+[[adapters.openclaw.skills]]
+name = "setup-mcp"
+source = "{datadir}/skills/setup-mcp/"
+
+[[adapters.openclaw.skills]]
+name = "aliyun-ecs"
+source = "{datadir}/skills/aliyun-ecs/"
+
+[[adapters.openclaw.skills]]
+name = "github"
+source = "{datadir}/skills/github/"
+
+[[adapters.openclaw.skills]]
+name = "kernel-dev"
+source = "{datadir}/skills/kernel-dev/"
+
+[[adapters.openclaw.skills]]
+name = "sysom-agentsight"
+source = "{datadir}/skills/sysom-agentsight/"
+
+[[adapters.openclaw.skills]]
+name = "sysom-diagnosis"
+source = "{datadir}/skills/sysom-diagnosis/"
+
+[[adapters.openclaw.skills]]
+name = "anolisa-guide"
+source = "{datadir}/skills/anolisa-guide/"
+
+[[adapters.openclaw.skills]]
+name = "anolisa-register"
+source = "{datadir}/skills/anolisa-register/"
+
+[[adapters.openclaw.skills]]
+name = "clawhub-skill-mng"
+source = "{datadir}/skills/clawhub-skill-mng/"
+
+[[adapters.openclaw.skills]]
+name = "cosh-guide"
+source = "{datadir}/skills/cosh-guide/"
+
+[[adapters.openclaw.skills]]
+name = "humanizer"
+source = "{datadir}/skills/humanizer/"
+
+[[adapters.openclaw.skills]]
+name = "image-gen"
+source = "{datadir}/skills/image-gen/"
+
+[[adapters.openclaw.skills]]
+name = "pdf-reader"
+source = "{datadir}/skills/pdf-reader/"
+
+[[adapters.openclaw.skills]]
+name = "xlsx"
+source = "{datadir}/skills/xlsx/"
+
+[[adapters.openclaw.skills]]
+name = "alinux-cve-query"
+source = "{datadir}/skills/alinux-cve-query/"
+
+[[adapters.openclaw.skills]]
+name = "alinux-admin"
+source = "{datadir}/skills/alinux-admin/"
+
+[[adapters.openclaw.skills]]
+name = "backup-restore"
+source = "{datadir}/skills/backup-restore/"
+
+[[adapters.openclaw.skills]]
+name = "regex-mastery"
+source = "{datadir}/skills/regex-mastery/"
+
+[[adapters.openclaw.skills]]
+name = "shell-scripting"
+source = "{datadir}/skills/shell-scripting/"
+
+[[adapters.openclaw.skills]]
+name = "storage-resize"
+source = "{datadir}/skills/storage-resize/"
+
+[[adapters.openclaw.skills]]
+name = "upgrade-alinux-kernel"
+source = "{datadir}/skills/upgrade-alinux-kernel/"
+
+[[adapters]]
+framework = "hermes"
+name = "os-skills-hermes"
+display_name = "OS Skills for Hermes"
+adapter_type = "skill_bundle"
+trust = "first-party"
+dest = "{datadir}/skills"
+detect = { binary = "hermes" }
+
+[[adapters.hermes.skills]]
+name = "qwenpaw-usage"
+source = "{datadir}/skills/qwenpaw-usage/"
+
+[[adapters.hermes.skills]]
+name = "install-claude-code"
+source = "{datadir}/skills/install-claude-code/"
+
+[[adapters.hermes.skills]]
+name = "install-qwenpaw"
+source = "{datadir}/skills/install-qwenpaw/"
+
+[[adapters.hermes.skills]]
+name = "install-hermes"
+source = "{datadir}/skills/install-hermes/"
+
+[[adapters.hermes.skills]]
+name = "install-openclaw"
+source = "{datadir}/skills/install-openclaw/"
+
+[[adapters.hermes.skills]]
+name = "setup-mcp"
+source = "{datadir}/skills/setup-mcp/"
+
+[[adapters.hermes.skills]]
+name = "aliyun-ecs"
+source = "{datadir}/skills/aliyun-ecs/"
+
+[[adapters.hermes.skills]]
+name = "github"
+source = "{datadir}/skills/github/"
+
+[[adapters.hermes.skills]]
+name = "kernel-dev"
+source = "{datadir}/skills/kernel-dev/"
+
+[[adapters.hermes.skills]]
+name = "sysom-agentsight"
+source = "{datadir}/skills/sysom-agentsight/"
+
+[[adapters.hermes.skills]]
+name = "sysom-diagnosis"
+source = "{datadir}/skills/sysom-diagnosis/"
+
+[[adapters.hermes.skills]]
+name = "anolisa-guide"
+source = "{datadir}/skills/anolisa-guide/"
+
+[[adapters.hermes.skills]]
+name = "anolisa-register"
+source = "{datadir}/skills/anolisa-register/"
+
+[[adapters.hermes.skills]]
+name = "clawhub-skill-mng"
+source = "{datadir}/skills/clawhub-skill-mng/"
+
+[[adapters.hermes.skills]]
+name = "cosh-guide"
+source = "{datadir}/skills/cosh-guide/"
+
+[[adapters.hermes.skills]]
+name = "humanizer"
+source = "{datadir}/skills/humanizer/"
+
+[[adapters.hermes.skills]]
+name = "image-gen"
+source = "{datadir}/skills/image-gen/"
+
+[[adapters.hermes.skills]]
+name = "pdf-reader"
+source = "{datadir}/skills/pdf-reader/"
+
+[[adapters.hermes.skills]]
+name = "xlsx"
+source = "{datadir}/skills/xlsx/"
+
+[[adapters.hermes.skills]]
+name = "alinux-cve-query"
+source = "{datadir}/skills/alinux-cve-query/"
+
+[[adapters.hermes.skills]]
+name = "alinux-admin"
+source = "{datadir}/skills/alinux-admin/"
+
+[[adapters.hermes.skills]]
+name = "backup-restore"
+source = "{datadir}/skills/backup-restore/"
+
+[[adapters.hermes.skills]]
+name = "regex-mastery"
+source = "{datadir}/skills/regex-mastery/"
+
+[[adapters.hermes.skills]]
+name = "shell-scripting"
+source = "{datadir}/skills/shell-scripting/"
+
+[[adapters.hermes.skills]]
+name = "storage-resize"
+source = "{datadir}/skills/storage-resize/"
+
+[[adapters.hermes.skills]]
+name = "upgrade-alinux-kernel"
+source = "{datadir}/skills/upgrade-alinux-kernel/"

--- a/src/os-skills/os-skills.spec.in
+++ b/src/os-skills/os-skills.spec.in
@@ -25,6 +25,9 @@ workflows, kernel development, security auditing, and system administration.
 %install
 rm -rf %{buildroot}
 install -d -m 0755 %{buildroot}%{_datadir}/anolisa/skills
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/components/os-skills
+install -p -m 0644 component.toml \
+    %{buildroot}%{_datadir}/anolisa/components/os-skills/component.toml
 
 # Find each skill directory (identified by containing SKILL.md) and copy it
 # flattened into the target skills directory.
@@ -53,6 +56,9 @@ install -p -m 0755 adapters/hermes/scripts/*.sh \
 %files
 %license LICENSE
 %dir %{_datadir}/anolisa
+%dir %{_datadir}/anolisa/components
+%dir %{_datadir}/anolisa/components/os-skills
+%{_datadir}/anolisa/components/os-skills/component.toml
 %dir %{_datadir}/anolisa/skills
 %{_datadir}/anolisa/skills/*
 %dir %{_datadir}/anolisa/adapters


### PR DESCRIPTION
## Ship Note

### What changed

- Added `src/os-skills/component.toml` for the os-skills component.
- Declared OpenClaw and Hermes adapters as `skill_bundle`.
- Listed the current 26 os-skills entries as framework-deliverable skills.
- Updated RPM spec and Makefile install paths to package the contract at:
  `/usr/share/anolisa/components/os-skills/component.toml`.

### Known limitations

- This PR depends on #1158 for `adapter_type = "skill_bundle"` support.
- The contract only handles skill delivery. It does not register plugins,
  set framework config, or manage services.
- The component version is currently static in the contract.

## Description

This packages an anolisa component contract for os-skills so that the RPM
can expose its installed skill library to agent framework adapters.

The contract maps the RPM-installed skill directories under `{datadir}/skills`
into OpenClaw and Hermes through skill-only adapters.

## Related Issue

no-issue: os-skills component contract split from adapter framework support

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [x] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [x] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
python3 - <<'PY'
import tomllib
from pathlib import Path

p = Path('src/os-skills/component.toml')
data = tomllib.loads(p.read_text())
repo_skills = {x.parent.name for x in Path('src/os-skills').glob('*/*/SKILL.md')}
repo_skills |= {x.parent.name for x in Path('src/os-skills').glob('*/*/*/SKILL.md')}

for adapter in data['adapters']:
    fw = adapter['framework']
    skills = adapter[fw]['skills']
    missing = [s['name'] for s in skills if s['name'] not in repo_skills]
    bad_source = [
        s for s in skills
        if s['source'] != f"{{datadir}}/skills/{s['name']}/"
    ]
    if missing:
        raise SystemExit(f"missing skill dirs for {fw}: {missing}")
    if bad_source:
        raise SystemExit(f"bad source templates for {fw}: {bad_source}")

print('component.toml parse and skill source check OK')
PY
```

## Additional Notes

This PR is intentionally separated from the adapter framework PR.
