### PR TITLE
fix(anolisa): unify component name alias resolution across all CLI commands

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -268,9 +268,11 @@ fn handle_enable(
     framework: Option<&str>,
 ) -> Result<(), CliError> {
     const COMMAND: &str = "adapter enable";
+    let installed = common::load_installed_state(ctx, COMMAND).unwrap_or_default();
+    let component = common::lookup_component_name(component, &installed, ctx, COMMAND);
     let manager = build_manager(ctx);
     let outcome = manager
-        .enable(component, framework, ctx.dry_run)
+        .enable(&component, framework, ctx.dry_run)
         .map_err(|e| map_err(COMMAND, e))?;
 
     match outcome {
@@ -327,9 +329,11 @@ fn handle_disable(
     framework: Option<&str>,
 ) -> Result<(), CliError> {
     const COMMAND: &str = "adapter disable";
+    let installed = common::load_installed_state(ctx, COMMAND).unwrap_or_default();
+    let component = common::lookup_component_name(component, &installed, ctx, COMMAND);
     let manager = build_manager(ctx);
     let outcome: DisableOutcome = manager
-        .disable(component, framework, ctx.dry_run)
+        .disable(&component, framework, ctx.dry_run)
         .map_err(|e| map_err(COMMAND, e))?;
 
     if outcome.dry_run {
@@ -407,8 +411,19 @@ fn disable_target(outcome: &DisableOutcome) -> String {
 
 fn handle_status(ctx: &CliContext, component: Option<&str>) -> Result<(), CliError> {
     const COMMAND: &str = "adapter status";
+    let component = match component {
+        Some(name) => {
+            let installed = common::load_installed_state(ctx, COMMAND).unwrap_or_default();
+            Some(common::lookup_component_name(
+                name, &installed, ctx, COMMAND,
+            ))
+        }
+        None => None,
+    };
     let manager = build_manager(ctx);
-    let report: StatusReport = manager.status(component).map_err(|e| map_err(COMMAND, e))?;
+    let report: StatusReport = manager
+        .status(component.as_deref())
+        .map_err(|e| map_err(COMMAND, e))?;
 
     if ctx.json {
         let receipts = report

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -7,7 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use anolisa_core::adapter::manager::AdapterManager;
-use anolisa_core::{Catalog, CatalogLayers, InstalledState, ObjectStatus};
+use anolisa_core::{Catalog, CatalogLayers, InstalledState, ObjectKind, ObjectStatus};
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::color::Palette;
@@ -182,6 +182,44 @@ pub fn load_installed_state(ctx: &CliContext, command: &str) -> Result<Installed
             path.display()
         ),
     })
+}
+
+/// Resolve a user-supplied component name to the stable state key.
+///
+/// Commands that address existing state (uninstall, forget, update, restart,
+/// doctor, adapter, logs) should call this before `find_object`.
+///
+/// 1. Exact state match wins — a component installed under its literal name
+///    is never re-mapped.
+/// 2. Otherwise the repo-side component index is consulted for package-name
+///    aliases (e.g., `copilot-shell` → `cosh`) via in-memory lookup only —
+///    no rpmdb/dnf queries are triggered.
+/// 3. Falls back to the literal input when resolution is ambiguous or the
+///    component index is unavailable.
+pub(crate) fn lookup_component_name(
+    input: &str,
+    installed: &InstalledState,
+    ctx: &CliContext,
+    command: &str,
+) -> String {
+    // 1. Exact state match wins.
+    if installed
+        .find_object(ObjectKind::Component, input)
+        .is_some()
+    {
+        return input.to_string();
+    }
+
+    // 2. Try in-memory alias resolution via the repo-side component index.
+    let layout = resolve_layout(ctx);
+    let repo_config = load_repo_config(ctx, &layout, command, RepoPersistPolicy::BestEffort).ok();
+    let env = anolisa_env::EnvService::detect();
+    let component_index = repo_config
+        .as_ref()
+        .and_then(|cfg| crate::resolution::load_optional_component_index(&layout, &env, cfg));
+
+    crate::resolution::lookup_component_alias(input, component_index.as_ref())
+        .unwrap_or_else(|| input.to_string())
 }
 
 /// Path for the component manifest saved as part of an installed component's

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -69,6 +69,12 @@ pub(crate) fn adopt_with_query(
 
     let installed = common::load_installed_state(ctx, COMMAND)?;
 
+    // Resolve package aliases (e.g., "copilot-shell" → "cosh") before the
+    // tracked-component gate, so the ownership pre-check addresses the
+    // canonical state key.
+    let resolved = common::lookup_component_name(target, &installed, ctx, COMMAND);
+    let target = resolved.as_str();
+
     // Tracked-component gate (pre-lock fast-fail for a clear, early message).
     // Re-adopting a component that is already `rpm-observed` is a refresh and
     // falls through to execute_adopt, which upserts. A component owned under any

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/bug.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/bug.rs
@@ -107,8 +107,13 @@ fn build_payload(
     ctx: &CliContext,
 ) -> Result<BugReportPayload, CliError> {
     let environment = collect_environment(ctx);
-    let components = collect_components(component, ctx)?;
-    let recent_logs = collect_recent_logs(component, limit, ctx)?;
+    // Resolve component alias before filtering state and logs.
+    let resolved = component.map(|name| {
+        let state = common::load_installed_state(ctx, COMMAND).unwrap_or_default();
+        common::lookup_component_name(name, &state, ctx, COMMAND)
+    });
+    let components = collect_components(resolved.as_deref(), ctx)?;
+    let recent_logs = collect_recent_logs(resolved.as_deref(), limit, ctx)?;
     let markdown = render_markdown(&environment, &components, &recent_logs);
 
     Ok(BugReportPayload {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -185,18 +185,20 @@ fn diagnose(component: Option<&str>, ctx: &CliContext) -> Result<DoctorPayload, 
         }
     };
 
+    let rpm_query = RpmPackageQuery::system();
+    let component = component.map(|name| common::lookup_component_name(name, &state, ctx, COMMAND));
+
     let status_catalog = if ctx.dry_run { None } else { catalog.as_ref() };
     let records = status::select_components(
         &state,
         &layout,
         status_catalog,
         ctx.install_mode.as_str(),
-        component,
+        component.as_deref(),
         None,
     );
     let env = anolisa_env::EnvService::detect();
     let resolver_env = resolver_env_from_facts(&env);
-    let rpm_query = RpmPackageQuery::system();
     let system_service = service_for_install_mode(ctx.install_mode.as_str(), &env);
     let user_service = user_service_for_install_mode(ctx.install_mode.as_str(), &env);
     let probe_ctx = DoctorProbeContext {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -58,9 +58,11 @@ struct ForgetPayload {
 /// Returns [`CliError`] when the component is absent, still has enabled adapter
 /// receipts, or the state write fails.
 pub fn handle(args: ForgetArgs, ctx: &CliContext) -> Result<(), CliError> {
-    let target = args.component.as_str();
-    let command = format!("forget {target}");
+    let input = args.component.as_str();
+    let command = format!("forget {input}");
     let installed = common::load_installed_state(ctx, COMMAND)?;
+    let resolved = common::lookup_component_name(input, &installed, ctx, COMMAND);
+    let target = resolved.as_str();
 
     let obj = installed
         .find_object(ObjectKind::Component, target)
@@ -296,6 +298,7 @@ fn now_iso8601() -> String {
 mod tests {
     use super::*;
 
+    use std::fs;
     use std::path::PathBuf;
 
     use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus, DriverPayload, OpenClawClaim};
@@ -580,11 +583,79 @@ mod tests {
         );
     }
 
+    fn seed_component_index(ctx: &CliContext, index: &str) {
+        let layout = common::resolve_layout(ctx);
+        let repo_v1 = layout.prefix.join("repo").join("v1");
+        fs::create_dir_all(&repo_v1).expect("mkdir repo");
+        fs::write(repo_v1.join("components.toml"), index).expect("write components.toml");
+        fs::create_dir_all(&layout.etc_dir).expect("mkdir etc");
+        fs::write(
+            layout.etc_dir.join("repo.toml"),
+            format!(
+                "schema_version = 1\n\
+                 default_backend = \"raw\"\n\
+                 \n\
+                 [backends.raw]\n\
+                 base_url = \"file://{}\"\n",
+                repo_v1.display()
+            ),
+        )
+        .expect("write repo.toml");
+    }
+
     /// CLI surface: `forget <component>` parses to the positional.
     #[test]
     fn forget_parses_positional_component() {
         use clap::Parser as _;
         let a = ForgetArgs::try_parse_from(["forget", "copilot-shell"]).expect("parse");
         assert_eq!(a.component, "copilot-shell");
+    }
+
+    /// Forget by package alias (e.g., "copilot-shell") must resolve to the
+    /// canonical component name ("cosh") before addressing state.
+    #[test]
+    fn forget_via_package_alias_succeeds() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+
+        seed_component_index(
+            &c,
+            r#"
+schema_version = 1
+
+[[components]]
+name = "cosh"
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+legacy_adopt = true
+
+[[components.aliases]]
+kind = "rpm-package"
+name = "copilot-shell"
+"#,
+        );
+
+        seed(
+            &c,
+            vec![rpm_observed_object("cosh", "copilot-shell", "2.2.0-1.al8")],
+            Vec::new(),
+        );
+        let _snapshot_dir = seed_manifest_snapshot(&c, "cosh");
+
+        handle(
+            ForgetArgs {
+                component: "copilot-shell".to_string(),
+            },
+            &c,
+        )
+        .expect("forget via alias");
+
+        let after = load_state(&c);
+        assert!(
+            after.find_object(ObjectKind::Component, "cosh").is_none(),
+            "state record for 'cosh' must be dropped",
+        );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -699,6 +699,12 @@ fn handle_one_with_config(
 ) -> Result<InstallOutcome, CliError> {
     let command = format!("install {component}");
     let installed = common::load_installed_state(ctx, COMMAND)?;
+
+    // Resolve package aliases (e.g., "copilot-shell" → "cosh") before Layer 1
+    // backend selection, so ExistingState detection and compatibility checks
+    // use the canonical component name stored in state.
+    let component = common::lookup_component_name(&component, &installed, ctx, COMMAND);
+
     let mut rpm_component_index: Option<ComponentIndex> = None;
 
     // ── Layer 1: pick the backend name + its source (§4). ──

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/logs.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/logs.rs
@@ -14,7 +14,7 @@ use clap::Parser;
 use anolisa_core::{CentralLog, LogFilter, LogKind, LogRecord, Severity};
 
 use crate::color::{Palette, pad_right};
-use crate::commands::common::resolve_layout;
+use crate::commands::common;
 use crate::context::CliContext;
 use crate::response::{CliError, render_json};
 
@@ -54,9 +54,17 @@ pub struct LogsArgs {
     pub limit: Option<usize>,
 }
 
-pub fn handle(args: LogsArgs, ctx: &CliContext) -> Result<(), CliError> {
+pub fn handle(mut args: LogsArgs, ctx: &CliContext) -> Result<(), CliError> {
+    // Resolve component alias (e.g., "copilot-shell" → "cosh") before
+    // filtering — log records store the canonical component name.
+    if let Some(component) = args.component.take() {
+        let installed = common::load_installed_state(ctx, COMMAND).unwrap_or_default();
+        args.component = Some(common::lookup_component_name(
+            &component, &installed, ctx, COMMAND,
+        ));
+    }
     let filter = build_filter(&args)?;
-    let layout = resolve_layout(ctx);
+    let layout = common::resolve_layout(ctx);
     let log = CentralLog::open(layout.central_log.clone());
 
     let records = log

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 
 use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
 use anolisa_core::lock::InstallLock;
-use anolisa_core::state::{InstalledState, ObjectKind, OperationRecord, Ownership, RpmMetadata};
+use anolisa_core::state::{ObjectKind, OperationRecord, Ownership, RpmMetadata};
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
@@ -26,7 +26,7 @@ use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::CliContext;
-use crate::resolution::{ResolutionUse, load_optional_component_index, resolve_rpm_component_name};
+use crate::resolution::{ResolutionUse, load_optional_component_index};
 use crate::response::{CliError, render_json};
 
 /// Command label for JSON envelopes and error routing.
@@ -97,7 +97,7 @@ fn repair_with_query(
 
     let installed = common::load_installed_state(ctx, COMMAND)?;
 
-    let component = resolve_repair_component_name(target, &installed, ctx, query);
+    let component = common::lookup_component_name(target, &installed, ctx, COMMAND);
 
     let obj = installed
         .find_object(ObjectKind::Component, &component)
@@ -221,44 +221,6 @@ fn repair_with_query(
     };
     render_repair(ctx, &payload);
     Ok(())
-}
-
-/// Resolve a repair target to the state key used for the component.
-///
-/// Exact state names win because repair is fundamentally a state reconciliation
-/// command. If the state has no exact match, fall back to the same RPM component
-/// resolver used by install/adopt/status so package-name aliases such as
-/// `copilot-shell` can address the canonical `cosh` row.
-fn resolve_repair_component_name(
-    target: &str,
-    installed: &InstalledState,
-    ctx: &CliContext,
-    query: &dyn PackageQuery,
-) -> String {
-    if installed
-        .find_object(ObjectKind::Component, target)
-        .is_some()
-    {
-        return target.to_string();
-    }
-
-    let layout = common::resolve_layout(ctx);
-    let repo_config =
-        common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort).ok();
-    let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
-    let env = anolisa_env::EnvService::detect();
-    let component_index = repo_config
-        .as_ref()
-        .and_then(|cfg| load_optional_component_index(&layout, &env, cfg));
-
-    resolve_rpm_component_name(
-        target,
-        rpm_backend,
-        component_index.as_ref(),
-        query,
-        ResolutionUse::RepairLegacy,
-    )
-    .unwrap_or_else(|| target.to_string())
 }
 
 /// Resolve the RPM package name `repair` should reconcile against.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -72,13 +72,14 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         ),
     })?;
 
+    let resolved = common::lookup_component_name(&args.component, &state, ctx, &command);
+
     let comp = state
-        .find_object(ObjectKind::Component, &args.component)
+        .find_object(ObjectKind::Component, &resolved)
         .ok_or_else(|| CliError::InvalidArgument {
             command: command.clone(),
             reason: format!(
-                "component '{}' is not installed — nothing to restart (run `anolisa status` to see what is installed)",
-                args.component
+                "component '{resolved}' is not installed — nothing to restart (run `anolisa status` to see what is installed)"
             ),
         })?;
 
@@ -86,23 +87,20 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
     // ANOLISA drove activation) or from live `rpm -ql` discovery (RPM installs,
     // which record no services). Discovery may also return notes — e.g. a
     // template unit it cannot expand in this tier — which seed `warnings`.
-    let (units, mut warnings) = collect_restart_units(comp, &args.component)?;
+    let (units, mut warnings) = collect_restart_units(comp, &resolved)?;
 
     if units.is_empty() {
         if warnings.is_empty() {
             // Ships no service units at all → nothing to restart, a usage error.
             return Err(CliError::InvalidArgument {
                 command,
-                reason: format!(
-                    "component '{}' has no restartable systemd service units",
-                    args.component
-                ),
+                reason: format!("component '{resolved}' has no restartable systemd service units"),
             });
         }
         // Ships only template units whose instances are per-user runtime state
         // restart cannot choose. Not an error: the package is fine,
         // so exit 0 and surface the per-user guidance already collected.
-        return render_guidance_only(&args.component, install_mode, warnings, ctx);
+        return render_guidance_only(&resolved, install_mode, warnings, ctx);
     }
 
     let env = EnvService::detect();
@@ -211,7 +209,7 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     if ctx.json {
         let payload = RestartPayload {
-            component: args.component.clone(),
+            component: resolved.clone(),
             install_mode: install_mode.to_string(),
             manager: manager_label.clone(),
             supported,
@@ -223,7 +221,7 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     if !ctx.quiet {
         render_human(
-            &args.component,
+            &resolved,
             &manager_label,
             supported,
             &results,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -56,9 +56,7 @@ use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::{CliContext, InstallMode};
 use crate::repo_config::BackendConfig;
-use crate::resolution::{
-    ComponentIndex, ResolutionUse, load_optional_component_index, resolve_rpm_component_name,
-};
+use crate::resolution::{ComponentIndex, ResolutionUse, load_optional_component_index};
 use crate::response::{CliError, render_json};
 
 const COMMAND: &str = "status";
@@ -143,6 +141,14 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     let adapter_scan = common::build_adapter_manager(ctx).scan().ok();
 
     let query = RpmPackageQuery::system();
+    let selected_component = args
+        .component
+        .as_deref()
+        .map(|target| common::lookup_component_name(target, &state, ctx, COMMAND));
+
+    // repo_config / component_index are still needed for the observed-record
+    // probe below (system mode only). Name resolution above is handled by
+    // common::lookup_component_name which loads its own config.
     let repo_config = (ctx.install_mode == InstallMode::System && args.component.is_some())
         .then(|| {
             common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::BestEffort).ok()
@@ -153,13 +159,6 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     let component_index = repo_config
         .as_ref()
         .and_then(|cfg| load_optional_component_index(&layout, &env, cfg));
-    let selected_component = args.component.as_deref().map(|target| {
-        if ctx.install_mode == InstallMode::System {
-            status_lookup_name(target, rpm_backend, component_index.as_ref(), &query)
-        } else {
-            target.to_string()
-        }
-    });
 
     let mut records = select_components(
         &state,
@@ -201,26 +200,6 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
         render_human(&records, ctx.verbose, ctx.no_color);
     }
     Ok(())
-}
-
-/// Resolve a user-supplied status target to the stable component name before
-/// looking in ANOLISA state. RPM package aliases such as `copilot-shell` should
-/// display the tracked `cosh` row when one exists, not synthesize a separate
-/// read-only observed row.
-fn status_lookup_name(
-    input: &str,
-    rpm_backend: Option<&BackendConfig>,
-    component_index: Option<&ComponentIndex>,
-    query: &dyn PackageQuery,
-) -> String {
-    resolve_rpm_component_name(
-        input,
-        rpm_backend,
-        component_index,
-        query,
-        ResolutionUse::StatusObserved,
-    )
-    .unwrap_or_else(|| input.to_string())
 }
 
 /// Pure selector: project [`InstalledState`] down to component records,
@@ -1126,6 +1105,7 @@ fn adapter_state_label(adapter: &AdapterSummaryRecord) -> &'static str {
 mod tests {
     use super::*;
     use crate::repo_config::RepoConfig;
+    use crate::resolution::resolve_rpm_component_name;
     use anolisa_core::{
         FileOwner, HealthEntry, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
         OwnedFile, OwnedFileKind, SubscriptionScope,
@@ -2580,7 +2560,14 @@ name = "copilot-shell"
         let q = FakeQuery::default();
 
         assert_eq!(
-            status_lookup_name("copilot-shell", None, Some(&idx), &q),
+            resolve_rpm_component_name(
+                "copilot-shell",
+                None,
+                Some(&idx),
+                &q,
+                ResolutionUse::StatusObserved,
+            )
+            .unwrap_or_else(|| "copilot-shell".to_string()),
             "cosh"
         );
 
@@ -2590,12 +2577,20 @@ name = "copilot-shell"
             "2.6.0-1.alnx4",
             ObjectStatus::Installed,
         ));
+        let resolved = resolve_rpm_component_name(
+            "copilot-shell",
+            None,
+            Some(&idx),
+            &q,
+            ResolutionUse::StatusObserved,
+        )
+        .unwrap_or_else(|| "copilot-shell".to_string());
         let records = select_components(
             &state,
             &dummy_layout(),
             None,
             "system",
-            Some(&status_lookup_name("copilot-shell", None, Some(&idx), &q)),
+            Some(&resolved),
             None,
         );
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -122,13 +122,20 @@ pub(crate) fn handle_with_deps(
     } else {
         LifecycleOperation::Uninstall
     };
-    let target = args.component.as_str();
-    let command = format!("{} {}", operation.as_str(), target);
+    let input = args.component.as_str();
+    let command = format!("{} {}", operation.as_str(), input);
 
     // Load installed state to plan against. Missing state is the same
     // as "target not installed" — surface that as INVALID_ARGUMENT so
     // the user sees the right exit code.
     let installed = common::load_installed_state(ctx, COMMAND)?;
+
+    // Resolve package aliases (e.g., "copilot-shell" → "cosh") before
+    // addressing state, matching the resolution that `install` and
+    // `status` already perform. Falls back to the literal input when
+    // resolution is ambiguous or the component index is unavailable.
+    let resolved = common::lookup_component_name(input, &installed, ctx, COMMAND);
+    let target = resolved.as_str();
 
     // A name that only matches a legacy `kind = "capability"` row written
     // by an older release is not uninstallable — say so instead of a bare
@@ -1023,6 +1030,7 @@ mod tests {
 
     use crate::context::InstallMode;
     use std::cell::{Cell, RefCell};
+    use std::fs;
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -1713,6 +1721,26 @@ mod tests {
             anolisa_platform::fs_layout::FsLayout::provenance_path_for_snapshot(&snapshot);
         std::fs::write(provenance, "schema_version = 1\n").expect("write provenance");
         dir
+    }
+
+    fn seed_component_index(ctx: &CliContext, index: &str) {
+        let layout = common::resolve_layout(ctx);
+        let repo_v1 = layout.prefix.join("repo").join("v1");
+        fs::create_dir_all(&repo_v1).expect("mkdir repo");
+        fs::write(repo_v1.join("components.toml"), index).expect("write components.toml");
+        fs::create_dir_all(&layout.etc_dir).expect("mkdir etc");
+        fs::write(
+            layout.etc_dir.join("repo.toml"),
+            format!(
+                "schema_version = 1\n\
+                 default_backend = \"raw\"\n\
+                 \n\
+                 [backends.raw]\n\
+                 base_url = \"file://{}\"\n",
+                repo_v1.display()
+            ),
+        )
+        .expect("write repo.toml");
     }
 
     fn args_rm(component: &str) -> UninstallArgs {
@@ -2431,6 +2459,63 @@ mod tests {
             err.reason().contains("repair"),
             "must point at repair: {}",
             err.reason(),
+        );
+    }
+
+    /// Uninstall by package alias (e.g., "copilot-shell") must resolve to the
+    /// canonical component name ("cosh") before addressing state, matching the
+    /// resolution that `install` performs when recording the component.
+    #[test]
+    fn uninstall_rpm_observed_via_package_alias_succeeds() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+
+        seed_component_index(
+            &c,
+            r#"
+schema_version = 1
+
+[[components]]
+name = "cosh"
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+legacy_adopt = true
+
+[[components.aliases]]
+kind = "rpm-package"
+name = "copilot-shell"
+"#,
+        );
+
+        // State records the canonical name "cosh", not the package alias
+        // "copilot-shell" — this is what install writes after resolution.
+        seed(
+            &c,
+            vec![rpm_object("cosh", "copilot-shell", Ownership::RpmObserved)],
+            Vec::new(),
+        );
+        let _snapshot_dir = seed_manifest_snapshot(&c, "cosh");
+        let rpm = FakeRpm::present("copilot-shell");
+
+        // User types the alias, not the canonical name.
+        run(args("copilot-shell", false), &c, &rpm, true).expect("uninstall via alias");
+
+        assert_eq!(
+            rpm.remove_calls.get(),
+            0,
+            "rpm-observed default must not run dnf remove",
+        );
+        let after = load_state(&c);
+        assert!(
+            after.find_object(ObjectKind::Component, "cosh").is_none(),
+            "ANOLISA state record for 'cosh' must be dropped",
         );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -168,7 +168,9 @@ struct ComponentUpdatePayload {
 /// Dispatch `update <component>` through the recorded component ownership.
 fn handle_component_update(component: &str, ctx: &CliContext) -> Result<(), CliError> {
     let command = format!("update {component}");
-    let target = resolve_update_target(component, ctx, &command)?;
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+    let resolved = common::lookup_component_name(component, &installed, ctx, COMMAND);
+    let target = resolve_update_target(&resolved, ctx, &command)?;
     let layout = common::resolve_layout(ctx);
     let repo_config = common::load_repo_config(ctx, &layout, &command, RepoPersistPolicy::Require)?;
     match target {
@@ -177,7 +179,7 @@ fn handle_component_update(component: &str, ctx: &CliContext) -> Result<(), CliE
             from_version,
             recorded_package,
         } => update_raw_component_with_repo(
-            component,
+            &resolved,
             &backend_name,
             &from_version,
             recorded_package.as_deref(),
@@ -195,7 +197,7 @@ fn handle_component_update(component: &str, ctx: &CliContext) -> Result<(), CliE
             let query = RpmPackageQuery::system_with_repo(repo.clone());
             let txn = RpmTransaction::system_with_repo(repo);
             update_rpm_component(
-                component,
+                &resolved,
                 &package,
                 ownership,
                 ctx,

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -363,10 +363,10 @@ impl<'a> ComponentResolver<'a> {
 
 /// Resolve an RPM-oriented user input to a stable component name.
 ///
-/// This is a read-only projection used by commands that address existing state
-/// (`status`, `repair`) before they decide whether to query or mutate package
-/// metadata. Ambiguous or failed resolution returns `None` so callers can fall
-/// back to the literal input or their command-specific error.
+/// This is a read-only projection used by tests that need to exercise the full
+/// RPM resolution chain (component index + package_map + rpmdb provides).
+/// Production code uses [`lookup_component_alias`] which is in-memory only.
+#[cfg(test)]
 pub(crate) fn resolve_rpm_component_name(
     input: &str,
     rpm_backend: Option<&BackendConfig>,
@@ -378,6 +378,41 @@ pub(crate) fn resolve_rpm_component_name(
     match resolver.resolve(input, BackendKind::Rpm, use_case, ResolveOptions::default()) {
         Ok(ResolutionSet::Unique(target)) => Some(target.component),
         _ => None,
+    }
+}
+
+/// In-memory alias resolution only — no rpmdb/dnf queries.
+///
+/// Used by [`common::lookup_component_name`](crate::commands::common::lookup_component_name)
+/// for commands that address existing state. Checks the component index for
+/// component-name, backend-package, and alias matches across both RPM and Raw
+/// backends. Returns `None` when no match is found or the match is ambiguous
+/// (multiple distinct components share the same alias/package name) so the
+/// caller can fall back to the literal input.
+pub(crate) fn lookup_component_alias(
+    input: &str,
+    component_index: Option<&ComponentIndex>,
+) -> Option<String> {
+    let idx = component_index?;
+
+    // Collect unique component names from both backends. A single input
+    // may match across RPM and Raw backends (e.g., the component name plus
+    // an alias), but all matches must resolve to the same component — if two
+    // distinct components share the same alias/package name, the lookup is
+    // ambiguous and must not silently pick one.
+    let mut components: BTreeSet<String> = BTreeSet::new();
+    for target in idx.targets_for_backend(input, BackendKind::Rpm, "rpm-package") {
+        components.insert(target.component);
+    }
+    for target in idx.targets_for_backend(input, BackendKind::Raw, "raw-package") {
+        components.insert(target.component);
+    }
+
+    // Return only when the lookup resolves to exactly one unique component.
+    if components.len() == 1 {
+        components.into_iter().next()
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
## Description

`anolisa install copilot-shell` succeeds, but `anolisa uninstall copilot-shell` fails with "component not installed". The user must type the canonical name `anolisa uninstall cosh` to uninstall.

**Root cause:** `install` and `adopt` resolve user-supplied names through the repo-side component index (`components.toml`) before writing state — `copilot-shell` is resolved to the canonical component name `cosh`. However, 10 other commands that read state skip this resolution step entirely, passing the raw user input directly to `find_object`.

**Fix:** Add `lookup_component_name` to `commands/common.rs` as the single entry point for resolving user-supplied names to canonical component state keys. All 12 commands (install, adopt, uninstall, forget, update, restart, doctor, adapter, status, repair, logs, bug) now call it before addressing state.

The function uses `lookup_component_alias` (`resolution.rs`) for in-memory component index lookup only — no rpmdb/dnf queries. This prevents hangs on unknown component names that would otherwise trigger RPM provider lookups.

`repair` and `status` are refactored to use the shared function, eliminating duplicated config/index loading code (`resolve_repair_component_name` and `status_lookup_name` wrappers removed).

## Related Issue

closes #1272

## Ship Note

All commands that accept a component name argument now resolve package aliases (e.g., `copilot-shell` → `cosh`) before addressing installed state. Users can consistently address components by either their canonical name or any declared alias.

`status` no longer skips alias resolution in user mode — both system and user modes now resolve aliases uniformly.

The repo-side `components.toml` must declare aliases for the resolution to work. If an alias is missing from `components.toml`, the literal input is used (same as before).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli` (391 passed, 0 failed)
- `cargo doc --no-deps`
- End-to-end on remote environment: `anolisa install --backend rpm copilot-shell` then `anolisa uninstall copilot-shell` — verified alias resolution works across install/uninstall cycle
