### PR TITLE
fix(anolisa): manifest-driven symlink migration

### DIFF
--- a/src/anolisa/crates/anolisa-cli/Cargo.toml
+++ b/src/anolisa/crates/anolisa-cli/Cargo.toml
@@ -26,9 +26,9 @@ console.workspace = true
 dirs.workspace = true
 ureq.workspace = true
 semver.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
 flate2.workspace = true
 tar.workspace = true
-sha2.workspace = true

--- a/src/anolisa/crates/anolisa-cli/src/color.rs
+++ b/src/anolisa/crates/anolisa-cli/src/color.rs
@@ -71,7 +71,9 @@ impl Palette {
         match key.as_str() {
             "adopted" | "installed" | "ok" | "ready" | "succeeded" | "true" => self.ok(raw),
             "degraded" | "disabled" | "partial" | "warn" | "warning" => self.warn(raw),
-            "blocked" | "error" | "fail" | "failed" | "false" => self.err(raw),
+            "blocked" | "error" | "fail" | "failed" | "false" | "referent_mismatch" => {
+                self.err(raw)
+            }
             "-" | "not_installed" | "unknown" => self.muted(raw),
             _ => self.paint(raw, Style::new().cyan()),
         }

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -277,6 +277,181 @@ pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
     manager
 }
 
+/// In-memory migration of pre-v4 symlink entries.
+///
+/// Loads each component's installed manifest, resolves its
+/// `FileKind::Symlink` entries, and upgrades matching
+/// `kind = File` `OwnedFile` entries to `kind = Symlink` with the
+/// manifest-declared referent — but only when every disk-level
+/// invariant holds (link exists, points at the manifest-declared
+/// target, referent is a regular file, and any recorded sha256
+/// matches the referent content).
+///
+/// Returns the number of entries migrated. Errors in individual
+/// components are silently skipped (conservative: the entry stays
+/// `kind = File` and the integrity probe reports `symlink_refused`).
+pub fn migrate_v3_symlinks(state: &mut InstalledState, layout: &FsLayout) -> usize {
+    use std::collections::HashMap;
+    use std::fs;
+
+    use anolisa_core::expand_layout_placeholders;
+    use anolisa_core::manifest::{ComponentManifest, FileKind};
+    use anolisa_core::path_safety::validate_owned_path;
+    use anolisa_core::state::{ObjectKind, OwnedFileKind};
+    use sha2::{Digest, Sha256};
+
+    const MAX_MIGRATE_PROBE_BYTES: u64 = 256 * 1024 * 1024;
+
+    fn hex_lower(bytes: &[u8]) -> String {
+        bytes.iter().fold(String::new(), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+    }
+
+    fn hash_file_streaming(path: &std::path::Path) -> std::io::Result<String> {
+        use std::io::Read;
+        let f = fs::File::open(path)?;
+        let mut reader = std::io::BufReader::new(f);
+        let mut hasher = Sha256::new();
+        let mut buf = [0u8; 8 * 1024];
+        let mut total: u64 = 0;
+        loop {
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            total += n as u64;
+            if total > MAX_MIGRATE_PROBE_BYTES {
+                return Err(std::io::Error::other(
+                    "file exceeds migration probe ceiling",
+                ));
+            }
+            hasher.update(&buf[..n]);
+        }
+        Ok(hex_lower(&hasher.finalize()))
+    }
+
+    if state.schema_version >= 4 {
+        return 0;
+    }
+
+    let mut migrated = 0usize;
+
+    for obj in &mut state.objects {
+        if obj.kind != ObjectKind::Component {
+            continue;
+        }
+        let has_legacy = obj.files.iter().any(|f| f.kind == OwnedFileKind::File);
+        if !has_legacy {
+            continue;
+        }
+
+        if validate_component_path_segment(&obj.name, "migrate").is_err() {
+            continue;
+        }
+        let manifest_path = layout
+            .state_dir
+            .join(INSTALLED_COMPONENT_MANIFESTS_SUBDIR)
+            .join(&obj.name)
+            .join(INSTALLED_COMPONENT_MANIFEST_FILE);
+        let toml_str = match fs::read_to_string(&manifest_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let manifest = match ComponentManifest::from_toml_str(&toml_str) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        let mut expected: HashMap<PathBuf, PathBuf> = HashMap::new();
+        for spec in &manifest.install.files {
+            if spec.kind != FileKind::Symlink {
+                continue;
+            }
+            let dest_template = match spec.install_path() {
+                Some(t) => t,
+                None => continue,
+            };
+            let referent_template = match spec.source.as_deref() {
+                Some(t) => t,
+                None => continue,
+            };
+            let dest = match expand_layout_placeholders(
+                dest_template,
+                layout,
+                &[("component", &obj.name)],
+            ) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            let referent = match expand_layout_placeholders(
+                referent_template,
+                layout,
+                &[("component", &obj.name)],
+            ) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            if validate_owned_path(layout, &dest).is_err()
+                || validate_owned_path(layout, &referent).is_err()
+            {
+                continue;
+            }
+            expected.insert(dest, referent);
+        }
+        if expected.is_empty() {
+            continue;
+        }
+
+        for file in &mut obj.files {
+            if file.kind != OwnedFileKind::File {
+                continue;
+            }
+            let Some(expected_referent) = expected.get(&file.path) else {
+                continue;
+            };
+            let Ok(sym_meta) = fs::symlink_metadata(&file.path) else {
+                continue;
+            };
+            if !sym_meta.file_type().is_symlink() {
+                continue;
+            }
+            let Ok(actual_referent) = fs::read_link(&file.path) else {
+                continue;
+            };
+            if actual_referent != *expected_referent {
+                continue;
+            }
+            let Ok(ref_meta) = fs::symlink_metadata(expected_referent) else {
+                continue;
+            };
+            if ref_meta.file_type().is_symlink() || !ref_meta.is_file() {
+                continue;
+            }
+            if let Some(ref recorded_sha) = file.sha256 {
+                if ref_meta.len() > MAX_MIGRATE_PROBE_BYTES {
+                    continue;
+                }
+                let actual = match hash_file_streaming(expected_referent) {
+                    Ok(h) => h,
+                    Err(_) => continue,
+                };
+                if actual != *recorded_sha {
+                    continue;
+                }
+            }
+            file.kind = OwnedFileKind::Symlink;
+            file.referent = Some(expected_referent.clone());
+            file.sha256 = None;
+            migrated += 1;
+        }
+    }
+
+    migrated
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,5 +575,351 @@ dest = "{datadir}/adapters/sec-core/openclaw/"
         assert!(!status_is_enabled("failed"));
         assert!(!status_is_enabled("not_installed"));
         assert!(!status_is_enabled(""));
+    }
+
+    mod migrate_v3_symlinks_tests {
+        use anolisa_core::state::{
+            FileOwner, InstalledObject, InstalledState, ObjectKind, ObjectStatus, OwnedFile,
+            OwnedFileKind, Ownership, SubscriptionScope,
+        };
+        use anolisa_platform::fs_layout::FsLayout;
+        use sha2::{Digest, Sha256};
+
+        fn hex_lower(bytes: &[u8]) -> String {
+            bytes.iter().fold(String::new(), |mut s, b| {
+                use std::fmt::Write;
+                let _ = write!(s, "{b:02x}");
+                s
+            })
+        }
+
+        fn sample_object(name: &str, files: Vec<OwnedFile>) -> InstalledObject {
+            InstalledObject {
+                kind: ObjectKind::Component,
+                name: name.to_string(),
+                version: "1.0.0".to_string(),
+                status: ObjectStatus::Installed,
+                manifest_digest: None,
+                distribution_source: None,
+                raw_package: None,
+                install_backend: None,
+                ownership: Some(Ownership::RawManaged),
+                rpm_metadata: None,
+                installed_at: "2026-01-01T00:00:00Z".to_string(),
+                last_operation_id: None,
+                managed: true,
+                adopted: false,
+                subscription_scope: SubscriptionScope::None,
+                enabled_features: Vec::new(),
+                component_refs: Vec::new(),
+                files,
+                external_modified_files: Vec::new(),
+                services: Vec::new(),
+                health: Vec::new(),
+            }
+        }
+
+        fn v3_state() -> InstalledState {
+            InstalledState {
+                schema_version: 3,
+                ..Default::default()
+            }
+        }
+
+        fn write_manifest(layout: &FsLayout, component: &str, toml: &str) {
+            let dir = layout
+                .state_dir
+                .join(super::INSTALLED_COMPONENT_MANIFESTS_SUBDIR)
+                .join(component);
+            std::fs::create_dir_all(&dir).expect("mkdir manifest dir");
+            std::fs::write(dir.join(super::INSTALLED_COMPONENT_MANIFEST_FILE), toml)
+                .expect("write manifest");
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn migrate_upgrades_manifest_declared_symlink() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+            std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bindir");
+            std::fs::create_dir_all(&layout.libexec_dir).expect("mkdir libexecdir");
+
+            let referent = layout.libexec_dir.join("tokenless").join("rtk");
+            std::fs::create_dir_all(referent.parent().unwrap()).expect("mkdir referent parent");
+            let payload = b"binary-payload";
+            std::fs::write(&referent, payload).expect("write referent");
+
+            let link = layout.bin_dir.join("rtk");
+            std::os::unix::fs::symlink(&referent, &link).expect("symlink");
+
+            let sha = hex_lower(&Sha256::digest(payload));
+
+            write_manifest(
+                &layout,
+                "tokenless",
+                r#"
+[component]
+name = "tokenless"
+version = "1.0.0"
+layer = "runtime"
+
+[[install.files]]
+source = "{libexecdir}/tokenless/rtk"
+dest = "{bindir}/rtk"
+type = "symlink"
+"#,
+            );
+
+            let owned = OwnedFile {
+                path: link.clone(),
+                owner: FileOwner::Anolisa,
+                sha256: Some(sha),
+                kind: OwnedFileKind::File,
+                referent: None,
+            };
+            let mut state = v3_state();
+            state.upsert_object(sample_object("tokenless", vec![owned]));
+
+            let count = super::migrate_v3_symlinks(&mut state, &layout);
+            assert_eq!(count, 1);
+
+            let file = &state.objects[0].files[0];
+            assert_eq!(file.kind, OwnedFileKind::Symlink);
+            assert_eq!(file.referent.as_deref(), Some(referent.as_path()));
+            assert!(file.sha256.is_none());
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn migrate_skips_when_disk_not_symlink() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+            std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bindir");
+            std::fs::create_dir_all(&layout.libexec_dir).expect("mkdir libexecdir");
+
+            let referent = layout.libexec_dir.join("tokenless").join("rtk");
+            std::fs::create_dir_all(referent.parent().unwrap()).expect("mkdir referent parent");
+            std::fs::write(&referent, b"binary").expect("write referent");
+
+            let regular = layout.bin_dir.join("rtk");
+            std::fs::write(&regular, b"regular-file").expect("write regular");
+
+            write_manifest(
+                &layout,
+                "tokenless",
+                r#"
+[component]
+name = "tokenless"
+version = "1.0.0"
+layer = "runtime"
+
+[[install.files]]
+source = "{libexecdir}/tokenless/rtk"
+dest = "{bindir}/rtk"
+type = "symlink"
+"#,
+            );
+
+            let owned = OwnedFile {
+                path: regular,
+                owner: FileOwner::Anolisa,
+                sha256: None,
+                kind: OwnedFileKind::File,
+                referent: None,
+            };
+            let mut state = v3_state();
+            state.upsert_object(sample_object("tokenless", vec![owned]));
+
+            let count = super::migrate_v3_symlinks(&mut state, &layout);
+            assert_eq!(count, 0);
+            assert_eq!(state.objects[0].files[0].kind, OwnedFileKind::File);
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn migrate_skips_when_readlink_mismatches() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+            std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bindir");
+            std::fs::create_dir_all(&layout.libexec_dir).expect("mkdir libexecdir");
+
+            let expected_referent = layout.libexec_dir.join("tokenless").join("rtk");
+            std::fs::create_dir_all(expected_referent.parent().unwrap()).expect("mkdir");
+            std::fs::write(&expected_referent, b"binary").expect("write expected");
+
+            let wrong_target = layout.libexec_dir.join("attacker").join("evil");
+            std::fs::create_dir_all(wrong_target.parent().unwrap()).expect("mkdir");
+            std::fs::write(&wrong_target, b"evil").expect("write evil");
+
+            let link = layout.bin_dir.join("rtk");
+            std::os::unix::fs::symlink(&wrong_target, &link).expect("symlink");
+
+            write_manifest(
+                &layout,
+                "tokenless",
+                r#"
+[component]
+name = "tokenless"
+version = "1.0.0"
+layer = "runtime"
+
+[[install.files]]
+source = "{libexecdir}/tokenless/rtk"
+dest = "{bindir}/rtk"
+type = "symlink"
+"#,
+            );
+
+            let owned = OwnedFile {
+                path: link,
+                owner: FileOwner::Anolisa,
+                sha256: None,
+                kind: OwnedFileKind::File,
+                referent: None,
+            };
+            let mut state = v3_state();
+            state.upsert_object(sample_object("tokenless", vec![owned]));
+
+            let count = super::migrate_v3_symlinks(&mut state, &layout);
+            assert_eq!(count, 0);
+            assert_eq!(state.objects[0].files[0].kind, OwnedFileKind::File);
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn migrate_skips_when_sha256_mismatches() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+            std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bindir");
+            std::fs::create_dir_all(&layout.libexec_dir).expect("mkdir libexecdir");
+
+            let referent = layout.libexec_dir.join("tokenless").join("rtk");
+            std::fs::create_dir_all(referent.parent().unwrap()).expect("mkdir");
+            std::fs::write(&referent, b"correct-payload").expect("write referent");
+
+            let link = layout.bin_dir.join("rtk");
+            std::os::unix::fs::symlink(&referent, &link).expect("symlink");
+
+            write_manifest(
+                &layout,
+                "tokenless",
+                r#"
+[component]
+name = "tokenless"
+version = "1.0.0"
+layer = "runtime"
+
+[[install.files]]
+source = "{libexecdir}/tokenless/rtk"
+dest = "{bindir}/rtk"
+type = "symlink"
+"#,
+            );
+
+            let owned = OwnedFile {
+                path: link,
+                owner: FileOwner::Anolisa,
+                sha256: Some("deadbeefdeadbeef".to_string()),
+                kind: OwnedFileKind::File,
+                referent: None,
+            };
+            let mut state = v3_state();
+            state.upsert_object(sample_object("tokenless", vec![owned]));
+
+            let count = super::migrate_v3_symlinks(&mut state, &layout);
+            assert_eq!(count, 0);
+            assert_eq!(state.objects[0].files[0].kind, OwnedFileKind::File);
+        }
+
+        #[test]
+        fn migrate_skips_when_manifest_missing() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+            std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bindir");
+
+            let owned = OwnedFile {
+                path: layout.bin_dir.join("rtk"),
+                owner: FileOwner::Anolisa,
+                sha256: None,
+                kind: OwnedFileKind::File,
+                referent: None,
+            };
+            let mut state = v3_state();
+            state.upsert_object(sample_object("tokenless", vec![owned]));
+
+            let count = super::migrate_v3_symlinks(&mut state, &layout);
+            assert_eq!(count, 0);
+            assert_eq!(state.objects[0].files[0].kind, OwnedFileKind::File);
+        }
+
+        #[test]
+        fn migrate_skips_traversal_component_name() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+            std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bindir");
+
+            let owned = OwnedFile {
+                path: layout.bin_dir.join("rtk"),
+                owner: FileOwner::Anolisa,
+                sha256: None,
+                kind: OwnedFileKind::File,
+                referent: None,
+            };
+            let mut state = v3_state();
+            state.upsert_object(sample_object("../../../etc", vec![owned]));
+
+            let count = super::migrate_v3_symlinks(&mut state, &layout);
+            assert_eq!(count, 0);
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn migrate_skips_when_schema_v4() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+            std::fs::create_dir_all(&layout.bin_dir).expect("mkdir bindir");
+            std::fs::create_dir_all(&layout.libexec_dir).expect("mkdir libexecdir");
+
+            let referent = layout.libexec_dir.join("tokenless").join("rtk");
+            std::fs::create_dir_all(referent.parent().unwrap()).expect("mkdir referent parent");
+            let payload = b"binary-payload";
+            std::fs::write(&referent, payload).expect("write referent");
+
+            let link = layout.bin_dir.join("rtk");
+            std::os::unix::fs::symlink(&referent, &link).expect("symlink");
+
+            let sha = hex_lower(&Sha256::digest(payload));
+
+            write_manifest(
+                &layout,
+                "tokenless",
+                r#"
+[component]
+name = "tokenless"
+version = "1.0.0"
+layer = "runtime"
+
+[[install.files]]
+source = "{libexecdir}/tokenless/rtk"
+dest = "{bindir}/rtk"
+type = "symlink"
+"#,
+            );
+
+            let owned = OwnedFile {
+                path: link.clone(),
+                owner: FileOwner::Anolisa,
+                sha256: Some(sha),
+                kind: OwnedFileKind::File,
+                referent: None,
+            };
+            let mut state = InstalledState::default();
+            state.upsert_object(sample_object("tokenless", vec![owned]));
+            assert_eq!(state.schema_version, 4);
+
+            let count = super::migrate_v3_symlinks(&mut state, &layout);
+            assert_eq!(count, 0);
+            assert_eq!(state.objects[0].files[0].kind, OwnedFileKind::File);
+        }
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -41,7 +41,7 @@ use anolisa_core::lock::InstallLock;
 use anolisa_core::path_safety::validate_owned_path;
 use anolisa_core::state::{
     FileOwner, InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind,
-    ObjectStatus, OperationRecord, OwnedFile, Ownership, RpmMetadata, ServiceRef,
+    ObjectStatus, OperationRecord, OwnedFile, OwnedFileKind, Ownership, RpmMetadata, ServiceRef,
 };
 use anolisa_core::{
     ArtifactType, CapabilityRequest, ComponentManifest, DependencyKind, DependencyResolution,
@@ -3102,13 +3102,34 @@ fn execute_raw(
         .map(|f| OwnedFile {
             path: f.path.clone(),
             owner: FileOwner::Anolisa,
-            sha256: Some(f.sha256.clone()),
+            sha256: if f.referent.is_some() {
+                None
+            } else {
+                Some(f.sha256.clone())
+            },
+            kind: if f.referent.is_some() {
+                OwnedFileKind::Symlink
+            } else {
+                OwnedFileKind::File
+            },
+            referent: f.referent.clone(),
         })
         .collect();
+    let manifest_sha256 = {
+        use sha2::{Digest, Sha256};
+        let hash = Sha256::digest(manifest_toml.as_bytes());
+        Some(hash.iter().fold(String::new(), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        }))
+    };
     owned_files.push(OwnedFile {
         path: manifest_path.clone(),
         owner: FileOwner::Anolisa,
-        sha256: None,
+        sha256: manifest_sha256,
+        kind: OwnedFileKind::File,
+        referent: None,
     });
     let mut installed_paths: Vec<String> = outcome
         .files
@@ -3181,6 +3202,7 @@ fn execute_raw(
         finished_at: Some(now_iso8601()),
     });
 
+    common::migrate_v3_symlinks(&mut state, layout);
     let state_path = layout.state_dir.join("installed.toml");
     if let Err(err) = state.save(&state_path) {
         let cleanup_warnings = rollback_activated_services(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -125,8 +125,9 @@ pub(crate) struct ComponentRecord {
 }
 
 pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
-    let state = common::load_installed_state(ctx, COMMAND)?;
+    let mut state = common::load_installed_state(ctx, COMMAND)?;
     let layout = common::resolve_layout(ctx);
+    common::migrate_v3_symlinks(&mut state, &layout);
     // Catalog is best-effort: if manifests are missing or malformed, status
     // still reports state-on-disk plus the integrity probe. The manifest
     // health checks layer is purely additive — never an error path that
@@ -1109,7 +1110,7 @@ mod tests {
     use super::*;
     use anolisa_core::{
         FileOwner, HealthEntry, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
-        OwnedFile, SubscriptionScope,
+        OwnedFile, OwnedFileKind, SubscriptionScope,
     };
     use std::path::{Path, PathBuf};
 
@@ -1280,6 +1281,8 @@ mod tests {
             sha256: Some(
                 "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5".to_string(),
             ),
+            kind: OwnedFileKind::File,
+            referent: None,
         }];
         state.upsert_object(comp);
 
@@ -1313,6 +1316,8 @@ mod tests {
             path: missing_path,
             owner: FileOwner::Anolisa,
             sha256: Some("deadbeef".to_string()),
+            kind: OwnedFileKind::File,
+            referent: None,
         }];
         state.upsert_object(comp);
 
@@ -1345,6 +1350,8 @@ mod tests {
             sha256: Some(
                 "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
             ),
+            kind: OwnedFileKind::File,
+            referent: None,
         }];
         state.upsert_object(comp);
 
@@ -1376,6 +1383,8 @@ mod tests {
             path: file_path,
             owner: FileOwner::Anolisa,
             sha256: None,
+            kind: OwnedFileKind::File,
+            referent: None,
         }];
         state.upsert_object(comp);
 
@@ -1405,6 +1414,8 @@ mod tests {
             path: missing_path,
             owner: FileOwner::Anolisa,
             sha256: Some("deadbeef".to_string()),
+            kind: OwnedFileKind::File,
+            referent: None,
         }];
         state.upsert_object(comp);
 
@@ -1439,6 +1450,8 @@ mod tests {
             path: PathBuf::from("/etc/shadow"),
             owner: FileOwner::Anolisa,
             sha256: Some("deadbeef".to_string()),
+            kind: OwnedFileKind::File,
+            referent: None,
         }];
         state.upsert_object(comp);
 
@@ -2148,6 +2161,8 @@ mod tests {
             path: missing_owned,
             owner: FileOwner::Anolisa,
             sha256: Some("deadbeef".to_string()),
+            kind: OwnedFileKind::File,
+            referent: None,
         }];
         state.upsert_object(comp);
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1236,6 +1236,7 @@ mod tests {
     fn uninstall_execute_on_installed_component_removes_owned_files_and_succeeds() {
         use anolisa_core::{
             FileOwner, InstalledObject, InstalledState, ObjectKind, ObjectStatus, OwnedFile,
+            OwnedFileKind,
         };
         use anolisa_platform::fs_layout::FsLayout;
 
@@ -1270,6 +1271,8 @@ mod tests {
                 path: owned.clone(),
                 owner: FileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: Vec::new(),
@@ -1318,6 +1321,7 @@ mod tests {
     fn uninstall_runs_contract_declared_pre_uninstall_hook() {
         use anolisa_core::{
             FileOwner, InstalledObject, InstalledState, ObjectKind, ObjectStatus, OwnedFile,
+            OwnedFileKind,
         };
         use anolisa_platform::fs_layout::FsLayout;
         use std::os::unix::fs::PermissionsExt;
@@ -1391,6 +1395,8 @@ mod tests {
                 path: owned.clone(),
                 owner: FileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: Vec::new(),
@@ -1426,6 +1432,7 @@ mod tests {
     fn purge_execute_is_still_gated_with_clear_hint() {
         use anolisa_core::{
             FileOwner, InstalledObject, InstalledState, ObjectKind, ObjectStatus, OwnedFile,
+            OwnedFileKind,
         };
         use anolisa_platform::fs_layout::FsLayout;
 
@@ -1459,6 +1466,8 @@ mod tests {
                 path: owned.clone(),
                 owner: FileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: Vec::new(),
@@ -2189,7 +2198,7 @@ mod tests {
     /// runs the unchanged raw teardown: owned files removed, state dropped.
     #[test]
     fn uninstall_raw_with_remove_system_package_flag_warns_but_succeeds() {
-        use anolisa_core::{FileOwner, OwnedFile};
+        use anolisa_core::{FileOwner, OwnedFile, OwnedFileKind};
         use anolisa_platform::fs_layout::FsLayout;
 
         let tmp = tempdir().expect("tmpdir");
@@ -2222,6 +2231,8 @@ mod tests {
                 path: owned.clone(),
                 owner: FileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: Vec::new(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -41,7 +41,8 @@ use anolisa_core::lock::InstallLock;
 use anolisa_core::path_safety::validate_owned_path;
 use anolisa_core::self_update::{self, ProgressFn, SelfUpdateOutcome};
 use anolisa_core::state::{
-    FileOwner, ObjectKind, ObjectStatus, OperationRecord, OwnedFile, Ownership, ServiceRef,
+    FileOwner, ObjectKind, ObjectStatus, OperationRecord, OwnedFile, OwnedFileKind, Ownership,
+    ServiceRef,
 };
 use anolisa_core::transaction::{
     RollbackAction, RollbackActionKind, Transaction, TransactionOutcomeStatus, TransactionStep,
@@ -778,13 +779,34 @@ fn execute_raw_update(
         .map(|f| OwnedFile {
             path: f.path.clone(),
             owner: FileOwner::Anolisa,
-            sha256: Some(f.sha256.clone()),
+            sha256: if f.referent.is_some() {
+                None
+            } else {
+                Some(f.sha256.clone())
+            },
+            kind: if f.referent.is_some() {
+                OwnedFileKind::Symlink
+            } else {
+                OwnedFileKind::File
+            },
+            referent: f.referent.clone(),
         })
         .collect();
+    let manifest_sha256 = {
+        use sha2::{Digest, Sha256};
+        let hash = Sha256::digest(manifest_toml.as_bytes());
+        Some(hash.iter().fold(String::new(), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        }))
+    };
     owned_files.push(OwnedFile {
         path: manifest_path.clone(),
         owner: FileOwner::Anolisa,
-        sha256: None,
+        sha256: manifest_sha256,
+        kind: OwnedFileKind::File,
+        referent: None,
     });
 
     let obj = match state.find_object_mut(ObjectKind::Component, component) {
@@ -823,6 +845,7 @@ fn execute_raw_update(
         finished_at: Some(now_iso8601()),
     });
 
+    common::migrate_v3_symlinks(&mut state, layout);
     if let Err(err) = state.save(&state_path) {
         let _ = tx.mark_failed(persist_idx, &err.to_string());
         return Err(raw_update_rollback(
@@ -3130,11 +3153,15 @@ sha256 = "{sha}"
                 path: bin,
                 owner: FileOwner::Anolisa,
                 sha256: Some(bin_sha),
+                kind: OwnedFileKind::File,
+                referent: None,
             },
             OwnedFile {
                 path: manifest_path,
                 owner: FileOwner::Anolisa,
                 sha256: None,
+                kind: OwnedFileKind::File,
+                referent: None,
             },
         ];
         let mut obj = raw_object(component, version);

--- a/src/anolisa/crates/anolisa-core/src/install_runner.rs
+++ b/src/anolisa/crates/anolisa-core/src/install_runner.rs
@@ -42,8 +42,12 @@ pub const SUPPORTED_ARTIFACT_TYPES: &[&str] = &["binary", "tar_gz"];
 pub struct InstalledFile {
     /// Absolute destination path actually written.
     pub path: PathBuf,
-    /// Lowercase-hex sha256 of the installed bytes.
+    /// Lowercase-hex sha256 of the installed bytes. Empty for symlink
+    /// entries (they record a [`referent`](Self::referent) instead).
     pub sha256: String,
+    /// For managed symlinks: the absolute referent path the link points at.
+    /// `None` for regular files.
+    pub referent: Option<PathBuf>,
 }
 
 /// Source-to-destination mapping after manifest layout substitution.
@@ -638,12 +642,12 @@ fn archive_key_from_path(path: &Path) -> Result<Option<String>, InstallError> {
     }
 }
 
-/// Create one validated symlink entry and hash what it resolves to.
+/// Create one validated symlink entry and record the referent path.
 ///
-/// The recorded sha256 is the *referent's* content (a `fs::read` of the
-/// link follows it), so integrity checks that re-hash owned paths see the
-/// same digest whether they visit the link or the file it points at. A
-/// referent that does not exist fails here: installing a dangling
+/// Returns `sha256 = ""` with `referent = Some(target_path)` — the
+/// integrity probe verifies symlinks by checking `readlink` against
+/// the recorded referent rather than hashing content through the link.
+/// A referent that does not exist fails here: installing a dangling
 /// convenience link would be a manifest defect, not a usable install.
 fn create_symlink(link: &ResolvedInstallFile) -> Result<InstalledFile, InstallError> {
     // Validated in validate_symlink_entries; unreachable here.
@@ -653,6 +657,16 @@ fn create_symlink(link: &ResolvedInstallFile) -> Result<InstalledFile, InstallEr
         .ok_or_else(|| InstallError::SymlinkMissingSource {
             path: link.dest.clone(),
         })?;
+    let referent_path = Path::new(referent);
+    if !referent_path.exists() {
+        return Err(InstallError::Io {
+            path: referent_path.to_path_buf(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "symlink referent does not exist",
+            ),
+        });
+    }
     if let Some(parent) = link.dest.parent() {
         fs::create_dir_all(parent).map_err(|source| InstallError::Io {
             path: parent.to_path_buf(),
@@ -663,20 +677,10 @@ fn create_symlink(link: &ResolvedInstallFile) -> Result<InstalledFile, InstallEr
         path: link.dest.clone(),
         source,
     })?;
-    let bytes = match fs::read(&link.dest) {
-        Ok(b) => b,
-        Err(source) => {
-            // Don't leave a dangling link behind the error.
-            let _ = fs::remove_file(&link.dest);
-            return Err(InstallError::Io {
-                path: PathBuf::from(referent),
-                source,
-            });
-        }
-    };
     Ok(InstalledFile {
         path: link.dest.clone(),
-        sha256: format!("{:x}", Sha256::digest(&bytes)),
+        sha256: String::new(),
+        referent: Some(PathBuf::from(referent)),
     })
 }
 
@@ -730,6 +734,7 @@ fn write_dest_atomic(
     Ok(InstalledFile {
         path: dest.to_path_buf(),
         sha256: sha,
+        referent: None,
     })
 }
 
@@ -1492,14 +1497,14 @@ mod tests {
 
         assert!(fs::symlink_metadata(&link_dest).unwrap().is_symlink());
         assert_eq!(fs::read_link(&link_dest).unwrap(), referent);
-        // Both entries are recorded and the link's digest is the referent's
-        // content, matching what an integrity re-hash of the path would see.
+        // Symlinks carry the referent path instead of a content hash.
         let link_file = outcome
             .files
             .iter()
             .find(|f| f.path == link_dest)
             .expect("link recorded in outcome");
-        assert_eq!(link_file.sha256, sha256_of(payload));
+        assert!(link_file.sha256.is_empty());
+        assert_eq!(link_file.referent.as_deref(), Some(referent.as_path()));
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/integrity.rs
+++ b/src/anolisa/crates/anolisa-core/src/integrity.rs
@@ -17,14 +17,19 @@
 //!     A forged `installed.toml` claiming `owner = anolisa` for
 //!     `/etc/shadow` (or `<bin_dir>/escape -> /etc/shadow`) is therefore
 //!     refused with `OutOfBounds` rather than read.
-//!   * Symlinks are refused via [`std::fs::symlink_metadata`] +
-//!     `O_NOFOLLOW` on the open call so a symlink planted at the
-//!     destination cannot redirect the read to a third-party file.
+//!   * Managed symlinks (`kind == Symlink`) are verified via
+//!     [`std::fs::read_link`] against the recorded referent path,
+//!     bypassing content hashing entirely.
+//!   * Legacy symlinks (`kind == File` but symlink on disk) are refused
+//!     with `IntegrityStatus::Symlink`. Pre-v4 entries are migrated to
+//!     `kind = Symlink` by `migrate_v3_symlinks` before the probe runs.
+//!   * Regular files are opened with `O_NOFOLLOW` so a symlink planted
+//!     at the destination cannot redirect the read to a third-party file.
 //!   * Special files (directories, fifos, sockets, devices) are refused
 //!     via the regular-file guard so `status` cannot hang on a fifo or
 //!     mis-hash a directory.
 //!
-//! All three guards report through dedicated [`IntegrityStatus`] variants
+//! All guards report through dedicated [`IntegrityStatus`] variants
 //! so the wire surface tells operators *why* the probe refused, not just
 //! that it failed.
 
@@ -35,7 +40,7 @@ use sha2::{Digest, Sha256};
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::path_safety::{PathBoundaryError, validate_owned_path};
-use crate::state::{FileOwner, OwnedFile};
+use crate::state::{FileOwner, OwnedFile, OwnedFileKind};
 
 /// Maximum bytes the integrity probe will read for one file. Owned
 /// artifacts in ANOLISA's catalogue are binaries / small data files; a
@@ -73,6 +78,15 @@ pub enum IntegrityStatus {
     MissingFile,
     /// File exists but cannot be read (permissions, broken symlink, etc).
     ReadError(String),
+    /// Managed symlink referent mismatch: the link either does not exist
+    /// as a symlink, or points at a different target than recorded.
+    ReferentMismatch {
+        /// Referent path recorded in `installed.toml`.
+        expected: String,
+        /// Actual `readlink` result, or `"(not a symlink)"` when the path
+        /// is not a symlink at all.
+        actual: String,
+    },
     /// File exists, sha256 was recorded, and bytes diverged.
     ShaMismatch {
         /// Lowercase sha256 recorded in `installed.toml`.
@@ -94,6 +108,7 @@ impl IntegrityStatus {
             Self::NotRegularFile => "not_regular_file",
             Self::MissingFile => "missing_file",
             Self::ReadError(_) => "read_error",
+            Self::ReferentMismatch { .. } => "referent_mismatch",
             Self::ShaMismatch { .. } => "sha256_mismatch",
         }
     }
@@ -111,6 +126,7 @@ impl IntegrityStatus {
                 | Self::NotRegularFile
                 | Self::MissingFile
                 | Self::ReadError(_)
+                | Self::ReferentMismatch { .. }
                 | Self::ShaMismatch { .. }
         )
     }
@@ -141,6 +157,12 @@ pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus 
         // either way the probe refuses to touch the path.
         let _: PathBoundaryError = err;
         return IntegrityStatus::OutOfBounds;
+    }
+
+    // Managed symlinks are verified against their recorded referent
+    // instead of hashing content through the link.
+    if file.kind == OwnedFileKind::Symlink {
+        return check_owned_symlink(layout, file);
     }
 
     // symlink_metadata does NOT follow — required so a planted symlink
@@ -174,6 +196,61 @@ pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus 
         Err(err) => IntegrityStatus::ReadError(err.to_string()),
         Ok(actual) if actual != expected => IntegrityStatus::ShaMismatch { expected, actual },
         Ok(_) => IntegrityStatus::Ok,
+    }
+}
+
+/// Verify a managed symlink entry: the path must be a symlink whose
+/// `readlink` result matches the recorded referent, and the referent
+/// must remain within ANOLISA-owned roots.
+fn check_owned_symlink(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus {
+    let expected_referent = match &file.referent {
+        Some(r) => r,
+        None => return IntegrityStatus::Unverified,
+    };
+
+    let meta = match fs::symlink_metadata(&file.path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return IntegrityStatus::MissingFile;
+        }
+        Err(err) => return IntegrityStatus::ReadError(err.to_string()),
+    };
+
+    if !meta.file_type().is_symlink() {
+        return IntegrityStatus::ReferentMismatch {
+            expected: expected_referent.display().to_string(),
+            actual: "(not a symlink)".to_string(),
+        };
+    }
+
+    let actual_referent = match fs::read_link(&file.path) {
+        Ok(r) => r,
+        Err(err) => return IntegrityStatus::ReadError(err.to_string()),
+    };
+
+    if actual_referent != *expected_referent {
+        return IntegrityStatus::ReferentMismatch {
+            expected: expected_referent.display().to_string(),
+            actual: actual_referent.display().to_string(),
+        };
+    }
+
+    if validate_owned_path(layout, &actual_referent).is_err() {
+        return IntegrityStatus::OutOfBounds;
+    }
+
+    // Verify the referent target actually exists and is a regular file.
+    // A dangling symlink whose readlink matches is still broken.
+    match fs::metadata(&file.path) {
+        Ok(m) if m.is_file() => IntegrityStatus::Ok,
+        Ok(_) => IntegrityStatus::NotRegularFile,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            IntegrityStatus::ReadError(format!(
+                "dangling symlink: referent {} does not exist",
+                expected_referent.display()
+            ))
+        }
+        Err(err) => IntegrityStatus::ReadError(err.to_string()),
     }
 }
 
@@ -247,6 +324,8 @@ mod tests {
             path,
             owner: FileOwner::Anolisa,
             sha256,
+            kind: OwnedFileKind::File,
+            referent: None,
         }
     }
 
@@ -261,6 +340,8 @@ mod tests {
             path: PathBuf::from("/definitely/not/here"),
             owner: FileOwner::External,
             sha256: Some("deadbeef".to_string()),
+            kind: OwnedFileKind::File,
+            referent: None,
         };
         assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Skipped);
     }
@@ -361,13 +442,10 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn symlink_under_owned_root_is_refused_without_following() {
-        // A symlink planted under bin_dir must NOT be followed even when
-        // its target is itself an ANOLISA-owned file. We park the decoy
-        // under `datadir/` (also an owned root) so path-safety passes and
-        // the symlink-specific guard is what fires. If integrity followed
-        // the symlink it would hash the decoy bytes and the assertion
-        // would be Ok or ShaMismatch instead.
+    fn old_state_symlink_under_kind_file_is_refused() {
+        // kind=File (pre-v4 default) + symlink on disk → Symlink refused,
+        // regardless of whether the hash matches. The probe does NOT
+        // follow the symlink; migration to kind=Symlink happens upstream.
         let tmp = tempdir().expect("tempdir");
         let layout = layout_under(tmp.path());
         fs::create_dir_all(&layout.datadir).expect("mkdir datadir");
@@ -376,7 +454,7 @@ mod tests {
         let link = layout.bin_dir.join("hello");
         std::os::unix::fs::symlink(&target, &link).expect("symlink");
         let owned = anolisa_owned(link, Some("deadbeef".to_string()));
-        assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Symlink);
+        assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Symlink,);
     }
 
     #[test]
@@ -408,6 +486,13 @@ mod tests {
         assert!(IntegrityStatus::MissingFile.is_failure());
         assert!(IntegrityStatus::ReadError("permission denied".into()).is_failure());
         assert!(
+            IntegrityStatus::ReferentMismatch {
+                expected: "a".into(),
+                actual: "b".into()
+            }
+            .is_failure()
+        );
+        assert!(
             IntegrityStatus::ShaMismatch {
                 expected: "a".into(),
                 actual: "b".into()
@@ -424,6 +509,14 @@ mod tests {
         assert_eq!(IntegrityStatus::MissingFile.label(), "missing_file");
         assert_eq!(IntegrityStatus::ReadError("x".into()).label(), "read_error");
         assert_eq!(
+            IntegrityStatus::ReferentMismatch {
+                expected: "a".into(),
+                actual: "b".into()
+            }
+            .label(),
+            "referent_mismatch"
+        );
+        assert_eq!(
             IntegrityStatus::ShaMismatch {
                 expected: "a".into(),
                 actual: "b".into()
@@ -431,5 +524,74 @@ mod tests {
             .label(),
             "sha256_mismatch"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn managed_symlink_ok_reports_ok() {
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let target = layout.bin_dir.join("real-bin");
+        fs::write(&target, b"binary-content").expect("write target");
+        let link = layout.bin_dir.join("alias");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        let owned = OwnedFile {
+            path: link,
+            owner: FileOwner::Anolisa,
+            sha256: None,
+            kind: OwnedFileKind::Symlink,
+            referent: Some(target),
+        };
+        assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Ok);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn managed_symlink_referent_mismatch() {
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let real_target = layout.bin_dir.join("real-bin");
+        fs::write(&real_target, b"real").expect("write real");
+        let recorded_target = layout.bin_dir.join("expected-bin");
+        fs::write(&recorded_target, b"expected").expect("write expected");
+        let link = layout.bin_dir.join("alias");
+        std::os::unix::fs::symlink(&real_target, &link).expect("symlink");
+        let owned = OwnedFile {
+            path: link,
+            owner: FileOwner::Anolisa,
+            sha256: None,
+            kind: OwnedFileKind::Symlink,
+            referent: Some(recorded_target.clone()),
+        };
+        match check_owned_file(&layout, &owned) {
+            IntegrityStatus::ReferentMismatch { expected, actual } => {
+                assert_eq!(expected, recorded_target.display().to_string());
+                assert_eq!(actual, real_target.display().to_string());
+            }
+            other => panic!("expected ReferentMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn managed_symlink_dangling_referent_reports_error() {
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let target = layout.bin_dir.join("gone");
+        let link = layout.bin_dir.join("alias");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        let owned = OwnedFile {
+            path: link,
+            owner: FileOwner::Anolisa,
+            sha256: None,
+            kind: OwnedFileKind::Symlink,
+            referent: Some(target),
+        };
+        match check_owned_file(&layout, &owned) {
+            IntegrityStatus::ReadError(msg) => {
+                assert!(msg.contains("dangling"), "msg: {msg}");
+            }
+            other => panic!("expected ReadError(dangling), got {other:?}"),
+        }
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -108,8 +108,8 @@ pub use service::{
 };
 pub use state::{
     BackupRecord, ExternalModifiedFile, FileOwner, HealthEntry, InstallMode, InstalledObject,
-    InstalledState, ObjectKind, ObjectStatus, OperationRecord, OwnedFile, Ownership, RpmMetadata,
-    STATE_SCHEMA_VERSION, ServiceRef, StateError, SubscriptionScope,
+    InstalledState, ObjectKind, ObjectStatus, OperationRecord, OwnedFile, OwnedFileKind, Ownership,
+    RpmMetadata, STATE_SCHEMA_VERSION, ServiceRef, StateError, SubscriptionScope,
 };
 pub use telemetry::{TelemetryConfig, TelemetryError, TelemetryStarter, validate_sls_account_id};
 pub use transaction::{

--- a/src/anolisa/crates/anolisa-core/src/lifecycle.rs
+++ b/src/anolisa/crates/anolisa-core/src/lifecycle.rs
@@ -1970,7 +1970,7 @@ mod tests {
 
     use crate::state::{
         ExternalModifiedFile, FileOwner as StateFileOwner, InstalledObject, InstalledState,
-        ObjectKind, ObjectStatus, OwnedFile, ServiceRef,
+        ObjectKind, ObjectStatus, OwnedFile, OwnedFileKind, ServiceRef,
     };
     use std::fs as std_fs;
     use std::path::Path;
@@ -2010,6 +2010,8 @@ mod tests {
                 path: owned_path.to_path_buf(),
                 owner: StateFileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: vec![ExternalModifiedFile {
                 path: external_path.to_path_buf(),
@@ -2181,6 +2183,8 @@ mod tests {
                 path: owned_path.clone(),
                 owner: StateFileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: Vec::new(),
@@ -2271,6 +2275,8 @@ mod tests {
                 path: owned_path.clone(),
                 owner: StateFileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: vec![ServiceRef {
@@ -3025,6 +3031,8 @@ mod tests {
                 path: victim.clone(),
                 owner: StateFileOwner::Anolisa,
                 sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: Vec::new(),

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -32,7 +32,14 @@ use crate::manifest::ServiceScope;
 /// v3 added `ownership` (provenance model) and `rpm_metadata` to
 /// [`InstalledObject`]. Both fields default-deserialize (`None`), so
 /// older files load unchanged and gain the new fields on next save.
-pub const STATE_SCHEMA_VERSION: u32 = 3;
+///
+/// v4 added `kind` ([`OwnedFileKind`]) and `referent` to [`OwnedFile`]
+/// so the integrity probe can distinguish managed symlinks from regular
+/// files. Both default-deserialize (`File` / `None`); pre-v4 symlink
+/// entries remain `kind = File` until migrated by
+/// `commands::common::migrate_v3_symlinks`, which uses the installed
+/// component manifest as the migration authority.
+pub const STATE_SCHEMA_VERSION: u32 = 4;
 
 fn is_legacy_rpm_backend(backend: Option<&str>) -> bool {
     matches!(backend, Some("rpm" | "yum"))
@@ -186,6 +193,28 @@ pub enum FileOwner {
     External,
 }
 
+/// Whether an [`OwnedFile`] is a regular file or a managed symlink.
+///
+/// Older `installed.toml` files (schema ≤ 3) lack this field; serde
+/// defaults to `File` so they load unchanged. New installs of symlink
+/// entries record `Symlink` together with a `referent` path so the
+/// integrity probe can verify the link target instead of refusing it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnedFileKind {
+    /// Regular file (data, executable, config, library).
+    #[default]
+    File,
+    /// Symbolic link created by the install runner. The integrity probe
+    /// verifies `readlink` against the recorded [`OwnedFile::referent`]
+    /// instead of hashing content through the link.
+    Symlink,
+}
+
+fn is_default_owned_file_kind(kind: &OwnedFileKind) -> bool {
+    *kind == OwnedFileKind::File
+}
+
 /// File installed and owned by ANOLISA.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OwnedFile {
@@ -196,8 +225,19 @@ pub struct OwnedFile {
     pub owner: FileOwner,
     /// Recorded content digest. Older state or externally adopted files may
     /// omit it, so integrity checks surface `unverified` instead of guessing.
+    /// Symlink entries omit this field — they record a [`referent`](Self::referent)
+    /// instead.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
+    /// Regular file vs. managed symlink. Defaults to `File` for backward
+    /// compatibility with state written before schema v4.
+    #[serde(default, skip_serializing_if = "is_default_owned_file_kind")]
+    pub kind: OwnedFileKind,
+    /// Expected symlink target (only meaningful when `kind == Symlink`).
+    /// The integrity probe verifies `readlink` matches this path and that
+    /// the referent stays within ANOLISA-owned roots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub referent: Option<PathBuf>,
 }
 
 /// External (non-ANOLISA) file that an operation modified. Linked back to
@@ -769,6 +809,8 @@ mod tests {
                 path: PathBuf::from("/tmp/anolisa/bin/foo"),
                 owner: FileOwner::Anolisa,
                 sha256: Some("deadbeef".to_string()),
+                kind: OwnedFileKind::File,
+                referent: None,
             }],
             external_modified_files: Vec::new(),
             services: vec![ServiceRef {
@@ -836,7 +878,7 @@ mod tests {
         let state: InstalledState =
             toml::from_str(&content).expect("template parses into InstalledState");
 
-        assert_eq!(state.schema_version, 1);
+        assert_eq!(state.schema_version, STATE_SCHEMA_VERSION);
         assert_eq!(state.install_mode, InstallMode::User);
         assert!(!state.objects.is_empty(), "expected at least one object");
         assert!(!state.backups.is_empty(), "expected at least one backup");

--- a/src/anolisa/templates/installed-state.toml
+++ b/src/anolisa/templates/installed-state.toml
@@ -3,7 +3,7 @@
 #   user-mode:   $XDG_STATE_HOME/anolisa/installed.toml
 #   system-mode: /var/lib/anolisa/installed.toml
 
-schema_version = 1
+schema_version = 4
 updated_at = "2026-06-01T10:00:00Z"
 install_mode = "user" # user | system
 prefix = "~/.local"
@@ -28,6 +28,14 @@ subscription_scope = "none" # none | registered | entitled | reporting
 path = "~/.local/bin/agentsight"
 owner = "anolisa" # anolisa | external
 sha256 = "replace-with-sha256"
+kind = "file" # file | symlink (v4+; defaults to "file" for pre-v4 state)
+
+# Example: managed symlink entry (v4+)
+[[objects.files]]
+path = "~/.local/bin/rtk"
+owner = "anolisa"
+kind = "symlink"
+referent = "~/.local/libexec/tokenless/rtk"
 
 [[objects.external_modified_files]]
 path = "~/.openclaw/config.toml"


### PR DESCRIPTION
## Description

Fixes `anolisa status` misreporting `failed` for components with manifest-declared symlinks (e.g. tokenless `rtk`/`toon`). The root cause was that the integrity probe unconditionally refused `kind=File` entries found as symlinks on disk (`symlink_refused`), and old state (schema ≤ 3) recorded symlink entries as plain `OwnedFile` with no way to distinguish them from planted symlinks.

A prior attempt to fix this by following the symlink and hashing content was reverted because it reintroduced a planted-symlink vulnerability by bypassing the `O_NOFOLLOW` defense.

## Design Note

The fix has three layers:

1. **OwnedFile schema v4**: `kind` (`File` | `Symlink`) and `referent` fields added to `OwnedFile` with `serde(default)` for backward compatibility. New installs record symlinks as `kind = Symlink` with the manifest-declared referent; the integrity probe verifies `readlink` instead of hashing content. `sha2` moved from `[dev-dependencies]` to `[dependencies]` in `anolisa-cli` because the migration function hashes referent content to verify the recorded `sha256` before upgrading. `referent_mismatch` added to the error-color palette so managed symlinks with wrong targets render as red in human output.

2. **Manifest-driven migration** (`migrate_v3_symlinks` in `commands/common.rs`): loads each component's installed manifest (`<state_dir>/component-manifests/<comp>/component.toml`) as the sole authority for which paths should be symlinks. Upgrades `kind = File` → `kind = Symlink` only after verifying: component name is a safe path segment, manifest declares the path as `type = "symlink"`, disk entry is a symlink, `readlink` matches the manifest-declared referent, referent is a regular file, and any recorded `sha256` matches referent content. Any failed check skips the entry (conservative: stays `kind = File`, probe reports `symlink_refused`).

3. **Integration**: `status` does in-memory migration before the integrity probe (read-only semantics preserved — no disk write, no lock). `install` / `update` call the same function before `state.save()` under the existing `InstallLock`, persisting the migration so subsequent `status` calls are a no-op. `repair` is not touched — it only handles rpmdb drift and does not support raw components.

The integrity probe's strong boundary is restored: `kind = File` + symlink on disk always returns `symlink_refused` regardless of hash. Only entries migrated to `kind = Symlink` (via manifest authority) get the `readlink`-based verification path. This ensures a planted symlink at a `kind = File` path cannot be legitimized by a migration that trusts disk state.

## Ship Note

- Components installed before manifest snapshotting was added (no `component-manifests/<comp>/component.toml` on disk) will not be migrated; their symlink entries stay `kind = File` and `status` continues to report `symlink_refused`. A `reinstall` / `update` resolves this.
- `status` re-runs the in-memory migration on every invocation until a write command (`install` / `update`) persists it. The cost is one `read_to_string` + TOML parse per component per `status` call — negligible for typical deployments with a handful of components, but worth noting.

## Test

- Unit (integrity): `kind = File` + symlink → `Symlink` refused (no follow); `kind = Symlink` + correct readlink → `Ok`; referent mismatch → `ReferentMismatch`; dangling referent → `ReadError`.
- Unit (migration): manifest-declared symlink upgraded when all invariants hold; skipped when disk is not a symlink; skipped when `readlink` mismatches manifest; skipped when `sha256` mismatches; skipped when manifest missing; skipped when component name contains path traversal.
- Full gate green: `cargo fmt --check`, `cargo check`, `cargo test` (1076 tests), `cargo doc --no-deps` — zero warnings.

Closes #1213