### PR TITLE
fix(rpm): handle unowned file queries

### DIFF
--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -210,10 +210,13 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
             return Ok(names);
         }
 
-        // "nothing provides it" is a normal empty result, mirroring the
-        // not-installed branch: rpm writes the notice to stdout, pinned to
-        // English by LC_ALL=C.
-        if out.stdout.contains("no package provides") {
+        // "Nothing provides it" is a normal empty result, but only for rpm's
+        // expected miss exit. File path lookups use a separate unowned-file
+        // marker from virtual capabilities.
+        let expected_miss = out.code == Some(1)
+            && (out.stdout.contains("no package provides")
+                || out.stdout.contains("is not owned by any package"));
+        if expected_miss {
             return Ok(Vec::new());
         }
 
@@ -903,6 +906,43 @@ mod tests {
             .what_provides_installed("anolisa-component(absent)")
             .unwrap();
         assert!(names.is_empty());
+    }
+
+    #[test]
+    fn what_provides_unowned_file_is_empty() {
+        let path = "/home/user/.local/bin/anolisa";
+        let q = query_with_rpm(
+            path,
+            ok_out(
+                Some(1),
+                "file /home/user/.local/bin/anolisa is not owned by any package\n",
+                "",
+            ),
+        );
+        let names = q.what_provides_installed(path).unwrap();
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn what_provides_unowned_file_with_unexpected_code_is_error() {
+        let path = "/home/user/.local/bin/anolisa";
+        let q = query_with_rpm(
+            path,
+            ok_out(
+                Some(2),
+                "file /home/user/.local/bin/anolisa is not owned by any package\n",
+                "",
+            ),
+        );
+        let err = q.what_provides_installed(path).unwrap_err();
+        assert!(matches!(
+            err,
+            PackageQueryError::QueryFailed {
+                command,
+                code: Some(2),
+                ..
+            } if command == RPM
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes `anolisa update self` failing for bare binary installs on RPM-based systems.

When the CLI probes whether the running executable is RPM-owned, it calls `rpm -q --whatprovides <current-exe>`. For an unowned file such as `/home/jiawa.syx/.local/bin/anolisa`, rpm exits with code `1` and writes `file ... is not owned by any package` to stdout. The RPM query layer only treated `no package provides ...` as a normal empty result, so this unowned-file miss was surfaced as `EXECUTION_FAILED` instead of letting self-update continue down the binary replacement path.

## Design Note

The fix keeps the ownership probe strict: a `whatprovides` miss is treated as empty only when both conditions hold:

1. rpm exits with its expected miss code (`1`).
2. stdout contains one of the known miss markers: `no package provides` for virtual capabilities, or `is not owned by any package` for file paths.

This preserves hard failure handling for rpmdb/query errors and unexpected exit codes, while allowing bare binary installs to behave as non-RPM-owned.

## Ship Note

- Bare binary installs can now run `anolisa update self` on RPM-based hosts without being blocked by the RPM ownership probe.
- RPM-owned CLI installs still delegate to `dnf update <package>`.
- Real rpm query failures remain errors; only the explicit miss-code + miss-text combination is downgraded to an empty provider set.
- No state, schema, or manifest changes.

## Test

- `cargo test -p anolisa-platform what_provides`
- `cargo test -p anolisa-cli self_update`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo doc --no-deps`
