### PR TITLE
refactor(anolisa): switch data source from catalog.json to components.toml

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -82,7 +82,7 @@ pub enum Commands {
 /// Primary commands — component lifecycle and operations.
 #[derive(Subcommand)]
 pub enum ComponentCommands {
-    /// List available components from remote catalog
+    /// List available components from the component index
     #[command(visible_alias = "ls")]
     List(tier1::list::ListArgs),
     /// Install a component from a configured backend (raw today; rpm/npm planned)

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -7,14 +7,11 @@
 use std::path::{Path, PathBuf};
 
 use anolisa_core::adapter::manager::AdapterManager;
-use anolisa_core::{
-    Catalog, CatalogLayers, FetchFailure, HttpFetch, InstalledState, ObjectStatus, UreqFetch,
-};
+use anolisa_core::{Catalog, CatalogLayers, InstalledState, ObjectStatus};
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::context::{CliContext, InstallMode};
 use crate::packaged;
-use crate::repo_config::{HostVars, RepoConfig, raw_relative_root};
 use crate::response::CliError;
 
 /// Subdirectory under `datadir` and `etc_dir` where component
@@ -199,79 +196,6 @@ fn dev_tree_manifests() -> Option<PathBuf> {
         .join("..")
         .join("manifests");
     candidate.is_dir().then_some(candidate)
-}
-
-// ── Component catalog URL resolution ────────────────────────────────
-
-/// Resolve the component catalog URL.
-///
-/// Resolution order (first non-empty wins):
-///   1. `$ANOLISA_CATALOG_URL` env var
-///   2. `[backends.raw].base_url` in `repo.toml`, plus `/catalog.json`
-///
-/// `repo.toml` follows its own discovery chain across user/site, packaged,
-/// and dev-tree disk locations.
-pub fn resolve_catalog_url(ctx: &CliContext, command: &str) -> Result<Option<String>, CliError> {
-    if let Ok(url) = std::env::var("ANOLISA_CATALOG_URL") {
-        let trimmed = url.trim();
-        if !trimmed.is_empty() {
-            return Ok(Some(trimmed.to_string()));
-        }
-    }
-
-    let layout = resolve_layout(ctx);
-    let repo_config = RepoConfig::load(&layout).map_err(|err| CliError::InvalidArgument {
-        command: command.to_string(),
-        reason: format!("failed to resolve component catalog from repo.toml: {err}"),
-    })?;
-    let (backend_name, backend) =
-        repo_config
-            .select_backend(Some("raw"))
-            .map_err(|err| CliError::InvalidArgument {
-                command: command.to_string(),
-                reason: format!("failed to resolve component catalog from repo.toml: {err}"),
-            })?;
-    let env = anolisa_env::EnvService::detect();
-    let host = HostVars {
-        os: env.os,
-        arch: env.arch,
-    };
-    let base_url = repo_config
-        .resolved_base_url(backend_name, backend, &host)
-        .map_err(|err| CliError::InvalidArgument {
-            command: command.to_string(),
-            reason: format!("failed to resolve component catalog from repo.toml: {err}"),
-        })?;
-    Ok(Some(format!(
-        "{}/catalog.json",
-        raw_relative_root(&base_url)
-    )))
-}
-
-/// Fetch raw bytes from a catalog URL.
-///
-/// Supports `file://` (local filesystem) and `http(s)://` (via `UreqFetch`).
-pub fn fetch_catalog_bytes(url: &str, command: &str) -> Result<Vec<u8>, CliError> {
-    if let Some(path) = url.strip_prefix("file://") {
-        return std::fs::read(path).map_err(|err| CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("failed to read catalog from {url}: {err}"),
-        });
-    }
-
-    if url.starts_with("http://") || url.starts_with("https://") {
-        return UreqFetch::default()
-            .get(url)
-            .map_err(|err: FetchFailure| CliError::Runtime {
-                command: command.to_string(),
-                reason: format!("failed to fetch catalog from {url}: {err}"),
-            });
-    }
-
-    Err(CliError::InvalidArgument {
-        command: command.to_string(),
-        reason: format!("unsupported catalog URL scheme: {url}"),
-    })
 }
 
 /// Wire-friendly label for an [`ObjectStatus`] value. Shared between the

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -25,7 +25,7 @@
 //! health checks.
 
 use clap::Parser;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -88,7 +88,7 @@ pub struct InstallArgs {
     /// Component name to install
     #[arg(value_name = "COMPONENT")]
     pub component: Option<String>,
-    /// Install every component listed in the catalog (mutually exclusive with COMPONENT)
+    /// Install every component in the component index (mutually exclusive with COMPONENT)
     #[arg(long, conflicts_with_all = ["component", "version", "package"])]
     pub all: bool,
     /// With --all, stop on the first failure instead of continuing
@@ -1672,24 +1672,6 @@ fn rpm_tooling_missing_error(command: &str) -> CliError {
 
 // ── --all support ───────────────────────────────────────────────────
 
-/// Minimal catalog shape used by `--all`. We only need the component name
-/// and (optionally) the `available` status, so this is a thin parse rather
-/// than a re-use of `list.rs`'s richer types. Keeping it local avoids a
-/// cross-module type dependency for one entry point.
-#[derive(Debug, Deserialize)]
-struct AllCatalogV1 {
-    schema_version: u32,
-    #[serde(default)]
-    components: Vec<AllCatalogEntry>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AllCatalogEntry {
-    name: String,
-    #[serde(default)]
-    status: Option<String>,
-}
-
 /// Wire shape for a batch entry.  `status` is one of:
 /// `installed` | `planned` (dry-run) | `adopted` | `adopt-planned` (dry-run) |
 /// `failed` | `skipped`.
@@ -1716,13 +1698,13 @@ struct AllSummaryPayload {
 }
 
 fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
-    let names = resolve_all_components(ctx)?;
+    let names = resolve_all_components(ctx, args.backend.as_deref())?;
     if names.is_empty() {
         if !ctx.quiet && !ctx.json {
             let color = Palette::new(ctx.no_color);
             println!(
                 "{}",
-                color.muted("no available components in catalog; nothing to install")
+                color.muted("no available components in component index; nothing to install")
             );
         }
         if ctx.json {
@@ -1926,45 +1908,40 @@ fn batch_status(outcome: InstallOutcome, dry_run: bool) -> &'static str {
     }
 }
 
-/// Fetch and parse the component catalog, returning the names of components
-/// whose `status` is `available`. Returns an error if the catalog URL is not
-/// configured or the catalog cannot be fetched/parsed.
-fn resolve_all_components(ctx: &CliContext) -> Result<Vec<String>, CliError> {
-    let url = common::resolve_catalog_url(ctx, "install --all")?.ok_or_else(|| {
-        CliError::InvalidArgument {
-            command: "install --all".to_string(),
-            reason: "component catalog is not configured; set ANOLISA_CATALOG_URL or \
-                 configure [backends.raw].base_url in repo.toml"
-                .to_string(),
-        }
+/// Load the component index and return names of components that support
+/// the given backend. When `backend` is `None`, the repo's default
+/// backend is used.
+fn resolve_all_components(
+    ctx: &CliContext,
+    backend: Option<&str>,
+) -> Result<Vec<String>, CliError> {
+    let layout = common::resolve_layout(ctx);
+    let env = anolisa_env::EnvService::detect();
+    let repo_config = RepoConfig::load(&layout).map_err(|err| CliError::InvalidArgument {
+        command: "install --all".to_string(),
+        reason: format!("failed to load repo.toml: {err}"),
     })?;
-    let bytes = common::fetch_catalog_bytes(&url, "install --all")?;
-    let catalog: AllCatalogV1 =
-        serde_json::from_slice(&bytes).map_err(|err| CliError::InvalidArgument {
-            command: "install --all".to_string(),
-            reason: format!("failed to parse component catalog JSON: {err}"),
-        })?;
-    if catalog.schema_version != 1 {
-        return Err(CliError::InvalidArgument {
-            command: "install --all".to_string(),
-            reason: format!(
-                "unsupported component catalog schema_version {}; expected 1",
-                catalog.schema_version
-            ),
-        });
-    }
-    let mut names: Vec<String> = Vec::new();
-    for entry in catalog.components {
-        if entry.name.trim().is_empty() {
-            if !ctx.quiet {
-                eprintln!("warning: catalog contains an entry with an empty name; skipping");
+    let index =
+        crate::resolution::load_component_index(&layout, &env, &repo_config).map_err(|err| {
+            CliError::Runtime {
+                command: "install --all".to_string(),
+                reason: format!("failed to load component index: {err}"),
             }
-            continue;
-        }
-        if entry.status.as_deref() == Some("available") {
-            names.push(entry.name);
-        }
-    }
+        })?;
+    let (selected_backend, _) =
+        repo_config
+            .select_backend(backend)
+            .map_err(|err| CliError::InvalidArgument {
+                command: "install --all".to_string(),
+                reason: format!("{err}"),
+            })?;
+    let selected_backend = selected_backend.to_string();
+    let names: Vec<String> = index
+        .components
+        .iter()
+        .filter(|entry| entry.backends.iter().any(|b| b.kind == selected_backend))
+        .map(|entry| entry.name.clone())
+        .collect();
     Ok(names)
 }
 
@@ -5563,59 +5540,6 @@ scope = "@anolisa"
             InstallArgs::try_parse_from(["install", "--all", "--fail-fast"]).expect("should parse");
         assert!(a.all);
         assert!(a.fail_fast);
-    }
-
-    // ── catalog parsing tests ────────────────────────────────────────
-
-    #[test]
-    fn all_catalog_filters_available_components() {
-        let json = r#"{
-            "schema_version": 1,
-            "components": [
-                {"name": "a", "status": "available"},
-                {"name": "b", "status": "planned"},
-                {"name": "c", "status": "available"},
-                {"name": "d"}
-            ]
-        }"#;
-        let catalog: AllCatalogV1 = serde_json::from_str(json).expect("parse");
-        assert_eq!(catalog.schema_version, 1);
-        let names: Vec<String> = catalog
-            .components
-            .into_iter()
-            .filter(|c| c.status.as_deref() == Some("available"))
-            .map(|c| c.name)
-            .filter(|n| !n.trim().is_empty())
-            .collect();
-        assert_eq!(names, vec!["a", "c"]);
-    }
-
-    #[test]
-    fn all_catalog_rejects_unsupported_schema_version() {
-        let json = r#"{"schema_version": 2, "components": []}"#;
-        let catalog: AllCatalogV1 = serde_json::from_str(json).expect("parse");
-        assert_ne!(catalog.schema_version, 1);
-    }
-
-    #[test]
-    fn all_catalog_skips_empty_names() {
-        let json = r#"{
-            "schema_version": 1,
-            "components": [
-                {"name": "", "status": "available"},
-                {"name": "  ", "status": "available"},
-                {"name": "valid", "status": "available"}
-            ]
-        }"#;
-        let catalog: AllCatalogV1 = serde_json::from_str(json).expect("parse");
-        let names: Vec<String> = catalog
-            .components
-            .into_iter()
-            .filter(|c| c.status.as_deref() == Some("available"))
-            .map(|c| c.name)
-            .filter(|n| !n.trim().is_empty())
-            .collect();
-        assert_eq!(names, vec!["valid"]);
     }
 
     // ── rpm adopt path (#958) ───────────────────────────────────────

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -1,80 +1,26 @@
-//! `anolisa list` — list available components from a remote catalog.
+//! `anolisa list` — list available components from the component index.
 //!
-//! Fetches a JSON component declaration file (v1 schema) from a
-//! configurable URL, maps each entry to a [`Row`], and renders as a
-//! human table or `--json` envelope.
-//!
-//! Install status is resolved from `installed.toml` by matching
-//! [`ObjectKind::Component`] objects against catalog entries.
-//! `--enabled` filters to rows whose status is `installed`.
+//! Reads the repo-side `components.toml` (the component identity index),
+//! merges install status from `installed.toml`, and renders as a human
+//! table or `--json` envelope.
 
 use anolisa_core::state::{InstalledState, ObjectKind, ObjectStatus};
 use clap::Parser;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::color::{Palette, pad_right};
 use crate::commands::common;
 use crate::context::CliContext;
-use crate::response::{CliError, CliResponse, SCHEMA_VERSION, render_json};
+use crate::resolution::{ComponentIndex, ComponentIndexEntry, load_component_index};
+use crate::response::{CliError, render_json};
 
 const COMMAND: &str = "list";
 
 #[derive(Parser)]
 pub struct ListArgs {
-    /// Show only components marked as available
-    #[arg(long)]
-    pub available: bool,
     /// Show only currently installed components
-    #[arg(long)]
-    pub enabled: bool,
-}
-
-// ── Deserialization types for the v1 component catalog JSON ─────────
-
-#[derive(Debug, Deserialize)]
-struct ComponentCatalogV1 {
-    schema_version: u32,
-    #[serde(default)]
-    components: Vec<ComponentEntry>,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct ComponentEntry {
-    name: String,
-    #[serde(default)]
-    display_name: Option<String>,
-    #[serde(default)]
-    summary: Option<String>,
-    #[serde(default)]
-    category: Option<String>,
-    #[serde(default)]
-    version: Option<String>,
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    backends: Option<Vec<BackendEntry>>,
-    #[serde(default)]
-    platforms: Option<Vec<PlatformEntry>>,
-    #[serde(default)]
-    tags: Option<Vec<String>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct BackendEntry {
-    #[serde(rename = "type")]
-    backend_type: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct PlatformEntry {
-    #[serde(default)]
-    os: Option<String>,
-    #[serde(default)]
-    arch: Option<String>,
-    #[serde(default)]
-    distros: Option<Vec<String>>,
+    #[arg(long, alias = "enabled")]
+    pub installed: bool,
 }
 
 // ── Wire / JSON output types ───────────────────────────────────────
@@ -84,11 +30,8 @@ pub struct Row {
     pub name: String,
     pub display_name: String,
     pub summary: String,
-    pub category: String,
-    pub version: String,
     pub backends: Vec<String>,
     pub status: String,
-    pub available: bool,
 }
 
 #[derive(Serialize)]
@@ -99,13 +42,22 @@ struct ListPayload {
 // ── Handler ────────────────────────────────────────────────────────
 
 pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
-    let Some(url) = common::resolve_catalog_url(ctx, COMMAND)? else {
-        return render_missing_catalog(ctx);
-    };
-    let bytes = common::fetch_catalog_bytes(&url, COMMAND)?;
-    let catalog = parse_catalog(&bytes)?;
+    let layout = common::resolve_layout(ctx);
+    let env = anolisa_env::EnvService::detect();
+    let repo_config =
+        crate::repo_config::RepoConfig::load(&layout).map_err(|err| CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: format!("failed to load repo.toml: {err}"),
+        })?;
+
+    let index =
+        load_component_index(&layout, &env, &repo_config).map_err(|err| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!("failed to load component index: {err}"),
+        })?;
+
     let state = common::load_installed_state(ctx, COMMAND)?;
-    let rows = build_rows(&catalog, &args, &state)?;
+    let rows = build_rows(&index, &args, &state);
 
     if ctx.json {
         return render_json(COMMAND, ListPayload { components: rows });
@@ -117,128 +69,35 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
     Ok(())
 }
 
-fn render_missing_catalog(ctx: &CliContext) -> Result<(), CliError> {
-    let config_path = common::resolve_layout(ctx).etc_dir.join("repo.toml");
-    let warning = format!(
-        "component catalog is not configured; \
-         the catalog provides the list of available components — without it, \
-         `anolisa ls` cannot display anything. \
-         Set ANOLISA_CATALOG_URL or configure [backends.raw].base_url in {}",
-        config_path.display()
-    );
-
-    if ctx.json {
-        let response = CliResponse {
-            ok: true,
-            schema_version: SCHEMA_VERSION,
-            command: COMMAND.to_string(),
-            data: Some(ListPayload {
-                components: Vec::new(),
-            }),
-            warnings: vec![warning],
-            error: None,
-        };
-        let s = serde_json::to_string_pretty(&response).map_err(|err| CliError::Runtime {
-            command: COMMAND.to_string(),
-            reason: format!("failed to serialize JSON response: {err}"),
-        })?;
-        println!("{s}");
-        return Ok(());
-    }
-
-    if !ctx.quiet {
-        let color = Palette::new(ctx.no_color);
-        println!("{}", color.muted("no component catalog configured"));
-        println!();
-        println!("  The component catalog provides the list of available ANOLISA components.");
-        println!("  Without it, `anolisa ls` cannot display anything.");
-        println!();
-        println!("  {}", color.label("config file:"));
-        println!("    {}", config_path.display());
-        println!();
-        println!("  {}", color.label("option 1 — environment variable:"));
-        println!(
-            "    export ANOLISA_CATALOG_URL=https://example.com/anolisa-releases/anolisa/v1/catalog.json"
-        );
-        println!();
-        println!("  {}", color.label("option 2 — add to repo.toml:"));
-        println!("    [backends.raw]");
-        println!("    base_url = \"https://example.com/anolisa-releases/anolisa/v1/\"");
-    }
-    Ok(())
-}
-
-fn parse_catalog(bytes: &[u8]) -> Result<ComponentCatalogV1, CliError> {
-    let catalog: ComponentCatalogV1 =
-        serde_json::from_slice(bytes).map_err(|err| CliError::InvalidArgument {
-            command: COMMAND.to_string(),
-            reason: format!("failed to parse component catalog JSON: {err}"),
-        })?;
-
-    if catalog.schema_version != 1 {
-        return Err(CliError::InvalidArgument {
-            command: COMMAND.to_string(),
-            reason: format!(
-                "unsupported component catalog schema_version {}; expected 1",
-                catalog.schema_version
-            ),
-        });
-    }
-
-    for entry in &catalog.components {
-        if entry.name.trim().is_empty() {
-            return Err(CliError::InvalidArgument {
-                command: COMMAND.to_string(),
-                reason: "component catalog contains an entry with an empty name".to_string(),
-            });
-        }
-    }
-
-    Ok(catalog)
-}
-
-fn build_rows(
-    catalog: &ComponentCatalogV1,
-    args: &ListArgs,
-    state: &InstalledState,
-) -> Result<Vec<Row>, CliError> {
-    let rows: Vec<Row> = catalog
+fn build_rows(index: &ComponentIndex, args: &ListArgs, state: &InstalledState) -> Vec<Row> {
+    index
         .components
         .iter()
-        .map(|entry| {
-            let backends: Vec<String> = entry
-                .backends
-                .as_ref()
-                .map(|bs| bs.iter().map(|b| b.backend_type.clone()).collect())
-                .unwrap_or_default();
-            let available = entry.status.as_deref() == Some("available");
-            let installed = state
-                .find_object(ObjectKind::Component, &entry.name)
-                .is_some_and(|obj| obj.status == ObjectStatus::Installed);
-            let status = if installed {
-                "installed"
-            } else {
-                "not_installed"
-            };
-            Row {
-                name: entry.name.clone(),
-                display_name: entry
-                    .display_name
-                    .clone()
-                    .unwrap_or_else(|| entry.name.clone()),
-                summary: entry.summary.clone().unwrap_or_default(),
-                category: entry.category.clone().unwrap_or_default(),
-                version: entry.version.clone().unwrap_or_default(),
-                backends,
-                status: status.to_string(),
-                available,
-            }
-        })
-        .filter(|row| !args.available || row.available)
-        .filter(|row| !args.enabled || row.status == "installed")
-        .collect();
+        .map(|entry| entry_to_row(entry, state))
+        .filter(|row| !args.installed || row.status == "installed")
+        .collect()
+}
 
-    Ok(rows)
+fn entry_to_row(entry: &ComponentIndexEntry, state: &InstalledState) -> Row {
+    let backends: Vec<String> = entry.backends.iter().map(|b| b.kind.clone()).collect();
+    let installed = state
+        .find_object(ObjectKind::Component, &entry.name)
+        .is_some_and(|obj| obj.status == ObjectStatus::Installed);
+    let status = if installed {
+        "installed"
+    } else {
+        "not_installed"
+    };
+    Row {
+        name: entry.name.clone(),
+        display_name: entry
+            .display_name
+            .clone()
+            .unwrap_or_else(|| entry.name.clone()),
+        summary: entry.summary.clone().unwrap_or_default(),
+        backends,
+        status: status.to_string(),
+    }
 }
 
 fn render_human(rows: &[Row], no_color: bool) {
@@ -247,11 +106,34 @@ fn render_human(rows: &[Row], no_color: bool) {
         println!("{}", color.muted("no components found"));
         return;
     }
+
+    let name_width = rows.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4) + 2;
+    let summary_width = rows
+        .iter()
+        .map(|r| r.summary.chars().count())
+        .max()
+        .unwrap_or(7)
+        .clamp(7, 50)
+        + 2;
+    let backends_width = rows
+        .iter()
+        .map(|r| {
+            if r.backends.is_empty() {
+                1
+            } else {
+                r.backends.join(",").len()
+            }
+        })
+        .max()
+        .unwrap_or(8)
+        .max(8)
+        + 2;
+
     println!(
         "{}",
         color.header(format!(
-            "{:<24} {:<16} {:<10} {:<12} {}",
-            "NAME", "CATEGORY", "VERSION", "BACKEND", "STATUS"
+            "{:<name_width$}{:<summary_width$}{:<backends_width$}{}",
+            "NAME", "SUMMARY", "BACKENDS", "STATUS",
         ))
     );
     for row in rows {
@@ -260,11 +142,17 @@ fn render_human(rows: &[Row], no_color: bool) {
         } else {
             row.backends.join(",")
         };
+        let max_chars = summary_width - 2;
+        let summary = if row.summary.chars().count() > max_chars {
+            let truncated: String = row.summary.chars().take(max_chars - 1).collect();
+            format!("{truncated}…")
+        } else {
+            row.summary.clone()
+        };
         println!(
-            "{:<24} {:<16} {:<10} {:<12} {}",
+            "{:<name_width$}{:<summary_width$}{:<backends_width$}{}",
             row.name,
-            row.category,
-            row.version,
+            summary,
             backend_str,
             color.status(pad_right(&row.status, 14)),
         );
@@ -274,40 +162,49 @@ fn render_human(rows: &[Row], no_color: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resolution::ComponentBackendEntry;
     use anolisa_core::state::InstalledObject;
 
-    fn sample_catalog_json() -> &'static str {
-        r#"{
-            "schema_version": 1,
-            "generated_at": "2026-06-11T00:00:00Z",
-            "channel": "stable",
-            "components": [
-                {
-                    "name": "agentsight",
-                    "display_name": "AgentSight",
-                    "summary": "Agent behavior tracing and token attribution",
-                    "category": "observability",
-                    "version": "0.1.4",
-                    "status": "available",
-                    "backends": [
-                        {"type": "oss", "url": "https://example.com/agentsight.tar.gz", "sha256": "abc"},
-                        {"type": "rpm", "repo_url": "https://repo.example.com", "package": "agentsight"}
+    fn sample_index() -> ComponentIndex {
+        ComponentIndex {
+            schema_version: 1,
+            generated_at: None,
+            publisher: Some("anolisa".to_string()),
+            components: vec![
+                ComponentIndexEntry {
+                    name: "agentsight".to_string(),
+                    display_name: Some("AgentSight".to_string()),
+                    summary: Some("eBPF-based AI agent observability tool".to_string()),
+                    backends: vec![
+                        ComponentBackendEntry {
+                            kind: "raw".to_string(),
+                            package: "agentsight".to_string(),
+                            provides: None,
+                            legacy_adopt: false,
+                        },
+                        ComponentBackendEntry {
+                            kind: "rpm".to_string(),
+                            package: "agentsight".to_string(),
+                            provides: Some("anolisa-component(agentsight)".to_string()),
+                            legacy_adopt: true,
+                        },
                     ],
-                    "platforms": [{"os": "linux", "arch": "x86_64", "distros": ["alinux3"]}],
-                    "tags": ["agent", "trace"]
+                    aliases: Vec::new(),
                 },
-                {
-                    "name": "tokenless",
-                    "display_name": "Tokenless",
-                    "summary": "Token compression runtime",
-                    "category": "runtime",
-                    "version": "0.2.0",
-                    "status": "deprecated",
-                    "backends": [{"type": "oss", "url": "https://example.com/tokenless.tar.gz"}],
-                    "tags": ["token"]
-                }
-            ]
-        }"#
+                ComponentIndexEntry {
+                    name: "tokenless".to_string(),
+                    display_name: Some("Tokenless".to_string()),
+                    summary: Some("LLM token optimization toolkit".to_string()),
+                    backends: vec![ComponentBackendEntry {
+                        kind: "raw".to_string(),
+                        package: "tokenless".to_string(),
+                        provides: None,
+                        legacy_adopt: false,
+                    }],
+                    aliases: Vec::new(),
+                },
+            ],
+        }
     }
 
     fn empty_state() -> InstalledState {
@@ -343,65 +240,31 @@ mod tests {
     }
 
     #[test]
-    fn parse_v1_catalog_builds_rows() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("valid v1 JSON");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+    fn index_builds_rows() {
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = empty_state();
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         assert_eq!(rows.len(), 2);
 
         let sight = &rows[0];
         assert_eq!(sight.name, "agentsight");
         assert_eq!(sight.display_name, "AgentSight");
-        assert_eq!(
-            sight.summary,
-            "Agent behavior tracing and token attribution"
-        );
-        assert_eq!(sight.category, "observability");
-        assert_eq!(sight.version, "0.1.4");
-        assert_eq!(sight.backends, vec!["oss", "rpm"]);
+        assert_eq!(sight.summary, "eBPF-based AI agent observability tool");
+        assert_eq!(sight.backends, vec!["raw", "rpm"]);
         assert_eq!(sight.status, "not_installed");
-        assert!(sight.available);
 
         let token = &rows[1];
         assert_eq!(token.name, "tokenless");
-        assert_eq!(token.backends, vec!["oss"]);
-        assert!(!token.available);
-    }
-
-    #[test]
-    fn schema_version_mismatch_errors() {
-        let json = r#"{"schema_version": 2, "components": []}"#;
-        let err = parse_catalog(json.as_bytes()).expect_err("must reject schema v2");
-        assert!(err.reason().contains("schema_version 2"));
-    }
-
-    #[test]
-    fn available_filter_keeps_only_available() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: true,
-            enabled: false,
-        };
-        let state = empty_state();
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].name, "agentsight");
-        assert!(rows[0].available);
+        assert_eq!(token.backends, vec!["raw"]);
     }
 
     #[test]
     fn empty_state_all_not_installed() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = empty_state();
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         for row in &rows {
             assert_eq!(row.status, "not_installed");
         }
@@ -409,13 +272,10 @@ mod tests {
 
     #[test]
     fn installed_component_shows_installed() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
 
         let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
         assert_eq!(sight.status, "not_installed");
@@ -426,113 +286,72 @@ mod tests {
 
     #[test]
     fn adapter_object_does_not_mark_component_installed() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = state_with_object(ObjectKind::Adapter, "tokenless", ObjectStatus::Installed);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
         assert_eq!(token.status, "not_installed");
     }
 
     #[test]
     fn failed_component_shows_not_installed() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Failed);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
         assert_eq!(token.status, "not_installed");
     }
 
     #[test]
     fn disabled_component_shows_not_installed() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Disabled);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
         assert_eq!(token.status, "not_installed");
     }
 
     #[test]
-    fn enabled_returns_only_installed() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: true,
-        };
+    fn installed_filter_returns_only_installed() {
+        let index = sample_index();
+        let args = ListArgs { installed: true };
         let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].name, "tokenless");
         assert_eq!(rows[0].status, "installed");
     }
 
     #[test]
-    fn enabled_with_empty_state_returns_empty() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: true,
-        };
+    fn installed_filter_with_empty_state_returns_empty() {
+        let index = sample_index();
+        let args = ListArgs { installed: true };
         let state = empty_state();
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         assert!(rows.is_empty());
-    }
-
-    #[test]
-    fn available_and_enabled_returns_intersection() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: true,
-            enabled: true,
-        };
-        // tokenless is installed but not available; agentsight is available but not installed
-        let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
-        assert!(rows.is_empty());
-
-        // agentsight is both available and installed
-        let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Installed);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].name, "agentsight");
     }
 
     #[test]
     fn json_payload_uses_components_key() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = empty_state();
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         let payload = ListPayload { components: rows };
         let json_str = serde_json::to_string(&payload).expect("serialize");
         let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
         assert!(val.get("components").is_some());
-        assert!(val.get("capabilities").is_none());
     }
 
     #[test]
     fn json_payload_status_reflects_install_state() {
-        let catalog = parse_catalog(sample_catalog_json().as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
+        let index = sample_index();
+        let args = ListArgs { installed: false };
         let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Installed);
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         let payload = ListPayload { components: rows };
         let json_str = serde_json::to_string(&payload).expect("serialize");
         let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
@@ -550,50 +369,53 @@ mod tests {
     }
 
     #[test]
-    fn empty_name_rejected() {
-        let json = r#"{"schema_version": 1, "components": [{"name": ""}]}"#;
-        let err = parse_catalog(json.as_bytes()).expect_err("must reject empty name");
-        assert!(err.reason().contains("empty name"));
-    }
-
-    #[test]
-    fn unknown_backend_type_preserved() {
-        let json = r#"{
-            "schema_version": 1,
-            "components": [{
-                "name": "test",
-                "backends": [{"type": "custom-repo"}]
-            }]
-        }"#;
-        let catalog = parse_catalog(json.as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
-        };
-        let state = empty_state();
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
-        assert_eq!(rows[0].backends, vec!["custom-repo"]);
-    }
-
-    #[test]
     fn missing_optional_fields_use_defaults() {
-        let json = r#"{"schema_version": 1, "components": [{"name": "minimal"}]}"#;
-        let catalog = parse_catalog(json.as_bytes()).expect("parse");
-        let args = ListArgs {
-            available: false,
-            enabled: false,
+        let index = ComponentIndex {
+            schema_version: 1,
+            generated_at: None,
+            publisher: None,
+            components: vec![ComponentIndexEntry {
+                name: "minimal".to_string(),
+                display_name: None,
+                summary: None,
+                backends: Vec::new(),
+                aliases: Vec::new(),
+            }],
         };
+        let args = ListArgs { installed: false };
         let state = empty_state();
-        let rows = build_rows(&catalog, &args, &state).expect("build_rows");
+        let rows = build_rows(&index, &args, &state);
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
         assert_eq!(row.name, "minimal");
         assert_eq!(row.display_name, "minimal");
         assert!(row.summary.is_empty());
-        assert!(row.category.is_empty());
-        assert!(row.version.is_empty());
         assert!(row.backends.is_empty());
         assert_eq!(row.status, "not_installed");
-        assert!(!row.available);
+    }
+
+    #[test]
+    fn unknown_backend_kind_preserved() {
+        let index = ComponentIndex {
+            schema_version: 1,
+            generated_at: None,
+            publisher: None,
+            components: vec![ComponentIndexEntry {
+                name: "test".to_string(),
+                display_name: None,
+                summary: None,
+                backends: vec![ComponentBackendEntry {
+                    kind: "custom-repo".to_string(),
+                    package: "test".to_string(),
+                    provides: None,
+                    legacy_adopt: false,
+                }],
+                aliases: Vec::new(),
+            }],
+        };
+        let args = ListArgs { installed: false };
+        let state = empty_state();
+        let rows = build_rows(&index, &args, &state);
+        assert_eq!(rows[0].backends, vec!["custom-repo"]);
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -110,6 +110,9 @@ pub(crate) enum ComponentIndexError {
     /// Invalid component row.
     #[error("invalid component index entry: {reason}")]
     Invalid { reason: String },
+    /// Backend resolution or download failure.
+    #[error("failed to fetch component index: {reason}")]
+    Fetch { reason: String },
 }
 
 /// Backend selected for identity resolution.
@@ -614,36 +617,55 @@ pub(crate) fn rpm_components_from_capabilities(capabilities: &[String]) -> Vec<S
     components
 }
 
+/// Load repo-side `components.toml`, returning a structured error on failure.
+///
+/// Used by commands (`ls`, `install --all`) that require the component index
+/// to function. For best-effort usage where a missing index is acceptable,
+/// use [`load_optional_component_index`] instead.
+pub(crate) fn load_component_index(
+    layout: &FsLayout,
+    env: &anolisa_env::EnvFacts,
+    repo_config: &RepoConfig,
+) -> Result<ComponentIndex, ComponentIndexError> {
+    let host = HostVars {
+        os: env.os.clone(),
+        arch: env.arch.clone(),
+    };
+    let (name, backend) =
+        repo_config
+            .select_backend(Some("raw"))
+            .map_err(|err| ComponentIndexError::Fetch {
+                reason: format!("cannot resolve raw backend in repo.toml: {err}"),
+            })?;
+    let base_url = repo_config
+        .resolved_base_url(name, backend, &host)
+        .map_err(|err| ComponentIndexError::Fetch {
+            reason: format!("cannot resolve base_url for raw backend: {err}"),
+        })?;
+    let url = component_index_url(&base_url);
+
+    let cache = DownloadCache::new(layout.cache_dir.clone());
+    #[cfg(test)]
+    if !url.starts_with("file://") {
+        return Err(ComponentIndexError::Fetch {
+            reason: format!("test mode: refusing non-file URL {url}"),
+        });
+    }
+    let downloaded = cache
+        .fetch(&url, None)
+        .map_err(|err| ComponentIndexError::Fetch {
+            reason: format!("failed to fetch {url}: {err}"),
+        })?;
+    ComponentIndex::load(&downloaded.cached_path)
+}
+
 /// Best-effort load of repo-side `components.toml`.
 pub(crate) fn load_optional_component_index(
     layout: &FsLayout,
     env: &anolisa_env::EnvFacts,
     repo_config: &RepoConfig,
 ) -> Option<ComponentIndex> {
-    let host = HostVars {
-        os: env.os.clone(),
-        arch: env.arch.clone(),
-    };
-    let Ok((name, backend)) = repo_config.select_backend(Some("raw")) else {
-        return None;
-    };
-    let Ok(base_url) = repo_config.resolved_base_url(name, backend, &host) else {
-        return None;
-    };
-    let url = component_index_url(&base_url);
-
-    let cache = DownloadCache::new(layout.cache_dir.clone());
-    #[cfg(test)]
-    if !url.starts_with("file://") {
-        return None;
-    }
-    let Ok(downloaded) = cache.fetch(&url, None) else {
-        return None;
-    };
-    if let Ok(index) = ComponentIndex::load(&downloaded.cached_path) {
-        return Some(index);
-    }
-    None
+    load_component_index(layout, env, repo_config).ok()
 }
 
 #[cfg(test)]

--- a/src/anolisa/scripts/demo-agentsight-uninstall.sh
+++ b/src/anolisa/scripts/demo-agentsight-uninstall.sh
@@ -26,8 +26,8 @@
 #        * the binary under `$PREFIX/usr/local/bin/agentsight` is gone,
 #        * `installed.toml` no longer carries the component,
 #        * `status --json` reports an empty `.data.components` array,
-#        * `list --json` (against a local catalog) does not report
-#          agentsight as installed,
+#        * `list --json` (against the local component index) does not
+#          report agentsight as installed,
 #        * a second `uninstall` fails with INVALID_ARGUMENT (exit 2).
 #
 # Scope / non-goals:
@@ -183,28 +183,23 @@ base_url = "file://$REPO_V1"
 EOF
 echo "[demo-uninstall] repo.toml at $PREFIX/etc/anolisa/repo.toml"
 
-# --- local component catalog for `list` ---------------------------------------
-# `list` fetches a JSON component catalog from $ANOLISA_CATALOG_URL (or
-# [catalog].url in <etc_dir>/config.toml). Provide a local one so the
-# final list assertion exercises a real catalog row for agentsight.
-CATALOG_PATH="$DEMO_ROOT/catalog.json"
-cat >"$CATALOG_PATH" <<EOF
-{
-  "schema_version": 1,
-  "components": [
-    {
-      "name": "agentsight",
-      "display_name": "AgentSight",
-      "summary": "Agent observability demo entry",
-      "category": "observability",
-      "version": "0.2.0",
-      "status": "available"
-    }
-  ]
-}
+# --- component index for `list` -----------------------------------------------
+# `list` reads `components.toml` from the raw backend's base_url. Provide
+# one so the final list assertion exercises a real component index entry
+# for agentsight.
+cat >"$REPO_V1/components.toml" <<'EOF'
+schema_version = 1
+
+[[components]]
+name = "agentsight"
+display_name = "AgentSight"
+summary = "Agent observability demo entry"
+
+[[components.backends]]
+kind = "raw"
+package = "agentsight"
 EOF
-export ANOLISA_CATALOG_URL="file://$CATALOG_PATH"
-echo "[demo-uninstall] catalog at $CATALOG_PATH"
+echo "[demo-uninstall] components.toml at $REPO_V1/components.toml"
 
 # Build once so the per-step `cargo run` invocations don't each pay
 # the compile cost.
@@ -337,14 +332,14 @@ if [ "$STATUS_LEN" != "0" ]; then
   fail "expected .data.components to be an empty array after uninstall, got length $STATUS_LEN"
 fi
 
-# --- list: catalog row for agentsight must not read installed -------------------
+# --- list: component index entry for agentsight must not read installed --------
 step "list --json"
 capture_cli "list" list --json
 LIST_OUT="$OUT"
 LIST_AGENTSIGHT="$(printf '%s' "$LIST_OUT" | jq -r \
   '[.data.components[] | select(.name == "agentsight")] | length')"
 if [ "$LIST_AGENTSIGHT" -lt 1 ]; then
-  fail "local catalog row for agentsight missing from 'list' output"
+  fail "agentsight missing from component index in 'list' output"
 fi
 LIST_INSTALLED="$(printf '%s' "$LIST_OUT" | jq -r \
   '[.data.components[] | select(.name == "agentsight" and .status == "installed")] | length')"


### PR DESCRIPTION
## Description

Switches `anolisa ls` and `install --all` from the remote `catalog.json` to `components.toml` (the component identity index). `catalog.json` was redundant and out of sync — missing RPM-only components (sec-core, skillfs) and showing only the raw backend for all entries.

Changes:
- `ls` handler rewritten to load `ComponentIndex` via a new `load_component_index()` in `resolution.rs`.
- Output columns changed from NAME/CATEGORY/VERSION/BACKEND/STATUS to NAME/SUMMARY/BACKENDS/STATUS.
- `--available` flag removed (all indexed components are available by definition).
- `--enabled` renamed to `--installed`; `--enabled` kept as a hidden alias for backward compatibility.
- `install --all` rewritten: `resolve_all_components()` now loads `ComponentIndex` instead of parsing catalog JSON.
- Removed `resolve_catalog_url()`, `fetch_catalog_bytes()`, `ANOLISA_CATALOG_URL` env var, and all catalog.json deserialization types (`AllCatalogV1`, `AllCatalogEntry`).
- Deduplicated `load_optional_component_index()` as a thin `.ok()` wrapper over the new strict loader.
- Updated `demo-agentsight-uninstall.sh` to use `components.toml` under the raw backend root instead of a standalone `catalog.json`.

## Design Note

`load_component_index()` is a strict variant of the existing `load_optional_component_index()`: it returns `Result<ComponentIndex, ComponentIndexError>` instead of `Option`, so `ls` and `install --all` surface meaningful errors on failure. Other commands (install, status, adopt, repair) continue using the best-effort optional loader unchanged. The optional loader is now a one-line `.ok()` wrapper over the strict version.

## Ship Note

- The remote `catalog.json` is no longer read by any code path but is not deleted from the distribution root by this PR; it can be decommissioned separately once no older CLI versions depend on it.
- `ls` no longer exposes version information. A dedicated `info <component>` command is the intended follow-up for per-component detail queries; deferred to keep this PR scoped.

## Test

- All existing tests rewritten to construct `ComponentIndex`/`ComponentIndexEntry` directly instead of parsing JSON.
- Full gate green: `cargo clippy --workspace` (0 warnings), `cargo test --workspace` (1067 passed, 0 failed).
- Grep confirms zero residual references to `catalog.json`, `ANOLISA_CATALOG_URL`, `resolve_catalog_url`, `fetch_catalog_bytes`, or `AllCatalogV1` across the entire repository.

Closes #1201