### PR TITLE
fix(skillfs): route post-publish grace paths to source

### DIFF
--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -251,7 +251,20 @@ impl SkillFs {
                     self.source_base().join(&skill_name)
                 } else {
                     match self.skill_read_dir(&skill_name) {
-                        Some(d) => d,
+                        Some(d) => {
+                            // I4: grace bypass — if the skill is on a
+                            // fallback snapshot but the path matches the
+                            // post-publish grace whitelist, resolve against
+                            // physical source so the installer can
+                            // create/stat files that don't exist in the
+                            // snapshot.
+                            if self.is_post_publish_grace_allowed(&skill_name, Some(&relative_path))
+                            {
+                                self.source_base().join(&skill_name)
+                            } else {
+                                d
+                            }
+                        }
                         None => {
                             // I4: grace bypass — if the skill is hidden but
                             // the path matches the post-publish grace
@@ -529,7 +542,14 @@ impl SkillFs {
                     self.source_base().join(&skill_name)
                 } else {
                     match self.skill_read_dir(&skill_name) {
-                        Some(d) => d,
+                        Some(d) => {
+                            if self.is_post_publish_grace_allowed(&skill_name, Some(&relative_path))
+                            {
+                                self.source_base().join(&skill_name)
+                            } else {
+                                d
+                            }
+                        }
                         None => {
                             // I4: grace bypass for getattr on passthrough path.
                             if self.is_post_publish_grace_allowed(&skill_name, Some(&relative_path))

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -375,7 +375,15 @@ impl SkillFs {
                         }
                         ReadResolution::Snapshot { dir, .. } if !is_mutating_open => {
                             if let PathType::Passthrough { relative_path, .. } = &path_type {
-                                physical = dir.join(relative_path);
+                                // I4: grace bypass — if the path matches the
+                                // post-publish whitelist, open from physical
+                                // source instead of the snapshot.
+                                if !self.is_post_publish_grace_allowed(
+                                    skill_name,
+                                    Some(relative_path.as_path()),
+                                ) {
+                                    physical = dir.join(relative_path);
+                                }
                             }
                         }
                         _ => {}

--- a/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
@@ -2420,3 +2420,292 @@ fn post_publish_grace_direct_pending_complete_triggers_session() {
         .args(["-u", &mountpoint.path().to_string_lossy()])
         .output();
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// I4: Post-publish grace fallback snapshot tests
+//
+// When the active resolver maps a skill to a Snapshot (fallback) that does NOT
+// contain `.clawhub`, and a post-publish grace session is active with pattern
+// `.clawhub/**`, exact-path writes to `.clawhub/**` must route to the physical
+// source instead of failing with ENOENT from the snapshot view.
+// ─────────────────────────────────────────────────────────────────────────────
+
+use skillfs_fuse::security::PostPublishSessionKind;
+
+struct FallbackGraceFixture {
+    #[allow(dead_code)]
+    source: tempfile::TempDir,
+    mountpoint: tempfile::TempDir,
+    handle: Option<MountHandle>,
+    #[allow(dead_code)]
+    notify_client: Arc<InMemoryNotifyClient>,
+    notify_controller: Arc<NotifyController>,
+    post_publish_controller: Arc<PostPublishGraceController>,
+}
+
+impl FallbackGraceFixture {
+    fn new(grace_ms: u64, seed: impl FnOnce(&Path, &Path)) -> Self {
+        let source = tempfile::tempdir().unwrap();
+        let snapshot_dir = source.path().join("fallback-skill/.skill-meta/versions/v1");
+        std::fs::create_dir_all(&snapshot_dir).unwrap();
+        seed(source.path(), &snapshot_dir);
+
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+        let mountpoint = tempfile::tempdir().unwrap();
+        let notify_client = Arc::new(InMemoryNotifyClient::new());
+
+        let notify_ctrl = NotifyController::new(
+            notify_client.clone(),
+            source.path().to_path_buf(),
+            Duration::from_millis(50),
+            5000,
+        );
+
+        let resolver = Arc::new(ActiveSkillResolver::new(source.path()));
+        resolver.set(
+            "fallback-skill".to_string(),
+            ActiveTarget::Snapshot {
+                snapshot_dir: snapshot_dir.clone(),
+                version: "v1".to_string(),
+            },
+        );
+
+        let pp_patterns = vec![PostPublishWritePattern::PrefixRecursive(
+            ".clawhub".to_string(),
+        )];
+        let pp_ctrl = PostPublishGraceController::new(Duration::from_millis(grace_ms), pp_patterns);
+
+        let config = MountConfig {
+            notify_controller: Some(notify_ctrl.clone()),
+            active_resolver: Some(resolver),
+            post_publish_controller: Some(pp_ctrl.clone()),
+            ..MountConfig::default()
+        };
+
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            shared,
+            MountOptions::default(),
+            false,
+            config,
+        )
+        .unwrap();
+
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            source,
+            mountpoint,
+            handle: Some(handle),
+            notify_client,
+            notify_controller: notify_ctrl,
+            post_publish_controller: pp_ctrl,
+        }
+    }
+
+    fn skill_path(&self) -> PathBuf {
+        self.mountpoint.path().join("skills/fallback-skill")
+    }
+}
+
+impl Drop for FallbackGraceFixture {
+    fn drop(&mut self) {
+        self.post_publish_controller.shutdown();
+        self.notify_controller.shutdown();
+        if let Some(handle) = self.handle.take() {
+            drop(handle);
+        }
+        let mp = self.mountpoint.path().to_path_buf();
+        std::thread::sleep(Duration::from_millis(150));
+        let _ = std::process::Command::new("fusermount3")
+            .args(["-u", &mp.to_string_lossy()])
+            .output();
+    }
+}
+
+#[test]
+fn post_publish_grace_fallback_snapshot_create_and_rename_to_source() {
+    skip_if_no_fuse!();
+
+    let fixture = FallbackGraceFixture::new(5000, |src, snapshot| {
+        // Physical source has the skill with .clawhub
+        let skill = src.join("fallback-skill");
+        std::fs::create_dir_all(skill.join(".clawhub")).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: test\n---\n",
+        )
+        .unwrap();
+
+        // Snapshot does NOT contain .clawhub — only SKILL.md
+        std::fs::write(
+            snapshot.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: snapshot\n---\n",
+        )
+        .unwrap();
+    });
+
+    // Start grace session
+    fixture
+        .post_publish_controller
+        .start_session("fallback-skill", PostPublishSessionKind::StagingRename);
+
+    let skill_via_fuse = fixture.skill_path();
+
+    // Create a temp file inside .clawhub via FUSE
+    let tmp_path = skill_via_fuse.join(".clawhub/.fs-safe-replace-001.tmp");
+    let result = std::fs::write(&tmp_path, r#"{"origin":"test"}"#);
+    assert!(
+        result.is_ok(),
+        "create .clawhub/.fs-safe-replace-*.tmp must succeed during grace on fallback: {:?}",
+        result.err()
+    );
+
+    // Rename to final path
+    let final_path = skill_via_fuse.join(".clawhub/origin.json");
+    let result = std::fs::rename(&tmp_path, &final_path);
+    assert!(
+        result.is_ok(),
+        "rename within .clawhub/** must succeed during grace on fallback: {:?}",
+        result.err()
+    );
+
+    // Verify the file is readable via FUSE
+    let content = std::fs::read_to_string(&final_path).unwrap();
+    assert_eq!(content, r#"{"origin":"test"}"#);
+
+    // Verify it landed in physical source
+    let phys_final = fixture
+        .source
+        .path()
+        .join("fallback-skill/.clawhub/origin.json");
+    assert!(
+        phys_final.exists(),
+        "final file must exist in physical source"
+    );
+}
+
+#[test]
+fn post_publish_grace_fallback_non_whitelisted_write_rejected() {
+    skip_if_no_fuse!();
+
+    let fixture = FallbackGraceFixture::new(5000, |src, snapshot| {
+        let skill = src.join("fallback-skill");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: test\n---\n",
+        )
+        .unwrap();
+        // Put a non-whitelisted file in physical source only
+        std::fs::create_dir_all(skill.join("data")).unwrap();
+        std::fs::write(skill.join("data/secret.txt"), "secret").unwrap();
+
+        std::fs::write(
+            snapshot.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: snapshot\n---\n",
+        )
+        .unwrap();
+    });
+
+    fixture
+        .post_publish_controller
+        .start_session("fallback-skill", PostPublishSessionKind::StagingRename);
+
+    let skill_via_fuse = fixture.skill_path();
+
+    // Non-whitelisted write must fail (data/ is not in .clawhub/**)
+    let result = std::fs::write(skill_via_fuse.join("data/injected.txt"), "bad");
+    assert!(
+        result.is_err(),
+        "non-whitelisted write must fail during grace on fallback snapshot"
+    );
+}
+
+#[test]
+fn post_publish_grace_fallback_readdir_does_not_leak_source() {
+    skip_if_no_fuse!();
+
+    let fixture = FallbackGraceFixture::new(5000, |src, snapshot| {
+        let skill = src.join("fallback-skill");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: test\n---\n",
+        )
+        .unwrap();
+        // Physical source has .clawhub and other dirs
+        std::fs::create_dir_all(skill.join(".clawhub")).unwrap();
+        std::fs::write(skill.join(".clawhub/origin.json"), "{}").unwrap();
+        std::fs::create_dir_all(skill.join("extra")).unwrap();
+
+        // Snapshot only has SKILL.md
+        std::fs::write(
+            snapshot.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: snapshot\n---\n",
+        )
+        .unwrap();
+    });
+
+    fixture
+        .post_publish_controller
+        .start_session("fallback-skill", PostPublishSessionKind::StagingRename);
+
+    let skill_via_fuse = fixture.skill_path();
+
+    // readdir on the skill directory should show snapshot contents,
+    // NOT physical source contents — grace must not leak directory listing.
+    let entries = common::list_dir_names(&skill_via_fuse);
+    assert!(
+        !entries.contains(&".clawhub".to_string()),
+        "readdir must not expose .clawhub from physical source during grace: {:?}",
+        entries
+    );
+    assert!(
+        !entries.contains(&"extra".to_string()),
+        "readdir must not expose extra/ from physical source during grace: {:?}",
+        entries
+    );
+}
+
+#[test]
+fn post_publish_grace_fallback_skill_md_not_opened_via_grace() {
+    skip_if_no_fuse!();
+
+    let fixture = FallbackGraceFixture::new(5000, |src, snapshot| {
+        let skill = src.join("fallback-skill");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: live\n---\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(skill.join(".clawhub")).unwrap();
+
+        // Snapshot SKILL.md has different content
+        std::fs::write(
+            snapshot.join("SKILL.md"),
+            "---\nname: fallback-skill\ndescription: snapshot\n---\n",
+        )
+        .unwrap();
+    });
+
+    fixture
+        .post_publish_controller
+        .start_session("fallback-skill", PostPublishSessionKind::StagingRename);
+
+    let skill_via_fuse = fixture.skill_path();
+
+    // SKILL.md must be served from the snapshot (compiled), not physical source.
+    // The .clawhub/** pattern must NOT grant access to SKILL.md.
+    let content = std::fs::read_to_string(skill_via_fuse.join("SKILL.md")).unwrap();
+    assert!(
+        content.contains("snapshot"),
+        "SKILL.md must come from snapshot, not physical source: {}",
+        content
+    );
+}


### PR DESCRIPTION

## Description

Fix SkillFS post-publish grace handling when a skill is already served from a
fallback snapshot.

OpenClaw may continue writing installer metadata such as
`.clawhub/origin.json` after the skill has been published and activated. When
the active view points to a fallback snapshot that does not contain
`.clawhub`, SkillFS previously resolved `lookup/getattr/open` through the
snapshot first, causing `.clawhub/**` atomic replace writes to fail with
`ENOENT` before they reached the physical source path.

This PR routes post-publish grace-whitelisted exact paths to the physical source
even when the active read view is a fallback snapshot. The bypass stays narrow:
directory listing remains snapshot-based, non-whitelisted paths still fail, and
`SKILL.md` is not unlocked by `.clawhub/**`.

## Related Issue

closes #1211

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran the focused SkillFS validation on Linux with Rust 1.86:

```bash
cd src/skillfs
cargo +1.86.0 fmt --all --check
cargo +1.86.0 check -p skillfs-fuse -p skillfs
cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
cargo +1.86.0 test -p skillfs-fuse --test install_staging_tests
```

The focused `install_staging_tests` suite passes with 48/48 tests.

## Additional Notes

The new regression coverage verifies:

- fallback snapshot + post-publish grace allows `.clawhub/**` atomic replace;
- the final file lands in the physical source;
- non-whitelisted writes still fail;
- `readdir` does not leak physical source-only content;
- `SKILL.md` remains served from the snapshot.