### PR TITLE
chore(anolisa): bump cli to 0.1.17

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17] - 2026-06-30
+
+### Added
+
+- Repository `components.toml` can now define component names, package aliases, and raw/RPM package mappings.
+- `anolisa list --installed` now filters installed components.
+
+### Changed
+
+- `anolisa list` and `install --all` now read components from `components.toml` instead of `catalog.json`.
+- `anolisa list` now shows `NAME`, `SUMMARY`, `BACKENDS`, and `STATUS`.
+- `anolisa list --enabled` is now a hidden alias for `--installed`.
+- `ANOLISA_CATALOG_URL` no longer changes list sources; configure `repo.toml` instead.
+- `anolisa install`, `status`, `adopt`, and `repair` now resolve RPM package aliases from `components.toml`.
+- `anolisa status` now suggests `sudo anolisa adopt <component>` for untracked RPM components.
+
+### Fixed
+
+- `anolisa status <RPM package>` now reports the canonical component row when an alias is installed.
+- `anolisa repair <RPM package>` now refreshes the canonical component row when an alias is used.
+- Non-root `anolisa osbase` mutations now reach the system helper instead of failing install-mode checks.
+- Commands now reject root `--install-mode user` before writing ambiguous user-mode state.
+- System-mode write commands now fail before changes when sudo is missing.
+- Existing installs with managed symlinks no longer show false symlink integrity failures after upgrade.
+- `anolisa status` now reports `referent_mismatch` when managed symlinks point elsewhere.
+
 ## [0.1.16] - 2026-06-29
 
 ### Added
@@ -335,6 +361,32 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.1.17] - 2026-06-30
+
+### 新增
+
+- 仓库 `components.toml` 现可声明组件与包名映射。
+- `anolisa list --installed` 现过滤已安装组件。
+
+### 变更
+
+- `anolisa list` 和 `install --all` 现读取 `components.toml`。
+- `anolisa list` 现显示 NAME、SUMMARY、BACKENDS、STATUS。
+- `anolisa list --enabled` 现作为隐藏别名保留。
+- `ANOLISA_CATALOG_URL` 不再控制列表来源。
+- `install`、`status`、`adopt`、`repair` 现解析 RPM 包别名。
+- `anolisa status` 现提示用 `sudo anolisa adopt` 收编 RPM。
+
+### 修复
+
+- `status <RPM 包>` 现显示规范组件行。
+- `repair <RPM 包>` 现刷新规范组件行。
+- 非 root `osbase` 变更命令现可进入系统 helper。
+- root 用户模式现会在写入前被拒绝。
+- 缺少 sudo 的系统模式写入现提前失败。
+- 旧符号链接安装不再误报完整性失败。
+- `status` 现报告符号链接目标不匹配。
 
 ## [0.1.16] - 2026-06-29
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "chrono",
  "dirs",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -124,7 +124,24 @@ install -m 0644 manifests/repo.toml %{buildroot}%{_sysconfdir}/anolisa/repo.toml
 #%%doc %%{_docdir}/%%{name}/README.md
 
 %changelog
-* Mon Jun 29 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Tue Jun 30 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Repository components.toml can now define component names, package aliases, and raw/RPM package mappings.
+- `anolisa list --installed` now filters installed components.
+- `anolisa list` and `install --all` now read components from components.toml instead of catalog.json.
+- `anolisa list` now shows NAME, SUMMARY, BACKENDS, and STATUS.
+- `anolisa list --enabled` is now a hidden alias for `--installed`.
+- ANOLISA_CATALOG_URL no longer changes list sources; configure repo.toml instead.
+- `anolisa install`, `status`, `adopt`, and `repair` now resolve RPM package aliases from components.toml.
+- `anolisa status` now suggests `sudo anolisa adopt <component>` for untracked RPM components.
+- `anolisa status <RPM package>` now reports the canonical component row when an alias is installed.
+- `anolisa repair <RPM package>` now refreshes the canonical component row when an alias is used.
+- Non-root `anolisa osbase` mutations now reach the system helper instead of failing install-mode checks.
+- Commands now reject root `--install-mode user` before writing ambiguous user-mode state.
+- System-mode write commands now fail before changes when sudo is missing.
+- Existing installs with managed symlinks no longer show false symlink integrity failures after upgrade.
+- `anolisa status` now reports `referent_mismatch` when managed symlinks point elsewhere.
+
+* Mon Jun 29 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.1.16-1
 - `anolisa osbase sandbox install runc` now installs runc, containerd, Docker, and Docker client.
 - `anolisa osbase sandbox install` now enables services declared by sandbox scenarios.
 - `anolisa osbase sandbox install` now runs scenario verification commands after installation.


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
bump cli version to 0.1.17

## Related Issue

<!--
  REQUIRED: Every PR must be linked to an existing issue.
  Use one of the closing keywords so the issue closes automatically on merge:

    closes #<number>
    fixes #<number>
    resolves #<number>

  If this is a trivial typo / doc-only fix with no issue, write:
    no-issue: <reason>
-->

no-issue

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

<!-- Which sub-project does this PR affect? -->

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

<!-- Check all that apply. -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

## Additional Notes

<!-- Any additional information, screenshots, or context. -->
