### PR TITLE
fix(skillfs): report validate parse failures

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -2131,7 +2131,6 @@ async fn cmd_validate(
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(source = %source.display(), "validating skills");
 
-    // Validate source directory
     if !source.exists() {
         return Err(format!("Source directory does not exist: {}", source.display()).into());
     }
@@ -2139,30 +2138,63 @@ async fn cmd_validate(
         return Err(format!("Source is not a directory: {}", source.display()).into());
     }
 
-    // Load skills
     let mut store = SkillStore::new();
     let config = ParseConfig::default();
-    let errors = store.load_from_directory(&source, &config);
+    let load_errors = store.load_from_directory(&source, &config);
 
-    // Output results
+    let mut success: usize = 0;
+    let mut degraded: usize = 0;
+    let mut parse_error_count: usize = 0;
+
+    let names = store.list();
+    for name in &names {
+        if let Some(entry) = store.get(name) {
+            match &entry.parse_status {
+                skillfs_core::ParseStatus::Ok => success += 1,
+                skillfs_core::ParseStatus::Degraded(_) => degraded += 1,
+                skillfs_core::ParseStatus::Error(_) => parse_error_count += 1,
+            }
+        }
+    }
+
+    let failed = parse_error_count + load_errors.len();
+    let total = success + degraded + failed;
+
     match format {
         OutputFormat::Text => {
-            println!("Validated {} skills from {}", store.len(), source.display());
+            println!("Validated {} skills from {}", total, source.display());
 
-            if errors.is_empty() {
+            if failed == 0 && degraded == 0 {
                 println!("✓ All skills loaded successfully");
             } else {
-                println!("✗ {} skills failed to load:", errors.len());
-                for err in &errors {
-                    println!("  - {}: {}", err.path.display(), err.error);
+                if failed > 0 {
+                    println!("✗ {} skill(s) failed:", failed);
+                    for err in &load_errors {
+                        println!("  - {}: {}", err.path.display(), err.error);
+                    }
+                    for name in &names {
+                        if let Some(entry) = store.get(name) {
+                            if entry.parse_status.is_error() {
+                                println!("  - {}: {}", name, entry.parse_status.message());
+                            }
+                        }
+                    }
+                }
+                if degraded > 0 {
+                    println!("⚠ {} skill(s) degraded:", degraded);
+                    for name in &names {
+                        if let Some(entry) = store.get(name) {
+                            if entry.parse_status.is_degraded() {
+                                println!("  - {}: {}", name, entry.parse_status.message());
+                            }
+                        }
+                    }
                 }
             }
 
-            // Show skill summary
             if !store.is_empty() {
                 println!("\nSkills:");
-                let names = store.list();
-                for name in names {
+                for name in &names {
                     if let Some(entry) = store.get(name) {
                         let status = match &entry.parse_status {
                             skillfs_core::ParseStatus::Ok => "✓",
@@ -2190,17 +2222,49 @@ async fn cmd_validate(
             }
         }
         OutputFormat::Json => {
-            let result = serde_json::json!({
-                "total": store.len() + errors.len(),
-                "success": store.len(),
-                "failed": errors.len(),
-                "errors": errors.iter().map(|e| {
+            let mut error_entries: Vec<serde_json::Value> = load_errors
+                .iter()
+                .map(|e| {
                     serde_json::json!({
                         "path": e.path.to_string_lossy().to_string(),
-                        "error": e.error
+                        "status": "load_error",
+                        "message": e.error
                     })
-                }).collect::<Vec<_>>(),
-                "skills": store.list().iter().map(|name| {
+                })
+                .collect();
+            for name in &names {
+                if let Some(entry) = store.get(name) {
+                    if entry.parse_status.is_error() {
+                        error_entries.push(serde_json::json!({
+                            "name": name,
+                            "status": "error",
+                            "message": entry.parse_status.message()
+                        }));
+                    }
+                }
+            }
+
+            let mut warning_entries: Vec<serde_json::Value> = Vec::new();
+            for name in &names {
+                if let Some(entry) = store.get(name) {
+                    if entry.parse_status.is_degraded() {
+                        warning_entries.push(serde_json::json!({
+                            "name": name,
+                            "status": "degraded",
+                            "message": entry.parse_status.message()
+                        }));
+                    }
+                }
+            }
+
+            let result = serde_json::json!({
+                "total": total,
+                "success": success,
+                "degraded": degraded,
+                "failed": failed,
+                "errors": error_entries,
+                "warnings": warning_entries,
+                "skills": names.iter().map(|name| {
                     if let Some(entry) = store.get(name) {
                         serde_json::json!({
                             "name": name,
@@ -2217,8 +2281,7 @@ async fn cmd_validate(
         }
     }
 
-    // Exit with error code if there were failures
-    if !errors.is_empty() {
+    if failed > 0 {
         std::process::exit(1);
     }
 

--- a/src/skillfs/crates/skillfs-cli/tests/validate_cli_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/validate_cli_tests.rs
@@ -1,0 +1,240 @@
+//! CLI validate subcommand tests.
+//!
+//! Verifies that `skillfs validate` correctly reports parse failures,
+//! warnings, and success in both text and JSON output, with correct
+//! exit codes.
+
+use std::path::Path;
+use std::process::Command;
+
+fn bin_path() -> &'static str {
+    env!("CARGO_BIN_EXE_skillfs")
+}
+
+/// Valid SKILL.md that parses as Ok.
+const VALID_SKILL: &str = r#"---
+name: good-skill
+description: A valid skill
+version: "1.0"
+---
+# Good Skill
+
+This skill works correctly.
+"#;
+
+/// SKILL.md with invalid YAML frontmatter → ParseStatus::Error.
+const ERROR_SKILL: &str = r#"---
+name: [invalid yaml
+  broken: {{{}
+---
+Body text.
+"#;
+
+/// SKILL.md with missing description → ParseStatus::Degraded.
+const DEGRADED_SKILL: &str = r#"---
+name: degraded-skill
+---
+"#;
+
+fn create_skill_dir(parent: &Path, name: &str, content: &str) {
+    let dir = parent.join(name);
+    std::fs::create_dir_all(&dir).expect("create skill dir");
+    std::fs::write(dir.join("SKILL.md"), content).expect("write SKILL.md");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. invalid-only text
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn invalid_only_text_exits_nonzero() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    create_skill_dir(source.path(), "bad-yaml", ERROR_SKILL);
+    create_skill_dir(source.path(), "empty-skill", "");
+
+    let out = Command::new(bin_path())
+        .args(["validate", source.path().to_str().unwrap()])
+        .output()
+        .expect("invoke skillfs validate");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit code, stdout={stdout}"
+    );
+    assert!(
+        !stdout.contains("All skills loaded successfully"),
+        "must not claim all-ok when errors exist, stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("failed") || stdout.contains("✗"),
+        "should report failures, stdout={stdout}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. invalid-only JSON
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn invalid_only_json_exits_nonzero() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    create_skill_dir(source.path(), "bad-yaml", ERROR_SKILL);
+
+    let out = Command::new(bin_path())
+        .args([
+            "validate",
+            source.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("invoke skillfs validate --format json");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit code, stdout={stdout}"
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    let failed = json["failed"].as_u64().expect("failed field");
+    assert!(failed > 0, "failed should be > 0, got {failed}");
+    let errors = json["errors"].as_array().expect("errors array");
+    assert!(!errors.is_empty(), "errors array should not be empty");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. mixed JSON (valid + degraded + error)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn mixed_json_counts_correctly() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+    create_skill_dir(source.path(), "degraded-skill", DEGRADED_SKILL);
+    create_skill_dir(source.path(), "bad-yaml", ERROR_SKILL);
+
+    let out = Command::new(bin_path())
+        .args([
+            "validate",
+            source.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("invoke skillfs validate --format json");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit (has errors), stdout={stdout}"
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+
+    let success = json["success"].as_u64().expect("success field");
+    assert_eq!(success, 1, "only Ok skill should count as success");
+
+    let degraded = json["degraded"].as_u64().expect("degraded field");
+    assert_eq!(degraded, 1, "one degraded skill expected");
+
+    let failed = json["failed"].as_u64().expect("failed field");
+    assert_eq!(failed, 1, "one error skill expected as failed");
+
+    let errors = json["errors"].as_array().expect("errors array");
+    assert_eq!(errors.len(), 1, "one error entry expected");
+
+    let warnings = json["warnings"].as_array().expect("warnings array");
+    assert_eq!(warnings.len(), 1, "one warning entry expected");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. degraded-only
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn degraded_only_exits_zero() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    create_skill_dir(source.path(), "degraded-skill", DEGRADED_SKILL);
+
+    let out = Command::new(bin_path())
+        .args(["validate", source.path().to_str().unwrap()])
+        .output()
+        .expect("invoke skillfs validate");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "degraded-only should exit 0, stdout={stdout}"
+    );
+    assert!(
+        !stdout.contains("All skills loaded successfully"),
+        "should not claim all-ok when degraded, stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("degraded") || stdout.contains("⚠"),
+        "should show degraded info, stdout={stdout}"
+    );
+}
+
+#[test]
+fn degraded_only_json_exits_zero() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    create_skill_dir(source.path(), "degraded-skill", DEGRADED_SKILL);
+
+    let out = Command::new(bin_path())
+        .args([
+            "validate",
+            source.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("invoke skillfs validate --format json");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "degraded-only should exit 0, stdout={stdout}"
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+
+    let degraded = json["degraded"].as_u64().expect("degraded field");
+    assert!(degraded > 0, "degraded should be > 0");
+
+    let failed = json["failed"].as_u64().expect("failed field");
+    assert_eq!(failed, 0, "no failures expected");
+
+    let warnings = json["warnings"].as_array().expect("warnings array");
+    assert!(!warnings.is_empty(), "warnings should not be empty");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. all-ok
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn all_ok_prints_success_message() {
+    let source = tempfile::tempdir().expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let out = Command::new(bin_path())
+        .args(["validate", source.path().to_str().unwrap()])
+        .output()
+        .expect("invoke skillfs validate");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "all-ok should exit 0, stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("All skills loaded successfully"),
+        "should print success message, stdout={stdout}"
+    );
+}


### PR DESCRIPTION

## Description

Fix `skillfs validate` summary reporting and exit-code behavior.

Previously, `skillfs validate` only counted load-level errors returned by
`SkillStore::load_from_directory()`. Skills that loaded into the store with
`ParseStatus::Error` or `ParseStatus::Degraded` were still counted as
successful at the top level, even though each skill entry exposed the invalid
status.

This made invalid skill directories unsuitable for CI/release validation because
text output could say `All skills loaded successfully`, JSON could report
`failed: 0`, and the process could exit with code 0.

This PR derives validate summary fields from each loaded skill's
`parse_status`:

- `Ok` counts as `success`
- `Degraded` counts as `degraded` / `warnings`
- `Error` counts as `failed` / `errors`
- load-level errors still count as `failed`
- exit code is non-zero when `failed > 0`
- degraded-only input remains exit code 0, but is visible in text and JSON

## Related Issue

closes #1223

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Ran the focused SkillFS validation with Rust 1.86:

```bash
cd src/skillfs
cargo +1.86.0 fmt --all --check
cargo +1.86.0 check -p skillfs -p skillfs-fuse
cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
cargo +1.86.0 test -p skillfs --test validate_cli_tests
cargo +1.86.0 test -p skillfs --test cli_startup_tests
cargo +1.86.0 test -p skillfs-core
```

The new `validate_cli_tests` suite passes with 6/6 tests.

## Additional Notes

This intentionally changes `skillfs validate` behavior for invalid skills:
directories containing `ParseStatus::Error` skills now return a non-zero exit
code. This matches the expected CI/release-gate contract from the linked issue.

Degraded-only directories still return exit code 0, but the degraded count and
warnings are now visible in JSON and text output.