### PR TITLE
fix(anolisa): distinguish missing from invalid manifest error

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -486,6 +486,7 @@ fn map_err(command: &str, err: AdapterError) -> CliError {
             reason: err.to_string(),
         },
         AdapterError::AdapterManifest { .. }
+        | AdapterError::MissingAdapterManifest { .. }
         | AdapterError::FrameworkCli { .. }
         | AdapterError::Lock(_)
         | AdapterError::State(_)
@@ -578,6 +579,32 @@ mod tests {
             },
         );
         assert!(matches!(err, CliError::Runtime { .. }));
+    }
+
+    #[test]
+    fn missing_manifest_maps_to_runtime_and_says_missing() {
+        let err = map_err(
+            "adapter enable",
+            AdapterError::MissingAdapterManifest {
+                component: "agent-memory".to_string(),
+                searched: vec![std::path::PathBuf::from(
+                    "/var/lib/anolisa/component-manifests/agent-memory/component.toml",
+                )],
+            },
+        );
+        match err {
+            CliError::Runtime { reason, .. } => {
+                assert!(
+                    reason.contains("missing"),
+                    "error should say 'missing', got: {reason}"
+                );
+                assert!(
+                    !reason.contains("invalid"),
+                    "error must not say 'invalid' for a missing file, got: {reason}"
+                );
+            }
+            other => panic!("expected Runtime, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -119,7 +119,10 @@ pub enum AdapterError {
     },
 
     /// The installed component manifest required by adapter enable is
-    /// missing, unreadable, or inconsistent with state.
+    /// present but unreadable, unparseable, or inconsistent with state.
+    ///
+    /// Contrast with [`MissingAdapterManifest`](Self::MissingAdapterManifest),
+    /// which is raised when *no* manifest file exists at any searched path.
     #[error("invalid installed component manifest for '{component}' at {path}: {reason}")]
     AdapterManifest {
         /// Component whose installed manifest was read.
@@ -128,6 +131,18 @@ pub enum AdapterError {
         path: PathBuf,
         /// Human-readable failure detail.
         reason: String,
+    },
+
+    /// No component manifest was found at the state snapshot path or under
+    /// any datadir root. This typically means the component's package (e.g.
+    /// RPM) did not ship a `component.toml`, so the install flow had nothing
+    /// to copy into the state directory.
+    #[error("missing installed component manifest for '{component}'; searched: {searched:?}")]
+    MissingAdapterManifest {
+        /// Component whose manifest was not found.
+        component: String,
+        /// Paths that were tried, in search order.
+        searched: Vec<PathBuf>,
     },
 
     /// No resource directory was found for the component/framework under

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -372,7 +372,8 @@ impl AdapterManager {
     /// # Errors
     ///
     /// [`AdapterError::ComponentNotInstalled`], [`AdapterError::AdapterNotDeclared`],
-    /// [`AdapterError::AdapterManifest`], [`AdapterError::UnknownFramework`],
+    /// [`AdapterError::AdapterManifest`], [`AdapterError::MissingAdapterManifest`],
+    /// [`AdapterError::UnknownFramework`],
     /// [`AdapterError::AmbiguousFramework`], [`AdapterError::UnsupportedAdapterType`],
     /// [`AdapterError::ResourceRootNotFound`],
     /// [`AdapterError::FrameworkNotDetected`], [`AdapterError::BundleInvalid`],
@@ -1668,10 +1669,9 @@ fn install_mode_str(mode: InstallMode) -> &'static str {
 fn map_contract_error(component: &str, err: super::contract::ContractError) -> AdapterError {
     match err {
         super::contract::ContractError::Unavailable { searched, .. } => {
-            AdapterError::AdapterManifest {
+            AdapterError::MissingAdapterManifest {
                 component: component.to_string(),
-                path: searched.into_iter().next().unwrap_or_default(),
-                reason: "component contract not found in the matched component scope".to_string(),
+                searched,
             }
         }
         super::contract::ContractError::ParseError { path, reason } => {


### PR DESCRIPTION
## Description

`anolisa adapter enable` reported "invalid installed component manifest"
even when the manifest file did not exist at all. The word "invalid"
implies the file is present but malformed, misleading users into
checking file contents instead of verifying the package payload.

This PR adds a `MissingAdapterManifest` variant to `AdapterError` for
the case where no `component.toml` is found at any searched path.
`map_contract_error` now routes `ContractError::Unavailable` to the new
"missing" variant, while `ParseError` and `Io` keep the existing
"invalid" wording. The new error also lists all searched paths to
accelerate diagnosis.

Before:
```
"reason": "invalid installed component manifest for 'agent-memory' at
/var/lib/anolisa/component-manifests/agent-memory/component.toml:
component contract not found in the matched component scope"
```

After:
```
"reason": "missing installed component manifest for 'agent-memory';
searched: [\"/var/lib/anolisa/component-manifests/agent-memory/component.toml\",
\"/usr/share/anolisa/components/agent-memory/component.toml\"]"
```

## Related Issue

Refs #1288

## Ship Note

`adapter enable` now distinguishes "missing" (file absent) from
"invalid" (file present but unparseable) in its error message. The
exit code and error class (`EXECUTION_FAILED`) remain unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p anolisa-core -- adapter::`
- `cargo test -p anolisa-cli -- adapter::`
- `cargo doc --no-deps`
