### PR TITLE
fix(anolisa): improve repo config provisioning fallback for read commands

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -126,6 +126,29 @@ pub(crate) enum RepoPersistPolicy {
     BestEffort,
 }
 
+/// Enforce the persist policy against a load result.
+///
+/// Extracted so the policy branch can be unit-tested without a real
+/// network fetch or filesystem setup.
+fn enforce_repo_persist_policy(
+    provisioning: &RepoConfigProvisioning,
+    persist_policy: RepoPersistPolicy,
+    command: &str,
+) -> Result<(), CliError> {
+    if persist_policy == RepoPersistPolicy::Require
+        && let RepoConfigProvisioning::DownloadedPersistFailed { dest, reason, .. } = provisioning
+    {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "repo config downloaded but could not be written to {}: {reason}",
+                dest.display()
+            ),
+        });
+    }
+    Ok(())
+}
+
 /// Load `repo.toml`, provisioning it if every local source is missing.
 ///
 /// `persist_policy` governs what happens when a freshly-downloaded config
@@ -142,19 +165,7 @@ pub(crate) fn load_repo_config(
         command: command.to_string(),
         reason: err.to_string(),
     })?;
-    if persist_policy == RepoPersistPolicy::Require {
-        if let RepoConfigProvisioning::DownloadedPersistFailed { dest, reason, .. } =
-            &repo_load.provisioning
-        {
-            return Err(CliError::Runtime {
-                command: command.to_string(),
-                reason: format!(
-                    "repo config downloaded but could not be written to {}: {reason}",
-                    dest.display()
-                ),
-            });
-        }
-    }
+    enforce_repo_persist_policy(&repo_load.provisioning, persist_policy, command)?;
     render_repo_config_provisioning(ctx, &repo_load.provisioning);
     Ok(repo_load.config)
 }
@@ -1000,6 +1011,72 @@ type = "symlink"
             let count = super::migrate_v3_symlinks(&mut state, &layout);
             assert_eq!(count, 0);
             assert_eq!(state.objects[0].files[0].kind, OwnedFileKind::File);
+        }
+    }
+
+    mod persist_policy {
+        use super::super::{
+            RepoConfigProvisioning, RepoPersistPolicy, enforce_repo_persist_policy,
+        };
+        use crate::response::CliError;
+        use std::path::PathBuf;
+
+        fn persist_failed() -> RepoConfigProvisioning {
+            RepoConfigProvisioning::DownloadedPersistFailed {
+                url: "https://example.com/repo.toml".to_string(),
+                dest: PathBuf::from("/etc/anolisa/repo.toml"),
+                reason: "permission denied".to_string(),
+            }
+        }
+
+        /// Require policy: DownloadedPersistFailed is escalated to CliError::Runtime
+        /// carrying the dest path and underlying reason.
+        #[test]
+        fn require_policy_rejects_persist_failure() {
+            let err =
+                enforce_repo_persist_policy(&persist_failed(), RepoPersistPolicy::Require, "list")
+                    .expect_err("Require must reject persist failure");
+            match err {
+                CliError::Runtime { command, reason } => {
+                    assert_eq!(command, "list");
+                    assert!(
+                        reason.contains("/etc/anolisa/repo.toml"),
+                        "reason should carry dest: {reason}"
+                    );
+                    assert!(
+                        reason.contains("permission denied"),
+                        "reason should carry inner cause: {reason}"
+                    );
+                }
+                other => panic!("expected Runtime, got {other:?}"),
+            }
+        }
+
+        /// BestEffort policy: DownloadedPersistFailed is tolerated (Ok).
+        #[test]
+        fn best_effort_policy_tolerates_persist_failure() {
+            enforce_repo_persist_policy(&persist_failed(), RepoPersistPolicy::BestEffort, "list")
+                .expect("BestEffort must accept persist failure");
+        }
+
+        /// Neither policy touches non-persist-failure provisioning states.
+        #[test]
+        fn non_persist_failure_states_are_always_ok() {
+            let downloaded = RepoConfigProvisioning::Downloaded {
+                url: "https://example.com/repo.toml".to_string(),
+                dest: PathBuf::from("/etc/anolisa/repo.toml"),
+            };
+            let existing = RepoConfigProvisioning::Existing;
+            let dry_run = RepoConfigProvisioning::FetchedForDryRun {
+                url: "https://example.com/repo.toml".to_string(),
+                dest: PathBuf::from("/etc/anolisa/repo.toml"),
+            };
+            for provisioning in [&downloaded, &existing, &dry_run] {
+                enforce_repo_persist_policy(provisioning, RepoPersistPolicy::Require, "install")
+                    .expect("Require must pass through non-persist-failure states");
+                enforce_repo_persist_policy(provisioning, RepoPersistPolicy::BestEffort, "list")
+                    .expect("BestEffort must pass through non-persist-failure states");
+            }
         }
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -105,19 +105,56 @@ fn render_repo_config_provisioning(ctx: &CliContext, provisioning: &RepoConfigPr
                 color.path(dest.display().to_string()),
             );
         }
+        RepoConfigProvisioning::DownloadedPersistFailed { url, dest, reason } => {
+            eprintln!(
+                "{} repo config fetched from {} but could not write to {}: {}",
+                color.warn("⚠"),
+                url,
+                color.path(dest.display().to_string()),
+                reason,
+            );
+        }
     }
 }
 
+/// Controls whether a failed persistence of downloaded repo config is fatal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepoPersistPolicy {
+    /// Mutating commands: persistence failure is an error.
+    Require,
+    /// Read-only / best-effort commands: warn and use in-memory config.
+    BestEffort,
+}
+
 /// Load `repo.toml`, provisioning it if every local source is missing.
+///
+/// `persist_policy` governs what happens when a freshly-downloaded config
+/// cannot be written to disk:
+/// - [`RepoPersistPolicy::Require`]: command fails (use for mutating ops).
+/// - [`RepoPersistPolicy::BestEffort`]: warn and return the in-memory config.
 pub(crate) fn load_repo_config(
     ctx: &CliContext,
     layout: &FsLayout,
     command: &str,
+    persist_policy: RepoPersistPolicy,
 ) -> Result<RepoConfig, CliError> {
     let repo_load = RepoConfig::load(layout, ctx.dry_run).map_err(|err| CliError::Runtime {
         command: command.to_string(),
         reason: err.to_string(),
     })?;
+    if persist_policy == RepoPersistPolicy::Require {
+        if let RepoConfigProvisioning::DownloadedPersistFailed { dest, reason, .. } =
+            &repo_load.provisioning
+        {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "repo config downloaded but could not be written to {}: {reason}",
+                    dest.display()
+                ),
+            });
+        }
+    }
     render_repo_config_provisioning(ctx, &repo_load.provisioning);
     Ok(repo_load.config)
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -15,6 +15,7 @@ use anolisa_platform::pkg_query::PackageQuery;
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::{RpmSituation, execute_adopt, probe_rpm_situation};
 use crate::context::CliContext;
 use crate::resolution::{ResolutionUse, load_optional_component_index};
@@ -102,7 +103,8 @@ pub(crate) fn adopt_with_query(
     // are supplementary to the explicit --package input, installed Provides
     // contract, and default name candidate, so unreadable config degrades to
     // "no rpm backend config" rather than failing the adopt.
-    let repo_config = common::load_repo_config(ctx, &layout, COMMAND).ok();
+    let repo_config =
+        common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort).ok();
     let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
     let env = anolisa_env::EnvService::detect();
     let component_index = repo_config

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -64,6 +64,7 @@ use chrono::{SecondsFormat, Utc};
 
 use crate::color::Palette;
 use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
 use crate::context::{CliContext, InstallMode};
 use crate::repo_config::{
     BackendConfig, HostVars, RepoConfig, RepoConfigError, normalize_override_url, raw_artifact_url,
@@ -647,7 +648,7 @@ fn handle_one(
 ) -> Result<InstallOutcome, CliError> {
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
-    let repo_config = common::load_repo_config(ctx, &layout, COMMAND)?;
+    let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
     let rpm_repo = if rpm_repo_required(&component, &args, ctx, &repo_config)? {
         configured_rpm_repo_source(&repo_config, &env)?
     } else {
@@ -683,7 +684,7 @@ pub(crate) fn handle_one_with_exec(
 ) -> Result<InstallOutcome, CliError> {
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
-    let repo_config = common::load_repo_config(ctx, &layout, COMMAND)?;
+    let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
     handle_one_with_config(component, args, ctx, exec, layout, env, repo_config)
 }
 
@@ -2242,7 +2243,8 @@ fn resolve_all_components(
 ) -> Result<Vec<String>, CliError> {
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
-    let repo_config = common::load_repo_config(ctx, &layout, "install --all")?;
+    let repo_config =
+        common::load_repo_config(ctx, &layout, "install --all", RepoPersistPolicy::Require)?;
     let index =
         crate::resolution::load_component_index(&layout, &env, &repo_config).map_err(|err| {
             CliError::Runtime {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 
 use crate::color::{Palette, pad_right};
 use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
 use crate::context::CliContext;
 use crate::resolution::{ComponentIndex, ComponentIndexEntry, load_component_index};
 use crate::response::{CliError, render_json};
@@ -44,7 +45,8 @@ struct ListPayload {
 pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
-    let repo_config = common::load_repo_config(ctx, &layout, COMMAND)?;
+    let repo_config =
+        common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort)?;
 
     let index =
         load_component_index(&layout, &env, &repo_config).map_err(|err| CliError::Runtime {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -23,6 +23,7 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::Palette;
 use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::CliContext;
 use crate::resolution::{ResolutionUse, load_optional_component_index, resolve_rpm_component_name};
@@ -242,7 +243,8 @@ fn resolve_repair_component_name(
     }
 
     let layout = common::resolve_layout(ctx);
-    let repo_config = common::load_repo_config(ctx, &layout, COMMAND).ok();
+    let repo_config =
+        common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort).ok();
     let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
     let env = anolisa_env::EnvService::detect();
     let component_index = repo_config
@@ -284,7 +286,8 @@ fn resolve_repair_package(
     // inputs (mirrors status::observed_record): a load failure just drops that
     // precedence tier.
     let layout = common::resolve_layout(ctx);
-    let repo_config = common::load_repo_config(ctx, &layout, COMMAND).ok();
+    let repo_config =
+        common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort).ok();
     let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
     let env = anolisa_env::EnvService::detect();
     let component_index = repo_config

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -52,6 +52,7 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::{Palette, pad_right};
 use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::{CliContext, InstallMode};
 use crate::repo_config::BackendConfig;
@@ -143,7 +144,9 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     let query = RpmPackageQuery::system();
     let repo_config = (ctx.install_mode == InstallMode::System && args.component.is_some())
-        .then(|| common::load_repo_config(ctx, &layout, COMMAND).ok())
+        .then(|| {
+            common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort).ok()
+        })
         .flatten();
     let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
     let env = EnvService::detect();

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -66,6 +66,7 @@ use super::install::{
 };
 use crate::color::Palette;
 use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
 use crate::context::CliContext;
 use crate::repo_config::{HostVars, RepoConfig};
 use crate::response::{self, CliError};
@@ -169,7 +170,7 @@ fn handle_component_update(component: &str, ctx: &CliContext) -> Result<(), CliE
     let command = format!("update {component}");
     let target = resolve_update_target(component, ctx, &command)?;
     let layout = common::resolve_layout(ctx);
-    let repo_config = common::load_repo_config(ctx, &layout, &command)?;
+    let repo_config = common::load_repo_config(ctx, &layout, &command, RepoPersistPolicy::Require)?;
     match target {
         UpdateTarget::Raw {
             backend_name,
@@ -388,7 +389,7 @@ fn update_raw_component(
     command: &str,
 ) -> Result<(), CliError> {
     let layout = common::resolve_layout(ctx);
-    let repo_config = common::load_repo_config(ctx, &layout, command)?;
+    let repo_config = common::load_repo_config(ctx, &layout, command, RepoPersistPolicy::Require)?;
     update_raw_component_with_repo(
         component,
         backend_name,

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -178,8 +178,23 @@ pub(crate) struct RepoConfigLoadResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RepoConfigProvisioning {
     Existing,
-    Downloaded { url: String, dest: PathBuf },
-    FetchedForDryRun { url: String, dest: PathBuf },
+    Downloaded {
+        url: String,
+        dest: PathBuf,
+    },
+    FetchedForDryRun {
+        url: String,
+        dest: PathBuf,
+    },
+    /// Downloaded and parsed successfully, but writing to disk failed.
+    ///
+    /// The in-memory config is valid; callers that only need read access may
+    /// proceed and warn, while mutating commands should treat this as an error.
+    DownloadedPersistFailed {
+        url: String,
+        dest: PathBuf,
+        reason: String,
+    },
 }
 
 /// Errors raised while provisioning a missing repo config.
@@ -329,14 +344,23 @@ impl RepoConfig {
             });
         }
 
-        write_repo_config(&dest, &body)?;
-        Ok(RepoConfigLoadResult {
-            config,
-            provisioning: RepoConfigProvisioning::Downloaded {
-                url: bootstrap_url.to_string(),
-                dest,
-            },
-        })
+        match write_repo_config(&dest, &body) {
+            Ok(()) => Ok(RepoConfigLoadResult {
+                config,
+                provisioning: RepoConfigProvisioning::Downloaded {
+                    url: bootstrap_url.to_string(),
+                    dest,
+                },
+            }),
+            Err(err) => Ok(RepoConfigLoadResult {
+                config,
+                provisioning: RepoConfigProvisioning::DownloadedPersistFailed {
+                    url: bootstrap_url.to_string(),
+                    dest,
+                    reason: err.to_string(),
+                },
+            }),
+        }
     }
 
     /// Local discovery helper used before the provisioning fallback.
@@ -1307,5 +1331,63 @@ scope = "@anolis"
             npm_cfg.package_name(npm, "tokenless", None),
             "@anolis/tokenless"
         );
+    }
+
+    /// When all local sources are missing and the dest directory is not writable,
+    /// `load_with_sources` still returns the valid in-memory config with a
+    /// `DownloadedPersistFailed` provisioning status.
+    #[test]
+    fn load_returns_config_when_persist_fails() {
+        let body = "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"https://example.com/v1/\"\n";
+        let url = serve_once(body.to_string());
+        // Point dest to a path that cannot be created (parent is a file, not a dir).
+        let tmp = tempfile::tempdir().expect("tmp");
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, "I am a file").expect("create blocker file");
+        let dest = blocker.join("repo.toml"); // parent is a file → write will fail
+
+        let result = RepoConfig::load_with_sources(missing_sources(dest.clone()), false, &url)
+            .expect("must succeed with in-memory config");
+
+        assert!(
+            matches!(
+                &result.provisioning,
+                RepoConfigProvisioning::DownloadedPersistFailed { reason, .. } if !reason.is_empty()
+            ),
+            "expected DownloadedPersistFailed, got {:?}",
+            result.provisioning
+        );
+        // The config is valid and usable despite the write failure.
+        assert_eq!(result.config.default_backend, "raw");
+        assert_eq!(
+            result.config.backends["raw"].base_url,
+            "https://example.com/v1/"
+        );
+    }
+
+    /// `DownloadedPersistFailed` carries the correct url and dest metadata.
+    #[test]
+    fn persist_failed_carries_metadata() {
+        let body = "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file:///srv/repo\"\n";
+        let url = serve_once(body.to_string());
+        let tmp = tempfile::tempdir().expect("tmp");
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, "I am a file").expect("create blocker");
+        let dest = blocker.join("repo.toml");
+
+        let result = RepoConfig::load_with_sources(missing_sources(dest.clone()), false, &url)
+            .expect("load");
+
+        match &result.provisioning {
+            RepoConfigProvisioning::DownloadedPersistFailed {
+                url: got_url,
+                dest: got_dest,
+                ..
+            } => {
+                assert_eq!(got_dest, &dest);
+                assert!(got_url.contains("127.0.0.1"));
+            }
+            other => panic!("expected DownloadedPersistFailed, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes repo config provisioning so that read-only commands no longer fail
when the downloaded config cannot be persisted to disk.

When all local repo.toml sources are missing, the loader downloads and
validates the published config. Previously, if writing to the active etc
dir failed, strict callers like `anolisa list` would fail entirely (even
though a valid in-memory config was available), and best-effort callers
like `status`/`adopt`/`repair` would silently discard the fetched config
via `.ok()`.

Now the loader represents "downloaded and valid, persistence failed" as a
successful load with a `DownloadedPersistFailed` provisioning status. A
single `load_repo_config` function takes a `RepoPersistPolicy` enum to
control whether persistence failure is fatal:

- `Require` — mutating commands (`install`, `update`) still fail.
- `BestEffort` — read-only commands (`list`, `status`, `adopt`, `repair`)
  use the in-memory config and emit a stderr warning.

## Related Issue

closes #1244

## Ship Note

`anolisa list` and other read-oriented commands now gracefully fall back
to the in-memory repo config when disk persistence fails, instead of
aborting. A warning is emitted to stderr so the user is aware that
`repo.toml` could not be saved locally.

Mutating commands (`install`, `update`) retain strict behavior — they
still require successful persistence before proceeding.

Known limitations:
- The warning is suppressed under `--quiet` and `--json` modes.
- Retry or recovery of the persist failure is not attempted.

Scenarios not covered:
- No real network-partition smoke was run in this PR.
- Coverage is by unit tests exercising the persist-failure path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Testing

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test -p anolisa-cli -- repo_config::tests`
- `cargo test`
- `git diff --check`
