### PR TITLE
fix(anolisa): delegate rpm-owned self update to dnf

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -27,7 +27,7 @@
 //! `update all` remains `NOT_IMPLEMENTED`.
 
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use chrono::{SecondsFormat, Utc};
@@ -1573,6 +1573,9 @@ fn fetch_and_write_repo_config(url: &str, dest: &Path) -> Result<(), String> {
 pub(in crate::commands) fn handle_self_update(ctx: &CliContext) -> Result<(), CliError> {
     let url = self_update::update_url();
     let current_version = env!("CARGO_PKG_VERSION");
+    let ops = SystemSelfUpdateOps;
+    let query = RpmPackageQuery::system();
+    let txn = RpmTransaction::system();
 
     let progress_cb: Option<ProgressFn> = if !ctx.json && !ctx.quiet {
         Some(Box::new(move |downloaded: u64, total: Option<u64>| {
@@ -1582,21 +1585,26 @@ pub(in crate::commands) fn handle_self_update(ctx: &CliContext) -> Result<(), Cl
         None
     };
 
-    let result =
-        self_update::check_and_update(&url, current_version, ctx.dry_run, progress_cb.as_ref());
+    let result = run_self_update_with_deps(
+        &url,
+        current_version,
+        ctx,
+        &ops,
+        &query,
+        &txn,
+        privilege::is_root(),
+        progress_cb.as_ref(),
+    );
 
     // Clear the progress line before any output (success or error).
     if progress_cb.is_some() {
         eprint!("\r\x1b[2K");
     }
 
-    let outcome = result.map_err(|e| CliError::Runtime {
-        command: "update self".to_string(),
-        reason: e.to_string(),
-    })?;
+    let run = result?;
 
     if ctx.json {
-        return render_json_outcome(&outcome, ctx.dry_run);
+        return render_json_outcome(&run, ctx.dry_run);
     }
 
     if ctx.quiet {
@@ -1604,7 +1612,7 @@ pub(in crate::commands) fn handle_self_update(ctx: &CliContext) -> Result<(), Cl
     }
 
     let color = Palette::new(ctx.no_color);
-    match &outcome {
+    match &run.manifest_outcome {
         SelfUpdateOutcome::AlreadyLatest { version } => {
             println!(
                 "{} anolisa {} is already the latest version",
@@ -1612,11 +1620,12 @@ pub(in crate::commands) fn handle_self_update(ctx: &CliContext) -> Result<(), Cl
                 version
             );
         }
-        SelfUpdateOutcome::UpdateAvailable { from, to } => {
-            if ctx.dry_run {
-                println!("{} update available: {} → {}", color.warn("⬆"), from, to);
-                println!("  run without --dry-run to apply");
-            } else {
+        SelfUpdateOutcome::UpdateAvailable { from, to } if ctx.dry_run => {
+            println!("{} update available: {} → {}", color.warn("⬆"), from, to);
+            println!("  run without --dry-run to apply");
+        }
+        SelfUpdateOutcome::UpdateAvailable { from, to } => match &run.apply_mode {
+            SelfUpdateApplyMode::Binary => {
                 println!("{} anolisa updated: {} → {}", color.ok("✓"), from, to);
                 println!("  view the changelog at {}", color.path(CLI_CHANGELOG_URL));
                 eprintln!(
@@ -1625,10 +1634,246 @@ pub(in crate::commands) fn handle_self_update(ctx: &CliContext) -> Result<(), Cl
                     color.warn("⚠")
                 );
             }
-        }
+            SelfUpdateApplyMode::RpmPackage {
+                package,
+                before_version,
+                after_version,
+            } => {
+                println!(
+                    "{} delegated anolisa self-update to dnf package {}",
+                    color.ok("✓"),
+                    color.path(package)
+                );
+                println!("  release manifest advertises {to} (running binary was {from})");
+                render_rpm_version_observation(before_version.as_deref(), after_version.as_deref());
+            }
+            SelfUpdateApplyMode::None => {}
+        },
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+struct SelfUpdateRun {
+    manifest_outcome: SelfUpdateOutcome,
+    apply_mode: SelfUpdateApplyMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SelfUpdateApplyMode {
+    None,
+    Binary,
+    RpmPackage {
+        package: String,
+        before_version: Option<String>,
+        after_version: Option<String>,
+    },
+}
+
+/// Host operations used by `update self`, split out so tests can prove the RPM
+/// branch delegates to the package manager instead of overwriting the binary.
+trait SelfUpdateOps {
+    fn check_update(
+        &self,
+        endpoint_url: &str,
+        current_version: &str,
+    ) -> Result<Option<self_update::ReleaseManifest>, self_update::SelfUpdateError>;
+
+    fn resolve_current_exe(&self) -> Result<PathBuf, self_update::SelfUpdateError>;
+
+    fn perform_binary_update(
+        &self,
+        artifact: &self_update::ReleaseArtifact,
+        current_exe: &Path,
+        on_progress: Option<&ProgressFn>,
+    ) -> Result<(), self_update::SelfUpdateError>;
+}
+
+struct SystemSelfUpdateOps;
+
+impl SelfUpdateOps for SystemSelfUpdateOps {
+    fn check_update(
+        &self,
+        endpoint_url: &str,
+        current_version: &str,
+    ) -> Result<Option<self_update::ReleaseManifest>, self_update::SelfUpdateError> {
+        self_update::check_update(endpoint_url, current_version)
+    }
+
+    fn resolve_current_exe(&self) -> Result<PathBuf, self_update::SelfUpdateError> {
+        self_update::resolve_current_exe()
+    }
+
+    fn perform_binary_update(
+        &self,
+        artifact: &self_update::ReleaseArtifact,
+        current_exe: &Path,
+        on_progress: Option<&ProgressFn>,
+    ) -> Result<(), self_update::SelfUpdateError> {
+        self_update::perform_update(artifact, current_exe, on_progress)
+    }
+}
+
+/// Check for a CLI self-update and apply it through the correct owner.
+///
+/// Raw/binary installs keep the existing verified archive replacement. If the
+/// running executable is owned by an installed RPM, the RPM database owns that
+/// path, so the update is delegated to `dnf update <package>` instead.
+#[allow(clippy::too_many_arguments)]
+fn run_self_update_with_deps(
+    endpoint_url: &str,
+    current_version: &str,
+    ctx: &CliContext,
+    ops: &dyn SelfUpdateOps,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    on_progress: Option<&ProgressFn>,
+) -> Result<SelfUpdateRun, CliError> {
+    let manifest = match ops
+        .check_update(endpoint_url, current_version)
+        .map_err(self_update_cli_err)?
+    {
+        None => {
+            return Ok(SelfUpdateRun {
+                manifest_outcome: SelfUpdateOutcome::AlreadyLatest {
+                    version: current_version.to_string(),
+                },
+                apply_mode: SelfUpdateApplyMode::None,
+            });
+        }
+        Some(manifest) => manifest,
+    };
+
+    let os = self_update::current_os();
+    let arch = self_update::current_arch();
+    let artifact = manifest
+        .artifact_for(os, arch)
+        .ok_or_else(|| self_update::SelfUpdateError::NoArtifact {
+            os: os.to_string(),
+            arch: arch.to_string(),
+        })
+        .map_err(self_update_cli_err)?;
+
+    if ctx.dry_run {
+        return Ok(SelfUpdateRun {
+            manifest_outcome: SelfUpdateOutcome::UpdateAvailable {
+                from: current_version.to_string(),
+                to: manifest.version,
+            },
+            apply_mode: SelfUpdateApplyMode::None,
+        });
+    }
+
+    let current_exe = ops.resolve_current_exe().map_err(self_update_cli_err)?;
+    let apply_mode = if let Some(package) = rpm_owner_for_current_exe(query, &current_exe)? {
+        if !is_root {
+            return Err(CliError::Runtime {
+                command: "update self".to_string(),
+                reason: format!(
+                    "updating RPM-owned anolisa package '{package}' requires root privileges; re-run with sudo: `sudo anolisa update self`"
+                ),
+            });
+        }
+        let before_version = installed_package_version_best_effort(query, &package);
+        txn.update(&package)
+            .map_err(|err| txn_err(err, "update self"))?;
+        let after_version = installed_package_version_best_effort(query, &package);
+        SelfUpdateApplyMode::RpmPackage {
+            package,
+            before_version,
+            after_version,
+        }
+    } else {
+        ops.perform_binary_update(artifact, &current_exe, on_progress)
+            .map_err(self_update_cli_err)?;
+        SelfUpdateApplyMode::Binary
+    };
+
+    Ok(SelfUpdateRun {
+        manifest_outcome: SelfUpdateOutcome::UpdateAvailable {
+            from: current_version.to_string(),
+            to: manifest.version,
+        },
+        apply_mode,
+    })
+}
+
+fn render_rpm_version_observation(before_version: Option<&str>, after_version: Option<&str>) {
+    match (before_version, after_version) {
+        (Some(before), Some(after)) if before != after => {
+            println!("  installed RPM version changed: {before} → {after}");
+        }
+        (Some(version), Some(_)) => {
+            println!("  installed RPM version remains {version}");
+        }
+        (Some(before), None) => {
+            println!(
+                "  installed RPM version before dnf was {before}; after dnf was not confirmed"
+            );
+        }
+        (None, Some(after)) => {
+            println!("  installed RPM version after dnf: {after}");
+        }
+        (None, None) => {
+            println!("  installed RPM version was not confirmed after dnf");
+        }
+    }
+}
+
+fn installed_package_version_best_effort(
+    query: &dyn PackageQuery,
+    package: &str,
+) -> Option<String> {
+    query
+        .query_installed(package)
+        .ok()
+        .flatten()
+        .map(|info| info.version.to_string())
+}
+
+fn self_update_cli_err(err: self_update::SelfUpdateError) -> CliError {
+    CliError::Runtime {
+        command: "update self".to_string(),
+        reason: err.to_string(),
+    }
+}
+
+fn rpm_owner_for_current_exe(
+    query: &dyn PackageQuery,
+    current_exe: &Path,
+) -> Result<Option<String>, CliError> {
+    let capability = current_exe.to_str().ok_or_else(|| CliError::Runtime {
+        command: "update self".to_string(),
+        reason: format!(
+            "current executable path is not valid UTF-8: {}",
+            current_exe.display()
+        ),
+    })?;
+
+    match query.what_provides_installed(capability) {
+        Ok(packages) => match packages.as_slice() {
+            [] => Ok(None),
+            [package] => Ok(Some(package.clone())),
+            _ => Err(CliError::Runtime {
+                command: "update self".to_string(),
+                reason: format!(
+                    "current executable '{}' is provided by multiple RPM packages ({}); refusing to choose one for self-update",
+                    current_exe.display(),
+                    packages.join(", ")
+                ),
+            }),
+        },
+        Err(PackageQueryError::CommandMissing { .. }) => Ok(None),
+        Err(err) => Err(CliError::Runtime {
+            command: "update self".to_string(),
+            reason: format!(
+                "cannot determine whether current executable '{}' is RPM-owned: {err}",
+                current_exe.display()
+            ),
+        }),
+    }
 }
 
 fn render_progress(downloaded: u64, total: Option<u64>) {
@@ -1657,32 +1902,75 @@ struct SelfUpdateData {
     latest_version: String,
     update_available: bool,
     updated: bool,
+    apply_mode: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rpm_version_before: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rpm_version_after: Option<String>,
 }
 
-fn build_json_data(outcome: &SelfUpdateOutcome, dry_run: bool) -> SelfUpdateData {
-    match outcome {
-        SelfUpdateOutcome::AlreadyLatest { version } => SelfUpdateData {
-            current_version: version.clone(),
-            latest_version: version.clone(),
-            update_available: false,
-            updated: false,
-        },
-        SelfUpdateOutcome::UpdateAvailable { from, to } => SelfUpdateData {
-            current_version: from.clone(),
-            latest_version: to.clone(),
-            update_available: true,
-            updated: !dry_run,
-        },
+fn build_json_data(run: &SelfUpdateRun, dry_run: bool) -> SelfUpdateData {
+    let (current_version, latest_version, update_available) = match &run.manifest_outcome {
+        SelfUpdateOutcome::AlreadyLatest { version } => (version.clone(), version.clone(), false),
+        SelfUpdateOutcome::UpdateAvailable { from, to } => (from.clone(), to.clone(), true),
+    };
+    let (apply_mode, package, rpm_version_before, rpm_version_after) = match &run.apply_mode {
+        SelfUpdateApplyMode::None => ("none", None, None, None),
+        SelfUpdateApplyMode::Binary => ("binary", None, None, None),
+        SelfUpdateApplyMode::RpmPackage {
+            package,
+            before_version,
+            after_version,
+        } => (
+            "rpm_package",
+            Some(package.clone()),
+            before_version.clone(),
+            after_version.clone(),
+        ),
+    };
+    let updated = match &run.apply_mode {
+        SelfUpdateApplyMode::Binary => update_available && !dry_run,
+        SelfUpdateApplyMode::RpmPackage {
+            before_version,
+            after_version,
+            ..
+        } => {
+            update_available
+                && !dry_run
+                && before_version
+                    .as_ref()
+                    .zip(after_version.as_ref())
+                    .is_some_and(|(before, after)| before != after)
+        }
+        SelfUpdateApplyMode::None => false,
+    };
+
+    SelfUpdateData {
+        current_version,
+        latest_version,
+        update_available,
+        updated,
+        apply_mode,
+        package,
+        rpm_version_before,
+        rpm_version_after,
     }
 }
 
-fn render_json_outcome(outcome: &SelfUpdateOutcome, dry_run: bool) -> Result<(), CliError> {
-    response::render_json("update self", build_json_data(outcome, dry_run))
+fn render_json_outcome(run: &SelfUpdateRun, dry_run: bool) -> Result<(), CliError> {
+    response::render_json("update self", build_json_data(run, dry_run))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
+    use std::path::{Path, PathBuf};
+
+    use anolisa_platform::pkg_query::PackageVersion;
 
     /// Serve one HTTP response on an ephemeral port and return its URL.
     fn serve_once(body: &'static str) -> String {
@@ -1733,20 +2021,73 @@ mod tests {
             from: "0.1.0".into(),
             to: "0.2.0".into(),
         };
-        let data = build_json_data(&outcome, true);
+        let run = self_run(outcome, SelfUpdateApplyMode::None);
+        let data = build_json_data(&run, true);
         assert!(data.update_available);
         assert!(!data.updated);
+        assert_eq!(data.apply_mode, "none");
     }
 
     #[test]
-    fn json_real_update_reports_both_true() {
+    fn json_binary_update_reports_both_true() {
         let outcome = SelfUpdateOutcome::UpdateAvailable {
             from: "0.1.0".into(),
             to: "0.2.0".into(),
         };
-        let data = build_json_data(&outcome, false);
+        let run = self_run(outcome, SelfUpdateApplyMode::Binary);
+        let data = build_json_data(&run, false);
         assert!(data.update_available);
         assert!(data.updated);
+        assert_eq!(data.apply_mode, "binary");
+        assert_eq!(data.package, None);
+    }
+
+    #[test]
+    fn json_rpm_delegation_reports_package_and_version_change() {
+        let outcome = SelfUpdateOutcome::UpdateAvailable {
+            from: "0.1.0".into(),
+            to: "0.2.0".into(),
+        };
+        let run = self_run(
+            outcome,
+            SelfUpdateApplyMode::RpmPackage {
+                package: "anolisa".to_string(),
+                before_version: Some("0.1.0".to_string()),
+                after_version: Some("0.2.0".to_string()),
+            },
+        );
+
+        let data = build_json_data(&run, false);
+
+        assert!(data.update_available);
+        assert!(data.updated);
+        assert_eq!(data.apply_mode, "rpm_package");
+        assert_eq!(data.package.as_deref(), Some("anolisa"));
+        assert_eq!(data.rpm_version_before.as_deref(), Some("0.1.0"));
+        assert_eq!(data.rpm_version_after.as_deref(), Some("0.2.0"));
+    }
+
+    #[test]
+    fn json_rpm_delegation_noops_are_not_reported_as_updated() {
+        let outcome = SelfUpdateOutcome::UpdateAvailable {
+            from: "0.1.0".into(),
+            to: "0.2.0".into(),
+        };
+        let run = self_run(
+            outcome,
+            SelfUpdateApplyMode::RpmPackage {
+                package: "anolisa".to_string(),
+                before_version: Some("0.1.0".to_string()),
+                after_version: Some("0.1.0".to_string()),
+            },
+        );
+
+        let data = build_json_data(&run, false);
+
+        assert!(data.update_available);
+        assert!(!data.updated);
+        assert_eq!(data.apply_mode, "rpm_package");
+        assert_eq!(data.package.as_deref(), Some("anolisa"));
     }
 
     #[test]
@@ -1754,9 +2095,379 @@ mod tests {
         let outcome = SelfUpdateOutcome::AlreadyLatest {
             version: "0.1.0".into(),
         };
-        let data = build_json_data(&outcome, false);
+        let run = self_run(outcome, SelfUpdateApplyMode::None);
+        let data = build_json_data(&run, false);
         assert!(!data.update_available);
         assert!(!data.updated);
+        assert_eq!(data.apply_mode, "none");
+    }
+
+    fn self_manifest(version: &str) -> self_update::ReleaseManifest {
+        self_update::ReleaseManifest {
+            schema_version: 1,
+            version: version.to_string(),
+            artifacts: vec![self_update::ReleaseArtifact {
+                os: self_update::current_os().to_string(),
+                arch: self_update::current_arch().to_string(),
+                url: "https://example.invalid/anolisa.tar.gz".to_string(),
+                sha256: "0".repeat(64),
+                size: Some(1),
+            }],
+        }
+    }
+
+    fn self_run(outcome: SelfUpdateOutcome, apply_mode: SelfUpdateApplyMode) -> SelfUpdateRun {
+        SelfUpdateRun {
+            manifest_outcome: outcome,
+            apply_mode,
+        }
+    }
+
+    fn package_info(name: &str, version: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: version.to_string(),
+                release: None,
+            },
+            arch: "x86_64".to_string(),
+            origin: None,
+        }
+    }
+
+    fn self_ctx(prefix: PathBuf, dry_run: bool) -> CliContext {
+        CliContext {
+            install_mode: crate::context::InstallMode::System,
+            prefix: Some(prefix),
+            json: false,
+            dry_run,
+            verbose: false,
+            quiet: true,
+            no_color: true,
+        }
+    }
+
+    struct FakeSelfUpdateOps {
+        manifest: Option<self_update::ReleaseManifest>,
+        current_exe: PathBuf,
+        binary_updates: Cell<usize>,
+    }
+
+    impl FakeSelfUpdateOps {
+        fn new(current_exe: &str) -> Self {
+            Self {
+                manifest: Some(self_manifest("0.2.0")),
+                current_exe: PathBuf::from(current_exe),
+                binary_updates: Cell::new(0),
+            }
+        }
+    }
+
+    impl SelfUpdateOps for FakeSelfUpdateOps {
+        fn check_update(
+            &self,
+            _endpoint_url: &str,
+            _current_version: &str,
+        ) -> Result<Option<self_update::ReleaseManifest>, self_update::SelfUpdateError> {
+            Ok(self.manifest.clone())
+        }
+
+        fn resolve_current_exe(&self) -> Result<PathBuf, self_update::SelfUpdateError> {
+            Ok(self.current_exe.clone())
+        }
+
+        fn perform_binary_update(
+            &self,
+            _artifact: &self_update::ReleaseArtifact,
+            current_exe: &Path,
+            _on_progress: Option<&ProgressFn>,
+        ) -> Result<(), self_update::SelfUpdateError> {
+            assert_eq!(current_exe, self.current_exe.as_path());
+            self.binary_updates.set(self.binary_updates.get() + 1);
+            Ok(())
+        }
+    }
+
+    struct FakeSelfQuery {
+        expected_capability: String,
+        providers: FakeSelfProviders,
+        queries: Cell<usize>,
+        expected_installed_package: Option<String>,
+        installed_versions: RefCell<VecDeque<Option<String>>>,
+        installed_queries: Cell<usize>,
+    }
+
+    enum FakeSelfProviders {
+        Packages(Vec<String>),
+        CommandMissing,
+    }
+
+    impl FakeSelfQuery {
+        fn new(expected_capability: &str, providers: Vec<&str>) -> Self {
+            Self {
+                expected_capability: expected_capability.to_string(),
+                providers: FakeSelfProviders::Packages(
+                    providers.into_iter().map(str::to_string).collect(),
+                ),
+                queries: Cell::new(0),
+                expected_installed_package: None,
+                installed_versions: RefCell::new(VecDeque::new()),
+                installed_queries: Cell::new(0),
+            }
+        }
+
+        fn missing_rpm(expected_capability: &str) -> Self {
+            Self {
+                expected_capability: expected_capability.to_string(),
+                providers: FakeSelfProviders::CommandMissing,
+                queries: Cell::new(0),
+                expected_installed_package: None,
+                installed_versions: RefCell::new(VecDeque::new()),
+                installed_queries: Cell::new(0),
+            }
+        }
+
+        fn with_installed_versions(
+            mut self,
+            expected_package: &str,
+            versions: Vec<Option<&str>>,
+        ) -> Self {
+            self.expected_installed_package = Some(expected_package.to_string());
+            self.installed_versions = RefCell::new(
+                versions
+                    .into_iter()
+                    .map(|version| version.map(str::to_string))
+                    .collect(),
+            );
+            self
+        }
+    }
+
+    impl PackageQuery for FakeSelfQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            self.installed_queries.set(self.installed_queries.get() + 1);
+            if let Some(expected_package) = &self.expected_installed_package {
+                assert_eq!(package, expected_package);
+            }
+            Ok(self
+                .installed_versions
+                .borrow_mut()
+                .pop_front()
+                .flatten()
+                .map(|version| package_info(package, &version)))
+        }
+
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+
+        fn what_provides_installed(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            self.queries.set(self.queries.get() + 1);
+            assert_eq!(capability, self.expected_capability);
+            match &self.providers {
+                FakeSelfProviders::Packages(providers) => Ok(providers.clone()),
+                FakeSelfProviders::CommandMissing => Err(PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                }),
+            }
+        }
+    }
+
+    struct FakeSelfTxn {
+        expected_package: String,
+        update_calls: Cell<usize>,
+    }
+
+    impl FakeSelfTxn {
+        fn new(expected_package: &str) -> Self {
+            Self {
+                expected_package: expected_package.to_string(),
+                update_calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl PackageTransaction for FakeSelfTxn {
+        fn install(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("self-update must not run dnf install");
+        }
+
+        fn update(&self, package: &str) -> Result<(), PackageTransactionError> {
+            self.update_calls.set(self.update_calls.get() + 1);
+            assert_eq!(package, self.expected_package);
+            Ok(())
+        }
+
+        fn remove(&self, _package: &str) -> Result<(), PackageTransactionError> {
+            panic!("self-update must not run dnf remove");
+        }
+    }
+
+    #[test]
+    fn rpm_owned_self_update_delegates_to_dnf_without_binary_swap() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = self_ctx(tmp.path().to_path_buf(), false);
+        let ops = FakeSelfUpdateOps::new("/usr/bin/anolisa");
+        let query = FakeSelfQuery::new("/usr/bin/anolisa", vec!["anolisa"])
+            .with_installed_versions("anolisa", vec![Some("0.1.0"), Some("0.2.0")]);
+        let txn = FakeSelfTxn::new("anolisa");
+
+        let run = run_self_update_with_deps(
+            "https://example.invalid/release-manifest.toml",
+            "0.1.0",
+            &c,
+            &ops,
+            &query,
+            &txn,
+            true,
+            None,
+        )
+        .expect("rpm-owned self update should succeed through dnf");
+
+        assert!(matches!(
+            run.manifest_outcome,
+            SelfUpdateOutcome::UpdateAvailable { from, to }
+                if from == "0.1.0" && to == "0.2.0"
+        ));
+        assert_eq!(
+            run.apply_mode,
+            SelfUpdateApplyMode::RpmPackage {
+                package: "anolisa".to_string(),
+                before_version: Some("0.1.0".to_string()),
+                after_version: Some("0.2.0".to_string())
+            }
+        );
+        assert_eq!(query.queries.get(), 1, "rpm ownership must be probed");
+        assert_eq!(
+            query.installed_queries.get(),
+            2,
+            "rpm package version must be checked before and after dnf"
+        );
+        assert_eq!(txn.update_calls.get(), 1, "dnf update must run once");
+        assert_eq!(
+            ops.binary_updates.get(),
+            0,
+            "RPM-owned executable must not be overwritten directly"
+        );
+    }
+
+    #[test]
+    fn rpm_owned_self_update_dnf_noop_is_not_reported_as_updated() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = self_ctx(tmp.path().to_path_buf(), false);
+        let ops = FakeSelfUpdateOps::new("/usr/bin/anolisa");
+        let query = FakeSelfQuery::new("/usr/bin/anolisa", vec!["anolisa"])
+            .with_installed_versions("anolisa", vec![Some("0.1.0"), Some("0.1.0")]);
+        let txn = FakeSelfTxn::new("anolisa");
+
+        let run = run_self_update_with_deps(
+            "https://example.invalid/release-manifest.toml",
+            "0.1.0",
+            &c,
+            &ops,
+            &query,
+            &txn,
+            true,
+            None,
+        )
+        .expect("dnf no-op is still a successful delegation");
+
+        let data = build_json_data(&run, false);
+
+        assert!(data.update_available);
+        assert!(!data.updated);
+        assert_eq!(data.apply_mode, "rpm_package");
+        assert_eq!(data.package.as_deref(), Some("anolisa"));
+    }
+
+    #[test]
+    fn non_rpm_self_update_keeps_binary_replacement_path() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = self_ctx(tmp.path().to_path_buf(), false);
+        let ops = FakeSelfUpdateOps::new("/opt/anolisa/bin/anolisa");
+        let query = FakeSelfQuery::new("/opt/anolisa/bin/anolisa", Vec::new());
+        let txn = FakeSelfTxn::new("anolisa");
+
+        let run = run_self_update_with_deps(
+            "https://example.invalid/release-manifest.toml",
+            "0.1.0",
+            &c,
+            &ops,
+            &query,
+            &txn,
+            false,
+            None,
+        )
+        .expect("non-rpm self update should use binary replacement");
+
+        assert_eq!(run.apply_mode, SelfUpdateApplyMode::Binary);
+        assert_eq!(query.queries.get(), 1);
+        assert_eq!(txn.update_calls.get(), 0, "dnf must not run");
+        assert_eq!(ops.binary_updates.get(), 1, "binary replacement must run");
+    }
+
+    #[test]
+    fn missing_rpm_tooling_keeps_binary_replacement_path() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = self_ctx(tmp.path().to_path_buf(), false);
+        let ops = FakeSelfUpdateOps::new("/opt/anolisa/bin/anolisa");
+        let query = FakeSelfQuery::missing_rpm("/opt/anolisa/bin/anolisa");
+        let txn = FakeSelfTxn::new("anolisa");
+
+        let run = run_self_update_with_deps(
+            "https://example.invalid/release-manifest.toml",
+            "0.1.0",
+            &c,
+            &ops,
+            &query,
+            &txn,
+            false,
+            None,
+        )
+        .expect("missing rpm must not block raw self-update");
+
+        assert_eq!(run.apply_mode, SelfUpdateApplyMode::Binary);
+        assert_eq!(query.queries.get(), 1);
+        assert_eq!(txn.update_calls.get(), 0, "dnf must not run");
+        assert_eq!(ops.binary_updates.get(), 1, "binary replacement must run");
+    }
+
+    #[test]
+    fn rpm_owned_self_update_requires_root_before_dnf() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = self_ctx(tmp.path().to_path_buf(), false);
+        let ops = FakeSelfUpdateOps::new("/usr/bin/anolisa");
+        let query = FakeSelfQuery::new("/usr/bin/anolisa", vec!["anolisa"]);
+        let txn = FakeSelfTxn::new("anolisa");
+
+        let err = run_self_update_with_deps(
+            "https://example.invalid/release-manifest.toml",
+            "0.1.0",
+            &c,
+            &ops,
+            &query,
+            &txn,
+            false,
+            None,
+        )
+        .expect_err("rpm-owned self update needs root");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(
+            err.reason().contains("root") && err.reason().contains("sudo"),
+            "reason must point at sudo: {}",
+            err.reason()
+        );
+        assert_eq!(txn.update_calls.get(), 0, "dnf must not run");
+        assert_eq!(
+            ops.binary_updates.get(),
+            0,
+            "binary replacement must not run"
+        );
     }
 
     #[test]
@@ -1824,13 +2535,9 @@ mod tests {
 
     // ── component update (#959): RPM path ───────────────────────────────
 
-    use std::cell::{Cell, RefCell};
-    use std::path::PathBuf;
-
     use anolisa_core::state::{
         InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, RpmMetadata,
     };
-    use anolisa_platform::pkg_query::PackageVersion;
 
     use crate::context::InstallMode;
 

--- a/src/anolisa/crates/anolisa-core/src/registry/config.rs
+++ b/src/anolisa/crates/anolisa-core/src/registry/config.rs
@@ -196,6 +196,10 @@ mod tests {
         path
     }
 
+    fn missing_config_path(dir: &TempDir) -> PathBuf {
+        dir.path().join("missing").join("config.toml")
+    }
+
     #[test]
     fn bundled_default_has_expected_values() {
         let c = RegistryConfig::bundled_default();
@@ -206,8 +210,9 @@ mod tests {
 
     #[test]
     fn missing_file_no_env_yields_defaults() {
-        let path = Path::new("/nonexistent/anolisa/config.toml");
-        let c = RegistryConfig::load(path, None).expect("missing file is not an error");
+        let dir = TempDir::new().unwrap();
+        let path = missing_config_path(&dir);
+        let c = RegistryConfig::load(&path, None).expect("missing file is not an error");
         assert_eq!(c.index_url, DEFAULT_INDEX_URL);
         assert!(c.offline_fallback);
     }
@@ -271,15 +276,16 @@ mod tests {
 
     #[test]
     fn load_if_configured_none_when_nothing_opts_in() {
-        let path = Path::new("/nonexistent/anolisa/config.toml");
+        let dir = TempDir::new().unwrap();
+        let path = missing_config_path(&dir);
         assert!(
-            RegistryConfig::load_if_configured(path, None)
+            RegistryConfig::load_if_configured(&path, None)
                 .expect("missing everything is not an error")
                 .is_none()
         );
         // Empty env value must not count as opting in.
         assert!(
-            RegistryConfig::load_if_configured(path, Some("  "))
+            RegistryConfig::load_if_configured(&path, Some("  "))
                 .expect("blank env is not an error")
                 .is_none()
         );
@@ -287,8 +293,9 @@ mod tests {
 
     #[test]
     fn load_if_configured_env_opts_in() {
-        let path = Path::new("/nonexistent/anolisa/config.toml");
-        let c = RegistryConfig::load_if_configured(path, Some("http://r.test/i.toml"))
+        let dir = TempDir::new().unwrap();
+        let path = missing_config_path(&dir);
+        let c = RegistryConfig::load_if_configured(&path, Some("http://r.test/i.toml"))
             .expect("valid")
             .expect("env opts in");
         assert_eq!(c.index_url, "http://r.test/i.toml");

--- a/src/anolisa/templates/repo.toml
+++ b/src/anolisa/templates/repo.toml
@@ -59,7 +59,7 @@ offline_fallback = true
 
 # rpm — resolution/install delegated to dnf against this repo.
 [backends.rpm]
-base_url = "http://mirrors.cloud.aliyuncs.com/alinux/$releasever/os/$basearch/os/"
+base_url = "http://mirrors.cloud.aliyuncs.com/alinux/$releasever/agentic-os/$basearch/os/"
 insecure = true
 gpgcheck = true
 


### PR DESCRIPTION
## Description

Fixes `anolisa update self` for RPM-packaged CLI installs. The command still checks the release manifest for a newer CLI version, but the apply step now detects whether the running executable is owned by an installed RPM via `rpm -q --whatprovides <current_exe>`.

Behavior:
- RPM-owned current executable -> delegates to `dnf update -y <package>` instead of replacing the binary path directly.
- RPM-owned current executable without root -> refuses before running dnf and prints a sudo hint.
- RPM-owned current executable after dnf -> re-queries rpmdb best-effort and reports the package EVR observation instead of claiming the release-manifest version was installed.
- Non-RPM install or host without rpm tooling -> keeps the existing verified tar.gz binary replacement path.
- Ambiguous RPM ownership -> refuses rather than choosing an arbitrary package.
- JSON output now includes `apply_mode`; RPM delegation includes the package name and observed RPM versions when available.

## Design Note

The ownership decision lives in the CLI update layer rather than in `anolisa_core::self_update`: core continues to own manifest/artifact validation and verified binary replacement, while the CLI chooses the correct writer for the current executable.

The implementation reuses the existing `PackageQuery` / `PackageTransaction` seams and adds a small `SelfUpdateOps` test seam so unit tests can prove the RPM branch never calls the binary replacement path. Output now also tracks the apply mode: binary updates keep the existing HTTPS-only signature warning, while RPM updates report the dnf package that was updated and only mark JSON `updated=true` when rpmdb shows the installed package version changed.

## Ship Note

- `update self --dry-run` remains a manifest/artifact availability check and does not probe rpm ownership or run dnf.
- The RPM path relies on the system package manager and repo signature policy; it does not consume the release-manifest artifact bytes for replacement.
- If rpm ownership probing hits a hard rpm query failure, self-update refuses rather than risking rpmdb drift.
- `templates/repo.toml` also switches the template RPM backend `base_url` from the generic `os` path to the `agentic-os` path. This is a template/default-config change only; existing `/etc/anolisa/repo.toml` files are not migrated by this PR.

## Test

- `cargo fmt --all -- --check`
- `cargo test -p anolisa-cli commands::tier1::update::tests`
- `cargo test -p anolisa-core registry::config::tests`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
