### PR TITLE
fix(anolisa): use repo.toml rpm source

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -56,6 +56,7 @@ use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
 use anolisa_platform::privilege;
 use anolisa_platform::rpm_query::RpmPackageQuery;
+use anolisa_platform::rpm_repo::DnfRepoSource;
 use anolisa_platform::rpm_transaction::RpmTransaction;
 use chrono::{SecondsFormat, Utc};
 
@@ -73,6 +74,7 @@ use crate::resolution::{
 use crate::response::{CliError, render_json, render_json_with_status};
 
 const COMMAND: &str = "install";
+const ANOLISA_RPM_REPO_ID: &str = "anolisa-configured";
 
 #[derive(Debug, Parser)]
 // `--version` here means the *component* version (the `cargo install`
@@ -409,31 +411,58 @@ fn handle_one(
     args: InstallArgs,
     ctx: &CliContext,
 ) -> Result<InstallOutcome, CliError> {
+    let layout = common::resolve_layout(ctx);
+    let env = anolisa_env::EnvService::detect();
+    let repo_config = RepoConfig::load(&layout).map_err(|err| repo_config_err(err, false))?;
+    let rpm_repo = if rpm_repo_required(&component, &args, ctx, &repo_config)? {
+        configured_rpm_repo_source(&repo_config, &env)?
+    } else {
+        None
+    };
+
     // Production uses the real rpm/dnf-backed query and transaction; tests
-    // inject fakes via `handle_one_with_exec`. Both constructors are
-    // side-effect-free (they only hold a command runner), so building them on
-    // the raw path costs nothing.
-    let query = RpmPackageQuery::system();
-    let txn = RpmTransaction::system();
+    // inject fakes via `handle_one_with_exec`. The real backends receive the
+    // repo.toml RPM source so availability probes and install transactions do
+    // not silently fall back to the host's enabled system repos.
+    let query = match rpm_repo.clone() {
+        Some(repo) => RpmPackageQuery::system_with_repo(repo),
+        None => RpmPackageQuery::system(),
+    };
+    let txn = match rpm_repo {
+        Some(repo) => RpmTransaction::system_with_repo(repo),
+        None => RpmTransaction::system(),
+    };
     let exec = RpmExec::new(&query, &txn, privilege::is_root());
-    handle_one_with_exec(component, args, ctx, &exec)
+    handle_one_with_config(component, args, ctx, &exec, layout, env, repo_config)
 }
 
 /// Core of [`handle_one`] with the RPM execution dependencies injected, so
 /// tests can drive the adopt and delegated-install paths without a live
 /// rpmdb/dnf or real privileges.
 // pub(crate): driven by the cross-command MVP lifecycle test (#963).
+#[cfg(test)]
 pub(crate) fn handle_one_with_exec(
     component: String,
     args: InstallArgs,
     ctx: &CliContext,
     exec: &RpmExec,
 ) -> Result<InstallOutcome, CliError> {
-    let command = format!("install {component}");
-
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
     let repo_config = RepoConfig::load(&layout).map_err(|err| repo_config_err(err, false))?;
+    handle_one_with_config(component, args, ctx, exec, layout, env, repo_config)
+}
+
+fn handle_one_with_config(
+    component: String,
+    args: InstallArgs,
+    ctx: &CliContext,
+    exec: &RpmExec,
+    layout: FsLayout,
+    env: anolisa_env::EnvFacts,
+    repo_config: RepoConfig,
+) -> Result<InstallOutcome, CliError> {
+    let command = format!("install {component}");
     let installed = common::load_installed_state(ctx, COMMAND)?;
     let mut rpm_component_index: Option<ComponentIndex> = None;
 
@@ -526,6 +555,65 @@ pub(crate) fn handle_one_with_exec(
         &installed,
         &backend_name,
     )
+}
+
+fn configured_rpm_repo_source(
+    repo_config: &RepoConfig,
+    env: &anolisa_env::EnvFacts,
+) -> Result<Option<DnfRepoSource>, CliError> {
+    let Some(backend) = repo_config.backends.get("rpm") else {
+        return Ok(None);
+    };
+    let host = HostVars {
+        os: env.os.clone(),
+        arch: env.arch.clone(),
+    };
+    let base_url = repo_config
+        .resolved_base_url("rpm", backend, &host)
+        .map_err(|err| repo_config_err(err, true))?;
+    Ok(Some(DnfRepoSource::new(
+        ANOLISA_RPM_REPO_ID,
+        base_url,
+        backend.gpgcheck,
+    )))
+}
+
+fn require_configured_rpm_backend(repo_config: &RepoConfig, command: &str) -> Result<(), CliError> {
+    if repo_config.backends.contains_key("rpm") {
+        Ok(())
+    } else {
+        Err(repo_config_err(
+            RepoConfigError::BackendNotConfigured {
+                name: "rpm".to_string(),
+            },
+            true,
+        )
+        .with_command(command))
+    }
+}
+
+fn rpm_repo_required(
+    component: &str,
+    args: &InstallArgs,
+    ctx: &CliContext,
+    repo_config: &RepoConfig,
+) -> Result<bool, CliError> {
+    if args
+        .backend
+        .as_deref()
+        .map(RepoConfig::canonical_backend_name)
+        == Some("rpm")
+    {
+        return Ok(true);
+    }
+    if args.backend.is_none() && repo_config.default_backend == "rpm" {
+        return Ok(true);
+    }
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+    Ok(installed
+        .find_object(ObjectKind::Component, component)
+        .and_then(installed_backend_label)
+        == Some("rpm"))
 }
 
 /// Existing raw-backend trunk: repo.toml → base_url → package → resolve →
@@ -937,6 +1025,7 @@ fn route_rpm_adopt(
             )
         }
         RpmSituation::Absent { target } => {
+            require_configured_rpm_backend(repo_config, command)?;
             if source == BackendSource::Explicit {
                 ensure_component_backend_compatible(installed, &target.component, "rpm", command)?;
             }
@@ -5901,6 +5990,33 @@ scope = "@anolisa"
         (tmp, ctx)
     }
 
+    /// System-mode ctx over a tempdir whose `repo.toml` keeps raw as the
+    /// default while also configuring an RPM backend for delegated installs.
+    fn system_ctx_with_configured_rpm_repo(dry_run: bool) -> (tempfile::TempDir, CliContext) {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix.clone()));
+        std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+        std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+        std::fs::write(
+            layout.etc_dir.join("repo.toml"),
+            r#"schema_version = 1
+default_backend = "raw"
+
+[backends.raw]
+base_url = "https://example.com/anolisa"
+
+[backends.rpm]
+base_url = "https://repo.example/anolisa"
+gpgcheck = false
+"#,
+        )
+        .expect("write repo.toml");
+        let mut ctx = ctx_with_prefix(false, Some(prefix));
+        ctx.dry_run = dry_run;
+        (tmp, ctx)
+    }
+
     fn load_state(ctx: &CliContext) -> InstalledState {
         let layout = common::resolve_layout(ctx);
         InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
@@ -5915,6 +6031,69 @@ scope = "@anolisa"
             "schema_version = 1\ndefault_backend = \"rpm\"\n[backends.rpm]\nbase_url = \"https://e/x\"\n[backends.rpm.package_map]\n{map}"
         ))
         .expect("parse repo")
+    }
+
+    fn linux_env() -> anolisa_env::EnvFacts {
+        anolisa_env::EnvFacts {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            libc: Some("glibc".to_string()),
+            kernel: Some("5.10.0".to_string()),
+            pkg_base: Some("alinux4".to_string()),
+            os_id: Some("alinux".to_string()),
+            os_version: Some("4".to_string()),
+            btf: Some(true),
+            cap_bpf: Some(true),
+            container: None,
+            user: "root".to_string(),
+            uid: 0,
+            home: PathBuf::from("/root"),
+        }
+    }
+
+    #[test]
+    fn configured_rpm_repo_source_uses_repo_toml_backend() {
+        let repo = RepoConfig::from_toml_str(
+            r#"schema_version = 1
+default_backend = "rpm"
+[vars]
+releasever = "4"
+[backends.rpm]
+base_url = "http://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
+insecure = true
+gpgcheck = false
+"#,
+        )
+        .expect("parse repo");
+        let source = configured_rpm_repo_source(&repo, &linux_env())
+            .expect("resolve rpm repo")
+            .expect("rpm repo exists");
+        assert_eq!(source.id(), ANOLISA_RPM_REPO_ID);
+        assert_eq!(
+            source.base_url(),
+            "http://repo.example/alinux/4/agentic-os/x86_64/os"
+        );
+        assert_eq!(source.gpgcheck(), Some(false));
+    }
+
+    #[test]
+    fn raw_default_does_not_require_rpm_repo_resolution() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let repo = RepoConfig::from_toml_str(
+            r#"schema_version = 1
+default_backend = "raw"
+[backends.raw]
+base_url = "https://example.com/anolisa"
+[backends.rpm]
+base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
+"#,
+        )
+        .expect("parse repo without resolving rpm variables");
+        let a = args("copilot-shell");
+        assert!(
+            !rpm_repo_required("copilot-shell", &a, &ctx, &repo).expect("check requirement"),
+            "raw default with no rpm state must not resolve the rpm backend"
+        );
     }
 
     fn available_component_provider(component: &str, package: &str) -> (String, Vec<String>) {
@@ -6548,7 +6727,7 @@ scope = "@anolisa"
     /// the EVR is read back from rpmdb, and ownership/backend are rpm.
     #[test]
     fn delegated_install_writes_rpm_managed_state() {
-        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
         let fake = FakeInstaller::new(
             "copilot-shell",
             pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
@@ -6590,7 +6769,7 @@ scope = "@anolisa"
     /// runs and no state is written.
     #[test]
     fn delegated_install_non_root_is_refused() {
-        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
         let fake = FakeInstaller::new(
             "copilot-shell",
             pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
@@ -6624,7 +6803,7 @@ scope = "@anolisa"
     /// writing state — even for a non-root caller.
     #[test]
     fn delegated_install_dry_run_previews_without_txn_or_state() {
-        let (_tmp, ctx) = system_ctx_with_raw_repo(true);
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(true);
         let fake = FakeInstaller::new(
             "copilot-shell",
             pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
@@ -6652,7 +6831,7 @@ scope = "@anolisa"
     /// A `dnf install` failure surfaces as EXECUTION_FAILED and writes no state.
     #[test]
     fn delegated_install_dnf_failure_surfaces() {
-        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
         let fake = FakeInstaller::new(
             "copilot-shell",
             pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
@@ -6680,6 +6859,42 @@ scope = "@anolisa"
                 .find_object(ObjectKind::Component, "copilot-shell")
                 .is_none(),
             "failed install must not write state"
+        );
+    }
+
+    #[test]
+    fn delegated_install_requires_configured_rpm_backend() {
+        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
+        let mut a = args("copilot-shell");
+        a.backend = Some("rpm".to_string());
+
+        let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+            .expect_err("missing rpm backend config must block dnf install");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("backend 'rpm' is not configured"),
+            "got: {}",
+            err.reason()
+        );
+        assert_eq!(
+            fake.install_calls.get(),
+            0,
+            "dnf must not run without a configured RPM source"
+        );
+        assert!(
+            load_state(&ctx)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none(),
+            "refused install must not write state"
         );
     }
 
@@ -6929,7 +7144,7 @@ scope = "@anolisa"
     #[test]
     fn delegated_install_snapshots_datadir_contract() {
         let _env_guard = crate::packaged::DataDirEnvGuard::clear();
-        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
         let layout = common::resolve_layout(&ctx);
         let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
         seed_datadir_contract(&layout, "copilot-shell", &contract);
@@ -6964,7 +7179,7 @@ scope = "@anolisa"
     #[test]
     fn delegated_install_without_datadir_contract_succeeds() {
         let _env_guard = crate::packaged::DataDirEnvGuard::clear();
-        let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
         let layout = common::resolve_layout(&ctx);
         // No datadir contract seeded.
 

--- a/src/anolisa/crates/anolisa-platform/src/lib.rs
+++ b/src/anolisa/crates/anolisa-platform/src/lib.rs
@@ -12,5 +12,6 @@ pub mod pkg_query;
 pub mod pkg_transaction;
 pub mod privilege;
 pub mod rpm_query;
+pub mod rpm_repo;
 pub mod rpm_transaction;
 pub mod systemd;

--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -9,6 +9,7 @@
 
 use crate::command::{CommandOutput, CommandRunner, SystemCommandRunner};
 use crate::pkg_query::{PackageInfo, PackageQuery, PackageQueryError, PackageVersion};
+use crate::rpm_repo::DnfRepoSource;
 
 /// Pipe-delimited query format for `rpm -q` (installed packages).
 ///
@@ -46,6 +47,7 @@ const DNF: &str = "dnf";
 /// call sites in production code parameter-free while staying zero-cost.
 pub struct RpmPackageQuery<R: CommandRunner = SystemCommandRunner> {
     runner: R,
+    repo: Option<DnfRepoSource>,
 }
 
 impl RpmPackageQuery<SystemCommandRunner> {
@@ -53,6 +55,15 @@ impl RpmPackageQuery<SystemCommandRunner> {
     pub fn system() -> Self {
         Self {
             runner: SystemCommandRunner,
+            repo: None,
+        }
+    }
+
+    /// Build a query that runs real `rpm`/`dnf` against an explicit repo.
+    pub fn system_with_repo(repo: DnfRepoSource) -> Self {
+        Self {
+            runner: SystemCommandRunner,
+            repo: Some(repo),
         }
     }
 }
@@ -60,7 +71,15 @@ impl RpmPackageQuery<SystemCommandRunner> {
 impl<R: CommandRunner> RpmPackageQuery<R> {
     /// Build a query backed by a custom runner (primarily for tests).
     pub fn with_runner(runner: R) -> Self {
-        Self { runner }
+        Self { runner, repo: None }
+    }
+
+    /// Build a query backed by a custom runner and explicit repo.
+    pub fn with_runner_and_repo(runner: R, repo: DnfRepoSource) -> Self {
+        Self {
+            runner,
+            repo: Some(repo),
+        }
     }
 
     /// List the absolute file paths an installed package owns (`rpm -q --list`).
@@ -108,6 +127,21 @@ impl<R: CommandRunner> RpmPackageQuery<R> {
             .map(str::to_string)
             .collect())
     }
+
+    fn run_dnf(&self, args: &[&str]) -> std::io::Result<CommandOutput> {
+        let args = self.dnf_args(args);
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        self.runner.run(DNF, &arg_refs)
+    }
+
+    fn dnf_args(&self, command_args: &[&str]) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(repo) = &self.repo {
+            repo.append_dnf_options(&mut args);
+        }
+        args.extend(command_args.iter().map(|arg| (*arg).to_string()));
+        args
+    }
 }
 
 impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
@@ -138,11 +172,7 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
 
     fn query_available(&self, package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
         let out = self
-            .runner
-            .run(
-                DNF,
-                &["repoquery", "--quiet", "--qf", AVAILABLE_QF, package],
-            )
+            .run_dnf(&["repoquery", "--quiet", "--qf", AVAILABLE_QF, package])
             .map_err(|e| map_spawn_error(e, DNF))?;
 
         if out.code != Some(0) {
@@ -162,11 +192,7 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
 
     fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
         let out = self
-            .runner
-            .run(
-                DNF,
-                &["repoquery", "--installed", "--qf", REPONAME_QF, package],
-            )
+            .run_dnf(&["repoquery", "--installed", "--qf", REPONAME_QF, package])
             .map_err(|e| map_spawn_error(e, DNF))?;
 
         if out.code != Some(0) {
@@ -229,18 +255,14 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
 
     fn what_provides_available(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
         let out = self
-            .runner
-            .run(
-                DNF,
-                &[
-                    "repoquery",
-                    "--quiet",
-                    "--qf",
-                    PROVIDES_NAME_QF,
-                    "--whatprovides",
-                    capability,
-                ],
-            )
+            .run_dnf(&[
+                "repoquery",
+                "--quiet",
+                "--qf",
+                PROVIDES_NAME_QF,
+                "--whatprovides",
+                capability,
+            ])
             .map_err(|e| map_spawn_error(e, DNF))?;
 
         if out.code != Some(0) {
@@ -283,8 +305,7 @@ impl<R: CommandRunner> PackageQuery for RpmPackageQuery<R> {
         package: &str,
     ) -> Result<Vec<String>, PackageQueryError> {
         let out = self
-            .runner
-            .run(DNF, &["repoquery", "--quiet", "--provides", package])
+            .run_dnf(&["repoquery", "--quiet", "--provides", package])
             .map_err(|e| map_spawn_error(e, DNF))?;
 
         if out.code != Some(0) {
@@ -442,11 +463,19 @@ mod tests {
         rpm: Option<FakeOutcome>,
         dnf: Option<FakeOutcome>,
         expected_package: String,
+        expected_args: Option<Vec<String>>,
     }
 
     impl CommandRunner for FakeCommandRunner {
         fn run(&self, program: &str, args: &[&str]) -> io::Result<CommandOutput> {
-            assert_call_contract(program, args, &self.expected_package);
+            if let Some(expected_args) = &self.expected_args {
+                assert_eq!(
+                    args, expected_args,
+                    "{program} args drifted from configured repo contract: {args:?}"
+                );
+            } else {
+                assert_call_contract(program, args, &self.expected_package);
+            }
             let outcome = match program {
                 RPM => self.rpm.as_ref(),
                 DNF => self.dnf.as_ref(),
@@ -619,6 +648,46 @@ mod tests {
         })
     }
 
+    #[test]
+    fn available_query_with_repo_uses_configured_repo_only() {
+        let q = RpmPackageQuery::with_runner_and_repo(
+            FakeCommandRunner {
+                rpm: None,
+                dnf: Some(ok_out(
+                    Some(0),
+                    "copilot-shell|0|2.3.0|1.al8|x86_64|anolisa-configured\n",
+                    "",
+                )),
+                expected_package: "copilot-shell".to_string(),
+                expected_args: Some(
+                    [
+                        "--disablerepo=*",
+                        "--repofrompath=anolisa-configured,http://repo.example/alinux/4/agentic-os/x86_64/os",
+                        "--enablerepo=anolisa-configured",
+                        "--setopt=anolisa-configured.gpgcheck=1",
+                        "repoquery",
+                        "--quiet",
+                        "--qf",
+                        AVAILABLE_QF,
+                        "copilot-shell",
+                    ]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                ),
+            },
+            DnfRepoSource::new(
+                "anolisa-configured",
+                "http://repo.example/alinux/4/agentic-os/x86_64/os",
+                Some(true),
+            ),
+        );
+        let infos = q
+            .query_available("copilot-shell")
+            .expect("available query ok");
+        assert_eq!(infos[0].origin.as_deref(), Some("anolisa-configured"));
+    }
+
     fn query_with_rpm(
         expected_package: &str,
         outcome: FakeOutcome,
@@ -627,6 +696,7 @@ mod tests {
             rpm: Some(outcome),
             dnf: None,
             expected_package: expected_package.to_string(),
+            expected_args: None,
         })
     }
 
@@ -638,6 +708,7 @@ mod tests {
             rpm: None,
             dnf: Some(outcome),
             expected_package: expected_package.to_string(),
+            expected_args: None,
         })
     }
 

--- a/src/anolisa/crates/anolisa-platform/src/rpm_repo.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_repo.rs
@@ -1,0 +1,52 @@
+//! DNF command-line options for an explicit RPM repository source.
+
+/// DNF repository supplied by ANOLISA configuration for one command run.
+///
+/// The repo is injected with `--repofrompath` instead of writing a repo file,
+/// keeping `repo.toml` authoritative for ANOLISA-managed RPM operations while
+/// leaving the host's persistent package-manager configuration untouched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnfRepoSource {
+    id: String,
+    base_url: String,
+    gpgcheck: Option<bool>,
+}
+
+impl DnfRepoSource {
+    /// Builds a temporary DNF repository descriptor.
+    pub fn new(id: impl Into<String>, base_url: impl Into<String>, gpgcheck: Option<bool>) -> Self {
+        Self {
+            id: id.into(),
+            base_url: base_url.into(),
+            gpgcheck,
+        }
+    }
+
+    /// Repository id used by DNF for this temporary source.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Base URL passed to DNF as the repo path.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Package signature verification setting from `repo.toml`.
+    pub fn gpgcheck(&self) -> Option<bool> {
+        self.gpgcheck
+    }
+
+    pub(crate) fn append_dnf_options(&self, args: &mut Vec<String>) {
+        args.push("--disablerepo=*".to_string());
+        args.push(format!("--repofrompath={},{}", self.id, self.base_url));
+        args.push(format!("--enablerepo={}", self.id));
+        if let Some(gpgcheck) = self.gpgcheck {
+            args.push(format!(
+                "--setopt={}.gpgcheck={}",
+                self.id,
+                if gpgcheck { "1" } else { "0" }
+            ));
+        }
+    }
+}

--- a/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
@@ -1,12 +1,13 @@
 //! RPM/DNF backend for [`PackageTransaction`].
 //!
-//! Runs `dnf <verb> -y <package>` (`install`/`update`/`remove`) through the
-//! injectable [`CommandRunner`] so the transaction can be tested with a fake
-//! runner instead of a live `dnf`. Only the spawn/exit classification lives
-//! here; privilege checks and state refresh stay in the CLI consumer.
+//! Runs `dnf` transactions (`install`/`update`/`remove`) through the injectable
+//! [`CommandRunner`] so the transaction can be tested with a fake runner
+//! instead of a live `dnf`. Only the spawn/exit classification lives here;
+//! privilege checks and state refresh stay in the CLI consumer.
 
 use crate::command::{CommandRunner, SystemCommandRunner};
 use crate::pkg_transaction::{PackageTransaction, PackageTransactionError};
+use crate::rpm_repo::DnfRepoSource;
 
 const DNF: &str = "dnf";
 
@@ -17,6 +18,7 @@ const DNF: &str = "dnf";
 /// production call sites parameter-free while staying zero-cost.
 pub struct RpmTransaction<R: CommandRunner = SystemCommandRunner> {
     runner: R,
+    repo: Option<DnfRepoSource>,
 }
 
 impl RpmTransaction<SystemCommandRunner> {
@@ -24,6 +26,15 @@ impl RpmTransaction<SystemCommandRunner> {
     pub fn system() -> Self {
         Self {
             runner: SystemCommandRunner,
+            repo: None,
+        }
+    }
+
+    /// Build a transaction that runs real `dnf` against an explicit repo.
+    pub fn system_with_repo(repo: DnfRepoSource) -> Self {
+        Self {
+            runner: SystemCommandRunner,
+            repo: Some(repo),
         }
     }
 }
@@ -31,10 +42,18 @@ impl RpmTransaction<SystemCommandRunner> {
 impl<R: CommandRunner> RpmTransaction<R> {
     /// Build a transaction backed by a custom runner (primarily for tests).
     pub fn with_runner(runner: R) -> Self {
-        Self { runner }
+        Self { runner, repo: None }
     }
 
-    /// Run `dnf <verb> -y <package>` and classify the outcome.
+    /// Build a transaction backed by a custom runner and explicit repo.
+    pub fn with_runner_and_repo(runner: R, repo: DnfRepoSource) -> Self {
+        Self {
+            runner,
+            repo: Some(repo),
+        }
+    }
+
+    /// Run a non-interactive `dnf` transaction and classify the outcome.
     ///
     /// Shared by [`install`](PackageTransaction::install),
     /// [`update`](PackageTransaction::update), and
@@ -44,9 +63,11 @@ impl<R: CommandRunner> RpmTransaction<R> {
     fn run_dnf(&self, verb: &str, package: &str) -> Result<(), PackageTransactionError> {
         // `-y` is required: ANOLISA orchestrates the lifecycle non-interactively,
         // so there is no TTY to answer dnf's confirmation prompt.
+        let args = self.dnf_args(verb, package);
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
         let out = self
             .runner
-            .run(DNF, &[verb, "-y", package])
+            .run(DNF, &arg_refs)
             .map_err(|e| map_spawn_error(e, DNF, verb))?;
 
         if out.code == Some(0) {
@@ -67,6 +88,18 @@ impl<R: CommandRunner> RpmTransaction<R> {
             code: out.code,
             stderr: detail,
         })
+    }
+
+    fn dnf_args(&self, verb: &str, package: &str) -> Vec<String> {
+        let Some(repo) = &self.repo else {
+            return vec![verb.to_string(), "-y".to_string(), package.to_string()];
+        };
+
+        let mut args = vec!["-y".to_string()];
+        repo.append_dnf_options(&mut args);
+        args.push(verb.to_string());
+        args.push(package.to_string());
+        args
     }
 }
 
@@ -125,6 +158,7 @@ mod tests {
         dnf: Option<FakeOutcome>,
         expected_verb: String,
         expected_package: String,
+        expected_args: Option<Vec<String>>,
     }
 
     impl CommandRunner for FakeCommandRunner {
@@ -133,15 +167,22 @@ mod tests {
             // verb, or misplaces the package argument must fail loudly rather
             // than pass on the canned output alone.
             assert_eq!(program, DNF, "transaction must shell out to dnf: {program}");
-            assert_eq!(
-                args,
-                [
-                    self.expected_verb.as_str(),
-                    "-y",
-                    self.expected_package.as_str()
-                ],
-                "dnf args drifted: {args:?}"
-            );
+            if let Some(expected_args) = &self.expected_args {
+                assert_eq!(
+                    args, expected_args,
+                    "dnf args drifted from configured repo contract: {args:?}"
+                );
+            } else {
+                assert_eq!(
+                    args,
+                    [
+                        self.expected_verb.as_str(),
+                        "-y",
+                        self.expected_package.as_str()
+                    ],
+                    "dnf args drifted: {args:?}"
+                );
+            }
             match &self.dnf {
                 Some(FakeOutcome::Ok(o)) => Ok(o.clone()),
                 Some(FakeOutcome::Err(kind)) => {
@@ -164,7 +205,29 @@ mod tests {
             dnf: Some(outcome),
             expected_verb: expected_verb.to_string(),
             expected_package: expected_package.to_string(),
+            expected_args: None,
         })
+    }
+
+    fn txn_with_repo(
+        expected_verb: &str,
+        expected_package: &str,
+        expected_args: &[&str],
+        outcome: FakeOutcome,
+    ) -> RpmTransaction<FakeCommandRunner> {
+        RpmTransaction::with_runner_and_repo(
+            FakeCommandRunner {
+                dnf: Some(outcome),
+                expected_verb: expected_verb.to_string(),
+                expected_package: expected_package.to_string(),
+                expected_args: Some(expected_args.iter().map(|s| s.to_string()).collect()),
+            },
+            DnfRepoSource::new(
+                "anolisa-configured",
+                "http://repo.example/alinux/4/agentic-os/x86_64/os",
+                Some(true),
+            ),
+        )
     }
 
     fn ok_out(code: Option<i32>, stdout: &str, stderr: &str) -> FakeOutcome {
@@ -190,6 +253,25 @@ mod tests {
         let t = txn(
             "install",
             "copilot-shell",
+            ok_out(Some(0), "Installed:\n  copilot-shell\n", ""),
+        );
+        t.install("copilot-shell").expect("install ok");
+    }
+
+    #[test]
+    fn install_with_repo_uses_configured_repo_only() {
+        let t = txn_with_repo(
+            "install",
+            "copilot-shell",
+            &[
+                "-y",
+                "--disablerepo=*",
+                "--repofrompath=anolisa-configured,http://repo.example/alinux/4/agentic-os/x86_64/os",
+                "--enablerepo=anolisa-configured",
+                "--setopt=anolisa-configured.gpgcheck=1",
+                "install",
+                "copilot-shell",
+            ],
             ok_out(Some(0), "Installed:\n  copilot-shell\n", ""),
         );
         t.install("copilot-shell").expect("install ok");


### PR DESCRIPTION
## Description

Fixes RPM-backed `anolisa install` so `[backends.rpm]` from `repo.toml`
is used for both RPM candidate queries and delegated DNF installs. The
RPM backend now injects the configured source as a transient DNF repo
with system repos disabled, preventing installs from resolving older
packages from host-enabled repositories.

## Design Note

The platform layer now owns `DnfRepoSource`, a small command-line
adapter for `--repofrompath`, `--enablerepo`, and per-repo `gpgcheck`.
`RpmPackageQuery` and `RpmTransaction` both accept that source, so
resolution and install use the same repository contract. The CLI only
renders the RPM source when an RPM path is selected or already recorded,
so raw-only installs do not fail on unrelated RPM variables.

## Ship Note

No persistent DNF repo files are written. DNF may still report installed
packages as `@System` when ANOLISA refreshes rpmdb origin metadata after
a transient-repo transaction.

## Test

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `cargo doc --workspace --no-deps --locked`
- On Alibaba Cloud Linux 4, installed `os-skills` with real
  `anolisa install --backend rpm os-skills`; it installed
  `os-skills-0.6.0-1.alnx4` from repo.toml's agentic-os source while
  host-enabled repos only offered older `0.0.x` builds.
- On the same host, installed Node.js 22 with real `dnf`, then installed
  `cosh` with real `anolisa install --backend raw cosh`; status reported
  raw-managed `cosh` v2.6.0 with integrity checks passing.
