### PR TITLE
fix(anolisa): keep adapter dry-run read-only

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -131,6 +131,7 @@ struct DisablePayload {
     component: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     framework: Option<String>,
+    dry_run: bool,
     claim_removed: bool,
     cleanup_complete: bool,
     messages: Vec<String>,
@@ -328,8 +329,28 @@ fn handle_disable(
     const COMMAND: &str = "adapter disable";
     let manager = build_manager(ctx);
     let outcome: DisableOutcome = manager
-        .disable(component, framework)
+        .disable(component, framework, ctx.dry_run)
         .map_err(|e| map_err(COMMAND, e))?;
+
+    if outcome.dry_run {
+        if ctx.json {
+            let payload = DisablePayload {
+                component: outcome.component.clone(),
+                framework: outcome.framework.clone(),
+                dry_run: true,
+                claim_removed: false,
+                cleanup_complete: outcome.report.cleanup_complete,
+                messages: outcome.report.messages.clone(),
+            };
+            return render_json(COMMAND, payload);
+        }
+        let target = disable_target(&outcome);
+        println!("[dry-run] would disable {target}:");
+        for msg in &outcome.report.messages {
+            println!("  - {msg}");
+        }
+        return Ok(());
+    }
 
     // Cleanup that did not complete is a degraded outcome: the receipt was
     // kept (marked cleanup_failed) so the operator can retry. Surface a
@@ -349,6 +370,7 @@ fn handle_disable(
         let payload = DisablePayload {
             component: outcome.component.clone(),
             framework: outcome.framework.clone(),
+            dry_run: false,
             claim_removed: outcome.claim_removed,
             cleanup_complete: outcome.report.cleanup_complete,
             messages: outcome.report.messages.clone(),
@@ -356,10 +378,7 @@ fn handle_disable(
         return render_json(COMMAND, payload);
     }
 
-    let target = match &outcome.framework {
-        Some(f) => format!("{}/{}", outcome.component, f),
-        None => outcome.component.clone(),
-    };
+    let target = disable_target(&outcome);
     if outcome.claim_removed {
         println!("Disabled {target}.");
     } else if outcome.report.cleanup_complete {
@@ -371,6 +390,15 @@ fn handle_disable(
         println!("  - {msg}");
     }
     degraded.map_or(Ok(()), Err)
+}
+
+/// Human-facing `component/framework` label for a disable outcome, falling
+/// back to the component alone when no framework was resolved.
+fn disable_target(outcome: &DisableOutcome) -> String {
+    match &outcome.framework {
+        Some(f) => format!("{}/{}", outcome.component, f),
+        None => outcome.component.clone(),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -69,11 +69,13 @@ pub struct DisableOutcome {
     /// Resolved framework, when one was determined (`None` only for the
     /// "component has no enabled adapters" no-op).
     pub framework: Option<String>,
-    /// The driver's cleanup report.
+    /// The driver's cleanup report (or the dry-run plan).
     pub report: DisableReport,
     /// True when the receipt was removed; false when it was kept and
-    /// marked `cleanup_failed` for retry.
+    /// marked `cleanup_failed` for retry. Always `false` under dry-run.
     pub claim_removed: bool,
+    /// True when the operation was a dry-run (no state mutated).
+    pub dry_run: bool,
 }
 
 /// One row of [`AdapterManager::scan`].
@@ -592,6 +594,10 @@ impl AdapterManager {
     /// receipts when `None`). Idempotent: disabling something with no
     /// receipt is a successful no-op.
     ///
+    /// When `dry_run`, resolves the receipt and validates it, then returns a
+    /// descriptive plan without mutating framework state, adapter receipts,
+    /// or `installed.toml`.
+    ///
     /// Takes the install lock for the whole operation.
     ///
     /// # Errors
@@ -604,6 +610,7 @@ impl AdapterManager {
         &self,
         component: &str,
         framework: Option<&str>,
+        dry_run: bool,
     ) -> Result<DisableOutcome, AdapterError> {
         let _lock = InstallLock::acquire(&self.layout.lock_file)?;
         let mut state = InstalledState::load(&self.state_path)?;
@@ -628,6 +635,7 @@ impl AdapterManager {
                                 )],
                             },
                             claim_removed: false,
+                            dry_run,
                         });
                     }
                     1 => claimed[0].clone(),
@@ -655,6 +663,7 @@ impl AdapterManager {
                         )],
                     },
                     claim_removed: false,
+                    dry_run,
                 });
             }
         };
@@ -694,7 +703,7 @@ impl AdapterManager {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
-            dry_run: false,
+            dry_run,
             ops: &probe_ops,
         };
         let mut allowed_roots = driver.allowed_external_roots(&probe_ctx);
@@ -721,12 +730,23 @@ impl AdapterManager {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
-            dry_run: false,
+            dry_run,
             ops: &ops,
         };
 
         // Re-validate the receipt before acting on it (forged-state guard).
         claim.validate(&self.layout, &driver.allowed_external_roots(&ctx))?;
+
+        if dry_run {
+            let report = plan_disable_report(&claim);
+            return Ok(DisableOutcome {
+                component: component.to_string(),
+                framework: Some(framework),
+                report,
+                claim_removed: false,
+                dry_run: true,
+            });
+        }
 
         let report = driver.disable(&claim, &ctx)?;
         let claim_removed = report.cleanup_complete;
@@ -753,6 +773,7 @@ impl AdapterManager {
             framework: Some(framework),
             report,
             claim_removed,
+            dry_run: false,
         })
     }
 
@@ -1898,6 +1919,83 @@ fn declared_bundle_entry(manifest: &ComponentManifest, framework: &str) -> Optio
         _ => {}
     }
     adapter.bundle.entry.clone()
+}
+
+/// Build a non-mutating [`DisableReport`] from a validated receipt,
+/// describing what a real disable would do. Uses the driver payload's
+/// resource IDs to determine which resources are actually cleaned up
+/// (skill dirs, plugin dirs), excluding the framework home/state dir
+/// which real disable never removes.
+///
+/// The returned `cleanup_complete` is always `true`: it signals that the
+/// planned cleanup description is complete, not that real cleanup ran.
+/// Callers must check [`DisableOutcome::dry_run`] to distinguish planned
+/// output from actual framework cleanup.
+fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
+    use super::claim::{ClaimResourceKind, DriverPayload};
+    let mut messages = Vec::new();
+
+    // Resource ids that a real disable actually acts on. Empty plugin ids
+    // (skill-bundle receipts carry no plugin resource) are excluded.
+    // `hermes_plugin_id` is the plugin resource id for Hermes receipts:
+    // real Hermes disable first runs `hermes plugins disable <id>` before
+    // removing the plugin directory, so its dry-run plan needs the extra
+    // CLI-disable line that OpenClaw (registry-only) does not.
+    let mut cleanup_ids: Vec<&str> = Vec::new();
+    let hermes_plugin_id: Option<&str> = match &claim.driver_payload {
+        DriverPayload::OpenClaw(oc) => {
+            cleanup_ids.extend(oc.skill_resources.iter().map(String::as_str));
+            if !oc.plugin_resource.is_empty() {
+                cleanup_ids.push(&oc.plugin_resource);
+            }
+            None
+        }
+        DriverPayload::Hermes(h) => {
+            cleanup_ids.extend(h.skill_resources.iter().map(String::as_str));
+            if h.plugin_resource.is_empty() {
+                None
+            } else {
+                cleanup_ids.push(&h.plugin_resource);
+                Some(h.plugin_resource.as_str())
+            }
+        }
+    };
+
+    for resource in &claim.resources {
+        if !cleanup_ids.contains(&resource.id.as_str()) {
+            // Not a resource that disable actually touches (e.g. the
+            // framework home/state directory).
+            if let ClaimResourceKind::FrameworkConfig { key, .. } = &resource.kind {
+                messages.push(format!("config key '{key}' left in place (not reversed)"));
+            }
+            continue;
+        }
+        match &resource.kind {
+            ClaimResourceKind::FrameworkPlugin {
+                framework,
+                plugin_id,
+            } => {
+                messages.push(format!("would unregister {framework} plugin '{plugin_id}'"));
+            }
+            ClaimResourceKind::ExternalPath { path } => {
+                // Hermes stores its plugin as a directory (ExternalPath) but
+                // disable also runs a CLI step first — surface it.
+                if Some(resource.id.as_str()) == hermes_plugin_id
+                    && let Some(plugin_id) = claim.plugin_id.as_deref()
+                {
+                    messages.push(format!("would disable hermes plugin '{plugin_id}'"));
+                }
+                messages.push(format!("would remove {}", path.display()));
+            }
+            _ => {}
+        }
+    }
+    messages.push("would remove adapter receipt".to_string());
+
+    DisableReport {
+        cleanup_complete: true,
+        messages,
+    }
 }
 
 /// A status report for a receipt that cannot be verified at all (e.g. no
@@ -4079,6 +4177,332 @@ dest = "{datadir}/skills"
             Some(&package_skills),
             "scan via snapshot+provenance must resolve {{datadir}}/skills \
              to the package datadir, not the empty local datadir"
+        );
+    }
+
+    // -- plan_disable_report --------------------------------------------------
+
+    fn make_claim_for_plan_test(
+        adapter_type: Option<&str>,
+        plugin_id: Option<&str>,
+        resources: Vec<crate::adapter::claim::ClaimResource>,
+        payload_skill_ids: Vec<String>,
+        payload_config_ids: Vec<String>,
+    ) -> crate::adapter::claim::AdapterClaim {
+        use crate::adapter::claim::{ClaimStatus, DriverPayload, OpenClawClaim};
+
+        AdapterClaim {
+            claim_schema: 1,
+            component: "test-comp".to_string(),
+            framework: "openclaw".to_string(),
+            plugin_id: plugin_id.map(str::to_string),
+            adapter_type: adapter_type.map(str::to_string),
+            enabled_at: "2026-06-30T00:00:00Z".to_string(),
+            resource_root: PathBuf::from("/fake/adapters/test-comp/openclaw"),
+            bundle_digest: None,
+            driver_schema: 1,
+            status: ClaimStatus::Enabled,
+            resources,
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "state_dir".to_string(),
+                plugin_resource: "plugin".to_string(),
+                skill_resources: payload_skill_ids,
+                config_resources: payload_config_ids,
+            }),
+        }
+    }
+
+    #[test]
+    fn plan_disable_report_plugin_adapter() {
+        use crate::adapter::claim::{ClaimResource, ClaimResourceKind};
+
+        let claim = make_claim_for_plan_test(
+            Some("plugin"),
+            Some("test-comp"),
+            vec![
+                ClaimResource {
+                    id: "state_dir".to_string(),
+                    purpose: "openclaw_state_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.openclaw"),
+                    },
+                },
+                ClaimResource {
+                    id: "plugin".to_string(),
+                    purpose: "openclaw_plugin".to_string(),
+                    kind: ClaimResourceKind::FrameworkPlugin {
+                        framework: "openclaw".to_string(),
+                        plugin_id: "test-comp".to_string(),
+                    },
+                },
+            ],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let report = plan_disable_report(&claim);
+        assert!(report.cleanup_complete);
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m.contains("would unregister") && m.contains("test-comp")),
+            "must describe plugin unregister: {:#?}",
+            report.messages
+        );
+        // Framework home/state_dir must NOT be listed as a removal target.
+        assert!(
+            !report
+                .messages
+                .iter()
+                .any(|m| m.contains("would remove") && m.contains(".openclaw")),
+            "must NOT claim to remove the framework home dir: {:#?}",
+            report.messages
+        );
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m.contains("would remove adapter receipt")),
+            "must note receipt removal: {:#?}",
+            report.messages
+        );
+    }
+
+    #[test]
+    fn plan_disable_report_skill_bundle_adapter() {
+        use crate::adapter::claim::{ClaimResource, ClaimResourceKind};
+
+        let claim = make_claim_for_plan_test(
+            Some("skill_bundle"),
+            None,
+            vec![
+                ClaimResource {
+                    id: "state_dir".to_string(),
+                    purpose: "openclaw_state_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.openclaw"),
+                    },
+                },
+                ClaimResource {
+                    id: "skill:os-tools".to_string(),
+                    purpose: "openclaw_skill".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.openclaw/skills/os-tools"),
+                    },
+                },
+            ],
+            vec!["skill:os-tools".to_string()],
+            Vec::new(),
+        );
+
+        let report = plan_disable_report(&claim);
+        assert!(report.cleanup_complete);
+        // plugin resource "plugin" has no matching ClaimResource so
+        // plugin unregister must NOT appear.
+        assert!(
+            !report
+                .messages
+                .iter()
+                .any(|m| m.contains("would unregister")),
+            "skill_bundle must not mention plugin unregister: {:#?}",
+            report.messages
+        );
+        // Framework home/state_dir must NOT be listed.
+        assert!(
+            !report
+                .messages
+                .iter()
+                .any(|m| m == "would remove /home/user/.openclaw"),
+            "must NOT claim to remove the framework home: {:#?}",
+            report.messages
+        );
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m.contains("would remove") && m.contains("skills/os-tools")),
+            "must describe skill dir removal: {:#?}",
+            report.messages
+        );
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m.contains("would remove adapter receipt")),
+            "must note receipt removal: {:#?}",
+            report.messages
+        );
+    }
+
+    #[test]
+    fn plan_disable_report_with_config_entries() {
+        use crate::adapter::claim::{ClaimResource, ClaimResourceKind};
+
+        let claim = make_claim_for_plan_test(
+            Some("plugin"),
+            Some("test-comp"),
+            vec![ClaimResource {
+                id: "config:0".to_string(),
+                purpose: "openclaw_config".to_string(),
+                kind: ClaimResourceKind::FrameworkConfig {
+                    framework: "openclaw".to_string(),
+                    key: "plugins.entries.test-comp.enabled".to_string(),
+                },
+            }],
+            Vec::new(),
+            vec!["config:0".to_string()],
+        );
+
+        let report = plan_disable_report(&claim);
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m.contains("config key") && m.contains("left in place")),
+            "must note config entries are not reversed: {:#?}",
+            report.messages
+        );
+    }
+
+    #[test]
+    fn plan_disable_report_hermes_plugin_adapter() {
+        use crate::adapter::claim::{
+            ClaimResource, ClaimResourceKind, ClaimStatus, DriverPayload, HermesClaim,
+        };
+
+        // Hermes stores both the home and the plugin as ExternalPath; only
+        // the plugin dir is a cleanup target, and disable runs a CLI step
+        // first.
+        let claim = AdapterClaim {
+            claim_schema: 1,
+            component: "test-comp".to_string(),
+            framework: "hermes".to_string(),
+            plugin_id: Some("test-comp".to_string()),
+            adapter_type: Some("plugin".to_string()),
+            enabled_at: "2026-06-30T00:00:00Z".to_string(),
+            resource_root: PathBuf::from("/fake/adapters/test-comp/hermes"),
+            bundle_digest: None,
+            driver_schema: 1,
+            status: ClaimStatus::Enabled,
+            resources: vec![
+                ClaimResource {
+                    id: "hermes_home".to_string(),
+                    purpose: "hermes_home".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.hermes"),
+                    },
+                },
+                ClaimResource {
+                    id: "hermes_plugin".to_string(),
+                    purpose: "hermes_plugin".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.hermes/plugins/test-comp"),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::Hermes(HermesClaim {
+                home_resource: "hermes_home".to_string(),
+                plugin_resource: "hermes_plugin".to_string(),
+                skill_resources: Vec::new(),
+            }),
+        };
+
+        let report = plan_disable_report(&claim);
+        assert!(report.cleanup_complete);
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m == "would disable hermes plugin 'test-comp'"),
+            "must describe the hermes CLI disable step: {:#?}",
+            report.messages
+        );
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m == "would remove /home/user/.hermes/plugins/test-comp"),
+            "must describe the hermes plugin directory removal: {:#?}",
+            report.messages
+        );
+        // Hermes home dir must NOT be a removal target.
+        assert!(
+            !report
+                .messages
+                .iter()
+                .any(|m| m == "would remove /home/user/.hermes"),
+            "must NOT claim to remove the hermes home: {:#?}",
+            report.messages
+        );
+    }
+
+    #[test]
+    fn plan_disable_report_hermes_skill_bundle_omits_plugin() {
+        use crate::adapter::claim::{
+            ClaimResource, ClaimResourceKind, ClaimStatus, DriverPayload, HermesClaim,
+        };
+
+        // skill_bundle Hermes receipts carry no plugin resource (empty id):
+        // the dry-run plan must not mention any plugin disable step.
+        let claim = AdapterClaim {
+            claim_schema: 1,
+            component: "test-comp".to_string(),
+            framework: "hermes".to_string(),
+            plugin_id: None,
+            adapter_type: Some("skill_bundle".to_string()),
+            enabled_at: "2026-06-30T00:00:00Z".to_string(),
+            resource_root: PathBuf::from("/fake/adapters/test-comp/hermes"),
+            bundle_digest: None,
+            driver_schema: 1,
+            status: ClaimStatus::Enabled,
+            resources: vec![
+                ClaimResource {
+                    id: "hermes_home".to_string(),
+                    purpose: "hermes_home".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.hermes"),
+                    },
+                },
+                ClaimResource {
+                    id: "hermes_skill_audit".to_string(),
+                    purpose: "hermes_skill".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/user/.hermes/skills/audit"),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::Hermes(HermesClaim {
+                home_resource: "hermes_home".to_string(),
+                plugin_resource: String::new(),
+                skill_resources: vec!["hermes_skill_audit".to_string()],
+            }),
+        };
+
+        let report = plan_disable_report(&claim);
+        assert!(
+            !report
+                .messages
+                .iter()
+                .any(|m| m.contains("disable hermes plugin")),
+            "skill_bundle must not mention a plugin disable step: {:#?}",
+            report.messages
+        );
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m == "would remove /home/user/.hermes/skills/audit"),
+            "must describe skill dir removal: {:#?}",
+            report.messages
+        );
+        assert!(
+            !report
+                .messages
+                .iter()
+                .any(|m| m == "would remove /home/user/.hermes"),
+            "must NOT claim to remove the hermes home: {:#?}",
+            report.messages
         );
     }
 }

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -320,7 +320,7 @@ fn enable_status_disable_happy_path() {
 
     // disable → removes receipt.
     let disabled = manager
-        .disable(COMPONENT, Some(FRAMEWORK))
+        .disable(COMPONENT, Some(FRAMEWORK), false)
         .expect("disable");
     assert!(disabled.claim_removed);
     assert!(disabled.report.cleanup_complete);
@@ -523,7 +523,7 @@ fn disable_keeps_receipt_when_uninstall_fails() {
     // Now force uninstall to fail.
     world.apply_env(&guard, Some("uninstall"));
     let disabled = manager
-        .disable(COMPONENT, Some(FRAMEWORK))
+        .disable(COMPONENT, Some(FRAMEWORK), false)
         .expect("disable runs");
     assert!(
         !disabled.claim_removed,
@@ -555,7 +555,7 @@ fn disable_without_cli_keeps_receipt_for_retry() {
     let missing = world._root.path().join("no-such-openclaw");
     guard.set_openclaw_bin(&missing);
     let disabled = manager
-        .disable(COMPONENT, Some(FRAMEWORK))
+        .disable(COMPONENT, Some(FRAMEWORK), false)
         .expect("disable");
     assert!(!disabled.claim_removed, "receipt kept when CLI absent");
     assert!(!disabled.report.cleanup_complete);
@@ -690,4 +690,162 @@ fn scan_lists_resource_with_detection_and_receipt_state() {
         .expect("entry");
     assert!(entry.enabled);
     assert_eq!(entry.claim_status, Some(ClaimStatus::Enabled));
+}
+
+// ---------------------------------------------------------------------------
+// dry-run disable regression tests (#1251)
+// ---------------------------------------------------------------------------
+
+/// Dry-run disable must leave `InstalledState` completely unchanged and
+/// must not invoke framework CLI operations. A following real disable
+/// must still clean up exactly once.
+#[test]
+fn dry_run_disable_leaves_state_unchanged() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    // Enable the adapter for real.
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let state_bytes_before = std::fs::read(&state_path).expect("read state file");
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_some(),
+        "pre-condition: receipt must exist after enable"
+    );
+    // The fake OpenClaw CLI wrote a registry marker for the plugin —
+    // framework-side state we must prove dry-run does not touch.
+    let registry_marker = world.openclaw_home.join("registry").join(COMPONENT);
+    assert!(
+        registry_marker.exists(),
+        "pre-condition: openclaw registry marker must exist after enable"
+    );
+
+    // Dry-run disable.
+    let outcome = manager
+        .disable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run disable");
+    assert!(outcome.dry_run, "outcome must be flagged dry-run");
+    assert!(
+        !outcome.claim_removed,
+        "dry-run must not remove the receipt"
+    );
+    assert!(
+        outcome.report.cleanup_complete,
+        "dry-run plan reports as complete"
+    );
+    assert!(
+        !outcome.report.messages.is_empty(),
+        "dry-run must describe planned actions"
+    );
+
+    // State file must be byte-identical — no writes at all.
+    let state_bytes_after = std::fs::read(&state_path).expect("read state file after dry-run");
+    assert_eq!(
+        state_bytes_before, state_bytes_after,
+        "installed.toml must be byte-identical after dry-run disable"
+    );
+    // Double-check: receipt still present and status unchanged.
+    let state_after = world.load_state();
+    let claim_after = state_after
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("receipt must still exist after dry-run disable");
+    assert_eq!(
+        claim_after.status,
+        anolisa_core::adapter::claim::ClaimStatus::Enabled,
+        "receipt status must remain Enabled, not cleanup_failed"
+    );
+    // Framework state must be untouched: the plugin registry marker must
+    // still exist (a real disable would have unregistered it).
+    assert!(
+        registry_marker.exists(),
+        "openclaw registry marker must still exist after dry-run disable"
+    );
+
+    // Following real disable cleans up exactly once.
+    let real = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("real disable");
+    assert!(!real.dry_run);
+    assert!(real.claim_removed, "real disable must remove receipt");
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_none(),
+        "receipt must be gone after real disable"
+    );
+}
+
+/// Dry-run disable must report meaningful planned actions for a plugin
+/// adapter (one with a `FrameworkPlugin` resource).
+#[test]
+fn dry_run_disable_reports_plugin_unregister() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+
+    let outcome = manager
+        .disable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run disable");
+    assert!(outcome.dry_run);
+
+    let has_unregister = outcome
+        .report
+        .messages
+        .iter()
+        .any(|m| m.contains("would unregister"));
+    assert!(
+        has_unregister,
+        "dry-run must describe the plugin unregister: {:?}",
+        outcome.report.messages
+    );
+
+    let has_receipt = outcome
+        .report
+        .messages
+        .iter()
+        .any(|m| m.contains("would remove adapter receipt"));
+    assert!(
+        has_receipt,
+        "dry-run must note receipt removal: {:?}",
+        outcome.report.messages
+    );
+}
+
+/// Dry-run disable of a component with no receipt is a no-op, same as
+/// a real disable, and the outcome carries the dry_run flag.
+#[test]
+fn dry_run_disable_no_receipt_is_noop() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let outcome = manager
+        .disable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run disable no receipt");
+    assert!(outcome.dry_run);
+    assert!(!outcome.claim_removed);
+    assert!(outcome.report.cleanup_complete);
+    assert!(
+        outcome
+            .report
+            .messages
+            .iter()
+            .any(|m| m.contains("no receipt")),
+        "must report no receipt: {:?}",
+        outcome.report.messages
+    );
 }


### PR DESCRIPTION
## Description

Fixes `anolisa adapter disable --dry-run` so previewing adapter cleanup no
longer mutates framework state or ANOLISA receipts.

The CLI now threads the global dry-run flag into adapter disable. The
manager resolves and validates the receipt, then returns a non-mutating
disable plan before any framework cleanup or state save happens.

The dry-run plan is built from receipt driver payload resource IDs, so it
only reports resources that real disable would touch. Framework home/state
directories such as `~/.openclaw` are not listed as removal targets.

## Related Issue

closes #1251

## Ship Note

`anolisa adapter disable --dry-run` is now read-only. It reports the
framework cleanup and receipt removal that a real disable would perform,
but it no longer unregisters plugins, removes skills, updates receipts, or
writes `installed.toml`.

JSON output for `adapter disable` now includes a `dry_run` boolean so
automation can distinguish planned cleanup from actual cleanup.

Known limitations:
- The dry-run plan is receipt-based and does not verify live framework state.
- Cascade cleanup during component uninstall remains tracked separately in #863.

Scenarios not covered:
- No real OpenClaw smoke was run in this PR.
- Coverage is by unit and integration regression tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p anolisa-core plan_disable_report --locked`
- `cargo test -p anolisa-core --test adapter_manager dry_run_disable --locked`
- `cargo test -p anolisa-cli adapter --locked`
- `git diff --check`

