### PR TITLE
feat(cosh): support multi-hook toggles

### DIFF
--- a/src/copilot-shell/CHANGELOG.md
+++ b/src/copilot-shell/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.6.0
 
+- Added multi-hook enable and disable support to `/hooks`. (#1200)
 - Added cosh-ng compatibility with cosh-switch. (#1169)
 - Added instance_id to SysOM API request params. (#1160)
 - Added anolisa component contract. (#1128)

--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1613,6 +1613,25 @@ export default {
   // ============================================================================
   // Hook dialogs
   // ============================================================================
+  'Hook "{{name}}" has been {{action}} for this session.':
+    'Hook "{{name}}" has been {{action}} for this session.',
+  '{{verb}} {{count}} hooks for this session: {{names}}':
+    '{{verb}} {{count}} hooks for this session: {{names}}',
+  'No matching hooks found: {{names}}': 'No matching hooks found: {{names}}',
+  'Unknown hooks: {{names}}': 'Unknown hooks: {{names}}',
+  'No disabled hooks to enable.': 'No disabled hooks to enable.',
+  'No enabled hooks to disable.': 'No enabled hooks to disable.',
+  'Select hooks to enable': 'Select hooks to enable',
+  'Select hooks to disable': 'Select hooks to disable',
+  'Enable disabled hooks': 'Enable disabled hooks',
+  'Disable active hooks': 'Disable active hooks',
+  '{{count}} selected': '{{count}} selected',
+  '↑↓/jk navigate, Space toggle, a select all, Enter confirm, Esc cancel':
+    '↑↓/jk navigate, Space toggle, a select all, Enter confirm, Esc cancel',
+  Enabled: 'Enabled',
+  Disabled: 'Disabled',
+  enabled: 'enabled',
+  disabled: 'disabled',
   '⚠️  **Hook Safety Check**': '⚠️  **Hook Safety Check**',
   'Send this prompt or cancel?': 'Send this prompt or cancel?',
   'A hook requires your confirmation to proceed.':

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -1429,6 +1429,25 @@ export default {
   // ============================================================================
   // Hook dialogs
   // ============================================================================
+  'Hook "{{name}}" has been {{action}} for this session.':
+    'Hook "{{name}}" 已在本次会话中{{action}}。',
+  '{{verb}} {{count}} hooks for this session: {{names}}':
+    '已在本次会话中{{verb}} {{count}} 个 Hook：{{names}}',
+  'No matching hooks found: {{names}}': '未找到匹配的 Hook：{{names}}',
+  'Unknown hooks: {{names}}': '未知 Hook：{{names}}',
+  'No disabled hooks to enable.': '没有可启用的已禁用 Hook。',
+  'No enabled hooks to disable.': '没有可禁用的已启用 Hook。',
+  'Select hooks to enable': '选择要启用的 Hook',
+  'Select hooks to disable': '选择要禁用的 Hook',
+  'Enable disabled hooks': '启用已禁用的 Hook',
+  'Disable active hooks': '禁用已启用的 Hook',
+  '{{count}} selected': '已选择 {{count}} 个',
+  '↑↓/jk navigate, Space toggle, a select all, Enter confirm, Esc cancel':
+    '↑↓/jk 导航，Space 切换，a 全选，Enter 确认，Esc 取消',
+  Enabled: '启用',
+  Disabled: '禁用',
+  enabled: '启用',
+  disabled: '禁用',
   '⚠️  **Hook Safety Check**': '⚠️  **Hook 安全检查提示**',
   'Send this prompt or cancel?': '是否继续发送这条 prompt？',
   'A hook requires your confirmation to proceed.':

--- a/src/copilot-shell/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/src/copilot-shell/packages/cli/src/nonInteractiveCliCommands.ts
@@ -171,6 +171,14 @@ function handleCommandResult(
         originalType: 'spawn_shell',
       };
 
+    case 'multi_select_hooks':
+      return {
+        type: 'unsupported',
+        reason:
+          'Hook multi-select is not supported in non-interactive mode. Use /hooks disable <hook-name...> with explicit names.',
+        originalType: 'multi_select_hooks',
+      };
+
     default: {
       // Exhaustiveness check
       const _exhaustive: never = result;

--- a/src/copilot-shell/packages/cli/src/test-utils/render.tsx
+++ b/src/copilot-shell/packages/cli/src/test-utils/render.tsx
@@ -60,6 +60,7 @@ const createMockUIState = (): UIState => ({
   commandContext: {} as never,
   shellConfirmationRequest: null,
   confirmationRequest: null,
+  hookMultiSelectRequest: null,
   confirmUpdateExtensionRequests: [],
   settingInputRequests: [],
   pluginChoiceRequests: [],

--- a/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/AppContainer.tsx
@@ -662,6 +662,7 @@ export const AppContainer = (props: AppContainerProps) => {
     commandContext,
     shellConfirmationRequest,
     confirmationRequest,
+    hookMultiSelectRequest,
   } = useSlashCommandProcessor(
     config,
     settings,
@@ -1560,6 +1561,7 @@ export const AppContainer = (props: AppContainerProps) => {
     isFolderTrustDialogOpen ||
     !!shellConfirmationRequest ||
     !!confirmationRequest ||
+    !!hookMultiSelectRequest ||
     confirmUpdateExtensionRequests.length > 0 ||
     settingInputRequests.length > 0 ||
     pluginChoiceRequests.length > 0 ||
@@ -1621,6 +1623,7 @@ export const AppContainer = (props: AppContainerProps) => {
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
+      hookMultiSelectRequest,
       confirmUpdateExtensionRequests,
       settingInputRequests,
       pluginChoiceRequests,
@@ -1723,6 +1726,7 @@ export const AppContainer = (props: AppContainerProps) => {
       commandContext,
       shellConfirmationRequest,
       confirmationRequest,
+      hookMultiSelectRequest,
       confirmUpdateExtensionRequests,
       settingInputRequests,
       pluginChoiceRequests,

--- a/src/copilot-shell/packages/cli/src/ui/commands/hooksCommand.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/hooksCommand.test.ts
@@ -1,0 +1,388 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect } from 'vitest';
+import { hooksCommand } from './hooksCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import {
+  type HookRegistryEntry,
+  HookType,
+  HooksConfigSource,
+  HookEventName,
+} from '@copilot-shell/core';
+import type {
+  MessageActionReturn,
+  MultiSelectHooksActionReturn,
+} from './types.js';
+
+function makeHook(
+  name: string,
+  enabled: boolean,
+  eventName: HookEventName = HookEventName.PreToolUse,
+): HookRegistryEntry {
+  return {
+    config: { type: HookType.Command, command: `run-${name}`, name },
+    source: HooksConfigSource.Project,
+    eventName,
+    enabled,
+  };
+}
+
+function createHookContext(hooks: HookRegistryEntry[]) {
+  const setHookEnabled = vi.fn();
+  return {
+    context: createMockCommandContext({
+      services: {
+        config: {
+          getHookSystem: () => ({
+            getRegistry: () => ({
+              getAllHooks: () => hooks,
+              setHookEnabled,
+            }),
+          }),
+        },
+      },
+    }),
+    setHookEnabled,
+  };
+}
+
+describe('hooksCommand', () => {
+  describe('disable subcommand', () => {
+    it('should disable a single hook', async () => {
+      const hooks = [makeHook('lint', true), makeHook('test', true)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable lint',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('info');
+      expect(result.content).toContain('lint');
+      expect(result.content).toContain('disabled');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', false);
+      expect(setHookEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('should disable multiple space-separated hooks', async () => {
+      const hooks = [
+        makeHook('lint', true),
+        makeHook('test', true),
+        makeHook('format', true),
+      ];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable lint test',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('info');
+      expect(result.content).toContain('2 hooks');
+      expect(result.content).toContain('lint');
+      expect(result.content).toContain('test');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', false);
+      expect(setHookEnabled).toHaveBeenCalledWith('test', false);
+      expect(setHookEnabled).toHaveBeenCalledTimes(2);
+    });
+
+    it('should disable multiple comma-separated hooks', async () => {
+      const hooks = [makeHook('lint', true), makeHook('test', true)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable lint,test',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.content).toContain('2 hooks');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', false);
+      expect(setHookEnabled).toHaveBeenCalledWith('test', false);
+    });
+
+    it('should deduplicate hook names', async () => {
+      const hooks = [makeHook('lint', true)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable lint lint lint',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.content).toContain('lint');
+      expect(result.content).toContain('disabled');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', false);
+      expect(setHookEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle mixed separators', async () => {
+      const hooks = [
+        makeHook('a', true),
+        makeHook('b', true),
+        makeHook('c', true),
+      ];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable a,b c',
+      )) as MessageActionReturn;
+
+      expect(result.content).toContain('3 hooks');
+      expect(setHookEnabled).toHaveBeenCalledWith('a', false);
+      expect(setHookEnabled).toHaveBeenCalledWith('b', false);
+      expect(setHookEnabled).toHaveBeenCalledWith('c', false);
+    });
+
+    it('should report unknown hooks without toggling them', async () => {
+      const hooks = [makeHook('test', true)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable lin test',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('info');
+      expect(result.content).toContain('test');
+      expect(result.content).toContain('Unknown hooks: lin');
+      expect(setHookEnabled).toHaveBeenCalledWith('test', false);
+      expect(setHookEnabled).not.toHaveBeenCalledWith('lin', false);
+      expect(setHookEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return an error when all requested hooks are unknown', async () => {
+      const hooks = [makeHook('test', true)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable missing',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('error');
+      expect(result.content).toContain('No matching hooks found: missing');
+      expect(setHookEnabled).not.toHaveBeenCalled();
+    });
+
+    it('should return multi_select_hooks when no args and there are enabled hooks', async () => {
+      const hooks = [
+        makeHook('lint', true),
+        makeHook('test', true),
+        makeHook('disabled-one', false),
+      ];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable',
+      )) as MultiSelectHooksActionReturn;
+
+      expect(result.type).toBe('multi_select_hooks');
+      expect(result.hookNames).toContain('lint');
+      expect(result.hookNames).toContain('test');
+      expect(result.hookNames).not.toContain('disabled-one');
+      expect(typeof result.onSelected).toBe('function');
+
+      const msg = result.onSelected(['lint', 'test']);
+      expect(msg.content).toContain('2 hooks');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', false);
+      expect(setHookEnabled).toHaveBeenCalledWith('test', false);
+    });
+
+    it('should return info when no args and no enabled hooks', async () => {
+      const hooks = [makeHook('lint', false)];
+      const { context } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('info');
+      expect(result.content).toContain('No enabled hooks');
+    });
+
+    it('should treat full args as single name when it matches a known hook with spaces', async () => {
+      const hooks: HookRegistryEntry[] = [
+        {
+          config: { type: HookType.Command, command: 'echo test' },
+          source: HooksConfigSource.Project,
+          eventName: HookEventName.PreToolUse,
+          enabled: true,
+        },
+      ];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable echo test',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.content).toContain('echo test');
+      expect(result.content).toContain('disabled');
+      expect(setHookEnabled).toHaveBeenCalledWith('echo test', false);
+      expect(setHookEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return error when hooks are not enabled', async () => {
+      const context = createMockCommandContext({
+        services: {
+          config: {
+            getHookSystem: () => null,
+          },
+        },
+      });
+
+      const result = (await hooksCommand.action!(
+        context,
+        'disable lint',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('error');
+    });
+  });
+
+  describe('enable subcommand', () => {
+    it('should enable a single hook', async () => {
+      const hooks = [makeHook('lint', false)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'enable lint',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.content).toContain('lint');
+      expect(result.content).toContain('enabled');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', true);
+    });
+
+    it('should enable multiple hooks', async () => {
+      const hooks = [makeHook('lint', false), makeHook('test', false)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'enable lint test',
+      )) as MessageActionReturn;
+
+      expect(result.content).toContain('2 hooks');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', true);
+      expect(setHookEnabled).toHaveBeenCalledWith('test', true);
+    });
+
+    it('should return multi_select_hooks when no args and there are disabled hooks', async () => {
+      const hooks = [makeHook('lint', false), makeHook('test', true)];
+      const { context, setHookEnabled } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'enable',
+      )) as MultiSelectHooksActionReturn;
+
+      expect(result.type).toBe('multi_select_hooks');
+      expect(result.hookNames).toContain('lint');
+      expect(result.hookNames).not.toContain('test');
+      expect(typeof result.onSelected).toBe('function');
+
+      const msg = result.onSelected(['lint']);
+      expect(msg.content).toContain('lint');
+      expect(setHookEnabled).toHaveBeenCalledWith('lint', true);
+    });
+
+    it('should return info when no args and no disabled hooks', async () => {
+      const hooks = [makeHook('lint', true)];
+      const { context } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'enable',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('info');
+      expect(result.content).toContain('No disabled hooks');
+    });
+  });
+
+  describe('list subcommand', () => {
+    it('should list all hooks', async () => {
+      const hooks = [
+        makeHook('lint', true),
+        makeHook('test', false, HookEventName.PostToolUse),
+      ];
+      const { context } = createHookContext(hooks);
+
+      const result = (await hooksCommand.action!(
+        context,
+        'list',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(result.content).toContain('lint');
+      expect(result.content).toContain('test');
+      expect(result.content).toContain('Enabled');
+      expect(result.content).toContain('Disabled');
+    });
+  });
+
+  describe('completion', () => {
+    it('should suggest enabled hooks for disable', async () => {
+      const hooks = [
+        makeHook('lint', true),
+        makeHook('test', true),
+        makeHook('disabled-one', false),
+      ];
+      const { context } = createHookContext(hooks);
+
+      const completions = await hooksCommand.completion!(context, 'disable ');
+
+      expect(completions).toContain('lint');
+      expect(completions).toContain('test');
+      expect(completions).not.toContain('disabled-one');
+    });
+
+    it('should filter out already typed hooks from completions', async () => {
+      const hooks = [
+        makeHook('lint', true),
+        makeHook('test', true),
+        makeHook('format', true),
+      ];
+      const { context } = createHookContext(hooks);
+
+      const completions = await hooksCommand.completion!(
+        context,
+        'disable lint ',
+      );
+
+      expect(completions).not.toContain('lint');
+      expect(completions).toContain('test');
+      expect(completions).toContain('format');
+    });
+
+    it('should suggest disabled hooks for enable', async () => {
+      const hooks = [makeHook('lint', false), makeHook('test', true)];
+      const { context } = createHookContext(hooks);
+
+      const completions = await hooksCommand.completion!(context, 'enable ');
+
+      expect(completions).toContain('lint');
+      expect(completions).not.toContain('test');
+    });
+  });
+});

--- a/src/copilot-shell/packages/cli/src/ui/commands/hooksCommand.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/hooksCommand.ts
@@ -12,7 +12,93 @@ import type {
 } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
-import type { HookRegistryEntry } from '@copilot-shell/core';
+import type { HookRegistryEntry, HookRegistry } from '@copilot-shell/core';
+
+function getHookName(hook: HookRegistryEntry): string {
+  return hook.config.name || hook.config.command || '';
+}
+
+function getKnownHookNames(registry: HookRegistry): Set<string> {
+  return new Set(registry.getAllHooks().map(getHookName).filter(Boolean));
+}
+
+function resolveHookNames(args: string, registry: HookRegistry): string[] {
+  const trimmed = args.trim();
+  if (!trimmed) return [];
+
+  const knownNames = getKnownHookNames(registry);
+
+  // Full args matches a known name (preserves names with spaces, e.g. "echo test")
+  if (knownNames.has(trimmed)) {
+    return [trimmed];
+  }
+
+  // Split on commas; for each segment, use as-is if it matches a known name,
+  // otherwise split on whitespace to support "hook-a hook-b"
+  const result: string[] = [];
+  for (const segment of trimmed.split(',')) {
+    const part = segment.trim();
+    if (!part) continue;
+    if (knownNames.has(part)) {
+      result.push(part);
+    } else {
+      for (const token of part.split(/\s+/)) {
+        if (token) result.push(token);
+      }
+    }
+  }
+
+  return [...new Set(result)];
+}
+
+function toggleHooks(
+  registry: HookRegistry,
+  names: string[],
+  enabled: boolean,
+): MessageActionReturn {
+  const verb = enabled ? t('Enabled') : t('Disabled');
+  const pastParticiple = enabled ? t('enabled') : t('disabled');
+  const knownNames = getKnownHookNames(registry);
+  const foundNames = names.filter((name) => knownNames.has(name));
+  const unknownNames = names.filter((name) => !knownNames.has(name));
+
+  if (foundNames.length === 0) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('No matching hooks found: {{names}}', {
+        names: unknownNames.join(', '),
+      }),
+    };
+  }
+
+  for (const name of foundNames) {
+    registry.setHookEnabled(name, enabled);
+  }
+
+  const successMessage =
+    foundNames.length === 1
+      ? t('Hook "{{name}}" has been {{action}} for this session.', {
+          name: foundNames[0]!,
+          action: pastParticiple,
+        })
+      : t('{{verb}} {{count}} hooks for this session: {{names}}', {
+          verb,
+          count: String(foundNames.length),
+          names: foundNames.join(', '),
+        });
+
+  const unknownMessage =
+    unknownNames.length > 0
+      ? ` ${t('Unknown hooks: {{names}}', { names: unknownNames.join(', ') })}`
+      : '';
+
+  return {
+    type: 'message',
+    messageType: 'info',
+    content: `${successMessage}${unknownMessage}`,
+  };
+}
 
 /**
  * Format hook source for display
@@ -97,7 +183,7 @@ const listCommand: SlashCommand = {
     for (const [eventName, hooks] of hooksByEvent) {
       output += `### ${eventName}\n`;
       for (const hook of hooks) {
-        const name = hook.config.name || hook.config.command || 'unnamed';
+        const name = getHookName(hook) || 'unnamed';
         const source = formatHookSource(hook.source);
         const status = formatHookStatus(hook.enabled);
         const matcher = hook.matcher ? ` (matcher: ${hook.matcher})` : '';
@@ -117,24 +203,13 @@ const listCommand: SlashCommand = {
 const enableCommand: SlashCommand = {
   name: 'enable',
   get description() {
-    return t('Enable a disabled hook');
+    return t('Enable disabled hooks');
   },
   kind: CommandKind.BUILT_IN,
   action: async (
     context: CommandContext,
     args: string,
-  ): Promise<MessageActionReturn> => {
-    const hookName = args.trim();
-    if (!hookName) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: t(
-          'Please specify a hook name. Usage: /hooks enable <hook-name>',
-        ),
-      };
-    }
-
+  ): Promise<SlashCommandActionReturn> => {
     const { config } = context.services;
     if (!config) {
       return {
@@ -154,15 +229,33 @@ const enableCommand: SlashCommand = {
     }
 
     const registry = hookSystem.getRegistry();
-    registry.setHookEnabled(hookName, true);
+    const names = resolveHookNames(args, registry);
+    if (names.length === 0) {
+      const disabledNames = [
+        ...new Set(
+          registry
+            .getAllHooks()
+            .filter((h) => !h.enabled)
+            .map(getHookName)
+            .filter(Boolean),
+        ),
+      ];
+      if (disabledNames.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: t('No disabled hooks to enable.'),
+        };
+      }
+      return {
+        type: 'multi_select_hooks',
+        hookNames: disabledNames,
+        title: t('Select hooks to enable'),
+        onSelected: (selected) => toggleHooks(registry, selected, true),
+      };
+    }
 
-    return {
-      type: 'message',
-      messageType: 'info',
-      content: t('Hook "{{name}}" has been enabled for this session.', {
-        name: hookName,
-      }),
-    };
+    return toggleHooks(registry, names, true);
   },
   completion: async (context: CommandContext, partialArg: string) => {
     const { config } = context.services;
@@ -173,12 +266,17 @@ const enableCommand: SlashCommand = {
 
     const registry = hookSystem.getRegistry();
     const allHooks = registry.getAllHooks();
+    const parts = partialArg.split(/\s+/);
+    const currentPartial = parts[parts.length - 1] ?? '';
+    const alreadyTyped = new Set(parts.slice(0, -1));
 
-    // Return disabled hooks for enable command (deduplicated by name)
     const disabledHookNames = allHooks
       .filter((hook) => !hook.enabled)
-      .map((hook) => hook.config.name || hook.config.command || '')
-      .filter((name) => name && name.startsWith(partialArg));
+      .map((hook) => getHookName(hook))
+      .filter(
+        (name) =>
+          name && name.startsWith(currentPartial) && !alreadyTyped.has(name),
+      );
     return [...new Set(disabledHookNames)];
   },
 };
@@ -186,24 +284,13 @@ const enableCommand: SlashCommand = {
 const disableCommand: SlashCommand = {
   name: 'disable',
   get description() {
-    return t('Disable an active hook');
+    return t('Disable active hooks');
   },
   kind: CommandKind.BUILT_IN,
   action: async (
     context: CommandContext,
     args: string,
-  ): Promise<MessageActionReturn> => {
-    const hookName = args.trim();
-    if (!hookName) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: t(
-          'Please specify a hook name. Usage: /hooks disable <hook-name>',
-        ),
-      };
-    }
-
+  ): Promise<SlashCommandActionReturn> => {
     const { config } = context.services;
     if (!config) {
       return {
@@ -223,15 +310,33 @@ const disableCommand: SlashCommand = {
     }
 
     const registry = hookSystem.getRegistry();
-    registry.setHookEnabled(hookName, false);
+    const names = resolveHookNames(args, registry);
+    if (names.length === 0) {
+      const enabledNames = [
+        ...new Set(
+          registry
+            .getAllHooks()
+            .filter((h) => h.enabled)
+            .map(getHookName)
+            .filter(Boolean),
+        ),
+      ];
+      if (enabledNames.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: t('No enabled hooks to disable.'),
+        };
+      }
+      return {
+        type: 'multi_select_hooks',
+        hookNames: enabledNames,
+        title: t('Select hooks to disable'),
+        onSelected: (selected) => toggleHooks(registry, selected, false),
+      };
+    }
 
-    return {
-      type: 'message',
-      messageType: 'info',
-      content: t('Hook "{{name}}" has been disabled for this session.', {
-        name: hookName,
-      }),
-    };
+    return toggleHooks(registry, names, false);
   },
   completion: async (context: CommandContext, partialArg: string) => {
     const { config } = context.services;
@@ -242,12 +347,17 @@ const disableCommand: SlashCommand = {
 
     const registry = hookSystem.getRegistry();
     const allHooks = registry.getAllHooks();
+    const parts = partialArg.split(/\s+/);
+    const currentPartial = parts[parts.length - 1] ?? '';
+    const alreadyTyped = new Set(parts.slice(0, -1));
 
-    // Return enabled hooks for disable command (deduplicated by name)
     const enabledHookNames = allHooks
       .filter((hook) => hook.enabled)
-      .map((hook) => hook.config.name || hook.config.command || '')
-      .filter((name) => name && name.startsWith(partialArg));
+      .map((hook) => getHookName(hook))
+      .filter(
+        (name) =>
+          name && name.startsWith(currentPartial) && !alreadyTyped.has(name),
+      );
     return [...new Set(enabledHookNames)];
   },
 };
@@ -255,8 +365,8 @@ const disableCommand: SlashCommand = {
 function buildHelpMessage(): string {
   const subcommands = [
     { name: 'list', description: t('List all configured hooks') },
-    { name: 'enable', description: t('Enable a disabled hook') },
-    { name: 'disable', description: t('Disable an active hook') },
+    { name: 'enable', description: t('Enable disabled hooks') },
+    { name: 'disable', description: t('Disable active hooks') },
   ];
 
   let output = `**${t('Manage Cosh hooks')}**\n\n`;

--- a/src/copilot-shell/packages/cli/src/ui/commands/types.ts
+++ b/src/copilot-shell/packages/cli/src/ui/commands/types.ts
@@ -207,6 +207,16 @@ export interface SpawnShellActionReturn {
   shell?: string;
 }
 
+export interface MultiSelectHooksActionReturn {
+  type: 'multi_select_hooks';
+  /** The hook names to present for selection. */
+  hookNames: string[];
+  /** Title displayed in the multi-select prompt. */
+  title: string;
+  /** Called with the selected hook names; returns the result to display. */
+  onSelected: (selectedNames: string[]) => MessageActionReturn;
+}
+
 export type SlashCommandActionReturn =
   | ToolActionReturn
   | MessageActionReturn
@@ -217,7 +227,8 @@ export type SlashCommandActionReturn =
   | SubmitPromptActionReturn
   | ConfirmShellCommandsActionReturn
   | ConfirmActionReturn
-  | SpawnShellActionReturn;
+  | SpawnShellActionReturn
+  | MultiSelectHooksActionReturn;
 
 export enum CommandKind {
   BUILT_IN = 'built-in',

--- a/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/DialogManager.tsx
@@ -13,6 +13,7 @@ import { ShellConfirmationDialog } from './ShellConfirmationDialog.js';
 import { ConsentPrompt } from './ConsentPrompt.js';
 import { SettingInputPrompt } from './SettingInputPrompt.js';
 import { PluginChoicePrompt } from './PluginChoicePrompt.js';
+import { HookMultiSelectPrompt } from './HookMultiSelectPrompt.js';
 import { ThemeDialog } from './ThemeDialog.js';
 import { SettingsDialog } from './SettingsDialog.js';
 import { AuthDialog } from '../auth/AuthDialog.js';
@@ -251,6 +252,17 @@ export const DialogManager = ({
       <ConsentPrompt
         prompt={uiState.confirmationRequest.prompt}
         onConfirm={uiState.confirmationRequest.onConfirm}
+        terminalWidth={terminalWidth}
+      />
+    );
+  }
+  if (uiState.hookMultiSelectRequest) {
+    return (
+      <HookMultiSelectPrompt
+        hookNames={uiState.hookMultiSelectRequest.hookNames}
+        title={uiState.hookMultiSelectRequest.title}
+        onSelect={uiState.hookMultiSelectRequest.onSelect}
+        onCancel={uiState.hookMultiSelectRequest.onCancel}
         terminalWidth={terminalWidth}
       />
     );

--- a/src/copilot-shell/packages/cli/src/ui/components/HookMultiSelectPrompt.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/HookMultiSelectPrompt.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import { render } from 'ink-testing-library';
+import { HookMultiSelectPrompt } from './HookMultiSelectPrompt.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+
+vi.mock('../hooks/useKeypress.js', () => ({
+  useKeypress: vi.fn(),
+}));
+
+const mockedUseKeypress = vi.mocked(useKeypress);
+
+describe('HookMultiSelectPrompt', () => {
+  const onSelect = vi.fn();
+  const onCancel = vi.fn();
+  const terminalWidth = 80;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders title and hook names', () => {
+      const { lastFrame } = render(
+        <HookMultiSelectPrompt
+          hookNames={['lint', 'test', 'format']}
+          title="Select hooks to disable"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      expect(lastFrame()).toContain('Select hooks to disable');
+      expect(lastFrame()).toContain('lint');
+      expect(lastFrame()).toContain('test');
+      expect(lastFrame()).toContain('format');
+    });
+
+    it('renders checkboxes unchecked by default', () => {
+      const { lastFrame } = render(
+        <HookMultiSelectPrompt
+          hookNames={['lint', 'test']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      expect(lastFrame()).toContain('[ ]');
+      expect(lastFrame()).not.toContain('[✓]');
+    });
+
+    it('renders help text', () => {
+      const { lastFrame } = render(
+        <HookMultiSelectPrompt
+          hookNames={['lint']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      expect(lastFrame()).toContain('Space');
+      expect(lastFrame()).toContain('Enter');
+      expect(lastFrame()).toContain('Esc');
+    });
+  });
+
+  describe('keyboard interaction', () => {
+    function latestHandler() {
+      const calls = mockedUseKeypress.mock.calls;
+      return calls[calls.length - 1][0];
+    }
+
+    function press(key: Partial<{ name: string; sequence: string }>) {
+      act(() => {
+        latestHandler()({ name: undefined, sequence: '', ...key } as never);
+      });
+    }
+
+    it('calls onCancel when escape is pressed', () => {
+      render(
+        <HookMultiSelectPrompt
+          hookNames={['lint']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      press({ name: 'escape' });
+      expect(onCancel).toHaveBeenCalled();
+    });
+
+    it('does not call onSelect when Enter is pressed with nothing selected', () => {
+      render(
+        <HookMultiSelectPrompt
+          hookNames={['lint', 'test']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      press({ name: 'return' });
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('Space toggles selection, Enter confirms', () => {
+      render(
+        <HookMultiSelectPrompt
+          hookNames={['lint', 'test', 'format']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      press({ sequence: ' ' }); // Select lint
+      press({ name: 'down' }); // Move to test
+      press({ sequence: ' ' }); // Select test
+      press({ name: 'return' }); // Confirm
+
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.arrayContaining(['lint', 'test']),
+      );
+      expect(onSelect.mock.calls[0][0]).toHaveLength(2);
+    });
+
+    it('Space toggles off a previously selected item', () => {
+      render(
+        <HookMultiSelectPrompt
+          hookNames={['lint', 'test']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      press({ sequence: ' ' }); // Select lint
+      press({ sequence: ' ' }); // Deselect lint
+      press({ name: 'down' }); // Move to test
+      press({ sequence: ' ' }); // Select test
+      press({ name: 'return' }); // Confirm
+
+      expect(onSelect).toHaveBeenCalledWith(['test']);
+    });
+
+    it('"a" selects all hooks', () => {
+      render(
+        <HookMultiSelectPrompt
+          hookNames={['lint', 'test', 'format']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      press({ sequence: 'a' }); // Select all
+      press({ name: 'return' }); // Confirm
+
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.arrayContaining(['lint', 'test', 'format']),
+      );
+      expect(onSelect.mock.calls[0][0]).toHaveLength(3);
+    });
+
+    it('"a" deselects all when all are already selected', () => {
+      render(
+        <HookMultiSelectPrompt
+          hookNames={['lint', 'test']}
+          title="Select"
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      press({ sequence: 'a' }); // Select all
+      press({ sequence: 'a' }); // Deselect all
+      press({ name: 'return' }); // Enter (nothing selected)
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/copilot-shell/packages/cli/src/ui/components/HookMultiSelectPrompt.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/components/HookMultiSelectPrompt.tsx
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import { useState, useCallback, useMemo } from 'react';
+import { theme } from '../semantic-colors.js';
+import { t } from '../../i18n/index.js';
+import { useKeypress, type Key } from '../hooks/useKeypress.js';
+
+type HookMultiSelectPromptProps = {
+  hookNames: string[];
+  title: string;
+  onSelect: (selectedNames: string[]) => void;
+  onCancel: () => void;
+  terminalWidth: number;
+};
+
+const MAX_VISIBLE_ITEMS = 10;
+
+export const HookMultiSelectPrompt = (props: HookMultiSelectPromptProps) => {
+  const { hookNames, title, onSelect, onCancel } = props;
+
+  const [cursorIndex, setCursorIndex] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const handleKeypress = useCallback(
+    (key: Key) => {
+      const { name, sequence } = key;
+
+      if (name === 'escape') {
+        onCancel();
+        return;
+      }
+
+      if (name === 'return') {
+        if (selected.size === 0) return;
+        onSelect([...selected]);
+        return;
+      }
+
+      // Toggle selection
+      if (sequence === ' ') {
+        const hookName = hookNames[cursorIndex];
+        if (hookName) {
+          setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(hookName)) {
+              next.delete(hookName);
+            } else {
+              next.add(hookName);
+            }
+            return next;
+          });
+        }
+        return;
+      }
+
+      // Select / deselect all
+      if (sequence === 'a') {
+        setSelected((prev) =>
+          prev.size === hookNames.length ? new Set() : new Set(hookNames),
+        );
+        return;
+      }
+
+      if (name === 'up' || sequence === 'k') {
+        setCursorIndex((prev) => (prev > 0 ? prev - 1 : hookNames.length - 1));
+        return;
+      }
+
+      if (name === 'down' || sequence === 'j') {
+        setCursorIndex((prev) => (prev < hookNames.length - 1 ? prev + 1 : 0));
+        return;
+      }
+    },
+    [hookNames, cursorIndex, selected, onSelect, onCancel],
+  );
+
+  useKeypress(handleKeypress, { isActive: true });
+
+  const { visibleHooks, startIndex, hasMore, hasLess } = useMemo(() => {
+    const total = hookNames.length;
+    if (total <= MAX_VISIBLE_ITEMS) {
+      return {
+        visibleHooks: hookNames,
+        startIndex: 0,
+        hasMore: false,
+        hasLess: false,
+      };
+    }
+
+    let start = 0;
+    const halfWindow = Math.floor(MAX_VISIBLE_ITEMS / 2);
+
+    if (cursorIndex <= halfWindow) {
+      start = 0;
+    } else if (cursorIndex >= total - halfWindow) {
+      start = total - MAX_VISIBLE_ITEMS;
+    } else {
+      start = cursorIndex - halfWindow;
+    }
+
+    const end = Math.min(start + MAX_VISIBLE_ITEMS, total);
+
+    return {
+      visibleHooks: hookNames.slice(start, end),
+      startIndex: start,
+      hasLess: start > 0,
+      hasMore: end < total,
+    };
+  }, [hookNames, cursorIndex]);
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      paddingY={1}
+      paddingX={2}
+      width="100%"
+    >
+      <Text bold color={theme.text.accent}>
+        {title}
+      </Text>
+
+      <Box marginTop={1} flexDirection="column">
+        {hasLess && (
+          <Box>
+            <Text dimColor>
+              {'  '}↑ {t('{{count}} more above', { count: String(startIndex) })}
+            </Text>
+          </Box>
+        )}
+
+        {visibleHooks.map((hookName, visibleIndex) => {
+          const actualIndex = startIndex + visibleIndex;
+          const isCursor = actualIndex === cursorIndex;
+          const isSelected = selected.has(hookName);
+          const checkbox = isSelected ? '[✓]' : '[ ]';
+          const prefix = isCursor ? '❯ ' : '  ';
+
+          return (
+            <Box key={hookName} flexDirection="row">
+              <Text color={isCursor ? theme.text.accent : undefined}>
+                {prefix}
+              </Text>
+              <Text
+                color={
+                  isSelected
+                    ? theme.text.accent
+                    : isCursor
+                      ? theme.text.accent
+                      : undefined
+                }
+                bold={isCursor}
+              >
+                {checkbox} {hookName}
+              </Text>
+            </Box>
+          );
+        })}
+
+        {hasMore && (
+          <Box>
+            <Text dimColor>
+              {'  '}↓{' '}
+              {t('{{count}} more below', {
+                count: String(
+                  hookNames.length - startIndex - MAX_VISIBLE_ITEMS,
+                ),
+              })}
+            </Text>
+          </Box>
+        )}
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text dimColor>
+          {t(
+            '↑↓/jk navigate, Space toggle, a select all, Enter confirm, Esc cancel',
+          )}
+        </Text>
+        {selected.size > 0 && (
+          <Text color={theme.text.accent}>
+            {t('{{count}} selected', { count: String(selected.size) })}
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -11,6 +11,7 @@ import type {
   ConsoleMessageItem,
   ShellConfirmationRequest,
   ConfirmationRequest,
+  HookMultiSelectRequest,
   LoopDetectionConfirmationRequest,
   UserPromptConfirmationRequest,
   SandboxBypassRequest,
@@ -62,6 +63,7 @@ export interface UIState {
   commandContext: CommandContext;
   shellConfirmationRequest: ShellConfirmationRequest | null;
   confirmationRequest: ConfirmationRequest | null;
+  hookMultiSelectRequest: HookMultiSelectRequest | null;
   confirmUpdateExtensionRequests: ConfirmationRequest[];
   settingInputRequests: SettingInputRequest[];
   pluginChoiceRequests: PluginChoiceRequest[];

--- a/src/copilot-shell/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -32,6 +32,7 @@ import type {
   SlashCommandProcessorResult,
   HistoryItem,
   ConfirmationRequest,
+  HookMultiSelectRequest,
 } from '../types.js';
 import { MessageType } from '../types.js';
 import type { LoadedSettings } from '../../config/settings.js';
@@ -132,6 +133,8 @@ export const useSlashCommandProcessor = (
     prompt: React.ReactNode;
     onConfirm: (confirmed: boolean) => void;
   }>(null);
+  const [hookMultiSelectRequest, setHookMultiSelectRequest] =
+    useState<HookMultiSelectRequest | null>(null);
 
   const [sessionShellAllowlist, setSessionShellAllowlist] = useState(
     new Set<string>(),
@@ -592,6 +595,48 @@ export const useSlashCommandProcessor = (
                     true,
                   );
                 }
+                case 'multi_select_hooks': {
+                  const { selected } = await new Promise<{
+                    selected: string[];
+                  }>((resolve) => {
+                    setHookMultiSelectRequest({
+                      hookNames: result.hookNames,
+                      title: result.title,
+                      onSelect: (selectedNames) => {
+                        setHookMultiSelectRequest(null);
+                        resolve({ selected: selectedNames });
+                      },
+                      onCancel: () => {
+                        setHookMultiSelectRequest(null);
+                        resolve({ selected: [] });
+                      },
+                    });
+                  });
+
+                  if (selected.length === 0) {
+                    addItemWithRecording(
+                      {
+                        type: MessageType.INFO,
+                        text: 'Operation cancelled.',
+                      },
+                      Date.now(),
+                    );
+                    return { type: 'handled' };
+                  }
+
+                  const actionResult = result.onSelected(selected);
+                  addItemWithRecording(
+                    {
+                      type:
+                        actionResult.messageType === 'error'
+                          ? MessageType.ERROR
+                          : MessageType.INFO,
+                      text: actionResult.content,
+                    },
+                    Date.now(),
+                  );
+                  return { type: 'handled' };
+                }
                 case 'spawn_shell': {
                   appEvents.emit(AppEvent.SpawnShell, result.shell ?? 'bash');
                   return { type: 'handled' };
@@ -725,5 +770,6 @@ export const useSlashCommandProcessor = (
     commandContext,
     shellConfirmationRequest,
     confirmationRequest,
+    hookMultiSelectRequest,
   };
 };

--- a/src/copilot-shell/packages/cli/src/ui/types.ts
+++ b/src/copilot-shell/packages/cli/src/ui/types.ts
@@ -458,6 +458,13 @@ export interface UserPromptConfirmationRequest {
   resolve: (confirmed: boolean) => void;
 }
 
+export interface HookMultiSelectRequest {
+  hookNames: string[];
+  title: string;
+  onSelect: (selectedNames: string[]) => void;
+  onCancel: () => void;
+}
+
 export interface SandboxBypassRequest {
   /** The command that failed inside the sandbox */
   original_command: string;


### PR DESCRIPTION
## Description

This PR adds multi-hook enable and disable support for `/hooks enable` and `/hooks disable`. Explicit arguments now support space-separated, comma-separated, and mixed hook names with deduplication, while registry-aware parsing preserves existing hooks whose fallback names contain spaces. When no hook names are provided, the interactive UI opens a multi-select prompt for the relevant enabled or disabled hooks.

## Related Issue

closes #1200

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `npm run test --workspace=packages/cli -- hooksCommand HookMultiSelectPrompt`
  - Passed: 26 tests

- `npm run typecheck --workspace=packages/cli`
  - Failed on existing unrelated errors around `logSessionSummary` exports and `SessionMetrics.toolErrorCounts`.
  - The failures do not point to files changed by this PR.

## Additional Notes

The second-and-later argument completion limitation remains out of scope because it belongs to the global slash completion parser rather than the `/hooks` command implementation.