### PR TITLE
feat(install): auto-provision system deps in raw backend

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -550,6 +550,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         std::fs::create_dir_all(state_dir).expect("mkdir state");
         state
@@ -657,6 +658,7 @@ dest = "{datadir}/adapters/sec-core/openclaw/"
                 external_modified_files: Vec::new(),
                 services: Vec::new(),
                 health: Vec::new(),
+                provisioned_packages: Vec::new(),
             }
         }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -328,6 +328,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -1476,6 +1476,7 @@ mod tests {
             rpm_package: None,
             rpm_evr: None,
             rpm_source_repo: None,
+            provisioned_packages: Vec::new(),
         }
     }
 
@@ -1502,6 +1503,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -347,6 +347,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -46,12 +46,14 @@ use anolisa_core::state::{
 use anolisa_core::{
     ArtifactType, CapabilityRequest, ComponentManifest, DependencyKind, DependencyResolution,
     DependencyResolver, DependencyStatus, DistributionEntry, DistributionIndex, FileKind,
-    HookPhase, HookSpec, ResolveQuery, ResolverEnv, ServiceActivation, ServiceManager,
-    ServiceRequest, ServiceRunOutcome, ServiceScope, apply_capabilities, apply_services,
-    capability_for_install_mode, deactivate_services, expand_layout_placeholders,
-    resolve_manifest_hooks, run_hooks, service_for_install_mode, user_service_for_install_mode,
+    HookPhase, HookSpec, ProvisionPlan, ProvisionStrategy, ResolveQuery, ResolverEnv,
+    ServiceActivation, ServiceManager, ServiceRequest, ServiceRunOutcome, ServiceScope,
+    apply_capabilities, apply_services, capability_for_install_mode, deactivate_services,
+    expand_layout_placeholders, resolve_manifest_hooks, run_hooks, service_for_install_mode,
+    user_service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::package_manager::detect_package_manager;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
 use anolisa_platform::privilege;
@@ -134,6 +136,8 @@ struct InstallPreview {
     /// downloaded (file/service details unavailable) or the component declares
     /// none.
     dependencies: Vec<DependencyResolution>,
+    /// Provisioner classification for dry-run display.
+    provision_plan: Option<ProvisionPlan>,
 }
 
 /// Project detected host facts onto the slice the dependency resolver needs.
@@ -182,6 +186,208 @@ pub(crate) fn run_runtime_preflight(
         });
     }
     Ok(plan.warnings)
+}
+
+/// Provision-aware dependency handling that replaces the old fail-fast
+/// `run_runtime_preflight` in the `execute_raw` path.
+///
+/// Behavior depends on `ctx.install_mode`:
+/// - **System**: auto-install missing system packages via the host package
+///   manager, then re-verify only the provisioned deps. Manual-only deps
+///   (e.g. `language-runtime` without a `packages` mapping) remain
+///   non-blocking warnings. Unresolvable platform capabilities fail fast.
+/// - **User**: report missing deps with remediation commands and return an
+///   error (the caller should exit without modifying the host).
+///
+/// Returns the list of package names that were auto-installed (empty in user
+/// mode or when all deps were already satisfied).
+fn run_provision(
+    manifest: &ComponentManifest,
+    env: &anolisa_env::EnvFacts,
+    ctx: &CliContext,
+    command: &str,
+    warnings: &mut Vec<String>,
+) -> Result<Vec<String>, CliError> {
+    if manifest.runtime_deps.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let resolver_env = resolver_env_from_facts(env);
+    let plan = DependencyResolver::system()
+        .resolve(&manifest.runtime_deps, &resolver_env)
+        .map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("invalid runtime dependency declaration: {err}"),
+        })?;
+    warnings.extend(plan.warnings.clone());
+
+    // Classify the resolver results into a provision plan.
+    let provision = ProvisionPlan::from_resolution(&plan, &manifest.runtime_deps, &resolver_env);
+
+    // Unresolvable deps (platform capabilities) are always fatal.
+    if provision.has_blockers() {
+        let lines: Vec<String> = provision
+            .unresolvable
+            .iter()
+            .map(|u| format!("  {} [unresolvable]: {}", u.name, u.reason))
+            .collect();
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "unsatisfiable platform requirements; no files were changed:\n{}",
+                lines.join("\n")
+            ),
+        });
+    }
+
+    // If everything is satisfied, nothing to do.
+    if provision.is_satisfied() {
+        return Ok(Vec::new());
+    }
+
+    // Select strategy based on install mode.
+    let strategy = select_provision_strategy(ctx);
+
+    match strategy {
+        ProvisionStrategy::ReportAndExit => {
+            // User mode: report missing deps and exit.
+            let mut lines = Vec::new();
+            for pkg in &provision.installable {
+                lines.push(format!("  {} (not installed)", pkg.name));
+            }
+            for dep in &provision.manual {
+                lines.push(format!("  {} (manual): {}", dep.name, dep.hint));
+            }
+
+            let remediation_cmds: Vec<&str> = provision
+                .installable
+                .iter()
+                .map(|p| p.remediation.as_str())
+                .collect();
+
+            let mut reason = format!(
+                "missing system dependencies in user mode; no files were changed:\n{}",
+                lines.join("\n")
+            );
+            if !remediation_cmds.is_empty() {
+                reason.push_str(&format!(
+                    "\n\nInstall them with:\n  {}\n\nThen retry:\n  anolisa install {}",
+                    remediation_cmds.join("\n  "),
+                    manifest.component.name
+                ));
+            }
+
+            Err(CliError::Runtime {
+                command: command.to_string(),
+                reason,
+            })
+        }
+        ProvisionStrategy::Auto => {
+            // System mode: auto-install missing packages.
+            if !provision.has_installable() {
+                // Only manual deps remain; warn but continue.
+                for dep in &provision.manual {
+                    warnings.push(format!(
+                        "dependency '{}' requires manual installation: {}",
+                        dep.name, dep.hint
+                    ));
+                }
+                return Ok(Vec::new());
+            }
+
+            let pkg_names = provision.installable_package_names();
+            let pkg_base = resolver_env.pkg_base.as_deref();
+
+            // Detect the host package manager.
+            let mgr = detect_package_manager(pkg_base).map_err(|err| CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "cannot auto-install dependencies: {err}; install manually:\n  {}",
+                    provision
+                        .installable
+                        .iter()
+                        .map(|p| p.remediation.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n  ")
+                ),
+            })?;
+
+            // Execute the install.
+            mgr.install(&pkg_names).map_err(|err| CliError::Runtime {
+                command: command.to_string(),
+                reason: format!("failed to install system dependencies: {err}"),
+            })?;
+
+            // Re-verify only the provisioned deps (manual deps stay as warnings).
+            let recheck = DependencyResolver::system()
+                .resolve(&manifest.runtime_deps, &resolver_env)
+                .map_err(|err| CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!("dependency re-verification failed: {err}"),
+                })?;
+            let provisioned_dep_names: std::collections::HashSet<&str> = provision
+                .installable
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect();
+            let still_failed: Vec<String> = recheck
+                .resolutions
+                .iter()
+                .filter(|r| !matches!(r.status, DependencyStatus::Resolved))
+                .filter(|r| {
+                    // Only fail on deps we actually tried to provision.
+                    provisioned_dep_names.contains(r.name.as_str())
+                })
+                .map(|r| format!("{} [{}]", r.name, r.kind.as_str()))
+                .collect();
+            if !still_failed.is_empty() {
+                let installed_names: Vec<String> =
+                    pkg_names.iter().map(|s| s.to_string()).collect();
+                let note = retained_packages_note(&installed_names);
+                return Err(CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!(
+                        "dependencies still unsatisfied after install:\n  {}{note}",
+                        still_failed.join("\n  ")
+                    ),
+                });
+            }
+
+            // Warn about manual deps.
+            for dep in &provision.manual {
+                warnings.push(format!(
+                    "dependency '{}' requires manual installation: {}",
+                    dep.name, dep.hint
+                ));
+            }
+
+            let installed: Vec<String> = pkg_names.iter().map(|s| s.to_string()).collect();
+            Ok(installed)
+        }
+    }
+}
+
+/// Build the note suffix appended to error messages when system packages were
+/// provisioned but the install did not complete. Returns an empty string when
+/// no packages were installed.
+fn retained_packages_note(provisioned: &[String]) -> String {
+    if provisioned.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n\nnote: system packages were installed and retained: {}",
+            provisioned.join(", ")
+        )
+    }
+}
+
+/// Select provision strategy based on install mode.
+fn select_provision_strategy(ctx: &CliContext) -> ProvisionStrategy {
+    if ctx.install_mode == InstallMode::System {
+        ProvisionStrategy::Auto
+    } else {
+        ProvisionStrategy::ReportAndExit
+    }
 }
 
 /// Execution input after the artifact has been verified and its install
@@ -279,6 +485,9 @@ struct DependencyPlanRow {
     kind: DependencyKind,
     /// Preflight outcome.
     status: DependencyPlanStatus,
+    /// Provisioner action the real install would take.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action: Option<DependencyPlanAction>,
     /// Remediation command (`unresolved`) or reason (`unresolvable`); absent
     /// when resolved.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -286,6 +495,16 @@ struct DependencyPlanRow {
     /// Optional human note (e.g. an unverified version constraint).
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<String>,
+}
+
+/// What the provisioner would do with an unresolved dependency.
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+enum DependencyPlanAction {
+    /// Will be auto-installed via system package manager.
+    AutoInstall,
+    /// Must be installed manually by the user.
+    Manual,
 }
 
 impl DependencyPlanRow {
@@ -304,9 +523,23 @@ impl DependencyPlanRow {
             name: r.name.clone(),
             kind: r.kind,
             status,
+            action: None,
             note,
             detail: r.detail.clone(),
         }
+    }
+
+    /// Annotate with the provisioner action based on the ProvisionPlan.
+    fn with_provision_action(mut self, provision: &ProvisionPlan) -> Self {
+        if matches!(self.status, DependencyPlanStatus::Resolved) {
+            return self;
+        }
+        if provision.installable.iter().any(|p| p.name == self.name) {
+            self.action = Some(DependencyPlanAction::AutoInstall);
+        } else if provision.manual.iter().any(|m| m.name == self.name) {
+            self.action = Some(DependencyPlanAction::Manual);
+        }
+        self
     }
 }
 
@@ -323,6 +556,7 @@ struct InstallResultPayload {
     artifact_url: String,
     files_installed: Vec<String>,
     services: Vec<String>,
+    provisioned_packages: Vec<String>,
     warnings: Vec<String>,
 }
 
@@ -1267,6 +1501,7 @@ pub(crate) fn execute_adopt(
         external_modified_files: Vec::new(),
         services: Vec::new(),
         health: Vec::new(),
+        provisioned_packages: Vec::new(),
     });
     state.operations.push(OperationRecord {
         id: operation_id.clone(),
@@ -1618,6 +1853,7 @@ fn persist_delegated_install(
         external_modified_files: Vec::new(),
         services: Vec::new(),
         health: Vec::new(),
+        provisioned_packages: Vec::new(),
     });
     state.operations.push(OperationRecord {
         id: operation_id.clone(),
@@ -2280,6 +2516,7 @@ fn build_install_preview(
             services: Vec::new(),
             capabilities: Vec::new(),
             dependencies: Vec::new(),
+            provision_plan: None,
         });
     };
 
@@ -2301,7 +2538,7 @@ fn build_install_preview(
         Err(err) => return Err(err),
     };
 
-    let dependencies = preview_dependencies(&contract.manifest, &mut resolution);
+    let (dependencies, provision_plan) = preview_dependencies(&contract.manifest, &mut resolution);
 
     Ok(InstallPreview {
         resolution,
@@ -2309,6 +2546,7 @@ fn build_install_preview(
         services,
         capabilities,
         dependencies,
+        provision_plan,
     })
 }
 
@@ -2319,23 +2557,24 @@ fn build_install_preview(
 fn preview_dependencies(
     manifest: &ComponentManifest,
     resolution: &mut RawResolution,
-) -> Vec<DependencyResolution> {
+) -> (Vec<DependencyResolution>, Option<ProvisionPlan>) {
     if manifest.runtime_deps.is_empty() {
-        return Vec::new();
+        return (Vec::new(), None);
     }
     let env = anolisa_env::EnvService::detect();
-    match DependencyResolver::system()
-        .resolve(&manifest.runtime_deps, &resolver_env_from_facts(&env))
-    {
+    let resolver_env = resolver_env_from_facts(&env);
+    match DependencyResolver::system().resolve(&manifest.runtime_deps, &resolver_env) {
         Ok(plan) => {
-            resolution.warnings.extend(plan.warnings);
-            plan.resolutions
+            resolution.warnings.extend(plan.warnings.clone());
+            let provision =
+                ProvisionPlan::from_resolution(&plan, &manifest.runtime_deps, &resolver_env);
+            (plan.resolutions, Some(provision))
         }
         Err(err) => {
             resolution
                 .warnings
                 .push(format!("dependency preflight skipped: {err}"));
-            Vec::new()
+            (Vec::new(), None)
         }
     }
 }
@@ -3007,18 +3246,22 @@ fn execute_raw(
             reason: format!("failed to parse component manifest for hook resolution: {err}"),
         })?;
 
-    // Runtime-dependency preflight — probe declared dependencies while the lock
-    // is held but before any filesystem mutation, so a missing dependency fails
-    // fast with a remediation instead of a service that silently dies after a
-    // "successful" install. The RPM backend never reaches here (dnf resolves its
-    // `Requires`), so a dependency is never resolved twice. Host facts are
-    // detected once and reused for the capability step below.
-    let env = anolisa_env::EnvService::detect();
-    resolution
-        .warnings
-        .extend(run_runtime_preflight(&manifest, &env, command)?);
-
+    // Validate hook declarations before any host mutation (contract authoring
+    // errors must be caught before provisioning installs system packages).
     let hooks = resolve_install_hooks(&manifest, layout, &resolution.component)?;
+
+    // Runtime-dependency provisioning — probe declared dependencies while the
+    // lock is held but before any filesystem mutation. In system mode, missing
+    // system packages are auto-installed via the host package manager. In user
+    // mode, missing deps are reported with remediation commands and the install
+    // is aborted. The RPM backend never reaches here (dnf resolves its
+    // `Requires`), so a dependency is never resolved twice.
+    let env = anolisa_env::EnvService::detect();
+    let provisioned_packages =
+        run_provision(&manifest, &env, ctx, command, &mut resolution.warnings)?;
+
+    let retained_pkg_note = retained_packages_note(&provisioned_packages);
+
     let log = CentralLog::open(layout.central_log.clone());
 
     // pre_install hook — before files land, so a strict failure aborts with
@@ -3036,7 +3279,10 @@ fn execute_raw(
     if let Some(hf) = pre_install.hard_failure.as_ref() {
         return Err(CliError::Runtime {
             command: command.to_string(),
-            reason: format!("pre_install hook failed: {}", hf.summary()),
+            reason: format!(
+                "pre_install hook failed: {}{retained_pkg_note}",
+                hf.summary()
+            ),
         });
     }
 
@@ -3049,7 +3295,7 @@ fn execute_raw(
         )
         .map_err(|err| CliError::Runtime {
             command: command.to_string(),
-            reason: format!("install failed: {err}"),
+            reason: format!("install failed: {err}{retained_pkg_note}"),
         })?;
 
     // From this point files are on disk — failures must roll them back.
@@ -3058,7 +3304,10 @@ fn execute_raw(
             Ok(path) => path,
             Err(err) => {
                 rollback_installed_files(&outcome.files);
-                return Err(err);
+                return Err(CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!("{err}{retained_pkg_note}"),
+                });
             }
         };
 
@@ -3086,7 +3335,7 @@ fn execute_raw(
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "required capability application failed; rolled back installed files and manifest: {reason}"
+                "required capability application failed; rolled back installed files and manifest: {reason}{retained_pkg_note}"
             ),
         });
     }
@@ -3110,7 +3359,7 @@ fn execute_raw(
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "post_install hook failed; rolled back installed files and manifest: {}",
+                "post_install hook failed; rolled back installed files and manifest: {}{retained_pkg_note}",
                 hf.summary()
             ),
         });
@@ -3177,7 +3426,7 @@ fn execute_raw(
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "post_enable hook failed; stopped/disabled activated services and rolled back installed files and manifest{cleanup_suffix}: {hook_summary}",
+                "post_enable hook failed; stopped/disabled activated services and rolled back installed files and manifest{cleanup_suffix}: {hook_summary}{retained_pkg_note}",
             ),
         });
     }
@@ -3279,6 +3528,7 @@ fn execute_raw(
             })
             .collect(),
         health: Vec::new(),
+        provisioned_packages: provisioned_packages.clone(),
     });
     state.operations.push(OperationRecord {
         id: operation_id.clone(),
@@ -3305,7 +3555,7 @@ fn execute_raw(
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "failed to save state; stopped/disabled activated services and attempted best-effort rollback of installed files and manifest{cleanup_suffix} (some files may remain on disk): {err}",
+                "failed to save state; stopped/disabled activated services and attempted best-effort rollback of installed files and manifest{cleanup_suffix} (some files may remain on disk): {err}{retained_pkg_note}",
             ),
         });
     }
@@ -3376,6 +3626,7 @@ fn execute_raw(
         artifact_url: resolution.artifact_url,
         files_installed: installed_paths,
         services: services.iter().map(|s| s.unit.clone()).collect(),
+        provisioned_packages,
         warnings: resolution.warnings,
     };
     if ctx.json {
@@ -3461,7 +3712,14 @@ fn render_plan(ctx: &CliContext, preview: &InstallPreview) -> Result<(), CliErro
         dependencies: preview
             .dependencies
             .iter()
-            .map(DependencyPlanRow::from_resolution)
+            .map(|r| {
+                let row = DependencyPlanRow::from_resolution(r);
+                if let Some(plan) = &preview.provision_plan {
+                    row.with_provision_action(plan)
+                } else {
+                    row
+                }
+            })
             .collect(),
         dry_run: true,
         warnings: resolved.warnings.clone(),
@@ -3518,9 +3776,16 @@ fn render_plan(ctx: &CliContext, preview: &InstallPreview) -> Result<(), CliErro
         println!("{}", color.header("dependencies (preflight):"));
         for d in &payload.dependencies {
             let (kind, status) = (d.kind.as_str(), d.status.as_str());
+            let action_tag = match d.action {
+                Some(DependencyPlanAction::AutoInstall) => " [auto-install]",
+                Some(DependencyPlanAction::Manual) => " [manual]",
+                None => "",
+            };
             match &d.note {
-                Some(note) => println!("  - {} [{kind}]: {status} — {note}", d.name),
-                None => println!("  - {} [{kind}]: {status}", d.name),
+                Some(note) => {
+                    println!("  - {} [{kind}]: {status}{action_tag} — {note}", d.name)
+                }
+                None => println!("  - {} [{kind}]: {status}{action_tag}", d.name),
             }
             if let Some(detail) = &d.detail {
                 println!("      {detail}");
@@ -3563,6 +3828,13 @@ fn render_result(payload: &InstallResultPayload, no_color: bool) {
         for s in &payload.services {
             println!("  - {s}");
         }
+    }
+    if !payload.provisioned_packages.is_empty() {
+        println!(
+            "{} {}",
+            color.label("provisioned packages:"),
+            payload.provisioned_packages.join(", ")
+        );
     }
     render_warnings(&payload.warnings, &color);
 }
@@ -3843,6 +4115,20 @@ mod tests {
 
     use crate::context::InstallMode;
     use anolisa_core::{FakeServiceManager, ServiceOp};
+
+    #[test]
+    fn retained_packages_note_empty_when_no_packages() {
+        assert_eq!(retained_packages_note(&[]), "");
+    }
+
+    #[test]
+    fn retained_packages_note_lists_provisioned_packages() {
+        let pkgs = vec!["nodejs".to_string(), "jq".to_string()];
+        let note = retained_packages_note(&pkgs);
+        assert!(note.contains("system packages were installed and retained"));
+        assert!(note.contains("nodejs"));
+        assert!(note.contains("jq"));
+    }
     use flate2::Compression;
     use flate2::write::GzEncoder;
     use sha2::{Digest, Sha256};
@@ -5475,6 +5761,7 @@ scope = "@anolisa"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -6419,6 +6706,7 @@ base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(
@@ -6492,6 +6780,7 @@ base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -6544,6 +6833,7 @@ base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         };
 
         assert_eq!(installed_backend_label(&obj), Some("rpm"));
@@ -6592,6 +6882,7 @@ base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -6660,6 +6951,7 @@ base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -7043,6 +7335,7 @@ base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -227,6 +227,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -726,6 +726,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 
@@ -753,6 +754,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -607,6 +607,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -122,6 +122,10 @@ pub(crate) struct ComponentRecord {
     /// it could not be determined.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) rpm_source_repo: Option<String>,
+    /// System packages auto-installed by the provisioner during component
+    /// install. Empty when no packages were provisioned.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) provisioned_packages: Vec<String>,
 }
 
 pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
@@ -261,6 +265,7 @@ pub(crate) fn select_components(
                 rpm_package: None,
                 rpm_evr: None,
                 rpm_source_repo: None,
+                provisioned_packages: Vec::new(),
             }],
         },
     }
@@ -310,6 +315,7 @@ fn observed_record(
             rpm_package: Some(info.name),
             rpm_evr: Some(evr),
             rpm_source_repo: source_repo,
+            provisioned_packages: Vec::new(),
         });
     }
     None
@@ -516,6 +522,7 @@ fn record_from_object(
         rpm_package,
         rpm_evr,
         rpm_source_repo,
+        provisioned_packages: obj.provisioned_packages.clone(),
     }
 }
 
@@ -1046,6 +1053,13 @@ fn render_human(records: &[ComponentRecord], verbose: bool, no_color: bool) {
                     record.enabled_features.join(", ")
                 );
             }
+            if !record.provisioned_packages.is_empty() {
+                println!(
+                    "    {} {}",
+                    color.label("provisioned_packages:"),
+                    record.provisioned_packages.join(", ")
+                );
+            }
             for entry in &record.health {
                 println!(
                     "    {} {} @ {}",
@@ -1158,6 +1172,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 
@@ -2346,6 +2361,7 @@ mod tests {
             rpm_package: None,
             rpm_evr: None,
             rpm_source_repo: None,
+            provisioned_packages: Vec::new(),
         };
         let json = serde_json::to_value(&record).expect("serialize");
         assert!(
@@ -2421,6 +2437,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 
@@ -2845,6 +2862,7 @@ name = "copilot-shell"
             rpm_package: None,
             rpm_evr: None,
             rpm_source_repo: None,
+            provisioned_packages: Vec::new(),
         }];
         // rpmdb has drifted, but the failed status must survive untouched.
         let q = FakeQuery {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1132,6 +1132,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -1277,6 +1278,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         let state_path = layout.state_dir.join("installed.toml");
         state.save(&state_path).expect("seed state save");
@@ -1401,6 +1403,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -1472,6 +1475,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         let state_path = layout.state_dir.join("installed.toml");
         state.save(&state_path).expect("seed state save");
@@ -1648,6 +1652,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 
@@ -2237,6 +2242,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -2680,6 +2680,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 
@@ -2707,6 +2708,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }
     }
 

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -2226,6 +2226,7 @@ value = true
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         std::fs::create_dir_all(&state_dir).expect("mkdir state");
         state
@@ -2333,6 +2334,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         std::fs::create_dir_all(state_dir).expect("mkdir state");
         state

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod metadata;
 pub mod osbase_install;
 pub mod path_safety;
 pub mod process;
+pub mod provisioner;
 pub mod register;
 pub mod registry;
 pub mod resolver;
@@ -84,6 +85,10 @@ pub use manifest::{
     PackageNames, RuntimeDependency, ServiceScope,
 };
 pub use metadata::MetadataClient;
+pub use provisioner::{
+    ManualDependency, ProvisionOutcome, ProvisionPlan, ProvisionStrategy, ProvisionablePackage,
+    UnresolvableDependency,
+};
 pub use register::{
     ConsentState, HistoryAction, HistoryEntry, ProductType, RegisterRecord, RegisterSource,
     RegisterState, RegistrationManager, SubscriptionError, current_operator, require_root,

--- a/src/anolisa/crates/anolisa-core/src/lifecycle.rs
+++ b/src/anolisa/crates/anolisa-core/src/lifecycle.rs
@@ -1347,6 +1347,10 @@ fn execute_uninstall_or_purge(
     }
 
     // Step 7 — drop the component object from state.
+    let provisioned_pkgs: Vec<String> = state
+        .find_object(ObjectKind::Component, target_name)
+        .map(|obj| obj.provisioned_packages.clone())
+        .unwrap_or_default();
     let _ = state.remove_object(ObjectKind::Component, target_name);
 
     // Step 7.5 — migrate away legacy capability objects. Releases that
@@ -1533,6 +1537,13 @@ fn execute_uninstall_or_purge(
     );
     let mut warnings = warnings;
     warnings.extend(post_uninstall.warnings);
+    if !provisioned_pkgs.is_empty() {
+        warnings.push(format!(
+            "system packages provisioned during install are retained: {}; \
+             remove manually if no longer needed",
+            provisioned_pkgs.join(", ")
+        ));
+    }
 
     Ok(LifecycleOutcome {
         operation_id,
@@ -2028,6 +2039,7 @@ mod tests {
                 scope: ServiceScope::System,
             }],
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -2189,6 +2201,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -2287,6 +2300,7 @@ mod tests {
                 scope: ServiceScope::User,
             }],
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state
             .save(&layout.state_dir.join("installed.toml"))
@@ -2854,6 +2868,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         let state_path = layout.state_dir.join("installed.toml");
         state.save(&state_path).expect("seed state save");
@@ -2925,6 +2940,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         state.upsert_object(InstalledObject {
             kind: ObjectKind::Capability,
@@ -2948,6 +2964,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         let state_path = layout.state_dir.join("installed.toml");
         state.save(&state_path).expect("seed state save");
@@ -3037,6 +3054,7 @@ mod tests {
             external_modified_files: Vec::new(),
             services: Vec::new(),
             health: Vec::new(),
+            provisioned_packages: Vec::new(),
         });
         let state_path = layout.state_dir.join("installed.toml");
         state.save(&state_path).expect("seed state save");

--- a/src/anolisa/crates/anolisa-core/src/osbase_install.rs
+++ b/src/anolisa/crates/anolisa-core/src/osbase_install.rs
@@ -744,6 +744,7 @@ fn run_manifest_install(
                 })
                 .collect(),
             health: vec![],
+            provisioned_packages: vec![],
         };
         state.upsert_object(obj);
         state

--- a/src/anolisa/crates/anolisa-core/src/provisioner.rs
+++ b/src/anolisa/crates/anolisa-core/src/provisioner.rs
@@ -1,0 +1,426 @@
+//! Dependency provisioner: install missing system packages after resolver preflight.
+//!
+//! This module bridges the gap between the read-only [`DependencyResolver`] and
+//! the install executor. It consumes a [`ResolutionPlan`], classifies each
+//! unsatisfied dependency by provisionability, and either auto-installs (system
+//! mode) or reports remediation (user mode).
+//!
+//! Design invariants:
+//! - The resolver remains pure (read-only, never mutates the host).
+//! - This layer is the single place that decides whether to call the platform
+//!   package manager.
+//! - `PlatformCapability` dependencies are never provisioned — a miss is fatal.
+//! - Behavior is deterministic: no interactive prompts, no TTY detection.
+
+use crate::manifest::{DependencyKind, RuntimeDependency};
+use crate::resolver::{DependencyStatus, ResolutionPlan, ResolverEnv};
+
+// ---------------------------------------------------------------------------
+// Strategy
+// ---------------------------------------------------------------------------
+
+/// How the provisioner should behave when dependencies are missing.
+/// Selected solely by `install_mode` — no CLI flags in this iteration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvisionStrategy {
+    /// Auto-install missing system packages without prompting (system mode).
+    Auto,
+    /// Report missing dependencies and signal the caller to exit (user mode).
+    ReportAndExit,
+}
+
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+
+/// A system package that can be auto-installed by the host package manager.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvisionablePackage {
+    /// Logical dependency name from the manifest.
+    pub name: String,
+    /// The actual package name to pass to `dnf install` / `apt install`.
+    /// Falls back to `name` when no `packages.rpm` / `packages.deb` mapping
+    /// exists in the manifest.
+    pub package_name: String,
+    /// Human-readable remediation command (e.g. `sudo dnf install btrfs-progs`).
+    pub remediation: String,
+}
+
+/// A dependency that requires manual intervention (e.g. a language runtime
+/// whose version constraint cannot be satisfied by the system package manager).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManualDependency {
+    /// Logical dependency name.
+    pub name: String,
+    /// Human-readable install hint surfaced to the user.
+    pub hint: String,
+}
+
+/// A dependency that cannot be satisfied on this host (kernel version,
+/// platform capability). The install must not proceed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvableDependency {
+    /// Logical dependency name.
+    pub name: String,
+    /// Why this host cannot satisfy the dependency.
+    pub reason: String,
+}
+
+/// Classified view of a resolver preflight, ready for the provisioner to act on.
+///
+/// Built from [`ResolutionPlan`] + the original [`RuntimeDependency`] slice so
+/// it can extract package-name mappings.
+#[derive(Debug, Clone, Default)]
+pub struct ProvisionPlan {
+    /// System packages that can be auto-installed
+    /// (`kind = SystemPackage`, `status = Unresolved`).
+    pub installable: Vec<ProvisionablePackage>,
+    /// Dependencies that require manual intervention
+    /// (`kind = LanguageRuntime`, `status = Unresolved`).
+    pub manual: Vec<ManualDependency>,
+    /// Dependencies that cannot be satisfied on this host
+    /// (`status = Unresolvable`).
+    pub unresolvable: Vec<UnresolvableDependency>,
+    /// Count of dependencies already satisfied.
+    pub satisfied_count: usize,
+    /// Non-fatal warnings forwarded from the resolver.
+    pub warnings: Vec<String>,
+}
+
+impl ProvisionPlan {
+    /// Build a provision plan from a completed resolver preflight.
+    ///
+    /// `deps` is the original manifest `runtime_deps` slice — needed to look up
+    /// the `packages` mapping for each unresolved system-package dependency.
+    /// `env` provides the host's package-base family for selecting the correct
+    /// package name.
+    pub fn from_resolution(
+        plan: &ResolutionPlan,
+        deps: &[RuntimeDependency],
+        env: &ResolverEnv,
+    ) -> Self {
+        let mut result = Self {
+            warnings: plan.warnings.clone(),
+            ..Default::default()
+        };
+
+        for resolution in &plan.resolutions {
+            match &resolution.status {
+                DependencyStatus::Resolved => {
+                    result.satisfied_count += 1;
+                }
+                DependencyStatus::Unresolved { remediation } => {
+                    // Look up the original dep for package-name mapping.
+                    let dep = deps.iter().find(|d| d.name == resolution.name);
+
+                    match resolution.kind {
+                        DependencyKind::SystemPackage => {
+                            let package_name =
+                                resolve_package_name(dep, env).unwrap_or(resolution.name.clone());
+                            result.installable.push(ProvisionablePackage {
+                                name: resolution.name.clone(),
+                                package_name,
+                                remediation: remediation.clone(),
+                            });
+                        }
+                        DependencyKind::LanguageRuntime => {
+                            // If the manifest provides a package mapping, treat
+                            // it as installable (the system repo might have it).
+                            if let Some(pkg) = resolve_package_name(dep, env) {
+                                result.installable.push(ProvisionablePackage {
+                                    name: resolution.name.clone(),
+                                    package_name: pkg,
+                                    remediation: remediation.clone(),
+                                });
+                            } else {
+                                result.manual.push(ManualDependency {
+                                    name: resolution.name.clone(),
+                                    hint: remediation.clone(),
+                                });
+                            }
+                        }
+                        DependencyKind::PlatformCapability => {
+                            // Should not happen (platform caps go Unresolvable),
+                            // but handle defensively.
+                            result.unresolvable.push(UnresolvableDependency {
+                                name: resolution.name.clone(),
+                                reason: remediation.clone(),
+                            });
+                        }
+                    }
+                }
+                DependencyStatus::Unresolvable { reason } => {
+                    result.unresolvable.push(UnresolvableDependency {
+                        name: resolution.name.clone(),
+                        reason: reason.clone(),
+                    });
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Whether the plan has any unresolvable dependencies that block install
+    /// regardless of mode.
+    pub fn has_blockers(&self) -> bool {
+        !self.unresolvable.is_empty()
+    }
+
+    /// Whether there are installable packages to provision.
+    pub fn has_installable(&self) -> bool {
+        !self.installable.is_empty()
+    }
+
+    /// Whether there are manual-only dependencies (warnings, non-blocking).
+    pub fn has_manual(&self) -> bool {
+        !self.manual.is_empty()
+    }
+
+    /// Whether every dependency is satisfied (nothing to do).
+    pub fn is_satisfied(&self) -> bool {
+        self.installable.is_empty() && self.manual.is_empty() && self.unresolvable.is_empty()
+    }
+
+    /// Aggregate package names for a single `PackageManager::install` call.
+    pub fn installable_package_names(&self) -> Vec<&str> {
+        self.installable
+            .iter()
+            .map(|p| p.package_name.as_str())
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Outcome
+// ---------------------------------------------------------------------------
+
+/// Result of running the provisioner for a single install operation.
+#[derive(Debug, Clone)]
+pub enum ProvisionOutcome {
+    /// All installable deps were provisioned successfully (system mode).
+    Provisioned {
+        /// Package names that were installed.
+        installed_packages: Vec<String>,
+    },
+    /// Provisioning failed for some packages (system mode).
+    Failed {
+        /// Why the package-manager call failed.
+        reason: String,
+    },
+    /// No provisioning needed — all deps already satisfied.
+    NothingToDo,
+    /// Reported missing deps and signaled exit (user mode).
+    Reported {
+        /// Logical dependency names that are missing.
+        missing: Vec<String>,
+        /// Remediation commands for the user.
+        remediation: Vec<String>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve the platform-appropriate package name for a dependency.
+///
+/// Priority: `packages.rpm` / `packages.deb` (matching host pkg_base) > `None`.
+/// Returns `None` when no mapping exists and the caller should fall back to
+/// the dependency's logical name or treat it as manual.
+fn resolve_package_name(dep: Option<&RuntimeDependency>, env: &ResolverEnv) -> Option<String> {
+    let dep = dep?;
+    match env.pkg_base.as_deref() {
+        Some("rpm") => {
+            if dep.kind == DependencyKind::SystemPackage {
+                // System packages always have a resolvable name.
+                Some(dep.packages.rpm.clone().unwrap_or_else(|| dep.name.clone()))
+            } else {
+                // Language runtimes need an explicit mapping.
+                dep.packages.rpm.clone()
+            }
+        }
+        Some("deb") => {
+            if dep.kind == DependencyKind::SystemPackage {
+                Some(dep.packages.deb.clone().unwrap_or_else(|| dep.name.clone()))
+            } else {
+                dep.packages.deb.clone()
+            }
+        }
+        _ => {
+            // Unknown package base: system packages fall back to dep name,
+            // language runtimes require an explicit mapping.
+            if dep.kind == DependencyKind::SystemPackage {
+                Some(
+                    dep.packages
+                        .rpm
+                        .clone()
+                        .or_else(|| dep.packages.deb.clone())
+                        .unwrap_or_else(|| dep.name.clone()),
+                )
+            } else {
+                dep.packages
+                    .rpm
+                    .clone()
+                    .or_else(|| dep.packages.deb.clone())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolver::DependencyResolution;
+
+    fn make_resolution(
+        name: &str,
+        kind: DependencyKind,
+        status: DependencyStatus,
+    ) -> DependencyResolution {
+        DependencyResolution {
+            name: name.to_string(),
+            kind,
+            status,
+            detail: None,
+        }
+    }
+
+    fn make_dep(name: &str, kind: DependencyKind) -> RuntimeDependency {
+        RuntimeDependency {
+            name: name.to_string(),
+            kind,
+            version: None,
+            probe: None,
+            source: None,
+            packages: Default::default(),
+            check: None,
+            min_kernel: None,
+        }
+    }
+
+    #[test]
+    fn satisfied_deps_counted() {
+        let plan = ResolutionPlan {
+            resolutions: vec![
+                make_resolution(
+                    "jq",
+                    DependencyKind::SystemPackage,
+                    DependencyStatus::Resolved,
+                ),
+                make_resolution(
+                    "curl",
+                    DependencyKind::SystemPackage,
+                    DependencyStatus::Resolved,
+                ),
+            ],
+            warnings: vec![],
+        };
+        let deps = vec![
+            make_dep("jq", DependencyKind::SystemPackage),
+            make_dep("curl", DependencyKind::SystemPackage),
+        ];
+        let env = ResolverEnv {
+            pkg_base: Some("rpm".into()),
+            ..Default::default()
+        };
+
+        let pp = ProvisionPlan::from_resolution(&plan, &deps, &env);
+        assert_eq!(pp.satisfied_count, 2);
+        assert!(pp.is_satisfied());
+    }
+
+    #[test]
+    fn unresolved_system_package_is_installable() {
+        let plan = ResolutionPlan {
+            resolutions: vec![make_resolution(
+                "kernel-headers",
+                DependencyKind::SystemPackage,
+                DependencyStatus::Unresolved {
+                    remediation: "sudo dnf install kernel-headers".into(),
+                },
+            )],
+            warnings: vec![],
+        };
+        let deps = vec![make_dep("kernel-headers", DependencyKind::SystemPackage)];
+        let env = ResolverEnv {
+            pkg_base: Some("rpm".into()),
+            ..Default::default()
+        };
+
+        let pp = ProvisionPlan::from_resolution(&plan, &deps, &env);
+        assert!(pp.has_installable());
+        assert_eq!(pp.installable[0].package_name, "kernel-headers");
+    }
+
+    #[test]
+    fn unresolved_language_runtime_without_package_is_manual() {
+        let plan = ResolutionPlan {
+            resolutions: vec![make_resolution(
+                "node",
+                DependencyKind::LanguageRuntime,
+                DependencyStatus::Unresolved {
+                    remediation: "install node>=20 manually".into(),
+                },
+            )],
+            warnings: vec![],
+        };
+        let deps = vec![make_dep("node", DependencyKind::LanguageRuntime)];
+        let env = ResolverEnv {
+            pkg_base: Some("rpm".into()),
+            ..Default::default()
+        };
+
+        let pp = ProvisionPlan::from_resolution(&plan, &deps, &env);
+        // No package mapping → manual
+        assert!(!pp.has_installable());
+        assert!(pp.has_manual());
+    }
+
+    #[test]
+    fn unresolvable_is_blocker() {
+        let plan = ResolutionPlan {
+            resolutions: vec![make_resolution(
+                "btf",
+                DependencyKind::PlatformCapability,
+                DependencyStatus::Unresolvable {
+                    reason: "kernel BTF not available".into(),
+                },
+            )],
+            warnings: vec![],
+        };
+        let deps = vec![make_dep("btf", DependencyKind::PlatformCapability)];
+        let env = ResolverEnv::default();
+
+        let pp = ProvisionPlan::from_resolution(&plan, &deps, &env);
+        assert!(pp.has_blockers());
+    }
+
+    #[test]
+    fn language_runtime_with_package_mapping_is_installable() {
+        let plan = ResolutionPlan {
+            resolutions: vec![make_resolution(
+                "node",
+                DependencyKind::LanguageRuntime,
+                DependencyStatus::Unresolved {
+                    remediation: "sudo dnf install nodejs".into(),
+                },
+            )],
+            warnings: vec![],
+        };
+        let mut dep = make_dep("node", DependencyKind::LanguageRuntime);
+        dep.packages.rpm = Some("nodejs".into());
+        let deps = vec![dep];
+        let env = ResolverEnv {
+            pkg_base: Some("rpm".into()),
+            ..Default::default()
+        };
+
+        let pp = ProvisionPlan::from_resolution(&plan, &deps, &env);
+        assert!(pp.has_installable());
+        // package_name is what gets passed to `dnf install`.
+        assert_eq!(pp.installable[0].package_name, "nodejs");
+        // name is the logical manifest dep name — used for recheck filtering.
+        assert_eq!(pp.installable[0].name, "node");
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/state.rs
+++ b/src/anolisa/crates/anolisa-core/src/state.rs
@@ -382,6 +382,12 @@ pub struct InstalledObject {
     /// Cached health results from the last status/probe pass.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub health: Vec<HealthEntry>,
+    /// System packages that were auto-installed by the provisioner during
+    /// this component's install (system mode only). Tracked so `status` can
+    /// report them and `uninstall` can hint at orphan cleanup. Never
+    /// auto-removed on uninstall.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provisioned_packages: Vec<String>,
 }
 
 impl InstalledObject {
@@ -826,6 +832,7 @@ mod tests {
                 checked_at: now_iso8601(),
                 reason: None,
             }],
+            provisioned_packages: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Description

Adds a dependency provisioner layer to the raw backend install path. When a component declares system package dependencies (via `packages = { rpm = "...", deb = "..." }` in `component.toml`), the CLI now resolves and installs them automatically in system mode before laying component files.

Behavior:
* System mode (root): auto-installs missing system packages via dnf/apt, then re-verifies.
* User mode (non-root): reports missing deps with remediation commands, then exits without modifying the system.
* `--dry-run` shows the provisioning plan without executing.
* `--json` includes provisioned packages in the structured output.
* No interactive prompts (agent-friendly).

## Design Note

The resolver remains pure (read-only, never modifies the system). A new `provisioner.rs` module in `anolisa-core` classifies resolver results into installable / manual / unresolvable categories based on the dependency kind and the presence of `packages` mappings. The CLI `run_provision` function in `install.rs` orchestrates the strategy selection (Auto vs ReportAndExit) based on `install_mode`.

Provisioned packages are persisted in `InstalledState.provisioned_packages` for traceability via `status` and `uninstall`.

## Ship Note

Existing components that declare `kind = "language-runtime"` without a `packages` mapping will continue to emit a non-blocking warning. To enable auto-provisioning for such deps, add `packages = { rpm = "..." }` to the component manifest.

## Test

* Unit: 5 tests in `provisioner.rs` covering all classification paths.
* `cargo build --release -p anolisa-cli --locked`
* `cargo test -p anolisa-core --locked`
* `cargo check --locked` (zero errors, zero warnings)
* Remote manual (Alinux 4): verified `anolisa install cosh` auto-installs `nodejs` (22.22.0) via dnf, then installs cosh successfully. Verified uninstall removes component files but retains system package.