### PR TITLE
fix(skillfs): fix in-place skill authoring

### DIFF
--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -169,9 +169,16 @@ impl SkillFs {
                             (parent_ino, FileType::Directory, "..".to_string()),
                         ];
 
-                        let md_path = format!("{}/SKILL.md", path);
-                        let md_ino = self.inodes.readdir_ino(&md_path);
-                        entries.push((md_ino, FileType::RegularFile, "SKILL.md".to_string()));
+                        // Only synthesize the virtual SKILL.md when the
+                        // manifest is actually readable (physical file
+                        // present in the resolved read dir, or the always
+                        // -virtual skill-discover). A newly-created empty
+                        // skill dir has none yet and must list as empty.
+                        if self.skill_md_listable(&skill_name) {
+                            let md_path = format!("{}/SKILL.md", path);
+                            let md_ino = self.inodes.readdir_ino(&md_path);
+                            entries.push((md_ino, FileType::RegularFile, "SKILL.md".to_string()));
+                        }
 
                         if skill_name != "skill-discover" {
                             let show_meta =
@@ -549,10 +556,16 @@ impl SkillFs {
                         (skills_dir_ino, FileType::Directory, "..".to_string()),
                     ];
 
-                    // Virtual SKILL.md always present
-                    let md_path = format!("{}/SKILL.md", path);
-                    let md_ino = self.inodes.readdir_ino(&md_path);
-                    entries.push((md_ino, FileType::RegularFile, "SKILL.md".to_string()));
+                    // Virtual SKILL.md is listed only when the manifest is
+                    // readable through the current read semantics (physical
+                    // file present, or the always-virtual skill-discover).
+                    // A freshly-created empty skill dir has none yet and
+                    // must not surface a phantom, broken entry.
+                    if self.skill_md_listable(skill_name) {
+                        let md_path = format!("{}/SKILL.md", path);
+                        let md_ino = self.inodes.readdir_ino(&md_path);
+                        entries.push((md_ino, FileType::RegularFile, "SKILL.md".to_string()));
+                    }
 
                     // Physical files (non skill-discover). For ledger
                     // fallback skills the snapshot directory drives the

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -732,17 +732,15 @@ impl SkillFs {
                 }
                 // `cp -a` preserves mode/timestamps on the freshly-created
                 // top-level skill directory. Route those metadata mutations
-                // to the physical source dir for ordinary skills instead of
-                // rejecting with EROFS. Keep the read-only façade for the
-                // always-virtual skill-discover, staging roots, and pending
-                // installs; hide hidden skills; lifecycle reserved names are
-                // rejected by the shared gate below. `.skill-meta/**` never
-                // parses as a SkillDir, so trusted-writer policy is
-                // unaffected.
-                if is_skill_discover_path(skill_name)
-                    || self.is_staging_skill_root(skill_name)
-                    || self.is_pending_install(skill_name)
-                {
+                // to the physical source dir instead of rejecting with
+                // EROFS. Pending installs are the CLI's direct final-skill
+                // authoring path, so they must preserve metadata too. Keep
+                // the read-only façade for the always-virtual skill-discover
+                // and staging roots; hide hidden skills; lifecycle reserved
+                // names are rejected by the shared gate below.
+                // `.skill-meta/**` never parses as a SkillDir, so
+                // trusted-writer policy is unaffected.
+                if is_skill_discover_path(skill_name) || self.is_staging_skill_root(skill_name) {
                     reply.error(libc::EROFS);
                     return;
                 }
@@ -753,6 +751,18 @@ impl SkillFs {
                 // A directory has no size to truncate.
                 if size.is_some() {
                     reply.error(libc::EISDIR);
+                    return;
+                }
+                // Ownership changes on the virtual skill directory stay
+                // restricted to privileged / trusted-writer callers. cp -a
+                // from an ordinary user only needs mode/atime/mtime
+                // preservation, so we do not widen the daemon-side chown
+                // surface for unprivileged callers.
+                if (uid.is_some() || gid.is_some())
+                    && req.uid() != 0
+                    && !self.evaluate_trusted_writer(req).is_allowed()
+                {
+                    reply.error(libc::EPERM);
                     return;
                 }
                 // Fall through to the shared physical setattr handling.

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -724,14 +724,38 @@ impl SkillFs {
                 }
                 return;
             }
-            PathType::SkillDir { .. } => {
-                // All skill directories treated as virtual read-only for metadata mutations
-                if has_mutation {
-                    reply.error(libc::EROFS);
-                } else {
+            PathType::SkillDir { skill_name } => {
+                // Pure stat keeps the virtual directory façade.
+                if !has_mutation {
                     reply.attr(&Duration::from_secs(1), &self.dir_attr());
+                    return;
                 }
-                return;
+                // `cp -a` preserves mode/timestamps on the freshly-created
+                // top-level skill directory. Route those metadata mutations
+                // to the physical source dir for ordinary skills instead of
+                // rejecting with EROFS. Keep the read-only façade for the
+                // always-virtual skill-discover, staging roots, and pending
+                // installs; hide hidden skills; lifecycle reserved names are
+                // rejected by the shared gate below. `.skill-meta/**` never
+                // parses as a SkillDir, so trusted-writer policy is
+                // unaffected.
+                if is_skill_discover_path(skill_name)
+                    || self.is_staging_skill_root(skill_name)
+                    || self.is_pending_install(skill_name)
+                {
+                    reply.error(libc::EROFS);
+                    return;
+                }
+                if self.should_reject_hidden_write(skill_name, None) {
+                    reply.error(libc::ENOENT);
+                    return;
+                }
+                // A directory has no size to truncate.
+                if size.is_some() {
+                    reply.error(libc::EISDIR);
+                    return;
+                }
+                // Fall through to the shared physical setattr handling.
             }
             PathType::InboxSkillDir { skill_name } => {
                 // L1: the inbox skill candidate dir is the live source

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -68,6 +68,27 @@ impl SkillFs {
         Some(compiler::compile(&raw, &self.env_profile))
     }
 
+    /// Whether a virtual `SKILL.md` entry should be listed for
+    /// `skill_name` in `readdir`/`opendir`.
+    ///
+    /// A freshly-created placeholder skill directory (via `mkdir`) has no
+    /// physical `SKILL.md` yet, so synthesizing the virtual entry
+    /// unconditionally produces a phantom listing whose `lookup`/`getattr`
+    /// then fail with `ENOENT` (broken entry with unknown attrs). Gate the
+    /// virtual entry on the manifest actually being readable through the
+    /// current read semantics: `skill-discover` is always virtual, and any
+    /// other skill lists `SKILL.md` only when the resolved read directory
+    /// (live source or snapshot) physically contains it.
+    pub(super) fn skill_md_listable(&self, skill_name: &str) -> bool {
+        if skill_name == "skill-discover" {
+            return true;
+        }
+        match self.skill_read_dir(skill_name) {
+            Some(dir) => dir.join("SKILL.md").exists(),
+            None => false,
+        }
+    }
+
     /// Physical directory to read **content from** for `skill_name`.
     ///
     /// For an unattached resolver (default) and for

--- a/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
@@ -1633,6 +1633,55 @@ fn pending_activation_clears_pending_and_shows_skill() {
     );
 }
 
+/// #1264 regression: a direct final-skill pending install dir must still
+/// accept `cp -a`-style metadata preservation (chmod + utimensat) on the
+/// top-level directory instead of failing with EROFS. Pending semantics
+/// (hidden from /skills listing) must be preserved.
+#[test]
+fn pending_skill_dir_metadata_preservation() {
+    skip_if_no_fuse!();
+
+    let fixture = PendingInstallFixture::new(5000, |src| {
+        create_skill(src, "existing");
+    });
+
+    let new_skill = fixture.skill_path("cp-a-pending");
+    std::fs::create_dir(&new_skill).unwrap();
+
+    // chmod (setattr mode) must succeed on the pending skill dir.
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(&new_skill, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod pending skill dir must succeed");
+
+    // utimensat (setattr atime/mtime) must succeed on the pending skill dir.
+    let c_path = std::ffi::CString::new(new_skill.to_string_lossy().into_owned()).unwrap();
+    let times = [
+        libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_NOW,
+        },
+        libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_NOW,
+        },
+    ];
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(
+        rc,
+        0,
+        "utimensat pending skill dir must succeed, errno={}",
+        std::io::Error::last_os_error()
+    );
+
+    // Pending skill must still be hidden from the /skills listing.
+    let skills = common::list_dir_names(&fixture.skills_root());
+    assert!(
+        !skills.contains(&"cp-a-pending".to_string()),
+        "pending skill must remain hidden from listing: {:?}",
+        skills
+    );
+}
+
 #[test]
 fn pending_activated_skill_uses_normal_notify() {
     skip_if_no_fuse!();

--- a/src/skillfs/crates/skillfs-fuse/tests/write_guard_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/write_guard_tests.rs
@@ -675,6 +675,221 @@ fn test_inplace_post_rename_write_does_not_resurrect_old_name() {
         .output();
 }
 // ─────────────────────────────────────────────────────────────────────────────
+// In-place mode: new-skill authoring (issue #1264)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Set atime/mtime on `path` via `utimensat`, emulating what `cp -a` does
+/// when preserving timestamps on the top-level skill directory.
+fn set_times_now(path: &std::path::Path) -> std::io::Result<()> {
+    let c_path = std::ffi::CString::new(path.to_string_lossy().into_owned())
+        .expect("CString path for utimensat");
+    let times = [
+        libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_NOW,
+        },
+        libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_NOW,
+        },
+    ];
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// In-place mode: a freshly `mkdir`'d skill directory with no physical
+/// SKILL.md must list as empty — no phantom, broken SKILL.md entry.
+#[test]
+fn test_inplace_new_skill_dir_has_no_phantom_skill_md() {
+    if !fuse_available() {
+        eprintln!("SKIP test_inplace_new_skill_dir_has_no_phantom_skill_md: FUSE not available");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    std::fs::create_dir(dir.path().join("seed-skill")).unwrap();
+    std::fs::write(
+        dir.path().join("seed-skill/SKILL.md"),
+        b"---\nname: seed-skill\ndescription: seed\n---\n",
+    )
+    .unwrap();
+
+    let handle = mount_inplace(dir.path());
+    std::thread::sleep(Duration::from_millis(300));
+
+    let new_skill = dir.path().join("test-ws");
+    std::fs::create_dir(&new_skill).expect("mkdir test-ws");
+
+    // Listing the new empty skill dir must not contain SKILL.md.
+    let entries: Vec<String> = std::fs::read_dir(&new_skill)
+        .expect("read_dir test-ws")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        !entries.iter().any(|n| n == "SKILL.md"),
+        "phantom SKILL.md listed for empty new skill dir, got: {:?}",
+        entries
+    );
+    assert!(
+        entries.is_empty(),
+        "new empty skill dir should list as empty, got: {:?}",
+        entries
+    );
+
+    // Direct probe of the phantom path must be ENOENT, not a broken entry.
+    let probe = std::fs::metadata(new_skill.join("SKILL.md"));
+    assert!(
+        probe.is_err(),
+        "SKILL.md must not stat in an empty new skill dir"
+    );
+
+    // A complete existing skill must still list its SKILL.md.
+    let seed_entries: Vec<String> = std::fs::read_dir(dir.path().join("seed-skill"))
+        .expect("read_dir seed-skill")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        seed_entries.iter().any(|n| n == "SKILL.md"),
+        "existing complete skill lost its SKILL.md listing, got: {:?}",
+        seed_entries
+    );
+
+    let _ = std::fs::remove_dir(&new_skill);
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(200));
+    let _ = std::process::Command::new("fusermount3")
+        .args(["-u", &dir.path().to_string_lossy()])
+        .output();
+}
+
+/// In-place mode: mkdir a new skill dir then write its SKILL.md — the file
+/// must become physically present, stat/read must succeed, and the store
+/// reparse must surface the skill with compiled content.
+#[test]
+fn test_inplace_new_skill_write_skill_md() {
+    if !fuse_available() {
+        eprintln!("SKIP test_inplace_new_skill_write_skill_md: FUSE not available");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    std::fs::create_dir(dir.path().join("seed-skill")).unwrap();
+    std::fs::write(
+        dir.path().join("seed-skill/SKILL.md"),
+        b"---\nname: seed-skill\ndescription: seed\n---\n",
+    )
+    .unwrap();
+
+    let handle = mount_inplace(dir.path());
+    std::thread::sleep(Duration::from_millis(300));
+
+    let new_skill = dir.path().join("authored");
+    std::fs::create_dir(&new_skill).expect("mkdir authored");
+
+    // Write the manifest through the mount (create + write path).
+    let skill_md = new_skill.join("SKILL.md");
+    std::fs::write(
+        &skill_md,
+        b"---\nname: authored\ndescription: authored in place\n---\n",
+    )
+    .expect("write SKILL.md");
+
+    // stat must now succeed.
+    let md = std::fs::metadata(&skill_md).expect("metadata SKILL.md after write");
+    assert!(md.is_file(), "SKILL.md exists but is not a regular file");
+
+    // read must return compiled content mentioning the skill name.
+    let content = std::fs::read_to_string(&skill_md).expect("read SKILL.md after write");
+    assert!(
+        content.contains("authored"),
+        "compiled SKILL.md does not mention skill name: {content}"
+    );
+
+    // SKILL.md must now appear in the skill dir listing.
+    let entries: Vec<String> = std::fs::read_dir(&new_skill)
+        .expect("read_dir authored")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        entries.iter().any(|n| n == "SKILL.md"),
+        "SKILL.md not listed after write, got: {:?}",
+        entries
+    );
+
+    // Reparse should keep the skill visible at the root.
+    std::thread::sleep(Duration::from_millis(300));
+    let root: Vec<String> = std::fs::read_dir(dir.path())
+        .expect("read_dir root")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        root.iter().any(|n| n == "authored"),
+        "authored skill not visible at root after reparse, got: {:?}",
+        root
+    );
+
+    let _ = std::fs::remove_file(&skill_md);
+    let _ = std::fs::remove_dir(&new_skill);
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(200));
+    let _ = std::process::Command::new("fusermount3")
+        .args(["-u", &dir.path().to_string_lossy()])
+        .output();
+}
+
+/// In-place mode: `cp -a`-style metadata preservation (chmod + utimensat)
+/// on an ordinary top-level skill directory must succeed rather than
+/// failing with EROFS.
+#[test]
+fn test_inplace_skill_dir_metadata_preservation() {
+    if !fuse_available() {
+        eprintln!("SKIP test_inplace_skill_dir_metadata_preservation: FUSE not available");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    std::fs::create_dir(dir.path().join("seed-skill")).unwrap();
+    std::fs::write(
+        dir.path().join("seed-skill/SKILL.md"),
+        b"---\nname: seed-skill\ndescription: seed\n---\n",
+    )
+    .unwrap();
+
+    let handle = mount_inplace(dir.path());
+    std::thread::sleep(Duration::from_millis(300));
+
+    let new_skill = dir.path().join("copied-skill");
+    std::fs::create_dir(&new_skill).expect("mkdir copied-skill");
+
+    // chmod (setattr mode) on the top-level skill dir must succeed.
+    use std::os::unix::fs::PermissionsExt as _;
+    assert_ok(
+        std::fs::set_permissions(&new_skill, std::fs::Permissions::from_mode(0o755)),
+        "chmod skill dir",
+    );
+
+    // utimensat (setattr atime/mtime) on the top-level skill dir must succeed.
+    assert_ok(set_times_now(&new_skill), "utimensat skill dir");
+
+    let _ = std::fs::remove_dir(&new_skill);
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(200));
+    let _ = std::process::Command::new("fusermount3")
+        .args(["-u", &dir.path().to_string_lossy()])
+        .output();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Post-rename write: stale frontmatter name must not resurrect old entry
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description

Fixes SkillFS in-place new-skill authoring for Openclaw-style skill roots. A freshly created skill directory no longer exposes a phantom `SKILL.md` entry before the manifest exists, while complete skills still expose compiled `SKILL.md` normally.

This also lets `cp -a` preserve mode and timestamps on ordinary top-level skill directories, including direct final-skill pending installs. `.skill-meta/**` remains trusted-writer-only by design.

## Related Issue

closes #1264

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `skillfs` (SkillFS)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo +1.86.0 fmt --all --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test -p skillfs-fuse --test install_staging_tests`
- `cargo +1.86.0 test -p skillfs-fuse --test write_guard_tests`
- Full `skillfs-fuse` suite: 28 test binaries, 0 failures
- `scripts/test.sh` FUSE e2e: passed

## Additional Notes

`SKILL.md` creation and write-through behavior is unchanged. Directory names remain the canonical SkillFS identity, and `.skill-meta/**` write access is not broadened.