### PR TITLE
docs(skillfs): add lightweight and detailed user guides

### DIFF
--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -1,34 +1,72 @@
 # SkillFS
 
-SkillFS is a FUSE-based virtual filesystem that exposes curated agent skills through a `/skills` view, using default view + skill-discover to control which skills are visible to Agents.
+SkillFS is a FUSE-based virtual filesystem for agent skills. It maps a physical
+skill source tree into a stable runtime view, compiles `SKILL.md` on read, and
+keeps ordinary files backed by the source tree.
 
-## Overview
+SkillFS does not make business-level security decisions. External components
+such as agent-sec-core or Skill Ledger scan skills and write activation state.
+SkillFS consumes that state and exposes each skill as live, fallback snapshot,
+or hidden.
 
-| Capability | Description |
-|------------|-------------|
-| View-based visibility | Default view skills appear in `/skills`; others accessible via `skill-discover` |
-| Conditional compilation | `SKILL.md` is compiled on read (OS conditions, command normalization) |
-| Physical write passthrough | Non-SKILL.md files pass through to the underlying filesystem |
-| skill-discover | Virtual skill that lists secondary view skills with source paths |
+## When to Use It
 
-## Prerequisites
+Use SkillFS when you need:
 
-| Requirement | Minimum |
-|-------------|---------|
-| OS | Linux |
-| Filesystem | FUSE3 (`libfuse3-dev` or equivalent) |
+- a stable mount path for agents;
+- separation between the source workspace and the agent-visible view;
+- default-view filtering plus `skill-discover` for secondary skills;
+- in-place policy and audit coverage for production access;
+- Skill Ledger integration for fallback and hidden runtime views;
+- `.skill-meta` protection from ordinary agent processes.
+
+Do not in-place mount an existing hub workspace directly when that workspace
+also contains registry metadata such as `.hub` directories or external
+manifests. Keep the hub workspace and the clean SkillFS source root separate.
+
+## Requirements
+
+| Requirement | Details |
+| --- | --- |
+| OS | Linux for FUSE mounts |
+| FUSE | FUSE3 (`libfuse3-dev`, `fuse3`, or equivalent) |
 | Device | `/dev/fuse` must be available |
-| Rust | >= 1.86 (source build only) |
+| Rust | 1.86+ for source builds |
+
+macOS can run non-FUSE commands such as `validate`, `list`, and `classify`, but
+it cannot mount SkillFS.
 
 ## Installation
 
 ```bash
-# Recommended
+# Recommended package install
 anolisa install skillfs
 
-# Source build (developers only)
-cd src/skillfs && cargo build --release
+# Source build for developers
+cd src/skillfs
+cargo +1.86.0 build --release
 ```
+
+## Source Layout
+
+SkillFS expects a source directory with one skill per child directory:
+
+```text
+/path/to/skills/
+  demo-weather/
+    SKILL.md
+    scripts/
+      run.sh
+  demo-search/
+    SKILL.md
+    config.json
+```
+
+The directory name is the canonical runtime skill id. The `name` field inside
+`SKILL.md` is display metadata and does not override the directory key.
+
+Do not treat `.skill-meta` as ordinary agent data. It stores SkillFS and ledger
+metadata and is hidden from ordinary callers.
 
 ## Quick Start
 
@@ -39,104 +77,115 @@ skillfs validate /path/to/skills
 # List all skills
 skillfs list /path/to/skills
 
-# Generate skillfs-views.toml (assigns skills to default + secondary views)
+# Generate skillfs-views.toml
 skillfs classify /path/to/skills
 
 # Mount the virtual filesystem
 skillfs mount /path/to/skills /mnt/skillfs --foreground
-# Agent accesses: /mnt/skillfs/skills/<skill-name>/SKILL.md
 ```
 
-## Usage
+After a normal mount, agents read:
 
-### skillfs mount — Mount Virtual Filesystem
+```text
+/mnt/skillfs/skills/<skill-name>/SKILL.md
+```
+
+Unmount a foreground test mount with `Ctrl+C` or:
 
 ```bash
-skillfs mount <SOURCE> <MOUNTPOINT> [OPTIONS]
+fusermount3 -u /mnt/skillfs
 ```
 
-- `SOURCE`: Directory containing skill folders (each with `SKILL.md`) and `skillfs-views.toml`
-- `MOUNTPOINT`: Directory where SkillFS exposes the virtual `/skills` view
+## Mount Layouts
 
-After mount, Agents access skills at:
-```
-<MOUNTPOINT>/skills/<skill-name>/SKILL.md
-```
+### Normal Mount
 
-The `skill-discover` virtual skill is always present at:
-```
-<MOUNTPOINT>/skills/skill-discover/SKILL.md
-```
-
-Key options:
-- `--foreground`: Keep in foreground (useful for tests and systemd)
-- `--security-mode`: Require in-place mount (SOURCE = MOUNTPOINT)
-- `--audit-log <PATH>`: Append filesystem audit events as JSONL
-- `--pid-file <PATH>`: Write PID file for process management
-
-Example:
-```bash
-# Development mount
-skillfs mount ./skills /mnt/skillfs --foreground
-
-# In-place mount with audit
-skillfs mount ./skills ./skills --security-mode --audit-log /var/log/skillfs/audit.jsonl
-```
-
-### skillfs classify — Generate View Configuration
+Normal mount uses different source and mountpoint directories:
 
 ```bash
-skillfs classify <SOURCE> [--primary-count N] [--dry-run]
+skillfs mount /path/to/skills /mnt/skillfs --foreground
 ```
 
-Generates `skillfs-views.toml` in the source directory. The first N skills go into the default view ("major"), the rest into a secondary view ("other").
+Agents access skills under `<MOUNTPOINT>/skills`. Direct writes to the source
+directory bypass SkillFS policy and audit, while writes through the mount pass
+through to the source tree.
+
+Use normal mount for local development, compatibility checks, and environments
+where the source workspace is managed by another process.
+
+### In-place Mount
+
+In-place mount uses the same directory for source and mountpoint:
 
 ```bash
-# Generate with default 6 primary skills
-skillfs classify /path/to/skills
-
-# Preview without writing
-skillfs classify /path/to/skills --dry-run
-
-# Customize primary count
-skillfs classify /path/to/skills --primary-count 10
+skillfs mount /path/to/skills /path/to/skills \
+  --foreground \
+  --security-mode \
+  --audit-log /var/log/skillfs/audit.jsonl
 ```
 
-### skillfs validate — Validate Skill Files
+SkillFS over-mounts the source directory, so normal userspace access goes
+through FUSE policy and audit. In-place mounts do not add a `/skills` layer:
 
-```bash
-skillfs validate <SOURCE> [--format text|json]
+```text
+/path/to/skills/<skill-name>/SKILL.md
 ```
 
-Validates all `SKILL.md` files in the source directory. Reports success, degraded (partial parse), and error states.
+Use in-place mount for production security integration. Tools that replace or
+rename the mountpoint directory itself, such as workspace checkpoint or rollback
+tools, must run before mounting or after unmounting.
+
+### Managed Mount
+
+`--managed` starts a detached supervisor that keeps the mount desired state as
+mounted and remounts after unexpected worker exits:
 
 ```bash
-# Text output (default)
+skillfs mount /path/to/skills /mnt/skillfs --managed
+skillfs stop /mnt/skillfs
+```
+
+`skillfs stop <MOUNTPOINT>` clears desired state, terminates the supervisor and
+worker, and unmounts. It is idempotent and safe to run when the mount is already
+stopped.
+
+Managed mode also detects stale or dead FUSE endpoints after unexpected worker
+termination, clears them, and remounts with bounded recovery retries. Default
+foreground mounts are unchanged: they still exit and unmount on `SIGTERM` or
+`Ctrl+C`.
+
+## CLI Utilities
+
+### validate
+
+```bash
 skillfs validate /path/to/skills
-
-# JSON output (for CI integration)
 skillfs validate /path/to/skills --format json
 ```
 
-### skillfs list — List Skills
+`validate` reports successful, degraded, and failed skill parses. Parse
+failures are included in the status summary and produce a non-zero exit code;
+degraded-only skills are reported but keep exit code 0.
+
+In JSON output, error and warning entries include a `path` field so consumers
+can locate the exact offending skill file.
+
+### list and classify
 
 ```bash
-skillfs list <SOURCE> [--enabled-only]
-```
-
-Lists all skills found in the source directory with their metadata.
-
-```bash
-# List all skills
 skillfs list /path/to/skills
-
-# Only show enabled skills
 skillfs list /path/to/skills --enabled-only
+skillfs classify /path/to/skills --primary-count 6
+skillfs classify /path/to/skills --dry-run
 ```
 
-## Configuration
+`list` reports discovered skills and metadata. `classify` generates or previews
+`skillfs-views.toml`; the first N skills go to the default view and the rest go
+to a secondary view.
 
-SkillFS uses `skillfs-views.toml` in the **source directory** (not a global config path) to control skill visibility:
+## Views and Discovery
+
+`skillfs-views.toml` in the source directory controls visibility:
 
 ```toml
 [[view]]
@@ -148,34 +197,237 @@ skills = ["github", "notion", "slack"]
 [[view]]
 name = "other"
 default = false
-description = "Additional skills accessible via skill-discover"
+description = "Additional skills accessible through skill-discover"
 skills = ["apple-notes", "blogwatcher"]
 ```
 
-Behavior:
-- The `default = true` view's skills appear in `<mountpoint>/skills/`
-- Secondary views are listed in `skill-discover/SKILL.md` with `source_path` for each skill
-- Skills not assigned to any view are automatically added to the default view on next mount
+The default view appears directly in the mounted skill view. Secondary views
+are listed by the virtual `skill-discover` skill, whose `SKILL.md` includes the
+skill names and source paths.
 
-## Architecture
+Skills not assigned to any view are added to the default view on the next
+mount.
 
+## Read and Write Semantics
+
+| Operation | Behavior |
+| --- | --- |
+| `readdir` | Controlled by views and runtime activation state |
+| Read `SKILL.md` | Returns compiled content, not raw source text |
+| Read ordinary files | Passes through to the physical source tree |
+| Write `SKILL.md` | Writes through and reparses the store |
+| Write ordinary files | Writes through without changing skill metadata |
+| Rename skill directory | Uses the directory name as the authoritative key |
+| Symlink or hardlink | Restricted to safe same-skill relative targets |
+| `user.*` xattr | Conservative passthrough on ordinary paths |
+
+In-place authoring supports newly created skill directories. A fresh directory
+does not expose a phantom `SKILL.md` before the manifest exists; once
+`SKILL.md` is written, SkillFS reparses it and exposes the compiled view.
+Pending or direct-final installs can preserve ordinary top-level skill
+directory metadata such as mode, timestamps, and ownership. `.skill-meta/**`
+remains restricted to trusted metadata paths.
+
+Without security integration, skills read from the live source tree. When
+security activation is enabled, visibility is constrained by the active
+mapping:
+
+- current: read from the live source tree, for example through the legacy
+  decision-command resolve path;
+- fallback: read from a trusted snapshot under `.skill-meta`;
+- hidden: hide the skill from ordinary callers.
+
+In activation file mode, activation JSON expresses fallback and hidden states.
+It does not write current/live state. If a skill has no activation JSON or
+activation xattr in this mode, SkillFS treats it as hidden by fail-safe default.
+
+## Security Integration
+
+### Activation File Mode
+
+Use activation file mode when an external daemon receives SkillFS mutation
+events, scans the source tree, and writes activation metadata:
+
+```bash
+skillfs mount /path/to/skills /mnt/skillfs \
+  --foreground \
+  --security \
+  --activation-mode file \
+  --notify-socket /run/skill-ledger.sock \
+  --activation-events-log /var/log/skillfs/activation-events.jsonl \
+  --activation-reload-mode poll
 ```
-crates/
-  skillfs-core/   parser, store, views, compiler, env, watcher
-  skillfs-fuse/   FUSE filesystem and POSIX passthrough layer
-  skillfs-cli/    mount / classify / validate / list
+
+Flow:
+
+```text
+Agent or installer writes through SkillFS
+  -> SkillFS sends a notify event
+  -> Skill Ledger scans and writes activation state
+  -> SkillFS reloads activation state
+  -> the skill becomes live, fallback, or hidden
 ```
 
-## FAQ
+`--activation-reload-mode poll` requires `--notify-socket` or
+`--activation-events-log`, because SkillFS needs a trigger source for polling.
 
-**Q: Where does the config file go?**
+For in-place activation and notify mounts, set `--ledger-backing-root` to a
+daemon-visible backing source path:
 
-A: `skillfs-views.toml` lives in the skills source directory (the same directory you pass as `<SOURCE>`), not in `~/.config/`.
+```bash
+skillfs mount /path/to/skills /path/to/skills \
+  --security-mode \
+  --security \
+  --activation-mode file \
+  --notify-socket /run/skill-ledger.sock \
+  --ledger-backing-root /run/user/$UID/skillfs-ledger/source
+```
 
-**Q: What does skill-discover do?**
+Avoid `/tmp` and `/var/tmp` for daemon integration paths when the daemon runs
+with `PrivateTmp=true`; those paths are invisible to the daemon and rejected by
+startup validation.
 
-A: It's a virtual skill always present in `/skills`. When secondary views exist, it lists those skills with their `source_path` so Agents can use `read_file` to access them directly.
+### Control Socket
 
-**Q: Can Agents write through the FUSE mount?**
+The trusted control socket is the preferred production path for activation
+writes:
 
-A: Yes. Non-SKILL.md files pass through to the physical filesystem. Writing to `SKILL.md` triggers a re-parse to keep the internal store consistent.
+```bash
+skillfs mount /path/to/skills /mnt/skillfs \
+  --security \
+  --activation-mode file \
+  --control-socket /run/skillfs/control.sock \
+  --trusted-peer-exe /usr/bin/skill-ledger
+```
+
+The socket requires `--security --activation-mode file`, is mutually exclusive
+with `--decision-command`, and requires a pinned trusted peer executable. Peer
+validation uses Linux peer credentials and executable identity checks.
+
+Supported JSONL request examples:
+
+```json
+{"schemaVersion":"1","method":"ping"}
+{"schemaVersion":"1","method":"status"}
+{"schemaVersion":"1","method":"meta.writeActivation","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
+{"schemaVersion":"1","method":"meta.setActivationXattr","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
+```
+
+### Trusted Mount-path Writer
+
+`--trusted-writer-exe <PATH>` is a compatibility gate for trusted writers that
+write through the mount path. Prefer the control socket for new production
+integrations.
+
+`--trusted-writer <NAME>` is deprecated and only matches the Linux process
+`comm` name. Use executable identity when compatibility allows it.
+
+### Decision-command Mode
+
+`--security --decision-command <COMMAND>` is the legacy compatibility path.
+SkillFS invokes the external command for scan and resolve decisions.
+
+Decision-command mode is mutually exclusive with activation file mode,
+`--notify-socket`, `--activation-events-log`, `--ledger-backing-root`, and
+`--control-socket`.
+
+## Install Protocols
+
+SkillFS supports installer-friendly lifecycle paths:
+
+- staging roots can be hidden from ordinary listing while exact staging paths
+  remain writable;
+- direct-to-final installs can remain hidden until activation appears;
+- `/.skillfs-inbox/<skill>/...` is an install or repair entry point for hidden
+  or new skills; writes land in the source tree and can trigger the external
+  security flow;
+- quiet-timeout notification can aggregate install mutations after a configured
+  quiet window;
+- post-publish grace can allow bounded installer metadata writes after publish;
+- post-publish grace paths for fallback skills are routed to the live source so
+  installers can finish metadata updates after publish.
+
+These behaviors are configured through the SkillFS TOML config and require a
+notify source such as `--notify-socket` or `--activation-events-log`.
+
+## Observability
+
+### Audit and Activation Logs
+
+`--audit-log <PATH>` writes filesystem audit events as JSONL.
+`--activation-events-log <PATH>` writes activation protocol events as JSONL for
+daemon-driven activation flows.
+
+### SLS Ops and Runtime Metrics
+
+SkillFS writes best-effort SLS records to:
+
+```text
+/var/log/anolisa/sls/ops/skillfs.jsonl
+```
+
+The file is owned and pre-created by the deployment/SLS component. SkillFS only
+appends when the file exists; it never creates the file or parent directory, and
+write failures do not change CLI or FUSE behavior.
+
+The following CLI commands append ops records: `mount`, `list`, `validate`, and
+`classify`. While a mount is alive, runtime metric records use
+`record_type = "runtime_metric"` and include mount lifecycle, view pruning,
+skill hits, and security policy outcomes. The legacy mount-session summary
+shares the same file for compatibility.
+
+## Common Options
+
+| Option | Purpose |
+| --- | --- |
+| `--foreground` | Run in the foreground |
+| `--managed` | Start a detached supervised mount |
+| `--security-mode` | Require source and mountpoint to be the same path |
+| `--security` | Enable security integration |
+| `--activation-mode file` | Consume activation JSON/xattr state |
+| `--activation-reload-mode poll` | Poll activation after notify triggers |
+| `--notify-socket <PATH>` | Send mutation events to an external daemon |
+| `--activation-events-log <PATH>` | Write activation protocol events as JSONL |
+| `--audit-log <PATH>` | Write filesystem audit events as JSONL |
+| `--control-socket <PATH>` | Accept trusted activation write requests |
+| `--trusted-peer-exe <PATH>` | Pin the trusted control socket peer |
+| `--trusted-writer-exe <PATH>` | Pin a trusted mount-path writer |
+| `--ledger-backing-root <PATH>` | Provide a daemon-visible source view |
+| `--decision-command <CMD>` | Use legacy external decision mode |
+| `--pid-file <PATH>` | Write a process pid file |
+| `--allow-other` | Allow other users to access the FUSE mount |
+| `--config <PATH>` | Load SkillFS TOML configuration |
+| `-v`, `--verbose` | Enable debug logging |
+| `--log-file <PATH>` | Write logs to a file |
+
+## Troubleshooting
+
+**A newly installed skill is not visible.**
+With security activation enabled, new skills can remain hidden until the ledger
+writes activation state. Check notify delivery and activation reload events.
+
+**Fallback reads an older version.**
+Fallback intentionally reads a trusted snapshot under `.skill-meta`, not the
+live source tree.
+
+**`.skill-meta` is not listed.**
+This is expected for ordinary callers. Trusted peers can access metadata through
+the configured trusted path.
+
+**Notify socket failures appear in logs.**
+Notify failures are warnings and do not stop FUSE service, but the external
+daemon may miss mutation events until the socket is fixed.
+
+**In-place activation fails at startup.**
+Check that `--ledger-backing-root` is set and visible to the daemon. Avoid
+`/tmp` and `/var/tmp` with services that use `PrivateTmp=true`.
+
+**A managed mount survived the launcher restart.**
+That is expected. Stop it with `skillfs stop <MOUNTPOINT>`.
+
+## More References
+
+- [SkillFS README](../../../../src/skillfs/README.md)
+- [External decision protocol](../../../../src/skillfs/docs/security/external-decision-protocol.md)
+- [Runtime activation plan](../../../../src/skillfs/docs/security/runtime-activation-implementation-plan.md)
+- [FUSE crate layout](../../../../src/skillfs/docs/architecture/fuse-crate-layout.md)

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -1,34 +1,71 @@
 # SkillFS
 
-SkillFS 是基于 FUSE 的虚拟文件系统，通过 default view + skill-discover 控制可见 Skill，将精选的 Agent 技能以 `/skills` 视图暴露给 Agent。
+SkillFS 是面向 Agent Skill 的 FUSE 虚拟文件系统。它把物理 skill 源目录映射成
+稳定的运行时视图，读取 `SKILL.md` 时返回编译后内容，普通文件仍由底层 source
+树承载。
 
-## 概述
+SkillFS 不做业务层安全判断。agent-sec-core 或 Skill Ledger 等外部组件负责扫描
+skill 并写入 activation 状态。SkillFS 消费这些状态，将每个 skill 暴露为 live、
+fallback snapshot 或 hidden。
 
-| 能力 | 说明 |
-|------|------|
-| 视图可见性控制 | 默认视图的 Skill 出现在 `/skills`；其他通过 `skill-discover` 访问 |
-| 条件编译 | 读取 `SKILL.md` 时执行编译（OS 条件、命令归一化） |
-| 物理写透传 | 非 SKILL.md 文件直接透传到底层文件系统 |
-| skill-discover | 虚拟技能，列出 secondary view 中的技能及其源文件路径 |
+## 适用场景
 
-## 前置条件
+适合使用 SkillFS 的场景：
 
-| 条件 | 最低要求 |
-|------|----------|
-| OS | Linux |
-| 文件系统 | FUSE3（`libfuse3-dev` 或等价包） |
+- 需要给 Agent 提供稳定的挂载路径；
+- 需要隔离 source workspace 和 Agent 可见视图；
+- 需要 default view 过滤，并通过 `skill-discover` 发现 secondary skills；
+- 生产访问需要 in-place policy 和 audit 覆盖；
+- 需要对接 Skill Ledger，提供 fallback / hidden 运行时视图；
+- 需要保护 `.skill-meta`，避免普通 Agent 进程读取元数据。
+
+不要直接对已有 hub workspace 做 in-place mount，尤其是该 workspace 同时包含
+`.hub` 目录、外部 manifest 或 registry 元数据时。推荐分离 hub workspace 和
+干净的 SkillFS source root。
+
+## 环境要求
+
+| 条件 | 说明 |
+| --- | --- |
+| OS | FUSE mount 需要 Linux |
+| FUSE | FUSE3（`libfuse3-dev`、`fuse3` 或等价包） |
 | 设备 | `/dev/fuse` 必须可用 |
-| Rust | >= 1.86（仅源码编译） |
+| Rust | 源码构建需要 1.86+ |
+
+macOS 可以运行 `validate`、`list`、`classify` 等不依赖 FUSE 的命令，但不能挂载
+SkillFS。
 
 ## 安装
 
 ```bash
-# 首选
+# 推荐包安装
 anolisa install skillfs
 
-# 源码编译（仅开发者）
-cd src/skillfs && cargo build --release
+# 开发者源码构建
+cd src/skillfs
+cargo +1.86.0 build --release
 ```
+
+## Source 布局
+
+SkillFS 期望 source 目录下每个子目录对应一个 skill：
+
+```text
+/path/to/skills/
+  demo-weather/
+    SKILL.md
+    scripts/
+      run.sh
+  demo-search/
+    SKILL.md
+    config.json
+```
+
+目录名是权威运行时 skill id。`SKILL.md` frontmatter 里的 `name` 字段是展示元数据，
+不会覆盖目录 key。
+
+不要把 `.skill-meta` 当作普通 Agent 数据使用。它保存 SkillFS 和 ledger 元数据，
+对普通调用方隐藏。
 
 ## 快速开始
 
@@ -39,104 +76,109 @@ skillfs validate /path/to/skills
 # 列出所有 skills
 skillfs list /path/to/skills
 
-# 生成 skillfs-views.toml（将技能分配到默认视图和 secondary 视图）
+# 生成 skillfs-views.toml
 skillfs classify /path/to/skills
 
 # 挂载虚拟文件系统
 skillfs mount /path/to/skills /mnt/skillfs --foreground
-# Agent 访问路径: /mnt/skillfs/skills/<skill-name>/SKILL.md
 ```
 
-## 使用详解
+normal mount 后，Agent 读取：
 
-### skillfs mount — 挂载虚拟文件系统
+```text
+/mnt/skillfs/skills/<skill-name>/SKILL.md
+```
+
+前台测试挂载可以用 `Ctrl+C` 停止，也可以执行：
 
 ```bash
-skillfs mount <SOURCE> <MOUNTPOINT> [OPTIONS]
+fusermount3 -u /mnt/skillfs
 ```
 
-- `SOURCE`：包含技能文件夹（每个含 `SKILL.md`）和 `skillfs-views.toml` 的目录
-- `MOUNTPOINT`：SkillFS 暴露虚拟 `/skills` 视图的目录
+## 挂载布局
 
-挂载后，Agent 通过以下路径访问技能：
-```
-<MOUNTPOINT>/skills/<skill-name>/SKILL.md
-```
+### Normal Mount
 
-`skill-discover` 虚拟技能始终存在：
-```
-<MOUNTPOINT>/skills/skill-discover/SKILL.md
-```
-
-关键选项：
-- `--foreground`：前台运行（便于测试和 systemd）
-- `--security-mode`：强制 in-place 挂载（SOURCE = MOUNTPOINT）
-- `--audit-log <PATH>`：以 JSONL 格式追加文件系统审计事件
-- `--pid-file <PATH>`：写入 PID 文件用于进程管理
-
-示例：
-```bash
-# 开发模式挂载
-skillfs mount ./skills /mnt/skillfs --foreground
-
-# In-place 挂载 + 审计
-skillfs mount ./skills ./skills --security-mode --audit-log /var/log/skillfs/audit.jsonl
-```
-
-### skillfs classify — 生成视图配置
+Normal mount 使用不同的 source 和 mountpoint 目录：
 
 ```bash
-skillfs classify <SOURCE> [--primary-count N] [--dry-run]
+skillfs mount /path/to/skills /mnt/skillfs --foreground
 ```
 
-在源目录中生成 `skillfs-views.toml`。前 N 个技能放入默认视图（"major"），其余放入 secondary 视图（"other"）。
+Agent 通过 `<MOUNTPOINT>/skills` 访问 skill。直接写 source 目录会绕过 SkillFS
+policy 和 audit；通过挂载路径写入时会透传到底层 source 树。
+
+适合本地开发、兼容性检查，以及 source workspace 由其他进程管理的环境。
+
+### In-place Mount
+
+In-place mount 使用同一个目录作为 source 和 mountpoint：
 
 ```bash
-# 默认 6 个主要技能
-skillfs classify /path/to/skills
-
-# 预览不写入
-skillfs classify /path/to/skills --dry-run
-
-# 自定义数量
-skillfs classify /path/to/skills --primary-count 10
+skillfs mount /path/to/skills /path/to/skills \
+  --foreground \
+  --security-mode \
+  --audit-log /var/log/skillfs/audit.jsonl
 ```
 
-### skillfs validate — 验证技能文件
+SkillFS 会 over-mount source 目录，因此普通用户态访问会经过 FUSE policy 和
+audit。In-place mount 不额外增加 `/skills` 层：
 
-```bash
-skillfs validate <SOURCE> [--format text|json]
+```text
+/path/to/skills/<skill-name>/SKILL.md
 ```
 
-验证源目录中所有 `SKILL.md` 文件。报告 success、degraded（部分解析）和 error 状态。
+生产安全集成建议使用 in-place mount。会替换或 rename mountpoint 目录本身的工具，
+例如 workspace checkpoint 或 rollback 工具，必须在 mount 前或 unmount 后运行。
+
+### Managed Mount
+
+`--managed` 会启动 detached supervisor，将 desired state 保持为 mounted，并在
+worker 意外退出后重新挂载：
 
 ```bash
-# 文本输出（默认）
+skillfs mount /path/to/skills /mnt/skillfs --managed
+skillfs stop /mnt/skillfs
+```
+
+`skillfs stop <MOUNTPOINT>` 会清除 desired state、终止 supervisor 和 worker，并
+执行 unmount。该命令是幂等的，挂载已经停止时重复执行也安全。
+
+Managed mode 还会在 worker 异常退出后检测 stale/dead FUSE endpoint，清理后按
+有界重试重新挂载。默认 foreground mount 行为不变：收到 `SIGTERM` 或 `Ctrl+C`
+时仍会退出并 unmount。
+
+## CLI 工具
+
+### validate
+
+```bash
 skillfs validate /path/to/skills
-
-# JSON 输出（CI 集成）
 skillfs validate /path/to/skills --format json
 ```
 
-### skillfs list — 列出技能
+`validate` 会报告 successful、degraded 和 failed skill parse。Parse failure 会
+进入状态汇总并返回非 0 exit code；仅 degraded 的 skill 会被报告，但 exit code 仍为
+0。
+
+JSON 输出中，error 和 warning entry 都包含 `path` 字段，方便调用方定位具体出错的
+skill 文件。
+
+### list 和 classify
 
 ```bash
-skillfs list <SOURCE> [--enabled-only]
-```
-
-列出源目录中发现的所有技能及其元数据。
-
-```bash
-# 列出全部
 skillfs list /path/to/skills
-
-# 仅显示已启用的
 skillfs list /path/to/skills --enabled-only
+skillfs classify /path/to/skills --primary-count 6
+skillfs classify /path/to/skills --dry-run
 ```
 
-## 配置
+`list` 输出发现的 skills 及其元数据。`classify` 生成或预览
+`skillfs-views.toml`；前 N 个 skills 进入 default view，其余进入 secondary view。
 
-SkillFS 使用 **源目录下** 的 `skillfs-views.toml`（不是全局配置路径）控制技能可见性：
+## Views 与 Discovery
+
+source 目录下的 `skillfs-views.toml` 控制可见性：
 
 ```toml
 [[view]]
@@ -148,34 +190,220 @@ skills = ["github", "notion", "slack"]
 [[view]]
 name = "other"
 default = false
-description = "Additional skills accessible via skill-discover"
+description = "Additional skills accessible through skill-discover"
 skills = ["apple-notes", "blogwatcher"]
 ```
 
-行为：
-- `default = true` 视图的技能出现在 `<mountpoint>/skills/`
-- Secondary 视图列在 `skill-discover/SKILL.md` 中，每个技能附带 `source_path`
-- 未分配到任何视图的技能在下次挂载时自动加入默认视图
+default view 会直接出现在挂载后的 skill 视图中。Secondary views 由虚拟
+`skill-discover` skill 列出，其 `SKILL.md` 包含 skill 名称和 source path。
 
-## 架构
+未分配到任何 view 的 skill 会在下次 mount 时加入 default view。
 
+## 读写语义
+
+| 操作 | 行为 |
+| --- | --- |
+| `readdir` | 由 views 和 runtime activation state 控制 |
+| 读取 `SKILL.md` | 返回编译后内容，不是原始 source 文本 |
+| 读取普通文件 | 透传到底层物理 source 树 |
+| 写入 `SKILL.md` | 写透传，并重新解析 store |
+| 写入普通文件 | 写透传，不改变 skill 元数据 |
+| rename skill 目录 | 目录名是权威 key |
+| symlink 或 hardlink | 限制为安全的同 skill 相对目标 |
+| `user.*` xattr | 普通路径上保守透传 |
+
+In-place authoring 支持新建 skill 目录。刚创建但尚未写入 manifest 的目录不会暴露
+phantom `SKILL.md`；写入 `SKILL.md` 后，SkillFS 会重新解析并暴露编译后的视图。
+Pending 或 direct-final install 可以保留普通顶层 skill 目录的 mode、timestamp 和
+ownership 等元数据。`.skill-meta/**` 仍只允许 trusted metadata path 访问。
+
+无安全集成时，skill 默认读取 live source 树。启用 security activation 后，
+可见性受 active mapping 限制：
+
+- current：读取 live source 树，例如旧 decision-command resolve 路径产生的状态；
+- fallback：读取 `.skill-meta` 下的可信 snapshot；
+- hidden：对普通调用方隐藏 skill。
+
+Activation file mode 下，Activation JSON 表达 fallback 和 hidden 两种状态，不写
+current/live 状态。如果该模式下某个 skill 没有 activation JSON 或 activation
+xattr，SkillFS 会按 fail-safe 默认值将其视为 hidden。
+
+## 安全集成
+
+### Activation File Mode
+
+当外部 daemon 接收 SkillFS mutation event、扫描 source 树并写入 activation 元数据
+时，使用 activation file mode：
+
+```bash
+skillfs mount /path/to/skills /mnt/skillfs \
+  --foreground \
+  --security \
+  --activation-mode file \
+  --notify-socket /run/skill-ledger.sock \
+  --activation-events-log /var/log/skillfs/activation-events.jsonl \
+  --activation-reload-mode poll
 ```
-crates/
-  skillfs-core/   parser, store, views, compiler, env, watcher
-  skillfs-fuse/   FUSE 文件系统与 POSIX 透传层
-  skillfs-cli/    mount / classify / validate / list
+
+流程：
+
+```text
+Agent 或 installer 通过 SkillFS 写入
+  -> SkillFS 发送 notify event
+  -> Skill Ledger 扫描并写 activation state
+  -> SkillFS reload activation state
+  -> skill 变为 live、fallback 或 hidden
 ```
 
-## 常见问题
+`--activation-reload-mode poll` 需要 `--notify-socket` 或
+`--activation-events-log`，因为 SkillFS 需要触发源来启动 polling。
 
-**Q: 配置文件放在哪里？**
+对于 in-place activation 和 notify mount，需要设置 `--ledger-backing-root`，给
+daemon 一个可见的 backing source path：
 
-A: `skillfs-views.toml` 位于技能源目录中（即你作为 `<SOURCE>` 传入的那个目录），不在 `~/.config/` 下。
+```bash
+skillfs mount /path/to/skills /path/to/skills \
+  --security-mode \
+  --security \
+  --activation-mode file \
+  --notify-socket /run/skill-ledger.sock \
+  --ledger-backing-root /run/user/$UID/skillfs-ledger/source
+```
 
-**Q: skill-discover 是什么？**
+当 daemon 使用 `PrivateTmp=true` 运行时，避免把集成路径放在 `/tmp` 或
+`/var/tmp`；这些路径对 daemon 不可见，并会被启动校验拒绝。
 
-A: 它是始终存在于 `/skills` 中的虚拟技能。当存在 secondary views 时，它会列出这些技能及其 `source_path`，供 Agent 通过 `read_file` 直接访问。
+### Control Socket
 
-**Q: Agent 能否通过 FUSE 挂载写入文件？**
+可信 control socket 是生产环境推荐的 activation 写入路径：
 
-A: 可以。非 SKILL.md 文件直接透传到物理文件系统。写入 `SKILL.md` 会触发重新解析以保持内部 store 一致。
+```bash
+skillfs mount /path/to/skills /mnt/skillfs \
+  --security \
+  --activation-mode file \
+  --control-socket /run/skillfs/control.sock \
+  --trusted-peer-exe /usr/bin/skill-ledger
+```
+
+该 socket 要求 `--security --activation-mode file`，与 `--decision-command` 互斥，
+并且必须指定可信 peer executable。Peer 校验使用 Linux peer credential 和
+executable identity。
+
+支持的 JSONL 请求示例：
+
+```json
+{"schemaVersion":"1","method":"ping"}
+{"schemaVersion":"1","method":"status"}
+{"schemaVersion":"1","method":"meta.writeActivation","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
+{"schemaVersion":"1","method":"meta.setActivationXattr","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
+```
+
+### Trusted Mount-path Writer
+
+`--trusted-writer-exe <PATH>` 是 mount path 可信写入兼容门禁。新生产集成优先使用
+control socket。
+
+`--trusted-writer <NAME>` 已废弃，仅匹配 Linux 进程 `comm` 名称。兼容条件允许时，
+应使用 executable identity。
+
+### Decision-command Mode
+
+`--security --decision-command <COMMAND>` 是旧的兼容路径。SkillFS 调用外部命令执行
+scan 和 resolve 决策。
+
+Decision-command mode 与 activation file mode、`--notify-socket`、
+`--activation-events-log`、`--ledger-backing-root` 和 `--control-socket` 互斥。
+
+## Install 协议
+
+SkillFS 支持面向 installer 的生命周期路径：
+
+- staging roots 可从普通 listing 隐藏，但精确 staging 路径仍可写；
+- direct-to-final install 可在 activation 出现前保持 hidden；
+- `/.skillfs-inbox/<skill>/...` 是 hidden 或 new skill 的 install/repair 入口；
+  写入会落到 source tree，并可触发外部安全流程；
+- quiet-timeout notification 可在配置的 quiet window 后聚合 install mutation；
+- post-publish grace 可允许发布后有界的 installer 元数据写入；
+- fallback skill 的 post-publish grace 路径会路由到 live source，便于 installer
+  在 publish 后完成元数据更新。
+
+这些行为通过 SkillFS TOML config 配置，并需要 `--notify-socket` 或
+`--activation-events-log` 等 notify source。
+
+## 可观测性
+
+### Audit 和 Activation Logs
+
+`--audit-log <PATH>` 写 filesystem audit events JSONL。
+`--activation-events-log <PATH>` 写 daemon-driven activation 流程中的 activation
+protocol events JSONL。
+
+### SLS Ops 和 Runtime Metrics
+
+SkillFS 会 best-effort 写 SLS records 到：
+
+```text
+/var/log/anolisa/sls/ops/skillfs.jsonl
+```
+
+该文件由部署侧/SLS 组件拥有并预创建。SkillFS 只在文件存在时追加写入；不会创建该文件
+或父目录，写入失败也不会改变 CLI 或 FUSE 行为。
+
+以下 CLI 命令会追加 ops records：`mount`、`list`、`validate` 和 `classify`。mount
+存活期间，runtime metric record 使用 `record_type = "runtime_metric"`，覆盖 mount
+lifecycle、view pruning、skill hits 和 security policy outcomes。兼容旧消费者的
+mount-session summary 仍共享同一个文件。
+
+## 常用参数
+
+| 参数 | 作用 |
+| --- | --- |
+| `--foreground` | 前台运行 |
+| `--managed` | 启动 detached supervised mount |
+| `--security-mode` | 要求 source 和 mountpoint 是同一路径 |
+| `--security` | 启用安全集成 |
+| `--activation-mode file` | 消费 activation JSON/xattr 状态 |
+| `--activation-reload-mode poll` | notify trigger 后 poll activation |
+| `--notify-socket <PATH>` | 向外部 daemon 发送 mutation event |
+| `--activation-events-log <PATH>` | 写 activation protocol events JSONL |
+| `--audit-log <PATH>` | 写 filesystem audit events JSONL |
+| `--control-socket <PATH>` | 接收可信 activation 写请求 |
+| `--trusted-peer-exe <PATH>` | 固定可信 control socket peer |
+| `--trusted-writer-exe <PATH>` | 固定可信 mount-path writer |
+| `--ledger-backing-root <PATH>` | 提供 daemon 可见的 source view |
+| `--decision-command <CMD>` | 使用旧 external decision 模式 |
+| `--pid-file <PATH>` | 写进程 pid file |
+| `--allow-other` | 允许其他用户访问 FUSE mount |
+| `--config <PATH>` | 加载 SkillFS TOML 配置 |
+| `-v`, `--verbose` | 启用 debug logging |
+| `--log-file <PATH>` | 将日志写入文件 |
+
+## 排障
+
+**新安装的 skill 不可见。**
+启用 security activation 后，新 skill 可能保持 hidden，直到 ledger 写入 activation
+state。检查 notify 投递和 activation reload events。
+
+**Fallback 读到旧版本。**
+这是预期行为。Fallback 读取 `.skill-meta` 下的可信 snapshot，而不是 live source。
+
+**看不到 `.skill-meta`。**
+普通调用方看不到该目录是预期行为。可信 peer 可以通过配置的 trusted path 访问元数据。
+
+**日志里出现 notify socket 失败。**
+Notify 失败只是 warning，不会停止 FUSE 服务，但外部 daemon 可能收不到 mutation
+event，直到 socket 修复。
+
+**In-place activation 启动失败。**
+检查是否设置了 `--ledger-backing-root`，以及该路径对 daemon 可见。使用
+`PrivateTmp=true` 的服务不要使用 `/tmp` 或 `/var/tmp`。
+
+**Managed mount 在 launcher 重启后仍然存在。**
+这是预期行为。使用 `skillfs stop <MOUNTPOINT>` 停止。
+
+## 更多参考
+
+- [SkillFS README](../../../../src/skillfs/README_zh.md)
+- [External decision protocol](../../../../src/skillfs/docs/security/external-decision-protocol.md)
+- [Runtime activation plan](../../../../src/skillfs/docs/security/runtime-activation-implementation-plan.md)
+- [FUSE crate layout](../../../../src/skillfs/docs/architecture/fuse-crate-layout.md)


### PR DESCRIPTION
## Summary

Add user-facing SkillFS documentation with a lightweight entry guide and a
detailed component reference.

## What Changed

- Add `docs/skillfs/skillfs.md` as the short user guide.
  - Explains what SkillFS is.
  - Covers normal mount, in-place mount, common parameters, and quick checks.
  - Links to the detailed SkillFS reference for advanced usage.

- Add `src/skillfs/docs/user-guide.md` as the full reference.
  - Covers view semantics, activation file mode, notify socket, reload,
    control socket, trusted writer, install protocols, and config examples.
  - Documents both production activation/control-socket mode and
    decision-command compatibility mode.
  - Keeps activation file semantics accurate: activation JSON expresses
    fallback snapshot or hidden; current is not written through activation JSON.

## Behavior / Compatibility

- Documentation-only change.
- No runtime behavior, CLI behavior, or test behavior changes.
- Source-build examples explicitly use the `src/skillfs` workspace path.
- Security integration docs avoid mixing mutually exclusive modes.

## Validation

- `git diff --check`
- `cd src/skillfs && cargo +1.86.0 fmt --all --check`