### PR TITLE
fix(anolisa): align install mode privilege policy

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -195,7 +195,8 @@ fn render_grouped_help(cap: &[(String, String)], mgmt: &[(String, String)]) -> S
 /// surfaces. Handlers must not re-parse global flags from their own
 /// `args` struct.
 pub fn dispatch(cli: Cli, ctx: &CliContext) -> Result<(), CliError> {
-    validate_global_args(ctx)?;
+    let policy = command_policy(&cli.command);
+    validate_global_args(&cli, ctx, policy)?;
     match cli.command {
         Commands::Component(cmd) => match cmd {
             ComponentCommands::List(args) => tier1::list::handle(args, ctx),
@@ -222,7 +223,55 @@ pub fn dispatch(cli: Cli, ctx: &CliContext) -> Result<(), CliError> {
     }
 }
 
-fn validate_global_args(ctx: &CliContext) -> Result<(), CliError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandScope {
+    ReadOnly,
+    ModeScopedMutation {
+        dry_run_without_root: bool,
+    },
+    SystemOnlyMutation {
+        dry_run_without_root: bool,
+        privilege_gate: PrivilegeGate,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrivilegeGate {
+    Dispatcher,
+    Handler,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CommandPolicy {
+    label: &'static str,
+    scope: CommandScope,
+}
+
+impl CommandPolicy {
+    const fn new(label: &'static str, scope: CommandScope) -> Self {
+        Self { label, scope }
+    }
+}
+
+fn validate_global_args(
+    cli: &Cli,
+    ctx: &CliContext,
+    policy: CommandPolicy,
+) -> Result<(), CliError> {
+    validate_global_args_with_euid(
+        ctx,
+        policy,
+        anolisa_platform::privilege::effective_uid(),
+        cli.install_mode.is_some(),
+    )
+}
+
+fn validate_global_args_with_euid(
+    ctx: &CliContext,
+    policy: CommandPolicy,
+    effective_uid: u32,
+    install_mode_explicit: bool,
+) -> Result<(), CliError> {
     if let Some(prefix) = &ctx.prefix
         && !is_safe_absolute_path(prefix)
     {
@@ -234,7 +283,215 @@ fn validate_global_args(ctx: &CliContext) -> Result<(), CliError> {
             ),
         });
     }
+
+    if let CommandScope::SystemOnlyMutation { privilege_gate, .. } = policy.scope
+        && ctx.install_mode != InstallMode::System
+    {
+        let omitted_helper_gated_system_command =
+            !install_mode_explicit && privilege_gate == PrivilegeGate::Handler;
+        if !omitted_helper_gated_system_command {
+            return Err(system_scope_error(policy.label, install_mode_explicit));
+        }
+    }
+
+    match policy.scope {
+        CommandScope::ReadOnly => {}
+        CommandScope::ModeScopedMutation {
+            dry_run_without_root,
+        } => {
+            let dry_run_preview = ctx.dry_run && dry_run_without_root;
+            if ctx.install_mode == InstallMode::System && effective_uid != 0 && !dry_run_preview {
+                return Err(system_permission_error(ctx, policy.label, true));
+            }
+        }
+        CommandScope::SystemOnlyMutation {
+            dry_run_without_root,
+            privilege_gate,
+        } => {
+            let dry_run_preview = ctx.dry_run && dry_run_without_root;
+            if privilege_gate == PrivilegeGate::Dispatcher && effective_uid != 0 && !dry_run_preview
+            {
+                return Err(system_permission_error(ctx, policy.label, false));
+            }
+        }
+    }
+
+    if ctx.install_mode == InstallMode::User && effective_uid == 0 {
+        return Err(root_user_mode_error(policy.label));
+    }
+
     Ok(())
+}
+
+fn root_user_mode_error(command: &str) -> CliError {
+    CliError::InvalidArgument {
+        command: command.to_string(),
+        reason: format!(
+            "--install-mode user is not supported while running as root; run `anolisa --install-mode user {command} ...` without sudo, or omit `--install-mode user` when using sudo for system mode"
+        ),
+    }
+}
+
+fn system_scope_error(command: &str, install_mode_explicit: bool) -> CliError {
+    let reason =
+        format!("command '{command}' operates on system scope, but current install mode is user");
+    if install_mode_explicit {
+        CliError::InvalidArgument {
+            command: command.to_string(),
+            reason,
+        }
+    } else {
+        CliError::PermissionDenied {
+            command: command.to_string(),
+            reason,
+            hint: Some(format!(
+                "run `sudo anolisa {command} ...`; sudo defaults this command to system mode"
+            )),
+        }
+    }
+}
+
+const fn mode_scoped(label: &'static str, dry_run_without_root: bool) -> CommandPolicy {
+    CommandPolicy::new(
+        label,
+        CommandScope::ModeScopedMutation {
+            dry_run_without_root,
+        },
+    )
+}
+
+const fn system_only(label: &'static str, dry_run_without_root: bool) -> CommandPolicy {
+    CommandPolicy::new(
+        label,
+        CommandScope::SystemOnlyMutation {
+            dry_run_without_root,
+            privilege_gate: PrivilegeGate::Dispatcher,
+        },
+    )
+}
+
+fn system_permission_error(ctx: &CliContext, command: &str, user_mode_supported: bool) -> CliError {
+    let target = ctx
+        .prefix
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "/usr/local".to_string());
+    let hint = if user_mode_supported {
+        format!(
+            "run `sudo anolisa {command} ...` for system mode, or `anolisa --install-mode user {command} ...` for user mode"
+        )
+    } else {
+        format!("run `sudo anolisa {command} ...`; sudo defaults this command to system mode")
+    };
+    CliError::PermissionDenied {
+        command: command.to_string(),
+        reason: format!("system mode needs write access to {target} and requires root"),
+        hint: Some(hint),
+    }
+}
+
+fn command_policy(command: &Commands) -> CommandPolicy {
+    match command {
+        Commands::Component(cmd) => match cmd {
+            ComponentCommands::List(_) => CommandPolicy::new("list", CommandScope::ReadOnly),
+            ComponentCommands::Install(_) => mode_scoped("install", true),
+            ComponentCommands::Uninstall(_) => mode_scoped("uninstall", true),
+            ComponentCommands::Status(_) => CommandPolicy::new("status", CommandScope::ReadOnly),
+            ComponentCommands::Doctor(_) => CommandPolicy::new("doctor", CommandScope::ReadOnly),
+            ComponentCommands::Logs(_) => CommandPolicy::new("logs", CommandScope::ReadOnly),
+            ComponentCommands::Restart(_) => mode_scoped("restart", false),
+            ComponentCommands::Update(_) => mode_scoped("update", true),
+            ComponentCommands::Repair(_) => system_only("repair", true),
+            ComponentCommands::Forget(_) => mode_scoped("forget", true),
+            ComponentCommands::Adopt(_) => system_only("adopt", false),
+            ComponentCommands::Adapter(args) => {
+                CommandPolicy::new("adapter", adapter_command_scope(args))
+            }
+        },
+        Commands::Management(cmd) => match cmd {
+            ManagementCommands::Register(args) => {
+                CommandPolicy::new("register", register_command_scope(args))
+            }
+            ManagementCommands::Unregister(_) => system_only("unregister", false),
+            ManagementCommands::Env(_) => CommandPolicy::new("env", CommandScope::ReadOnly),
+            ManagementCommands::Bug(_) => CommandPolicy::new("bug", CommandScope::ReadOnly),
+            ManagementCommands::Osbase(args) => {
+                CommandPolicy::new("osbase", osbase_command_scope(args))
+            }
+            ManagementCommands::System(args) => {
+                CommandPolicy::new("system", system_command_scope(args))
+            }
+        },
+    }
+}
+
+fn adapter_command_scope(args: &adapter::AdapterArgs) -> CommandScope {
+    match &args.command {
+        adapter::AdapterCommands::Scan | adapter::AdapterCommands::Status { .. } => {
+            CommandScope::ReadOnly
+        }
+        adapter::AdapterCommands::Enable { .. } => CommandScope::ModeScopedMutation {
+            dry_run_without_root: true,
+        },
+        adapter::AdapterCommands::Disable { .. } => CommandScope::ModeScopedMutation {
+            dry_run_without_root: false,
+        },
+    }
+}
+
+fn register_command_scope(args: &register::RegisterArgs) -> CommandScope {
+    match &args.command {
+        Some(register::RegisterCommands::Status { .. }) => CommandScope::ReadOnly,
+        None => system_only_scope(false),
+    }
+}
+
+fn system_command_scope(args: &system::SystemArgs) -> CommandScope {
+    match &args.command {
+        system::SystemCommands::Status { .. } => CommandScope::ReadOnly,
+        system::SystemCommands::Serve { .. }
+        | system::SystemCommands::Setup { .. }
+        | system::SystemCommands::Teardown => system_only_scope(false),
+    }
+}
+
+fn osbase_command_scope(args: &osbase::OsbaseArgs) -> CommandScope {
+    match &args.command {
+        osbase::OsbaseCommands::Kernel(kernel) => match &kernel.command {
+            osbase::KernelCommands::Status => CommandScope::ReadOnly,
+            osbase::KernelCommands::Install { .. } | osbase::KernelCommands::Remove => {
+                helper_gated_system_only_scope()
+            }
+        },
+        osbase::OsbaseCommands::Sandbox(sandbox) => match &sandbox.command {
+            osbase::SandboxCommands::List { .. } | osbase::SandboxCommands::Status { .. } => {
+                CommandScope::ReadOnly
+            }
+            osbase::SandboxCommands::Install { .. }
+            | osbase::SandboxCommands::Uninstall { .. }
+            | osbase::SandboxCommands::Remove { .. } => helper_gated_system_only_scope(),
+        },
+        osbase::OsbaseCommands::Security(security) => match &security.command {
+            osbase::SecurityCommands::Status { .. } => CommandScope::ReadOnly,
+            osbase::SecurityCommands::Install { .. } | osbase::SecurityCommands::Remove { .. } => {
+                helper_gated_system_only_scope()
+            }
+        },
+    }
+}
+
+const fn system_only_scope(dry_run_without_root: bool) -> CommandScope {
+    CommandScope::SystemOnlyMutation {
+        dry_run_without_root,
+        privilege_gate: PrivilegeGate::Dispatcher,
+    }
+}
+
+const fn helper_gated_system_only_scope() -> CommandScope {
+    CommandScope::SystemOnlyMutation {
+        dry_run_without_root: false,
+        privilege_gate: PrivilegeGate::Handler,
+    }
 }
 
 fn is_safe_absolute_path(path: &Path) -> bool {
@@ -265,20 +522,232 @@ mod tests {
         }
     }
 
+    fn user_ctx() -> CliContext {
+        CliContext {
+            install_mode: InstallMode::User,
+            prefix: None,
+            json: false,
+            dry_run: false,
+            verbose: false,
+            quiet: false,
+            no_color: false,
+        }
+    }
+
     #[test]
     fn global_prefix_must_be_absolute() {
-        let err = validate_global_args(&ctx_with_prefix(PathBuf::from("relative")))
-            .expect_err("relative prefix must be rejected");
+        let err = validate_global_args_with_euid(
+            &ctx_with_prefix(PathBuf::from("relative")),
+            mode_scoped("global", false),
+            0,
+            true,
+        )
+        .expect_err("relative prefix must be rejected");
 
         assert_eq!(err.code(), "INVALID_ARGUMENT");
     }
 
     #[test]
     fn global_prefix_rejects_traversal_segments() {
-        let err = validate_global_args(&ctx_with_prefix(PathBuf::from("/opt/../etc")))
-            .expect_err("traversing prefix must be rejected");
+        let err = validate_global_args_with_euid(
+            &ctx_with_prefix(PathBuf::from("/opt/../etc")),
+            mode_scoped("global", false),
+            0,
+            true,
+        )
+        .expect_err("traversing prefix must be rejected");
 
         assert_eq!(err.code(), "INVALID_ARGUMENT");
+    }
+
+    #[test]
+    fn system_mode_without_root_is_rejected_before_writes() {
+        let err = validate_global_args_with_euid(
+            &ctx_with_prefix(PathBuf::from("/")),
+            mode_scoped("install", true),
+            1000,
+            true,
+        )
+        .expect_err("non-root system mode must be rejected");
+
+        assert_eq!(err.code(), "PERMISSION_DENIED");
+        assert!(err.reason().contains("system mode"));
+        assert!(err.hint().unwrap().contains("--install-mode user"));
+    }
+
+    #[test]
+    fn system_mode_dry_run_without_root_is_allowed_for_previewing_commands() {
+        let mut ctx = ctx_with_prefix(PathBuf::from("/"));
+        ctx.dry_run = true;
+
+        validate_global_args_with_euid(&ctx, mode_scoped("install", true), 1000, true)
+            .expect("non-root system dry-run should reach preview-capable handlers");
+    }
+
+    #[test]
+    fn system_only_dry_run_without_root_is_allowed_for_previewing_commands() {
+        let mut ctx = ctx_with_prefix(PathBuf::from("/"));
+        ctx.dry_run = true;
+
+        validate_global_args_with_euid(&ctx, system_only("repair", true), 1000, true)
+            .expect("non-root system dry-run should reach preview-capable system handlers");
+    }
+
+    #[test]
+    fn system_mode_dry_run_without_root_is_rejected_without_preview_contract() {
+        let mut ctx = ctx_with_prefix(PathBuf::from("/"));
+        ctx.dry_run = true;
+
+        let err = validate_global_args_with_euid(&ctx, mode_scoped("restart", false), 1000, true)
+            .expect_err("dry-run should not bypass commands without preview semantics");
+
+        assert_eq!(err.code(), "PERMISSION_DENIED");
+    }
+
+    #[test]
+    fn system_only_dry_run_without_root_is_rejected_without_preview_contract() {
+        let mut ctx = ctx_with_prefix(PathBuf::from("/"));
+        ctx.dry_run = true;
+
+        let err = validate_global_args_with_euid(&ctx, system_only("adopt", false), 1000, true)
+            .expect_err("dry-run should not bypass system commands without preview semantics");
+
+        assert_eq!(err.code(), "PERMISSION_DENIED");
+    }
+
+    #[test]
+    fn helper_gated_system_only_mutation_reaches_handler_without_root_in_explicit_system_mode() {
+        validate_global_args_with_euid(
+            &ctx_with_prefix(PathBuf::from("/")),
+            CommandPolicy::new("osbase", helper_gated_system_only_scope()),
+            1000,
+            true,
+        )
+        .expect("helper-gated system mutations should reach their handler preflight");
+    }
+
+    #[test]
+    fn helper_gated_system_only_mutation_reaches_handler_when_mode_is_omitted() {
+        let command = Commands::Management(ManagementCommands::Osbase(osbase::OsbaseArgs {
+            command: osbase::OsbaseCommands::Sandbox(osbase::SandboxArgs {
+                command: osbase::SandboxCommands::Install {
+                    target: "kata-containers".to_string(),
+                    dry_run: false,
+                    force: false,
+                    no_verify: false,
+                },
+            }),
+        }));
+
+        validate_global_args_with_euid(&user_ctx(), command_policy(&command), 1000, false)
+            .expect("omitted install mode should not block helper-gated system mutations");
+    }
+
+    #[test]
+    fn helper_gated_system_only_mutation_still_rejects_explicit_user_mode() {
+        let err = validate_global_args_with_euid(
+            &user_ctx(),
+            CommandPolicy::new("osbase", helper_gated_system_only_scope()),
+            1000,
+            true,
+        )
+        .expect_err("explicit user mode is invalid for helper-gated system commands");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("system scope"));
+        assert!(err.hint().is_none());
+    }
+
+    #[test]
+    fn read_only_system_mode_without_root_is_not_preemptively_rejected() {
+        validate_global_args_with_euid(
+            &ctx_with_prefix(PathBuf::from("/")),
+            CommandPolicy::new("status", CommandScope::ReadOnly),
+            1000,
+            true,
+        )
+        .expect("read-only commands should reach their normal read path");
+    }
+
+    #[test]
+    fn root_user_mode_is_rejected() {
+        let err =
+            validate_global_args_with_euid(&user_ctx(), mode_scoped("install", true), 0, true)
+                .expect_err("root user-mode would create ambiguous ownership semantics");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("not supported while running as root"));
+        assert!(err.reason().contains("without sudo"));
+    }
+
+    #[test]
+    fn nested_read_only_commands_are_not_preemptively_rejected() {
+        fn assert_read_only(command: Commands) {
+            let policy = command_policy(&command);
+            validate_global_args_with_euid(
+                &ctx_with_prefix(PathBuf::from("/")),
+                policy,
+                1000,
+                true,
+            )
+            .expect("nested read-only commands should reach their handlers");
+        }
+
+        assert_read_only(Commands::Component(ComponentCommands::Adapter(
+            adapter::AdapterArgs {
+                command: adapter::AdapterCommands::Status { component: None },
+            },
+        )));
+        assert_read_only(Commands::Management(ManagementCommands::Register(
+            register::RegisterArgs {
+                command: Some(register::RegisterCommands::Status { json: false }),
+                yes: false,
+            },
+        )));
+        assert_read_only(Commands::Management(ManagementCommands::System(
+            system::SystemArgs {
+                command: system::SystemCommands::Status { json: false },
+            },
+        )));
+        assert_read_only(Commands::Management(ManagementCommands::Osbase(
+            osbase::OsbaseArgs {
+                command: osbase::OsbaseCommands::Sandbox(osbase::SandboxArgs {
+                    command: osbase::SandboxCommands::List { json: false },
+                }),
+            },
+        )));
+    }
+
+    #[test]
+    fn system_only_user_mode_points_at_sudo_default() {
+        let err =
+            validate_global_args_with_euid(&user_ctx(), system_only("adopt", false), 1000, false)
+                .expect_err("system-only command should reject user mode");
+
+        assert_eq!(err.code(), "PERMISSION_DENIED");
+        assert!(err.hint().unwrap().contains("sudo anolisa adopt"));
+        assert!(!err.hint().unwrap().contains("--install-mode system"));
+    }
+
+    #[test]
+    fn system_only_explicit_user_mode_is_invalid_argument() {
+        let err =
+            validate_global_args_with_euid(&user_ctx(), system_only("adopt", false), 1000, true)
+                .expect_err("explicit user mode is invalid for system-only commands");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("system scope"));
+        assert!(err.hint().is_none());
+    }
+
+    #[test]
+    fn root_system_only_user_mode_reports_scope_error() {
+        let err = validate_global_args_with_euid(&user_ctx(), system_only("adopt", false), 0, true)
+            .expect_err("system-only command should not use generic root user-mode guidance");
+
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(err.reason().contains("system scope"));
+        assert!(!err.reason().contains("without sudo"));
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -27,7 +27,7 @@ const INSTALLED_COMPONENT_MANIFESTS_SUBDIR: &str = "component-manifests";
 const INSTALLED_COMPONENT_MANIFEST_FILE: &str = "component.toml";
 
 /// Build the layout for the active install mode, honoring `--prefix`
-/// (system-mode) and resolving `$HOME` via `EnvService::detect` (user-mode).
+/// (system-mode) and the current process user's home (user-mode).
 pub fn resolve_layout(ctx: &CliContext) -> FsLayout {
     match ctx.install_mode {
         InstallMode::System => FsLayout::system(ctx.prefix.clone()),
@@ -35,6 +35,52 @@ pub fn resolve_layout(ctx: &CliContext) -> FsLayout {
             let home = anolisa_env::EnvService::detect().home;
             FsLayout::user(home)
         }
+    }
+}
+
+/// Refuse a handler-level system-only path when called with user-mode context.
+///
+/// The dispatcher handles normal CLI entry. This guard protects direct calls
+/// from tests and shared command helpers that bypass the dispatcher.
+pub(crate) fn require_system_mode(
+    ctx: &CliContext,
+    command: &str,
+    reason: &str,
+    sudo_command: &str,
+) -> Result<(), CliError> {
+    if ctx.install_mode == InstallMode::System {
+        return Ok(());
+    }
+
+    Err(CliError::InvalidArgument {
+        command: command.to_string(),
+        reason: format!("{reason}; run `{sudo_command}`"),
+    })
+}
+
+/// Build a consistent package-transaction permission error.
+pub(crate) fn package_permission_error(command: &str, bin: &str, action: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("permission denied running {bin}; re-run the {action} with sudo"),
+    }
+}
+
+/// Build a consistent non-zero package-transaction error.
+pub(crate) fn package_transaction_failed_error(
+    command: &str,
+    operation: &str,
+    code: Option<i32>,
+    stderr: &str,
+) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "dnf {operation} failed (exit {}): {}",
+            code.map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string()),
+            stderr.trim(),
+        ),
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/system.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/system.rs
@@ -74,13 +74,11 @@ pub fn handle(args: SystemArgs, ctx: &CliContext) -> Result<(), CliError> {
 }
 
 fn handle_serve(socket: &str) -> Result<(), CliError> {
-    if !privilege::is_root() {
-        return Err(CliError::PermissionDenied {
-            command: "system serve".to_string(),
-            reason: "the system helper daemon must run as root (euid 0)".to_string(),
-            hint: Some("run with sudo or as a systemd service".to_string()),
-        });
-    }
+    require_root(
+        "system serve",
+        "the system helper daemon must run as root (euid 0)",
+        "run with sudo or as a systemd service",
+    )?;
 
     let server = DaemonServer::new(socket);
     server.run().map_err(|e| CliError::Runtime {
@@ -101,6 +99,18 @@ fn resolve_layout(ctx: &CliContext) -> FsLayout {
     FsLayout::system(ctx.prefix.clone())
 }
 
+fn require_root(command: &str, reason: &str, hint: &str) -> Result<(), CliError> {
+    if privilege::is_root() {
+        return Ok(());
+    }
+
+    Err(CliError::PermissionDenied {
+        command: command.to_string(),
+        reason: reason.to_string(),
+        hint: Some(hint.to_string()),
+    })
+}
+
 fn handle_setup(
     helper_path_override: Option<&str>,
     upgrade: bool,
@@ -108,14 +118,11 @@ fn handle_setup(
 ) -> Result<(), CliError> {
     let cmd = "system setup";
 
-    // 1. Check root
-    if !privilege::is_root() {
-        return Err(CliError::PermissionDenied {
-            command: cmd.to_string(),
-            reason: "system setup must be run as root (euid 0)".to_string(),
-            hint: Some("run with: sudo anolisa system setup".to_string()),
-        });
-    }
+    require_root(
+        cmd,
+        "system setup must be run as root (euid 0)",
+        "run with: sudo anolisa system setup",
+    )?;
 
     let layout = resolve_layout(ctx);
     let helper_path: PathBuf = match helper_path_override {
@@ -439,14 +446,11 @@ fn verify_socket(cmd: &str) -> Result<(), CliError> {
 fn handle_teardown(ctx: &CliContext) -> Result<(), CliError> {
     let cmd = "system teardown";
 
-    // 1. Check root
-    if !privilege::is_root() {
-        return Err(CliError::PermissionDenied {
-            command: cmd.to_string(),
-            reason: "system teardown must be run as root (euid 0)".to_string(),
-            hint: Some("run with: sudo anolisa system teardown".to_string()),
-        });
-    }
+    require_root(
+        cmd,
+        "system teardown must be run as root (euid 0)",
+        "run with: sudo anolisa system teardown",
+    )?;
 
     let layout = resolve_layout(ctx);
     let helper_path = layout.libexec_dir.join("anolisa-system-helper");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -16,7 +16,7 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::commands::common;
 use crate::commands::tier1::install::{RpmSituation, execute_adopt, probe_rpm_situation};
-use crate::context::{CliContext, InstallMode};
+use crate::context::CliContext;
 use crate::repo_config::RepoConfig;
 use crate::response::CliError;
 
@@ -59,19 +59,12 @@ pub(crate) fn adopt_with_query(
 ) -> Result<(), CliError> {
     let command = format!("adopt {target}");
 
-    // Adoption records a *system* RPM into system-scope state; user mode has no
-    // system rpmdb to observe into. Refuse rather than record a system package
-    // against user-scope state (mirrors install's `--backend rpm` user-mode
-    // rejection).
-    if ctx.install_mode != InstallMode::System {
-        return Err(CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "adopt records a system RPM and requires system scope; re-run with --install-mode system (got {} mode)",
-                ctx.install_mode.as_str()
-            ),
-        });
-    }
+    common::require_system_mode(
+        ctx,
+        &command,
+        "adopt records a system RPM and requires system scope",
+        &format!("sudo anolisa adopt {target}"),
+    )?;
 
     let installed = common::load_installed_state(ctx, COMMAND)?;
 
@@ -124,7 +117,7 @@ pub(crate) fn adopt_with_query(
         RpmSituation::Absent { package } => Err(CliError::InvalidArgument {
             command,
             reason: format!(
-                "no installed RPM '{package}' found for component '{target}'; adopt only records an already-installed system RPM — run `anolisa --install-mode system install {target}` to install it"
+                "no installed RPM '{package}' found for component '{target}'; adopt only records an already-installed system RPM — run `sudo anolisa install {target}` to install it"
             ),
         }),
         // Several provider packages: the user must disambiguate.
@@ -148,6 +141,7 @@ pub(crate) fn adopt_with_query(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::InstallMode;
 
     use std::path::PathBuf;
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -215,7 +215,6 @@ fn persist_forget(
     if let Err(err) = log.append(&record) {
         eprintln!("warning: failed to write central log: {err}");
     }
-
     Ok((operation_id, ownership_label))
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -750,18 +750,12 @@ fn route_rpm_adopt(
     situation: Option<RpmSituation>,
     exec: &RpmExec,
 ) -> Result<InstallOutcome, CliError> {
-    // Adopt is a system-scope action (§4.1). The only way to reach `rpm` in
-    // user mode is an explicit `--backend rpm`, which we reject rather than
-    // record a system RPM into user-scope state.
-    if ctx.install_mode != InstallMode::System {
-        return Err(CliError::InvalidArgument {
-            command: command.to_string(),
-            reason: format!(
-                "--backend rpm adopts a system RPM and requires system scope; re-run with --install-mode system (got {} mode)",
-                ctx.install_mode.as_str()
-            ),
-        });
-    }
+    common::require_system_mode(
+        ctx,
+        command,
+        "--backend rpm adopts a system RPM and requires system scope",
+        &format!("sudo anolisa install --backend rpm {component}"),
+    )?;
 
     // Explicit `--backend rpm` may switch an already-installed component's
     // provenance; reuse the same guard the raw path uses.
@@ -1202,7 +1196,7 @@ fn execute_delegated_install(
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "installing system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa --install-mode system install --backend rpm {component}`"
+                "installing system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa install --backend rpm {component}`"
             ),
         });
     }
@@ -1464,19 +1458,12 @@ fn render_delegated_install(ctx: &CliContext, payload: &DelegatedInstallPayload)
 fn txn_install_err(err: PackageTransactionError, command: &str) -> CliError {
     match err {
         PackageTransactionError::CommandMissing { .. } => rpm_tooling_missing_error(command),
-        PackageTransactionError::PermissionDenied { command: bin } => CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("permission denied running {bin}; re-run the install with sudo"),
-        },
-        PackageTransactionError::TransactionFailed { code, stderr, .. } => CliError::Runtime {
-            command: command.to_string(),
-            reason: format!(
-                "dnf install failed (exit {}): {}",
-                code.map(|c| c.to_string())
-                    .unwrap_or_else(|| "signal".to_string()),
-                stderr.trim(),
-            ),
-        },
+        PackageTransactionError::PermissionDenied { command: bin } => {
+            common::package_permission_error(command, &bin, "install")
+        }
+        PackageTransactionError::TransactionFailed { code, stderr, .. } => {
+            common::package_transaction_failed_error(command, "install", code, &stderr)
+        }
     }
 }
 
@@ -6518,7 +6505,7 @@ scope = "@anolisa"
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
             err.reason().contains("system"),
-            "rejection must point at --install-mode system: {}",
+            "rejection must point at system scope: {}",
             err.reason()
         );
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/mvp_lifecycle.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/mvp_lifecycle.rs
@@ -18,8 +18,8 @@
 //!   covered by `super::status::tests::probe_rpm_drift_detects_missing`
 //! - ③ user-mode raw shadows system RPM — covered by
 //!   `super::update::tests::user_raw_override_does_not_touch_system_rpm`; not
-//!   re-done here because `common::resolve_layout` binds user mode to the real
-//!   `$HOME`, so a command-layer user-mode test cannot be isolated without
+//!   re-done here because `common::resolve_layout` binds user mode to the
+//!   current process home, so a command-layer user-mode test cannot be isolated without
 //!   polluting the home dir or mutating process-global `XDG_*` (which would race
 //!   other tests).
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -87,6 +87,13 @@ fn repair_with_query(
     query: &dyn PackageQuery,
 ) -> Result<(), CliError> {
     let command = format!("repair {target}");
+    common::require_system_mode(
+        ctx,
+        &command,
+        "repair reconciles system RPM state and requires system scope",
+        &format!("sudo anolisa repair {target}"),
+    )?;
+
     let installed = common::load_installed_state(ctx, COMMAND)?;
 
     let obj = installed
@@ -505,6 +512,7 @@ fn now_iso8601() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::InstallMode;
 
     use std::path::PathBuf;
 
@@ -512,8 +520,6 @@ mod tests {
         InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
     };
     use anolisa_platform::pkg_query::PackageVersion;
-
-    use crate::context::InstallMode;
 
     /// Configurable in-memory [`PackageQuery`] for the repair tests. Repair runs
     /// no transaction, so a query alone drives every path.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -971,7 +971,7 @@ fn render_human(records: &[ComponentRecord], verbose: bool, no_color: bool) {
         // Observed = present in rpmdb but not yet tracked; point at adopt.
         if record.status == "observed" {
             println!(
-                "    {} run 'anolisa --install-mode system install {}' to adopt as rpm-observed",
+                "    {} run 'sudo anolisa adopt {}' to adopt as rpm-observed",
                 color.label("hint:"),
                 record.name,
             );

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -560,7 +560,7 @@ fn uninstall_rpm_component(
                     return Err(CliError::Runtime {
                         command: command.to_string(),
                         reason: format!(
-                            "removing system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa --install-mode system uninstall {component}{flag_suffix}`"
+                            "removing system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa uninstall {component}{flag_suffix}`"
                         ),
                     });
                 }
@@ -678,7 +678,6 @@ fn uninstall_rpm_component(
     if let Err(err) = log.append(&record) {
         eprintln!("warning: failed to write central log: {err}");
     }
-
     if !ctx.json && !ctx.quiet {
         let color = Palette::new(ctx.no_color);
         for w in &warnings {
@@ -762,19 +761,12 @@ fn txn_remove_err(err: PackageTransactionError, command: &str) -> CliError {
             command: command.to_string(),
             reason: format!("{bin} not found on PATH; cannot remove the RPM package"),
         },
-        PackageTransactionError::PermissionDenied { command: bin } => CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("permission denied running {bin}; re-run the uninstall with sudo"),
-        },
-        PackageTransactionError::TransactionFailed { code, stderr, .. } => CliError::Runtime {
-            command: command.to_string(),
-            reason: format!(
-                "dnf remove failed (exit {}): {}",
-                code.map(|c| c.to_string())
-                    .unwrap_or_else(|| "signal".to_string()),
-                stderr.trim(),
-            ),
-        },
+        PackageTransactionError::PermissionDenied { command: bin } => {
+            common::package_permission_error(command, &bin, "uninstall")
+        }
+        PackageTransactionError::TransactionFailed { code, stderr, .. } => {
+            common::package_transaction_failed_error(command, "remove", code, &stderr)
+        }
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -1139,7 +1139,7 @@ fn update_rpm_component(
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "updating system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa --install-mode system update {component}`"
+                "updating system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa update {component}`"
             ),
         });
     }
@@ -1455,19 +1455,12 @@ fn rpm_tooling_missing_error(command: &str) -> CliError {
 fn txn_err(err: PackageTransactionError, command: &str) -> CliError {
     match err {
         PackageTransactionError::CommandMissing { .. } => rpm_tooling_missing_error(command),
-        PackageTransactionError::PermissionDenied { command: bin } => CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("permission denied running {bin}; re-run the update with sudo"),
-        },
-        PackageTransactionError::TransactionFailed { code, stderr, .. } => CliError::Runtime {
-            command: command.to_string(),
-            reason: format!(
-                "dnf update failed (exit {}): {}",
-                code.map(|c| c.to_string())
-                    .unwrap_or_else(|| "signal".to_string()),
-                stderr.trim(),
-            ),
-        },
+        PackageTransactionError::PermissionDenied { command: bin } => {
+            common::package_permission_error(command, &bin, "update")
+        }
+        PackageTransactionError::TransactionFailed { code, stderr, .. } => {
+            common::package_transaction_failed_error(command, "update", code, &stderr)
+        }
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/context.rs
+++ b/src/anolisa/crates/anolisa-cli/src/context.rs
@@ -57,10 +57,10 @@ pub struct CliContext {
 /// When the user passes `--install-mode`, that value wins unconditionally.
 /// Otherwise the default is inferred from the process's effective UID:
 /// root → [`InstallMode::System`], non-root → [`InstallMode::User`].
-fn resolve_install_mode(explicit: Option<InstallMode>, is_root: bool) -> InstallMode {
+fn resolve_install_mode(explicit: Option<InstallMode>, effective_uid: u32) -> InstallMode {
     match explicit {
         Some(mode) => mode,
-        None if is_root => InstallMode::System,
+        None if effective_uid == 0 => InstallMode::System,
         None => InstallMode::User,
     }
 }
@@ -72,16 +72,8 @@ impl CliContext {
     /// The effective [`InstallMode`] is inferred from euid when
     /// `--install-mode` is not provided on the command line.
     pub fn from_cli(cli: &crate::commands::Cli) -> Self {
-        let is_root = privilege::is_root();
-        let effective_mode = resolve_install_mode(cli.install_mode, is_root);
-
-        if cli.install_mode == Some(InstallMode::User) && is_root && !cli.quiet {
-            eprintln!(
-                "warning: running as root with --install-mode=user; \
-                 state will resolve under the root user's home directory, \
-                 not the system store"
-            );
-        }
+        let effective_uid = privilege::effective_uid();
+        let effective_mode = resolve_install_mode(cli.install_mode, effective_uid);
 
         Self {
             install_mode: effective_mode,
@@ -101,18 +93,18 @@ mod tests {
 
     #[test]
     fn omitted_as_root_resolves_to_system() {
-        assert_eq!(resolve_install_mode(None, true), InstallMode::System);
+        assert_eq!(resolve_install_mode(None, 0), InstallMode::System);
     }
 
     #[test]
     fn omitted_as_non_root_resolves_to_user() {
-        assert_eq!(resolve_install_mode(None, false), InstallMode::User);
+        assert_eq!(resolve_install_mode(None, 1000), InstallMode::User);
     }
 
     #[test]
     fn explicit_user_stays_user_even_as_root() {
         assert_eq!(
-            resolve_install_mode(Some(InstallMode::User), true),
+            resolve_install_mode(Some(InstallMode::User), 0),
             InstallMode::User,
         );
     }
@@ -120,7 +112,7 @@ mod tests {
     #[test]
     fn explicit_system_stays_system_even_as_non_root() {
         assert_eq!(
-            resolve_install_mode(Some(InstallMode::System), false),
+            resolve_install_mode(Some(InstallMode::System), 1000),
             InstallMode::System,
         );
     }

--- a/src/anolisa/crates/anolisa-platform/src/privilege.rs
+++ b/src/anolisa/crates/anolisa-platform/src/privilege.rs
@@ -1,19 +1,11 @@
-//! Privilege escalation helpers (sudo/polkit).
+//! Privilege inspection helpers.
 
 /// Check if the current process has root privileges.
 pub fn is_root() -> bool {
     nix::unistd::geteuid().is_root()
 }
 
-/// Escalate privileges via sudo for the given command.
-pub fn escalate_command(cmd: &str, args: &[&str]) -> std::process::Command {
-    if is_root() {
-        let mut command = std::process::Command::new(cmd);
-        command.args(args);
-        command
-    } else {
-        let mut command = std::process::Command::new("sudo");
-        command.arg(cmd).args(args);
-        command
-    }
+/// Effective uid used for permission-gate decisions.
+pub fn effective_uid() -> u32 {
+    nix::unistd::geteuid().as_raw()
 }


### PR DESCRIPTION
## Description

Aligns global install-mode handling with the process privilege model:

- `--install-mode` remains the explicit mode intent; when omitted, root defaults to system mode and non-root defaults to user mode.
- `sudo/root + --install-mode user` is rejected instead of trying to infer the sudo caller or chown files back afterward.
- Non-root system mutations are rejected before writes, with actionable `sudo` / user-mode guidance.
- System-only commands reject user mode, while read-only commands remain allowed to inspect system scope.
- User-mode layout resolves from the current process user's home, not from `SUDO_USER`.

The RPM lifecycle surfaces are covered by the same policy: `install --backend rpm`, `adopt`, and `repair` stay system-scope; RPM install/update/uninstall still run normally under sudo/system mode.

## Design Note

The dispatcher now owns the cross-command privilege policy through `CommandPolicy` / `CommandScope`, so handlers no longer each infer root/system/user behavior independently.

`ModeScopedMutation` carries a `dry_run_without_root` flag. This preserves read-only preview behavior for commands that actually have a dry-run contract (`install`, `update`, `uninstall`, `forget`, `adapter enable`) without accidentally allowing commands such as `restart` to bypass the root gate.

Handler-level system-mode checks remain for direct helper/test calls, but are centralized through `common::require_system_mode`. Repeated package transaction error formatting and `system` command root checks were also collapsed into small local helpers.

The old sudo-user implementation path is removed: no `SUDO_UID` / `SUDO_GID` ownership repair, no `SUDO_USER` user-layout resolution, and no automatic sudo escalation helper.

## Ship Note

- `sudo anolisa --install-mode user ...` is now invalid. Run user-mode commands without sudo, or omit `--install-mode user` when using sudo for system mode.
- Ordinary `sudo anolisa install/update/uninstall/adopt/repair ...` keeps defaulting to system mode.
- Non-root `--install-mode system --dry-run` is still allowed only for commands whose handlers provide a read-only preview path.
- `system setup` still uses `SUDO_USER` only to add the invoking user to the system helper group; that is unrelated to user-mode install layout.

## Test

- Unit (dispatcher): non-root system mutation rejected before writes; preview-capable system dry-run allowed without root; commands without dry-run preview stay rejected; read-only nested commands are not preemptively blocked.
- Unit (dispatcher): root + user mode rejected; system-only user mode reports the correct scope error; explicit user mode maps to `INVALID_ARGUMENT`, default user mode points at sudo/system mode.
- Unit (handlers): `adopt`, `repair`, and `install --backend rpm` still reject user-mode direct helper calls.
- Full gate green: `cargo fmt --all -- --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `git diff --check`.
