### PR TITLE
fix(skillfs): add CLI SLS ops logging

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -24,11 +24,11 @@ use skillfs_fuse::security::{
     DEFAULT_RELOAD_INTERVAL_MS, DEFAULT_RELOAD_TIMEOUT_MS, DecisionCommand,
     InstallerStagingController, JsonlProtocolEventWriter, JsonlSecurityEventWriter, LedgerAdapter,
     LedgerBackingRoot, NoopProtocolEventWriter, NoopSecurityEventWriter, NotifyController,
-    ProtocolEventWriter, RefreshController, ReloadMode, RuntimeDecisionOutcome, SecurityConfig,
-    SecurityEventWriter, SecurityModeConfig, SessionStatsWriter, SkillfsSessionStats,
-    SourceDriftObserver, StagingMatcher, TrustedPeerConfig, TrustedWriterConfig,
-    UnixSocketNotifyClient, bootstrap_activation, resolve_events_path,
-    resolve_protocol_events_path, spawn_drift_watcher,
+    ProtocolEventWriter, RefreshController, ReloadMode, RuntimeDecisionOutcome, RuntimeMetricsSink,
+    RuntimeMetricsWriter, SecurityConfig, SecurityEventWriter, SecurityModeConfig,
+    SessionStatsWriter, SkillfsSessionStats, SourceDriftObserver, StagingMatcher,
+    TrustedPeerConfig, TrustedWriterConfig, UnixSocketNotifyClient, bootstrap_activation,
+    resolve_events_path, resolve_protocol_events_path, spawn_drift_watcher,
 };
 use skillfs_fuse::{FuseError as FuseErr, MountConfig, MountOptions, mount_configured};
 use tokio::signal;
@@ -1978,6 +1978,9 @@ async fn cmd_mount(
 
     // --- Session stats: create collector before mount starts ---
     let session_stats = Arc::new(SkillfsSessionStats::new());
+    // Captured for the runtime `view_pruned` metric event (emitted below).
+    let runtime_pruned_skill_count: u64;
+    let runtime_token_saved_estimate: u64;
     {
         // Load ViewsConfig once; derive all metrics from a single canonical set.
         let store_guard = shared_store.read();
@@ -2008,6 +2011,7 @@ async fn cmd_mount(
 
         let default_exposed_count = default_served.len() as u64;
         session_stats.set_skill_counts(total_skills, default_exposed_count);
+        runtime_pruned_skill_count = total_skills.saturating_sub(default_exposed_count);
 
         // prompt_token_saved_estimate: body chars of pruned skills / 4.
         // Pruned = in store but NOT in default_served.
@@ -2027,6 +2031,7 @@ async fn cmd_mount(
             0
         };
         session_stats.set_prompt_token_saved_estimate(token_estimate);
+        runtime_token_saved_estimate = token_estimate;
 
         // V1 skill_hit_times: default-view served skills (deduplicated).
         for name in &default_served {
@@ -2075,10 +2080,24 @@ async fn cmd_mount(
         std::env::var("ANOLISA_AGENT_NAME").unwrap_or_else(|_| "agent".to_string());
     let stats_for_flush = session_stats.clone();
 
+    // --- Runtime metrics: real-time delta events for the SLS ops log ---
+    // Best-effort: writes are skipped when the deployment-owned file is absent
+    // and never affect mount behavior or exit status.
+    let runtime_metrics = Arc::new(RuntimeMetricsSink::new(
+        RuntimeMetricsWriter::new(sls_ops::resolve_ops_log_path()),
+        session_id_for_flush.clone(),
+        agent_name_for_flush.clone(),
+    ));
+    // `view_pruned`: emitted once at startup after views are computed.
+    runtime_metrics.emit_view_pruned(runtime_pruned_skill_count, runtime_token_saved_estimate);
+
     // Mark mount ready immediately before spawning — the FUSE session
     // start is the closest signal we have.
     session_stats.mark_mount_ready();
 
+    // Clone for the FUSE runtime; the original stays in this scope for the
+    // lifecycle events (mount_start / heartbeat / mount_end / mount_error).
+    let mount_runtime_metrics = runtime_metrics.clone();
     let mount_task = tokio::task::spawn_blocking(move || {
         mount_configured(
             &mountpoint,
@@ -2098,8 +2117,24 @@ async fn cmd_mount(
                 quiet_timeout_controller,
                 pending_install_controller,
                 post_publish_controller,
+                runtime_metrics: Some(mount_runtime_metrics),
             },
         )
+    });
+
+    // `mount_start`: the FUSE task spawned successfully.
+    runtime_metrics.emit_mount_start();
+
+    // Emit a periodic `mount_heartbeat` (duration delta) while the mount is
+    // alive. Aborted on every exit path below.
+    let heartbeat_metrics = runtime_metrics.clone();
+    let heartbeat_handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+        ticker.tick().await; // consume the immediate first tick
+        loop {
+            ticker.tick().await;
+            heartbeat_metrics.emit_heartbeat();
+        }
     });
 
     // A5: start activation watcher after mount is spawned.
@@ -2168,6 +2203,9 @@ async fn cmd_mount(
         _ = signal::ctrl_c() => {
             info!("received Ctrl+C, unmounting");
             trigger_unmount(&mountpoint_for_signal);
+            // Clean exit: stop heartbeats and emit the final runtime metric.
+            heartbeat_handle.abort();
+            runtime_metrics.emit_mount_end();
             // Flush session stats before exit.
             flush_session_stats(&stats_for_flush, &session_id_for_flush, &agent_name_for_flush);
             if let Some(h) = drift_handle {
@@ -2186,6 +2224,9 @@ async fn cmd_mount(
         } => {
             info!("received SIGTERM, unmounting");
             trigger_unmount(&mountpoint_for_signal);
+            // Clean exit: stop heartbeats and emit the final runtime metric.
+            heartbeat_handle.abort();
+            runtime_metrics.emit_mount_end();
             // Flush session stats before exit.
             flush_session_stats(&stats_for_flush, &session_id_for_flush, &agent_name_for_flush);
             if let Some(h) = drift_handle {
@@ -2199,10 +2240,12 @@ async fn cmd_mount(
         }
     };
 
-    // Mount exited on its own (FUSE event loop returned). Make sure the
-    // drift watcher does not outlive the mount it was paired with: shut
-    // it down explicitly so the underlying notify watcher and the drift
-    // adapter task are torn down deterministically before this function
+    // Mount exited on its own (FUSE event loop returned). Stop heartbeats.
+    heartbeat_handle.abort();
+
+    // Make sure the drift watcher does not outlive the mount it was paired
+    // with: shut it down explicitly so the underlying notify watcher and the
+    // drift adapter task are torn down deterministically before this function
     // returns.
     if let Some(h) = drift_handle {
         h.shutdown().await;
@@ -2216,6 +2259,8 @@ async fn cmd_mount(
 
     match result {
         Ok(()) => {
+            // Clean exit: emit the final runtime metric delta.
+            runtime_metrics.emit_mount_end();
             // Only flush session stats on successful mount exit.
             // Failed mounts must not write mount_times=1.
             flush_session_stats(
@@ -2227,9 +2272,12 @@ async fn cmd_mount(
             Ok(())
         }
         Err(e) => {
-            // Mount failed — do NOT write a success summary.
+            // Mount failed — emit a runtime error metric, and do NOT write a
+            // success summary.
+            let reason = format!("Mount failed: {}", e);
+            runtime_metrics.emit_mount_error(&reason);
             info!("mount failed; skipping session stats flush");
-            Err(format!("Mount failed: {}", e).into())
+            Err(reason.into())
         }
     }
 }

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -36,6 +36,7 @@ use tracing::{error, info, warn};
 
 mod help_text;
 mod managed;
+mod sls_ops;
 
 // ---------------------------------------------------------------------------
 // CLI Arguments
@@ -421,9 +422,18 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
                 // Managed mode: spawn a detached supervisor and return once
                 // the mount is ready. The supervisor re-invokes this binary
                 // as a foreground worker using the preserved raw arguments.
-                return managed::run_client(&raw_args, &source, &mountpoint);
+                // Log this public mount invocation too — the detached worker's
+                // own mount record is separate.
+                let start = std::time::Instant::now();
+                let result = managed::run_client(&raw_args, &source, &mountpoint);
+                sls_ops::log_command("mount", start, err_reason(&result));
+                return result;
             }
-            cmd_mount(
+            // Log the mount startup attempt as a best-effort ops record. The
+            // mount may be long-running, so this captures startup success or
+            // failure; the mount-session summary writer remains untouched.
+            let start = std::time::Instant::now();
+            let result = cmd_mount(
                 source,
                 mountpoint,
                 allow_other,
@@ -448,21 +458,53 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
                 trusted_peer_uid,
                 trusted_peer_gid,
             )
-            .await
+            .await;
+            sls_ops::log_command("mount", start, err_reason(&result));
+            result
         }
         Commands::Classify {
             source,
             primary_count,
             dry_run,
-        } => cmd_classify(source, primary_count, dry_run).await,
-        Commands::Validate { source, format } => cmd_validate(source, format).await,
+        } => {
+            let start = std::time::Instant::now();
+            let result = cmd_classify(source, primary_count, dry_run).await;
+            sls_ops::log_command("classify", start, err_reason(&result));
+            result
+        }
+        Commands::Validate { source, format } => {
+            let start = std::time::Instant::now();
+            let (result, validation_failed) = cmd_validate(source, format).await;
+            // A validation failure exits non-zero but is not a command error;
+            // record it with a concise err_reason before exiting.
+            let reason = match err_reason(&result) {
+                Some(r) => Some(r),
+                None if validation_failed => Some("validation failed".to_string()),
+                None => None,
+            };
+            sls_ops::log_command("validate", start, reason);
+            if result.is_ok() && validation_failed {
+                std::process::exit(1);
+            }
+            result
+        }
         Commands::List {
             source,
             enabled_only,
-        } => cmd_list(source, enabled_only).await,
+        } => {
+            let start = std::time::Instant::now();
+            let result = cmd_list(source, enabled_only).await;
+            sls_ops::log_command("list", start, err_reason(&result));
+            result
+        }
         Commands::Stop { mountpoint } => managed::run_stop(&mountpoint),
         Commands::Supervise { instance } => managed::run_supervisor(&instance),
     }
+}
+
+/// Extract a concise error string from a command result for the SLS ops log.
+fn err_reason<T>(result: &Result<T, Box<dyn std::error::Error>>) -> Option<String> {
+    result.as_ref().err().map(|e| e.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -2313,17 +2355,29 @@ async fn cmd_classify(
 // Validate Command
 // ---------------------------------------------------------------------------
 
+/// Validate skills in `source`.
+///
+/// Returns `(result, validation_failed)`. `validation_failed` is `true` when
+/// one or more skills failed to load or parse; the caller records an SLS ops
+/// record and then exits non-zero. Directory-level problems are returned as
+/// `Err` in the result.
 async fn cmd_validate(
     source: PathBuf,
     format: OutputFormat,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> (Result<(), Box<dyn std::error::Error>>, bool) {
     info!(source = %source.display(), "validating skills");
 
     if !source.exists() {
-        return Err(format!("Source directory does not exist: {}", source.display()).into());
+        return (
+            Err(format!("Source directory does not exist: {}", source.display()).into()),
+            false,
+        );
     }
     if !source.is_dir() {
-        return Err(format!("Source is not a directory: {}", source.display()).into());
+        return (
+            Err(format!("Source is not a directory: {}", source.display()).into()),
+            false,
+        );
     }
 
     let mut store = SkillStore::new();
@@ -2465,15 +2519,14 @@ async fn cmd_validate(
                     }
                 }).collect::<Vec<_>>()
             });
-            println!("{}", serde_json::to_string_pretty(&result)?);
+            match serde_json::to_string_pretty(&result) {
+                Ok(s) => println!("{}", s),
+                Err(e) => return (Err(e.into()), failed > 0),
+            }
         }
     }
 
-    if failed > 0 {
-        std::process::exit(1);
-    }
-
-    Ok(())
+    (Ok(()), failed > 0)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/skillfs/crates/skillfs-cli/src/sls_ops.rs
+++ b/src/skillfs/crates/skillfs-cli/src/sls_ops.rs
@@ -1,0 +1,403 @@
+//! Best-effort SLS ops JSONL writer for SkillFS CLI subcommands.
+//!
+//! Each CLI invocation (`list`, `validate`, `classify`, `mount`) appends one
+//! JSON line to the deployment-owned ops log:
+//!   `/var/log/anolisa/sls/ops/skillfs.jsonl`
+//!
+//! Design contract (mirrors the mount-session summary writer and the tokenless
+//! SLS writer):
+//!
+//! * The target file is owned by the anolisa SLS component, which creates,
+//!   rotates, and removes it. The CLI only appends: when the file does not
+//!   exist the write is silently skipped ("SLS collection not active"). The
+//!   CLI never creates the file or its parent directory.
+//! * Every write opens the file, appends one JSONL line, and closes the handle
+//!   so rename-based rotation never strands writes in a stale fd.
+//! * Write failures never change CLI stdout/stderr, exit status, or panic.
+//! * The default path may be overridden via `SKILLFS_SLS_OPS_PATH` for tests.
+//!   The override is validated: it must not contain `..` and, after resolving
+//!   symlinks, must live under `/var/log/` or `/tmp/`. Canonicalization means a
+//!   parent-directory symlink (e.g. `/tmp/link -> /etc`) cannot escape those
+//!   roots. `/var/log/` is additionally trusted pre-canonicalization so a
+//!   root-owned `/var/log` symlinked to another filesystem still resolves.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use serde::Serialize;
+use tracing::warn;
+
+/// Default ops log path per the deployment convention.
+pub const SKILLFS_SLS_OPS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/skillfs.jsonl";
+
+/// Environment variable to override the ops log path (test-scoped).
+pub const SLS_OPS_PATH_ENV: &str = "SKILLFS_SLS_OPS_PATH";
+
+/// agent_name recorded for CLI-initiated operations.
+const CLI_AGENT_NAME: &str = "cli";
+
+/// Allowed prefixes (post-canonicalization) for the `SKILLFS_SLS_OPS_PATH`
+/// override. `/tmp/` is world-writable, so it is only appropriate for tests;
+/// production uses the default `/var/log/` path.
+const ALLOWED_OVERRIDE_PREFIXES: &[&str] = &["/var/log/", "/tmp/"];
+
+/// Root-owned prefixes trusted pre-canonicalization: creating a symlink there
+/// requires privilege, so the original path can be trusted even when
+/// canonicalization resolves it elsewhere. World-writable `/tmp/` is excluded
+/// so a user-placed symlink there cannot escape.
+const TRUSTED_OVERRIDE_PREFIXES: &[&str] = &["/var/log/"];
+
+/// One SLS ops record for a single CLI command attempt.
+///
+/// Field names use the dot-namespaced keys expected by the SLS schema; serde
+/// `rename` produces the exact JSON keys.
+#[derive(Debug, Clone, Serialize)]
+pub struct SlsOpsRecord {
+    #[serde(rename = "component.name")]
+    pub component_name: String,
+    #[serde(rename = "component.version")]
+    pub component_version: String,
+    #[serde(rename = "component.agent_name")]
+    pub agent_name: String,
+    pub ops_id: String,
+    pub ops_name: String,
+    pub ops_time: u64,
+    pub err_reason: String,
+}
+
+impl SlsOpsRecord {
+    /// Build a record for `ops_name` that took `elapsed_ms`, with `err_reason`
+    /// set to `"none"` on success or a concise error string otherwise.
+    pub fn new(ops_name: &str, elapsed_ms: u64, err_reason: Option<String>) -> Self {
+        Self {
+            component_name: "skillfs".to_string(),
+            component_version: env!("CARGO_PKG_VERSION").to_string(),
+            agent_name: CLI_AGENT_NAME.to_string(),
+            ops_id: generate_ops_id(ops_name),
+            ops_name: ops_name.to_string(),
+            ops_time: elapsed_ms,
+            err_reason: err_reason.unwrap_or_else(|| "none".to_string()),
+        }
+    }
+}
+
+/// Generate an ops id unique enough for local operations: pid + nanosecond
+/// timestamp + the command name.
+fn generate_ops_id(ops_name: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{}-{}", ops_name, std::process::id(), nanos)
+}
+
+/// Canonicalize a path, walking up the parent chain to resolve symlinks when
+/// the leaf does not exist yet. Falls back to the original if nothing resolves.
+fn canonicalize_or_reconstruct(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        let mut cursor = path.to_path_buf();
+        let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+        loop {
+            match cursor.canonicalize() {
+                Ok(canon) => {
+                    let mut result = canon;
+                    for name in suffix.iter().rev() {
+                        result.push(name);
+                    }
+                    return result;
+                }
+                Err(_) => {
+                    if let Some(name) = cursor.file_name() {
+                        suffix.push(name.to_os_string());
+                    }
+                    match cursor.parent() {
+                        Some(p) => cursor = p.to_path_buf(),
+                        None => return path.to_path_buf(),
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Validate an override path: reject `..` traversal, then canonicalize to
+/// resolve symlinks (including in parent components) before the prefix check.
+/// Returns the canonicalized path if acceptable, else `None`.
+///
+/// A path is accepted when the resolved path is under an allowed prefix, OR the
+/// original path is under a root-owned trusted prefix (see
+/// [`TRUSTED_OVERRIDE_PREFIXES`]). The trusted fallback covers a root-owned
+/// `/var/log` symlinked elsewhere; `/tmp/` is excluded so a user-placed parent
+/// symlink there cannot escape the allowed roots.
+fn validate_override_path(path: &Path) -> Option<PathBuf> {
+    if path
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
+        return None;
+    }
+
+    let resolved = canonicalize_or_reconstruct(path);
+    let resolved_str = resolved.to_str().unwrap_or("");
+    let original_str = path.to_str().unwrap_or("");
+    let resolved_ok = ALLOWED_OVERRIDE_PREFIXES
+        .iter()
+        .any(|prefix| resolved_str.starts_with(prefix));
+    let original_ok = TRUSTED_OVERRIDE_PREFIXES
+        .iter()
+        .any(|prefix| original_str.starts_with(prefix));
+    if resolved_ok || original_ok {
+        Some(resolved)
+    } else {
+        None
+    }
+}
+
+/// Resolve the ops log path from the optional env override, falling back to the
+/// default when unset, empty, or invalid.
+fn resolve_ops_path(env_val: Option<&str>) -> PathBuf {
+    env_val
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .and_then(|p| validate_override_path(&p))
+        .unwrap_or_else(|| PathBuf::from(SKILLFS_SLS_OPS_LOG_PATH))
+}
+
+/// Best-effort JSONL ops writer.
+pub struct SlsOpsWriter {
+    path: PathBuf,
+}
+
+impl Default for SlsOpsWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SlsOpsWriter {
+    /// Create a writer from the `SKILLFS_SLS_OPS_PATH` override (validated),
+    /// falling back to the default deployment path.
+    pub fn new() -> Self {
+        let env_val = std::env::var(SLS_OPS_PATH_ENV).ok();
+        Self {
+            path: resolve_ops_path(env_val.as_deref()),
+        }
+    }
+
+    /// Create a writer targeting an explicit path (for tests).
+    #[cfg(test)]
+    fn with_path(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Append one ops record as a JSONL line (open + append + close).
+    ///
+    /// Skips silently when the target file does not exist — deployment owns
+    /// file creation. Serialization or write failures are logged via
+    /// `tracing::warn` and swallowed; they never change CLI behavior.
+    pub fn write(&self, record: &SlsOpsRecord) {
+        if !self.path.exists() {
+            return;
+        }
+
+        let mut line = match serde_json::to_string(record) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, "skillfs sls ops: failed to serialize record");
+                return;
+            }
+        };
+        line.push('\n');
+
+        let mut opts = std::fs::OpenOptions::new();
+        opts.append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            // A legit SLS file is never a symlink; O_NOFOLLOW blocks a
+            // swap-to-symlink between the existence check and the open.
+            opts.custom_flags(libc::O_NOFOLLOW);
+        }
+
+        if let Err(e) = opts
+            .open(&self.path)
+            .and_then(|mut f| f.write_all(line.as_bytes()))
+        {
+            warn!(
+                error = %e,
+                path = %self.path.display(),
+                "skillfs sls ops: failed to append record (non-fatal)"
+            );
+        }
+    }
+}
+
+/// Log one CLI command attempt to the ops log. Best-effort: never panics,
+/// never changes exit status.
+///
+/// `err_reason` is `None` for success and `Some(reason)` for a concise failure
+/// description.
+pub fn log_command(ops_name: &str, start: Instant, err_reason: Option<String>) {
+    let elapsed_ms = start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let record = SlsOpsRecord::new(ops_name, elapsed_ms, err_reason);
+    SlsOpsWriter::new().write(&record);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_has_expected_fields_on_success() {
+        let record = SlsOpsRecord::new("list", 12, None);
+        let json = serde_json::to_string(&record).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(obj["component.name"], "skillfs");
+        assert_eq!(obj["component.agent_name"], "cli");
+        assert!(
+            !obj["component.version"].as_str().unwrap().is_empty(),
+            "component.version must be populated"
+        );
+        assert_eq!(obj["ops_name"], "list");
+        assert_eq!(obj["ops_time"], 12);
+        assert_eq!(obj["err_reason"], "none");
+        assert!(
+            obj["ops_id"].as_str().unwrap().starts_with("list-"),
+            "ops_id should embed the ops_name"
+        );
+    }
+
+    #[test]
+    fn record_captures_error_reason() {
+        let record = SlsOpsRecord::new("validate", 5, Some("2 skill(s) failed".to_string()));
+        let json = serde_json::to_string(&record).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(obj["ops_name"], "validate");
+        assert_eq!(obj["err_reason"], "2 skill(s) failed");
+    }
+
+    #[test]
+    fn writer_appends_one_line_to_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&path).unwrap();
+
+        let writer = SlsOpsWriter::with_path(&path);
+        writer.write(&SlsOpsRecord::new("list", 3, None));
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let obj: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(obj["component.name"], "skillfs");
+        assert_eq!(obj["ops_name"], "list");
+    }
+
+    #[test]
+    fn writer_appends_multiple_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&path).unwrap();
+
+        let writer = SlsOpsWriter::with_path(&path);
+        writer.write(&SlsOpsRecord::new("list", 1, None));
+        writer.write(&SlsOpsRecord::new("validate", 2, Some("bad".to_string())));
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(first["ops_name"], "list");
+        assert_eq!(second["ops_name"], "validate");
+        assert_eq!(second["err_reason"], "bad");
+    }
+
+    #[test]
+    fn writer_skips_missing_file_without_creating() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.jsonl");
+
+        let writer = SlsOpsWriter::with_path(&path);
+        writer.write(&SlsOpsRecord::new("classify", 4, None));
+
+        assert!(
+            !path.exists(),
+            "writer must not create the missing ops log file"
+        );
+    }
+
+    #[test]
+    fn writer_is_non_fatal_on_invalid_path() {
+        // Missing parent directory: the file does not exist, so the write is
+        // skipped silently and must not panic.
+        let writer = SlsOpsWriter::with_path("/nonexistent/deep/dir/skillfs.jsonl");
+        writer.write(&SlsOpsRecord::new("mount", 7, None)); // no panic
+    }
+
+    #[test]
+    fn resolve_ops_path_defaults_when_unset() {
+        assert_eq!(
+            resolve_ops_path(None),
+            PathBuf::from(SKILLFS_SLS_OPS_LOG_PATH)
+        );
+        assert_eq!(
+            resolve_ops_path(Some("")),
+            PathBuf::from(SKILLFS_SLS_OPS_LOG_PATH)
+        );
+    }
+
+    #[test]
+    fn resolve_ops_path_rejects_traversal_and_bad_prefix() {
+        assert_eq!(
+            resolve_ops_path(Some("/var/log/../../etc/passwd")),
+            PathBuf::from(SKILLFS_SLS_OPS_LOG_PATH)
+        );
+        assert_eq!(
+            resolve_ops_path(Some("/etc/cron.d/evil")),
+            PathBuf::from(SKILLFS_SLS_OPS_LOG_PATH)
+        );
+    }
+
+    #[test]
+    fn resolve_ops_path_accepts_allowed_prefixes() {
+        // Under /tmp (a real dir on Linux) the reconstructed path keeps the
+        // /tmp/ prefix; a /var/log/ path is accepted via the trusted fallback.
+        let tmp = resolve_ops_path(Some("/tmp/skillfs-test.jsonl"));
+        assert!(
+            tmp.to_str().unwrap().starts_with("/tmp/"),
+            "unexpected resolved tmp path: {}",
+            tmp.display()
+        );
+        let varlog = resolve_ops_path(Some("/var/log/custom/skillfs.jsonl"));
+        assert_eq!(
+            varlog,
+            PathBuf::from("/var/log/custom/skillfs.jsonl"),
+            "trusted /var/log path should be accepted as-is"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_rejects_tmp_parent_symlink_escape() {
+        // /tmp/ is world-writable: a parent-directory symlink there must not be
+        // usable to escape the allowed roots. Canonicalization resolves the
+        // symlink, and /tmp/ is not a trusted prefix, so the path is rejected
+        // and resolution falls back to the default.
+        let dir = tempfile::tempdir_in("/tmp").unwrap();
+        let link = dir.path().join("escape");
+        std::os::unix::fs::symlink("/etc", &link).unwrap();
+        let escaped = link.join("cron.d/evil.jsonl");
+        assert!(validate_override_path(&escaped).is_none());
+        assert_eq!(
+            resolve_ops_path(escaped.to_str()),
+            PathBuf::from(SKILLFS_SLS_OPS_LOG_PATH)
+        );
+    }
+}

--- a/src/skillfs/crates/skillfs-cli/src/sls_ops.rs
+++ b/src/skillfs/crates/skillfs-cli/src/sls_ops.rs
@@ -154,6 +154,14 @@ fn validate_override_path(path: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Resolve the ops log path used by every SkillFS SLS writer (CLI ops and
+/// runtime metrics), honoring the validated `SKILLFS_SLS_OPS_PATH` override.
+/// Falls back to the default deployment path.
+pub fn resolve_ops_log_path() -> PathBuf {
+    let env_val = std::env::var(SLS_OPS_PATH_ENV).ok();
+    resolve_ops_path(env_val.as_deref())
+}
+
 /// Resolve the ops log path from the optional env override, falling back to the
 /// default when unset, empty, or invalid.
 fn resolve_ops_path(env_val: Option<&str>) -> PathBuf {

--- a/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
@@ -1,0 +1,167 @@
+//! CLI-level tests for SLS ops JSONL logging.
+//!
+//! Each `skillfs` subcommand appends one ops record to the deployment-owned
+//! ops log. Tests point the writer at a temp file via `SKILLFS_SLS_OPS_PATH`
+//! (validated to live under `/tmp/`) and assert the appended record.
+
+use std::path::Path;
+use std::process::Command;
+
+fn bin_path() -> &'static str {
+    env!("CARGO_BIN_EXE_skillfs")
+}
+
+const VALID_SKILL: &str = r#"---
+name: good-skill
+description: A valid skill
+version: "1.0"
+---
+# Good Skill
+
+This skill works correctly.
+"#;
+
+/// SKILL.md with invalid YAML frontmatter → ParseStatus::Error.
+const ERROR_SKILL: &str = r#"---
+name: [invalid yaml
+  broken: {{{}
+---
+Body text.
+"#;
+
+fn create_skill_dir(parent: &Path, name: &str, content: &str) {
+    let dir = parent.join(name);
+    std::fs::create_dir_all(&dir).expect("create skill dir");
+    std::fs::write(dir.join("SKILL.md"), content).expect("write SKILL.md");
+}
+
+/// Create the deployment-owned ops log under /tmp so the CLI (which never
+/// creates the file) will append to it.
+fn make_ops_log(dir: &Path) -> std::path::PathBuf {
+    let ops_log = dir.join("skillfs-ops.jsonl");
+    std::fs::File::create(&ops_log).expect("pre-create ops log");
+    ops_log
+}
+
+/// Read all JSONL records from the ops log.
+fn read_records(ops_log: &Path) -> Vec<serde_json::Value> {
+    let content = std::fs::read_to_string(ops_log).unwrap_or_default();
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("valid JSON record"))
+        .collect()
+}
+
+fn run_skillfs(args: &[&str], ops_log: &Path) -> std::process::Output {
+    Command::new(bin_path())
+        .args(args)
+        // Temp dirs live under /tmp on Linux, an allowed override prefix.
+        .env("SKILLFS_SLS_OPS_PATH", ops_log)
+        .output()
+        .expect("invoke skillfs")
+}
+
+#[test]
+fn list_appends_ops_record_on_success() {
+    // /tmp-based temp dir required so the override prefix check accepts it.
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let out = run_skillfs(&["list", source.path().to_str().unwrap()], &ops_log);
+    assert!(out.status.success(), "list should succeed");
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1, "expected one ops record");
+    assert_eq!(records[0]["component.name"], "skillfs");
+    assert_eq!(records[0]["component.agent_name"], "cli");
+    assert_eq!(records[0]["ops_name"], "list");
+    assert_eq!(records[0]["err_reason"], "none");
+    assert!(
+        !records[0]["component.version"].as_str().unwrap().is_empty(),
+        "component.version must be populated"
+    );
+}
+
+#[test]
+fn validate_appends_ops_record_on_success() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let out = run_skillfs(&["validate", source.path().to_str().unwrap()], &ops_log);
+    assert!(out.status.success(), "validate should succeed");
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["ops_name"], "validate");
+    assert_eq!(records[0]["err_reason"], "none");
+}
+
+#[test]
+fn validate_appends_record_before_nonzero_exit() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "bad-yaml", ERROR_SKILL);
+
+    let out = run_skillfs(&["validate", source.path().to_str().unwrap()], &ops_log);
+    assert!(
+        !out.status.success(),
+        "validate with a bad skill must exit non-zero"
+    );
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1, "record must be written before exiting");
+    assert_eq!(records[0]["ops_name"], "validate");
+    assert_ne!(
+        records[0]["err_reason"], "none",
+        "failed validation must set a non-none err_reason"
+    );
+}
+
+#[test]
+fn classify_dry_run_appends_ops_record_on_success() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let out = run_skillfs(
+        &["classify", source.path().to_str().unwrap(), "--dry-run"],
+        &ops_log,
+    );
+    assert!(out.status.success(), "classify --dry-run should succeed");
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["ops_name"], "classify");
+    assert_eq!(records[0]["err_reason"], "none");
+}
+
+#[test]
+fn missing_ops_log_is_not_created_and_command_succeeds() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    // Do NOT create the ops log — the CLI must skip writing without creating it.
+    let ops_log = dir.path().join("absent-ops.jsonl");
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let out = run_skillfs(&["list", source.path().to_str().unwrap()], &ops_log);
+    assert!(
+        out.status.success(),
+        "list should still succeed when the ops log is absent"
+    );
+    assert!(
+        !ops_log.exists(),
+        "CLI must not create the missing ops log file"
+    );
+}

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -111,6 +111,9 @@ impl SkillFs {
                     && !self.is_post_publish_grace_allowed(&skill_name, None)
                     && !self.evaluate_trusted_writer(_req).is_allowed()
                 {
+                    // A direct lookup of a ledger-hidden skill is a real
+                    // security denial (best-effort runtime metric).
+                    self.metric_policy_denied();
                     reply.error(libc::ENOENT);
                     return;
                 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -363,17 +363,46 @@ impl SkillFs {
                         PathType::SkillMd { .. } => Some(Path::new("SKILL.md")),
                         _ => None,
                     };
+                    // Best-effort runtime metrics. `skill_hit` fires for any
+                    // agent-visible read open of a real skill file; `policy_*`
+                    // fires only when an active resolver actually made a
+                    // security decision — plain non-security passthrough (no
+                    // resolver) is NOT counted as an allow. `.skill-meta/**` and
+                    // skill-discover are excluded.
+                    let is_discover = skill_name == "skill-discover";
+                    let is_meta = matches!(
+                        &path_type,
+                        PathType::Passthrough { relative_path, .. }
+                            if crate::security::is_skill_meta_path(relative_path)
+                    );
+                    let record_hit = !is_discover && !is_meta && !is_mutating_open;
+                    let policy_decided = self.active_resolver.is_some() && !is_discover && !is_meta;
                     match self.resolve_skill_read(skill_name) {
                         ReadResolution::Hidden
                             if !self.is_post_publish_grace_allowed(skill_name, grace_rel) =>
                         {
+                            if policy_decided {
+                                self.metric_policy_denied();
+                            }
                             reply.error(libc::ENOENT);
                             return;
                         }
                         ReadResolution::Hidden => {
-                            // I4: grace bypass — let the open proceed against source.
+                            // I4: grace bypass — serve from source (allowed).
+                            if record_hit {
+                                self.metric_skill_hit();
+                            }
+                            if policy_decided {
+                                self.metric_policy_allow();
+                            }
                         }
                         ReadResolution::Snapshot { dir, .. } if !is_mutating_open => {
+                            if record_hit {
+                                self.metric_skill_hit();
+                            }
+                            if policy_decided {
+                                self.metric_policy_fallback();
+                            }
                             if let PathType::Passthrough { relative_path, .. } = &path_type {
                                 // I4: grace bypass — if the path matches the
                                 // post-publish whitelist, open from physical
@@ -386,7 +415,22 @@ impl SkillFs {
                                 }
                             }
                         }
-                        _ => {}
+                        ReadResolution::Snapshot { .. } => {
+                            // Mutating open resolving to a snapshot: the write
+                            // still targets live source; count the fallback
+                            // decision but not a read hit.
+                            if policy_decided {
+                                self.metric_policy_fallback();
+                            }
+                        }
+                        ReadResolution::Source => {
+                            if record_hit {
+                                self.metric_skill_hit();
+                            }
+                            if policy_decided {
+                                self.metric_policy_allow();
+                            }
+                        }
                     }
                 }
             }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -21,7 +21,7 @@ use crate::inode::InodeManager;
 use crate::security::{
     ActiveSkillResolver, InstallerStagingController, NoopEventSink, NotifyController,
     PendingInstallController, PostPublishGraceController, ProcessIdentityResolver,
-    QuietTimeoutController, RefreshController, SecurityPolicy, SkillEventSink,
+    QuietTimeoutController, RefreshController, RuntimeMetricsSink, SecurityPolicy, SkillEventSink,
     SkillMetaProtectionPolicy, StagingMatcher, TrustedWriterConfig, default_identity_resolver,
 };
 use crate::sync::{SyncEvent, spawn_sync_worker};
@@ -111,6 +111,11 @@ pub struct SkillFs {
     quiet_timeout_controller: Option<Arc<QuietTimeoutController>>,
     pending_install_controller: Option<Arc<PendingInstallController>>,
     post_publish_controller: Option<Arc<PostPublishGraceController>>,
+    /// Best-effort runtime metric delta sink. When `Some`, agent-visible skill
+    /// opens emit a `skill_hit` delta and — when an active resolver made a real
+    /// security decision — a `policy_allow` / `policy_fallback` / `policy_denied`
+    /// delta. Metric emission is best-effort and never changes FUSE behavior.
+    runtime_metrics: Option<Arc<RuntimeMetricsSink>>,
 }
 
 impl SkillFs {
@@ -188,6 +193,7 @@ impl SkillFs {
             quiet_timeout_controller: None,
             pending_install_controller: None,
             post_publish_controller: None,
+            runtime_metrics: None,
         };
 
         // In normal mode pre-populate the /skills inode.
@@ -353,6 +359,42 @@ impl SkillFs {
     ) -> Self {
         self.post_publish_controller = Some(controller);
         self
+    }
+
+    /// Attach a best-effort runtime metric delta sink. When set, agent-visible
+    /// skill opens and real security/policy decisions emit `runtime_metric`
+    /// JSONL deltas. Emission never changes FUSE behavior or errno mapping.
+    pub fn with_runtime_metrics(mut self, sink: Arc<RuntimeMetricsSink>) -> Self {
+        self.runtime_metrics = Some(sink);
+        self
+    }
+
+    /// Record one agent-visible skill open (`skill_hit` delta). Best-effort.
+    pub(super) fn metric_skill_hit(&self) {
+        if let Some(s) = &self.runtime_metrics {
+            s.record_skill_hit();
+        }
+    }
+
+    /// Record a security/policy allow decision (`policy_allow` delta). Best-effort.
+    pub(super) fn metric_policy_allow(&self) {
+        if let Some(s) = &self.runtime_metrics {
+            s.record_policy_allow();
+        }
+    }
+
+    /// Record a security/policy fallback decision (`policy_fallback` delta). Best-effort.
+    pub(super) fn metric_policy_fallback(&self) {
+        if let Some(s) = &self.runtime_metrics {
+            s.record_policy_fallback();
+        }
+    }
+
+    /// Record a security/policy denial (`policy_denied` delta). Best-effort.
+    pub(super) fn metric_policy_denied(&self) {
+        if let Some(s) = &self.runtime_metrics {
+            s.record_policy_denied();
+        }
     }
 
     fn virtual_file_attr(&self, size: u64) -> FileAttr {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
@@ -200,6 +200,7 @@ impl SkillFs {
                             .with_caller(req.uid(), req.gid())
                             .with_detail(deny_detail);
                         self.emit_event(event);
+                        self.metric_policy_denied();
                         return Some(errno);
                     }
                 }
@@ -215,6 +216,7 @@ impl SkillFs {
                         .with_detail(format!("op={:?} reason={} {}", operation, reason, extra));
                 }
                 self.emit_event(event);
+                self.metric_policy_denied();
                 Some(errno)
             }
         }
@@ -302,6 +304,7 @@ impl SkillFs {
         };
         event = event.with_detail(final_detail);
         self.emit_event(event);
+        self.metric_policy_denied();
         Some(errno)
     }
 

--- a/src/skillfs/crates/skillfs-fuse/src/mount.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/mount.rs
@@ -15,8 +15,8 @@ use tracing::{error, info, warn};
 
 use crate::security::{
     ActiveSkillResolver, InstallerStagingController, NotifyController, PendingInstallController,
-    PostPublishGraceController, QuietTimeoutController, RefreshController, SecurityPolicy,
-    SkillEventSink, StagingMatcher, TrustedWriterConfig,
+    PostPublishGraceController, QuietTimeoutController, RefreshController, RuntimeMetricsSink,
+    SecurityPolicy, SkillEventSink, StagingMatcher, TrustedWriterConfig,
 };
 use crate::{FuseError, MountHandle, MountOptions, SkillFs};
 
@@ -34,6 +34,9 @@ pub struct MountConfig {
     pub quiet_timeout_controller: Option<Arc<QuietTimeoutController>>,
     pub pending_install_controller: Option<Arc<PendingInstallController>>,
     pub post_publish_controller: Option<Arc<PostPublishGraceController>>,
+    /// Best-effort runtime metric delta sink. When `Some`, agent-visible skill
+    /// opens and security/policy decisions emit `runtime_metric` JSONL records.
+    pub runtime_metrics: Option<Arc<RuntimeMetricsSink>>,
 }
 
 /// Mount the SkillFS FUSE filesystem (blocking) with a unified
@@ -63,6 +66,7 @@ pub fn mount_configured(
         config.quiet_timeout_controller,
         config.pending_install_controller,
         config.post_publish_controller,
+        config.runtime_metrics,
     )
 }
 
@@ -99,6 +103,7 @@ pub fn mount_background_configured(
             config.quiet_timeout_controller,
             config.pending_install_controller,
             config.post_publish_controller,
+            config.runtime_metrics,
         ) {
             error!(error = %e, "background mount failed");
         }
@@ -134,6 +139,7 @@ fn mount_inner(
     quiet_timeout_controller: Option<Arc<QuietTimeoutController>>,
     pending_install_controller: Option<Arc<PendingInstallController>>,
     post_publish_controller: Option<Arc<PostPublishGraceController>>,
+    runtime_metrics: Option<Arc<RuntimeMetricsSink>>,
 ) -> Result<(), FuseError> {
     info!(mountpoint = %mountpoint.display(), source = %source.display(), in_place, "mounting SkillFS");
 
@@ -230,6 +236,9 @@ fn mount_inner(
     if let Some(c) = post_publish_controller {
         fs = fs.with_post_publish_controller(c);
     }
+    if let Some(s) = runtime_metrics {
+        fs = fs.with_runtime_metrics(s);
+    }
     info!("starting FUSE filesystem");
 
     // Neutralize the daemon process's file-creation mask. The FUSE protocol
@@ -272,7 +281,7 @@ pub fn mount(
 ) -> Result<(), FuseError> {
     mount_inner(
         mountpoint, source, store, options, in_place, None, None, None, None, None, None, None,
-        None, None, None, None,
+        None, None, None, None, None,
     )
 }
 
@@ -302,7 +311,7 @@ pub fn mount_with_security(
 ) -> Result<(), FuseError> {
     mount_inner(
         mountpoint, source, store, options, in_place, event_sink, policy, None, None, None, None,
-        None, None, None, None, None,
+        None, None, None, None, None, None,
     )
 }
 
@@ -337,6 +346,7 @@ pub fn mount_with_security_and_active_resolver(
         event_sink,
         policy,
         active_resolver,
+        None,
         None,
         None,
         None,
@@ -387,6 +397,7 @@ pub fn mount_with_security_active_resolver_and_demo_refresh(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -429,6 +440,7 @@ pub fn mount_with_security_active_resolver_demo_refresh_and_trusted_writer(
         refresh_controller,
         None,
         trusted_writer,
+        None,
         None,
         None,
         None,
@@ -593,6 +605,7 @@ pub fn mount_background_with_security_active_resolver_demo_refresh_and_trusted_w
             refresh_controller,
             None,
             trusted_writer,
+            None,
             None,
             None,
             None,

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -110,6 +110,7 @@ pub mod path;
 pub mod policy;
 pub mod protocol_events;
 pub mod refresh;
+pub mod runtime_metrics;
 pub mod session_stats;
 pub mod session_stats_writer;
 pub mod trusted_writer;
@@ -194,6 +195,9 @@ pub use protocol_events::{
 pub use refresh::{
     DEFAULT_REFRESH_DEBOUNCE_MS, FailedResolveBehavior, MutationKind, RefreshController,
     RefreshObservation,
+};
+pub use runtime_metrics::{
+    RuntimeMetricRecord, RuntimeMetricsSink, RuntimeMetricsWriter, SKILLFS_RUNTIME_METRICS_LOG_PATH,
 };
 pub use session_stats::{
     RuntimeDecisionOutcome, SkillfsSessionStats, SkillfsSessionSummary, serialize_session_summary,

--- a/src/skillfs/crates/skillfs-fuse/src/security/runtime_metrics.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/runtime_metrics.rs
@@ -1,0 +1,411 @@
+//! Real-time runtime metric delta events for the SLS ops log.
+//!
+//! Unlike the shutdown-only [`super::session_stats`] summary, this module emits
+//! one JSONL record per metric event **while the mount is alive**, so the SLS /
+//! product side can aggregate deltas continuously instead of waiting for the
+//! mount to exit.
+//!
+//! Records carry `record_type = "runtime_metric"` to distinguish them from the
+//! CLI ops records and the legacy session summary that share the same file:
+//!   `/var/log/anolisa/sls/ops/skillfs.jsonl`
+//!
+//! Design contract (identical to the other SkillFS SLS writers):
+//!
+//! * The target file is owned by the deployment/SLS component. This writer only
+//!   appends: when the file does not exist the write is silently skipped
+//!   ("SLS collection not active"). It never creates the file or parent dir.
+//! * Every write opens the file, appends one JSONL line, and closes the handle.
+//! * All emission is best-effort: serialization or write failures are logged via
+//!   `tracing::warn` and swallowed. Emission never panics, never blocks on retry,
+//!   and never changes FUSE or CLI behavior.
+//!
+//! Each metric field is a **delta** (e.g. `skill_hit_times = 1` per event); the
+//! aggregator sums them per session.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use serde::Serialize;
+use tracing::warn;
+
+/// Default ops log path (shared with CLI ops and the legacy session summary).
+pub const SKILLFS_RUNTIME_METRICS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/skillfs.jsonl";
+
+/// One runtime metric delta record.
+///
+/// Common fields are always present; delta fields are sparse — only the metric(s)
+/// updated by a given event are serialized (`skip_serializing_if = Option::is_none`).
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeMetricRecord {
+    #[serde(rename = "component.name")]
+    pub component_name: String,
+    #[serde(rename = "component.version")]
+    pub component_version: String,
+    #[serde(rename = "component.agent_name")]
+    pub agent_name: String,
+    pub record_type: String,
+    pub session_id: String,
+    pub event_name: String,
+    pub err_reason: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_times: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_hit_times: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_allow_times: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_fallback_times: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_denied_times: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pruned_skill_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_token_saved_estimate: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_duration_ms: Option<u64>,
+}
+
+impl RuntimeMetricRecord {
+    fn new(
+        component_version: String,
+        agent_name: String,
+        session_id: String,
+        event_name: &str,
+        err_reason: &str,
+    ) -> Self {
+        Self {
+            component_name: "skillfs".to_string(),
+            component_version,
+            agent_name,
+            record_type: "runtime_metric".to_string(),
+            session_id,
+            event_name: event_name.to_string(),
+            err_reason: err_reason.to_string(),
+            mount_times: None,
+            skill_hit_times: None,
+            policy_allow_times: None,
+            policy_fallback_times: None,
+            policy_denied_times: None,
+            pruned_skill_count: None,
+            prompt_token_saved_estimate: None,
+            mount_duration_ms: None,
+        }
+    }
+}
+
+/// Best-effort append-only JSONL writer for runtime metric records.
+pub struct RuntimeMetricsWriter {
+    path: PathBuf,
+}
+
+impl RuntimeMetricsWriter {
+    /// Create a writer targeting `path`.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Create a writer targeting the default deployment path.
+    pub fn default_path() -> Self {
+        Self::new(SKILLFS_RUNTIME_METRICS_LOG_PATH)
+    }
+
+    /// The target file path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append one record as a JSONL line. Skips silently when the file is
+    /// absent; serialization/write failures are logged and swallowed.
+    pub fn write(&self, record: &RuntimeMetricRecord) {
+        if !self.path.exists() {
+            return;
+        }
+        let mut line = match serde_json::to_string(record) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, "skillfs runtime metrics: failed to serialize record");
+                return;
+            }
+        };
+        line.push('\n');
+
+        let mut opts = std::fs::OpenOptions::new();
+        opts.append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            // A legit SLS file is never a symlink; O_NOFOLLOW blocks a
+            // swap-to-symlink between the existence check and the open.
+            opts.custom_flags(libc::O_NOFOLLOW);
+        }
+        if let Err(e) = opts
+            .open(&self.path)
+            .and_then(|mut f| f.write_all(line.as_bytes()))
+        {
+            warn!(
+                error = %e,
+                path = %self.path.display(),
+                "skillfs runtime metrics: failed to append record (non-fatal)"
+            );
+        }
+    }
+}
+
+/// Emits runtime metric delta events for a single mount session.
+///
+/// Thread-safe (`Send + Sync`): timing state is held behind a `Mutex` and all
+/// emission is best-effort. Cloneable references are shared between the CLI mount
+/// lifecycle (start/heartbeat/end) and the FUSE runtime (skill hits, policy
+/// outcomes) via `Arc`.
+pub struct RuntimeMetricsSink {
+    writer: RuntimeMetricsWriter,
+    component_version: String,
+    agent_name: String,
+    session_id: String,
+    /// Instant of the last emitted heartbeat (or `mount_start`). Used to compute
+    /// the `mount_duration_ms` delta for heartbeat and `mount_end`.
+    last_mark: Mutex<Option<Instant>>,
+}
+
+impl RuntimeMetricsSink {
+    /// Create a sink writing to `writer`, tagged with `session_id` / `agent_name`.
+    pub fn new(writer: RuntimeMetricsWriter, session_id: String, agent_name: String) -> Self {
+        Self {
+            writer,
+            component_version: env!("CARGO_PKG_VERSION").to_string(),
+            agent_name,
+            session_id,
+            last_mark: Mutex::new(None),
+        }
+    }
+
+    fn record(&self, event_name: &str, err_reason: &str) -> RuntimeMetricRecord {
+        RuntimeMetricRecord::new(
+            self.component_version.clone(),
+            self.agent_name.clone(),
+            self.session_id.clone(),
+            event_name,
+            err_reason,
+        )
+    }
+
+    /// Snapshot `now`, returning the delta in ms since the previous mark and
+    /// updating the mark. Falls back to 0 when no previous mark exists.
+    fn take_duration_ms(&self) -> u64 {
+        let now = Instant::now();
+        let mut guard = self.last_mark.lock().unwrap_or_else(|e| e.into_inner());
+        let delta = guard
+            .map(|prev| {
+                now.duration_since(prev)
+                    .as_millis()
+                    .min(u128::from(u64::MAX)) as u64
+            })
+            .unwrap_or(0);
+        *guard = Some(now);
+        delta
+    }
+
+    /// `mount_start`: emitted after the mount task spawns successfully.
+    pub fn emit_mount_start(&self) {
+        {
+            let mut guard = self.last_mark.lock().unwrap_or_else(|e| e.into_inner());
+            *guard = Some(Instant::now());
+        }
+        let mut rec = self.record("mount_start", "none");
+        rec.mount_times = Some(1);
+        self.writer.write(&rec);
+    }
+
+    /// `view_pruned`: emitted once at startup after views are computed.
+    pub fn emit_view_pruned(&self, pruned_skill_count: u64, prompt_token_saved_estimate: u64) {
+        let mut rec = self.record("view_pruned", "none");
+        rec.pruned_skill_count = Some(pruned_skill_count);
+        rec.prompt_token_saved_estimate = Some(prompt_token_saved_estimate);
+        self.writer.write(&rec);
+    }
+
+    /// `skill_hit`: one agent-visible skill open.
+    pub fn record_skill_hit(&self) {
+        let mut rec = self.record("skill_hit", "none");
+        rec.skill_hit_times = Some(1);
+        self.writer.write(&rec);
+    }
+
+    /// `policy_allow`: a security/policy decision serving the current/allowed view.
+    pub fn record_policy_allow(&self) {
+        let mut rec = self.record("policy_allow", "none");
+        rec.policy_allow_times = Some(1);
+        self.writer.write(&rec);
+    }
+
+    /// `policy_fallback`: a security/policy decision serving the fallback/snapshot view.
+    pub fn record_policy_fallback(&self) {
+        let mut rec = self.record("policy_fallback", "none");
+        rec.policy_fallback_times = Some(1);
+        self.writer.write(&rec);
+    }
+
+    /// `policy_denied`: a security/policy denial or rejection.
+    pub fn record_policy_denied(&self) {
+        let mut rec = self.record("policy_denied", "none");
+        rec.policy_denied_times = Some(1);
+        self.writer.write(&rec);
+    }
+
+    /// `mount_heartbeat`: periodic liveness tick carrying the duration delta
+    /// since the last heartbeat / start.
+    pub fn emit_heartbeat(&self) {
+        let delta = self.take_duration_ms();
+        let mut rec = self.record("mount_heartbeat", "none");
+        rec.mount_duration_ms = Some(delta);
+        self.writer.write(&rec);
+    }
+
+    /// `mount_end`: clean exit; carries the remaining duration since the last mark.
+    pub fn emit_mount_end(&self) {
+        let delta = self.take_duration_ms();
+        let mut rec = self.record("mount_end", "none");
+        rec.mount_duration_ms = Some(delta);
+        self.writer.write(&rec);
+    }
+
+    /// `mount_error`: mount startup/runtime failure; carries a concise reason and
+    /// the elapsed duration since the last mark.
+    pub fn emit_mount_error(&self, err_reason: &str) {
+        let delta = self.take_duration_ms();
+        let mut rec = self.record("mount_error", err_reason);
+        rec.mount_duration_ms = Some(delta);
+        self.writer.write(&rec);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sink_to(path: &Path) -> RuntimeMetricsSink {
+        RuntimeMetricsSink::new(
+            RuntimeMetricsWriter::new(path),
+            "sess-1".to_string(),
+            "agent".to_string(),
+        )
+    }
+
+    fn read_records(path: &Path) -> Vec<serde_json::Value> {
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("valid JSON"))
+            .collect()
+    }
+
+    #[test]
+    fn record_has_common_fields_and_sparse_deltas() {
+        let rec = RuntimeMetricRecord::new(
+            "9.9.9".to_string(),
+            "agent".to_string(),
+            "sess".to_string(),
+            "skill_hit",
+            "none",
+        );
+        let mut rec = rec;
+        rec.skill_hit_times = Some(1);
+        let obj: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&rec).unwrap()).unwrap();
+
+        assert_eq!(obj["component.name"], "skillfs");
+        assert_eq!(obj["component.version"], "9.9.9");
+        assert_eq!(obj["component.agent_name"], "agent");
+        assert_eq!(obj["record_type"], "runtime_metric");
+        assert_eq!(obj["session_id"], "sess");
+        assert_eq!(obj["event_name"], "skill_hit");
+        assert_eq!(obj["err_reason"], "none");
+        assert_eq!(obj["skill_hit_times"], 1);
+        // Unset deltas must be omitted.
+        assert!(obj.as_object().unwrap().get("policy_allow_times").is_none());
+        assert!(obj.as_object().unwrap().get("mount_duration_ms").is_none());
+    }
+
+    #[test]
+    fn writer_appends_to_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&path).unwrap();
+
+        let sink = sink_to(&path);
+        sink.emit_mount_start();
+        sink.record_skill_hit();
+
+        let records = read_records(&path);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["event_name"], "mount_start");
+        assert_eq!(records[0]["mount_times"], 1);
+        assert_eq!(records[1]["event_name"], "skill_hit");
+        assert_eq!(records[1]["skill_hit_times"], 1);
+    }
+
+    #[test]
+    fn writer_skips_missing_file_without_creating() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("absent.jsonl");
+        let sink = sink_to(&path);
+        sink.record_policy_denied();
+        assert!(!path.exists(), "must not create the missing file");
+    }
+
+    #[test]
+    fn writer_non_fatal_on_bad_path() {
+        let sink = sink_to(Path::new("/nonexistent/deep/dir/skillfs.jsonl"));
+        sink.record_skill_hit(); // no panic
+    }
+
+    #[test]
+    fn each_event_sets_expected_delta() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&path).unwrap();
+
+        let sink = sink_to(&path);
+        sink.emit_view_pruned(24, 1200);
+        sink.record_policy_allow();
+        sink.record_policy_fallback();
+        sink.record_policy_denied();
+        sink.emit_mount_end();
+
+        let r = read_records(&path);
+        assert_eq!(r[0]["event_name"], "view_pruned");
+        assert_eq!(r[0]["pruned_skill_count"], 24);
+        assert_eq!(r[0]["prompt_token_saved_estimate"], 1200);
+        assert_eq!(r[1]["event_name"], "policy_allow");
+        assert_eq!(r[1]["policy_allow_times"], 1);
+        assert_eq!(r[2]["event_name"], "policy_fallback");
+        assert_eq!(r[2]["policy_fallback_times"], 1);
+        assert_eq!(r[3]["event_name"], "policy_denied");
+        assert_eq!(r[3]["policy_denied_times"], 1);
+        assert_eq!(r[4]["event_name"], "mount_end");
+        assert!(r[4]["mount_duration_ms"].is_u64());
+    }
+
+    #[test]
+    fn mount_error_carries_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&path).unwrap();
+
+        let sink = sink_to(&path);
+        sink.emit_mount_error("mount failed: boom");
+
+        let r = read_records(&path);
+        assert_eq!(r[0]["event_name"], "mount_error");
+        assert_eq!(r[0]["err_reason"], "mount failed: boom");
+        assert!(r[0]["mount_duration_ms"].is_u64());
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/tests/runtime_metrics_fuse_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/runtime_metrics_fuse_tests.rs
@@ -1,0 +1,325 @@
+//! FUSE integration tests for real-time runtime metric delta events.
+//!
+//! A `RuntimeMetricsSink` is threaded into the mount via `MountConfig` and
+//! pointed at a pre-created temp JSONL file. Reading a mounted skill through the
+//! FUSE layer must emit `skill_hit` and — when an active resolver made a real
+//! security decision — the corresponding `policy_*` delta record.
+//!
+//! Gated with `fuse_available()`: skips cleanly when `/dev/fuse` / `fusermount3`
+//! are absent.
+
+#![allow(clippy::too_many_arguments)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+use skillfs_fuse::security::{
+    ActiveSkillResolver, LedgerResolveResult, RuntimeMetricsSink, RuntimeMetricsWriter,
+};
+use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
+
+#[path = "common/mod.rs"]
+mod common;
+
+use crate::common::{create_skill_dir, fuse_available};
+
+/// Normal-mode mount that injects a `RuntimeMetricsSink` (and optionally an
+/// `ActiveSkillResolver`) and points the metrics writer at `metrics_path`.
+struct MetricsMount {
+    // Held only to keep the temp source dir alive for the mount's lifetime.
+    _source: tempfile::TempDir,
+    mountpoint: tempfile::TempDir,
+    handle: Option<MountHandle>,
+}
+
+impl MetricsMount {
+    fn new<S, R>(metrics_path: &Path, seed: S, resolver_builder: R) -> Self
+    where
+        S: FnOnce(&Path),
+        R: FnOnce(&Path) -> Option<Arc<ActiveSkillResolver>>,
+    {
+        // Source and mountpoint under /tmp so FUSE has a real backing dir.
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let resolver = resolver_builder(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+        let sink = Arc::new(RuntimeMetricsSink::new(
+            RuntimeMetricsWriter::new(metrics_path),
+            "test-session".to_string(),
+            "agent".to_string(),
+        ));
+
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            shared,
+            MountOptions::default(),
+            false, // normal mode
+            MountConfig {
+                active_resolver: resolver,
+                runtime_metrics: Some(sink),
+                ..MountConfig::default()
+            },
+        )
+        .expect("mount_background_configured");
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            _source: source,
+            mountpoint,
+            handle: Some(handle),
+        }
+    }
+
+    fn skills_dir(&self) -> PathBuf {
+        self.mountpoint.path().join("skills")
+    }
+
+    fn skill_md(&self, name: &str) -> PathBuf {
+        self.skills_dir().join(name).join("SKILL.md")
+    }
+}
+
+impl Drop for MetricsMount {
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            drop(h);
+        }
+        let mp = self.mountpoint.path().to_path_buf();
+        std::thread::sleep(Duration::from_millis(150));
+        let _ = std::process::Command::new("fusermount3")
+            .args(["-u", &mp.to_string_lossy()])
+            .output();
+    }
+}
+
+/// Pre-create the deployment-owned metrics file so the writer appends to it.
+fn make_metrics_file() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("metrics tempdir");
+    let path = dir.path().join("skillfs.jsonl");
+    std::fs::File::create(&path).expect("pre-create metrics file");
+    (dir, path)
+}
+
+fn read_records(path: &Path) -> Vec<serde_json::Value> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("valid JSON record"))
+        .collect()
+}
+
+fn events_named<'a>(records: &'a [serde_json::Value], name: &str) -> Vec<&'a serde_json::Value> {
+    records
+        .iter()
+        .filter(|r| r["record_type"] == "runtime_metric" && r["event_name"] == name)
+        .collect()
+}
+
+fn current_result(skill: &str) -> LedgerResolveResult {
+    let json = format!(
+        r#"{{
+            "schemaVersion": 1,
+            "skillName": "{skill}",
+            "status": "pass",
+            "decision": "current",
+            "currentVersion": "v000001",
+            "trustedVersion": "v000001"
+        }}"#
+    );
+    LedgerResolveResult::from_json_str(&json).expect("current json")
+}
+
+fn fallback_result(skill: &str, snapshot_segment: &str) -> LedgerResolveResult {
+    let json = format!(
+        r#"{{
+            "schemaVersion": 1,
+            "skillName": "{skill}",
+            "status": "deny",
+            "decision": "fallback",
+            "currentVersion": "v000003",
+            "trustedVersion": "{snapshot_segment}",
+            "target": ".skill-meta/versions/{snapshot_segment}",
+            "targetKind": "relative_to_skill_dir",
+            "reason": "current version has high-risk findings"
+        }}"#
+    );
+    LedgerResolveResult::from_json_str(&json).expect("fallback json")
+}
+
+fn hidden_result(skill: &str) -> LedgerResolveResult {
+    let json = format!(
+        r#"{{
+            "schemaVersion": 1,
+            "skillName": "{skill}",
+            "status": "deny",
+            "decision": "hidden",
+            "reason": "no trusted version available"
+        }}"#
+    );
+    LedgerResolveResult::from_json_str(&json).expect("hidden json")
+}
+
+fn write_snapshot(source: &Path, skill: &str, version: &str, skill_md: &str) {
+    let dir = source
+        .join(skill)
+        .join(".skill-meta/versions")
+        .join(version);
+    std::fs::create_dir_all(&dir).expect("create snapshot dir");
+    std::fs::write(dir.join("SKILL.md"), skill_md).expect("write snapshot SKILL.md");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn skill_open_emits_skill_hit_without_resolver_but_no_policy() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let (_dir, metrics) = make_metrics_file();
+    let mount = MetricsMount::new(
+        &metrics,
+        |src| create_skill_dir(src, "weather"),
+        |_src| None, // no resolver → plain passthrough, not a security decision
+    );
+
+    let _ = std::fs::read_to_string(mount.skill_md("weather")).expect("read skill md");
+    std::thread::sleep(Duration::from_millis(100));
+
+    let records = read_records(&metrics);
+    assert!(
+        !events_named(&records, "skill_hit").is_empty(),
+        "expected a skill_hit record, got {records:?}"
+    );
+    assert!(
+        events_named(&records, "policy_allow").is_empty(),
+        "plain passthrough (no resolver) must NOT emit policy_allow, got {records:?}"
+    );
+    let hit = events_named(&records, "skill_hit")[0];
+    assert_eq!(hit["skill_hit_times"], 1);
+    assert_eq!(hit["component.name"], "skillfs");
+    assert_eq!(hit["session_id"], "test-session");
+}
+
+#[test]
+fn current_skill_open_emits_policy_allow() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let (_dir, metrics) = make_metrics_file();
+    let mount = MetricsMount::new(
+        &metrics,
+        |src| create_skill_dir(src, "weather"),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&current_result("weather")).unwrap();
+            Some(Arc::new(r))
+        },
+    );
+
+    let _ = std::fs::read_to_string(mount.skill_md("weather")).expect("read skill md");
+    std::thread::sleep(Duration::from_millis(100));
+
+    let records = read_records(&metrics);
+    assert!(
+        !events_named(&records, "skill_hit").is_empty(),
+        "expected skill_hit, got {records:?}"
+    );
+    assert!(
+        !events_named(&records, "policy_allow").is_empty(),
+        "resolver Current decision must emit policy_allow, got {records:?}"
+    );
+    assert_eq!(
+        events_named(&records, "policy_allow")[0]["policy_allow_times"],
+        1
+    );
+}
+
+#[test]
+fn snapshot_skill_open_emits_policy_fallback() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let (_dir, metrics) = make_metrics_file();
+    let snapshot_md = "---\nname: weather\ndescription: trusted snapshot\n---\n\n# body\n";
+    let mount = MetricsMount::new(
+        &metrics,
+        |src| {
+            create_skill_dir(src, "weather");
+            write_snapshot(src, "weather", "v000001.snapshot", snapshot_md);
+        },
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&fallback_result("weather", "v000001.snapshot"))
+                .unwrap();
+            Some(Arc::new(r))
+        },
+    );
+
+    let served = std::fs::read_to_string(mount.skill_md("weather")).expect("read snapshot md");
+    assert!(
+        served.contains("trusted snapshot"),
+        "expected snapshot serve"
+    );
+    std::thread::sleep(Duration::from_millis(100));
+
+    let records = read_records(&metrics);
+    assert!(
+        !events_named(&records, "policy_fallback").is_empty(),
+        "resolver Snapshot decision must emit policy_fallback, got {records:?}"
+    );
+    assert_eq!(
+        events_named(&records, "policy_fallback")[0]["policy_fallback_times"],
+        1
+    );
+}
+
+#[test]
+fn hidden_skill_open_emits_policy_denied() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let (_dir, metrics) = make_metrics_file();
+    let mount = MetricsMount::new(
+        &metrics,
+        |src| create_skill_dir(src, "weather"),
+        |src_root| {
+            let r = ActiveSkillResolver::new(src_root.to_path_buf());
+            r.set_from_resolve(&hidden_result("weather")).unwrap();
+            Some(Arc::new(r))
+        },
+    );
+
+    // A hidden skill's SKILL.md open must fail (ENOENT) and record a denial.
+    let _ = std::fs::read_to_string(mount.skill_md("weather"));
+    std::thread::sleep(Duration::from_millis(100));
+
+    let records = read_records(&metrics);
+    assert!(
+        !events_named(&records, "policy_denied").is_empty(),
+        "resolver Hidden decision must emit policy_denied, got {records:?}"
+    );
+    assert_eq!(
+        events_named(&records, "policy_denied")[0]["policy_denied_times"],
+        1
+    );
+}


### PR DESCRIPTION
## Description

SkillFS did not emit SLS ops logs for CLI commands, so
`/var/log/anolisa/sls/ops/skillfs.jsonl` could stay empty after
`skillfs list`, `validate`, or `classify`. This PR adds best-effort CLI ops
records and real-time runtime metric delta events for SkillFS.

**What changed**
- Added CLI ops JSONL records for `list`, `validate`, `classify`, and `mount`.
- Added `runtime_metric` delta records for mount lifecycle, skill hits, view
  pruning, and security policy outcomes.
- Threaded a best-effort runtime metrics sink through the FUSE runtime while
  keeping the legacy mount-session summary for compatibility.

**Behavior / Compatibility**
- Logging is best-effort: missing SLS files are skipped, files are never
  created by SkillFS, and write failures do not change CLI or FUSE behavior.
- Plain non-security passthrough reads emit `skill_hit` only; `policy_*` metrics
  are emitted only for real security / resolver policy decisions.
- `mount_start` is emitted after the mount worker task starts. A very early
  FUSE startup failure may produce both `mount_start` and `mount_error`; tighter
  confirmed-readiness semantics can be tracked separately.

## Related Issue

closes #1306

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `skillfs` (SkillFS)

## Testing

- `cargo +1.86.0 fmt --all --check`
- `cargo +1.86.0 test -p skillfs`
- `cargo +1.86.0 test -p skillfs-fuse`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `scripts/test.sh`

Manual smoke on lifsea confirmed:
- CLI ops records are appended for `validate`, `list`, `classify`, and `mount`.
- Runtime metric records include `view_pruned`, `mount_start`, `skill_hit`, and
  `mount_end`.
- Plain passthrough skill reads do not emit spurious `policy_allow` records.