### PR TITLE
fix(cosh): surface AfterModel hook non-blocking notifications

### DIFF
--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.test.ts
@@ -611,15 +611,15 @@ describe('CoreToolScheduler', () => {
       expect(completedCalls).toHaveLength(1);
       const completedCall = completedCalls[0];
       expect(completedCall.status).toBe('error');
-
-      if (completedCall.status === 'error') {
-        const errorMessage = completedCall.response.error?.message;
-        expect(errorMessage).toBe(
-          'copilot-shell requires permission to use write_file, but that permission was declined.',
-        );
-        // Should NOT contain "not found in registry"
-        expect(errorMessage).not.toContain('not found in registry');
+      if (completedCall.status !== 'error') {
+        throw new Error(`Expected error status, got ${completedCall.status}`);
       }
+      const errorMessage = completedCall.response.error?.message;
+      expect(errorMessage).toBe(
+        'copilot-shell requires permission to use write_file, but that permission was declined.',
+      );
+      // Should NOT contain "not found in registry"
+      expect(errorMessage).not.toContain('not found in registry');
     });
 
     it('should return "not found" message for truly missing tools (not excluded)', async () => {
@@ -700,14 +700,14 @@ describe('CoreToolScheduler', () => {
       expect(completedCalls).toHaveLength(1);
       const completedCall = completedCalls[0];
       expect(completedCall.status).toBe('error');
-
-      if (completedCall.status === 'error') {
-        const errorMessage = completedCall.response.error?.message;
-        // Should contain "not found in registry"
-        expect(errorMessage).toContain('not found in registry');
-        // Should NOT contain permission message
-        expect(errorMessage).not.toContain('requires permission');
+      if (completedCall.status !== 'error') {
+        throw new Error(`Expected error status, got ${completedCall.status}`);
       }
+      const errorMessage = completedCall.response.error?.message;
+      // Should contain "not found in registry"
+      expect(errorMessage).toContain('not found in registry');
+      // Should NOT contain permission message
+      expect(errorMessage).not.toContain('requires permission');
     });
   });
 });
@@ -1254,9 +1254,10 @@ describe('CoreToolScheduler YOLO mode', () => {
     expect(completedCalls).toHaveLength(1);
     const completedCall = completedCalls[0];
     expect(completedCall.status).toBe('success');
-    if (completedCall.status === 'success') {
-      expect(completedCall.response.resultDisplay).toBe('Tool executed');
+    if (completedCall.status !== 'success') {
+      throw new Error(`Expected success status, got ${completedCall.status}`);
     }
+    expect(completedCall.response.resultDisplay).toBe('Tool executed');
   });
 });
 
@@ -1636,9 +1637,10 @@ describe('CoreToolScheduler request queueing', () => {
     expect(completedCalls).toHaveLength(1);
     const completedCall = completedCalls[0];
     expect(completedCall.status).toBe('success');
-    if (completedCall.status === 'success') {
-      expect(completedCall.response.resultDisplay).toBe('Tool executed');
+    if (completedCall.status !== 'success') {
+      throw new Error(`Expected success status, got ${completedCall.status}`);
     }
+    expect(completedCall.response.resultDisplay).toBe('Tool executed');
   });
 
   it('should handle two synchronous calls to schedule', async () => {
@@ -3135,6 +3137,249 @@ describe('CoreToolScheduler Sequential Execution', () => {
     await vi.waitFor(() => {
       expect(onAllToolCallsCompleteExecCmd).toHaveBeenCalled();
     });
+  });
+});
+
+describe('CoreToolScheduler PostToolUseFailure notifications', () => {
+  it('should emit notifications via outputUpdateHandler when PostToolUseFailure hook returns allow+reason', async () => {
+    const failingTool = new MockTool({
+      name: 'run_shell_command',
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'error output',
+        returnDisplay: 'error output',
+        error: { message: 'Permission denied', type: 'SANDBOX_ERROR' },
+      }),
+      shouldConfirmExecute: vi.fn().mockResolvedValue(false),
+    });
+
+    const failureHookOutput = {
+      decision: 'allow' as const,
+      isBlockingDecision: () => false,
+      shouldStopExecution: () => false,
+      isAskDecision: () => false,
+      systemMessage: undefined,
+      reason: 'Sandbox violation logged',
+      getSandboxBypassRequest: () => undefined,
+      notifications: [
+        {
+          hookName: 'sandbox-guard',
+          message: 'Sandbox violation logged',
+          decision: 'allow' as const,
+        },
+      ],
+    };
+    const mockHookSystem = {
+      firePreToolUseEvent: vi.fn().mockResolvedValue(undefined),
+      firePostToolUseEvent: vi.fn().mockResolvedValue(undefined),
+      firePostToolUseFailureEvent: vi.fn().mockResolvedValue(failureHookOutput),
+      setHookEnabled: vi.fn(),
+    };
+
+    const toolRegistry = {
+      getTool: () => failingTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => failingTool,
+      getToolByDisplayName: () => failingTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const outputUpdateHandlerMock = vi.fn();
+
+    const mockConfig = {
+      getSessionId: () => 'test-session-failure-notif',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getAllowedTools: () => [],
+      getToolRegistry: () => toolRegistry,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getUseSmartEdit: () => false,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      isInteractive: () => true,
+      getExperimentalZedIntegration: () => false,
+      getEnableHooks: () => true,
+      getHookSystem: () => mockHookSystem,
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate: vi.fn(),
+      outputUpdateHandler: outputUpdateHandlerMock,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+      onSandboxBypassRequested: vi.fn().mockResolvedValue(false),
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'fail-notif-1',
+          name: 'run_shell_command',
+          args: { command: 'dangerous-cmd' },
+          isClientInitiated: false,
+          prompt_id: 'p-fail',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+
+    expect(outputUpdateHandlerMock).toHaveBeenCalledWith('fail-notif-1', {
+      hookName: 'sandbox-guard',
+      hookMessage: 'Sandbox violation logged',
+      decision: 'allow',
+      mergedDecision: 'allow',
+    });
+  });
+
+  it('should emit notifications for non-shell tool failures without onSandboxBypassRequested', async () => {
+    const failingEditTool = new MockTool({
+      name: 'edit',
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'error output',
+        returnDisplay: 'error output',
+        error: { message: 'File not found' },
+      }),
+      shouldConfirmExecute: vi.fn().mockResolvedValue(false),
+    });
+
+    const failureHookOutput = {
+      decision: 'allow' as const,
+      isBlockingDecision: () => false,
+      shouldStopExecution: () => false,
+      isAskDecision: () => false,
+      systemMessage: undefined,
+      reason: 'Edit failure logged',
+      getSandboxBypassRequest: () => undefined,
+      notifications: [
+        {
+          hookName: 'audit-hook',
+          message: 'Edit failure logged',
+          decision: 'allow' as const,
+        },
+      ],
+    };
+    const mockHookSystem = {
+      firePreToolUseEvent: vi.fn().mockResolvedValue(undefined),
+      firePostToolUseEvent: vi.fn().mockResolvedValue(undefined),
+      firePostToolUseFailureEvent: vi.fn().mockResolvedValue(failureHookOutput),
+    };
+
+    const toolRegistry = {
+      getTool: () => failingEditTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => failingEditTool,
+      getToolByDisplayName: () => failingEditTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const outputUpdateHandlerMock = vi.fn();
+
+    const mockConfig = {
+      getSessionId: () => 'test-session-edit-failure',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getAllowedTools: () => [],
+      getToolRegistry: () => toolRegistry,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getUseSmartEdit: () => false,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      isInteractive: () => true,
+      getExperimentalZedIntegration: () => false,
+      getEnableHooks: () => true,
+      getHookSystem: () => mockHookSystem,
+    } as unknown as Config;
+
+    // No onSandboxBypassRequested provided
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate: vi.fn(),
+      outputUpdateHandler: outputUpdateHandlerMock,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'edit-fail-1',
+          name: 'edit',
+          args: { file: '/missing.ts' },
+          isClientInitiated: false,
+          prompt_id: 'p-edit-fail',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+
+    expect(mockHookSystem.firePostToolUseFailureEvent).toHaveBeenCalledWith(
+      'edit-fail-1',
+      'edit',
+      { file: '/missing.ts' },
+      'File not found',
+      undefined,
+    );
+
+    expect(outputUpdateHandlerMock).toHaveBeenCalledWith('edit-fail-1', {
+      hookName: 'audit-hook',
+      hookMessage: 'Edit failure logged',
+      decision: 'allow',
+      mergedDecision: 'allow',
+    });
+
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('error');
   });
 });
 

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -1651,8 +1651,7 @@ export class CoreToolScheduler {
                     const isBlockingFailure =
                       failureOutput.isBlockingDecision() ||
                       failureOutput.shouldStopExecution();
-                    const isAskFailure =
-                      failureOutput.isAskDecision?.() ?? false;
+                    const isAskFailure = failureOutput.isAskDecision();
                     const mergedDecisionFailure: HookDecision | undefined =
                       isBlockingFailure
                         ? failureOutput.decision === 'deny'

--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -1620,92 +1620,131 @@ export class CoreToolScheduler {
             // It is a failure
             const error = new Error(toolResult.error.message);
 
-            // Attempt sandbox bypass if hooks are enabled and a bypass callback is registered
+            // Fire PostToolUseFailure hook for all tool failures (not
+            // just shell/sandbox) so that allow+reason notifications are
+            // always surfaced to the UI.
             let handledBySandboxBypass = false;
-            if (
-              this.config.getEnableHooks() &&
-              this.onSandboxBypassRequested &&
-              toolName === ShellTool.Name
-            ) {
+            let failureOutput:
+              | Awaited<
+                  ReturnType<
+                    NonNullable<
+                      ReturnType<Config['getHookSystem']>
+                    >['firePostToolUseFailureEvent']
+                  >
+                >
+              | undefined;
+            if (this.config.getEnableHooks()) {
               const hookSystem = this.config.getHookSystem();
               if (hookSystem) {
                 try {
-                  const failureOutput =
-                    await hookSystem.firePostToolUseFailureEvent(
-                      callId,
-                      toolName,
-                      scheduledCall.request.args,
-                      toolResult.error.message,
-                      toolResult.error.type,
-                    );
-                  const bypassRequest =
-                    failureOutput?.getSandboxBypassRequest?.();
-                  if (bypassRequest) {
-                    const approved =
-                      await this.onSandboxBypassRequested(bypassRequest);
-                    if (approved) {
-                      hookSystem.setHookEnabled('sandbox-guard', false);
-                      try {
-                        const originalArgs = {
-                          ...scheduledCall.request.args,
-                          command: bypassRequest.original_command,
-                        };
-                        const originalInvocation = this.buildInvocation(
-                          scheduledCall.tool,
-                          originalArgs,
-                        );
-                        if (!(originalInvocation instanceof Error)) {
-                          let retryPromise: Promise<ToolResult>;
-                          if (
-                            originalInvocation instanceof ShellToolInvocation
-                          ) {
-                            // Provide a setPidCallback so the bypass process pid
-                            // is tracked in tool call state. Without this, the
-                            // ShellInputPrompt would keep referencing the dead
-                            // linux-sandbox PTY and sudo password input would fail.
-                            const bypassSetPidCallback = (pid: number) => {
-                              this.toolCalls = this.toolCalls.map((tc) =>
-                                tc.request.callId === callId &&
-                                tc.status === 'executing'
-                                  ? { ...tc, pid }
-                                  : tc,
+                  failureOutput = await hookSystem.firePostToolUseFailureEvent(
+                    callId,
+                    toolName,
+                    scheduledCall.request.args,
+                    toolResult.error.message,
+                    toolResult.error.type,
+                  );
+                  if (
+                    this.outputUpdateHandler &&
+                    failureOutput?.notifications?.length
+                  ) {
+                    const isBlockingFailure =
+                      failureOutput.isBlockingDecision() ||
+                      failureOutput.shouldStopExecution();
+                    const isAskFailure =
+                      failureOutput.isAskDecision?.() ?? false;
+                    const mergedDecisionFailure: HookDecision | undefined =
+                      isBlockingFailure
+                        ? failureOutput.decision === 'deny'
+                          ? 'deny'
+                          : 'block'
+                        : isAskFailure
+                          ? 'ask'
+                          : failureOutput.decision;
+                    for (const n of failureOutput.notifications) {
+                      this.outputUpdateHandler(callId, {
+                        hookName: n.hookName,
+                        hookMessage: n.message,
+                        decision: n.decision,
+                        mergedDecision: mergedDecisionFailure,
+                      });
+                    }
+                  }
+
+                  // Sandbox bypass: only for shell tools with a registered bypass callback
+                  if (
+                    this.onSandboxBypassRequested &&
+                    toolName === ShellTool.Name
+                  ) {
+                    const bypassRequest =
+                      failureOutput?.getSandboxBypassRequest?.();
+                    if (bypassRequest) {
+                      const approved =
+                        await this.onSandboxBypassRequested(bypassRequest);
+                      if (approved) {
+                        hookSystem.setHookEnabled('sandbox-guard', false);
+                        try {
+                          const originalArgs = {
+                            ...scheduledCall.request.args,
+                            command: bypassRequest.original_command,
+                          };
+                          const originalInvocation = this.buildInvocation(
+                            scheduledCall.tool,
+                            originalArgs,
+                          );
+                          if (!(originalInvocation instanceof Error)) {
+                            let retryPromise: Promise<ToolResult>;
+                            if (
+                              originalInvocation instanceof ShellToolInvocation
+                            ) {
+                              // Provide a setPidCallback so the bypass process pid
+                              // is tracked in tool call state. Without this, the
+                              // ShellInputPrompt would keep referencing the dead
+                              // linux-sandbox PTY and sudo password input would fail.
+                              const bypassSetPidCallback = (pid: number) => {
+                                this.toolCalls = this.toolCalls.map((tc) =>
+                                  tc.request.callId === callId &&
+                                  tc.status === 'executing'
+                                    ? { ...tc, pid }
+                                    : tc,
+                                );
+                                this.notifyToolCallsUpdate();
+                              };
+                              retryPromise = originalInvocation.execute(
+                                signal,
+                                liveOutputCallback,
+                                shellExecutionConfig,
+                                bypassSetPidCallback,
+                                this.onPasswordPrompt,
                               );
-                              this.notifyToolCallsUpdate();
-                            };
-                            retryPromise = originalInvocation.execute(
-                              signal,
-                              liveOutputCallback,
-                              shellExecutionConfig,
-                              bypassSetPidCallback,
-                              this.onPasswordPrompt,
-                            );
-                          } else {
-                            retryPromise = originalInvocation.execute(
-                              signal,
-                              liveOutputCallback,
-                              shellExecutionConfig,
-                            );
+                            } else {
+                              retryPromise = originalInvocation.execute(
+                                signal,
+                                liveOutputCallback,
+                                shellExecutionConfig,
+                              );
+                            }
+                            const retryResult = await retryPromise;
+                            if (retryResult.error === undefined) {
+                              const retryContent = retryResult.llmContent;
+                              const retryResponse = convertToFunctionResponse(
+                                toolName,
+                                callId,
+                                retryContent,
+                              );
+                              this.setStatusInternal(callId, 'success', {
+                                callId,
+                                responseParts: retryResponse,
+                                resultDisplay: retryResult.returnDisplay,
+                                error: undefined,
+                                errorType: undefined,
+                              });
+                              handledBySandboxBypass = true;
+                            }
                           }
-                          const retryResult = await retryPromise;
-                          if (retryResult.error === undefined) {
-                            const retryContent = retryResult.llmContent;
-                            const retryResponse = convertToFunctionResponse(
-                              toolName,
-                              callId,
-                              retryContent,
-                            );
-                            this.setStatusInternal(callId, 'success', {
-                              callId,
-                              responseParts: retryResponse,
-                              resultDisplay: retryResult.returnDisplay,
-                              error: undefined,
-                              errorType: undefined,
-                            });
-                            handledBySandboxBypass = true;
-                          }
+                        } finally {
+                          hookSystem.setHookEnabled('sandbox-guard', true);
                         }
-                      } finally {
-                        hookSystem.setHookEnabled('sandbox-guard', true);
                       }
                     }
                   }

--- a/src/copilot-shell/packages/core/src/core/geminiChat.test.ts
+++ b/src/copilot-shell/packages/core/src/core/geminiChat.test.ts
@@ -21,6 +21,7 @@ import {
 import type { Config } from '../config/config.js';
 import { setSimulate429 } from '../utils/testUtils.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
+import { AfterModelHookOutput } from '../hooks/types.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -134,6 +135,48 @@ describe('GeminiChat', () => {
   });
 
   describe('sendMessageStream', () => {
+    it('should queue AfterModel systemMessage fallback when notifications are absent', async () => {
+      const stream = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'Hello from model' }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        stream,
+      );
+
+      const mockHookSystem = {
+        fireAfterModelEvent: vi
+          .fn()
+          .mockResolvedValue(
+            new AfterModelHookOutput({ systemMessage: 'fallback notice' }),
+          ),
+      };
+      vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
+      vi.mocked(mockConfig.getHookSystem).mockReturnValue(
+        mockHookSystem as unknown as ReturnType<Config['getHookSystem']>,
+      );
+
+      const responseStream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test message' },
+        'prompt-id-after-model-fallback',
+      );
+      for await (const _ of responseStream) {
+        /* consume stream */
+      }
+
+      expect(chat.drainHookSystemMessages()).toEqual(['fallback notice']);
+    });
+
     it('should succeed if a tool call is followed by an empty part', async () => {
       // 1. Mock a stream that contains a tool call, then an invalid (empty) part.
       const streamWithToolCall = (async function* () {

--- a/src/copilot-shell/packages/core/src/core/geminiChat.ts
+++ b/src/copilot-shell/packages/core/src/core/geminiChat.ts
@@ -224,6 +224,8 @@ export class GeminiChat {
   // model.
   private sendPromise: Promise<void> = Promise.resolve();
 
+  private pendingHookSystemMessages: string[] = [];
+
   /**
    * Creates a new GeminiChat instance.
    *
@@ -240,6 +242,12 @@ export class GeminiChat {
     private readonly chatRecordingService?: ChatRecordingService,
   ) {
     validateHistory(history);
+  }
+
+  drainHookSystemMessages(): string[] {
+    const msgs = this.pendingHookSystemMessages;
+    this.pendingHookSystemMessages = [];
+    return msgs;
   }
 
   setSystemInstruction(sysInstr: string) {
@@ -831,6 +839,23 @@ export class GeminiChat {
                   ...this.history[this.history.length - 1],
                   parts: modifiedParts,
                 };
+              }
+            }
+
+            // Queue non-blocking notifications for the UI (rendered as
+            // HookSystemMessage after the stream completes in Turn.run()).
+            if (
+              !afterResult.isBlockingDecision() &&
+              !afterResult.shouldStopExecution()
+            ) {
+              if (afterResult.notifications?.length) {
+                for (const n of afterResult.notifications) {
+                  this.pendingHookSystemMessages.push(n.message);
+                }
+              } else if (afterResult.systemMessage || afterResult.reason) {
+                this.pendingHookSystemMessages.push(
+                  afterResult.systemMessage ?? afterResult.reason!,
+                );
               }
             }
 

--- a/src/copilot-shell/packages/core/src/core/turn.test.ts
+++ b/src/copilot-shell/packages/core/src/core/turn.test.ts
@@ -18,6 +18,7 @@ import { StreamEventType } from './geminiChat.js';
 const mockSendMessageStream = vi.fn();
 const mockGetHistory = vi.fn();
 const mockMaybeIncludeSchemaDepthContext = vi.fn();
+const mockDrainHookSystemMessages = vi.fn();
 
 vi.mock('@google/genai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@google/genai')>();
@@ -43,6 +44,7 @@ describe('Turn', () => {
     sendMessageStream: typeof mockSendMessageStream;
     getHistory: typeof mockGetHistory;
     maybeIncludeSchemaDepthContext: typeof mockMaybeIncludeSchemaDepthContext;
+    drainHookSystemMessages: typeof mockDrainHookSystemMessages;
   };
   let mockChatInstance: MockedChatInstance;
 
@@ -52,9 +54,11 @@ describe('Turn', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       maybeIncludeSchemaDepthContext: mockMaybeIncludeSchemaDepthContext,
+      drainHookSystemMessages: mockDrainHookSystemMessages,
     };
     turn = new Turn(mockChatInstance as unknown as GeminiChat, 'prompt-id-1');
     mockGetHistory.mockReturnValue([]);
+    mockDrainHookSystemMessages.mockReturnValue([]);
     mockSendMessageStream.mockResolvedValue((async function* () {})());
   });
 
@@ -871,6 +875,125 @@ describe('Turn', () => {
         // consume stream
       }
       expect(turn.getDebugResponses()).toEqual([resp1, resp2]);
+    });
+  });
+
+  describe('AfterModel hook non-blocking notifications', () => {
+    it('should yield HookSystemMessage events from drainHookSystemMessages after stream completes', async () => {
+      const mockResponseStream = (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [
+              {
+                content: { parts: [{ text: 'Hello from model' }] },
+                finishReason: 'STOP',
+              },
+            ],
+          } as GenerateContentResponse,
+        };
+      })();
+      mockSendMessageStream.mockResolvedValue(mockResponseStream);
+      mockDrainHookSystemMessages.mockReturnValue([
+        'PII detected: email redacted',
+        'Content flagged for review',
+      ]);
+
+      const events = [];
+      const reqParts: Part[] = [{ text: 'Hi' }];
+      for await (const event of turn.run(
+        'test-model',
+        reqParts,
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      const hookMessages = events.filter(
+        (e) => e.type === GeminiEventType.HookSystemMessage,
+      );
+      expect(hookMessages).toHaveLength(2);
+      expect(hookMessages[0].value).toBe('PII detected: email redacted');
+      expect(hookMessages[1].value).toBe('Content flagged for review');
+
+      const contentEvents = events.filter(
+        (e) => e.type === GeminiEventType.Content,
+      );
+      expect(contentEvents).toHaveLength(1);
+      expect(contentEvents[0].value).toBe('Hello from model');
+
+      const finishedEvents = events.filter(
+        (e) => e.type === GeminiEventType.Finished,
+      );
+      expect(finishedEvents).toHaveLength(1);
+    });
+
+    it('should yield no HookSystemMessage when drainHookSystemMessages returns empty', async () => {
+      const mockResponseStream = (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [
+              {
+                content: { parts: [{ text: 'OK' }] },
+                finishReason: 'STOP',
+              },
+            ],
+          } as GenerateContentResponse,
+        };
+      })();
+      mockSendMessageStream.mockResolvedValue(mockResponseStream);
+      mockDrainHookSystemMessages.mockReturnValue([]);
+
+      const events = [];
+      for await (const event of turn.run(
+        'test-model',
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      const hookMessages = events.filter(
+        (e) => e.type === GeminiEventType.HookSystemMessage,
+      );
+      expect(hookMessages).toHaveLength(0);
+    });
+
+    it('should emit HookSystemMessage after Finished event', async () => {
+      const mockResponseStream = (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [
+              {
+                content: { parts: [{ text: 'Done' }] },
+                finishReason: 'STOP',
+              },
+            ],
+          } as GenerateContentResponse,
+        };
+      })();
+      mockSendMessageStream.mockResolvedValue(mockResponseStream);
+      mockDrainHookSystemMessages.mockReturnValue(['systemMessage from hook']);
+
+      const events = [];
+      for await (const event of turn.run(
+        'test-model',
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      const finishedIdx = events.findIndex(
+        (e) => e.type === GeminiEventType.Finished,
+      );
+      const hookMsgIdx = events.findIndex(
+        (e) => e.type === GeminiEventType.HookSystemMessage,
+      );
+      expect(finishedIdx).toBeGreaterThanOrEqual(0);
+      expect(hookMsgIdx).toBeGreaterThan(finishedIdx);
     });
   });
 });

--- a/src/copilot-shell/packages/core/src/core/turn.ts
+++ b/src/copilot-shell/packages/core/src/core/turn.ts
@@ -347,6 +347,12 @@ export class Turn {
           };
         }
       }
+
+      // Drain any non-blocking AfterModel hook messages that were buffered
+      // during processStreamResponse() and surface them as HookSystemMessage.
+      for (const msg of this.chat.drainHookSystemMessages()) {
+        yield { type: GeminiEventType.HookSystemMessage, value: msg };
+      }
     } catch (e) {
       if (signal.aborted) {
         yield { type: GeminiEventType.UserCancelled };

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.test.ts
@@ -5,6 +5,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from '@google/genai';
 import { HookSystem } from './hookSystem.js';
 import { HookRegistry } from './hookRegistry.js';
 import { HookRunner } from './hookRunner.js';
@@ -65,6 +69,8 @@ describe('HookSystem', () => {
       firePreToolUseEvent: vi.fn(),
       fireStopEvent: vi.fn(),
       firePostToolUseEvent: vi.fn(),
+      fireAfterModelEvent: vi.fn(),
+      firePostToolUseFailureEvent: vi.fn(),
     } as unknown as HookEventHandler;
 
     vi.mocked(HookRegistry).mockImplementation(() => mockHookRegistry);
@@ -443,6 +449,156 @@ describe('HookSystem', () => {
       );
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('fireAfterModelEvent', () => {
+    const dummyRequest = { model: 'test' } as GenerateContentParameters;
+    const dummyResponse = {
+      candidates: [],
+    } as unknown as GenerateContentResponse;
+
+    it('should attach aggregator notifications to the returned output', async () => {
+      const notifications = [
+        {
+          hookName: 'pii-hook',
+          message: 'PII detected in model response',
+          decision: 'allow' as HookDecision,
+        },
+      ];
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 5,
+        finalOutput: {
+          decision: 'allow' as HookDecision,
+          reason: 'PII detected in model response',
+        },
+        notifications,
+      };
+      vi.mocked(mockHookEventHandler.fireAfterModelEvent).mockResolvedValue(
+        mockResult,
+      );
+
+      const result = await hookSystem.fireAfterModelEvent(
+        dummyRequest,
+        dummyResponse,
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.notifications).toEqual(notifications);
+    });
+
+    it('should leave notifications undefined when aggregator emits none', async () => {
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 5,
+        finalOutput: {
+          decision: 'allow' as HookDecision,
+        },
+      };
+      vi.mocked(mockHookEventHandler.fireAfterModelEvent).mockResolvedValue(
+        mockResult,
+      );
+
+      const result = await hookSystem.fireAfterModelEvent(
+        dummyRequest,
+        dummyResponse,
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.notifications).toBeUndefined();
+    });
+
+    it('should return undefined when no final output', async () => {
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 0,
+        finalOutput: undefined,
+        notifications: [
+          {
+            hookName: 'pii-hook',
+            message: 'discarded when no output',
+            decision: 'allow' as HookDecision,
+          },
+        ],
+      };
+      vi.mocked(mockHookEventHandler.fireAfterModelEvent).mockResolvedValue(
+        mockResult,
+      );
+
+      const result = await hookSystem.fireAfterModelEvent(
+        dummyRequest,
+        dummyResponse,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('firePostToolUseFailureEvent', () => {
+    it('should attach aggregator notifications to the returned output', async () => {
+      const notifications = [
+        {
+          hookName: 'sandbox-guard',
+          message: 'Command blocked by sandbox',
+          decision: 'allow' as HookDecision,
+        },
+      ];
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 3,
+        finalOutput: {
+          decision: 'allow' as HookDecision,
+          reason: 'Command blocked by sandbox',
+        },
+        notifications,
+      };
+      vi.mocked(
+        mockHookEventHandler.firePostToolUseFailureEvent,
+      ).mockResolvedValue(mockResult);
+
+      const result = await hookSystem.firePostToolUseFailureEvent(
+        'call-1',
+        'shell',
+        { command: 'rm -rf /' },
+        'Permission denied',
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.notifications).toEqual(notifications);
+    });
+
+    it('should leave notifications undefined when aggregator emits none', async () => {
+      const mockResult = {
+        success: true,
+        allOutputs: [],
+        errors: [],
+        totalDuration: 3,
+        finalOutput: {
+          decision: 'allow' as HookDecision,
+        },
+      };
+      vi.mocked(
+        mockHookEventHandler.firePostToolUseFailureEvent,
+      ).mockResolvedValue(mockResult);
+
+      const result = await hookSystem.firePostToolUseFailureEvent(
+        'call-1',
+        'shell',
+        { command: 'ls' },
+        'error',
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.notifications).toBeUndefined();
     });
   });
 });

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -166,12 +166,16 @@ export class HookSystem {
       error,
       errorType,
     );
-    return result.finalOutput
+    const output = result.finalOutput
       ? (createHookOutput(
           'PostToolUseFailure',
           result.finalOutput,
         ) as PostToolUseFailureHookOutput)
       : undefined;
+    if (output && result.notifications?.length) {
+      output.notifications = result.notifications;
+    }
+    return output;
   }
 
   async firePostToolUseEvent(
@@ -302,6 +306,11 @@ export class HookSystem {
           result.finalOutput,
         ) as AfterModelHookOutput)
       : undefined;
+    // Carry per-hook notifications from the aggregator so the caller can
+    // surface non-blocking AfterModel messages to the UI (mirrors PreToolUse/PostToolUse).
+    if (output && result.notifications?.length) {
+      output.notifications = result.notifications;
+    }
     debugLogger.info(
       `[Hook Debug] hookSystem.fireAfterModelEvent: facade returning, hasOutput=${!!output}`,
     );


### PR DESCRIPTION
## Description

AfterModel hooks returning non-blocking `allow` with `reason` or
`systemMessage` were silently discarded — the UI never showed them.
This fix surfaces those notifications as `HookSystemMessage` events,
aligning AfterModel with the existing PreToolUse/PostToolUse behavior.

Additionally, `PostToolUseFailure` hook notifications are now fired for
all tool failures (not just shell+sandbox), and the `mergedDecision`
logic is aligned with the PostToolUse success path.

## Related Issue

closes #1180

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass

## Testing

```bash
cd src/copilot-shell
vitest run packages/core/src/hooks/hookSystem.test.ts \
       packages/core/src/core/turn.test.ts \
       packages/core/src/core/coreToolScheduler.test.ts \
       packages/core/src/core/geminiChat.test.ts
# 120 tests passed

- hookSystem.test.ts: AfterModel and PostToolUseFailure notification
carry-over (6 new tests)
- turn.test.ts: HookSystemMessage events from drain after stream
completes (3 new tests)
- coreToolScheduler.test.ts: PostToolUseFailure notifications for
shell tool with sandbox bypass and non-shell tool without bypass
(2 new tests)