### PR TITLE
feat(skillfs): add anolisa component contract

### DIFF
--- a/src/skillfs/component.toml
+++ b/src/skillfs/component.toml
@@ -1,0 +1,27 @@
+manifest_version = 2
+anolisa_min_version = "0.1.0"
+
+[component]
+name = "skillfs"
+version = "0.2.0"
+layer = "runtime"
+domain = "tools"
+description = "AI agent skill management via virtual filesystem"
+stability = "experimental"
+
+[install]
+modes = ["system"]
+
+[backends.rpm]
+package = "skillfs"
+
+[environment]
+requires_os = "linux"
+
+[dependencies]
+runtime = ["fuse3"]
+
+[[health_checks]]
+name = "binary"
+kind = "command"
+command = "{bindir}/skillfs --version"

--- a/src/skillfs/skillfs.spec.in
+++ b/src/skillfs/skillfs.spec.in
@@ -22,6 +22,7 @@ BuildRequires:  pkgconfig(fuse3)
 
 Requires:       fuse3
 Requires:       fuse3-libs%{?_isa}
+Provides:       anolisa-component(skillfs)
 
 %description
 SkillFS is a FUSE-based filesystem that exposes AI agent skills through
@@ -41,6 +42,10 @@ rm -rf %{buildroot}
 install -d -m 0755 %{buildroot}%{_localbindir}
 install -p -m 0755 target/release/skillfs %{buildroot}%{_localbindir}/skillfs
 
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/components/skillfs
+install -p -m 0644 component.toml \
+    %{buildroot}%{_datadir}/anolisa/components/skillfs/component.toml
+
 install -d -m 0755 %{buildroot}%{_datadir}/anolisa/runtime/skills/skillfs
 cp -rp docs/skills/skillfs-mount/. \
     %{buildroot}%{_datadir}/anolisa/runtime/skills/skillfs/
@@ -49,6 +54,8 @@ cp -rp docs/skills/skillfs-mount/. \
 %license LICENSE
 %doc README.md CHANGELOG.md
 %attr(0755,root,root) %{_localbindir}/skillfs
+%dir %{_datadir}/anolisa/components/skillfs
+%{_datadir}/anolisa/components/skillfs/component.toml
 %dir %{_datadir}/anolisa/runtime
 %dir %{_datadir}/anolisa/runtime/skills
 %{_datadir}/anolisa/runtime/skills/skillfs/


### PR DESCRIPTION
## Ship Note

### What changed

- Added `src/skillfs/component.toml`.
- Packaged it at:
  `/usr/share/anolisa/components/skillfs/component.toml`.
- Added `Provides: anolisa-component(skillfs)` to the RPM spec.
- Declared component metadata, RPM backend, Linux environment,
  `fuse3` runtime dependency, and a `skillfs --version` health check.

### Known limitations

- This PR does not add any `[[adapters]]`.
- This is only for future `anolisa adopt skillfs` style discovery.
- No OpenClaw, Hermes, service, or skill delivery integration is added.

## Description

This adds the minimal anolisa component contract for SkillFS, following
the same no-adapter shape used by components such as `cosh`.

## Related Issue

no-issue: prepare SkillFS package metadata for future anolisa adopt flow

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] For `skillfs`: component contract parses and RPM spec preprocesses
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
python3 - <<'PY'
import tomllib
from pathlib import Path

data = tomllib.loads(Path('src/skillfs/component.toml').read_text())
assert data['component']['name'] == 'skillfs'
assert data['component']['version'] == '0.2.0'
assert data['backends']['rpm']['package'] == 'skillfs'
assert data['install']['modes'] == ['system']
assert 'adapters' not in data
assert data['health_checks'][0]['command'] == '{bindir}/skillfs --version'
print('skillfs component.toml parse OK')
PY

tmp=$(mktemp /tmp/skillfs-spec.XXXXXX)
sed 's/@VERSION@/0.2.0/g' src/skillfs/skillfs.spec.in > "$tmp"
rpmspec -P "$tmp" >/tmp/skillfs-spec.out
rm -f "$tmp"
```

## Additional Notes

This intentionally mirrors a metadata-only component contract. Runtime
service management and framework adapter integration are out of scope.
