### PR TITLE
fix(cosh-ng): suppress bashdb warning on Alibaba Cloud Linux

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
@@ -313,8 +313,15 @@ _cosh_preexec_marker() {
     fi
     _COSH_AT_PROMPT=0
   fi
+  shopt -u extdebug 2>/dev/null || true
   trap '_cosh_preexec_marker' DEBUG
   return 0
+}
+
+_cosh_suspend_extdebug() {
+  local s=$?
+  shopt -u extdebug 2>/dev/null || true
+  return $s
 }
 
 _cosh_precmd_marker() {
@@ -325,17 +332,18 @@ _cosh_precmd_marker() {
   unset _COSH_HANDOFF_ACTIVE 2>/dev/null || true
   _cosh_emit_marker "precmd" "" "$status"
   _COSH_AT_PROMPT=1
+  shopt -s extdebug 2>/dev/null || true
 }
 
 # ── Hook setup (re-set after user rcfile may have overridden) ──
 shopt -s extdebug 2>/dev/null || true
 _COSH_OLD_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null | sed "s/^trap -- '\\(.*\\)' DEBUG$/\\1/" || true)"
 trap '_cosh_preexec_marker' DEBUG
-# Append precmd to existing PROMPT_COMMAND
+# Prepend extdebug suspend + append precmd to existing PROMPT_COMMAND
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
-  PROMPT_COMMAND+=(_cosh_precmd_marker)
+  PROMPT_COMMAND=(_cosh_suspend_extdebug "${PROMPT_COMMAND[@]}" _cosh_precmd_marker)
 else
-  PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}_cosh_precmd_marker"
+  PROMPT_COMMAND="_cosh_suspend_extdebug;${PROMPT_COMMAND:+$PROMPT_COMMAND;}_cosh_precmd_marker"
 fi
 if [[ -n "${COSH_SHELL_ISOLATED:-}" ]]; then
   builtin history -c 2>/dev/null || true


### PR DESCRIPTION
## Description

On Alibaba Cloud Linux, `/etc/sysconfig/bash-prompt-history` detects
`shopt extdebug` and attempts to load `/usr/share/bashdb/bashdb-main.inc`,
producing a warning when bashdb is not installed. This happens because
cosh-ng enables extdebug for DEBUG trap interception, and system scripts
in PROMPT_COMMAND see it on subsequent prompt draws.

Fix: disable extdebug at the end of preexec (before command runs) and
prepend a suspend helper in PROMPT_COMMAND, then re-enable in precmd
(which runs last). System scripts now execute with extdebug off — their
normal expected environment — while cosh's intercept still works.

## Related Issue

no-issue: environment-specific warning fix with no tracking issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- Verified bash syntax with `bash -n`
- Verified `$?` preservation through `_cosh_suspend_extdebug` (exit code 42 → preserved correctly)
- `cargo check -p cosh-shell` passes

## Additional Notes

The `return 1` (intercept) path in preexec cannot disable extdebug before
returning — bash checks extdebug AFTER the trap returns to decide whether
to honor the skip. The prepended `_cosh_suspend_extdebug` in
PROMPT_COMMAND covers this case: after an intercept, the next
PROMPT_COMMAND cycle disables extdebug before system scripts run.