### PR TITLE
feat(anolisa): list command local-aware summary with bounded rpmdb probe

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -4,16 +4,26 @@
 //! merges install status from `installed.toml`, and renders as a human
 //! table or `--json` envelope.
 
-use anolisa_core::state::{InstalledState, ObjectKind};
+mod render;
+mod state_view;
+
+#[cfg(test)]
+mod tests;
+
+use anolisa_core::state::InstalledState;
+use anolisa_platform::pkg_query::PackageQuery;
+use anolisa_platform::rpm_query::RpmPackageQuery;
 use clap::Parser;
 use serde::Serialize;
 
-use crate::color::{Palette, pad_right};
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
-use crate::context::CliContext;
+use crate::context::{CliContext, InstallMode};
 use crate::resolution::{ComponentIndex, ComponentIndexEntry, load_component_index};
 use crate::response::{CliError, render_json};
+
+use self::render::render_human;
+use self::state_view::{LocalProjection, project_component};
 
 const COMMAND: &str = "list";
 
@@ -33,6 +43,17 @@ pub struct Row {
     pub summary: String,
     pub backends: Vec<String>,
     pub status: String,
+    pub local_state: String,
+    pub ownership: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpm_package: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpm_evr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpm_arch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpm_source_repo: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -55,7 +76,16 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
         })?;
 
     let state = common::load_installed_state(ctx, COMMAND)?;
-    let rows = build_rows(&index, &args, &state);
+    let rpm_query = match ctx.install_mode {
+        InstallMode::System => Some(RpmPackageQuery::system()),
+        InstallMode::User => None,
+    };
+    let rows = build_rows(
+        &index,
+        &args,
+        &state,
+        rpm_query.as_ref().map(|query| query as &dyn PackageQuery),
+    );
 
     if ctx.json {
         return render_json(COMMAND, ListPayload { components: rows });
@@ -67,21 +97,30 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
     Ok(())
 }
 
-fn build_rows(index: &ComponentIndex, args: &ListArgs, state: &InstalledState) -> Vec<Row> {
+fn build_rows(
+    index: &ComponentIndex,
+    args: &ListArgs,
+    state: &InstalledState,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> Vec<Row> {
     index
         .components
         .iter()
-        .map(|entry| entry_to_row(entry, state))
-        .filter(|row| !args.installed || common::status_is_enabled(&row.status))
+        .filter_map(|entry| {
+            let projection = project_component(entry, state, rpm_query);
+            if args.installed && !projection.local_state.matches_installed_filter() {
+                return None;
+            }
+            Some(entry_to_row(entry, projection))
+        })
         .collect()
 }
 
-fn entry_to_row(entry: &ComponentIndexEntry, state: &InstalledState) -> Row {
+fn entry_to_row(entry: &ComponentIndexEntry, projection: LocalProjection) -> Row {
     let backends: Vec<String> = entry.backends.iter().map(|b| b.kind.clone()).collect();
-    let status = state
-        .find_object(ObjectKind::Component, &entry.name)
-        .map(|obj| common::object_status_str(obj.status))
-        .unwrap_or("not_installed");
+    let local_state = projection.local_state.label().to_string();
+    let ownership = projection.ownership_label().to_string();
+    let action = projection.action_label().to_string();
     Row {
         name: entry.name.clone(),
         display_name: entry
@@ -90,349 +129,13 @@ fn entry_to_row(entry: &ComponentIndexEntry, state: &InstalledState) -> Row {
             .unwrap_or_else(|| entry.name.clone()),
         summary: entry.summary.clone().unwrap_or_default(),
         backends,
-        status: status.to_string(),
-    }
-}
-
-fn render_human(rows: &[Row], no_color: bool) {
-    let color = Palette::new(no_color);
-    if rows.is_empty() {
-        println!("{}", color.muted("no components found"));
-        return;
-    }
-
-    let name_width = rows.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4) + 2;
-    let summary_width = rows
-        .iter()
-        .map(|r| r.summary.chars().count())
-        .max()
-        .unwrap_or(7)
-        .clamp(7, 50)
-        + 2;
-    let backends_width = rows
-        .iter()
-        .map(|r| {
-            if r.backends.is_empty() {
-                1
-            } else {
-                r.backends.join(",").len()
-            }
-        })
-        .max()
-        .unwrap_or(8)
-        .max(8)
-        + 2;
-
-    println!(
-        "{}",
-        color.header(format!(
-            "{:<name_width$}{:<summary_width$}{:<backends_width$}{}",
-            "NAME", "SUMMARY", "BACKENDS", "STATUS",
-        ))
-    );
-    for row in rows {
-        let backend_str = if row.backends.is_empty() {
-            "-".to_string()
-        } else {
-            row.backends.join(",")
-        };
-        let max_chars = summary_width - 2;
-        let summary = if row.summary.chars().count() > max_chars {
-            let truncated: String = row.summary.chars().take(max_chars - 1).collect();
-            format!("{truncated}…")
-        } else {
-            row.summary.clone()
-        };
-        println!(
-            "{:<name_width$}{:<summary_width$}{:<backends_width$}{}",
-            row.name,
-            summary,
-            backend_str,
-            color.status(pad_right(&row.status, 14)),
-        );
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::resolution::ComponentBackendEntry;
-    use anolisa_core::state::{InstalledObject, ObjectStatus};
-
-    fn sample_index() -> ComponentIndex {
-        ComponentIndex {
-            schema_version: 1,
-            generated_at: None,
-            publisher: Some("anolisa".to_string()),
-            components: vec![
-                ComponentIndexEntry {
-                    name: "agentsight".to_string(),
-                    display_name: Some("AgentSight".to_string()),
-                    summary: Some("eBPF-based AI agent observability tool".to_string()),
-                    backends: vec![
-                        ComponentBackendEntry {
-                            kind: "raw".to_string(),
-                            package: "agentsight".to_string(),
-                            provides: None,
-                            legacy_adopt: false,
-                        },
-                        ComponentBackendEntry {
-                            kind: "rpm".to_string(),
-                            package: "agentsight".to_string(),
-                            provides: Some("anolisa-component(agentsight)".to_string()),
-                            legacy_adopt: true,
-                        },
-                    ],
-                    aliases: Vec::new(),
-                },
-                ComponentIndexEntry {
-                    name: "tokenless".to_string(),
-                    display_name: Some("Tokenless".to_string()),
-                    summary: Some("LLM token optimization toolkit".to_string()),
-                    backends: vec![ComponentBackendEntry {
-                        kind: "raw".to_string(),
-                        package: "tokenless".to_string(),
-                        provides: None,
-                        legacy_adopt: false,
-                    }],
-                    aliases: Vec::new(),
-                },
-            ],
-        }
-    }
-
-    fn empty_state() -> InstalledState {
-        InstalledState::default()
-    }
-
-    fn state_with_object(kind: ObjectKind, name: &str, status: ObjectStatus) -> InstalledState {
-        let mut state = InstalledState::default();
-        state.objects.push(InstalledObject {
-            kind,
-            name: name.to_string(),
-            version: "0.1.0".to_string(),
-            status,
-            manifest_digest: None,
-            distribution_source: None,
-            raw_package: None,
-            install_backend: None,
-            ownership: None,
-            rpm_metadata: None,
-            installed_at: "2026-06-12T00:00:00Z".to_string(),
-            last_operation_id: None,
-            managed: true,
-            adopted: false,
-            subscription_scope: Default::default(),
-            enabled_features: Vec::new(),
-            component_refs: Vec::new(),
-            files: Vec::new(),
-            external_modified_files: Vec::new(),
-            services: Vec::new(),
-            health: Vec::new(),
-            provisioned_packages: Vec::new(),
-        });
-        state
-    }
-
-    #[test]
-    fn index_builds_rows() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = empty_state();
-        let rows = build_rows(&index, &args, &state);
-        assert_eq!(rows.len(), 2);
-
-        let sight = &rows[0];
-        assert_eq!(sight.name, "agentsight");
-        assert_eq!(sight.display_name, "AgentSight");
-        assert_eq!(sight.summary, "eBPF-based AI agent observability tool");
-        assert_eq!(sight.backends, vec!["raw", "rpm"]);
-        assert_eq!(sight.status, "not_installed");
-
-        let token = &rows[1];
-        assert_eq!(token.name, "tokenless");
-        assert_eq!(token.backends, vec!["raw"]);
-    }
-
-    #[test]
-    fn empty_state_all_not_installed() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = empty_state();
-        let rows = build_rows(&index, &args, &state);
-        for row in &rows {
-            assert_eq!(row.status, "not_installed");
-        }
-    }
-
-    #[test]
-    fn installed_component_shows_installed() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
-        let rows = build_rows(&index, &args, &state);
-
-        let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
-        assert_eq!(sight.status, "not_installed");
-
-        let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
-        assert_eq!(token.status, "installed");
-    }
-
-    #[test]
-    fn adopted_rpm_component_shows_adopted() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
-        let rows = build_rows(&index, &args, &state);
-
-        let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
-        assert_eq!(sight.status, "adopted");
-    }
-
-    #[test]
-    fn adapter_object_does_not_mark_component_installed() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = state_with_object(ObjectKind::Adapter, "tokenless", ObjectStatus::Installed);
-        let rows = build_rows(&index, &args, &state);
-        let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
-        assert_eq!(token.status, "not_installed");
-    }
-
-    #[test]
-    fn failed_component_shows_failed() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Failed);
-        let rows = build_rows(&index, &args, &state);
-        let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
-        assert_eq!(token.status, "failed");
-    }
-
-    #[test]
-    fn disabled_component_shows_disabled() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Disabled);
-        let rows = build_rows(&index, &args, &state);
-        let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
-        assert_eq!(token.status, "disabled");
-    }
-
-    #[test]
-    fn installed_filter_returns_only_installed() {
-        let index = sample_index();
-        let args = ListArgs { installed: true };
-        let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
-        let rows = build_rows(&index, &args, &state);
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].name, "tokenless");
-        assert_eq!(rows[0].status, "installed");
-    }
-
-    #[test]
-    fn installed_filter_includes_adopted_rpm_components() {
-        let index = sample_index();
-        let args = ListArgs { installed: true };
-        let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
-        let rows = build_rows(&index, &args, &state);
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].name, "agentsight");
-        assert_eq!(rows[0].status, "adopted");
-    }
-
-    #[test]
-    fn installed_filter_with_empty_state_returns_empty() {
-        let index = sample_index();
-        let args = ListArgs { installed: true };
-        let state = empty_state();
-        let rows = build_rows(&index, &args, &state);
-        assert!(rows.is_empty());
-    }
-
-    #[test]
-    fn json_payload_uses_components_key() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = empty_state();
-        let rows = build_rows(&index, &args, &state);
-        let payload = ListPayload { components: rows };
-        let json_str = serde_json::to_string(&payload).expect("serialize");
-        let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
-        assert!(val.get("components").is_some());
-    }
-
-    #[test]
-    fn json_payload_status_reflects_install_state() {
-        let index = sample_index();
-        let args = ListArgs { installed: false };
-        let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Installed);
-        let rows = build_rows(&index, &args, &state);
-        let payload = ListPayload { components: rows };
-        let json_str = serde_json::to_string(&payload).expect("serialize");
-        let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
-        let components = val["components"].as_array().unwrap();
-        let sight = components
-            .iter()
-            .find(|c| c["name"] == "agentsight")
-            .unwrap();
-        assert_eq!(sight["status"], "installed");
-        let token = components
-            .iter()
-            .find(|c| c["name"] == "tokenless")
-            .unwrap();
-        assert_eq!(token["status"], "not_installed");
-    }
-
-    #[test]
-    fn missing_optional_fields_use_defaults() {
-        let index = ComponentIndex {
-            schema_version: 1,
-            generated_at: None,
-            publisher: None,
-            components: vec![ComponentIndexEntry {
-                name: "minimal".to_string(),
-                display_name: None,
-                summary: None,
-                backends: Vec::new(),
-                aliases: Vec::new(),
-            }],
-        };
-        let args = ListArgs { installed: false };
-        let state = empty_state();
-        let rows = build_rows(&index, &args, &state);
-        assert_eq!(rows.len(), 1);
-        let row = &rows[0];
-        assert_eq!(row.name, "minimal");
-        assert_eq!(row.display_name, "minimal");
-        assert!(row.summary.is_empty());
-        assert!(row.backends.is_empty());
-        assert_eq!(row.status, "not_installed");
-    }
-
-    #[test]
-    fn unknown_backend_kind_preserved() {
-        let index = ComponentIndex {
-            schema_version: 1,
-            generated_at: None,
-            publisher: None,
-            components: vec![ComponentIndexEntry {
-                name: "test".to_string(),
-                display_name: None,
-                summary: None,
-                backends: vec![ComponentBackendEntry {
-                    kind: "custom-repo".to_string(),
-                    package: "test".to_string(),
-                    provides: None,
-                    legacy_adopt: false,
-                }],
-                aliases: Vec::new(),
-            }],
-        };
-        let args = ListArgs { installed: false };
-        let state = empty_state();
-        let rows = build_rows(&index, &args, &state);
-        assert_eq!(rows[0].backends, vec!["custom-repo"]);
+        status: projection.status,
+        local_state,
+        ownership,
+        action,
+        rpm_package: projection.rpm_package,
+        rpm_evr: projection.rpm_evr,
+        rpm_arch: projection.rpm_arch,
+        rpm_source_repo: projection.rpm_source_repo,
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
@@ -1,0 +1,90 @@
+use crate::color::{Palette, pad_right};
+use crate::commands::tier1::list::Row;
+
+pub(super) fn human_header(rows: &[Row]) -> String {
+    let widths = HumanWidths::for_rows(rows);
+    format!(
+        "{:<name_width$}{:<backends_width$}{:<local_state_width$}{:<ownership_width$}{}",
+        "NAME",
+        "BACKENDS",
+        "LOCAL STATE",
+        "OWNERSHIP",
+        "ACTION",
+        name_width = widths.name,
+        backends_width = widths.backends,
+        local_state_width = widths.local_state,
+        ownership_width = widths.ownership,
+    )
+}
+
+struct HumanWidths {
+    name: usize,
+    backends: usize,
+    local_state: usize,
+    ownership: usize,
+}
+
+impl HumanWidths {
+    fn for_rows(rows: &[Row]) -> Self {
+        Self {
+            name: rows.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4) + 4,
+            backends: rows
+                .iter()
+                .map(|r| {
+                    if r.backends.is_empty() {
+                        1
+                    } else {
+                        r.backends.join(",").len()
+                    }
+                })
+                .max()
+                .unwrap_or(8)
+                .max(8)
+                + 4,
+            local_state: rows
+                .iter()
+                .map(|r| r.local_state.len())
+                .max()
+                .unwrap_or(11)
+                .max(11)
+                + 4,
+            ownership: rows
+                .iter()
+                .map(|r| r.ownership.len())
+                .max()
+                .unwrap_or(9)
+                .max(9)
+                + 4,
+        }
+    }
+}
+
+pub(super) fn render_human(rows: &[Row], no_color: bool) {
+    let color = Palette::new(no_color);
+    if rows.is_empty() {
+        println!("{}", color.muted("no components found"));
+        return;
+    }
+
+    let widths = HumanWidths::for_rows(rows);
+
+    println!("{}", color.header(human_header(rows)));
+    for row in rows {
+        let backend_str = if row.backends.is_empty() {
+            "-".to_string()
+        } else {
+            row.backends.join(",")
+        };
+        println!(
+            "{:<name_width$}{:<backends_width$}{}{:<ownership_width$}{}",
+            row.name,
+            backend_str,
+            pad_right(color.status(&row.local_state), widths.local_state),
+            row.ownership,
+            row.action,
+            name_width = widths.name,
+            backends_width = widths.backends,
+            ownership_width = widths.ownership,
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/state_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/state_view.rs
@@ -1,0 +1,283 @@
+use anolisa_core::state::{InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership};
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
+
+use crate::commands::common;
+use crate::resolution::ComponentIndexEntry;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LocalState {
+    Observed,
+    Tracked,
+    Installed,
+    Drifted,
+    Missing,
+    Failed,
+    Degraded,
+    Disabled,
+    NotInstalled,
+}
+
+impl LocalState {
+    pub(super) const fn label(self) -> &'static str {
+        match self {
+            Self::Observed => "observed",
+            Self::Tracked => "tracked",
+            Self::Installed => "installed",
+            Self::Drifted => "drifted",
+            Self::Missing => "missing",
+            Self::Failed => "failed",
+            Self::Degraded => "degraded",
+            Self::Disabled => "disabled",
+            Self::NotInstalled => "not_installed",
+        }
+    }
+
+    pub(super) const fn matches_installed_filter(self) -> bool {
+        match self {
+            Self::Observed | Self::Tracked | Self::Installed | Self::Degraded => true,
+            Self::Drifted | Self::Missing | Self::Failed | Self::Disabled | Self::NotInstalled => {
+                false
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListAction {
+    Install,
+    Status,
+}
+
+impl ListAction {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Install => "install",
+            Self::Status => "status",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LocalProjection {
+    pub(super) backend: Option<String>,
+    pub(super) local_state: LocalState,
+    pub(super) ownership: Option<Ownership>,
+    action: ListAction,
+    pub(super) status: String,
+    pub(super) rpm_package: Option<String>,
+    pub(super) rpm_evr: Option<String>,
+    pub(super) rpm_arch: Option<String>,
+    pub(super) rpm_source_repo: Option<String>,
+}
+
+impl LocalProjection {
+    #[cfg(test)]
+    pub(super) const fn local_state_label(&self) -> &'static str {
+        self.local_state.label()
+    }
+
+    pub(super) fn ownership_label(&self) -> &'static str {
+        match self.ownership {
+            Some(o) => o.label(),
+            // Observed RPMs are owned by the package manager even though
+            // ANOLISA has not claimed any ownership yet.
+            None if self.local_state == LocalState::Observed => "rpm",
+            None => "none",
+        }
+    }
+
+    pub(super) const fn action_label(&self) -> &'static str {
+        self.action.label()
+    }
+}
+
+pub(super) fn project_component(
+    entry: &ComponentIndexEntry,
+    state: &InstalledState,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> LocalProjection {
+    match state.find_object(ObjectKind::Component, &entry.name) {
+        Some(object) => project_tracked_object(object, rpm_query),
+        None => project_untracked_entry(entry, rpm_query),
+    }
+}
+
+fn project_untracked_entry(
+    entry: &ComponentIndexEntry,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> LocalProjection {
+    match observed_rpm_info(entry, rpm_query) {
+        Some(info) => projection_from_observed_rpm(info),
+        None => LocalProjection {
+            backend: None,
+            local_state: LocalState::NotInstalled,
+            ownership: None,
+            action: ListAction::Install,
+            status: "not_installed".to_string(),
+            rpm_package: None,
+            rpm_evr: None,
+            rpm_arch: None,
+            rpm_source_repo: None,
+        },
+    }
+}
+
+fn project_tracked_object(
+    object: &InstalledObject,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> LocalProjection {
+    let ownership = object.effective_ownership();
+    let base_state = tracked_state_without_rpm_drift(object.status, ownership);
+    let local_state = match base_state {
+        LocalState::Installed | LocalState::Tracked => {
+            rpm_drift_state(object, rpm_query).unwrap_or(base_state)
+        }
+        LocalState::Observed
+        | LocalState::Drifted
+        | LocalState::Missing
+        | LocalState::Failed
+        | LocalState::Degraded
+        | LocalState::Disabled
+        | LocalState::NotInstalled => base_state,
+    };
+    let rpm_info = object.rpm_metadata.as_ref();
+
+    LocalProjection {
+        backend: Some(backend_label_for_ownership(ownership).to_string()),
+        local_state,
+        ownership: Some(ownership),
+        action: ListAction::Status,
+        status: common::object_status_str(object.status).to_string(),
+        rpm_package: rpm_info.map(|meta| meta.package_name.clone()),
+        rpm_evr: rpm_info.and_then(|meta| meta.evr.clone()),
+        rpm_arch: rpm_info.and_then(|meta| meta.arch.clone()),
+        rpm_source_repo: rpm_info.and_then(|meta| meta.source_repo.clone()),
+    }
+}
+
+fn tracked_state_without_rpm_drift(status: ObjectStatus, ownership: Ownership) -> LocalState {
+    match status {
+        ObjectStatus::Installed => match ownership {
+            Ownership::RawManaged | Ownership::RpmManaged => LocalState::Installed,
+            Ownership::RpmObserved => LocalState::Tracked,
+        },
+        ObjectStatus::Partial => LocalState::Degraded,
+        ObjectStatus::Disabled => LocalState::Disabled,
+        ObjectStatus::Failed => LocalState::Failed,
+        ObjectStatus::Adopted => match ownership {
+            Ownership::RawManaged | Ownership::RpmManaged => LocalState::Installed,
+            Ownership::RpmObserved => LocalState::Tracked,
+        },
+    }
+}
+
+fn backend_label_for_ownership(ownership: Ownership) -> &'static str {
+    match ownership {
+        Ownership::RawManaged => "raw",
+        Ownership::RpmManaged | Ownership::RpmObserved => "rpm",
+    }
+}
+
+fn rpm_drift_state(
+    object: &InstalledObject,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> Option<LocalState> {
+    let metadata = object.rpm_metadata.as_ref()?;
+    let query = rpm_query?;
+    match query.query_installed(&metadata.package_name) {
+        Ok(Some(info)) => {
+            let live_evr = info.version.to_string();
+            let evr_drifted = metadata.evr.as_deref().is_some_and(|evr| evr != live_evr);
+            let arch_drifted = metadata
+                .arch
+                .as_deref()
+                .is_some_and(|arch| arch != info.arch);
+            if evr_drifted || arch_drifted {
+                Some(LocalState::Drifted)
+            } else {
+                None
+            }
+        }
+        Ok(None) => Some(LocalState::Missing),
+        Err(PackageQueryError::CommandMissing { .. })
+        | Err(PackageQueryError::PermissionDenied { .. })
+        | Err(PackageQueryError::QueryFailed { .. })
+        | Err(PackageQueryError::UnexpectedOutput { .. }) => None,
+    }
+}
+
+fn observed_rpm_info(
+    entry: &ComponentIndexEntry,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> Option<PackageInfo> {
+    let query = rpm_query?;
+
+    // 1. Probe RPM backend package names.
+    for backend in entry.backends.iter().filter(|b| b.kind == "rpm") {
+        if let Some(info) = safe_query_installed(query, &backend.package) {
+            return Some(info);
+        }
+    }
+
+    // 2. Probe RPM package aliases (alternate historical names).
+    for alias in entry.aliases.iter().filter(|a| a.kind == "rpm-package") {
+        if let Some(info) = safe_query_installed(query, &alias.name) {
+            return Some(info);
+        }
+    }
+
+    // 3. Fallback: use `what_provides` for backends that declare a Provides
+    //    capability. This catches legacy RPMs whose package name differs from
+    //    the index entry but still declares `anolisa-component(<name>)`.
+    for backend in entry.backends.iter().filter(|b| b.kind == "rpm") {
+        let Some(capability) = backend.provides.as_deref().filter(|p| !p.is_empty()) else {
+            continue;
+        };
+        if let Some(info) = safe_what_provides(query, capability) {
+            return Some(info);
+        }
+    }
+
+    None
+}
+
+/// Query an installed package, treating all errors as "not found" so the list
+/// command degrades gracefully when `rpm`/`dnf` is absent or the query fails.
+fn safe_query_installed(query: &dyn PackageQuery, package: &str) -> Option<PackageInfo> {
+    match query.query_installed(package) {
+        Ok(Some(mut info)) => {
+            if info.origin.is_none() {
+                info.origin = query.installed_origin(&info.name).ok().flatten();
+            }
+            Some(info)
+        }
+        Ok(None) => None,
+        Err(_) => None,
+    }
+}
+
+/// Resolve a capability to a single installed package via `what_provides`,
+/// then fetch its full info. Returns `None` for zero or ambiguous (>1)
+/// providers so the list summary never picks an arbitrary package.
+fn safe_what_provides(query: &dyn PackageQuery, capability: &str) -> Option<PackageInfo> {
+    let names = query.what_provides_installed(capability).ok()?;
+    if names.len() == 1 {
+        safe_query_installed(query, &names[0])
+    } else {
+        None
+    }
+}
+
+fn projection_from_observed_rpm(info: PackageInfo) -> LocalProjection {
+    LocalProjection {
+        backend: Some("rpm".to_string()),
+        local_state: LocalState::Observed,
+        ownership: None,
+        action: ListAction::Install,
+        status: "not_installed".to_string(),
+        rpm_package: Some(info.name),
+        rpm_evr: Some(info.version.to_string()),
+        rpm_arch: Some(info.arch),
+        rpm_source_repo: info.origin,
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests.rs
@@ -1,0 +1,6 @@
+mod compatibility;
+mod output;
+mod projection;
+mod projection_tracked;
+mod rows;
+mod support;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
@@ -1,0 +1,223 @@
+use anolisa_core::state::{ObjectKind, ObjectStatus};
+
+use crate::commands::tier1::list::{ListArgs, ListPayload, build_rows};
+use crate::resolution::{ComponentBackendEntry, ComponentIndex, ComponentIndexEntry};
+
+use super::support::{empty_state, sample_index, state_with_object};
+
+#[test]
+fn index_builds_rows() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = empty_state();
+    let rows = build_rows(&index, &args, &state, None);
+    assert_eq!(rows.len(), 2);
+
+    let sight = &rows[0];
+    assert_eq!(sight.name, "agentsight");
+    assert_eq!(sight.display_name, "AgentSight");
+    assert_eq!(sight.summary, "eBPF-based AI agent observability tool");
+    assert_eq!(sight.backends, vec!["raw", "rpm"]);
+    assert_eq!(sight.status, "not_installed");
+
+    let token = &rows[1];
+    assert_eq!(token.name, "tokenless");
+    assert_eq!(token.backends, vec!["raw"]);
+}
+
+#[test]
+fn empty_state_all_not_installed() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = empty_state();
+    let rows = build_rows(&index, &args, &state, None);
+    for row in &rows {
+        assert_eq!(row.status, "not_installed");
+        assert_eq!(row.local_state, "not_installed");
+    }
+}
+
+#[test]
+fn installed_component_shows_installed() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
+    let rows = build_rows(&index, &args, &state, None);
+
+    let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
+    assert_eq!(sight.status, "not_installed");
+
+    let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
+    assert_eq!(token.status, "installed");
+}
+
+#[test]
+fn adopted_rpm_component_shows_adopted() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
+    let rows = build_rows(&index, &args, &state, None);
+
+    let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
+    assert_eq!(sight.status, "adopted");
+}
+
+#[test]
+fn compatibility_status_labels_are_preserved_before_local_projection() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
+
+    let rows = build_rows(&index, &args, &state, None);
+
+    let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
+    assert_eq!(sight.status, "adopted");
+    let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
+    assert_eq!(token.status, "not_installed");
+}
+
+#[test]
+fn adapter_object_does_not_mark_component_installed() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_object(ObjectKind::Adapter, "tokenless", ObjectStatus::Installed);
+    let rows = build_rows(&index, &args, &state, None);
+    let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
+    assert_eq!(token.status, "not_installed");
+}
+
+#[test]
+fn failed_component_shows_failed() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Failed);
+    let rows = build_rows(&index, &args, &state, None);
+    let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
+    assert_eq!(token.status, "failed");
+}
+
+#[test]
+fn disabled_component_shows_disabled() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Disabled);
+    let rows = build_rows(&index, &args, &state, None);
+    let token = rows.iter().find(|r| r.name == "tokenless").unwrap();
+    assert_eq!(token.status, "disabled");
+}
+
+#[test]
+fn installed_filter_returns_only_installed() {
+    let index = sample_index();
+    let args = ListArgs { installed: true };
+    let state = state_with_object(ObjectKind::Component, "tokenless", ObjectStatus::Installed);
+    let rows = build_rows(&index, &args, &state, None);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "tokenless");
+    assert_eq!(rows[0].status, "installed");
+}
+
+#[test]
+fn installed_filter_includes_adopted_rpm_components() {
+    let index = sample_index();
+    let args = ListArgs { installed: true };
+    let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Adopted);
+    let rows = build_rows(&index, &args, &state, None);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "agentsight");
+    assert_eq!(rows[0].status, "adopted");
+}
+
+#[test]
+fn installed_filter_with_empty_state_returns_empty() {
+    let index = sample_index();
+    let args = ListArgs { installed: true };
+    let state = empty_state();
+    let rows = build_rows(&index, &args, &state, None);
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn json_payload_uses_components_key() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = empty_state();
+    let rows = build_rows(&index, &args, &state, None);
+    let payload = ListPayload { components: rows };
+    let json_str = serde_json::to_string(&payload).expect("serialize");
+    let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
+    assert!(val.get("components").is_some());
+}
+
+#[test]
+fn json_payload_status_reflects_install_state() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Installed);
+    let rows = build_rows(&index, &args, &state, None);
+    let payload = ListPayload { components: rows };
+    let json_str = serde_json::to_string(&payload).expect("serialize");
+    let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
+    let components = val["components"].as_array().unwrap();
+    let sight = components
+        .iter()
+        .find(|c| c["name"] == "agentsight")
+        .unwrap();
+    assert_eq!(sight["status"], "installed");
+    let token = components
+        .iter()
+        .find(|c| c["name"] == "tokenless")
+        .unwrap();
+    assert_eq!(token["status"], "not_installed");
+}
+
+#[test]
+fn missing_optional_fields_use_defaults() {
+    let index = ComponentIndex {
+        schema_version: 1,
+        generated_at: None,
+        publisher: None,
+        components: vec![ComponentIndexEntry {
+            name: "minimal".to_string(),
+            display_name: None,
+            summary: None,
+            backends: Vec::new(),
+            aliases: Vec::new(),
+        }],
+    };
+    let args = ListArgs { installed: false };
+    let state = empty_state();
+    let rows = build_rows(&index, &args, &state, None);
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.name, "minimal");
+    assert_eq!(row.display_name, "minimal");
+    assert!(row.summary.is_empty());
+    assert!(row.backends.is_empty());
+    assert_eq!(row.status, "not_installed");
+}
+
+#[test]
+fn unknown_backend_kind_preserved() {
+    let index = ComponentIndex {
+        schema_version: 1,
+        generated_at: None,
+        publisher: None,
+        components: vec![ComponentIndexEntry {
+            name: "test".to_string(),
+            display_name: None,
+            summary: None,
+            backends: vec![ComponentBackendEntry {
+                kind: "custom-repo".to_string(),
+                package: "test".to_string(),
+                provides: None,
+                legacy_adopt: false,
+            }],
+            aliases: Vec::new(),
+        }],
+    };
+    let args = ListArgs { installed: false };
+    let state = empty_state();
+    let rows = build_rows(&index, &args, &state, None);
+    assert_eq!(rows[0].backends, vec!["custom-repo"]);
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
@@ -1,0 +1,68 @@
+use anolisa_core::state::InstalledState;
+
+use crate::commands::tier1::list::render::human_header;
+use crate::commands::tier1::list::{ListArgs, ListPayload, Row, build_rows};
+
+use super::support::{FakeRpmQuery, pkg_info, sample_index};
+
+#[test]
+fn row_json_retains_status_and_adds_local_fields() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = InstalledState::default();
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "agentsight".to_string(),
+            pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+    let rows = build_rows(&index, &args, &state, Some(&query));
+    let payload = ListPayload { components: rows };
+
+    let json_str = serde_json::to_string(&payload).expect("serialize");
+    let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
+    let sight = val["components"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|component| component["name"] == "agentsight")
+        .unwrap();
+
+    assert_eq!(sight["status"], "not_installed");
+    assert_eq!(sight["local_state"], "observed");
+    assert_eq!(sight["ownership"], "rpm");
+    assert_eq!(sight["action"], "install");
+}
+
+#[test]
+fn human_header_contains_local_state() {
+    let rows = vec![Row {
+        name: "agentsight".to_string(),
+        display_name: "AgentSight".to_string(),
+        summary: "observability".to_string(),
+        backends: vec!["rpm".to_string()],
+        status: "not_installed".to_string(),
+        local_state: "observed".to_string(),
+        ownership: "none".to_string(),
+        action: "install".to_string(),
+        rpm_package: Some("agentsight".to_string()),
+        rpm_evr: Some("1.2.3-1.al8".to_string()),
+        rpm_arch: Some("x86_64".to_string()),
+        rpm_source_repo: Some("@System".to_string()),
+    }];
+
+    assert!(human_header(&rows).contains("LOCAL STATE"));
+}
+
+#[test]
+fn list_clap_surface_has_no_catalog_or_tracked_args() {
+    use crate::commands::Cli;
+    use clap::CommandFactory;
+
+    let help = Cli::command().render_long_help().to_string();
+
+    assert!(!help.contains("--catalog"));
+    assert!(!help.contains("--tracked"));
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/projection.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/projection.rs
@@ -1,0 +1,257 @@
+use anolisa_core::state::{InstalledState, ObjectStatus, Ownership};
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
+
+use super::support::{
+    FakeRpmQuery, component_object, pkg_info, projection_for, projection_for_index,
+    rpm_component_object, sample_index_with_aliases, state_with_component_object,
+};
+
+#[test]
+fn local_projection_labels_cover_list_states() {
+    let empty = InstalledState::default();
+    let absent_query = FakeRpmQuery::default();
+    let observed_query = FakeRpmQuery {
+        installed: vec![(
+            "agentsight".to_string(),
+            pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+
+    let observed = projection_for("agentsight", &empty, &observed_query);
+    assert_eq!(observed.local_state_label(), "observed");
+
+    let tracked = projection_for(
+        "agentsight",
+        &state_with_component_object(rpm_component_object(
+            "agentsight",
+            ObjectStatus::Adopted,
+            Ownership::RpmObserved,
+            "agentsight",
+            "1.2.3-1.al8",
+        )),
+        &observed_query,
+    );
+    assert_eq!(tracked.local_state_label(), "tracked");
+
+    let installed = projection_for(
+        "tokenless",
+        &state_with_component_object(component_object(
+            "tokenless",
+            ObjectStatus::Installed,
+            Ownership::RawManaged,
+        )),
+        &absent_query,
+    );
+    assert_eq!(installed.local_state_label(), "installed");
+
+    let drifted = projection_for(
+        "agentsight",
+        &state_with_component_object(rpm_component_object(
+            "agentsight",
+            ObjectStatus::Installed,
+            Ownership::RpmManaged,
+            "agentsight",
+            "1.2.3-1.al8",
+        )),
+        &FakeRpmQuery {
+            installed: vec![(
+                "agentsight".to_string(),
+                pkg_info("agentsight", "2.0.0", Some("1.al8"), "x86_64"),
+            )],
+            command_missing: false,
+            what_provides: Vec::new(),
+        },
+    );
+    assert_eq!(drifted.local_state_label(), "drifted");
+
+    let missing = projection_for(
+        "agentsight",
+        &state_with_component_object(rpm_component_object(
+            "agentsight",
+            ObjectStatus::Installed,
+            Ownership::RpmManaged,
+            "agentsight",
+            "1.2.3-1.al8",
+        )),
+        &absent_query,
+    );
+    assert_eq!(missing.local_state_label(), "missing");
+
+    let failed = projection_for(
+        "tokenless",
+        &state_with_component_object(component_object(
+            "tokenless",
+            ObjectStatus::Failed,
+            Ownership::RawManaged,
+        )),
+        &absent_query,
+    );
+    assert_eq!(failed.local_state_label(), "failed");
+
+    let degraded = projection_for(
+        "tokenless",
+        &state_with_component_object(component_object(
+            "tokenless",
+            ObjectStatus::Partial,
+            Ownership::RawManaged,
+        )),
+        &absent_query,
+    );
+    assert_eq!(degraded.local_state_label(), "degraded");
+
+    let disabled = projection_for(
+        "tokenless",
+        &state_with_component_object(component_object(
+            "tokenless",
+            ObjectStatus::Disabled,
+            Ownership::RawManaged,
+        )),
+        &absent_query,
+    );
+    assert_eq!(disabled.local_state_label(), "disabled");
+
+    let not_installed = projection_for("tokenless", &empty, &absent_query);
+    assert_eq!(not_installed.local_state_label(), "not_installed");
+}
+
+#[test]
+fn untracked_observed_rpm_projection_uses_rpm_backend_rpm_ownership_and_install_action() {
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "agentsight".to_string(),
+            pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+
+    let projection = projection_for("agentsight", &InstalledState::default(), &query);
+
+    assert_eq!(projection.local_state_label(), "observed");
+    assert_eq!(projection.backend.as_deref(), Some("rpm"));
+    assert_eq!(projection.ownership_label(), "rpm");
+    assert_eq!(projection.action_label(), "install");
+    assert_eq!(projection.rpm_package.as_deref(), Some("agentsight"));
+    assert_eq!(projection.status, "not_installed");
+}
+
+#[test]
+fn untracked_observed_rpm_projection_fetches_source_repo_when_installed_info_has_no_origin() {
+    struct OriginQuery;
+
+    impl PackageQuery for OriginQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            assert_eq!(package, "agentsight");
+            let mut info = pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64");
+            info.origin = None;
+            Ok(Some(info))
+        }
+
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+
+        fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+            assert_eq!(package, "agentsight");
+            Ok(Some("alinux3-plus".to_string()))
+        }
+    }
+
+    let projection = projection_for("agentsight", &InstalledState::default(), &OriginQuery);
+
+    assert_eq!(projection.local_state_label(), "observed");
+    assert_eq!(projection.rpm_source_repo.as_deref(), Some("alinux3-plus"));
+}
+
+#[test]
+fn rpm_query_command_missing_keeps_state_index_projection() {
+    let query = FakeRpmQuery {
+        installed: Vec::new(),
+        command_missing: true,
+        what_provides: Vec::new(),
+    };
+
+    let projection = projection_for("agentsight", &InstalledState::default(), &query);
+
+    assert_eq!(projection.local_state_label(), "not_installed");
+    assert_eq!(projection.backend, None);
+    assert_eq!(projection.ownership_label(), "none");
+    assert_eq!(projection.action_label(), "install");
+    assert_eq!(projection.status, "not_installed");
+}
+
+#[test]
+fn observed_rpm_found_via_alias_when_backend_package_not_installed() {
+    let index = sample_index_with_aliases();
+    // Backend package "copilot-shell" is not installed; alias "cosh-old" is.
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "cosh-old".to_string(),
+            pkg_info("cosh-old", "1.0.0", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+
+    let projection = projection_for_index(&index, "cosh", &InstalledState::default(), &query);
+
+    assert_eq!(projection.local_state_label(), "observed");
+    assert_eq!(projection.ownership_label(), "rpm");
+    assert_eq!(projection.action_label(), "install");
+    assert_eq!(projection.rpm_package.as_deref(), Some("cosh-old"));
+}
+
+#[test]
+fn observed_rpm_found_via_provides_when_no_direct_match() {
+    let index = sample_index_with_aliases();
+    // Neither backend package nor alias is installed, but a package providing
+    // `anolisa-component(cosh)` exists in rpmdb.
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "cosh-legacy".to_string(),
+            pkg_info("cosh-legacy", "0.9.0", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: vec![(
+            "anolisa-component(cosh)".to_string(),
+            vec!["cosh-legacy".to_string()],
+        )],
+    };
+
+    let projection = projection_for_index(&index, "cosh", &InstalledState::default(), &query);
+
+    assert_eq!(projection.local_state_label(), "observed");
+    assert_eq!(projection.ownership_label(), "rpm");
+    assert_eq!(projection.action_label(), "install");
+    assert_eq!(projection.rpm_package.as_deref(), Some("cosh-legacy"));
+}
+
+#[test]
+fn observed_rpm_provides_with_ambiguous_providers_is_not_observed() {
+    let index = sample_index_with_aliases();
+    // Two packages provide the same capability — list must not pick one.
+    let query = FakeRpmQuery {
+        installed: vec![
+            (
+                "cosh-legacy".to_string(),
+                pkg_info("cosh-legacy", "0.9.0", Some("1.al8"), "x86_64"),
+            ),
+            (
+                "cosh-vendor".to_string(),
+                pkg_info("cosh-vendor", "1.0.0", Some("1.al8"), "x86_64"),
+            ),
+        ],
+        command_missing: false,
+        what_provides: vec![(
+            "anolisa-component(cosh)".to_string(),
+            vec!["cosh-legacy".to_string(), "cosh-vendor".to_string()],
+        )],
+    };
+
+    let projection = projection_for_index(&index, "cosh", &InstalledState::default(), &query);
+
+    assert_eq!(projection.local_state_label(), "not_installed");
+    assert_eq!(projection.ownership_label(), "none");
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/projection_tracked.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/projection_tracked.rs
@@ -1,0 +1,85 @@
+use anolisa_core::state::{ObjectStatus, Ownership};
+
+use super::support::{
+    FakeRpmQuery, pkg_info, projection_for, rpm_component_object, state_with_component_object,
+};
+
+#[test]
+fn tracked_rpm_observed_projection_keeps_compatibility_status_available() {
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "agentsight".to_string(),
+            pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+    let state = state_with_component_object(rpm_component_object(
+        "agentsight",
+        ObjectStatus::Adopted,
+        Ownership::RpmObserved,
+        "agentsight",
+        "1.2.3-1.al8",
+    ));
+
+    let projection = projection_for("agentsight", &state, &query);
+
+    assert_eq!(projection.local_state_label(), "tracked");
+    assert_eq!(projection.ownership_label(), "rpm-observed");
+    assert_eq!(projection.action_label(), "status");
+    assert_eq!(projection.status, "adopted");
+}
+
+#[test]
+fn tracked_rpm_observed_projection_surfaces_rpm_drift_and_missing() {
+    let state = state_with_component_object(rpm_component_object(
+        "agentsight",
+        ObjectStatus::Adopted,
+        Ownership::RpmObserved,
+        "agentsight",
+        "1.2.3-1.al8",
+    ));
+
+    let drifted = projection_for(
+        "agentsight",
+        &state,
+        &FakeRpmQuery {
+            installed: vec![(
+                "agentsight".to_string(),
+                pkg_info("agentsight", "2.0.0", Some("1.al8"), "x86_64"),
+            )],
+            command_missing: false,
+            what_provides: Vec::new(),
+        },
+    );
+    assert_eq!(drifted.local_state_label(), "drifted");
+    assert_eq!(drifted.status, "adopted");
+
+    let missing = projection_for("agentsight", &state, &FakeRpmQuery::default());
+    assert_eq!(missing.local_state_label(), "missing");
+    assert_eq!(missing.status, "adopted");
+}
+
+#[test]
+fn tracked_rpm_problem_states_do_not_run_drift_probe() {
+    let query = FakeRpmQuery::default();
+    let cases = [
+        (ObjectStatus::Failed, "failed"),
+        (ObjectStatus::Partial, "degraded"),
+        (ObjectStatus::Disabled, "disabled"),
+    ];
+
+    for (status, expected_state) in cases {
+        let state = state_with_component_object(rpm_component_object(
+            "agentsight",
+            status,
+            Ownership::RpmObserved,
+            "agentsight",
+            "1.2.3-1.al8",
+        ));
+
+        let projection = projection_for("agentsight", &state, &query);
+
+        assert_eq!(projection.local_state_label(), expected_state);
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/rows.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/rows.rs
@@ -1,0 +1,249 @@
+use anolisa_core::state::{InstalledState, ObjectStatus, Ownership};
+
+use crate::commands::tier1::list::{ListArgs, build_rows};
+
+use super::support::{
+    FakeRpmQuery, component_object, pkg_info, rpm_component_object, sample_index,
+    state_with_component_object,
+};
+
+#[test]
+fn rows_use_local_projection_for_untracked_observed_rpm() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = InstalledState::default();
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "agentsight".to_string(),
+            pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+
+    let rows = build_rows(&index, &args, &state, Some(&query));
+
+    let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
+    assert_eq!(sight.status, "not_installed");
+    assert_eq!(sight.local_state, "observed");
+    assert_eq!(sight.ownership, "rpm");
+    assert_eq!(sight.action, "install");
+}
+
+#[test]
+fn rows_without_rpm_query_do_not_surface_observed_system_rpms() {
+    let index = sample_index();
+    let state = InstalledState::default();
+
+    let all_rows = build_rows(&index, &ListArgs { installed: false }, &state, None);
+    let sight = all_rows.iter().find(|r| r.name == "agentsight").unwrap();
+    assert_eq!(sight.local_state, "not_installed");
+    assert_eq!(sight.ownership, "none");
+    assert_eq!(sight.rpm_package, None);
+
+    let installed_rows = build_rows(&index, &ListArgs { installed: true }, &state, None);
+    assert!(installed_rows.is_empty());
+}
+
+#[test]
+fn rows_ignore_rpm_query_failures() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = InstalledState::default();
+    let query = FakeRpmQuery {
+        installed: Vec::new(),
+        command_missing: true,
+        what_provides: Vec::new(),
+    };
+
+    let rows = build_rows(&index, &args, &state, Some(&query));
+
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|row| row.local_state == "not_installed"));
+}
+
+#[test]
+fn rows_use_status_action_for_tracked_rpm_observed_state() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_component_object(rpm_component_object(
+        "agentsight",
+        ObjectStatus::Adopted,
+        Ownership::RpmObserved,
+        "agentsight",
+        "1.2.3-1.al8",
+    ));
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "agentsight".to_string(),
+            pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+
+    let rows = build_rows(&index, &args, &state, Some(&query));
+
+    let sight = rows.iter().find(|r| r.name == "agentsight").unwrap();
+    assert_eq!(sight.status, "adopted");
+    assert_eq!(sight.local_state, "tracked");
+    assert_eq!(sight.ownership, "rpm-observed");
+    assert_eq!(sight.action, "status");
+}
+
+#[test]
+fn rows_project_raw_and_rpm_managed_state_as_installed() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let query = FakeRpmQuery {
+        installed: vec![(
+            "agentsight".to_string(),
+            pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+        )],
+        command_missing: false,
+        what_provides: Vec::new(),
+    };
+
+    let raw_state = state_with_component_object(component_object(
+        "tokenless",
+        ObjectStatus::Installed,
+        Ownership::RawManaged,
+    ));
+    let raw_rows = build_rows(&index, &args, &raw_state, Some(&query));
+    let token = raw_rows.iter().find(|r| r.name == "tokenless").unwrap();
+    assert_eq!(token.local_state, "installed");
+    assert_eq!(token.ownership, "raw-managed");
+
+    let rpm_state = state_with_component_object(rpm_component_object(
+        "agentsight",
+        ObjectStatus::Installed,
+        Ownership::RpmManaged,
+        "agentsight",
+        "1.2.3-1.al8",
+    ));
+    let rpm_rows = build_rows(&index, &args, &rpm_state, Some(&query));
+    let sight = rpm_rows.iter().find(|r| r.name == "agentsight").unwrap();
+    assert_eq!(sight.local_state, "installed");
+    assert_eq!(sight.ownership, "rpm-managed");
+}
+
+#[test]
+fn rows_surface_rpm_drift_and_missing() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = state_with_component_object(rpm_component_object(
+        "agentsight",
+        ObjectStatus::Installed,
+        Ownership::RpmManaged,
+        "agentsight",
+        "1.2.3-1.al8",
+    ));
+
+    let drifted_rows = build_rows(
+        &index,
+        &args,
+        &state,
+        Some(&FakeRpmQuery {
+            installed: vec![(
+                "agentsight".to_string(),
+                pkg_info("agentsight", "2.0.0", Some("1.al8"), "x86_64"),
+            )],
+            command_missing: false,
+            what_provides: Vec::new(),
+        }),
+    );
+    let drifted = drifted_rows
+        .iter()
+        .find(|r| r.name == "agentsight")
+        .unwrap();
+    assert_eq!(drifted.local_state, "drifted");
+
+    let missing_rows = build_rows(&index, &args, &state, Some(&FakeRpmQuery::default()));
+    let missing = missing_rows
+        .iter()
+        .find(|r| r.name == "agentsight")
+        .unwrap();
+    assert_eq!(missing.local_state, "missing");
+}
+
+#[test]
+fn installed_filter_keeps_only_currently_installed_local_states() {
+    let index = sample_index();
+    let args = ListArgs { installed: true };
+
+    let observed_rows = build_rows(
+        &index,
+        &args,
+        &InstalledState::default(),
+        Some(&FakeRpmQuery {
+            installed: vec![(
+                "agentsight".to_string(),
+                pkg_info("agentsight", "1.2.3", Some("1.al8"), "x86_64"),
+            )],
+            command_missing: false,
+            what_provides: Vec::new(),
+        }),
+    );
+    assert_eq!(
+        observed_rows
+            .iter()
+            .map(|row| row.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["agentsight"]
+    );
+
+    let included_cases = [
+        (ObjectStatus::Installed, Ownership::RawManaged, "installed"),
+        (ObjectStatus::Adopted, Ownership::RpmObserved, "tracked"),
+        (ObjectStatus::Partial, Ownership::RawManaged, "degraded"),
+    ];
+    for (status, ownership, expected_state) in included_cases {
+        let state = state_with_component_object(component_object("tokenless", status, ownership));
+        let rows = build_rows(&index, &args, &state, Some(&FakeRpmQuery::default()));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].local_state, expected_state);
+    }
+
+    for status in [ObjectStatus::Failed, ObjectStatus::Disabled] {
+        let state = state_with_component_object(component_object(
+            "tokenless",
+            status,
+            Ownership::RawManaged,
+        ));
+        let rows = build_rows(&index, &args, &state, Some(&FakeRpmQuery::default()));
+        assert!(rows.is_empty());
+    }
+
+    let rpm_state = state_with_component_object(rpm_component_object(
+        "agentsight",
+        ObjectStatus::Installed,
+        Ownership::RpmManaged,
+        "agentsight",
+        "1.2.3-1.al8",
+    ));
+    let drifted_rows = build_rows(
+        &index,
+        &args,
+        &rpm_state,
+        Some(&FakeRpmQuery {
+            installed: vec![(
+                "agentsight".to_string(),
+                pkg_info("agentsight", "2.0.0", Some("1.al8"), "x86_64"),
+            )],
+            command_missing: false,
+            what_provides: Vec::new(),
+        }),
+    );
+    assert!(drifted_rows.is_empty());
+
+    let missing_rows = build_rows(&index, &args, &rpm_state, Some(&FakeRpmQuery::default()));
+    assert!(missing_rows.is_empty());
+
+    let empty_rows = build_rows(
+        &index,
+        &args,
+        &InstalledState::default(),
+        Some(&FakeRpmQuery::default()),
+    );
+    assert!(empty_rows.is_empty());
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
@@ -1,0 +1,257 @@
+use anolisa_core::state::{
+    InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership, RpmMetadata,
+};
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError, PackageVersion};
+
+use crate::commands::tier1::list::state_view::{self, LocalProjection};
+use crate::resolution::{
+    ComponentAliasEntry, ComponentBackendEntry, ComponentIndex, ComponentIndexEntry,
+};
+
+pub(super) fn sample_index() -> ComponentIndex {
+    ComponentIndex {
+        schema_version: 1,
+        generated_at: None,
+        publisher: Some("anolisa".to_string()),
+        components: vec![
+            ComponentIndexEntry {
+                name: "agentsight".to_string(),
+                display_name: Some("AgentSight".to_string()),
+                summary: Some("eBPF-based AI agent observability tool".to_string()),
+                backends: vec![
+                    ComponentBackendEntry {
+                        kind: "raw".to_string(),
+                        package: "agentsight".to_string(),
+                        provides: None,
+                        legacy_adopt: false,
+                    },
+                    ComponentBackendEntry {
+                        kind: "rpm".to_string(),
+                        package: "agentsight".to_string(),
+                        provides: Some("anolisa-component(agentsight)".to_string()),
+                        legacy_adopt: true,
+                    },
+                ],
+                aliases: Vec::new(),
+            },
+            ComponentIndexEntry {
+                name: "tokenless".to_string(),
+                display_name: Some("Tokenless".to_string()),
+                summary: Some("LLM token optimization toolkit".to_string()),
+                backends: vec![ComponentBackendEntry {
+                    kind: "raw".to_string(),
+                    package: "tokenless".to_string(),
+                    provides: None,
+                    legacy_adopt: false,
+                }],
+                aliases: Vec::new(),
+            },
+        ],
+    }
+}
+
+pub(super) fn empty_state() -> InstalledState {
+    InstalledState::default()
+}
+
+pub(super) fn state_with_object(
+    kind: ObjectKind,
+    name: &str,
+    status: ObjectStatus,
+) -> InstalledState {
+    let mut state = InstalledState::default();
+    state.objects.push(InstalledObject {
+        kind,
+        name: name.to_string(),
+        version: "0.1.0".to_string(),
+        status,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: None,
+        ownership: None,
+        rpm_metadata: None,
+        installed_at: "2026-06-12T00:00:00Z".to_string(),
+        last_operation_id: None,
+        managed: true,
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    });
+    state
+}
+
+pub(super) fn state_with_component_object(mut object: InstalledObject) -> InstalledState {
+    let mut state = InstalledState::default();
+    object.kind = ObjectKind::Component;
+    state.objects.push(object);
+    state
+}
+
+pub(super) fn component_object(
+    name: &str,
+    status: ObjectStatus,
+    ownership: Ownership,
+) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: name.to_string(),
+        version: "0.1.0".to_string(),
+        status,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some(if ownership.is_rpm() { "rpm" } else { "raw" }.to_string()),
+        ownership: Some(ownership),
+        rpm_metadata: None,
+        installed_at: "2026-06-12T00:00:00Z".to_string(),
+        last_operation_id: None,
+        managed: ownership.owns_removal(),
+        adopted: ownership == Ownership::RpmObserved,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
+pub(super) fn rpm_component_object(
+    name: &str,
+    status: ObjectStatus,
+    ownership: Ownership,
+    package: &str,
+    evr: &str,
+) -> InstalledObject {
+    let mut object = component_object(name, status, ownership);
+    object.rpm_metadata = Some(RpmMetadata {
+        package_name: package.to_string(),
+        evr: Some(evr.to_string()),
+        arch: Some("x86_64".to_string()),
+        source_repo: Some("@System".to_string()),
+    });
+    object
+}
+
+#[derive(Default)]
+pub(super) struct FakeRpmQuery {
+    pub(super) installed: Vec<(String, PackageInfo)>,
+    pub(super) command_missing: bool,
+    pub(super) what_provides: Vec<(String, Vec<String>)>,
+}
+
+impl PackageQuery for FakeRpmQuery {
+    fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+        if self.command_missing {
+            return Err(PackageQueryError::CommandMissing {
+                command: "rpm".to_string(),
+            });
+        }
+        Ok(self
+            .installed
+            .iter()
+            .find(|(name, _)| name == package)
+            .map(|(_, info)| info.clone()))
+    }
+
+    fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+        Ok(Vec::new())
+    }
+
+    fn what_provides_installed(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        if self.command_missing {
+            return Err(PackageQueryError::CommandMissing {
+                command: "rpm".to_string(),
+            });
+        }
+        Ok(self
+            .what_provides
+            .iter()
+            .find(|(cap, _)| cap == capability)
+            .map(|(_, names)| names.clone())
+            .unwrap_or_default())
+    }
+}
+
+pub(super) fn pkg_info(
+    name: &str,
+    version: &str,
+    release: Option<&str>,
+    arch: &str,
+) -> PackageInfo {
+    PackageInfo {
+        name: name.to_string(),
+        version: PackageVersion {
+            epoch: None,
+            version: version.to_string(),
+            release: release.map(str::to_string),
+        },
+        arch: arch.to_string(),
+        origin: Some("@System".to_string()),
+    }
+}
+
+pub(super) fn projection_for(
+    component: &str,
+    state: &InstalledState,
+    query: &dyn PackageQuery,
+) -> LocalProjection {
+    let index = sample_index();
+    projection_for_index(&index, component, state, query)
+}
+
+pub(super) fn projection_for_index(
+    index: &ComponentIndex,
+    component: &str,
+    state: &InstalledState,
+    query: &dyn PackageQuery,
+) -> LocalProjection {
+    let entry = index
+        .components
+        .iter()
+        .find(|entry| entry.name == component)
+        .unwrap();
+    state_view::project_component(entry, state, Some(query))
+}
+
+/// A component whose RPM backend package name differs from the component name,
+/// with an rpm-package alias — mirrors the real `cosh` / `copilot-shell` mapping.
+pub(super) fn sample_index_with_aliases() -> ComponentIndex {
+    ComponentIndex {
+        schema_version: 1,
+        generated_at: None,
+        publisher: Some("anolisa".to_string()),
+        components: vec![ComponentIndexEntry {
+            name: "cosh".to_string(),
+            display_name: Some("Copilot Shell".to_string()),
+            summary: Some("shell".to_string()),
+            backends: vec![
+                ComponentBackendEntry {
+                    kind: "raw".to_string(),
+                    package: "cosh".to_string(),
+                    provides: None,
+                    legacy_adopt: false,
+                },
+                ComponentBackendEntry {
+                    kind: "rpm".to_string(),
+                    package: "copilot-shell".to_string(),
+                    provides: Some("anolisa-component(cosh)".to_string()),
+                    legacy_adopt: true,
+                },
+            ],
+            aliases: vec![ComponentAliasEntry {
+                kind: "rpm-package".to_string(),
+                name: "cosh-old".to_string(),
+            }],
+        }],
+    }
+}


### PR DESCRIPTION
## Description

Adds local-aware summary columns to `anolisa list`, based on `docs/cli_state_commands_proposed.md` §3. The list command now performs a bounded rpmdb probe so users can see mirror-preinstalled or admin-preinstalled ANOLISA RPM components even when `installed.toml` has no record.

Behavior:

- New columns: `LOCAL STATE`, `OWNERSHIP`, `ACTION` (replacing the old `SUMMARY`/`STATUS` table).
- Row states: `not_installed`, `observed`, `tracked`, `installed`, `drifted`, `missing`, `failed`, `degraded`, `disabled`.
- `observed` = rpmdb has the package but ANOLISA state has no record; ownership shows `rpm` (package manager owns files); action is `install`.
- Bounded rpmdb probe covers three stages: RPM backend package names → rpm-package aliases → `whatprovides` capability lookup for legacy-adoptable components.
- `list` stays read-only: no state writes, no dnf/rpm transactions, no auto-track.
- JSON output preserves the `status` field for backward compatibility and adds `local_state`, `ownership`, `action`, and optional `rpm_package`/`rpm_evr`/`rpm_arch`/`rpm_source_repo`.
- Table column alignment fixed for ANSI color codes (pad colored strings via `measure_text_width`).

## Design Note

The state projection logic lives in `state_view.rs`, separated from rendering (`render.rs`) and the handler (`list.rs`). `LocalProjection` is the intermediate struct that maps `InstalledState` + component index + rpmdb probe into user-facing row fields.

The OWNERSHIP column for `observed` state shows `rpm` rather than `none`: the package manager owns file transactions even though ANOLISA has not claimed ownership. This is a display-level concern — the core `Ownership` enum is unchanged (`None` in state means "ANOLISA has not claimed ownership").

The provides-based probe (`what_provides_installed`) returns `None` for zero or ambiguous (>1) providers so the list summary never picks an arbitrary package. Detailed resolution is left to `status`.

## Ship Note

- Source repo enrichment for observed RPMs is deferred: `query_installed` returns `origin: None`, so `rpm_source_repo` is `None` for observed state in JSON. The `status` command already populates this via `installed_origin()`.
- The `--installed` filter now uses `local_state != not_installed` instead of the old `status_is_enabled` check, so `observed` components appear with `--installed`.

## Test

- Unit (projection): all 9 local states covered; observed via direct package, alias, and provides; ambiguous providers → not_installed; command-missing → graceful degradation.
- Unit (rows): observed/tracked/installed/drifted/missing row assertions; `--installed` filter semantics; rpm query failure tolerance.
- Unit (output): JSON retains `status` + adds local fields; human header contains `LOCAL STATE`; no `--catalog`/`--tracked` args.
- Unit (compatibility): all pre-existing list tests pass unchanged (using `None` rpm_query).
- Full gate green: `cargo fmt --all -- --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test -p anolisa-cli` (408 passed).