### PR TITLE
fix(skill): verify OpenClaw gateway write scope

### DIFF
--- a/src/os-skills/ai/install-openclaw/SKILL.md
+++ b/src/os-skills/ai/install-openclaw/SKILL.md
@@ -5,7 +5,7 @@ description: Install and configure OpenClaw non-interactively with Alibaba Cloud
 
 # OpenClaw Non-Interactive Setup
 
-Use this skill to turn a user's one-sentence request into a complete local OpenClaw setup. The normal path is one script command: resolve the Alibaba Cloud Model Studio plan, validate the API key/Base URL/model combination with the official `anthropic-messages` endpoint shape, install Node.js/npm/OpenClaw when needed, write config, install/restart the local gateway service, and verify `openclaw gateway health`.
+Use this skill to turn a user's one-sentence request into a complete local OpenClaw setup. The normal path is one script command: resolve the Alibaba Cloud Model Studio plan, validate the API key/Base URL/model combination with the official `anthropic-messages` endpoint shape, install Node.js/npm/OpenClaw when needed, write config, install/restart the local gateway service, and verify a real local `openclaw agent` message through Gateway.
 
 Do not execute `openclaw onboard` unless the user explicitly asks for interactive setup or asks to skip first-run BOOTSTRAP onboarding. After setup, always tell the user they can run `openclaw onboard --skip-bootstrap` if they want the first real task to run without the introductory BOOTSTRAP flow. Do not configure DingTalk unless the user provides DingTalk credentials or asks for DingTalk access.
 
@@ -132,6 +132,7 @@ python3 /home/ecs-user/.copilot-shell/skills/install-openclaw/scripts/install_op
 - Writes Alibaba Cloud Model Studio config with `api = anthropic-messages`.
 - Sets `gateway.mode = local`, `gateway.bind = loopback`, and `gateway.auth.mode = none` for local single-machine setup.
 - Starts OpenClaw through `openclaw gateway install` and `openclaw gateway restart` unless `--skip-gateway` is passed.
+- After the Gateway port is listening, runs a bounded local message smoke test to verify the local operator device has `operator.write`. If stale read-only local operator device state exists, the script clears it and retries the message smoke test.
 - If the gateway port is occupied by OpenClaw, it clears that stale listener. If the port is occupied by another process, it stops and prints the process details for the user to decide.
 - **Auto-installs the tokenless OpenClaw plugin** after OpenClaw is installed, for token usage tracking and response compression. Pass `--skip-tokenless` to opt out.
 - Prints first-run BOOTSTRAP guidance by default. Tell the user `openclaw onboard --skip-bootstrap` keeps the first real task from being interrupted by OpenClaw's introductory `BOOTSTRAP.md` flow, and that they can still adjust `IDENTITY.md`, `USER.md`, and `SOUL.md` later under the OpenClaw workspace.
@@ -142,11 +143,12 @@ The script prints useful checks. Prefer:
 
 ```bash
 openclaw models list
+openclaw agent --message "hello" --agent main
 openclaw gateway health
 openclaw status
 ```
 
-Only run `openclaw agent --message "hello" --agent main` as an optional model smoke test after gateway health passes. Do not treat `EMBEDDED FALLBACK` as success; if it mentions `pairing required` or `scope upgrade pending approval`, read `references/troubleshooting.md`.
+The script already runs the message smoke test unless `--skip-gateway-write-check` is passed. Do not treat `EMBEDDED FALLBACK` as success; if it mentions `pairing required`, `scope upgrade pending approval`, or `missing scope: operator.write`, read `references/troubleshooting.md`.
 
 ## References
 

--- a/src/os-skills/ai/install-openclaw/references/troubleshooting.md
+++ b/src/os-skills/ai/install-openclaw/references/troubleshooting.md
@@ -20,6 +20,7 @@ uses `sudo env NPM_CONFIG_REGISTRY=... npm install -g openclaw@latest`.
 ```bash
 openclaw --version
 openclaw models list
+openclaw agent --message "hello" --agent main
 openclaw gateway health
 openclaw status
 openclaw plugins list
@@ -27,11 +28,11 @@ openclaw channels status --probe
 openclaw logs --follow
 ```
 
-If an agent shell appears stuck during gateway startup, use `scripts/install_openclaw.py`. It starts OpenClaw through `openclaw gateway install` and `openclaw gateway restart`, then polls `openclaw gateway health`. Do not run `openclaw gateway --force` as a long-lived foreground command from an agent shell.
+If an agent shell appears stuck during gateway startup, use `scripts/install_openclaw.py`. It starts OpenClaw through `openclaw gateway install` and `openclaw gateway restart`, waits for the gateway port, then runs an agent message smoke test. Do not run `openclaw gateway --force` as a long-lived foreground command from an agent shell.
 
 If the script stops because the gateway port is used by a non-OpenClaw process, ask the user whether to stop that process or choose another port with `--gateway-port`.
 
-If `openclaw agent --message ...` prints `EMBEDDED FALLBACK`, do not count the model smoke test as healthy. First check whether the gateway itself is healthy:
+If `openclaw agent --message ...` prints `EMBEDDED FALLBACK`, do not count the model smoke test as healthy. Rerun the installer first so it can reset stale read-only local operator device state, then check whether the gateway itself is healthy:
 
 ```bash
 openclaw gateway health
@@ -39,11 +40,12 @@ openclaw status
 journalctl --user -u openclaw-gateway.service -n 200 --no-pager
 ```
 
-If the fallback says `pairing required` or `scope upgrade pending approval`, the gateway is up but the local CLI device needs approval. Approve the latest pending device request non-interactively:
+If the fallback says `pairing required` or `scope upgrade pending approval`, rerun the installer instead of manually approving devices. The script clears stale read-only local operator pairing state and retries the message smoke test:
 
 ```bash
-openclaw devices list
-openclaw devices approve --latest
+python3 scripts/install_openclaw.py \
+  --billing payg \
+  --api-key "$BAILIAN_API_KEY"
 ```
 
 Check the config:
@@ -164,10 +166,10 @@ If schema validation says `must NOT have additional properties`, remove unsuppor
 
 ## Device Identity Required
 
-If the dashboard/browser reports `device identity required`, approve or reset devices:
+If the dashboard/browser reports `device identity required`, reset pending devices before opening the dashboard again:
 
 ```bash
-openclaw devices approve --latest
+openclaw devices clear --pending --yes
 openclaw dashboard --no-open
 ```
 

--- a/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
+++ b/src/os-skills/ai/install-openclaw/scripts/install_openclaw.py
@@ -946,22 +946,18 @@ def wait_gateway_ready(args):
     last_output = ""
     while time.monotonic() < deadline:
         try:
-            result = run_command(
-                ["openclaw", "gateway", "health"],
-                check=False,
-                timeout=args.gateway_status_timeout,
-                capture_output=True,
-            )
-            last_output = (result.stdout or "") + (result.stderr or "")
-            if result.returncode == 0 and "OK" in last_output:
-                print("Gateway health check passed.")
+            with socket.create_connection(
+                ("127.0.0.1", args.gateway_port),
+                timeout=min(2, args.gateway_status_timeout),
+            ):
+                print("Gateway port is listening.")
                 return
-        except subprocess.TimeoutExpired:
-            last_output = "openclaw gateway health timed out"
+        except OSError as exc:
+            last_output = str(exc)
 
         time.sleep(2)
 
-    print("Gateway health check did not pass before timeout. Recent health output:")
+    print("Gateway port did not listen before timeout. Recent socket output:")
     print(last_output.strip() or "(no status output)")
     try:
         result = run_command(
@@ -978,6 +974,207 @@ def wait_gateway_ready(args):
         print("openclaw gateway status --deep timed out")
     print("Recent gateway service logs:")
     print_gateway_logs(args)
+
+
+def completed_output(result):
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def gateway_smoke_succeeded(result):
+    output = completed_output(result).lower()
+    blocked_markers = [
+        "embedded fallback",
+        "missing scope",
+        "pairing required",
+        "scope upgrade pending approval",
+        "gateway disconnected",
+    ]
+    return result.returncode == 0 and not any(marker in output for marker in blocked_markers)
+
+
+def gateway_scope_blocked(result):
+    output = completed_output(result).lower()
+    return any(
+        marker in output
+        for marker in [
+            "missing scope: operator.write",
+            "pairing required",
+            "scope upgrade pending approval",
+        ]
+    )
+
+
+def device_auth_path(args):
+    return Path(args.config).expanduser().parent / "identity" / "device-auth.json"
+
+
+def paired_devices_path(args):
+    return Path(args.config).expanduser().parent / "devices" / "paired.json"
+
+
+def has_write_scope(scopes):
+    return "operator.write" in scopes or "operator.admin" in scopes
+
+
+def device_operator_scopes(device):
+    scopes = []
+    for key in ("scopes", "approvedScopes"):
+        value = device.get(key)
+        if isinstance(value, list):
+            scopes.extend(value)
+    tokens = device.get("tokens")
+    if isinstance(tokens, dict):
+        operator = tokens.get("operator")
+        if isinstance(operator, dict) and isinstance(operator.get("scopes"), list):
+            scopes.extend(operator["scopes"])
+    return scopes
+
+
+def clear_read_only_operator_pairings(args):
+    path = paired_devices_path(args)
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(data, dict):
+        return
+
+    changed = False
+    for device_id, device in list(data.items()):
+        if not isinstance(device, dict):
+            continue
+        roles = device.get("roles") if isinstance(device.get("roles"), list) else []
+        is_operator = device.get("role") == "operator" or "operator" in roles
+        if is_operator and not has_write_scope(device_operator_scopes(device)):
+            del data[device_id]
+            changed = True
+
+    if changed:
+        tmp_path = path.with_name(path.name + ".tmp")
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        os.replace(tmp_path, path)
+        print(f"  cleared read-only operator pairing: {path}")
+
+
+def cached_operator_has_write_scope(args):
+    path = device_auth_path(args)
+    if not path.exists():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    scopes = []
+    if isinstance(data.get("tokens"), dict):
+        operator = data["tokens"].get("operator")
+        if isinstance(operator, dict) and isinstance(operator.get("scopes"), list):
+            scopes = operator["scopes"]
+    elif data.get("role") == "operator" and isinstance(data.get("scopes"), list):
+        scopes = data["scopes"]
+    return has_write_scope(scopes)
+
+
+def clear_cached_operator_device_auth(args):
+    path = device_auth_path(args)
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        backup = path.with_name(path.name + ".bak")
+        backup.write_bytes(path.read_bytes())
+        path.unlink()
+        print(f"  cleared unreadable cached device auth: {path}")
+        return
+
+    changed = False
+    if isinstance(data.get("tokens"), dict) and "operator" in data["tokens"]:
+        del data["tokens"]["operator"]
+        changed = True
+    elif data.get("role") == "operator":
+        path.unlink()
+        print(f"  cleared cached operator device auth: {path}")
+        return
+
+    if changed:
+        tmp_path = path.with_name(path.name + ".tmp")
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        os.replace(tmp_path, path)
+        print(f"  cleared cached operator device auth: {path}")
+
+
+def run_gateway_write_smoke(args, timeout):
+    cmd = ["openclaw", "agent", "--message", "hello", "--agent", "main"]
+    try:
+        return run_command(
+            cmd,
+            check=False,
+            timeout=timeout,
+            capture_output=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output = exc.output or ""
+        stderr = exc.stderr or f"Gateway write-scope smoke test timed out after {timeout}s"
+        if isinstance(output, bytes):
+            output = output.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        return subprocess.CompletedProcess(cmd, 124, stdout=output, stderr=stderr)
+
+
+def print_smoke_output(result):
+    output = completed_output(result).strip()
+    if output:
+        print(output)
+
+
+def ensure_gateway_write_scope(args):
+    if args.dry_run:
+        return
+    if args.skip_gateway_write_check:
+        print("\n--- Skipping gateway write-scope check (--skip-gateway-write-check) ---\n")
+        return
+
+    print("\n--- Verifying Gateway operator write scope ---\n")
+
+    if not cached_operator_has_write_scope(args):
+        clear_cached_operator_device_auth(args)
+        clear_read_only_operator_pairings(args)
+
+    deadline = time.monotonic() + args.gateway_write_check_timeout
+    result = subprocess.CompletedProcess([], 1, stdout="", stderr="smoke test not run")
+    pairing_reset = False
+
+    while time.monotonic() < deadline:
+        remaining = max(1, int(deadline - time.monotonic()))
+        result = run_gateway_write_smoke(args, timeout=min(30, remaining))
+        if gateway_smoke_succeeded(result):
+            print("Gateway write-scope smoke test passed.")
+            return
+
+        if gateway_scope_blocked(result) and not pairing_reset:
+            print("Gateway write scope is blocked by stale local operator pairing; resetting it.")
+            clear_cached_operator_device_auth(args)
+            clear_read_only_operator_pairings(args)
+            pairing_reset = True
+
+        if time.monotonic() + 2 >= deadline:
+            break
+        time.sleep(2)
+
+    print("Gateway write-scope smoke test failed. Recent output:")
+    print_smoke_output(result)
+    raise SystemExit(
+        "OpenClaw Gateway port is listening, but the local operator device cannot "
+        "send messages before the write-scope check timeout."
+    )
 
 
 def install_openclaw(args):
@@ -1082,6 +1279,7 @@ def start_gateway(args):
         timeout=args.gateway_command_timeout,
     )
     wait_gateway_ready(args)
+    ensure_gateway_write_scope(args)
 
 
 def print_summary(metadata, args):
@@ -1097,10 +1295,10 @@ def print_summary(metadata, args):
 
     print("\nUseful checks:")
     print("  openclaw models list")
+    print('  openclaw agent --message "hello" --agent main')
     print("  openclaw gateway health")
     print("  openclaw status")
-    print('  openclaw agent --message "hello" --agent main')
-    print("  # If agent output says EMBEDDED FALLBACK, approve the local device or fix gateway.")
+    print("  # If agent output says EMBEDDED FALLBACK, rerun the installer or fix gateway.")
     print("\nFirst real task tip:")
     print("  openclaw onboard --skip-bootstrap")
     print(
@@ -1172,6 +1370,12 @@ def parse_args():
     parser.add_argument("--gateway-command-timeout", type=int, default=30)
     parser.add_argument("--gateway-ready-timeout", type=int, default=30)
     parser.add_argument("--gateway-status-timeout", type=int, default=8)
+    parser.add_argument("--gateway-write-check-timeout", type=int, default=60)
+    parser.add_argument(
+        "--skip-gateway-write-check",
+        action="store_true",
+        help="Skip the post-start local operator write-scope smoke test.",
+    )
     parser.add_argument(
         "--gateway-log",
         default=str(Path("~/.openclaw/setup-gateway-start.log").expanduser()),


### PR DESCRIPTION
## Description

Fix the `install-openclaw` skill flow so a fresh non-interactive install does not create a stale read-only local operator pairing before the first real Gateway message.

Previously, the script used `openclaw gateway health` as the startup readiness check. On current OpenClaw, that can create/cache a local operator device with only `operator.read`, then later `openclaw tui` or `openclaw agent` fails with `missing scope: operator.write` / `scope upgrade pending approval`.

This PR changes the flow to:

- Check Gateway readiness by local port listening instead of `openclaw gateway health`
- Use a real `openclaw agent --message hello --agent main` smoke test as the write-capable verification
- Clear stale read-only local operator pairing state and retry when needed
- Update the skill instructions to make the message smoke test the install verification step

## Related Issue

closes #1203

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [x] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [x] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `python3 -m py_compile src/os-skills/ai/install-openclaw/scripts/install_openclaw.py`
- `git diff --check`
- Verified on Agentic_os from a clean OpenClaw environment:
  - Backed up and removed existing `~/.openclaw`
  - Uninstalled global OpenClaw
  - Ran the install script with pay-as-you-go billing and `qwen3.7-max`
  - Confirmed API preflight passed
  - Confirmed Gateway started successfully
  - Confirmed script message smoke test passed
  - Confirmed `openclaw gateway health` passed after install
  - Confirmed `openclaw agent --message "Hello from post-install validation" --agent main` works without fallback
  - Confirmed local operator token scopes include `operator.read` and `operator.write`

## Additional Notes

This intentionally avoids relying on `openclaw devices approve --latest`, because in the tested OpenClaw version it does not perform a non-interactive approval for this flow.