### PR TITLE
fix(cosh): prioritize error details over compact mode on Ctrl+O

### DIFF
--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -72,7 +72,7 @@ import { type InitializationResult } from '../core/initializer.js';
 import { useFocus } from './hooks/useFocus.js';
 import { useBracketedPaste } from './hooks/useBracketedPaste.js';
 import { useKeypress, type Key } from './hooks/useKeypress.js';
-import { keyMatchers, Command } from './keyMatchers.js';
+import { keyMatchers, Command, resolveCtrlOAction } from './keyMatchers.js';
 import { useLoadingIndicator } from './hooks/useLoadingIndicator.js';
 import { useFolderTrust } from './hooks/useFolderTrust.js';
 import { useIdeTrustListener } from './hooks/useIdeTrustListener.js';
@@ -1300,6 +1300,21 @@ export const AppContainer = (props: AppContainerProps) => {
     [pendingSlashCommandHistoryItems, pendingGeminiHistoryItems],
   );
 
+  const filteredConsoleMessages = useMemo(() => {
+    if (config.getDebugMode()) {
+      return consoleMessages;
+    }
+    return consoleMessages.filter((msg) => msg.type !== 'debug');
+  }, [consoleMessages, config]);
+
+  const errorCount = useMemo(
+    () =>
+      filteredConsoleMessages
+        .filter((msg) => msg.type === 'error')
+        .reduce((total, msg) => total + msg.count, 0),
+    [filteredConsoleMessages],
+  );
+
   const handleGlobalKeypress = useCallback(
     (key: Key) => {
       // Debug log keystrokes if enabled
@@ -1414,7 +1429,10 @@ export const AppContainer = (props: AppContainerProps) => {
         setConstrainHeight(true);
       }
 
-      if (keyMatchers[Command.TOGGLE_COMPACT_MODE]?.(key)) {
+      const ctrlOAction = resolveCtrlOAction(key, errorCount, showErrorDetails);
+      if (ctrlOAction === 'showErrorDetails') {
+        setShowErrorDetails((prev) => !prev);
+      } else if (ctrlOAction === 'toggleCompactMode') {
         const newValue = !compactMode;
         setCompactMode(newValue);
         void settings.setValue(SettingScope.User, 'ui.compactMode', newValue);
@@ -1424,8 +1442,6 @@ export const AppContainer = (props: AppContainerProps) => {
         } else {
           setFrozenSnapshot(null);
         }
-      } else if (keyMatchers[Command.SHOW_ERROR_DETAILS](key)) {
-        setShowErrorDetails((prev) => !prev);
       } else if (keyMatchers[Command.TOGGLE_TOOL_DESCRIPTIONS](key)) {
         const newValue = !showToolDescriptions;
         setShowToolDescriptions(newValue);
@@ -1454,6 +1470,8 @@ export const AppContainer = (props: AppContainerProps) => {
     [
       constrainHeight,
       setConstrainHeight,
+      errorCount,
+      showErrorDetails,
       setShowErrorDetails,
       showToolDescriptions,
       setShowToolDescriptions,
@@ -1534,22 +1552,6 @@ export const AppContainer = (props: AppContainerProps) => {
     settings.merged.ui?.hideWindowTitle,
     stdout,
   ]);
-
-  const filteredConsoleMessages = useMemo(() => {
-    if (config.getDebugMode()) {
-      return consoleMessages;
-    }
-    return consoleMessages.filter((msg) => msg.type !== 'debug');
-  }, [consoleMessages, config]);
-
-  // Computed values
-  const errorCount = useMemo(
-    () =>
-      filteredConsoleMessages
-        .filter((msg) => msg.type === 'error')
-        .reduce((total, msg) => total + msg.count, 0),
-    [filteredConsoleMessages],
-  );
 
   const nightly = props.version.includes('nightly');
 

--- a/src/copilot-shell/packages/cli/src/ui/keyMatchers.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/keyMatchers.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { keyMatchers, Command, createKeyMatchers } from './keyMatchers.js';
+import {
+  keyMatchers,
+  Command,
+  createKeyMatchers,
+  resolveCtrlOAction,
+} from './keyMatchers.js';
 import type { KeyBindingConfig } from '../config/keyBindings.js';
 import { defaultKeyBindings } from '../config/keyBindings.js';
 import type { Key } from './hooks/useKeypress.js';
@@ -377,6 +382,27 @@ describe('keyMatchers', () => {
       expect(matchers[Command.HOME](createKey('a', { ctrl: true }))).toBe(
         false,
       );
+    });
+  });
+
+  describe('resolveCtrlOAction', () => {
+    const ctrlO = createKey('o', { ctrl: true });
+    const otherKey = createKey('t', { ctrl: true });
+
+    it('returns showErrorDetails when errors exist', () => {
+      expect(resolveCtrlOAction(ctrlO, 1, false)).toBe('showErrorDetails');
+    });
+
+    it('returns showErrorDetails when details panel is open (allows closing)', () => {
+      expect(resolveCtrlOAction(ctrlO, 0, true)).toBe('showErrorDetails');
+    });
+
+    it('returns toggleCompactMode when no errors and details closed', () => {
+      expect(resolveCtrlOAction(ctrlO, 0, false)).toBe('toggleCompactMode');
+    });
+
+    it('returns null for non-Ctrl+O keys', () => {
+      expect(resolveCtrlOAction(otherKey, 1, false)).toBe(null);
     });
   });
 });

--- a/src/copilot-shell/packages/cli/src/ui/keyMatchers.ts
+++ b/src/copilot-shell/packages/cli/src/ui/keyMatchers.ts
@@ -97,5 +97,28 @@ export function createKeyMatchers(
  */
 export const keyMatchers: KeyMatchers = createKeyMatchers(defaultKeyBindings);
 
+/**
+ * Resolves which action Ctrl+O should trigger given the current error state.
+ * Returns 'showErrorDetails' when errors are present or the details panel is
+ * already open (so it can be closed), 'toggleCompactMode' otherwise.
+ */
+export function resolveCtrlOAction(
+  key: Key,
+  errorCount: number,
+  showErrorDetails: boolean,
+  matchers: KeyMatchers = keyMatchers,
+): 'showErrorDetails' | 'toggleCompactMode' | null {
+  if (
+    matchers[Command.SHOW_ERROR_DETAILS](key) &&
+    (errorCount > 0 || showErrorDetails)
+  ) {
+    return 'showErrorDetails';
+  }
+  if (matchers[Command.TOGGLE_COMPACT_MODE]?.(key)) {
+    return 'toggleCompactMode';
+  }
+  return null;
+}
+
 // Re-export Command for convenience
 export { Command };


### PR DESCRIPTION
## Description

Ctrl+O is bound to both `SHOW_ERROR_DETAILS` and `TOGGLE_COMPACT_MODE`. The handler in `AppContainer.tsx` checked compact mode first, so the error details branch never executed — making the footer hint "(ctrl+o for details)" non-functional.

Extract a `resolveCtrlOAction` pure function in `keyMatchers.ts` that resolves the conflict: when `errorCount > 0` or the details panel is already open, Ctrl+O toggles error details; otherwise it falls through to compact mode. This preserves backward compatibility while fixing the broken hint.

## Related Issue

closes #1199

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `resolveCtrlOAction` unit tests in `keyMatchers.test.ts` (4 cases):
  - errors present → returns `showErrorDetails`
  - details panel open, errorCount=0 → returns `showErrorDetails`
  - no errors, details closed → returns `toggleCompactMode`
  - non-Ctrl+O key → returns `null`
- ESLint passes, pre-commit hooks pass

## Additional Notes

N/A