### PR TITLE
fix(anolisa): accept rpm package-name component input

### DIFF
--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -76,7 +76,7 @@ install -m 0755 target/release/anolisa %{buildroot}%{_bindir}/anolisa
 
 # -- default repo config --
 install -d %{buildroot}%{_sysconfdir}/anolisa
-install -m 0644 templates/repo.toml %{buildroot}%{_sysconfdir}/anolisa/repo.toml
+install -m 0644 manifests/repo.toml %{buildroot}%{_sysconfdir}/anolisa/repo.toml
 
 # -- manifests (capabilities, osbase, runtime) --
 # NOTE: data files under %{_datadir_anolisa} are intentionally NOT installed.

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -209,8 +209,8 @@ fn dev_tree_manifests() -> Option<PathBuf> {
 ///   1. `$ANOLISA_CATALOG_URL` env var
 ///   2. `[backends.raw].base_url` in `repo.toml`, plus `/catalog.json`
 ///
-/// `repo.toml` follows its own discovery chain, including the embedded
-/// default, so upgraded hosts do not need a pre-existing local config file.
+/// `repo.toml` follows its own discovery chain across user/site, packaged,
+/// and dev-tree disk locations.
 pub fn resolve_catalog_url(ctx: &CliContext, command: &str) -> Result<Option<String>, CliError> {
     if let Ok(url) = std::env::var("ANOLISA_CATALOG_URL") {
         let trimmed = url.trim();

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -18,6 +18,7 @@ use crate::commands::common;
 use crate::commands::tier1::install::{RpmSituation, execute_adopt, probe_rpm_situation};
 use crate::context::CliContext;
 use crate::repo_config::RepoConfig;
+use crate::resolution::{ResolutionUse, load_optional_component_index};
 use crate::response::CliError;
 
 /// Command label for JSON envelopes and error routing.
@@ -98,41 +99,73 @@ pub(crate) fn adopt_with_query(
     }
 
     let layout = common::resolve_layout(ctx);
-    // repo.toml only feeds the package-name map (`[backends.rpm].package_map`).
-    // It is supplementary: --package, the provides contract, and the default
-    // name still resolve a candidate without it, so a missing/unreadable config
-    // degrades to "no rpm backend config" rather than failing the adopt.
+    // repo.toml locates the RPM backend and raw-hosted component index. Both
+    // are supplementary to the explicit --package input, installed Provides
+    // contract, and default name candidate, so unreadable config degrades to
+    // "no rpm backend config" rather than failing the adopt.
     let repo_config = RepoConfig::load(&layout).ok();
     let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
+    let env = anolisa_env::EnvService::detect();
+    let component_index = repo_config
+        .as_ref()
+        .and_then(|cfg| load_optional_component_index(&layout, &env, cfg));
 
-    match probe_rpm_situation(target, cli_override, rpm_backend, ctx, query, &command)? {
+    match probe_rpm_situation(
+        target,
+        cli_override,
+        rpm_backend,
+        component_index.as_ref(),
+        ResolutionUse::Adopt,
+        query,
+        &command,
+    )? {
         // Exactly one installed RPM: record it (or preview on --dry-run). reused
         // verbatim from the install path, including the lock-held re-validation.
-        RpmSituation::Adoptable { package, info } => {
-            execute_adopt(ctx, &layout, &command, target, package, info, query)?;
+        RpmSituation::Adoptable { target, info } => {
+            execute_adopt(
+                ctx,
+                &layout,
+                &command,
+                &target.component,
+                target.package,
+                info,
+                query,
+            )?;
             Ok(())
         }
         // Nothing installed under this name: adopt never installs, so point at
         // install for the delegated `dnf install` path.
-        RpmSituation::Absent { package } => Err(CliError::InvalidArgument {
+        RpmSituation::Absent { target: resolved } => Err(CliError::InvalidArgument {
             command,
             reason: format!(
-                "no installed RPM '{package}' found for component '{target}'; adopt only records an already-installed system RPM — run `sudo anolisa install {target}` to install it"
+                "no installed RPM '{}' found for component '{}'; adopt only records an already-installed system RPM — run `sudo anolisa install {}` to install it",
+                resolved.package, resolved.component, resolved.component
+            ),
+        }),
+        RpmSituation::NotAnolisaComponent => Err(CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "component '{target}' is not an ANOLISA RPM component; configure the repo-side component index or publish Provides: anolisa-component({target})"
             ),
         }),
         // Several provider packages: the user must disambiguate.
-        RpmSituation::Ambiguous(names) => Err(CliError::InvalidArgument {
+        RpmSituation::Ambiguous(targets) => Err(CliError::InvalidArgument {
             command,
             reason: format!(
-                "multiple installed RPMs provide component '{target}': {}; cannot adopt unambiguously — pin one with `--package <name>`",
-                names.join(", ")
+                "multiple RPM candidates match '{target}': {}; cannot adopt unambiguously — pin one with `--package <name>`",
+                targets
+                    .iter()
+                    .map(|target| target.package.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
         }),
         // One name, several installed versions: a drift the user must resolve.
-        RpmSituation::MultiVersion(package) => Err(CliError::InvalidArgument {
+        RpmSituation::MultiVersion(resolved) => Err(CliError::InvalidArgument {
             command,
             reason: format!(
-                "RPM package '{package}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first"
+                "RPM package '{}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first",
+                resolved.package
             ),
         }),
     }
@@ -160,6 +193,10 @@ mod tests {
         multi_version: Vec<String>,
         /// capability → provider package names for `what_provides_installed`.
         provides: Vec<(String, Vec<String>)>,
+        /// capability → provider package names for `what_provides_available`.
+        available_provides: Vec<(String, Vec<String>)>,
+        /// package → declared provides capabilities.
+        package_provides: Vec<(String, Vec<String>)>,
         /// package → source repo for `installed_origin`.
         origins: Vec<(String, String)>,
     }
@@ -199,6 +236,28 @@ mod tests {
                 .map(|(_, v)| v.clone())
                 .unwrap_or_default())
         }
+        fn what_provides_available(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .available_provides
+                .iter()
+                .find(|(c, _)| c == capability)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default())
+        }
+        fn provided_capabilities_installed(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .package_provides
+                .iter()
+                .find(|(p, _)| p == package)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default())
+        }
     }
 
     fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
@@ -212,6 +271,20 @@ mod tests {
             arch: arch.to_string(),
             origin: None,
         }
+    }
+
+    fn component_provider(component: &str, package: &str) -> (String, Vec<String>) {
+        (
+            format!("anolisa-component({component})"),
+            vec![package.to_string()],
+        )
+    }
+
+    fn package_component_provide(package: &str, component: &str) -> (String, Vec<String>) {
+        (
+            package.to_string(),
+            vec![format!("anolisa-component({component})")],
+        )
     }
 
     fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
@@ -293,6 +366,7 @@ mod tests {
                 "copilot-shell".to_string(),
                 pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
+            package_provides: vec![package_component_provide("copilot-shell", "copilot-shell")],
             origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
@@ -335,6 +409,7 @@ mod tests {
                 "copilot-shell".to_string(),
                 pkg_info("copilot-shell", "2.0.0", Some("1.al8"), "x86_64"),
             )],
+            package_provides: vec![package_component_provide("copilot-shell", "copilot-shell")],
             ..Default::default()
         };
         adopt_with_query("copilot-shell", None, &c, &q).expect("refresh ok");
@@ -374,6 +449,7 @@ mod tests {
                 "anolisa-other".to_string(),
                 pkg_info("anolisa-other", "9.9.9", Some("1.al8"), "x86_64"),
             )],
+            provides: vec![component_provider("copilot-shell", "anolisa-other")],
             ..Default::default()
         };
         let err = adopt_with_query("copilot-shell", Some("anolisa-other"), &c, &q)
@@ -421,6 +497,7 @@ mod tests {
                 "anolisa-other".to_string(),
                 pkg_info("anolisa-other", "9.9.9", Some("1.al8"), "x86_64"),
             )],
+            provides: vec![component_provider("copilot-shell", "anolisa-other")],
             ..Default::default()
         };
         let err = adopt_with_query("copilot-shell", Some("anolisa-other"), &c, &q)
@@ -511,7 +588,11 @@ mod tests {
     fn adopt_refuses_absent_package() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
-        let err = adopt_with_query("copilot-shell", None, &c, &FakeQuery::default())
+        let q = FakeQuery {
+            available_provides: vec![component_provider("copilot-shell", "copilot-shell")],
+            ..Default::default()
+        };
+        let err = adopt_with_query("copilot-shell", None, &c, &q)
             .expect_err("absent package must be refused");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
@@ -553,6 +634,7 @@ mod tests {
                 "copilot-shell".to_string(),
                 pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
+            available_provides: vec![component_provider("copilot-shell", "copilot-shell")],
             multi_version: vec!["copilot-shell".to_string()],
             ..Default::default()
         };
@@ -572,6 +654,7 @@ mod tests {
                 "copilot-shell".to_string(),
                 pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
+            package_provides: vec![package_component_provide("copilot-shell", "copilot-shell")],
             ..Default::default()
         };
         adopt_with_query("copilot-shell", None, &c, &q).expect("dry-run ok");
@@ -593,6 +676,7 @@ mod tests {
                 "custom-pkg".to_string(),
                 pkg_info("custom-pkg", "3.0.0", Some("1"), "x86_64"),
             )],
+            provides: vec![component_provider("copilot-shell", "custom-pkg")],
             ..Default::default()
         };
         adopt_with_query("copilot-shell", Some("custom-pkg"), &c, &q).expect("adopt ok");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -66,6 +66,10 @@ use crate::repo_config::{
     BackendConfig, HostVars, RepoConfig, RepoConfigError, normalize_override_url, raw_artifact_url,
     raw_index_url, raw_relative_root,
 };
+use crate::resolution::{
+    BackendKind, ComponentIndex, ComponentResolver, ResolutionSet, ResolutionSource, ResolutionUse,
+    ResolveOptions, ResolvedTarget, load_optional_component_index, rpm_component_provide,
+};
 use crate::response::{CliError, render_json, render_json_with_status};
 
 const COMMAND: &str = "install";
@@ -431,6 +435,7 @@ pub(crate) fn handle_one_with_exec(
     let env = anolisa_env::EnvService::detect();
     let repo_config = RepoConfig::load(&layout).map_err(|err| repo_config_err(err, false))?;
     let installed = common::load_installed_state(ctx, COMMAND)?;
+    let mut rpm_component_index: Option<ComponentIndex> = None;
 
     // ── Layer 1: pick the backend name + its source (§4). ──
     //
@@ -461,20 +466,26 @@ pub(crate) fn handle_one_with_exec(
             // layer 2, rather than being rejected by the raw trunk.
             (label.to_string(), BackendSource::ExistingState)
         } else if ctx.install_mode == InstallMode::System {
+            rpm_component_index = load_optional_component_index(&layout, &env, &repo_config);
             let situation = probe_rpm_situation(
                 &component,
                 args.package.as_deref(),
                 repo_config.backends.get("rpm"),
-                ctx,
+                rpm_component_index.as_ref(),
+                ResolutionUse::Install,
                 exec.query,
                 &command,
             )?;
-            if matches!(situation, RpmSituation::Absent { .. }) {
-                // Absent + no `--backend`: fall through to the default backend.
-                // If that is `rpm`, layer 2 re-probes and delegates a `dnf
-                // install`; if it is `raw`, the raw trunk installs. Either way
-                // the probe's `adopt_situation` is dropped — the package is not
-                // present to adopt.
+            if matches!(
+                situation,
+                RpmSituation::Absent { .. } | RpmSituation::NotAnolisaComponent
+            ) {
+                // Absent or not an ANOLISA RPM component + no `--backend`: fall
+                // through to the default backend. If that is `rpm`, layer 2
+                // re-probes and either delegates a `dnf install` or rejects the
+                // non-component; if it is `raw`, the raw trunk installs. Either
+                // way the probe's `adopt_situation` is dropped — there is no
+                // installed system RPM to adopt.
                 (repo_config.default_backend.clone(), BackendSource::Default)
             } else {
                 adopt_situation = Some(situation);
@@ -486,6 +497,9 @@ pub(crate) fn handle_one_with_exec(
 
     // ── Layer 2: pick the action by (backend, rpmdb, mode) (§7.1). ──
     if backend_name == "rpm" {
+        if rpm_component_index.is_none() {
+            rpm_component_index = load_optional_component_index(&layout, &env, &repo_config);
+        }
         return route_rpm_adopt(
             &component,
             &args,
@@ -496,6 +510,7 @@ pub(crate) fn handle_one_with_exec(
             &installed,
             source,
             adopt_situation,
+            rpm_component_index.as_ref(),
             exec,
         );
     }
@@ -571,7 +586,14 @@ fn handle_raw_install(
                 .map_err(|err| repo_config_err(err, true))?
         }
     };
-    let package = repo_config.package_name(backend, &component, args.package.as_deref());
+    let (component, package) = resolve_raw_identity(
+        layout,
+        env,
+        repo_config,
+        backend,
+        component,
+        args.package.as_deref(),
+    );
 
     let resolved = resolve_raw(
         ctx,
@@ -598,14 +620,87 @@ fn handle_raw_install(
     Ok(InstallOutcome::Installed)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn resolve_raw_identity(
+    layout: &FsLayout,
+    env: &anolisa_env::EnvFacts,
+    repo_config: &RepoConfig,
+    backend: &BackendConfig,
+    component: String,
+    cli_override: Option<&str>,
+) -> (String, String) {
+    if cli_override.is_some() || backend.package_map.contains_key(&component) {
+        let package = repo_config.package_name(backend, &component, cli_override);
+        return (component, package);
+    }
+
+    let component_index = load_optional_component_index(layout, env, repo_config);
+    let resolver = ComponentResolver::new(component_index.as_ref(), None, None);
+    match resolver.resolve(
+        &component,
+        BackendKind::Raw,
+        ResolutionUse::Install,
+        ResolveOptions::default(),
+    ) {
+        Ok(ResolutionSet::Unique(target)) => (target.component, target.package),
+        _ => {
+            let package = repo_config.package_name(backend, &component, cli_override);
+            (component, package)
+        }
+    }
+}
+
 // ── rpm adopt path (#958) ───────────────────────────────────────────
 
-/// Result of probing whether `component` is present as a system RPM (§5/§7.1).
+/// Resolved RPM component/package pair.
+#[derive(Debug, Clone)]
+pub(crate) struct RpmTarget {
+    pub(crate) component: String,
+    pub(crate) package: String,
+    source: ResolutionSource,
+    legacy_adopt: bool,
+}
+
+impl RpmTarget {
+    fn new(component: impl Into<String>, package: impl Into<String>) -> Self {
+        Self {
+            component: component.into(),
+            package: package.into(),
+            source: ResolutionSource::InstalledRpmProvides,
+            legacy_adopt: true,
+        }
+    }
+
+    fn from_resolved(target: ResolvedTarget) -> Self {
+        Self {
+            component: target.component,
+            package: target.package,
+            source: target.source,
+            legacy_adopt: target.legacy_adopt,
+        }
+    }
+
+    fn label(&self) -> String {
+        if self.component == self.package {
+            self.package.clone()
+        } else {
+            format!("{} -> {}", self.component, self.package)
+        }
+    }
+}
+
+impl PartialEq for RpmTarget {
+    fn eq(&self, other: &Self) -> bool {
+        self.component == other.component && self.package == other.package
+    }
+}
+
+/// Result of probing whether a target is present as a system RPM (§5/§7.1).
 pub(crate) enum RpmSituation {
     /// Exactly one candidate package name, installed once — ready to adopt.
     Adoptable {
-        /// Resolved package name (the candidate that hit rpmdb).
-        package: String,
+        /// Resolved component/package identity.
+        target: RpmTarget,
         /// rpmdb query result carrying EVR/arch for the state record.
         info: PackageInfo,
     },
@@ -616,18 +711,20 @@ pub(crate) enum RpmSituation {
     /// `rpm-managed`. A *missing* rpm/dnf binary is a different case —
     /// it is a hard warn-and-exit, not `Absent`.
     Absent {
-        /// Resolved package name to hand to `dnf install`.
-        package: String,
+        /// Resolved component/package identity to hand to `dnf install`.
+        target: RpmTarget,
     },
+    /// No ANOLISA component identity could be proven for the input.
+    NotAnolisaComponent,
     /// `provides` reverse-lookup matched several distinct installed packages
     /// (§5.5). Reported, never silently adopted.
-    Ambiguous(Vec<String>),
+    Ambiguous(Vec<RpmTarget>),
     /// The candidate resolved but rpmdb holds several installed versions of it
     /// (`UnexpectedOutput`, §5.5) — a drift state, not a clean adopt target.
-    MultiVersion(String),
+    MultiVersion(RpmTarget),
 }
 
-/// Resolve the candidate RPM package name(s) for `component` and probe rpmdb.
+/// Resolve the candidate RPM component/package pair(s) and probe rpmdb.
 ///
 /// Errors when a query hard-fails. A missing `rpm`/`dnf` binary is a
 /// warn-and-exit ([`rpm_tooling_missing_error`]): the probe cannot prove the
@@ -639,17 +736,18 @@ pub(crate) fn probe_rpm_situation(
     component: &str,
     cli_override: Option<&str>,
     rpm_backend: Option<&BackendConfig>,
-    ctx: &CliContext,
+    component_index: Option<&ComponentIndex>,
+    use_case: ResolutionUse,
     query: &dyn PackageQuery,
     command: &str,
 ) -> Result<RpmSituation, CliError> {
-    let manifest = load_optional_manifest(ctx, component);
-    let candidates = match rpm_package_candidates(
+    let candidates = match rpm_package_candidates_with_index(
         cli_override,
-        manifest.as_ref(),
         rpm_backend,
+        component_index,
         query,
         component,
+        use_case,
     ) {
         Ok(candidates) => candidates,
         // No rpm/dnf on this host: refuse to silently fall back to raw (§7.1).
@@ -659,77 +757,123 @@ pub(crate) fn probe_rpm_situation(
         Err(err) => return Err(pkg_query_err(err, command)),
     };
 
+    if candidates.is_empty() {
+        return Ok(RpmSituation::NotAnolisaComponent);
+    }
     if candidates.len() >= 2 {
         return Ok(RpmSituation::Ambiguous(candidates));
     }
-    // `rpm_package_candidates` always backfills the default name, so exactly
-    // one candidate remains here.
-    let package = candidates
+    // Empty and ambiguous candidate sets were handled above, so exactly one
+    // package remains here.
+    let target = candidates
         .into_iter()
         .next()
-        .unwrap_or_else(|| component.to_string());
+        .unwrap_or_else(|| RpmTarget::new(component, component));
 
-    match query.query_installed(&package) {
-        Ok(Some(info)) => Ok(RpmSituation::Adoptable { package, info }),
-        Ok(None) => Ok(RpmSituation::Absent { package }),
+    match query.query_installed(&target.package) {
+        Ok(Some(info)) => {
+            if rpm_installed_target_allowed(&target, query)
+                .map_err(|err| pkg_query_err(err, command))?
+            {
+                Ok(RpmSituation::Adoptable { target, info })
+            } else {
+                Ok(RpmSituation::NotAnolisaComponent)
+            }
+        }
+        Ok(None) => Ok(RpmSituation::Absent { target }),
         // Same name, several installed versions: a drift the caller reports.
-        Err(PackageQueryError::UnexpectedOutput { .. }) => Ok(RpmSituation::MultiVersion(package)),
+        Err(PackageQueryError::UnexpectedOutput { .. }) => Ok(RpmSituation::MultiVersion(target)),
         // No rpm/dnf on this host: refuse to silently fall back to raw (§7.1).
         Err(PackageQueryError::CommandMissing { .. }) => Err(rpm_tooling_missing_error(command)),
         Err(err) => Err(pkg_query_err(err, command)),
     }
 }
 
-/// Resolve candidate RPM package names for `component`, highest precedence
-/// first (§5): CLI `--package` > manifest `[backends.rpm].package` > repo.toml
-/// `package_map` > RPM `provides` reverse-lookup > the bare component name.
+/// Resolve candidate RPM component/package pairs for `input`.
 ///
-/// The first four levels short-circuit to a single candidate; only the
-/// `provides` level can yield several (the ambiguous case, §5.5). The bare
-/// component name backfills whenever `provides` is empty, so the result is
-/// never empty. The component name matches the RPM spec `Name:` (e.g.
-/// `tokenless`), which carries no `anolisa-` prefix.
+/// Precedence, in order: CLI `--package`, repo-side component index,
+/// repo.toml `package_map`, installed/available
+/// `anolisa-component(<name>)` providers, then the input package's own
+/// `Provides: anolisa-component(<component>)` metadata.
+///
+/// Ordinary RPM packages without ANOLISA metadata return an empty vector:
+/// `install --backend rpm <arg>` installs ANOLISA components, not arbitrary
+/// `dnf install <arg>` targets.
 ///
 /// # Errors
-/// Propagates a hard [`PackageQueryError`] from the `provides` query; an empty
-/// `provides` result is the normal "no contract / no match" branch and falls
-/// through to default naming.
+/// Propagates a hard [`PackageQueryError`] from the package query; empty
+/// query results are the normal "no explicit component identity" branch.
+#[cfg(test)]
 pub(crate) fn rpm_package_candidates(
     cli_override: Option<&str>,
-    manifest: Option<&ComponentManifest>,
     rpm_backend: Option<&BackendConfig>,
     query: &dyn PackageQuery,
-    component: &str,
-) -> Result<Vec<String>, PackageQueryError> {
-    if let Some(name) = cli_override {
-        return Ok(vec![name.to_string()]);
-    }
-    if let Some(name) = manifest.and_then(ComponentManifest::rpm_package) {
-        return Ok(vec![name.to_string()]);
-    }
-    if let Some(mapped) = rpm_backend.and_then(|b| b.package_map.get(component)) {
-        return Ok(vec![mapped.clone()]);
-    }
-    // Virtual-provides contract (`anolisa-component(<name>)`). It does not yet
-    // exist on the packaging side, so this returns empty today and the chain
-    // falls through to default naming — by design, not an error (§5.3).
-    let provides = query.what_provides_installed(&format!("anolisa-component({component})"))?;
-    if !provides.is_empty() {
-        return Ok(provides);
-    }
-    // Default to the bare component name: it matches the published RPM spec
-    // `Name:` (no `anolisa-` prefix) and mirrors the raw backend's default in
-    // `RepoConfig::package_name`.
-    Ok(vec![component.to_string()])
+    input: &str,
+) -> Result<Vec<RpmTarget>, PackageQueryError> {
+    rpm_package_candidates_with_index(
+        cli_override,
+        rpm_backend,
+        None,
+        query,
+        input,
+        ResolutionUse::Install,
+    )
 }
 
-/// Best-effort lookup of a component's manifest from the bundled catalog, for
-/// the `[backends.rpm].package` mapping level. Adopt does not require a local
-/// manifest (§5.1): any failure or miss yields `None` and the package-name
-/// chain falls through to the lower tiers.
-fn load_optional_manifest(ctx: &CliContext, component: &str) -> Option<ComponentManifest> {
-    let catalog = common::load_bundled_catalog(ctx, COMMAND).ok()?;
-    catalog.component(component).cloned()
+pub(crate) fn rpm_package_candidates_with_index(
+    cli_override: Option<&str>,
+    rpm_backend: Option<&BackendConfig>,
+    component_index: Option<&ComponentIndex>,
+    query: &dyn PackageQuery,
+    input: &str,
+    use_case: ResolutionUse,
+) -> Result<Vec<RpmTarget>, PackageQueryError> {
+    let resolver = ComponentResolver::new(component_index, rpm_backend, Some(query));
+    let resolved = resolver.resolve(
+        input,
+        BackendKind::Rpm,
+        use_case,
+        ResolveOptions {
+            package_override: cli_override,
+        },
+    )?;
+    Ok(match resolved {
+        ResolutionSet::None => Vec::new(),
+        ResolutionSet::Unique(target) => vec![RpmTarget::from_resolved(target)],
+        ResolutionSet::Ambiguous(targets) => {
+            targets.into_iter().map(RpmTarget::from_resolved).collect()
+        }
+    })
+}
+
+fn rpm_installed_target_allowed(
+    target: &RpmTarget,
+    query: &dyn PackageQuery,
+) -> Result<bool, PackageQueryError> {
+    if matches!(
+        target.source,
+        ResolutionSource::RepoPackageMap
+            | ResolutionSource::InstalledRpmProvides
+            | ResolutionSource::AvailableRpmProvides
+    ) || target.legacy_adopt
+    {
+        return Ok(true);
+    }
+    let expected = rpm_component_provide(&target.component);
+    Ok(query
+        .provided_capabilities_installed(&target.package)?
+        .iter()
+        .any(|capability| rpm_capability_matches_component(capability, &expected)))
+}
+
+fn rpm_capability_matches_component(capability: &str, expected: &str) -> bool {
+    let capability = capability.trim();
+    if capability == expected {
+        return true;
+    }
+    capability
+        .strip_prefix(expected)
+        .is_some_and(|rest| rest.trim_start().starts_with('='))
 }
 
 /// Layer 2 for the `rpm` backend: reject in user mode, otherwise adopt an
@@ -748,6 +892,7 @@ fn route_rpm_adopt(
     installed: &InstalledState,
     source: BackendSource,
     situation: Option<RpmSituation>,
+    component_index: Option<&ComponentIndex>,
     exec: &RpmExec,
 ) -> Result<InstallOutcome, CliError> {
     common::require_system_mode(
@@ -769,30 +914,63 @@ fn route_rpm_adopt(
             component,
             args.package.as_deref(),
             repo_config.backends.get("rpm"),
-            ctx,
+            component_index,
+            ResolutionUse::Install,
             exec.query,
             command,
         )?,
     };
 
     match situation {
-        RpmSituation::Adoptable { package, info } => {
-            execute_adopt(ctx, layout, command, component, package, info, exec.query)
+        RpmSituation::Adoptable { target, info } => {
+            if source == BackendSource::Explicit {
+                ensure_component_backend_compatible(installed, &target.component, "rpm", command)?;
+            }
+            execute_adopt(
+                ctx,
+                layout,
+                command,
+                &target.component,
+                target.package,
+                info,
+                exec.query,
+            )
         }
-        RpmSituation::Absent { package } => {
-            execute_delegated_install(exec, ctx, layout, command, component, &package)
+        RpmSituation::Absent { target } => {
+            if source == BackendSource::Explicit {
+                ensure_component_backend_compatible(installed, &target.component, "rpm", command)?;
+            }
+            execute_delegated_install(
+                exec,
+                ctx,
+                layout,
+                command,
+                &target.component,
+                &target.package,
+            )
         }
-        RpmSituation::Ambiguous(names) => Err(CliError::InvalidArgument {
+        RpmSituation::NotAnolisaComponent => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
-                "multiple installed RPMs provide component '{component}': {}; cannot adopt unambiguously — pin one with `--package <name>` or fix the manifest/package_map mapping",
-                names.join(", ")
+                "component '{component}' is not an ANOLISA RPM component; use the ANOLISA component name and configure the repo-side component index or publish Provides: anolisa-component({component})"
             ),
         }),
-        RpmSituation::MultiVersion(package) => Err(CliError::InvalidArgument {
+        RpmSituation::Ambiguous(targets) => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
-                "RPM package '{package}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first",
+                "multiple RPM candidates match '{component}': {}; cannot resolve unambiguously — pin one with `--package <name>` or fix the component index / package metadata",
+                targets
+                    .iter()
+                    .map(RpmTarget::label)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }),
+        RpmSituation::MultiVersion(target) => Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "RPM package '{}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first",
+                target.package
             ),
         }),
     }
@@ -5516,6 +5694,10 @@ scope = "@anolisa"
             self.install_succeeds = false;
             self
         }
+
+        fn component_capability(&self) -> String {
+            rpm_component_provide(&self.package)
+        }
     }
 
     impl PackageQuery for FakeInstaller {
@@ -5542,10 +5724,46 @@ scope = "@anolisa"
 
         fn what_provides_installed(
             &self,
-            _capability: &str,
+            capability: &str,
         ) -> Result<Vec<String>, PackageQueryError> {
-            // Default-naming path: the probe falls through to the bare component name.
-            Ok(Vec::new())
+            if capability == self.component_capability() && self.installed.borrow().is_some() {
+                Ok(vec![self.package.clone()])
+            } else {
+                Ok(Vec::new())
+            }
+        }
+
+        fn what_provides_available(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if capability == self.component_capability() {
+                Ok(vec![self.package.clone()])
+            } else {
+                Ok(Vec::new())
+            }
+        }
+
+        fn provided_capabilities_installed(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if package == self.package && self.installed.borrow().is_some() {
+                Ok(vec![self.component_capability()])
+            } else {
+                Ok(Vec::new())
+            }
+        }
+
+        fn provided_capabilities_available(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if package == self.package {
+                Ok(vec![self.component_capability()])
+            } else {
+                Ok(Vec::new())
+            }
         }
     }
 
@@ -5580,6 +5798,9 @@ scope = "@anolisa"
         installed: Vec<(String, PackageInfo)>,
         origins: Vec<(String, String)>,
         provides: Vec<(String, Vec<String>)>,
+        available_provides: Vec<(String, Vec<String>)>,
+        package_provides: Vec<(String, Vec<String>)>,
+        available_package_provides: Vec<(String, Vec<String>)>,
         multi_version: Vec<String>,
         origin_fails: bool,
         /// Simulate a host with no rpm/dnf: every rpmdb-touching query returns
@@ -5643,6 +5864,63 @@ scope = "@anolisa"
                 .map(|(_, names)| names.clone())
                 .unwrap_or_default())
         }
+
+        fn what_provides_available(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if self.command_missing {
+                return Err(PackageQueryError::CommandMissing {
+                    command: "dnf".to_string(),
+                });
+            }
+            Ok(self
+                .available_provides
+                .iter()
+                .find(|(cap, _)| cap == capability)
+                .map(|(_, names)| names.clone())
+                .unwrap_or_default())
+        }
+
+        fn provided_capabilities_installed(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if self.command_missing {
+                return Err(PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                });
+            }
+            Ok(self
+                .package_provides
+                .iter()
+                .find(|(pkg, _)| pkg == package)
+                .map(|(_, capabilities)| capabilities.clone())
+                .or_else(|| {
+                    self.installed
+                        .iter()
+                        .any(|(name, _)| name == package)
+                        .then(|| vec![rpm_component_provide(package)])
+                })
+                .unwrap_or_default())
+        }
+
+        fn provided_capabilities_available(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if self.command_missing {
+                return Err(PackageQueryError::CommandMissing {
+                    command: "dnf".to_string(),
+                });
+            }
+            Ok(self
+                .available_package_provides
+                .iter()
+                .find(|(pkg, _)| pkg == package)
+                .map(|(_, capabilities)| capabilities.clone())
+                .unwrap_or_default())
+        }
     }
 
     fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
@@ -5693,67 +5971,114 @@ scope = "@anolisa"
         .expect("parse repo")
     }
 
+    fn available_component_provider(component: &str, package: &str) -> (String, Vec<String>) {
+        (rpm_component_provide(component), vec![package.to_string()])
+    }
+
+    fn package_component_provide(package: &str, component: &str) -> (String, Vec<String>) {
+        (
+            package.to_string(),
+            vec![
+                format!("{package} = 1.0.0"),
+                rpm_component_provide(component),
+            ],
+        )
+    }
+
+    fn target(component: &str, package: &str) -> RpmTarget {
+        RpmTarget::new(component, package)
+    }
+
     // ── §5 package-name mapping ──
 
     #[test]
-    fn candidates_cli_override_wins() {
-        let q = FakeQuery::default();
-        let got =
-            rpm_package_candidates(Some("explicit-pkg"), None, None, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["explicit-pkg".to_string()]);
-    }
-
-    #[test]
-    fn candidates_manifest_package_wins_over_default() {
-        let manifest = ComponentManifest::from_toml_str(
-            "[component]\nname = \"copilot-shell\"\nversion = \"1.0.0\"\nlayer = \"runtime\"\n\n[backends.rpm]\npackage = \"vendor-copilot\"\n",
-        )
-        .expect("parse manifest");
-        let q = FakeQuery::default();
-        let got = rpm_package_candidates(None, Some(&manifest), None, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["vendor-copilot".to_string()]);
-    }
-
-    #[test]
-    fn candidates_package_map_wins_over_default() {
-        let repo = repo_with_rpm_map(&[("copilot-shell", "site-copilot")]);
+    fn candidates_cli_override_matching_package_map_is_accepted() {
+        let repo = repo_with_rpm_map(&[("cosh", "site-copilot")]);
         let backend = repo.backends.get("rpm");
         let q = FakeQuery::default();
-        let got = rpm_package_candidates(None, None, backend, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["site-copilot".to_string()]);
+        let got = rpm_package_candidates(Some("site-copilot"), backend, &q, "cosh").unwrap();
+        assert_eq!(got, vec![target("cosh", "site-copilot")]);
+    }
+
+    #[test]
+    fn candidates_cli_override_uses_override_package_provides() {
+        let q = FakeQuery {
+            available_provides: vec![available_component_provider("cosh", "explicit-pkg")],
+            ..Default::default()
+        };
+        let got = rpm_package_candidates(Some("explicit-pkg"), None, &q, "cosh").unwrap();
+        assert_eq!(got, vec![target("cosh", "explicit-pkg")]);
+    }
+
+    #[test]
+    fn candidates_cli_override_without_component_identity_returns_empty() {
+        let q = FakeQuery::default();
+        let got = rpm_package_candidates(Some("explicit-pkg"), None, &q, "cosh").unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn candidates_package_map_wins() {
+        let repo = repo_with_rpm_map(&[("cosh", "site-copilot")]);
+        let backend = repo.backends.get("rpm");
+        let q = FakeQuery::default();
+        let got = rpm_package_candidates(None, backend, &q, "cosh").unwrap();
+        assert_eq!(got, vec![target("cosh", "site-copilot")]);
     }
 
     #[test]
     fn candidates_provides_single_match() {
         let q = FakeQuery {
             provides: vec![(
-                "anolisa-component(copilot-shell)".to_string(),
+                "anolisa-component(cosh)".to_string(),
                 vec!["copilot-shell".to_string()],
             )],
             ..Default::default()
         };
-        let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["copilot-shell".to_string()]);
+        let got = rpm_package_candidates(None, None, &q, "cosh").unwrap();
+        assert_eq!(got, vec![target("cosh", "copilot-shell")]);
     }
 
     #[test]
     fn candidates_provides_multiple_is_ambiguous() {
         let q = FakeQuery {
             provides: vec![(
-                "anolisa-component(copilot-shell)".to_string(),
+                "anolisa-component(cosh)".to_string(),
                 vec!["pkg-a".to_string(), "pkg-b".to_string()],
             )],
             ..Default::default()
         };
-        let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["pkg-a".to_string(), "pkg-b".to_string()]);
+        let got = rpm_package_candidates(None, None, &q, "cosh").unwrap();
+        assert_eq!(got, vec![target("cosh", "pkg-a"), target("cosh", "pkg-b")]);
     }
 
     #[test]
-    fn candidates_falls_back_to_default_naming() {
+    fn candidates_package_name_uses_package_own_provides() {
+        let q = FakeQuery {
+            available_package_provides: vec![package_component_provide("copilot-shell", "cosh")],
+            ..Default::default()
+        };
+        let got = rpm_package_candidates(None, None, &q, "copilot-shell").unwrap();
+        assert_eq!(got, vec![target("cosh", "copilot-shell")]);
+    }
+
+    #[test]
+    fn candidates_plain_package_without_metadata_returns_empty() {
         let q = FakeQuery::default();
-        let got = rpm_package_candidates(None, None, None, &q, "copilot-shell").unwrap();
-        assert_eq!(got, vec!["copilot-shell".to_string()]);
+        let got = rpm_package_candidates(None, None, &q, "copilot-shell").unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn rpm_component_capability_accepts_versioned_provides() {
+        assert!(rpm_capability_matches_component(
+            "anolisa-component(cosh) = 1.0.0",
+            "anolisa-component(cosh)"
+        ));
+        assert!(!rpm_capability_matches_component(
+            "anolisa-component(cosh-extra) = 1.0.0",
+            "anolisa-component(cosh)"
+        ));
     }
 
     // ── §5/§7.1 situation probe ──
@@ -5767,20 +6092,22 @@ scope = "@anolisa"
                 "copilot-shell".to_string(),
                 pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
             )],
+            package_provides: vec![package_component_provide("copilot-shell", "copilot-shell")],
             ..Default::default()
         };
         let situation = probe_rpm_situation(
             "copilot-shell",
             None,
             repo.backends.get("rpm"),
-            &ctx,
+            None,
+            ResolutionUse::Install,
             &q,
             "install",
         )
         .expect("probe");
         match situation {
-            RpmSituation::Adoptable { package, info } => {
-                assert_eq!(package, "copilot-shell");
+            RpmSituation::Adoptable { target, info } => {
+                assert_eq!(target.package, "copilot-shell");
                 assert_eq!(info.version.to_string(), "2.3.0-1.al8");
             }
             other => panic!(
@@ -5794,12 +6121,19 @@ scope = "@anolisa"
     fn probe_reports_absent_when_not_installed() {
         let (_tmp, ctx) = system_ctx_with_raw_repo(false);
         let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
-        let q = FakeQuery::default();
+        let q = FakeQuery {
+            available_provides: vec![available_component_provider(
+                "copilot-shell",
+                "copilot-shell",
+            )],
+            ..Default::default()
+        };
         let situation = probe_rpm_situation(
             "copilot-shell",
             None,
             repo.backends.get("rpm"),
-            &ctx,
+            None,
+            ResolutionUse::Install,
             &q,
             "install",
         )
@@ -5822,7 +6156,8 @@ scope = "@anolisa"
             "copilot-shell",
             None,
             repo.backends.get("rpm"),
-            &ctx,
+            None,
+            ResolutionUse::Install,
             &q,
             "install",
         )
@@ -5832,8 +6167,8 @@ scope = "@anolisa"
 
     #[test]
     fn probe_reports_multi_version_drift() {
-        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
-        let repo = RepoConfig::load(&common::resolve_layout(&ctx)).expect("repo");
+        let (_tmp, _ctx) = system_ctx_with_raw_repo(false);
+        let repo = repo_with_rpm_map(&[("copilot-shell", "copilot-shell")]);
         let q = FakeQuery {
             multi_version: vec!["copilot-shell".to_string()],
             ..Default::default()
@@ -5842,7 +6177,8 @@ scope = "@anolisa"
             "copilot-shell",
             None,
             repo.backends.get("rpm"),
-            &ctx,
+            None,
+            ResolutionUse::Install,
             &q,
             "install",
         )
@@ -5854,6 +6190,7 @@ scope = "@anolisa"
         match s {
             RpmSituation::Adoptable { .. } => "Adoptable",
             RpmSituation::Absent { .. } => "Absent",
+            RpmSituation::NotAnolisaComponent => "NotAnolisaComponent",
             RpmSituation::Ambiguous(_) => "Ambiguous",
             RpmSituation::MultiVersion(_) => "MultiVersion",
         }
@@ -6498,6 +6835,7 @@ scope = "@anolisa"
             &repo,
             &installed,
             BackendSource::Explicit,
+            None,
             None,
             &exec,
         )

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/mvp_lifecycle.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/mvp_lifecycle.rs
@@ -100,8 +100,22 @@ impl PackageQuery for RpmWorld {
     fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
         Ok((package == self.package).then(|| self.origin.clone()))
     }
-    fn what_provides_installed(&self, _capability: &str) -> Result<Vec<String>, PackageQueryError> {
-        Ok(Vec::new())
+    fn what_provides_installed(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        if capability.starts_with("anolisa-component(") && self.installed.borrow().is_some() {
+            Ok(vec![self.package.clone()])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+    fn provided_capabilities_installed(
+        &self,
+        package: &str,
+    ) -> Result<Vec<String>, PackageQueryError> {
+        if package == self.package && self.installed.borrow().is_some() {
+            Ok(vec!["anolisa-component(cosh)".to_string()])
+        } else {
+            Ok(Vec::new())
+        }
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -17,15 +17,16 @@ use serde::Serialize;
 
 use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
 use anolisa_core::lock::InstallLock;
-use anolisa_core::state::{ObjectKind, OperationRecord, Ownership, RpmMetadata};
+use anolisa_core::state::{InstalledState, ObjectKind, OperationRecord, Ownership, RpmMetadata};
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::Palette;
 use crate::commands::common;
-use crate::commands::tier1::install::rpm_package_candidates;
+use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::CliContext;
 use crate::repo_config::RepoConfig;
+use crate::resolution::{ResolutionUse, load_optional_component_index, resolve_rpm_component_name};
 use crate::response::{CliError, render_json};
 
 /// Command label for JSON envelopes and error routing.
@@ -96,8 +97,10 @@ fn repair_with_query(
 
     let installed = common::load_installed_state(ctx, COMMAND)?;
 
+    let component = resolve_repair_component_name(target, &installed, ctx, query);
+
     let obj = installed
-        .find_object(ObjectKind::Component, target)
+        .find_object(ObjectKind::Component, &component)
         .ok_or_else(|| CliError::InvalidArgument {
             command: command.clone(),
             reason: format!(
@@ -119,7 +122,8 @@ fn repair_with_query(
     // identity to confirm; when absent (a legacy row with no rpm_metadata), fall
     // back to the adopt candidate chain so repair can backfill the metadata the
     // update path refuses to run without.
-    let package = resolve_repair_package(target, obj.rpm_metadata.as_ref(), ctx, query, &command)?;
+    let package =
+        resolve_repair_package(&component, obj.rpm_metadata.as_ref(), ctx, query, &command)?;
     let recorded_evr = obj.rpm_metadata.as_ref().and_then(|m| m.evr.clone());
     let ownership_label = ownership.label();
 
@@ -132,7 +136,7 @@ fn repair_with_query(
             return Err(CliError::Runtime {
                 command,
                 reason: format!(
-                    "RPM package '{package}' for component '{target}' is recorded in ANOLISA state but is not present in rpmdb — it may have been removed with `rpm -e`; run `anolisa forget {target}` to drop the stale state, or reinstall"
+                    "RPM package '{package}' for component '{component}' is recorded in ANOLISA state but is not present in rpmdb — it may have been removed with `rpm -e`; run `anolisa forget {component}` to drop the stale state, or reinstall"
                 ),
             });
         }
@@ -172,7 +176,7 @@ fn repair_with_query(
 
     if ctx.dry_run {
         let payload = RepairPayload {
-            component: target.to_string(),
+            component,
             package,
             backend: "rpm",
             ownership: ownership_label,
@@ -191,7 +195,7 @@ fn repair_with_query(
 
     let operation_id = persist_repair(
         ctx,
-        target,
+        &component,
         &package,
         ownership,
         &info,
@@ -202,7 +206,7 @@ fn repair_with_query(
     )?;
 
     let payload = RepairPayload {
-        component: target.to_string(),
+        component,
         package,
         backend: "rpm",
         ownership: ownership_label,
@@ -219,12 +223,49 @@ fn repair_with_query(
     Ok(())
 }
 
+/// Resolve a repair target to the state key used for the component.
+///
+/// Exact state names win because repair is fundamentally a state reconciliation
+/// command. If the state has no exact match, fall back to the same RPM component
+/// resolver used by install/adopt/status so package-name aliases such as
+/// `copilot-shell` can address the canonical `cosh` row.
+fn resolve_repair_component_name(
+    target: &str,
+    installed: &InstalledState,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+) -> String {
+    if installed
+        .find_object(ObjectKind::Component, target)
+        .is_some()
+    {
+        return target.to_string();
+    }
+
+    let layout = common::resolve_layout(ctx);
+    let repo_config = RepoConfig::load(&layout).ok();
+    let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
+    let env = anolisa_env::EnvService::detect();
+    let component_index = repo_config
+        .as_ref()
+        .and_then(|cfg| load_optional_component_index(&layout, &env, cfg));
+
+    resolve_rpm_component_name(
+        target,
+        rpm_backend,
+        component_index.as_ref(),
+        query,
+        ResolutionUse::RepairLegacy,
+    )
+    .unwrap_or_else(|| target.to_string())
+}
+
 /// Resolve the RPM package name `repair` should reconcile against.
 ///
 /// A recorded, non-empty package name is the identity to confirm. When it is
 /// absent — a legacy row written before `rpm_metadata` existed — fall back to
-/// the adopt candidate chain ([`rpm_package_candidates`]) so repair can backfill
-/// the metadata that `update` refuses to run without.
+/// the shared component resolver so repair can backfill the metadata that
+/// `update` refuses to run without.
 fn resolve_repair_package(
     component: &str,
     meta: Option<&RpmMetadata>,
@@ -239,38 +280,49 @@ fn resolve_repair_package(
         return Ok(name.to_string());
     }
 
-    // Legacy row with no recorded package name: resolve via the same candidate
-    // chain adopt uses. repo.toml / catalog are best-effort inputs (mirrors
-    // status::observed_record): a load failure just drops that precedence tier.
+    // Legacy row with no recorded package name: resolve via the same component
+    // identity resolver adopt uses. repo.toml / components.toml are best-effort
+    // inputs (mirrors status::observed_record): a load failure just drops that
+    // precedence tier.
     let layout = common::resolve_layout(ctx);
     let repo_config = RepoConfig::load(&layout).ok();
     let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
-    let manifest = common::load_bundled_catalog(ctx, COMMAND)
-        .ok()
-        .and_then(|cat| cat.component(component).cloned());
+    let env = anolisa_env::EnvService::detect();
+    let component_index = repo_config
+        .as_ref()
+        .and_then(|cfg| load_optional_component_index(&layout, &env, cfg));
 
-    let candidates =
-        match rpm_package_candidates(None, manifest.as_ref(), rpm_backend, query, component) {
-            Ok(candidates) => candidates,
-            Err(PackageQueryError::CommandMissing { .. }) => {
-                return Err(rpm_tooling_missing_error(command));
-            }
-            Err(err) => return Err(rpm_query_err(err, command)),
-        };
+    let candidates = match rpm_package_candidates_with_index(
+        None,
+        rpm_backend,
+        component_index.as_ref(),
+        query,
+        component,
+        ResolutionUse::RepairLegacy,
+    ) {
+        Ok(candidates) => candidates,
+        Err(PackageQueryError::CommandMissing { .. }) => {
+            return Err(rpm_tooling_missing_error(command));
+        }
+        Err(err) => return Err(rpm_query_err(err, command)),
+    };
     if candidates.len() >= 2 {
         return Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
-                "multiple candidate RPMs for component '{component}': {}; cannot repair unambiguously — reinstall to pin one, or fix the manifest/package_map mapping",
-                candidates.join(", ")
+                "multiple candidate RPMs for component '{component}': {}; cannot repair unambiguously — reinstall to pin one, or fix the component index / package metadata",
+                candidates
+                    .iter()
+                    .map(|target| target.package.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
         });
     }
-    // `rpm_package_candidates` always backfills the default name, so this is the
-    // single-candidate case.
     candidates
         .into_iter()
         .next()
+        .map(|target| target.package)
         .ok_or_else(|| CliError::Runtime {
             command: command.to_string(),
             reason: format!("could not resolve an RPM package name for component '{component}'"),
@@ -514,7 +566,7 @@ mod tests {
     use super::*;
     use crate::context::InstallMode;
 
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
 
     use anolisa_core::state::{
         InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
@@ -583,6 +635,16 @@ mod tests {
                 Ok(None)
             }
         }
+        fn provided_capabilities_installed(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if package == self.package && self.installed.is_some() {
+                Ok(vec![format!("anolisa-component({package})")])
+            } else {
+                Ok(Vec::new())
+            }
+        }
     }
 
     fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
@@ -608,6 +670,26 @@ mod tests {
             quiet: true,
             no_color: true,
         }
+    }
+
+    fn seed_component_index(ctx: &CliContext, index: &str) {
+        let layout = common::resolve_layout(ctx);
+        let repo_v1 = layout.prefix.join("repo").join("v1");
+        fs::create_dir_all(&repo_v1).expect("mkdir repo");
+        fs::write(repo_v1.join("components.toml"), index).expect("write components.toml");
+        fs::create_dir_all(&layout.etc_dir).expect("mkdir etc");
+        fs::write(
+            layout.etc_dir.join("repo.toml"),
+            format!(
+                "schema_version = 1\n\
+                 default_backend = \"raw\"\n\
+                 \n\
+                 [backends.raw]\n\
+                 base_url = \"file://{}\"\n",
+                repo_v1.display()
+            ),
+        )
+        .expect("write repo.toml");
     }
 
     /// An RPM-backed component object (observed or managed).
@@ -738,6 +820,66 @@ mod tests {
         assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
         assert_eq!(meta.source_repo.as_deref(), Some("alinux-updates"));
         assert_ne!(obj.last_operation_id.as_deref(), Some("op-prior"));
+    }
+
+    #[test]
+    fn repair_resolves_package_alias_to_canonical_state_component() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed_component_index(
+            &c,
+            r#"
+schema_version = 1
+
+[[components]]
+name = "cosh"
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+legacy_adopt = true
+
+[[components.aliases]]
+kind = "rpm-package"
+name = "copilot-shell"
+"#,
+        );
+        seed(
+            &c,
+            rpm_object(
+                "cosh",
+                "copilot-shell",
+                "2.2.0-1.al8",
+                Ownership::RpmObserved,
+                ObjectStatus::Adopted,
+            ),
+        );
+        let rpm = FakeQuery::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
+        )
+        .with_origin("alinux-updates");
+
+        repair_with_query("copilot-shell", &c, &rpm).expect("repair via package alias");
+
+        let state = load_state(&c);
+        let obj = state
+            .find_object(ObjectKind::Component, "cosh")
+            .cloned()
+            .expect("canonical component repaired");
+        assert_eq!(obj.version, "2.3.0-1.al8");
+        assert_eq!(
+            obj.rpm_metadata
+                .as_ref()
+                .map(|meta| meta.package_name.as_str()),
+            Some("copilot-shell")
+        );
+        assert!(
+            state
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "repair must refresh the canonical state row, not create a package-name row"
+        );
     }
 
     /// The "keeping ownership / does not switch backend" criterion holds for the
@@ -994,8 +1136,8 @@ mod tests {
         );
         obj.rpm_metadata = None;
         seed(&c, obj);
-        // No recorded package_name, so the candidate chain falls through to the
-        // bare component name `<component>`.
+        // No recorded package_name, so the shared resolver recovers it from the
+        // installed package's ANOLISA provides metadata.
         let rpm = FakeQuery::new(
             "legacy-rpm",
             Some(pkg_info("legacy-rpm", "1.0.0", Some("1.al8"), "x86_64")),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -6,10 +6,10 @@
 //! an empty result; an unknown component name surfaces a synthetic
 //! `not_installed` record rather than an error (launch spec §7.1).
 //!
-//! This handler does NOT consult the resolver — it reports state-on-disk
-//! plus live read-only probes. Every persisted field in [`ComponentRecord`]
-//! is projected straight from [`InstalledObject`]; the only synthesized data
-//! are the integrity and manifest health entries layered on top.
+//! This handler reports state-on-disk plus live read-only probes. Every
+//! persisted field in [`ComponentRecord`] is projected straight from
+//! [`InstalledObject`]; synthesized data is limited to read-only rpmdb,
+//! integrity, adapter, and manifest health observations.
 
 use chrono::{SecondsFormat, Utc};
 use clap::Parser;
@@ -22,9 +22,8 @@ use anolisa_core::adapter::claim::ClaimStatus;
 use anolisa_core::adapter::manager::ScanEntry;
 use anolisa_core::path_safety::{PathBoundaryError, validate_owned_path};
 use anolisa_core::{
-    Catalog, ComponentManifest, HealthEntry, HealthSpec, InstalledObject, InstalledState,
-    IntegrityStatus, ObjectKind, RpmMetadata, ServiceState, check_owned_file,
-    service_for_install_mode as service_factory,
+    Catalog, HealthEntry, HealthSpec, InstalledObject, InstalledState, IntegrityStatus, ObjectKind,
+    RpmMetadata, ServiceState, check_owned_file, service_for_install_mode as service_factory,
 };
 
 /// Wall-clock ceiling for a single manifest command-kind probe. `status`
@@ -53,9 +52,12 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::{Palette, pad_right};
 use crate::commands::common;
-use crate::commands::tier1::install::rpm_package_candidates;
+use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::{CliContext, InstallMode};
 use crate::repo_config::{BackendConfig, RepoConfig};
+use crate::resolution::{
+    ComponentIndex, ResolutionUse, load_optional_component_index, resolve_rpm_component_name,
+};
 use crate::response::{CliError, render_json};
 
 const COMMAND: &str = "status";
@@ -134,12 +136,29 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     let adapter_scan = common::build_adapter_manager(ctx).scan().ok();
 
+    let query = RpmPackageQuery::system();
+    let repo_config = (ctx.install_mode == InstallMode::System && args.component.is_some())
+        .then(|| RepoConfig::load(&layout).ok())
+        .flatten();
+    let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
+    let env = EnvService::detect();
+    let component_index = repo_config
+        .as_ref()
+        .and_then(|cfg| load_optional_component_index(&layout, &env, cfg));
+    let selected_component = args.component.as_deref().map(|target| {
+        if ctx.install_mode == InstallMode::System {
+            status_lookup_name(target, rpm_backend, component_index.as_ref(), &query)
+        } else {
+            target.to_string()
+        }
+    });
+
     let mut records = select_components(
         &state,
         &layout,
         catalog.as_ref(),
         install_mode,
-        args.component.as_deref(),
+        selected_component.as_deref(),
         adapter_scan.as_ref().map(|r| r.entries.as_slice()),
     );
 
@@ -147,16 +166,14 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     // ANOLISA state but present in rpmdb (system mode), upgrade the synthetic
     // `not_installed` row to `observed` with the package/EVR/repo. This never
     // writes state — adopting is `install`'s job.
-    if let Some(target) = args.component.as_deref()
+    if let Some(target) = selected_component.as_deref()
         && ctx.install_mode == InstallMode::System
         && records.len() == 1
         && records[0].status == "not_installed"
     {
-        let repo_config = RepoConfig::load(&layout).ok();
-        let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
-        let manifest = catalog.as_ref().and_then(|c| c.component(target).cloned());
-        let query = RpmPackageQuery::system();
-        if let Some(observed) = observed_record(target, rpm_backend, manifest.as_ref(), &query) {
+        if let Some(observed) =
+            observed_record(target, rpm_backend, component_index.as_ref(), &query)
+        {
             records = vec![observed];
         }
     }
@@ -165,8 +182,7 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     // and override the wire status with `drifted` / `missing` on divergence.
     // Like the observed report above this stays strictly read-only — it adjusts
     // only the wire records, never `installed.toml`.
-    let drift_query = RpmPackageQuery::system();
-    apply_rpm_drift(&mut records, &state, &drift_query);
+    apply_rpm_drift(&mut records, &state, &query);
 
     if ctx.json {
         let data = serde_json::json!({ "components": records });
@@ -177,6 +193,26 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
         render_human(&records, ctx.verbose, ctx.no_color);
     }
     Ok(())
+}
+
+/// Resolve a user-supplied status target to the stable component name before
+/// looking in ANOLISA state. RPM package aliases such as `copilot-shell` should
+/// display the tracked `cosh` row when one exists, not synthesize a separate
+/// read-only observed row.
+fn status_lookup_name(
+    input: &str,
+    rpm_backend: Option<&BackendConfig>,
+    component_index: Option<&ComponentIndex>,
+    query: &dyn PackageQuery,
+) -> String {
+    resolve_rpm_component_name(
+        input,
+        rpm_backend,
+        component_index,
+        query,
+        ResolutionUse::StatusObserved,
+    )
+    .unwrap_or_else(|| input.to_string())
 }
 
 /// Pure selector: project [`InstalledState`] down to component records,
@@ -239,22 +275,30 @@ pub(crate) fn select_components(
 fn observed_record(
     component: &str,
     rpm_backend: Option<&BackendConfig>,
-    manifest: Option<&ComponentManifest>,
+    component_index: Option<&ComponentIndex>,
     query: &dyn PackageQuery,
 ) -> Option<ComponentRecord> {
-    // Same candidate chain as adopt (§5), minus the CLI `--package` override
-    // (status takes no such flag).
-    let candidates = rpm_package_candidates(None, manifest, rpm_backend, query, component).ok()?;
-    for package in candidates {
-        let Ok(Some(info)) = query.query_installed(&package) else {
+    // Same resolver as adopt (§5), minus the CLI `--package` override (status
+    // takes no such flag).
+    let candidates = rpm_package_candidates_with_index(
+        None,
+        rpm_backend,
+        component_index,
+        query,
+        component,
+        ResolutionUse::StatusObserved,
+    )
+    .ok()?;
+    for target in candidates {
+        let Ok(Some(info)) = query.query_installed(&target.package) else {
             // Not this candidate (absent), or a hard error / multi-version
             // drift: status does not adjudicate drift, so move on.
             continue;
         };
         let evr = info.version.to_string();
-        let source_repo = query.installed_origin(&package).ok().flatten();
+        let source_repo = query.installed_origin(&target.package).ok().flatten();
         return Some(ComponentRecord {
-            name: component.to_string(),
+            name: target.component,
             status: "observed".to_string(),
             version: Some(evr.clone()),
             installed_at: None,
@@ -2451,6 +2495,16 @@ mod tests {
                 .find(|(n, _)| n == package)
                 .map(|(_, r)| r.clone()))
         }
+        fn provided_capabilities_installed(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            if self.installed.iter().any(|(n, _)| n == package) {
+                Ok(vec![format!("anolisa-component({package})")])
+            } else {
+                Ok(Vec::new())
+            }
+        }
     }
 
     fn pkg_info(name: &str, version: &str, release: &str) -> PackageInfo {
@@ -2464,6 +2518,53 @@ mod tests {
             arch: "x86_64".to_string(),
             origin: None,
         }
+    }
+
+    #[test]
+    fn status_lookup_name_uses_component_index_alias_before_state_selection() {
+        let idx = ComponentIndex::from_toml_str(
+            r#"
+schema_version = 1
+
+[[components]]
+name = "cosh"
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+legacy_adopt = true
+
+[[components.aliases]]
+kind = "rpm-package"
+name = "copilot-shell"
+"#,
+            "components.toml",
+        )
+        .expect("component index");
+        let q = FakeQuery::default();
+
+        assert_eq!(
+            status_lookup_name("copilot-shell", None, Some(&idx), &q),
+            "cosh"
+        );
+
+        let mut state = InstalledState::default();
+        state.upsert_object(component_object(
+            "cosh",
+            "2.6.0-1.alnx4",
+            ObjectStatus::Installed,
+        ));
+        let records = select_components(
+            &state,
+            &dummy_layout(),
+            None,
+            "system",
+            Some(&status_lookup_name("copilot-shell", None, Some(&idx), &q)),
+            None,
+        );
+
+        assert_eq!(records[0].name, "cosh");
+        assert_eq!(records[0].status, "installed");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/main.rs
+++ b/src/anolisa/crates/anolisa-cli/src/main.rs
@@ -3,6 +3,7 @@ mod commands;
 mod context;
 mod packaged;
 mod repo_config;
+mod resolution;
 mod response;
 
 use std::process::ExitCode;

--- a/src/anolisa/crates/anolisa-cli/src/packaged.rs
+++ b/src/anolisa/crates/anolisa-cli/src/packaged.rs
@@ -41,9 +41,8 @@ pub const DATA_DIR_ENV: &str = "ANOLISA_DATA_DIR";
 ///
 /// Returns `None` when none of the three lookup steps point at an
 /// existing directory. Callers must fall back to whatever non-packaged
-/// source they care about (dev-tree manifests / embedded execution
-/// policy) — this helper deliberately does NOT consult those because
-/// it lives in a separate concern.
+/// source they care about, such as dev-tree manifests. This helper
+/// deliberately does NOT consult those because it lives in a separate concern.
 pub fn packaged_datadir_root(layout: &FsLayout) -> Option<PathBuf> {
     if let Some(env_dir) = std::env::var_os(DATA_DIR_ENV) {
         let candidate = PathBuf::from(env_dir);

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -37,9 +37,6 @@
 //!   2. **Packaged** — `<datadir>/templates/repo.toml`.
 //!   3. **Dev-tree** — `<workspace>/templates/repo.toml` via
 //!      `CARGO_MANIFEST_DIR` (what `cargo run` / `cargo test` see).
-//!   4. **Embedded** — the same template baked in with `include_str!`,
-//!      so a standalone binary always boots with the bundled default
-//!      (raw backend → public OSS mirror).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -53,9 +50,6 @@ use crate::packaged;
 const REPO_FILE: &str = "repo.toml";
 /// Subdirectory under `datadir` for the packaged copy.
 const REPO_SUBDIR: &str = "templates";
-
-/// Bundled baseline baked into the binary; final discovery fallback.
-const EMBEDDED_REPO_CONFIG: &str = include_str!("../../../templates/repo.toml");
 
 /// Wire-format schema version of `repo.toml`.
 pub const REPO_CONFIG_SCHEMA_VERSION: u32 = 1;
@@ -88,9 +82,8 @@ const LEGACY_RPM_BACKEND_NAME_WARNING: &str =
 /// Errors surfaced while loading, parsing, or resolving `repo.toml`.
 #[derive(Debug, thiserror::Error)]
 pub enum RepoConfigError {
-    /// No config found in any discovery location and no embedded copy —
-    /// reachable only in synthetic tests that disable every source.
-    #[error("repo config not found (searched etc dir, packaged datadir, dev-tree, embedded copy)")]
+    /// No config found in any discovery location.
+    #[error("repo config not found (searched etc dir, packaged datadir, dev-tree)")]
     NotFound,
 
     /// Disk read failed (e.g. permission denied).
@@ -219,9 +212,12 @@ pub struct BackendConfig {
     #[serde(default)]
     #[allow(dead_code)]
     pub offline_fallback: Option<bool>,
-    /// Site-local component → package-name deviations. The normal
-    /// mapping belongs in the component manifest; this only covers
-    /// renamed mirrors, experimental builds, etc.
+    /// Site-local component -> package-name fallback.
+    ///
+    /// Normal repository mappings belong in the repo-side component index and
+    /// take precedence during component resolution. This map is for
+    /// deployments that need local names before, or outside, the published
+    /// index contract.
     #[serde(default)]
     pub package_map: BTreeMap<String, String>,
 }
@@ -252,11 +248,6 @@ impl RepoConfig {
                 config.emit_deprecation_warnings(path);
                 return Ok(config);
             }
-        }
-        if let Some(embedded) = sources.embedded {
-            let config = Self::parse_with_path(embedded, Path::new("<embedded>"))?;
-            config.emit_deprecation_warnings(Path::new("<embedded>"));
-            return Ok(config);
         }
         Err(RepoConfigError::NotFound)
     }
@@ -549,6 +540,15 @@ pub fn raw_index_url(base_url: &str) -> String {
     format!("{}/index.toml", raw_root(base_url))
 }
 
+/// Component identity index location under the raw repository root.
+///
+/// `components.toml` is separate from raw `index.toml`: the former resolves a
+/// stable ANOLISA component identity to backend-native package names, while the
+/// latter selects raw artifact versions and hashes.
+pub fn component_index_url(base_url: &str) -> String {
+    format!("{}/components.toml", raw_root(base_url))
+}
+
 /// Root that repo-relative index-row `url`s join onto. Same prefix the
 /// index itself lives under, so a mirrored tree stays self-contained.
 pub fn raw_relative_root(base_url: &str) -> String {
@@ -622,8 +622,6 @@ pub(crate) struct RepoConfigSources {
     pub packaged: Option<PathBuf>,
     /// Dev-tree copy resolved from `CARGO_MANIFEST_DIR`.
     pub dev_tree: Option<PathBuf>,
-    /// Embedded TOML body; `None` only in synthetic tests.
-    pub embedded: Option<&'static str>,
 }
 
 impl RepoConfigSources {
@@ -640,7 +638,6 @@ impl RepoConfigSources {
                     .join(REPO_SUBDIR)
                     .join(REPO_FILE),
             ),
-            embedded: Some(EMBEDDED_REPO_CONFIG),
         }
     }
 }
@@ -656,11 +653,14 @@ mod tests {
         }
     }
 
-    /// The bundled template must parse, default to raw, and resolve a
-    /// clean base_url — this is the boot contract of every shipped binary.
+    /// The packaged template must parse, default to raw, and resolve a
+    /// clean base_url.
     #[test]
-    fn bundled_template_parses_and_defaults_to_raw() {
-        let cfg = RepoConfig::from_toml_str(EMBEDDED_REPO_CONFIG).expect("bundled template");
+    fn packaged_template_parses_and_defaults_to_raw() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo_path = manifest_dir.join("../../templates/repo.toml");
+        let content = std::fs::read_to_string(&repo_path).expect("read packaged template");
+        let cfg = RepoConfig::from_toml_str(&content).expect("packaged template");
         assert_eq!(cfg.schema_version, REPO_CONFIG_SCHEMA_VERSION);
         assert_eq!(cfg.default_backend, "raw");
         let (name, backend) = cfg.select_backend(None).expect("default backend");
@@ -673,22 +673,30 @@ mod tests {
     }
 
     #[test]
-    fn embedded_fallback_loads_when_disk_sources_missing() {
+    fn repository_manifest_parses() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo_path = manifest_dir.join("../../manifests/repo.toml");
+        let content = std::fs::read_to_string(&repo_path).expect("read repo manifest");
+        let cfg = RepoConfig::from_toml_str(&content).expect("repo manifest");
+        cfg.select_backend(Some("rpm")).expect("rpm backend");
+    }
+
+    #[test]
+    fn missing_disk_sources_returns_not_found() {
         let tmp = tempfile::tempdir().expect("tmp");
         let sources = RepoConfigSources {
             etc: Some(tmp.path().join("nope.toml")),
             packaged: Some(tmp.path().join("nope2.toml")),
             dev_tree: Some(tmp.path().join("nope3.toml")),
-            embedded: Some(EMBEDDED_REPO_CONFIG),
         };
-        let cfg = RepoConfig::load_with_sources(sources).expect("embedded fallback");
-        assert_eq!(cfg.default_backend, "raw");
+        let err = RepoConfig::load_with_sources(sources).expect_err("no fallback");
+        assert!(matches!(err, RepoConfigError::NotFound));
     }
 
     /// Etc-dir config wins over every other source — that is the
     /// user-editable override point.
     #[test]
-    fn etc_config_wins_over_embedded() {
+    fn etc_config_wins_over_other_disk_sources() {
         let tmp = tempfile::tempdir().expect("tmp");
         let path = tmp.path().join("repo.toml");
         std::fs::write(
@@ -704,7 +712,6 @@ base_url = "file:///srv/local-repo"
             etc: Some(path),
             packaged: None,
             dev_tree: None,
-            embedded: Some(EMBEDDED_REPO_CONFIG),
         };
         let cfg = RepoConfig::load_with_sources(sources).expect("load");
         assert_eq!(cfg.backends["raw"].base_url, "file:///srv/local-repo");
@@ -933,6 +940,14 @@ base_url = "https://example.com/$typo_var/repo"
         assert_eq!(
             url,
             "https://mirror.example.com/anolisa-releases/anolisa/v1/tokenless/0.5.0/linux/x86_64/tokenless-0.5.0-linux-x86_64.tar.gz"
+        );
+    }
+
+    #[test]
+    fn component_index_url_uses_raw_repository_root() {
+        assert_eq!(
+            component_index_url("file:///srv/repo"),
+            "file:///srv/repo/v1/components.toml"
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -1,0 +1,1073 @@
+//! Component identity resolution across install backends.
+//!
+//! This module owns the mapping from user input to two identities: the stable
+//! ANOLISA component name and the selected backend's native package name.
+//! Command handlers should consume this resolved pair instead of duplicating
+//! backend-specific candidate chains.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anolisa_core::download::DownloadCache;
+use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::repo_config::{BackendConfig, HostVars, RepoConfig, component_index_url};
+
+/// On-disk schema version for repo-side `components.toml`.
+pub(crate) const COMPONENT_INDEX_SCHEMA_VERSION: u32 = 1;
+
+/// Repository-side component identity and backend mapping index.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub(crate) struct ComponentIndex {
+    /// Wire schema version; loaders reject versions they do not understand.
+    pub(crate) schema_version: u32,
+    /// Optional publish timestamp for diagnostics.
+    ///
+    /// This is not required in v1 indexes, so absent fields deserialize as
+    /// `None` to keep hand-authored indexes small.
+    #[serde(default)]
+    pub(crate) generated_at: Option<String>,
+    /// Optional publishing party for diagnostics.
+    ///
+    /// This is informational metadata, not part of resolution.
+    #[serde(default)]
+    pub(crate) publisher: Option<String>,
+    /// Component rows.
+    ///
+    /// Empty indexes are valid so repositories can publish the file before
+    /// every backend mapping has been populated.
+    #[serde(default)]
+    pub(crate) components: Vec<ComponentIndexEntry>,
+}
+
+/// One ANOLISA component and its backend-native identities.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub(crate) struct ComponentIndexEntry {
+    /// Stable ANOLISA component name.
+    pub(crate) name: String,
+    /// Optional human label; not used by resolution v1.
+    #[serde(default)]
+    pub(crate) display_name: Option<String>,
+    /// Optional one-line summary; not used by resolution v1.
+    #[serde(default)]
+    pub(crate) summary: Option<String>,
+    /// Backend-native package names for this component.
+    ///
+    /// Components may initially ship on only one backend, so the list defaults
+    /// to empty rather than forcing placeholder rows.
+    #[serde(default)]
+    pub(crate) backends: Vec<ComponentBackendEntry>,
+    /// Alternate user inputs that should resolve to this component.
+    ///
+    /// Alias rows are optional and mainly cover historical RPM package names.
+    #[serde(default)]
+    pub(crate) aliases: Vec<ComponentAliasEntry>,
+}
+
+/// Backend-native identity for a component.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub(crate) struct ComponentBackendEntry {
+    /// Backend kind such as `raw` or `rpm`.
+    pub(crate) kind: String,
+    /// Backend-native package/artifact name.
+    pub(crate) package: String,
+    /// Expected RPM Provides capability, when this backend is `rpm`.
+    ///
+    /// This lets repo publishers document the intended package metadata while
+    /// still allowing historical rows to exist before RPM specs are updated.
+    #[serde(default)]
+    pub(crate) provides: Option<String>,
+    /// Whether repo metadata may identify a historical installed RPM that lacks
+    /// the newer installed `Provides: anolisa-component(...)` declaration.
+    ///
+    /// Defaulting to false keeps new package mappings strict unless the repo
+    /// publisher explicitly marks them as legacy-adoptable.
+    #[serde(default)]
+    pub(crate) legacy_adopt: bool,
+}
+
+/// Alternate input name for a component.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub(crate) struct ComponentAliasEntry {
+    /// Alias kind, e.g. `rpm-package`.
+    pub(crate) kind: String,
+    /// Alias value.
+    pub(crate) name: String,
+}
+
+/// Parse or validation failures for `components.toml`.
+#[derive(Debug, Error)]
+pub(crate) enum ComponentIndexError {
+    /// TOML parse or read error.
+    #[error("failed to parse component index at {path}: {reason}")]
+    Parse { path: String, reason: String },
+    /// Unsupported schema version.
+    #[error("unsupported component index schema_version {actual} (expected {expected})")]
+    UnsupportedSchema { actual: u32, expected: u32 },
+    /// Invalid component row.
+    #[error("invalid component index entry: {reason}")]
+    Invalid { reason: String },
+}
+
+/// Backend selected for identity resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackendKind {
+    /// Raw artifact backend.
+    Raw,
+    /// RPM package backend.
+    Rpm,
+    /// Any other configured backend.
+    Other,
+}
+
+impl BackendKind {
+    pub(crate) fn from_name(name: &str) -> Self {
+        match name {
+            "raw" => Self::Raw,
+            "rpm" => Self::Rpm,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Command context for a resolution request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolutionUse {
+    /// `install` may install or adopt.
+    Install,
+    /// `adopt` only records an already-installed RPM.
+    Adopt,
+    /// `status` observes without writing state.
+    StatusObserved,
+    /// `repair` only migrates existing legacy RPM state rows.
+    RepairLegacy,
+}
+
+/// Source that produced a resolved component/package pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolutionSource {
+    /// Repository `components.toml`.
+    ComponentIndex,
+    /// Site-local `[backends.rpm.package_map]`.
+    RepoPackageMap,
+    /// RPM metadata declares or provides `anolisa-component(...)` on host.
+    InstalledRpmProvides,
+    /// RPM repository metadata declares or provides `anolisa-component(...)`.
+    AvailableRpmProvides,
+    /// Raw distribution index fallback.
+    RawDistributionIndex,
+}
+
+/// Final identity pair used by command handlers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedTarget {
+    pub(crate) component: String,
+    pub(crate) backend: BackendKind,
+    pub(crate) package: String,
+    pub(crate) source: ResolutionSource,
+    pub(crate) legacy_adopt: bool,
+}
+
+impl ResolvedTarget {
+    fn new(
+        component: impl Into<String>,
+        backend: BackendKind,
+        package: impl Into<String>,
+        source: ResolutionSource,
+        legacy_adopt: bool,
+    ) -> Self {
+        Self {
+            component: component.into(),
+            backend,
+            package: package.into(),
+            source,
+            legacy_adopt,
+        }
+    }
+}
+
+/// Cardinality result for resolving an input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResolutionSet {
+    /// No ANOLISA component identity could be proven.
+    None,
+    /// Exactly one target.
+    Unique(ResolvedTarget),
+    /// Several targets match and the caller must disambiguate.
+    Ambiguous(Vec<ResolvedTarget>),
+}
+
+/// Options that affect resolution.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ResolveOptions<'a> {
+    /// CLI package override, when supplied.
+    pub(crate) package_override: Option<&'a str>,
+}
+
+/// Resolver over a repository component index plus backend-specific fallbacks.
+pub(crate) struct ComponentResolver<'a> {
+    component_index: Option<&'a ComponentIndex>,
+    rpm_backend: Option<&'a BackendConfig>,
+    rpm_query: Option<&'a dyn PackageQuery>,
+}
+
+impl<'a> ComponentResolver<'a> {
+    pub(crate) fn new(
+        component_index: Option<&'a ComponentIndex>,
+        rpm_backend: Option<&'a BackendConfig>,
+        rpm_query: Option<&'a dyn PackageQuery>,
+    ) -> Self {
+        Self {
+            component_index,
+            rpm_backend,
+            rpm_query,
+        }
+    }
+
+    /// Resolve `input` for `backend`.
+    pub(crate) fn resolve(
+        &self,
+        input: &str,
+        backend: BackendKind,
+        use_case: ResolutionUse,
+        opts: ResolveOptions<'_>,
+    ) -> Result<ResolutionSet, PackageQueryError> {
+        match backend {
+            BackendKind::Rpm => self.resolve_rpm(input, use_case, opts),
+            BackendKind::Raw => Ok(self.resolve_raw(input)),
+            BackendKind::Other => Ok(ResolutionSet::None),
+        }
+    }
+
+    fn resolve_raw(&self, input: &str) -> ResolutionSet {
+        let targets = self
+            .component_index
+            .map(|idx| idx.targets_for_backend(input, BackendKind::Raw, "raw-package"))
+            .unwrap_or_default();
+        normalize_resolution_set(if targets.is_empty() {
+            vec![ResolvedTarget::new(
+                input,
+                BackendKind::Raw,
+                input,
+                ResolutionSource::RawDistributionIndex,
+                false,
+            )]
+        } else {
+            targets
+        })
+    }
+
+    fn resolve_rpm(
+        &self,
+        input: &str,
+        use_case: ResolutionUse,
+        opts: ResolveOptions<'_>,
+    ) -> Result<ResolutionSet, PackageQueryError> {
+        let query = self
+            .rpm_query
+            .expect("rpm resolution requires a PackageQuery");
+        let mapped = self.rpm_backend.and_then(|b| b.package_map.get(input));
+
+        if let Some(package) = opts.package_override {
+            let mut targets = Vec::new();
+            if mapped.is_some_and(|mapped| mapped == package) {
+                targets.push(ResolvedTarget::new(
+                    input,
+                    BackendKind::Rpm,
+                    package,
+                    ResolutionSource::RepoPackageMap,
+                    true,
+                ));
+            }
+            if let Some(idx) = self.component_index {
+                targets.extend(idx.targets_for_component_package(input, BackendKind::Rpm, package));
+            }
+            if let Some(target) = rpm_package_provides_component(query, package, input)? {
+                targets.push(target);
+            }
+            return Ok(normalize_resolution_set(targets));
+        }
+
+        if let Some(idx) = self.component_index {
+            let targets = idx.targets_for_backend(input, BackendKind::Rpm, "rpm-package");
+            if !targets.is_empty() {
+                return Ok(normalize_resolution_set(targets));
+            }
+        }
+
+        if let Some(package) = mapped {
+            return Ok(ResolutionSet::Unique(ResolvedTarget::new(
+                input,
+                BackendKind::Rpm,
+                package,
+                ResolutionSource::RepoPackageMap,
+                true,
+            )));
+        }
+
+        let provide = rpm_component_provide(input);
+        let installed_providers = query.what_provides_installed(&provide)?;
+        if !installed_providers.is_empty() {
+            return Ok(normalize_resolution_set(
+                installed_providers
+                    .into_iter()
+                    .map(|package| {
+                        ResolvedTarget::new(
+                            input,
+                            BackendKind::Rpm,
+                            package,
+                            ResolutionSource::InstalledRpmProvides,
+                            true,
+                        )
+                    })
+                    .collect(),
+            ));
+        }
+
+        let available_providers = query.what_provides_available(&provide)?;
+        if !available_providers.is_empty() {
+            let repo_backed_legacy = matches!(
+                use_case,
+                ResolutionUse::Install
+                    | ResolutionUse::Adopt
+                    | ResolutionUse::StatusObserved
+                    | ResolutionUse::RepairLegacy
+            );
+            return Ok(normalize_resolution_set(
+                available_providers
+                    .into_iter()
+                    .map(|package| {
+                        ResolvedTarget::new(
+                            input,
+                            BackendKind::Rpm,
+                            package,
+                            ResolutionSource::AvailableRpmProvides,
+                            repo_backed_legacy,
+                        )
+                    })
+                    .collect(),
+            ));
+        }
+
+        Ok(normalize_resolution_set(rpm_package_name_targets(
+            query, input,
+        )?))
+    }
+}
+
+/// Resolve an RPM-oriented user input to a stable component name.
+///
+/// This is a read-only projection used by commands that address existing state
+/// (`status`, `repair`) before they decide whether to query or mutate package
+/// metadata. Ambiguous or failed resolution returns `None` so callers can fall
+/// back to the literal input or their command-specific error.
+pub(crate) fn resolve_rpm_component_name(
+    input: &str,
+    rpm_backend: Option<&BackendConfig>,
+    component_index: Option<&ComponentIndex>,
+    query: &dyn PackageQuery,
+    use_case: ResolutionUse,
+) -> Option<String> {
+    let resolver = ComponentResolver::new(component_index, rpm_backend, Some(query));
+    match resolver.resolve(input, BackendKind::Rpm, use_case, ResolveOptions::default()) {
+        Ok(ResolutionSet::Unique(target)) => Some(target.component),
+        _ => None,
+    }
+}
+
+impl ComponentIndex {
+    /// Parse and validate `components.toml`.
+    pub(crate) fn from_toml_str(
+        s: &str,
+        path: impl AsRef<Path>,
+    ) -> Result<Self, ComponentIndexError> {
+        let path = path.as_ref().display().to_string();
+        let parsed: Self = toml::from_str(s).map_err(|err| ComponentIndexError::Parse {
+            path: path.clone(),
+            reason: err.to_string(),
+        })?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    /// Load and validate from disk.
+    pub(crate) fn load(path: impl AsRef<Path>) -> Result<Self, ComponentIndexError> {
+        let path_ref = path.as_ref();
+        let content =
+            std::fs::read_to_string(path_ref).map_err(|err| ComponentIndexError::Parse {
+                path: path_ref.display().to_string(),
+                reason: err.to_string(),
+            })?;
+        Self::from_toml_str(&content, path_ref)
+    }
+
+    fn validate(&self) -> Result<(), ComponentIndexError> {
+        if self.schema_version != COMPONENT_INDEX_SCHEMA_VERSION {
+            return Err(ComponentIndexError::UnsupportedSchema {
+                actual: self.schema_version,
+                expected: COMPONENT_INDEX_SCHEMA_VERSION,
+            });
+        }
+        let mut names = BTreeSet::new();
+        for entry in &self.components {
+            let name = entry.name.trim();
+            if name.is_empty() {
+                return Err(ComponentIndexError::Invalid {
+                    reason: "component name must not be empty".to_string(),
+                });
+            }
+            if !names.insert(name.to_string()) {
+                return Err(ComponentIndexError::Invalid {
+                    reason: format!("duplicate component '{name}'"),
+                });
+            }
+            for backend in &entry.backends {
+                if backend.kind.trim().is_empty() {
+                    return Err(ComponentIndexError::Invalid {
+                        reason: format!("component '{name}' has an empty backend kind"),
+                    });
+                }
+                if backend.package.trim().is_empty() {
+                    return Err(ComponentIndexError::Invalid {
+                        reason: format!("component '{name}' has an empty backend package"),
+                    });
+                }
+                if let Some(provides) = backend.provides.as_deref()
+                    && BackendKind::from_name(&backend.kind) == BackendKind::Rpm
+                    && provides != rpm_component_provide(name)
+                {
+                    return Err(ComponentIndexError::Invalid {
+                        reason: format!(
+                            "component '{name}' rpm provides must be '{}', got '{provides}'",
+                            rpm_component_provide(name)
+                        ),
+                    });
+                }
+            }
+            for alias in &entry.aliases {
+                if alias.kind.trim().is_empty() || alias.name.trim().is_empty() {
+                    return Err(ComponentIndexError::Invalid {
+                        reason: format!("component '{name}' has an empty alias kind or name"),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn targets_for_backend(
+        &self,
+        input: &str,
+        backend: BackendKind,
+        alias_kind: &str,
+    ) -> Vec<ResolvedTarget> {
+        let mut targets = Vec::new();
+        for entry in &self.components {
+            let matches_component = entry.name == input;
+            let matches_alias = entry
+                .aliases
+                .iter()
+                .any(|alias| alias.kind == alias_kind && alias.name == input);
+            for backend_entry in entry.backends_for(backend) {
+                let matches_package = backend_entry.package == input;
+                if matches_component || matches_alias || matches_package {
+                    targets.push(index_target(entry, backend, backend_entry));
+                }
+            }
+        }
+        targets
+    }
+
+    fn targets_for_component_package(
+        &self,
+        component: &str,
+        backend: BackendKind,
+        package: &str,
+    ) -> Vec<ResolvedTarget> {
+        let mut targets = Vec::new();
+        for entry in &self.components {
+            if entry.name != component {
+                continue;
+            }
+            for backend_entry in entry.backends_for(backend) {
+                if backend_entry.package == package {
+                    targets.push(index_target(entry, backend, backend_entry));
+                }
+            }
+        }
+        targets
+    }
+}
+
+impl ComponentIndexEntry {
+    fn backends_for(&self, backend: BackendKind) -> impl Iterator<Item = &ComponentBackendEntry> {
+        self.backends
+            .iter()
+            .filter(move |entry| BackendKind::from_name(&entry.kind) == backend)
+    }
+}
+
+fn index_target(
+    entry: &ComponentIndexEntry,
+    backend: BackendKind,
+    backend_entry: &ComponentBackendEntry,
+) -> ResolvedTarget {
+    ResolvedTarget::new(
+        entry.name.clone(),
+        backend,
+        backend_entry.package.clone(),
+        ResolutionSource::ComponentIndex,
+        backend_entry.legacy_adopt,
+    )
+}
+
+fn normalize_resolution_set(mut targets: Vec<ResolvedTarget>) -> ResolutionSet {
+    let mut deduped = Vec::new();
+    for target in targets.drain(..) {
+        if !deduped.iter().any(|seen: &ResolvedTarget| {
+            seen.component == target.component
+                && seen.backend == target.backend
+                && seen.package == target.package
+        }) {
+            deduped.push(target);
+        }
+    }
+    match deduped.len() {
+        0 => ResolutionSet::None,
+        1 => ResolutionSet::Unique(deduped.remove(0)),
+        _ => ResolutionSet::Ambiguous(deduped),
+    }
+}
+
+pub(crate) fn rpm_component_provide(component: &str) -> String {
+    format!("anolisa-component({component})")
+}
+
+fn rpm_package_provides_component(
+    query: &dyn PackageQuery,
+    package: &str,
+    component: &str,
+) -> Result<Option<ResolvedTarget>, PackageQueryError> {
+    let capability = rpm_component_provide(component);
+    let (providers, source) = match query.query_installed(package)? {
+        Some(_) => (
+            query.what_provides_installed(&capability)?,
+            ResolutionSource::InstalledRpmProvides,
+        ),
+        None => (
+            query.what_provides_available(&capability)?,
+            ResolutionSource::AvailableRpmProvides,
+        ),
+    };
+    Ok(providers
+        .iter()
+        .any(|provider| provider == package)
+        .then(|| ResolvedTarget::new(component, BackendKind::Rpm, package, source, true)))
+}
+
+fn rpm_package_name_targets(
+    query: &dyn PackageQuery,
+    package: &str,
+) -> Result<Vec<ResolvedTarget>, PackageQueryError> {
+    let installed = query.query_installed(package)?.is_some();
+    let capabilities = if installed {
+        query.provided_capabilities_installed(package)?
+    } else {
+        query.provided_capabilities_available(package)?
+    };
+    Ok(rpm_components_from_capabilities(&capabilities)
+        .into_iter()
+        .map(|component| {
+            ResolvedTarget::new(
+                component,
+                BackendKind::Rpm,
+                package,
+                if installed {
+                    ResolutionSource::InstalledRpmProvides
+                } else {
+                    ResolutionSource::AvailableRpmProvides
+                },
+                true,
+            )
+        })
+        .collect())
+}
+
+pub(crate) fn rpm_components_from_capabilities(capabilities: &[String]) -> Vec<String> {
+    let mut components = Vec::new();
+    for capability in capabilities {
+        let Some(rest) = capability.trim().strip_prefix("anolisa-component(") else {
+            continue;
+        };
+        let Some(end) = rest.find(')') else {
+            continue;
+        };
+        let component = rest[..end].trim();
+        if component.is_empty() || components.iter().any(|c| c == component) {
+            continue;
+        }
+        components.push(component.to_string());
+    }
+    components
+}
+
+/// Best-effort load of repo-side `components.toml`.
+pub(crate) fn load_optional_component_index(
+    layout: &FsLayout,
+    env: &anolisa_env::EnvFacts,
+    repo_config: &RepoConfig,
+) -> Option<ComponentIndex> {
+    let host = HostVars {
+        os: env.os.clone(),
+        arch: env.arch.clone(),
+    };
+    let Ok((name, backend)) = repo_config.select_backend(Some("raw")) else {
+        return None;
+    };
+    let Ok(base_url) = repo_config.resolved_base_url(name, backend, &host) else {
+        return None;
+    };
+    let url = component_index_url(&base_url);
+
+    let cache = DownloadCache::new(layout.cache_dir.clone());
+    #[cfg(test)]
+    if !url.starts_with("file://") {
+        return None;
+    }
+    let Ok(downloaded) = cache.fetch(&url, None) else {
+        return None;
+    };
+    if let Ok(index) = ComponentIndex::load(&downloaded.cached_path) {
+        return Some(index);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anolisa_platform::pkg_query::{PackageInfo, PackageVersion};
+
+    #[derive(Default)]
+    struct FakeQuery {
+        installed: Vec<(String, PackageInfo)>,
+        component_providers: Vec<(String, Vec<String>)>,
+        available_component_providers: Vec<(String, Vec<String>)>,
+        package_provides: Vec<(String, Vec<String>)>,
+        available_package_provides: Vec<(String, Vec<String>)>,
+    }
+
+    impl PackageQuery for FakeQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            Ok(self
+                .installed
+                .iter()
+                .find(|(name, _)| name == package)
+                .map(|(_, info)| info.clone()))
+        }
+
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+
+        fn what_provides_installed(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .component_providers
+                .iter()
+                .find(|(cap, _)| cap == capability)
+                .map(|(_, providers)| providers.clone())
+                .unwrap_or_default())
+        }
+
+        fn what_provides_available(
+            &self,
+            capability: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .available_component_providers
+                .iter()
+                .find(|(cap, _)| cap == capability)
+                .map(|(_, providers)| providers.clone())
+                .unwrap_or_default())
+        }
+
+        fn provided_capabilities_installed(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .package_provides
+                .iter()
+                .find(|(pkg, _)| pkg == package)
+                .map(|(_, caps)| caps.clone())
+                .unwrap_or_default())
+        }
+
+        fn provided_capabilities_available(
+            &self,
+            package: &str,
+        ) -> Result<Vec<String>, PackageQueryError> {
+            Ok(self
+                .available_package_provides
+                .iter()
+                .find(|(pkg, _)| pkg == package)
+                .map(|(_, caps)| caps.clone())
+                .unwrap_or_default())
+        }
+    }
+
+    fn pkg_info(name: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.to_string(),
+            version: PackageVersion {
+                epoch: None,
+                version: "1.0.0".to_string(),
+                release: Some("1.al8".to_string()),
+            },
+            arch: "x86_64".to_string(),
+            origin: None,
+        }
+    }
+
+    fn index() -> ComponentIndex {
+        ComponentIndex::from_toml_str(
+            r#"
+schema_version = 1
+publisher = "anolisa"
+
+[[components]]
+name = "cosh"
+display_name = "Copilot Shell"
+summary = "shell"
+
+[[components.backends]]
+kind = "raw"
+package = "cosh"
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+provides = "anolisa-component(cosh)"
+legacy_adopt = true
+
+[[components.aliases]]
+kind = "rpm-package"
+name = "copilot-shell"
+"#,
+            "components.toml",
+        )
+        .expect("parse index")
+    }
+
+    #[test]
+    fn repository_component_index_template_is_valid() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let index_path = manifest_dir.join("../../manifests/components.toml");
+        ComponentIndex::load(&index_path).expect("component index template must parse");
+    }
+
+    #[test]
+    fn repository_component_index_uses_sec_core_as_canonical_name() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let index_path = manifest_dir.join("../../manifests/components.toml");
+        let idx = ComponentIndex::load(&index_path).expect("component index template must parse");
+        let query = FakeQuery::default();
+        let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
+
+        let got = resolver
+            .resolve(
+                "sec-core",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve sec-core");
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "sec-core");
+                assert_eq!(target.package, "agent-sec-core");
+                assert_eq!(target.source, ResolutionSource::ComponentIndex);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+
+        let package_name = resolver
+            .resolve(
+                "agent-sec-core",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve package name");
+        match package_name {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "sec-core");
+                assert_eq!(target.package, "agent-sec-core");
+                assert_eq!(target.source, ResolutionSource::ComponentIndex);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_optional_component_index_uses_raw_index_for_rpm_resolution() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let layout =
+            anolisa_platform::fs_layout::FsLayout::system(Some(tmp.path().join("install-root")));
+        let raw_parent = tmp.path().join("a-raw");
+        let raw_v1 = raw_parent.join("v1");
+        let rpm_root = tmp.path().join("z-rpm");
+        std::fs::create_dir_all(&raw_v1).expect("mkdir raw repo");
+        std::fs::create_dir_all(&rpm_root).expect("mkdir rpm repo");
+        std::fs::write(
+            raw_v1.join("components.toml"),
+            r#"
+schema_version = 1
+
+[[components]]
+name = "raw-index"
+"#,
+        )
+        .expect("write raw components.toml");
+        std::fs::write(
+            rpm_root.join("components.toml"),
+            r#"
+schema_version = 1
+
+[[components]]
+name = "rpm-ignored"
+"#,
+        )
+        .expect("write rpm components.toml");
+        let repo_config = RepoConfig::from_toml_str(&format!(
+            r#"
+schema_version = 1
+default_backend = "rpm"
+
+[backends.raw]
+base_url = "file://{}"
+
+[backends.rpm]
+base_url = "file://{}"
+"#,
+            raw_parent.display(),
+            rpm_root.display()
+        ))
+        .expect("repo config");
+        let env = anolisa_env::EnvFacts {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            libc: None,
+            kernel: None,
+            pkg_base: None,
+            os_id: None,
+            os_version: None,
+            btf: None,
+            cap_bpf: None,
+            container: None,
+            user: "tester".to_string(),
+            uid: 1000,
+            home: tmp.path().join("home"),
+        };
+
+        let idx =
+            load_optional_component_index(&layout, &env, &repo_config).expect("load raw index");
+
+        assert_eq!(idx.components.len(), 1);
+        assert_eq!(idx.components[0].name, "raw-index");
+    }
+
+    #[test]
+    fn component_index_resolves_component_name_to_rpm_package() {
+        let idx = index();
+        let query = FakeQuery::default();
+        let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
+        let got = resolver
+            .resolve(
+                "cosh",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve");
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "cosh");
+                assert_eq!(target.package, "copilot-shell");
+                assert_eq!(target.source, ResolutionSource::ComponentIndex);
+                assert!(target.legacy_adopt);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn component_index_precedes_package_map() {
+        let idx = index();
+        let repo = RepoConfig::from_toml_str(
+            r#"
+schema_version = 1
+default_backend = "rpm"
+
+[backends.rpm]
+base_url = "https://example.invalid/rpm"
+
+[backends.rpm.package_map]
+cosh = "site-copilot"
+"#,
+        )
+        .expect("repo config");
+        let query = FakeQuery::default();
+        let resolver = ComponentResolver::new(Some(&idx), repo.backends.get("rpm"), Some(&query));
+        let got = resolver
+            .resolve(
+                "cosh",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve");
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.package, "copilot-shell");
+                assert_eq!(target.source, ResolutionSource::ComponentIndex);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn component_index_resolves_rpm_package_alias_to_component() {
+        let idx = index();
+        let query = FakeQuery::default();
+        let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
+        let got = resolver
+            .resolve(
+                "copilot-shell",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve");
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "cosh");
+                assert_eq!(target.package, "copilot-shell");
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn component_index_resolves_raw_component() {
+        let idx = index();
+        let resolver = ComponentResolver::new(Some(&idx), None, None);
+        let got = resolver
+            .resolve(
+                "cosh",
+                BackendKind::Raw,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve");
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "cosh");
+                assert_eq!(target.package, "cosh");
+                assert_eq!(target.source, ResolutionSource::ComponentIndex);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rpm_package_name_falls_back_to_package_own_provides() {
+        let query = FakeQuery {
+            installed: vec![("copilot-shell".to_string(), pkg_info("copilot-shell"))],
+            package_provides: vec![(
+                "copilot-shell".to_string(),
+                vec!["anolisa-component(cosh) = 1.0.0".to_string()],
+            )],
+            ..Default::default()
+        };
+        let resolver = ComponentResolver::new(None, None, Some(&query));
+        let got = resolver
+            .resolve(
+                "copilot-shell",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve");
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "cosh");
+                assert_eq!(target.package, "copilot-shell");
+                assert_eq!(target.source, ResolutionSource::InstalledRpmProvides);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn available_component_provider_identifies_absent_package() {
+        let query = FakeQuery {
+            available_component_providers: vec![(
+                "anolisa-component(cosh)".to_string(),
+                vec!["copilot-shell".to_string()],
+            )],
+            ..Default::default()
+        };
+        let resolver = ComponentResolver::new(None, None, Some(&query));
+        let got = resolver
+            .resolve(
+                "cosh",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve");
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "cosh");
+                assert_eq!(target.package, "copilot-shell");
+                assert_eq!(target.source, ResolutionSource::AvailableRpmProvides);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plain_rpm_package_without_metadata_is_none() {
+        let query = FakeQuery {
+            installed: vec![("bash".to_string(), pkg_info("bash"))],
+            ..Default::default()
+        };
+        let resolver = ComponentResolver::new(None, None, Some(&query));
+        let got = resolver
+            .resolve(
+                "bash",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve");
+        assert_eq!(got, ResolutionSet::None);
+    }
+
+    #[test]
+    fn unsupported_schema_is_rejected() {
+        let err = ComponentIndex::from_toml_str("schema_version = 99", "components.toml")
+            .expect_err("unsupported schema");
+        assert!(matches!(
+            err,
+            ComponentIndexError::UnsupportedSchema { actual: 99, .. }
+        ));
+    }
+}

--- a/src/anolisa/crates/anolisa-platform/src/pkg_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/pkg_query.rs
@@ -148,4 +148,49 @@ pub trait PackageQuery {
     fn what_provides_installed(&self, _capability: &str) -> Result<Vec<String>, PackageQueryError> {
         Ok(Vec::new())
     }
+
+    /// Names of *available* repository packages that provide `capability`,
+    /// de-duplicated by name.
+    ///
+    /// This is the repository-side counterpart to
+    /// [`what_provides_installed`](Self::what_provides_installed). It lets
+    /// callers resolve a component capability before install/adopt without
+    /// requiring the package to be installed yet.
+    ///
+    /// # Errors
+    /// See [`PackageQueryError`]; "nothing provides it" is `Ok(vec![])`.
+    fn what_provides_available(&self, _capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        Ok(Vec::new())
+    }
+
+    /// Provides capabilities declared by an installed package.
+    ///
+    /// Used when user input may be a backend-native package name: the caller can
+    /// inspect the package's own metadata and recover the ANOLISA component
+    /// identity only if it declares `anolisa-component(<name>)`.
+    ///
+    /// # Errors
+    /// See [`PackageQueryError`]; a missing package is represented as an empty
+    /// capability list by backends that can distinguish that branch.
+    fn provided_capabilities_installed(
+        &self,
+        _package: &str,
+    ) -> Result<Vec<String>, PackageQueryError> {
+        Ok(Vec::new())
+    }
+
+    /// Provides capabilities declared by an available repository package.
+    ///
+    /// This mirrors
+    /// [`provided_capabilities_installed`](Self::provided_capabilities_installed)
+    /// for packages not yet present on the host.
+    ///
+    /// # Errors
+    /// See [`PackageQueryError`]; no available package yields `Ok(vec![])`.
+    fn provided_capabilities_available(
+        &self,
+        _package: &str,
+    ) -> Result<Vec<String>, PackageQueryError> {
+        Ok(Vec::new())
+    }
 }

--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -223,6 +223,87 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
             stderr: out.stderr,
         })
     }
+
+    fn what_provides_available(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        let out = self
+            .runner
+            .run(
+                DNF,
+                &[
+                    "repoquery",
+                    "--quiet",
+                    "--qf",
+                    PROVIDES_NAME_QF,
+                    "--whatprovides",
+                    capability,
+                ],
+            )
+            .map_err(|e| map_spawn_error(e, DNF))?;
+
+        if out.code != Some(0) {
+            return Err(PackageQueryError::QueryFailed {
+                command: DNF.to_string(),
+                code: out.code,
+                stderr: out.stderr,
+            });
+        }
+
+        Ok(dedup_nonempty_lines(&out.stdout))
+    }
+
+    fn provided_capabilities_installed(
+        &self,
+        package: &str,
+    ) -> Result<Vec<String>, PackageQueryError> {
+        let out = self
+            .runner
+            .run(RPM, &["-q", "--provides", package])
+            .map_err(|e| map_spawn_error(e, RPM))?;
+
+        if out.code == Some(0) {
+            return Ok(dedup_nonempty_lines(&out.stdout));
+        }
+
+        if out.stdout.contains("is not installed") {
+            return Ok(Vec::new());
+        }
+
+        Err(PackageQueryError::QueryFailed {
+            command: RPM.to_string(),
+            code: out.code,
+            stderr: out.stderr,
+        })
+    }
+
+    fn provided_capabilities_available(
+        &self,
+        package: &str,
+    ) -> Result<Vec<String>, PackageQueryError> {
+        let out = self
+            .runner
+            .run(DNF, &["repoquery", "--quiet", "--provides", package])
+            .map_err(|e| map_spawn_error(e, DNF))?;
+
+        if out.code != Some(0) {
+            return Err(PackageQueryError::QueryFailed {
+                command: DNF.to_string(),
+                code: out.code,
+                stderr: out.stderr,
+            });
+        }
+
+        Ok(dedup_nonempty_lines(&out.stdout))
+    }
+}
+
+fn dedup_nonempty_lines(stdout: &str) -> Vec<String> {
+    let mut values: Vec<String> = Vec::new();
+    for value in stdout.lines().map(str::trim).filter(|l| !l.is_empty()) {
+        if !values.iter().any(|seen| seen == value) {
+            values.push(value.to_string());
+        }
+    }
+    values
 }
 
 /// Map a spawn-phase [`std::io::Error`] to a query error by [`std::io::ErrorKind`].
@@ -407,6 +488,19 @@ mod tests {
                     "rpm capability argument must be last: {args:?}"
                 );
             }
+            // `rpm -q --provides <pkg>` (provided_capabilities_installed)
+            RPM if args.get(1) == Some(&"--provides") => {
+                assert_eq!(
+                    args.len(),
+                    3,
+                    "rpm package-provides needs [-q, --provides, <pkg>]: {args:?}"
+                );
+                assert_eq!(args[0], "-q");
+                assert_eq!(
+                    args[2], expected_package,
+                    "rpm package argument must be last: {args:?}"
+                );
+            }
             // `rpm -q --list <pkg>` (list_files)
             RPM if args.get(1) == Some(&"--list") => {
                 assert_eq!(
@@ -453,6 +547,41 @@ mod tests {
                 );
                 assert_eq!(
                     args[4], expected_package,
+                    "dnf package argument must be last: {args:?}"
+                );
+            }
+            // `dnf repoquery --quiet --qf <fmt> --whatprovides <cap>`
+            // (what_provides_available)
+            DNF if args.get(4) == Some(&"--whatprovides") => {
+                assert_eq!(
+                    args.len(),
+                    6,
+                    "dnf available-whatprovides needs [repoquery, --quiet, --qf, <fmt>, --whatprovides, <cap>]: {args:?}"
+                );
+                assert_eq!(args[0], "repoquery");
+                assert_eq!(args[1], "--quiet");
+                assert_eq!(args[2], "--qf");
+                assert_eq!(
+                    args[3], PROVIDES_NAME_QF,
+                    "dnf whatprovides --qf drifted from PROVIDES_NAME_QF: {args:?}"
+                );
+                assert_eq!(
+                    args[5], expected_package,
+                    "dnf capability argument must be last: {args:?}"
+                );
+            }
+            // `dnf repoquery --quiet --provides <pkg>`
+            // (provided_capabilities_available)
+            DNF if args.get(2) == Some(&"--provides") => {
+                assert_eq!(
+                    args.len(),
+                    4,
+                    "dnf available-provides needs [repoquery, --quiet, --provides, <pkg>]: {args:?}"
+                );
+                assert_eq!(args[0], "repoquery");
+                assert_eq!(args[1], "--quiet");
+                assert_eq!(
+                    args[3], expected_package,
                     "dnf package argument must be last: {args:?}"
                 );
             }
@@ -784,6 +913,96 @@ mod tests {
         assert!(matches!(
             err,
             PackageQueryError::QueryFailed { command, .. } if command == RPM
+        ));
+    }
+
+    #[test]
+    fn available_what_provides_returns_package_names() {
+        let q = query_with_dnf(
+            "anolisa-component(tokenless)",
+            ok_out(Some(0), "tokenless\nvendor-tokenless\n", ""),
+        );
+        let names = q
+            .what_provides_available("anolisa-component(tokenless)")
+            .unwrap();
+        assert_eq!(
+            names,
+            vec!["tokenless".to_string(), "vendor-tokenless".to_string()]
+        );
+    }
+
+    #[test]
+    fn available_what_provides_empty_is_empty_vec() {
+        let q = query_with_dnf("anolisa-component(absent)", ok_out(Some(0), "", ""));
+        let names = q
+            .what_provides_available("anolisa-component(absent)")
+            .unwrap();
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn available_what_provides_failure_maps_to_error() {
+        let q = query_with_dnf("x", ok_out(Some(1), "", "error: repo not found"));
+        let err = q.what_provides_available("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageQueryError::QueryFailed { command, .. } if command == DNF
+        ));
+    }
+
+    #[test]
+    fn installed_package_provides_returns_capabilities() {
+        let q = query_with_rpm(
+            "tokenless",
+            ok_out(
+                Some(0),
+                "tokenless = 2.0.1\nanolisa-component(cosh)\nanolisa-component(cosh)\n",
+                "",
+            ),
+        );
+        let capabilities = q.provided_capabilities_installed("tokenless").unwrap();
+        assert_eq!(
+            capabilities,
+            vec![
+                "tokenless = 2.0.1".to_string(),
+                "anolisa-component(cosh)".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn installed_package_provides_missing_package_is_empty() {
+        let q = query_with_rpm(
+            "ghost",
+            ok_out(Some(1), "package ghost is not installed", ""),
+        );
+        let capabilities = q.provided_capabilities_installed("ghost").unwrap();
+        assert!(capabilities.is_empty());
+    }
+
+    #[test]
+    fn available_package_provides_returns_capabilities() {
+        let q = query_with_dnf(
+            "tokenless",
+            ok_out(Some(0), "tokenless = 2.0.1\nanolisa-component(cosh)\n", ""),
+        );
+        let capabilities = q.provided_capabilities_available("tokenless").unwrap();
+        assert_eq!(
+            capabilities,
+            vec![
+                "tokenless = 2.0.1".to_string(),
+                "anolisa-component(cosh)".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn available_package_provides_failure_maps_to_error() {
+        let q = query_with_dnf("x", ok_out(Some(1), "", "error: repo not found"));
+        let err = q.provided_capabilities_available("x").unwrap_err();
+        assert!(matches!(
+            err,
+            PackageQueryError::QueryFailed { command, .. } if command == DNF
         ));
     }
 

--- a/src/anolisa/manifests/components.toml
+++ b/src/anolisa/manifests/components.toml
@@ -1,0 +1,131 @@
+schema_version = 1
+generated_at = "2026-06-30T00:00:00Z"
+publisher = "anolisa"
+
+# Repo-side component identity index.
+#
+# `index.toml` remains the raw artifact version/hash index. This file is only
+# for resolving stable ANOLISA component names to backend-native package names.
+# Scope: runtime components only. The ANOLISA CLI package itself and osbase
+# package lists are intentionally excluded because they are not component
+# identities.
+
+[[components]]
+name = "cosh"
+display_name = "Copilot Shell"
+summary = "Copilot shell launcher and deterministic CLI gateway"
+
+[[components.backends]]
+kind = "raw"
+package = "cosh"
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+provides = "anolisa-component(cosh)"
+legacy_adopt = true
+
+[[components.aliases]]
+kind = "rpm-package"
+name = "copilot-shell"
+
+[[components.aliases]]
+kind = "raw-package"
+name = "copilot-shell"
+
+[[components]]
+name = "agentsight"
+display_name = "AgentSight"
+summary = "eBPF-based AI agent observability tool"
+
+[[components.backends]]
+kind = "raw"
+package = "agentsight"
+
+[[components.backends]]
+kind = "rpm"
+package = "agentsight"
+provides = "anolisa-component(agentsight)"
+legacy_adopt = true
+
+[[components]]
+name = "agent-memory"
+display_name = "Agent Memory"
+summary = "Agent persistent memory and context"
+
+[[components.backends]]
+kind = "raw"
+package = "agent-memory"
+
+[[components.backends]]
+kind = "rpm"
+package = "agent-memory"
+provides = "anolisa-component(agent-memory)"
+legacy_adopt = true
+
+[[components]]
+name = "os-skills"
+display_name = "OS Skills"
+summary = "Curated OS Skill library for agent runtimes"
+
+[[components.backends]]
+kind = "raw"
+package = "os-skills"
+
+[[components.backends]]
+kind = "rpm"
+package = "os-skills"
+provides = "anolisa-component(os-skills)"
+legacy_adopt = true
+
+[[components]]
+name = "tokenless"
+display_name = "Tokenless"
+summary = "LLM token optimization toolkit"
+
+[[components.backends]]
+kind = "raw"
+package = "tokenless"
+
+[[components.backends]]
+kind = "rpm"
+package = "tokenless"
+provides = "anolisa-component(tokenless)"
+legacy_adopt = true
+
+[[components]]
+name = "ws-ckpt"
+display_name = "Workspace Checkpoint"
+summary = "Workspace checkpoint and rollback service"
+
+[[components.backends]]
+kind = "raw"
+package = "ws-ckpt"
+
+[[components.backends]]
+kind = "rpm"
+package = "ws-ckpt"
+provides = "anolisa-component(ws-ckpt)"
+legacy_adopt = true
+
+[[components]]
+name = "sec-core"
+display_name = "Agent Security Core"
+summary = "Agent security core adapters and runtime"
+
+[[components.backends]]
+kind = "rpm"
+package = "agent-sec-core"
+provides = "anolisa-component(sec-core)"
+legacy_adopt = true
+
+[[components]]
+name = "skillfs"
+display_name = "SkillFS"
+summary = "AI agent skill management via virtual filesystem"
+
+[[components.backends]]
+kind = "rpm"
+package = "skillfs"
+provides = "anolisa-component(skillfs)"
+legacy_adopt = true

--- a/src/anolisa/manifests/repo.toml
+++ b/src/anolisa/manifests/repo.toml
@@ -10,13 +10,13 @@
 # base_url rules:
 #
 #   * It is a directory root, not a file. What lives under it is a
-#     per-backend convention: raw → the v1 distribution root containing
-#     `index.toml`; rpm → handed to dnf as-is (must contain `repodata/`);
-#     npm → the registry API root.
+#     per-backend convention: raw -> the v1 distribution root containing
+#     `index.toml`; rpm -> handed to dnf as-is (must contain `repodata/`);
+#     npm -> the registry API root.
 #   * It may reference `$os`, `$arch`, `$basearch`, `$releasever`,
 #     `$channel`. Values come from host detection, overridable in
 #     `[vars]`. Referencing an unknown or unset variable is a hard
-#     error — never a silent pass-through.
+#     error -- never a silent pass-through.
 #   * Schemes: `file://` and `https://` are always allowed. `http://`
 #     requires `insecure = true` on the backend entry. No query string
 #     or fragment.
@@ -34,7 +34,7 @@ default_backend = "raw"
 channel = "stable"
 releasever = "4"
 
-# raw — tar.gz/binary artifacts resolved through the ANOLISA
+# raw -- tar.gz/binary artifacts resolved through the ANOLISA
 # distribution index.
 #
 # base_url is the raw v1 distribution root. `index.toml` lives directly
@@ -48,22 +48,22 @@ releasever = "4"
 # derived from artifact_type.
 #
 # Rows may still carry a repo-relative `url` (joined onto the static
-# prefix) or an absolute `url` as an escape hatch — an explicit url
+# prefix) or an absolute `url` as an escape hatch -- an explicit url
 # always wins over the derived layout. The index itself stays mandatory
-# either way: it is the version list and sha256 manifest — resolution
+# either way: it is the version list and sha256 manifest -- resolution
 # and verification never run on URL guessing.
 [backends.raw]
 base_url = "https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/"
 cache_ttl_secs = 3600
 offline_fallback = true
 
-# rpm — resolution/install delegated to dnf against this repo.
+# rpm -- resolution/install delegated to dnf against this repo.
 [backends.rpm]
 base_url = "http://mirrors.cloud.aliyuncs.com/alinux/$releasever/agentic-os/$basearch/os/"
 insecure = true
 gpgcheck = true
 
-# npm — Node-ecosystem components.
+# npm -- Node-ecosystem components.
 #
 # [backends.npm]
 # base_url = "https://registry.npmjs.org"


### PR DESCRIPTION
## Description

Fix RPM component resolution by introducing a repo-side `components.toml` identity index. The index maps stable ANOLISA component names to backend-native package names, so `anolisa install --backend rpm <component>` can install RPM packages whose names differ from the component identity.

Behavior:
- Official raw/rpm component identity lives in `components.toml`.
- `index.toml` remains the raw artifact version/hash index.
- `[backends.rpm.package_map]` remains only as a site-local fallback.
- The RPM backend resolves component names and RPM package-name input through the shared component resolver.
- ANOLISA state records the canonical component identity while dnf receives the backend-native RPM package name.
- Plain RPM packages without ANOLISA identity metadata or repo-index entries are still rejected; this does not become a generic `dnf install <name>` wrapper.

The initial published component index covers:
- `cosh` -> RPM package `copilot-shell`
- `agentsight`
- `agent-memory`
- `os-skills`
- `tokenless`
- `ws-ckpt`
- `sec-core` -> RPM package `agent-sec-core`
- `skillfs`

## Design Note

`ComponentResolver` is shared by install, adopt, status, and repair. Repo-side `components.toml` has priority for official mappings, local `package_map` is checked only as a compatibility/site override, installed/available RPM Provides remain as metadata-based fallback, and package-name input can resolve back to the canonical component name.

The packaged default repo config now comes from `manifests/repo.toml`. The CLI no longer embeds `repo.toml` into the binary; it loads repo config only from user/site config, packaged datadir, or the dev tree.

`components.toml` is loaded from the raw repository root and cached locally. The PR intentionally does not define or probe a `components.toml` sidecar under the RPM mirror root; that contract can be added later if needed.

## Real-Machine Test

Built `anolisa-cli` locally and copied it to a temporary prefix on `root@47.98.130.237`. The test did not set `ANOLISA_DATA_DIR`; the binary found `repo.toml` through its adjacent packaged datadir at `<tmp>/share/anolisa/templates/repo.toml`.

Ran real `anolisa install --backend rpm` operations, not dry-run, against the machine system dnf/rpmdb for every component in `components.toml`:
- `os-skills` installed package `os-skills` version `0.6.0-1.alnx4`
- `cosh` installed package `copilot-shell` version `2.6.0-1.alnx4`
- `agentsight` installed package `agentsight` version `0.7.0-1.alnx4`
- `agent-memory` installed package `agent-memory` version `0.2.0-1.alnx4`
- `tokenless` installed package `tokenless` version `0.6.0-1.alnx4`
- `ws-ckpt` installed package `ws-ckpt` version `0.4.0-1.alnx4`
- `sec-core` installed package `agent-sec-core` version `0.7.0-1.alnx4`
- `skillfs` installed package `skillfs` version `0.3.0-1.alnx4`

After install, `anolisa status` reported all eight as installed. The important rename path was verified: `sec-core` stayed the canonical component name in ANOLISA state, while the RPM package was `agent-sec-core`.

Cleanup was also verified: ran `anolisa uninstall --remove-system-package` for all eight components, confirmed the corresponding RPM packages were absent from rpmdb, and removed the temporary test prefix.

## Verification

- `cargo fmt --all`
- `cargo test -p anolisa-cli repo_config::tests:: -- --nocapture`
- `cargo test -p anolisa-cli resolution::tests:: -- --nocapture`
- `cargo check --workspace --all-targets`
- `cargo doc --workspace --no-deps`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets`

Closes #1196
