### PR TITLE
feat(anolisa): add cosh, codex, claude-code adapter drivers

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -21,12 +21,16 @@ use anolisa_platform::fs_layout::FsLayout;
 use crate::manifest::AdapterSpec;
 
 pub mod claim;
+pub mod claude_code;
+pub mod codex;
 pub mod contract;
+pub mod cosh;
 pub mod driver;
 pub mod hermes;
 pub mod manager;
 pub mod openclaw;
 pub mod registry;
+mod util;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -93,9 +97,9 @@ pub enum AdapterError {
     },
 
     /// The manifest declares an `adapter_type` that is not yet supported
-    /// by any built-in driver (e.g. `extension`, `service`).
+    /// by any built-in driver (e.g. `service`).
     #[error(
-        "adapter type '{adapter_type}' for {component}/{framework} is not supported; only 'plugin' and 'skill_bundle' are implemented"
+        "adapter type '{adapter_type}' for {component}/{framework} is not supported; only 'plugin', 'skill_bundle', and 'extension' are implemented"
     )]
     UnsupportedAdapterType {
         /// Component whose adapter was requested.

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -120,11 +120,46 @@ impl AdapterClaim {
         layout: &FsLayout,
         allowed_external_roots: &[PathBuf],
     ) -> Result<(), ClaimValidationError> {
+        self.validate_with_owned_roots(layout, allowed_external_roots, &[])
+    }
+
+    /// Like [`Self::validate`], but additionally trusts `extra_owned_roots`
+    /// as ANOLISA-owned locations for symlink *targets*.
+    ///
+    /// A symlink target (e.g. Codex's plugin symlink pointing back at the
+    /// resource bundle) is normally validated against the primary layout's
+    /// owned roots. When the bundle is resolved from a packaged datadir that
+    /// differs from `layout.datadir` (registered via
+    /// [`push_primary_datadir_root`](super::manager::AdapterManager::push_primary_datadir_root)),
+    /// that target lives outside the layout roots yet is still legitimately
+    /// ANOLISA-owned. The Manager passes its trusted datadir roots here so
+    /// such targets validate.
+    ///
+    /// `extra_owned_roots` MUST come from Manager configuration (visible
+    /// datadir roots), never from receipt fields such as `resource_root` —
+    /// otherwise a forged receipt could authorize its own symlink target.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`ClaimValidationError`] encountered: an owned
+    /// path outside ANOLISA roots, an external path outside every
+    /// `allowed_external_roots` entry, a traversal/symlink escape, or an
+    /// invalid plugin id.
+    pub fn validate_with_owned_roots(
+        &self,
+        layout: &FsLayout,
+        allowed_external_roots: &[PathBuf],
+        extra_owned_roots: &[PathBuf],
+    ) -> Result<(), ClaimValidationError> {
         if let Some(pid) = &self.plugin_id {
             validate_plugin_id(pid)?;
         }
         for resource in &self.resources {
-            resource.validate(layout, allowed_external_roots)?;
+            resource.validate_with_owned_roots(
+                layout,
+                allowed_external_roots,
+                extra_owned_roots,
+            )?;
             match &resource.kind {
                 ClaimResourceKind::FrameworkPlugin { framework, .. }
                 | ClaimResourceKind::FrameworkMarketplace { framework, .. }
@@ -180,6 +215,22 @@ impl ClaimResource {
         layout: &FsLayout,
         allowed_external_roots: &[PathBuf],
     ) -> Result<(), ClaimValidationError> {
+        self.validate_with_owned_roots(layout, allowed_external_roots, &[])
+    }
+
+    /// Like [`Self::validate`], but trusts `extra_owned_roots` as additional
+    /// ANOLISA-owned locations for a symlink *target*. See
+    /// [`AdapterClaim::validate_with_owned_roots`] for the trust contract.
+    ///
+    /// # Errors
+    ///
+    /// See [`AdapterClaim::validate`].
+    pub fn validate_with_owned_roots(
+        &self,
+        layout: &FsLayout,
+        allowed_external_roots: &[PathBuf],
+        extra_owned_roots: &[PathBuf],
+    ) -> Result<(), ClaimValidationError> {
         match &self.kind {
             ClaimResourceKind::OwnedPath { path } => {
                 validate_owned_path(layout, path).map_err(|source| {
@@ -205,9 +256,10 @@ impl ClaimResource {
                 // would follow it to its (owned) target and wrongly reject
                 // an in-boundary link. The `target` must be an
                 // ANOLISA-owned path (validated against the *trusted layout*
-                // roots, never the receipt-derived external roots): a forged
-                // receipt must not be able to point a claimed symlink at,
-                // say, `/etc` and have it validate. Owned-path validation is
+                // roots plus any Manager-supplied trusted datadir roots,
+                // never the receipt-derived external roots): a forged receipt
+                // must not be able to point a claimed symlink at, say,
+                // `/etc` and have it validate. Owned-path validation is
                 // independent of the receipt, closing the self-authorization
                 // hole.
                 validate_external_link_location(link, allowed_external_roots).map_err(
@@ -216,7 +268,7 @@ impl ClaimResource {
                         source,
                     },
                 )?;
-                validate_owned_path(layout, target).map_err(|source| {
+                validate_owned_symlink_target(layout, target, extra_owned_roots).map_err(|source| {
                     ClaimValidationError::OwnedPath {
                         id: self.id.clone(),
                         source,
@@ -592,6 +644,39 @@ pub fn validate_external_link_location(
         }
     }
     Ok(())
+}
+
+/// Validate a symlink `target` as an ANOLISA-owned path.
+///
+/// A target is accepted when it lives under one of the primary layout's
+/// owned roots ([`validate_owned_path`]) **or** under one of
+/// `extra_owned_roots` — trusted datadir roots supplied by the Manager for
+/// bundles resolved from a packaged datadir that differs from
+/// `layout.datadir`. `extra_owned_roots` must be Manager configuration, not
+/// receipt data, so a forged target (e.g. `/etc`) that is under neither is
+/// rejected.
+///
+/// # Errors
+///
+/// The [`PathBoundaryError`] from the layout check when the target is under
+/// neither the layout roots nor any extra trusted root.
+fn validate_owned_symlink_target(
+    layout: &FsLayout,
+    target: &Path,
+    extra_owned_roots: &[PathBuf],
+) -> Result<(), PathBoundaryError> {
+    match validate_owned_path(layout, target) {
+        Ok(()) => Ok(()),
+        Err(owned_err) => {
+            if !extra_owned_roots.is_empty()
+                && validate_external_path(target, extra_owned_roots).is_ok()
+            {
+                Ok(())
+            } else {
+                Err(owned_err)
+            }
+        }
+    }
 }
 
 /// Reject a plugin id unless it is a non-empty string of argv-safe

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -326,14 +326,14 @@ pub enum ClaimResourceKind {
         /// Absolute external path.
         path: PathBuf,
     },
-    /// A symlink ANOLISA created and took over. Both the `link` location
-    /// and its `target` are validated against the driver's static
-    /// external roots (a symlink can otherwise redirect a later removal
-    /// outside the allowed boundary).
+    /// A symlink ANOLISA created and took over. The `link` location is
+    /// validated against the driver's static external roots, while the
+    /// `target` must live under ANOLISA-owned roots (including trusted
+    /// datadir roots supplied by the Manager for packaged bundles).
     Symlink {
         /// Absolute path of the link ANOLISA created.
         link: PathBuf,
-        /// Absolute path the link points at.
+        /// Absolute ANOLISA-owned path the link points at.
         target: PathBuf,
     },
     /// A record in a framework's plugin registry. `plugin_id` is

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -127,6 +127,7 @@ impl AdapterClaim {
             resource.validate(layout, allowed_external_roots)?;
             match &resource.kind {
                 ClaimResourceKind::FrameworkPlugin { framework, .. }
+                | ClaimResourceKind::FrameworkMarketplace { framework, .. }
                 | ClaimResourceKind::FrameworkConfig { framework, .. }
                     if framework != &self.framework =>
                 {
@@ -196,7 +197,41 @@ impl ClaimResource {
                     }
                 })
             }
+            ClaimResourceKind::Symlink { link, target } => {
+                // The `link` is a per-user framework path, validated against
+                // the driver's static external roots so disable removes only
+                // ANOLISA's own entry. We validate the link *location*
+                // without resolving the link itself: canonicalizing the link
+                // would follow it to its (owned) target and wrongly reject
+                // an in-boundary link. The `target` must be an
+                // ANOLISA-owned path (validated against the *trusted layout*
+                // roots, never the receipt-derived external roots): a forged
+                // receipt must not be able to point a claimed symlink at,
+                // say, `/etc` and have it validate. Owned-path validation is
+                // independent of the receipt, closing the self-authorization
+                // hole.
+                validate_external_link_location(link, allowed_external_roots).map_err(
+                    |source| ClaimValidationError::ExternalPath {
+                        id: self.id.clone(),
+                        source,
+                    },
+                )?;
+                validate_owned_path(layout, target).map_err(|source| {
+                    ClaimValidationError::OwnedPath {
+                        id: self.id.clone(),
+                        source,
+                    }
+                })
+            }
             ClaimResourceKind::FrameworkPlugin { plugin_id, .. } => validate_plugin_id(plugin_id),
+            ClaimResourceKind::FrameworkMarketplace { marketplace, .. } => {
+                validate_marketplace_name(marketplace).map_err(|_| {
+                    ClaimValidationError::MarketplaceName {
+                        id: self.id.clone(),
+                        marketplace: marketplace.clone(),
+                    }
+                })
+            }
             ClaimResourceKind::FrameworkConfig { key, .. } => {
                 if key.is_empty() {
                     return Err(ClaimValidationError::ConfigKey {
@@ -215,13 +250,13 @@ impl ClaimResource {
 
 /// The closed set of resource kinds a receipt may declare.
 ///
-/// MVP implements only the three kinds OpenClaw needs. Additional kinds
-/// (`Tree`, `JsonKeys`, `Symlink`, `FrameworkMarketplace`) are introduced
-/// when their first driver lands — adding a variant here is a deliberate,
-/// reviewed extension of the security boundary, never an open map.
+/// Additional kinds (`Tree`, `JsonKeys`) are introduced when their first
+/// driver lands — adding a variant here is a deliberate, reviewed
+/// extension of the security boundary, never an open map. `Symlink` and
+/// `FrameworkMarketplace` landed with the Codex/Claude Code drivers.
 ///
 /// Externally tagged with snake_case variant keys (`owned_path`,
-/// `external_path`, `framework_plugin`).
+/// `external_path`, `framework_plugin`, `symlink`, `framework_marketplace`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ClaimResourceKind {
@@ -239,6 +274,16 @@ pub enum ClaimResourceKind {
         /// Absolute external path.
         path: PathBuf,
     },
+    /// A symlink ANOLISA created and took over. Both the `link` location
+    /// and its `target` are validated against the driver's static
+    /// external roots (a symlink can otherwise redirect a later removal
+    /// outside the allowed boundary).
+    Symlink {
+        /// Absolute path of the link ANOLISA created.
+        link: PathBuf,
+        /// Absolute path the link points at.
+        target: PathBuf,
+    },
     /// A record in a framework's plugin registry. `plugin_id` is
     /// whitelist-sanitized before it enters any argv.
     FrameworkPlugin {
@@ -246,6 +291,15 @@ pub enum ClaimResourceKind {
         framework: String,
         /// Native plugin id.
         plugin_id: String,
+    },
+    /// A source registered in a framework's marketplace (e.g. Codex,
+    /// Claude Code). `marketplace` is whitelist-sanitized before it enters
+    /// any argv.
+    FrameworkMarketplace {
+        /// Framework that owns the marketplace (e.g. `codex`).
+        framework: String,
+        /// Marketplace name ANOLISA registered.
+        marketplace: String,
     },
     /// A framework configuration key/value pair that ANOLISA applied.
     /// The key path is framework-specific; the value is the TOML
@@ -270,6 +324,15 @@ pub enum DriverPayload {
     /// Hermes driver payload.
     #[serde(rename = "hermes")]
     Hermes(HermesClaim),
+    /// Cosh (copilot-shell) driver payload.
+    #[serde(rename = "cosh")]
+    Cosh(CoshClaim),
+    /// Codex driver payload.
+    #[serde(rename = "codex")]
+    Codex(CodexClaim),
+    /// Claude Code driver payload.
+    #[serde(rename = "claude_code")]
+    ClaudeCode(ClaudeCodeClaim),
 }
 
 /// OpenClaw driver payload. Holds only [`ClaimResource::id`] references —
@@ -303,6 +366,50 @@ pub struct HermesClaim {
     /// Resource ids of delivered skill directories.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skill_resources: Vec<String>,
+}
+
+/// Cosh (copilot-shell) driver payload. Holds only [`ClaimResource::id`]
+/// references. Cosh is extension-based: ANOLISA drops an auto-discovered
+/// extension tree into the user's cosh home and takes over only that
+/// directory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoshClaim {
+    /// Resource id of the delivered extension directory
+    /// ([`ClaimResourceKind::ExternalPath`]).
+    pub extension_dir_resource: String,
+}
+
+/// Codex driver payload. Holds only [`ClaimResource::id`] references. Codex
+/// requires a local marketplace layout (a directory plus a symlink to the
+/// resource root) before a plugin can be added from it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodexClaim {
+    /// Resource id of the marketplace root directory ANOLISA created
+    /// ([`ClaimResourceKind::ExternalPath`]).
+    pub marketplace_dir_resource: String,
+    /// Resource id of the plugin symlink under the marketplace root
+    /// ([`ClaimResourceKind::Symlink`]).
+    pub symlink_resource: String,
+    /// Resource id of the registered marketplace
+    /// ([`ClaimResourceKind::FrameworkMarketplace`]).
+    pub marketplace_resource: String,
+    /// Resource id of the installed plugin
+    /// ([`ClaimResourceKind::FrameworkPlugin`]).
+    pub plugin_resource: String,
+}
+
+/// Claude Code driver payload. Holds only [`ClaimResource::id`] references.
+/// Claude Code owns its own registry and settings; ANOLISA only registers a
+/// marketplace pointing at the shared resource root and installs the plugin
+/// — it never writes `~/.claude/settings.json` directly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClaudeCodeClaim {
+    /// Resource id of the registered marketplace
+    /// ([`ClaimResourceKind::FrameworkMarketplace`]).
+    pub marketplace_resource: String,
+    /// Resource id of the installed plugin
+    /// ([`ClaimResourceKind::FrameworkPlugin`]).
+    pub plugin_resource: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -348,6 +455,16 @@ pub enum ClaimValidationError {
         id: String,
         /// Why it was rejected.
         reason: String,
+    },
+    /// A `marketplace` name in a [`ClaimResourceKind::FrameworkMarketplace`]
+    /// resource is empty or contains characters outside the argv-safe
+    /// whitelist.
+    #[error("invalid marketplace name '{marketplace}' in resource '{id}'")]
+    MarketplaceName {
+        /// Offending resource id.
+        id: String,
+        /// The rejected marketplace name.
+        marketplace: String,
     },
     /// A resource declares a framework that differs from the claim's.
     #[error(
@@ -424,6 +541,59 @@ pub fn validate_external_path(
     Ok(())
 }
 
+/// Validate the *location* of a symlink `link` against `allowed_roots`
+/// without following the link itself.
+///
+/// [`validate_external_path`] canonicalizes the whole path, which for an
+/// existing symlink resolves through it to the target — the wrong thing for
+/// a claimed link that legitimately points at an ANOLISA-owned path outside
+/// the external roots. Instead this rejects traversal, requires the link to
+/// live lexically under an allowed root, and canonicalizes only the link's
+/// **parent** (catching a symlinked ancestor that escapes the boundary)
+/// while leaving the final link component unresolved.
+///
+/// # Errors
+///
+/// [`ExternalPathError::Traversal`] for `.`/`..` segments;
+/// [`ExternalPathError::OutsideAllowedRoots`] when the link (or its
+/// canonicalized parent) is not under any allowed root.
+pub fn validate_external_link_location(
+    link: &Path,
+    allowed_roots: &[PathBuf],
+) -> Result<(), ExternalPathError> {
+    use std::path::Component;
+    for component in link.components() {
+        if matches!(component, Component::ParentDir | Component::CurDir) {
+            return Err(ExternalPathError::Traversal {
+                path: link.to_path_buf(),
+            });
+        }
+    }
+    if !allowed_roots.iter().any(|root| link.starts_with(root)) {
+        return Err(ExternalPathError::OutsideAllowedRoots {
+            path: link.to_path_buf(),
+        });
+    }
+    if let Some(parent) = link.parent()
+        && let Some(canonical_parent) = canonicalize_nearest_existing(parent)
+    {
+        let canonical_roots: Vec<PathBuf> = allowed_roots
+            .iter()
+            .filter_map(|r| canonicalize_nearest_existing(r))
+            .collect();
+        if !canonical_roots.is_empty()
+            && !canonical_roots
+                .iter()
+                .any(|r| canonical_parent.starts_with(r))
+        {
+            return Err(ExternalPathError::OutsideAllowedRoots {
+                path: link.to_path_buf(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Reject a plugin id unless it is a non-empty string of argv-safe
 /// characters (`[A-Za-z0-9._-]`) that is neither `.`/`..` nor leading
 /// with `-` (which an argv parser could mistake for a flag).
@@ -457,6 +627,20 @@ pub fn validate_plugin_id(plugin_id: &str) -> Result<(), ClaimValidationError> {
         });
     }
     Ok(())
+}
+
+/// Reject a marketplace name unless it is a non-empty string of argv-safe
+/// characters (`[A-Za-z0-9._-]`) that is neither `.`/`..` nor leading with
+/// `-`. Codex/Claude Code marketplace names are passed to the framework
+/// CLI (`marketplace add/remove`) and combined into a `plugin@marketplace`
+/// argument, so the same whitelist as [`validate_plugin_id`] applies.
+///
+/// # Errors
+///
+/// [`ClaimValidationError::PluginId`] with a specific reason (reused so the
+/// argv-safety whitelist stays defined in one place).
+pub fn validate_marketplace_name(marketplace: &str) -> Result<(), ClaimValidationError> {
+    validate_plugin_id(marketplace)
 }
 
 /// Reject a skill name that is empty, `.`/`..`, starts with `-`, or
@@ -808,6 +992,243 @@ mod tests {
         assert!(validate_config_key("a`b").is_err(), "backtick");
         assert!(validate_config_key("a b").is_err(), "space");
         assert!(validate_config_key("a|b").is_err(), "pipe");
+    }
+
+    fn sample_codex_claim() -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "tokenless".to_string(),
+            framework: "codex".to_string(),
+            plugin_id: Some("tokenless".to_string()),
+            adapter_type: Some("plugin".to_string()),
+            enabled_at: "2026-07-04T10:30:45Z".to_string(),
+            resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/codex"),
+            bundle_digest: Some("sha256:c0de".to_string()),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: vec![
+                ClaimResource {
+                    id: "codex_marketplace_dir".to_string(),
+                    purpose: "codex_marketplace_dir".to_string(),
+                    kind: ClaimResourceKind::ExternalPath {
+                        path: PathBuf::from("/home/alice/.local/share/anolisa/codex-marketplace"),
+                    },
+                },
+                ClaimResource {
+                    id: "codex_symlink".to_string(),
+                    purpose: "codex_plugin_symlink".to_string(),
+                    kind: ClaimResourceKind::Symlink {
+                        link: PathBuf::from(
+                            "/home/alice/.local/share/anolisa/codex-marketplace/tokenless",
+                        ),
+                        target: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/codex"),
+                    },
+                },
+                ClaimResource {
+                    id: "codex_marketplace".to_string(),
+                    purpose: "codex_marketplace".to_string(),
+                    kind: ClaimResourceKind::FrameworkMarketplace {
+                        framework: "codex".to_string(),
+                        marketplace: "anolisa-tokenless".to_string(),
+                    },
+                },
+                ClaimResource {
+                    id: "codex_plugin".to_string(),
+                    purpose: "codex_plugin".to_string(),
+                    kind: ClaimResourceKind::FrameworkPlugin {
+                        framework: "codex".to_string(),
+                        plugin_id: "tokenless".to_string(),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::Codex(CodexClaim {
+                marketplace_dir_resource: "codex_marketplace_dir".to_string(),
+                symlink_resource: "codex_symlink".to_string(),
+                marketplace_resource: "codex_marketplace".to_string(),
+                plugin_resource: "codex_plugin".to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn codex_claim_toml_and_json_round_trip() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            adapter_claims: Vec<AdapterClaim>,
+        }
+        let wrapper = Wrapper {
+            adapter_claims: vec![sample_codex_claim()],
+        };
+        let text = toml::to_string_pretty(&wrapper).expect("serialize Codex to TOML");
+        let parsed: Wrapper = toml::from_str(&text).expect("parse Codex from TOML");
+        assert_eq!(wrapper, parsed, "Codex round-trip mismatch; TOML:\n{text}");
+
+        let claim = sample_codex_claim();
+        let json = serde_json::to_string(&claim).expect("serialize Codex JSON");
+        let back: AdapterClaim = serde_json::from_str(&json).expect("parse Codex JSON");
+        assert_eq!(claim, back);
+    }
+
+    #[test]
+    fn codex_claim_validates_under_allowed_roots() {
+        let layout = FsLayout::system(None);
+        let allowed = vec![
+            PathBuf::from("/home/alice/.local/share/anolisa"),
+            PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/codex"),
+        ];
+        sample_codex_claim()
+            .validate(&layout, &allowed)
+            .expect("codex claim under allowed roots must pass");
+    }
+
+    #[test]
+    fn cosh_claim_round_trips_and_validates() {
+        let claim = AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "tokenless".to_string(),
+            framework: "cosh".to_string(),
+            plugin_id: Some("tokenless".to_string()),
+            adapter_type: Some("extension".to_string()),
+            enabled_at: "2026-07-04T10:30:45Z".to_string(),
+            resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/common"),
+            bundle_digest: Some("sha256:c05h".to_string()),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: vec![ClaimResource {
+                id: "cosh_extension_dir".to_string(),
+                purpose: "cosh_extension_dir".to_string(),
+                kind: ClaimResourceKind::ExternalPath {
+                    path: PathBuf::from("/home/alice/.copilot-shell/extensions/tokenless"),
+                },
+            }],
+            driver_payload: DriverPayload::Cosh(CoshClaim {
+                extension_dir_resource: "cosh_extension_dir".to_string(),
+            }),
+        };
+        let json = serde_json::to_string(&claim).expect("serialize Cosh JSON");
+        let back: AdapterClaim = serde_json::from_str(&json).expect("parse Cosh JSON");
+        assert_eq!(claim, back);
+
+        let layout = FsLayout::system(None);
+        let allowed = vec![PathBuf::from("/home/alice/.copilot-shell")];
+        claim
+            .validate(&layout, &allowed)
+            .expect("cosh claim under allowed roots must pass");
+    }
+
+    #[test]
+    fn claude_code_claim_round_trips() {
+        let claim = AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "tokenless".to_string(),
+            framework: "claude-code".to_string(),
+            plugin_id: Some("tokenless".to_string()),
+            adapter_type: Some("plugin".to_string()),
+            enabled_at: "2026-07-04T10:30:45Z".to_string(),
+            resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/claude-code"),
+            bundle_digest: None,
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: vec![
+                ClaimResource {
+                    id: "cc_marketplace".to_string(),
+                    purpose: "claude_code_marketplace".to_string(),
+                    kind: ClaimResourceKind::FrameworkMarketplace {
+                        framework: "claude-code".to_string(),
+                        marketplace: "anolisa".to_string(),
+                    },
+                },
+                ClaimResource {
+                    id: "cc_plugin".to_string(),
+                    purpose: "claude_code_plugin".to_string(),
+                    kind: ClaimResourceKind::FrameworkPlugin {
+                        framework: "claude-code".to_string(),
+                        plugin_id: "tokenless".to_string(),
+                    },
+                },
+            ],
+            driver_payload: DriverPayload::ClaudeCode(ClaudeCodeClaim {
+                marketplace_resource: "cc_marketplace".to_string(),
+                plugin_resource: "cc_plugin".to_string(),
+            }),
+        };
+        let json = serde_json::to_string(&claim).expect("serialize Claude Code JSON");
+        let back: AdapterClaim = serde_json::from_str(&json).expect("parse Claude Code JSON");
+        assert_eq!(claim, back);
+    }
+
+    #[test]
+    fn forged_symlink_target_outside_roots_rejected() {
+        let layout = FsLayout::system(None);
+        let allowed = vec![
+            PathBuf::from("/home/alice/.local/share/anolisa"),
+            PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/codex"),
+        ];
+        let mut claim = sample_codex_claim();
+        // Repoint the symlink target at /etc — outside every owned root.
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::Symlink { target, .. } = &mut res.kind {
+                *target = PathBuf::from("/etc/cron.d/evil");
+            }
+        }
+        let err = claim.validate(&layout, &allowed).expect_err("must reject");
+        // The target is validated as an ANOLISA-owned path, so a non-owned
+        // target is an OwnedPath boundary violation.
+        assert!(
+            matches!(err, ClaimValidationError::OwnedPath { .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// A forged receipt cannot self-authorize a symlink target by also
+    /// forging its own `resource_root`: the target is validated against the
+    /// trusted layout, not against anything the receipt names.
+    #[test]
+    fn forged_symlink_target_not_authorized_by_forged_resource_root() {
+        let layout = FsLayout::system(None);
+        let allowed = vec![PathBuf::from("/home/alice/.local/share/anolisa")];
+        let mut claim = sample_codex_claim();
+        claim.resource_root = PathBuf::from("/etc");
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::Symlink { target, .. } = &mut res.kind {
+                *target = PathBuf::from("/etc/cron.d/evil");
+            }
+        }
+        let err = claim.validate(&layout, &allowed).expect_err("must reject");
+        assert!(
+            matches!(err, ClaimValidationError::OwnedPath { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn marketplace_framework_mismatch_rejected() {
+        let layout = FsLayout::system(None);
+        let allowed = vec![
+            PathBuf::from("/home/alice/.local/share/anolisa"),
+            PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/codex"),
+        ];
+        let mut claim = sample_codex_claim();
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::FrameworkMarketplace { framework, .. } = &mut res.kind {
+                *framework = "claude-code".to_string();
+            }
+        }
+        let err = claim.validate(&layout, &allowed).expect_err("must reject");
+        assert!(
+            matches!(err, ClaimValidationError::FrameworkMismatch { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_marketplace_name_rejects_unsafe() {
+        validate_marketplace_name("anolisa").expect("plain");
+        validate_marketplace_name("anolisa-tokenless").expect("dash");
+        assert!(validate_marketplace_name("").is_err(), "empty");
+        assert!(validate_marketplace_name("a b").is_err(), "space");
+        assert!(validate_marketplace_name("a@b").is_err(), "at-sign");
+        assert!(validate_marketplace_name("-x").is_err(), "leading dash");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
@@ -1,0 +1,672 @@
+//! Claude Code framework driver.
+//!
+//! Claude Code v2 installs plugins from a registered marketplace. ANOLISA
+//! exposes the component's resource root (which ships
+//! `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`) as a
+//! single-plugin marketplace named `anolisa`, then installs the plugin via
+//! the official CLI:
+//!
+//! ```text
+//! claude plugin validate <resource_root>
+//! claude plugin marketplace add <resource_root>
+//! claude plugin install <plugin>@anolisa
+//! ```
+//!
+//! `disable` reverses this with `claude plugin uninstall` /
+//! `claude plugin marketplace remove`. ANOLISA never edits
+//! `~/.claude/settings.json` directly: when the CLI is unavailable it
+//! reports cleanup as incomplete and keeps the receipt, rather than
+//! hand-patching a file it does not own.
+//!
+//! Env contract: `CLAUDE_BIN` overrides the executable (tests point it at a
+//! fake CLI).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::AdapterError;
+use super::claim::{
+    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
+    ClaudeCodeClaim, DRIVER_SCHEMA_VERSION, DriverPayload, validate_marketplace_name,
+    validate_plugin_id,
+};
+use super::driver::{
+    AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
+    ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
+    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+};
+use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+
+/// Default timeout for a Claude Code CLI invocation.
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Marketplace name ANOLISA registers with Claude Code. Matches the name
+/// declared in every component's `.claude-plugin/marketplace.json`.
+///
+/// Ownership constraint: `anolisa` is a shared, ANOLISA-owned marketplace
+/// by convention — all ANOLISA components publish into it, and this driver
+/// assumes any marketplace of that name is ANOLISA's to add/remove. If a
+/// user has an unrelated marketplace also named `anolisa`, enable would
+/// re-point it and disable would remove it. That collision is accepted as
+/// out of scope: the name is reserved for ANOLISA. A future multi-owner
+/// design would need to verify the marketplace *source* before removal.
+const MARKETPLACE_NAME: &str = "anolisa";
+
+/// Native marketplace manifest inside a Claude Code plugin bundle.
+const MARKETPLACE_MANIFEST: &str = ".claude-plugin/marketplace.json";
+/// Native plugin manifest inside a Claude Code plugin bundle.
+const PLUGIN_MANIFEST: &str = ".claude-plugin/plugin.json";
+
+/// Resource ids used in Claude Code receipts.
+const RES_MARKETPLACE: &str = "claude_code_marketplace";
+const RES_PLUGIN: &str = "claude_code_plugin";
+
+/// Claude Code driver. Stateless; all per-operation context arrives via
+/// [`DriverCtx`].
+pub struct ClaudeCodeDriver;
+
+impl ClaudeCodeDriver {
+    /// Construct the driver.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ClaudeCodeDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameworkDriver for ClaudeCodeDriver {
+    fn name(&self) -> &'static str {
+        "claude-code"
+    }
+
+    fn detect(&self, _env: &HostEnv) -> DetectResult {
+        match find_binary_in_path(&claude_bin()) {
+            Some(path) => DetectResult {
+                detected: true,
+                reason: format!("claude CLI found at {}", path.display()),
+            },
+            None => DetectResult {
+                detected: false,
+                reason: "claude CLI not found on PATH".to_string(),
+            },
+        }
+    }
+
+    fn allowed_external_roots(&self, _ctx: &DriverCtx) -> Vec<PathBuf> {
+        // Claude Code owns its own registry and settings; ANOLISA writes no
+        // external filesystem paths of its own (the marketplace source is
+        // the shared resource root, added by reference via the CLI).
+        Vec::new()
+    }
+
+    fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError> {
+        let root = &ctx.resource_root;
+        if !root.is_dir() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root does not exist or is not a directory".to_string(),
+            });
+        }
+        if !root.join(MARKETPLACE_MANIFEST).is_file() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: format!(
+                    "Claude Code marketplace manifest '{MARKETPLACE_MANIFEST}' missing"
+                ),
+            });
+        }
+        if !root.join(PLUGIN_MANIFEST).is_file() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: format!(
+                    "Claude Code plugin manifest '{PLUGIN_MANIFEST}' missing (run: make stamp-adapter-templates)"
+                ),
+            });
+        }
+        let plugin_id = Some(
+            ctx.declared_plugin_id
+                .clone()
+                .filter(|id| !id.is_empty())
+                .unwrap_or_else(|| ctx.component.clone()),
+        );
+        Ok(AdapterBundle {
+            resource_root: root.clone(),
+            digest: digest_tree(root),
+            plugin_id,
+        })
+    }
+
+    fn plan_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<DriverPlan, AdapterError> {
+        let plugin = plugin_name(bundle, ctx);
+        let plugin_ref = plugin_ref(&plugin);
+        let install_cmd = build_plugin_install_cmd(&plugin_ref);
+        let actions = vec![
+            format!(
+                "validate Claude Code plugin at {}",
+                bundle.resource_root.display()
+            ),
+            format!(
+                "register Claude Code marketplace '{MARKETPLACE_NAME}' from {}",
+                bundle.resource_root.display()
+            ),
+            format!("install Claude Code plugin '{plugin_ref}'"),
+        ];
+        Ok(DriverPlan {
+            framework: self.name().to_string(),
+            component: ctx.component.clone(),
+            actions,
+            register_command: Some(display_command(&install_cmd)),
+        })
+    }
+
+    fn prepare_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterClaim, AdapterError> {
+        let plugin = plugin_name(bundle, ctx);
+        validate_plugin_id(&plugin)?;
+        validate_marketplace_name(MARKETPLACE_NAME)?;
+
+        let resources = vec![
+            ClaimResource {
+                id: RES_MARKETPLACE.to_string(),
+                purpose: "claude_code_marketplace".to_string(),
+                kind: ClaimResourceKind::FrameworkMarketplace {
+                    framework: self.name().to_string(),
+                    marketplace: MARKETPLACE_NAME.to_string(),
+                },
+            },
+            ClaimResource {
+                id: RES_PLUGIN.to_string(),
+                purpose: "claude_code_plugin".to_string(),
+                kind: ClaimResourceKind::FrameworkPlugin {
+                    framework: self.name().to_string(),
+                    plugin_id: plugin.clone(),
+                },
+            },
+        ];
+
+        Ok(AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: ctx.component.clone(),
+            framework: self.name().to_string(),
+            plugin_id: Some(plugin),
+            adapter_type: ctx.adapter_type.clone(),
+            enabled_at: now_iso8601(),
+            resource_root: bundle.resource_root.clone(),
+            bundle_digest: bundle.digest.clone(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources,
+            driver_payload: DriverPayload::ClaudeCode(ClaudeCodeClaim {
+                marketplace_resource: RES_MARKETPLACE.to_string(),
+                plugin_resource: RES_PLUGIN.to_string(),
+            }),
+        })
+    }
+
+    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+        let plugin = claim_plugin(claim).ok_or_else(|| AdapterError::BundleInvalid {
+            root: claim.resource_root.clone(),
+            reason: "claude-code receipt has no plugin resource".to_string(),
+        })?;
+
+        // 1. Validate the bundle via the official CLI — same gate `install`
+        //    hits, but surfaces a cleaner error here.
+        let validate_cmd = build_validate_cmd(&claim.resource_root);
+        let program = validate_cmd.program.clone();
+        let output = ctx.ops.run_framework_cli(validate_cmd)?;
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
+                program,
+                reason: cli_failure_reason("plugin validate", &output),
+            });
+        }
+
+        // 2. Register the marketplace (idempotent: skip when already listed
+        //    so a re-enable does not error on a duplicate source).
+        if !marketplace_registered(ctx) {
+            let add_cmd = build_marketplace_add_cmd(&claim.resource_root);
+            let program = add_cmd.program.clone();
+            let output = ctx.ops.run_framework_cli(add_cmd)?;
+            if !output.success() {
+                return Err(AdapterError::FrameworkCli {
+                    program,
+                    reason: cli_failure_reason("plugin marketplace add", &output),
+                });
+            }
+        }
+
+        // 3. Install the plugin from the marketplace.
+        let install_cmd = build_plugin_install_cmd(&plugin_ref(&plugin));
+        let program = install_cmd.program.clone();
+        let output = ctx.ops.run_framework_cli(install_cmd)?;
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
+                program,
+                reason: cli_failure_reason("plugin install", &output),
+            });
+        }
+        Ok(())
+    }
+
+    fn status(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterStatusReport, AdapterError> {
+        let mut conditions = Vec::new();
+        let detect = self.detect(&HostEnv {
+            user_home: ctx.user_home.clone(),
+        });
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::FrameworkDetected,
+            status: bool_status(detect.detected),
+            reason: Some(detect.reason.clone()),
+            resource: None,
+        });
+        conditions.push(bundle_match_condition(claim));
+
+        let plugin = claim_plugin(claim);
+        let (mkt_status, plugin_status) = if !detect.detected {
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::MarketplaceRegistered,
+                status: ConditionStatus::Unknown,
+                reason: Some("claude CLI unavailable; cannot verify".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_MARKETPLACE.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::PluginRegistered,
+                status: ConditionStatus::Unknown,
+                reason: Some("claude CLI unavailable; cannot verify".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_PLUGIN.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::VerificationSupported,
+                status: ConditionStatus::False,
+                reason: Some("claude CLI unavailable".to_string()),
+                resource: None,
+            });
+            (ConditionStatus::Unknown, ConditionStatus::Unknown)
+        } else {
+            let mkt = marketplace_registered(ctx);
+            let plugin_ok = plugin
+                .as_deref()
+                .map(|p| plugin_registered(p, ctx))
+                .unwrap_or(false);
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::MarketplaceRegistered,
+                status: bool_status(mkt),
+                reason: (!mkt).then(|| "marketplace not in `plugin marketplace list`".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_MARKETPLACE.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::PluginRegistered,
+                status: bool_status(plugin_ok),
+                reason: (!plugin_ok).then(|| "plugin not in `plugin list`".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_PLUGIN.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::VerificationSupported,
+                status: ConditionStatus::True,
+                reason: None,
+                resource: None,
+            });
+            (bool_status(mkt), bool_status(plugin_ok))
+        };
+
+        let summary = summarize(claim.status, detect.detected, mkt_status, plugin_status);
+        Ok(AdapterStatusReport {
+            summary,
+            conditions,
+        })
+    }
+
+    fn disable(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        // Deregistration is only possible through the CLI. ANOLISA must not
+        // hand-edit ~/.claude/settings.json, so without the CLI we report
+        // cleanup as incomplete and keep the receipt for a later retry.
+        if find_binary_in_path(&claude_bin()).is_none() {
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![
+                    "claude CLI not found on PATH; receipt kept (ANOLISA will not hand-edit settings.json)"
+                        .to_string(),
+                ],
+            });
+        }
+
+        let mut messages = Vec::new();
+        let mut cleanup_complete = true;
+
+        if let Some(plugin) = claim_plugin(claim) {
+            let cmd = build_plugin_uninstall_cmd(&plugin_ref(&plugin));
+            let output = ctx.ops.run_framework_cli(cmd)?;
+            if output.success() {
+                messages.push(format!(
+                    "uninstalled claude-code plugin '{}'",
+                    plugin_ref(&plugin)
+                ));
+            } else {
+                cleanup_complete = false;
+                messages.push(format!(
+                    "claude plugin uninstall failed: {}",
+                    cli_failure_reason("plugin uninstall", &output)
+                ));
+            }
+        } else {
+            messages.push("receipt records no plugin to uninstall".to_string());
+        }
+
+        let cmd = build_marketplace_remove_cmd();
+        let output = ctx.ops.run_framework_cli(cmd)?;
+        if output.success() {
+            messages.push(format!(
+                "removed claude-code marketplace '{MARKETPLACE_NAME}'"
+            ));
+        } else {
+            cleanup_complete = false;
+            messages.push(format!(
+                "claude plugin marketplace remove failed: {}",
+                cli_failure_reason("plugin marketplace remove", &output)
+            ));
+        }
+
+        Ok(DisableReport {
+            cleanup_complete,
+            messages,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/// `CLAUDE_BIN` override, else `claude`.
+fn claude_bin() -> String {
+    std::env::var("CLAUDE_BIN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "claude".to_string())
+}
+
+/// Plugin name for the receipt: declared plugin id, else component.
+fn plugin_name(bundle: &AdapterBundle, ctx: &DriverCtx) -> String {
+    bundle
+        .plugin_id
+        .clone()
+        .unwrap_or_else(|| ctx.component.clone())
+}
+
+/// `<plugin>@anolisa` argument for `claude plugin install/uninstall`.
+fn plugin_ref(plugin: &str) -> String {
+    format!("{plugin}@{MARKETPLACE_NAME}")
+}
+
+/// Extract the plugin name from a receipt's plugin resource.
+fn claim_plugin(claim: &AdapterClaim) -> Option<String> {
+    claim
+        .resource(RES_PLUGIN)
+        .and_then(|r| match &r.kind {
+            ClaimResourceKind::FrameworkPlugin { plugin_id, .. } => Some(plugin_id.clone()),
+            _ => None,
+        })
+        .or_else(|| claim.plugin_id.clone())
+}
+
+fn base_cmd(args: Vec<String>) -> FrameworkCommand {
+    FrameworkCommand {
+        program: claude_bin(),
+        args,
+        env_set: Vec::new(),
+        env_remove: Vec::new(),
+        path_prepend: Vec::new(),
+        timeout: CLI_TIMEOUT,
+    }
+}
+
+fn build_validate_cmd(resource_root: &Path) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "validate".to_string(),
+        resource_root.to_string_lossy().into_owned(),
+    ])
+}
+
+fn build_marketplace_add_cmd(resource_root: &Path) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "marketplace".to_string(),
+        "add".to_string(),
+        resource_root.to_string_lossy().into_owned(),
+    ])
+}
+
+fn build_marketplace_remove_cmd() -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "marketplace".to_string(),
+        "remove".to_string(),
+        MARKETPLACE_NAME.to_string(),
+    ])
+}
+
+fn build_marketplace_list_cmd() -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "marketplace".to_string(),
+        "list".to_string(),
+    ])
+}
+
+fn build_plugin_install_cmd(plugin_ref: &str) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "install".to_string(),
+        plugin_ref.to_string(),
+    ])
+}
+
+fn build_plugin_uninstall_cmd(plugin_ref: &str) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "uninstall".to_string(),
+        plugin_ref.to_string(),
+    ])
+}
+
+fn build_plugin_list_cmd() -> FrameworkCommand {
+    base_cmd(vec!["plugin".to_string(), "list".to_string()])
+}
+
+/// True when `claude plugin marketplace list` reports the ANOLISA
+/// marketplace.
+fn marketplace_registered(ctx: &DriverCtx) -> bool {
+    match ctx.ops.run_framework_cli(build_marketplace_list_cmd()) {
+        Ok(output) if output.success() => list_contains_token(&output.stdout, MARKETPLACE_NAME),
+        _ => false,
+    }
+}
+
+/// True when `claude plugin list` reports the plugin (bare name or
+/// `plugin@anolisa` ref).
+fn plugin_registered(plugin: &str, ctx: &DriverCtx) -> bool {
+    match ctx.ops.run_framework_cli(build_plugin_list_cmd()) {
+        Ok(output) if output.success() => {
+            list_contains_token(&output.stdout, plugin)
+                || list_contains_token(&output.stdout, &plugin_ref(plugin))
+        }
+        _ => false,
+    }
+}
+
+/// True when `token` appears as a whole whitespace-delimited word on any
+/// line of `stdout`.
+fn list_contains_token(stdout: &str, token: &str) -> bool {
+    stdout
+        .lines()
+        .any(|line| line.split_whitespace().any(|t| t == token))
+}
+
+/// Build the `ResourceBundleMatches` condition.
+fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
+    let kind = AdapterConditionKind::ResourceBundleMatches;
+    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
+        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+            kind,
+            status: ConditionStatus::True,
+            reason: None,
+            resource: None,
+        },
+        (Some(_), Some(_)) => AdapterCondition {
+            kind,
+            status: ConditionStatus::False,
+            reason: Some("resource bundle changed since enable".to_string()),
+            resource: None,
+        },
+        _ => AdapterCondition {
+            kind,
+            status: ConditionStatus::Unknown,
+            reason: Some("no digest recorded or resource root unavailable".to_string()),
+            resource: None,
+        },
+    }
+}
+
+/// Roll signals into a summary. Healthy requires the framework detected and
+/// both marketplace and plugin verified present.
+fn summarize(
+    claim_status: ClaimStatus,
+    detected: bool,
+    marketplace: ConditionStatus,
+    plugin: ConditionStatus,
+) -> AdapterSummary {
+    if claim_status == ClaimStatus::CleanupFailed {
+        return AdapterSummary::CleanupFailed;
+    }
+    if !detected {
+        return AdapterSummary::Degraded;
+    }
+    match (marketplace, plugin) {
+        (ConditionStatus::True, ConditionStatus::True) => AdapterSummary::Healthy,
+        (ConditionStatus::False, _) | (_, ConditionStatus::False) => AdapterSummary::Degraded,
+        _ => AdapterSummary::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_ref_uses_anolisa_marketplace() {
+        assert_eq!(plugin_ref("tokenless"), "tokenless@anolisa");
+    }
+
+    #[test]
+    fn cmd_shapes() {
+        assert_eq!(
+            build_validate_cmd(Path::new("/data/cc")).args,
+            vec!["plugin", "validate", "/data/cc"]
+        );
+        assert_eq!(
+            build_marketplace_add_cmd(Path::new("/data/cc")).args,
+            vec!["plugin", "marketplace", "add", "/data/cc"]
+        );
+        assert_eq!(
+            build_plugin_install_cmd("tokenless@anolisa").args,
+            vec!["plugin", "install", "tokenless@anolisa"]
+        );
+        assert_eq!(
+            build_plugin_uninstall_cmd("tokenless@anolisa").args,
+            vec!["plugin", "uninstall", "tokenless@anolisa"]
+        );
+        assert_eq!(
+            build_marketplace_remove_cmd().args,
+            vec!["plugin", "marketplace", "remove", "anolisa"]
+        );
+    }
+
+    #[test]
+    fn read_bundle_requires_both_manifests() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("claude-code");
+        std::fs::create_dir_all(root.join(".claude-plugin")).expect("mkdir");
+        let layout = anolisa_platform::fs_layout::FsLayout::user(PathBuf::from("/tmp/cc-home"));
+
+        struct StubOps;
+        impl super::super::driver::AdapterOps for StubOps {
+            fn run_framework_cli(
+                &self,
+                _: FrameworkCommand,
+            ) -> Result<super::super::driver::CliOutput, AdapterError> {
+                unimplemented!()
+            }
+            fn copy_tree(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn copy_file(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn remove_tree(&self, _: &Path) -> Result<bool, AdapterError> {
+                unimplemented!()
+            }
+            fn write_file(&self, _: &Path, _: &[u8]) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+        }
+        let ops = StubOps;
+        let mk_ctx = |root: &Path| DriverCtx {
+            component: "tokenless".to_string(),
+            framework: "claude-code".to_string(),
+            layout: &layout,
+            resource_root: root.to_path_buf(),
+            user_home: Some(PathBuf::from("/tmp/cc-home")),
+            declared_plugin_id: Some("tokenless".to_string()),
+            adapter_type: Some("plugin".to_string()),
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            dry_run: true,
+            ops: &ops,
+        };
+        let driver = ClaudeCodeDriver::new();
+
+        // marketplace.json only -> still missing plugin.json.
+        std::fs::write(root.join(MARKETPLACE_MANIFEST), b"{}").expect("write");
+        let err = driver
+            .read_bundle(&mk_ctx(&root))
+            .expect_err("plugin.json missing must fail");
+        assert!(matches!(err, AdapterError::BundleInvalid { .. }));
+
+        // Both present -> ok.
+        std::fs::write(root.join(PLUGIN_MANIFEST), b"{}").expect("write");
+        let bundle = driver.read_bundle(&mk_ctx(&root)).expect("both present");
+        assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
@@ -3,14 +3,22 @@
 //! Claude Code v2 installs plugins from a registered marketplace. ANOLISA
 //! exposes the component's resource root (which ships
 //! `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`) as a
-//! single-plugin marketplace named `anolisa`, then installs the plugin via
-//! the official CLI:
+//! single-plugin marketplace, then installs the plugin via the official CLI:
 //!
 //! ```text
 //! claude plugin validate <resource_root>
 //! claude plugin marketplace add <resource_root>
-//! claude plugin install <plugin>@anolisa
+//! claude plugin install <plugin>@anolisa-<component>
 //! ```
+//!
+//! **Marketplace name is component-scoped** (`anolisa-<component>`), so two
+//! ANOLISA components can each register their own Claude Code marketplace
+//! without one's disable removing or shadowing another's. Claude Code names
+//! a marketplace after the `name` field in the bundle's
+//! `.claude-plugin/marketplace.json` (ANOLISA cannot rename it via the CLI),
+//! so `read_bundle` enforces that the bundle declares exactly
+//! `anolisa-<component>` — a bundle that still uses the bare shared
+//! `anolisa` name is rejected with an actionable error.
 //!
 //! `disable` reverses this with `claude plugin uninstall` /
 //! `claude plugin marketplace remove`. ANOLISA never edits
@@ -40,17 +48,11 @@ use super::util::{bool_status, cli_failure_reason, digest_tree, display_command,
 /// Default timeout for a Claude Code CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Marketplace name ANOLISA registers with Claude Code. Matches the name
-/// declared in every component's `.claude-plugin/marketplace.json`.
-///
-/// Ownership constraint: `anolisa` is a shared, ANOLISA-owned marketplace
-/// by convention — all ANOLISA components publish into it, and this driver
-/// assumes any marketplace of that name is ANOLISA's to add/remove. If a
-/// user has an unrelated marketplace also named `anolisa`, enable would
-/// re-point it and disable would remove it. That collision is accepted as
-/// out of scope: the name is reserved for ANOLISA. A future multi-owner
-/// design would need to verify the marketplace *source* before removal.
-const MARKETPLACE_NAME: &str = "anolisa";
+/// Prefix for the component-scoped Claude Code marketplace name. The full
+/// name is `anolisa-<component>` (see [`marketplace_name`]), so each
+/// component owns a distinct marketplace and disable never touches another
+/// component's registration.
+const MARKETPLACE_PREFIX: &str = "anolisa";
 
 /// Native marketplace manifest inside a Claude Code plugin bundle.
 const MARKETPLACE_MANIFEST: &str = ".claude-plugin/marketplace.json";
@@ -127,6 +129,32 @@ impl FrameworkDriver for ClaudeCodeDriver {
                 ),
             });
         }
+        // Claude Code names the marketplace after the manifest's `name`
+        // field (ANOLISA cannot rename it via the CLI), so the bundle MUST
+        // declare the component-scoped name; otherwise two components would
+        // collide on a shared marketplace and one's disable would remove the
+        // other's. Enforce it here so the mismatch fails before any state is
+        // written.
+        let expected = marketplace_name(&ctx.component);
+        match read_marketplace_manifest_name(root)? {
+            Some(name) if name == expected => {}
+            Some(name) => {
+                return Err(AdapterError::BundleInvalid {
+                    root: root.clone(),
+                    reason: format!(
+                        "Claude Code marketplace name '{name}' in {MARKETPLACE_MANIFEST} must be component-scoped as '{expected}'"
+                    ),
+                });
+            }
+            None => {
+                return Err(AdapterError::BundleInvalid {
+                    root: root.clone(),
+                    reason: format!(
+                        "Claude Code {MARKETPLACE_MANIFEST} declares no 'name'; expected '{expected}'"
+                    ),
+                });
+            }
+        }
         let plugin_id = Some(
             ctx.declared_plugin_id
                 .clone()
@@ -146,7 +174,8 @@ impl FrameworkDriver for ClaudeCodeDriver {
         ctx: &DriverCtx,
     ) -> Result<DriverPlan, AdapterError> {
         let plugin = plugin_name(bundle, ctx);
-        let plugin_ref = plugin_ref(&plugin);
+        let marketplace = marketplace_name(&ctx.component);
+        let plugin_ref = plugin_ref(&plugin, &marketplace);
         let install_cmd = build_plugin_install_cmd(&plugin_ref);
         let actions = vec![
             format!(
@@ -154,7 +183,7 @@ impl FrameworkDriver for ClaudeCodeDriver {
                 bundle.resource_root.display()
             ),
             format!(
-                "register Claude Code marketplace '{MARKETPLACE_NAME}' from {}",
+                "register Claude Code marketplace '{marketplace}' from {}",
                 bundle.resource_root.display()
             ),
             format!("install Claude Code plugin '{plugin_ref}'"),
@@ -173,8 +202,9 @@ impl FrameworkDriver for ClaudeCodeDriver {
         ctx: &DriverCtx,
     ) -> Result<AdapterClaim, AdapterError> {
         let plugin = plugin_name(bundle, ctx);
+        let marketplace = marketplace_name(&ctx.component);
         validate_plugin_id(&plugin)?;
-        validate_marketplace_name(MARKETPLACE_NAME)?;
+        validate_marketplace_name(&marketplace)?;
 
         let resources = vec![
             ClaimResource {
@@ -182,7 +212,7 @@ impl FrameworkDriver for ClaudeCodeDriver {
                 purpose: "claude_code_marketplace".to_string(),
                 kind: ClaimResourceKind::FrameworkMarketplace {
                     framework: self.name().to_string(),
-                    marketplace: MARKETPLACE_NAME.to_string(),
+                    marketplace: marketplace.clone(),
                 },
             },
             ClaimResource {
@@ -219,6 +249,14 @@ impl FrameworkDriver for ClaudeCodeDriver {
             root: claim.resource_root.clone(),
             reason: "claude-code receipt has no plugin resource".to_string(),
         })?;
+        // Read the marketplace strictly from the receipt's validated
+        // resource — never fall back to a name derived from ctx, so a
+        // malformed/forged receipt missing the marketplace resource cannot
+        // drive `marketplace add` / `plugin install`.
+        let marketplace = claim_marketplace(claim).ok_or_else(|| AdapterError::BundleInvalid {
+            root: claim.resource_root.clone(),
+            reason: "claude-code receipt has no marketplace resource".to_string(),
+        })?;
 
         // 1. Validate the bundle via the official CLI — same gate `install`
         //    hits, but surfaces a cleaner error here.
@@ -234,7 +272,7 @@ impl FrameworkDriver for ClaudeCodeDriver {
 
         // 2. Register the marketplace (idempotent: skip when already listed
         //    so a re-enable does not error on a duplicate source).
-        if !marketplace_registered(ctx) {
+        if !marketplace_registered(&marketplace, ctx) {
             let add_cmd = build_marketplace_add_cmd(&claim.resource_root);
             let program = add_cmd.program.clone();
             let output = ctx.ops.run_framework_cli(add_cmd)?;
@@ -247,7 +285,7 @@ impl FrameworkDriver for ClaudeCodeDriver {
         }
 
         // 3. Install the plugin from the marketplace.
-        let install_cmd = build_plugin_install_cmd(&plugin_ref(&plugin));
+        let install_cmd = build_plugin_install_cmd(&plugin_ref(&plugin, &marketplace));
         let program = install_cmd.program.clone();
         let output = ctx.ops.run_framework_cli(install_cmd)?;
         if !output.success() {
@@ -277,6 +315,9 @@ impl FrameworkDriver for ClaudeCodeDriver {
         conditions.push(bundle_match_condition(claim));
 
         let plugin = claim_plugin(claim);
+        // Read strictly from the receipt; a receipt with no marketplace
+        // resource is malformed and must not be treated as healthy.
+        let marketplace = claim_marketplace(claim);
         let (mkt_status, plugin_status) = if !detect.detected {
             conditions.push(AdapterCondition {
                 kind: AdapterConditionKind::MarketplaceRegistered,
@@ -301,11 +342,11 @@ impl FrameworkDriver for ClaudeCodeDriver {
                 resource: None,
             });
             (ConditionStatus::Unknown, ConditionStatus::Unknown)
-        } else {
-            let mkt = marketplace_registered(ctx);
+        } else if let Some(marketplace) = marketplace {
+            let mkt = marketplace_registered(&marketplace, ctx);
             let plugin_ok = plugin
                 .as_deref()
-                .map(|p| plugin_registered(p, ctx))
+                .map(|p| plugin_registered(p, &marketplace, ctx))
                 .unwrap_or(false);
             conditions.push(AdapterCondition {
                 kind: AdapterConditionKind::MarketplaceRegistered,
@@ -330,6 +371,32 @@ impl FrameworkDriver for ClaudeCodeDriver {
                 resource: None,
             });
             (bool_status(mkt), bool_status(plugin_ok))
+        } else {
+            // Receipt has no marketplace resource: malformed. Do not run the
+            // CLI; report a degraded, unverifiable state.
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::MarketplaceRegistered,
+                status: ConditionStatus::False,
+                reason: Some("receipt has no marketplace resource".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_MARKETPLACE.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::PluginRegistered,
+                status: ConditionStatus::Unknown,
+                reason: Some("cannot verify plugin without a marketplace resource".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_PLUGIN.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::VerificationSupported,
+                status: ConditionStatus::False,
+                reason: Some("receipt has no marketplace resource".to_string()),
+                resource: None,
+            });
+            (ConditionStatus::False, ConditionStatus::Unknown)
         };
 
         let summary = summarize(claim.status, detect.detected, mkt_status, plugin_status);
@@ -357,17 +424,29 @@ impl FrameworkDriver for ClaudeCodeDriver {
             });
         }
 
+        // Fail closed: act only on the marketplace the receipt recorded. A
+        // malformed/forged receipt without a marketplace resource must not
+        // trigger `plugin uninstall` / `marketplace remove` against a name
+        // derived from ctx — keep the receipt for manual resolution instead.
+        let Some(marketplace) = claim_marketplace(claim) else {
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![
+                    "claude-code receipt has no marketplace resource; receipt kept (nothing safely removable)"
+                        .to_string(),
+                ],
+            });
+        };
+
         let mut messages = Vec::new();
         let mut cleanup_complete = true;
 
         if let Some(plugin) = claim_plugin(claim) {
-            let cmd = build_plugin_uninstall_cmd(&plugin_ref(&plugin));
+            let plugin_ref = plugin_ref(&plugin, &marketplace);
+            let cmd = build_plugin_uninstall_cmd(&plugin_ref);
             let output = ctx.ops.run_framework_cli(cmd)?;
             if output.success() {
-                messages.push(format!(
-                    "uninstalled claude-code plugin '{}'",
-                    plugin_ref(&plugin)
-                ));
+                messages.push(format!("uninstalled claude-code plugin '{plugin_ref}'"));
             } else {
                 cleanup_complete = false;
                 messages.push(format!(
@@ -379,12 +458,10 @@ impl FrameworkDriver for ClaudeCodeDriver {
             messages.push("receipt records no plugin to uninstall".to_string());
         }
 
-        let cmd = build_marketplace_remove_cmd();
+        let cmd = build_marketplace_remove_cmd(&marketplace);
         let output = ctx.ops.run_framework_cli(cmd)?;
         if output.success() {
-            messages.push(format!(
-                "removed claude-code marketplace '{MARKETPLACE_NAME}'"
-            ));
+            messages.push(format!("removed claude-code marketplace '{marketplace}'"));
         } else {
             cleanup_complete = false;
             messages.push(format!(
@@ -412,6 +489,11 @@ fn claude_bin() -> String {
         .unwrap_or_else(|| "claude".to_string())
 }
 
+/// Component-scoped marketplace name: `anolisa-<component>`.
+fn marketplace_name(component: &str) -> String {
+    format!("{MARKETPLACE_PREFIX}-{component}")
+}
+
 /// Plugin name for the receipt: declared plugin id, else component.
 fn plugin_name(bundle: &AdapterBundle, ctx: &DriverCtx) -> String {
     bundle
@@ -420,9 +502,40 @@ fn plugin_name(bundle: &AdapterBundle, ctx: &DriverCtx) -> String {
         .unwrap_or_else(|| ctx.component.clone())
 }
 
-/// `<plugin>@anolisa` argument for `claude plugin install/uninstall`.
-fn plugin_ref(plugin: &str) -> String {
-    format!("{plugin}@{MARKETPLACE_NAME}")
+/// `<plugin>@<marketplace>` argument for `claude plugin install/uninstall`.
+/// Both halves are validated separately (no `@` inside either token), so the
+/// composed ref cannot smuggle a metacharacter into the argv.
+fn plugin_ref(plugin: &str, marketplace: &str) -> String {
+    format!("{plugin}@{marketplace}")
+}
+
+/// Read the `name` field from the bundle's `.claude-plugin/marketplace.json`.
+/// Returns `None` when the field is absent/empty.
+///
+/// # Errors
+///
+/// [`AdapterError::BundleInvalid`] when the manifest cannot be parsed;
+/// [`AdapterError::Io`] on a read failure other than not-found.
+fn read_marketplace_manifest_name(root: &Path) -> Result<Option<String>, AdapterError> {
+    #[derive(serde::Deserialize)]
+    struct MarketplaceManifest {
+        name: Option<String>,
+    }
+    let path = root.join(MARKETPLACE_MANIFEST);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(AdapterError::Io { path, source }),
+    };
+    let manifest: MarketplaceManifest =
+        serde_json::from_slice(&bytes).map_err(|source| AdapterError::BundleInvalid {
+            root: root.to_path_buf(),
+            reason: format!(
+                "failed to parse {} as a Claude Code marketplace manifest: {source}",
+                path.display()
+            ),
+        })?;
+    Ok(manifest.name.filter(|n| !n.is_empty()))
 }
 
 /// Extract the plugin name from a receipt's plugin resource.
@@ -434,6 +547,14 @@ fn claim_plugin(claim: &AdapterClaim) -> Option<String> {
             _ => None,
         })
         .or_else(|| claim.plugin_id.clone())
+}
+
+/// Extract the marketplace name from a receipt's marketplace resource.
+fn claim_marketplace(claim: &AdapterClaim) -> Option<String> {
+    claim.resource(RES_MARKETPLACE).and_then(|r| match &r.kind {
+        ClaimResourceKind::FrameworkMarketplace { marketplace, .. } => Some(marketplace.clone()),
+        _ => None,
+    })
 }
 
 fn base_cmd(args: Vec<String>) -> FrameworkCommand {
@@ -464,12 +585,12 @@ fn build_marketplace_add_cmd(resource_root: &Path) -> FrameworkCommand {
     ])
 }
 
-fn build_marketplace_remove_cmd() -> FrameworkCommand {
+fn build_marketplace_remove_cmd(marketplace: &str) -> FrameworkCommand {
     base_cmd(vec![
         "plugin".to_string(),
         "marketplace".to_string(),
         "remove".to_string(),
-        MARKETPLACE_NAME.to_string(),
+        marketplace.to_string(),
     ])
 }
 
@@ -501,22 +622,21 @@ fn build_plugin_list_cmd() -> FrameworkCommand {
     base_cmd(vec!["plugin".to_string(), "list".to_string()])
 }
 
-/// True when `claude plugin marketplace list` reports the ANOLISA
-/// marketplace.
-fn marketplace_registered(ctx: &DriverCtx) -> bool {
+/// True when `claude plugin marketplace list` reports `marketplace`.
+fn marketplace_registered(marketplace: &str, ctx: &DriverCtx) -> bool {
     match ctx.ops.run_framework_cli(build_marketplace_list_cmd()) {
-        Ok(output) if output.success() => list_contains_token(&output.stdout, MARKETPLACE_NAME),
+        Ok(output) if output.success() => list_contains_token(&output.stdout, marketplace),
         _ => false,
     }
 }
 
 /// True when `claude plugin list` reports the plugin (bare name or
-/// `plugin@anolisa` ref).
-fn plugin_registered(plugin: &str, ctx: &DriverCtx) -> bool {
+/// `plugin@<marketplace>` ref).
+fn plugin_registered(plugin: &str, marketplace: &str, ctx: &DriverCtx) -> bool {
     match ctx.ops.run_framework_cli(build_plugin_list_cmd()) {
         Ok(output) if output.success() => {
             list_contains_token(&output.stdout, plugin)
-                || list_contains_token(&output.stdout, &plugin_ref(plugin))
+                || list_contains_token(&output.stdout, &plugin_ref(plugin, marketplace))
         }
         _ => false,
     }
@@ -581,8 +701,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn plugin_ref_uses_anolisa_marketplace() {
-        assert_eq!(plugin_ref("tokenless"), "tokenless@anolisa");
+    fn marketplace_name_and_plugin_ref_are_component_scoped() {
+        assert_eq!(marketplace_name("tokenless"), "anolisa-tokenless");
+        assert_eq!(
+            plugin_ref("tokenless", "anolisa-tokenless"),
+            "tokenless@anolisa-tokenless"
+        );
     }
 
     #[test]
@@ -596,16 +720,16 @@ mod tests {
             vec!["plugin", "marketplace", "add", "/data/cc"]
         );
         assert_eq!(
-            build_plugin_install_cmd("tokenless@anolisa").args,
-            vec!["plugin", "install", "tokenless@anolisa"]
+            build_plugin_install_cmd("tokenless@anolisa-tokenless").args,
+            vec!["plugin", "install", "tokenless@anolisa-tokenless"]
         );
         assert_eq!(
-            build_plugin_uninstall_cmd("tokenless@anolisa").args,
-            vec!["plugin", "uninstall", "tokenless@anolisa"]
+            build_plugin_uninstall_cmd("tokenless@anolisa-tokenless").args,
+            vec!["plugin", "uninstall", "tokenless@anolisa-tokenless"]
         );
         assert_eq!(
-            build_marketplace_remove_cmd().args,
-            vec!["plugin", "marketplace", "remove", "anolisa"]
+            build_marketplace_remove_cmd("anolisa-tokenless").args,
+            vec!["plugin", "marketplace", "remove", "anolisa-tokenless"]
         );
     }
 
@@ -658,15 +782,79 @@ mod tests {
         let driver = ClaudeCodeDriver::new();
 
         // marketplace.json only -> still missing plugin.json.
-        std::fs::write(root.join(MARKETPLACE_MANIFEST), b"{}").expect("write");
+        std::fs::write(
+            root.join(MARKETPLACE_MANIFEST),
+            br#"{"name":"anolisa-tokenless"}"#,
+        )
+        .expect("write");
         let err = driver
             .read_bundle(&mk_ctx(&root))
             .expect_err("plugin.json missing must fail");
         assert!(matches!(err, AdapterError::BundleInvalid { .. }));
 
-        // Both present -> ok.
+        // Both present, component-scoped marketplace name -> ok.
         std::fs::write(root.join(PLUGIN_MANIFEST), b"{}").expect("write");
         let bundle = driver.read_bundle(&mk_ctx(&root)).expect("both present");
         assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
+    }
+
+    #[test]
+    fn read_bundle_rejects_shared_marketplace_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("claude-code");
+        std::fs::create_dir_all(root.join(".claude-plugin")).expect("mkdir");
+        // Bare shared "anolisa" name (the pre-scoping value) must be rejected.
+        std::fs::write(root.join(MARKETPLACE_MANIFEST), br#"{"name":"anolisa"}"#).expect("write");
+        std::fs::write(root.join(PLUGIN_MANIFEST), b"{}").expect("write");
+        let layout = anolisa_platform::fs_layout::FsLayout::user(PathBuf::from("/tmp/cc-home2"));
+
+        struct StubOps;
+        impl super::super::driver::AdapterOps for StubOps {
+            fn run_framework_cli(
+                &self,
+                _: FrameworkCommand,
+            ) -> Result<super::super::driver::CliOutput, AdapterError> {
+                unimplemented!()
+            }
+            fn copy_tree(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn copy_file(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn remove_tree(&self, _: &Path) -> Result<bool, AdapterError> {
+                unimplemented!()
+            }
+            fn write_file(&self, _: &Path, _: &[u8]) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+        }
+        let ops = StubOps;
+        let ctx = DriverCtx {
+            component: "tokenless".to_string(),
+            framework: "claude-code".to_string(),
+            layout: &layout,
+            resource_root: root.clone(),
+            user_home: Some(PathBuf::from("/tmp/cc-home2")),
+            declared_plugin_id: Some("tokenless".to_string()),
+            adapter_type: Some("plugin".to_string()),
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            dry_run: true,
+            ops: &ops,
+        };
+        let err = ClaudeCodeDriver::new()
+            .read_bundle(&ctx)
+            .expect_err("bare 'anolisa' marketplace name must be rejected");
+        match err {
+            AdapterError::BundleInvalid { reason, .. } => {
+                assert!(reason.contains("anolisa-tokenless"), "reason: {reason}");
+            }
+            other => panic!("expected BundleInvalid, got {other:?}"),
+        }
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -1,0 +1,859 @@
+//! Codex framework driver.
+//!
+//! Codex installs plugins from a *marketplace*: a directory holding a
+//! `.agents/plugins/marketplace.json` manifest plus a symlink to the plugin
+//! source. ANOLISA builds a per-user marketplace under
+//! `${XDG_DATA_HOME:-~/.local/share}/anolisa/codex-marketplace/`, points a
+//! symlink at the component's resource root, then drives the official CLI:
+//!
+//! ```text
+//! codex plugin marketplace add <marketplace_root>
+//! codex plugin add <plugin>@<marketplace>
+//! ```
+//!
+//! `disable` reverses this via `codex plugin remove` /
+//! `codex plugin marketplace remove` and then removes the marketplace
+//! directory (which contains the symlink). All CLI, file, and symlink IO
+//! goes through the Manager's [`AdapterOps`](super::driver::AdapterOps).
+//!
+//! Env contract: `CODEX_BIN` overrides the executable (tests point it at a
+//! fake CLI); `XDG_DATA_HOME` relocates the marketplace base.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::AdapterError;
+use super::claim::{
+    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus, CodexClaim,
+    DRIVER_SCHEMA_VERSION, DriverPayload, validate_marketplace_name, validate_plugin_id,
+};
+use super::driver::{
+    AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
+    ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
+    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+};
+use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+
+/// Default timeout for a Codex CLI invocation.
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Codex-native plugin manifest inside the bundle. Its presence is what
+/// makes the resource root a valid codex plugin (the contract may override
+/// via `[adapters.bundle].entry`).
+const CODEX_PLUGIN_MANIFEST: &str = ".codex-plugin/plugin.json";
+
+/// Resource ids used in Codex receipts.
+const RES_MARKETPLACE_DIR: &str = "codex_marketplace_dir";
+const RES_SYMLINK: &str = "codex_symlink";
+const RES_MARKETPLACE: &str = "codex_marketplace";
+const RES_PLUGIN: &str = "codex_plugin";
+
+/// Codex driver. Stateless; all per-operation context arrives via
+/// [`DriverCtx`].
+pub struct CodexDriver;
+
+impl CodexDriver {
+    /// Construct the driver.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CodexDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameworkDriver for CodexDriver {
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+
+    fn detect(&self, _env: &HostEnv) -> DetectResult {
+        match find_binary_in_path(&codex_bin()) {
+            Some(path) => DetectResult {
+                detected: true,
+                reason: format!("codex CLI found at {}", path.display()),
+            },
+            None => DetectResult {
+                detected: false,
+                reason: "codex CLI not found on PATH".to_string(),
+            },
+        }
+    }
+
+    fn allowed_external_roots(&self, ctx: &DriverCtx) -> Vec<PathBuf> {
+        // The only external root Codex writes is ANOLISA's own namespace in
+        // the user's data home; the marketplace dir and the plugin symlink
+        // both live below it. The symlink *target* points back at the
+        // ANOLISA-owned resource bundle and is validated separately against
+        // the trusted layout roots (see `ClaimResourceKind::Symlink`), so it
+        // must NOT be authorized via a receipt-derived external root here.
+        marketplace_base(ctx.user_home.as_deref())
+            .into_iter()
+            .collect()
+    }
+
+    fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError> {
+        let root = &ctx.resource_root;
+        if !root.is_dir() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root does not exist or is not a directory".to_string(),
+            });
+        }
+        // Require the codex-native plugin manifest before persisting a
+        // receipt, so a malformed bundle fails at read time rather than
+        // after `prepare_enable` has written state and `codex plugin add`
+        // fails downstream. The contract may name a different entry.
+        let manifest = ctx
+            .declared_bundle_entry
+            .as_deref()
+            .unwrap_or(CODEX_PLUGIN_MANIFEST);
+        if !root.join(manifest).is_file() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: format!("codex plugin manifest '{manifest}' missing from resource root"),
+            });
+        }
+        let plugin_id = Some(
+            ctx.declared_plugin_id
+                .clone()
+                .filter(|id| !id.is_empty())
+                .unwrap_or_else(|| ctx.component.clone()),
+        );
+        Ok(AdapterBundle {
+            resource_root: root.clone(),
+            digest: digest_tree(root),
+            plugin_id,
+        })
+    }
+
+    fn plan_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<DriverPlan, AdapterError> {
+        let layout = MarketplaceLayout::resolve(bundle, ctx)?;
+        let add_cmd = build_marketplace_add_cmd(&layout.root);
+        let plugin_cmd = build_plugin_add_cmd(&layout.plugin_ref());
+        let actions = vec![
+            format!(
+                "write codex marketplace manifest {}",
+                layout.manifest().display()
+            ),
+            format!(
+                "symlink {} -> {}",
+                layout.symlink().display(),
+                bundle.resource_root.display()
+            ),
+            format!("register codex marketplace '{}'", layout.marketplace),
+            format!("add codex plugin '{}'", layout.plugin_ref()),
+        ];
+        Ok(DriverPlan {
+            framework: self.name().to_string(),
+            component: ctx.component.clone(),
+            actions,
+            register_command: Some(format!(
+                "{} && {}",
+                display_command(&add_cmd),
+                display_command(&plugin_cmd)
+            )),
+        })
+    }
+
+    fn prepare_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterClaim, AdapterError> {
+        let layout = MarketplaceLayout::resolve(bundle, ctx)?;
+        validate_plugin_id(&layout.plugin)?;
+        validate_marketplace_name(&layout.marketplace)?;
+
+        let resources = vec![
+            ClaimResource {
+                id: RES_MARKETPLACE_DIR.to_string(),
+                purpose: "codex_marketplace_dir".to_string(),
+                kind: ClaimResourceKind::ExternalPath {
+                    path: layout.root.clone(),
+                },
+            },
+            ClaimResource {
+                id: RES_SYMLINK.to_string(),
+                purpose: "codex_plugin_symlink".to_string(),
+                kind: ClaimResourceKind::Symlink {
+                    link: layout.symlink(),
+                    target: bundle.resource_root.clone(),
+                },
+            },
+            ClaimResource {
+                id: RES_MARKETPLACE.to_string(),
+                purpose: "codex_marketplace".to_string(),
+                kind: ClaimResourceKind::FrameworkMarketplace {
+                    framework: self.name().to_string(),
+                    marketplace: layout.marketplace.clone(),
+                },
+            },
+            ClaimResource {
+                id: RES_PLUGIN.to_string(),
+                purpose: "codex_plugin".to_string(),
+                kind: ClaimResourceKind::FrameworkPlugin {
+                    framework: self.name().to_string(),
+                    plugin_id: layout.plugin.clone(),
+                },
+            },
+        ];
+
+        Ok(AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: ctx.component.clone(),
+            framework: self.name().to_string(),
+            plugin_id: Some(layout.plugin.clone()),
+            adapter_type: ctx.adapter_type.clone(),
+            enabled_at: now_iso8601(),
+            resource_root: bundle.resource_root.clone(),
+            bundle_digest: bundle.digest.clone(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources,
+            driver_payload: DriverPayload::Codex(CodexClaim {
+                marketplace_dir_resource: RES_MARKETPLACE_DIR.to_string(),
+                symlink_resource: RES_SYMLINK.to_string(),
+                marketplace_resource: RES_MARKETPLACE.to_string(),
+                plugin_resource: RES_PLUGIN.to_string(),
+            }),
+        })
+    }
+
+    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+        let layout = MarketplaceLayout::from_claim(claim)?;
+
+        // 1. Write the marketplace manifest and the plugin symlink.
+        ctx.ops
+            .write_file(&layout.manifest(), marketplace_json(&layout).as_bytes())?;
+        ctx.ops
+            .create_symlink(&layout.symlink(), &claim.resource_root)?;
+
+        // 2. Register the marketplace, replacing any stale registration so
+        //    re-enable is idempotent.
+        if marketplace_registered(&layout.marketplace, ctx) {
+            let _ = ctx
+                .ops
+                .run_framework_cli(build_marketplace_remove_cmd(&layout.marketplace));
+        }
+        let add_cmd = build_marketplace_add_cmd(&layout.root);
+        let program = add_cmd.program.clone();
+        let output = ctx.ops.run_framework_cli(add_cmd)?;
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
+                program,
+                reason: cli_failure_reason("plugin marketplace add", &output),
+            });
+        }
+
+        // 3. Add the plugin from the marketplace.
+        let plugin_cmd = build_plugin_add_cmd(&layout.plugin_ref());
+        let program = plugin_cmd.program.clone();
+        let output = ctx.ops.run_framework_cli(plugin_cmd)?;
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
+                program,
+                reason: cli_failure_reason("plugin add", &output),
+            });
+        }
+        Ok(())
+    }
+
+    fn status(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterStatusReport, AdapterError> {
+        let mut conditions = Vec::new();
+        let detect = self.detect(&HostEnv {
+            user_home: ctx.user_home.clone(),
+        });
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::FrameworkDetected,
+            status: bool_status(detect.detected),
+            reason: Some(detect.reason.clone()),
+            resource: None,
+        });
+        conditions.push(bundle_match_condition(claim));
+
+        // Symlink presence is a reliable filesystem check independent of
+        // the CLI.
+        let symlink_ok = claim_symlink(claim)
+            .map(|(link, target)| symlink_points_to(&link, &target))
+            .unwrap_or(false);
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::SymlinkPresent,
+            status: bool_status(symlink_ok),
+            reason: (!symlink_ok).then(|| "plugin symlink missing or retargeted".to_string()),
+            resource: Some(ClaimResourceRef {
+                id: RES_SYMLINK.to_string(),
+            }),
+        });
+
+        let layout = MarketplaceLayout::from_claim(claim).ok();
+        let (mkt_status, plugin_status) = if !detect.detected {
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::MarketplaceRegistered,
+                status: ConditionStatus::Unknown,
+                reason: Some("codex CLI unavailable; cannot verify".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_MARKETPLACE.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::PluginRegistered,
+                status: ConditionStatus::Unknown,
+                reason: Some("codex CLI unavailable; cannot verify".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_PLUGIN.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::VerificationSupported,
+                status: ConditionStatus::False,
+                reason: Some("codex CLI unavailable".to_string()),
+                resource: None,
+            });
+            (ConditionStatus::Unknown, ConditionStatus::Unknown)
+        } else if let Some(layout) = layout {
+            let mkt = marketplace_registered(&layout.marketplace, ctx);
+            let plugin = plugin_registered(&layout, ctx);
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::MarketplaceRegistered,
+                status: bool_status(mkt),
+                reason: (!mkt).then(|| "marketplace not in `plugin marketplace list`".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_MARKETPLACE.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::PluginRegistered,
+                status: bool_status(plugin),
+                reason: (!plugin).then(|| "plugin not in `plugin list`".to_string()),
+                resource: Some(ClaimResourceRef {
+                    id: RES_PLUGIN.to_string(),
+                }),
+            });
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::VerificationSupported,
+                status: ConditionStatus::True,
+                reason: None,
+                resource: None,
+            });
+            (bool_status(mkt), bool_status(plugin))
+        } else {
+            conditions.push(AdapterCondition {
+                kind: AdapterConditionKind::VerificationSupported,
+                status: ConditionStatus::False,
+                reason: Some("codex receipt is missing marketplace layout data".to_string()),
+                resource: None,
+            });
+            (ConditionStatus::Unknown, ConditionStatus::Unknown)
+        };
+
+        let summary = summarize(claim.status, detect.detected, mkt_status, plugin_status);
+        Ok(AdapterStatusReport {
+            summary,
+            conditions,
+        })
+    }
+
+    fn disable(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        let mut messages = Vec::new();
+        let mut cleanup_complete = true;
+        let layout = MarketplaceLayout::from_claim(claim)?;
+
+        // Framework-side deregistration needs the CLI. Without it the codex
+        // config would keep a dangling marketplace/plugin entry, so keep
+        // the receipt for a later retry rather than deleting our directory
+        // and pretending cleanup finished.
+        if find_binary_in_path(&codex_bin()).is_none() {
+            return Ok(DisableReport {
+                cleanup_complete: false,
+                messages: vec![
+                    "codex CLI not found on PATH; receipt kept so cleanup can be retried"
+                        .to_string(),
+                ],
+            });
+        }
+
+        // Remove the plugin registration. We do not trust the exit code
+        // (an already-removed plugin exits non-zero), but we must not
+        // silently ignore a real failure either: verify absence via
+        // `plugin list` and only then treat it as clean.
+        let plugin_ref = layout.plugin_ref();
+        let out = ctx
+            .ops
+            .run_framework_cli(build_plugin_remove_cmd(&plugin_ref))?;
+        if out.success() {
+            messages.push(format!("removed codex plugin '{plugin_ref}'"));
+        } else if !plugin_registered(&layout, ctx) {
+            messages.push(format!("codex plugin '{plugin_ref}' already absent"));
+        } else {
+            cleanup_complete = false;
+            messages.push(format!(
+                "codex plugin remove failed: {}",
+                cli_failure_reason("plugin remove", &out)
+            ));
+        }
+
+        // Remove the marketplace registration, verifying the same way.
+        let out = ctx
+            .ops
+            .run_framework_cli(build_marketplace_remove_cmd(&layout.marketplace))?;
+        if out.success() {
+            messages.push(format!(
+                "removed codex marketplace '{}'",
+                layout.marketplace
+            ));
+        } else if !marketplace_registered(&layout.marketplace, ctx) {
+            messages.push(format!(
+                "codex marketplace '{}' already absent",
+                layout.marketplace
+            ));
+        } else {
+            cleanup_complete = false;
+            messages.push(format!(
+                "codex marketplace remove failed: {}",
+                cli_failure_reason("plugin marketplace remove", &out)
+            ));
+        }
+
+        match ctx.ops.remove_tree(&layout.root) {
+            Ok(true) => messages.push(format!(
+                "removed codex marketplace directory {}",
+                layout.root.display()
+            )),
+            Ok(false) => messages.push(format!(
+                "codex marketplace directory {} already absent",
+                layout.root.display()
+            )),
+            Err(err) => {
+                cleanup_complete = false;
+                messages.push(format!(
+                    "failed to remove codex marketplace directory {}: {err}",
+                    layout.root.display()
+                ));
+            }
+        }
+
+        Ok(DisableReport {
+            cleanup_complete,
+            messages,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace layout
+// ---------------------------------------------------------------------------
+
+/// Resolved per-user codex marketplace layout for one component.
+struct MarketplaceLayout {
+    /// Marketplace root directory ANOLISA owns.
+    root: PathBuf,
+    /// Marketplace name registered with codex (`anolisa-<component>`).
+    marketplace: String,
+    /// Plugin name inside the marketplace.
+    plugin: String,
+}
+
+impl MarketplaceLayout {
+    /// Resolve from a freshly read bundle + context (enable/plan path).
+    fn resolve(bundle: &AdapterBundle, ctx: &DriverCtx) -> Result<Self, AdapterError> {
+        let root = marketplace_root(ctx.user_home.as_deref())?;
+        let plugin = bundle
+            .plugin_id
+            .clone()
+            .unwrap_or_else(|| ctx.component.clone());
+        Ok(Self {
+            root,
+            marketplace: marketplace_name(&ctx.component),
+            plugin,
+        })
+    }
+
+    /// Reconstruct from a persisted receipt (apply/status/disable path).
+    /// Reads the validated resource entries so the layout stays anchored to
+    /// what the Manager already re-validated.
+    fn from_claim(claim: &AdapterClaim) -> Result<Self, AdapterError> {
+        let root = claim
+            .resource(RES_MARKETPLACE_DIR)
+            .and_then(|r| match &r.kind {
+                ClaimResourceKind::ExternalPath { path } => Some(path.clone()),
+                _ => None,
+            })
+            .ok_or_else(|| AdapterError::BundleInvalid {
+                root: claim.resource_root.clone(),
+                reason: "codex receipt has no marketplace directory resource".to_string(),
+            })?;
+        let marketplace = claim
+            .resource(RES_MARKETPLACE)
+            .and_then(|r| match &r.kind {
+                ClaimResourceKind::FrameworkMarketplace { marketplace, .. } => {
+                    Some(marketplace.clone())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| AdapterError::BundleInvalid {
+                root: claim.resource_root.clone(),
+                reason: "codex receipt has no marketplace resource".to_string(),
+            })?;
+        let plugin = claim
+            .resource(RES_PLUGIN)
+            .and_then(|r| match &r.kind {
+                ClaimResourceKind::FrameworkPlugin { plugin_id, .. } => Some(plugin_id.clone()),
+                _ => None,
+            })
+            .or_else(|| claim.plugin_id.clone())
+            .ok_or_else(|| AdapterError::BundleInvalid {
+                root: claim.resource_root.clone(),
+                reason: "codex receipt has no plugin resource".to_string(),
+            })?;
+        Ok(Self {
+            root,
+            marketplace,
+            plugin,
+        })
+    }
+
+    /// `<root>/.agents/plugins/marketplace.json`.
+    fn manifest(&self) -> PathBuf {
+        self.root
+            .join(".agents")
+            .join("plugins")
+            .join("marketplace.json")
+    }
+
+    /// `<root>/<plugin>` — the symlink codex resolves relative to the
+    /// marketplace root.
+    fn symlink(&self) -> PathBuf {
+        self.root.join(&self.plugin)
+    }
+
+    /// `<plugin>@<marketplace>` argument for `codex plugin add/remove`.
+    fn plugin_ref(&self) -> String {
+        format!("{}@{}", self.plugin, self.marketplace)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/// `CODEX_BIN` override, else `codex`.
+fn codex_bin() -> String {
+    std::env::var("CODEX_BIN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "codex".to_string())
+}
+
+/// Marketplace name for a component: `anolisa-<component>`, matching the
+/// name the legacy install script registered.
+fn marketplace_name(component: &str) -> String {
+    format!("anolisa-{component}")
+}
+
+/// ANOLISA data-home base: `${XDG_DATA_HOME:-<user_home>/.local/share}/anolisa`.
+fn marketplace_base(user_home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+        let s = xdg.to_string_lossy();
+        let trimmed = s.trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed).join("anolisa"));
+        }
+    }
+    user_home.map(|h| h.join(".local").join("share").join("anolisa"))
+}
+
+/// Marketplace root directory, or an error when `$HOME`/`XDG_DATA_HOME`
+/// cannot be resolved.
+fn marketplace_root(user_home: Option<&Path>) -> Result<PathBuf, AdapterError> {
+    marketplace_base(user_home)
+        .map(|base| base.join("codex-marketplace"))
+        .ok_or_else(|| AdapterError::FrameworkCli {
+            program: codex_bin(),
+            reason: "cannot resolve codex marketplace dir (no $HOME and no XDG_DATA_HOME)"
+                .to_string(),
+        })
+}
+
+/// Render the codex marketplace manifest JSON. Pure data built from
+/// validated identifiers — never an argv or executable path.
+fn marketplace_json(layout: &MarketplaceLayout) -> String {
+    format!(
+        r#"{{
+    "name": "{marketplace}",
+    "interface": {{
+        "displayName": "ANOLISA {plugin}"
+    }},
+    "plugins": [
+        {{
+            "name": "{plugin}",
+            "source": {{
+                "source": "local",
+                "path": "./{plugin}"
+            }},
+            "policy": {{
+                "installation": "AVAILABLE"
+            }},
+            "category": "developer-tools"
+        }}
+    ]
+}}
+"#,
+        marketplace = layout.marketplace,
+        plugin = layout.plugin,
+    )
+}
+
+fn base_cmd(args: Vec<String>) -> FrameworkCommand {
+    FrameworkCommand {
+        program: codex_bin(),
+        args,
+        env_set: Vec::new(),
+        env_remove: Vec::new(),
+        path_prepend: Vec::new(),
+        timeout: CLI_TIMEOUT,
+    }
+}
+
+fn build_marketplace_add_cmd(root: &Path) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "marketplace".to_string(),
+        "add".to_string(),
+        root.to_string_lossy().into_owned(),
+    ])
+}
+
+fn build_marketplace_remove_cmd(marketplace: &str) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "marketplace".to_string(),
+        "remove".to_string(),
+        marketplace.to_string(),
+    ])
+}
+
+fn build_marketplace_list_cmd() -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "marketplace".to_string(),
+        "list".to_string(),
+    ])
+}
+
+fn build_plugin_add_cmd(plugin_ref: &str) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "add".to_string(),
+        plugin_ref.to_string(),
+    ])
+}
+
+fn build_plugin_remove_cmd(plugin_ref: &str) -> FrameworkCommand {
+    base_cmd(vec![
+        "plugin".to_string(),
+        "remove".to_string(),
+        plugin_ref.to_string(),
+    ])
+}
+
+fn build_plugin_list_cmd() -> FrameworkCommand {
+    base_cmd(vec!["plugin".to_string(), "list".to_string()])
+}
+
+/// True when `codex plugin marketplace list` reports `marketplace`.
+fn marketplace_registered(marketplace: &str, ctx: &DriverCtx) -> bool {
+    match ctx.ops.run_framework_cli(build_marketplace_list_cmd()) {
+        Ok(output) if output.success() => list_contains_token(&output.stdout, marketplace),
+        _ => false,
+    }
+}
+
+/// True when `codex plugin list` reports the plugin (by bare name or
+/// `plugin@marketplace` ref).
+fn plugin_registered(layout: &MarketplaceLayout, ctx: &DriverCtx) -> bool {
+    match ctx.ops.run_framework_cli(build_plugin_list_cmd()) {
+        Ok(output) if output.success() => {
+            list_contains_token(&output.stdout, &layout.plugin)
+                || list_contains_token(&output.stdout, &layout.plugin_ref())
+        }
+        _ => false,
+    }
+}
+
+/// True when `token` appears as a whole whitespace-delimited word on any
+/// line of `stdout`.
+fn list_contains_token(stdout: &str, token: &str) -> bool {
+    stdout
+        .lines()
+        .any(|line| line.split_whitespace().any(|t| t == token))
+}
+
+/// True when `link` is a symlink resolving to `target`.
+fn symlink_points_to(link: &Path, target: &Path) -> bool {
+    std::fs::read_link(link)
+        .map(|dest| dest == target)
+        .unwrap_or(false)
+}
+
+/// Extract `(link, target)` from a receipt's symlink resource.
+fn claim_symlink(claim: &AdapterClaim) -> Option<(PathBuf, PathBuf)> {
+    claim.resource(RES_SYMLINK).and_then(|r| match &r.kind {
+        ClaimResourceKind::Symlink { link, target } => Some((link.clone(), target.clone())),
+        _ => None,
+    })
+}
+
+/// Build the `ResourceBundleMatches` condition.
+fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
+    let kind = AdapterConditionKind::ResourceBundleMatches;
+    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
+        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+            kind,
+            status: ConditionStatus::True,
+            reason: None,
+            resource: None,
+        },
+        (Some(_), Some(_)) => AdapterCondition {
+            kind,
+            status: ConditionStatus::False,
+            reason: Some("resource bundle changed since enable".to_string()),
+            resource: None,
+        },
+        _ => AdapterCondition {
+            kind,
+            status: ConditionStatus::Unknown,
+            reason: Some("no digest recorded or resource root unavailable".to_string()),
+            resource: None,
+        },
+    }
+}
+
+/// Roll signals into a summary. Healthy requires the framework detected and
+/// both marketplace and plugin verified present.
+fn summarize(
+    claim_status: ClaimStatus,
+    detected: bool,
+    marketplace: ConditionStatus,
+    plugin: ConditionStatus,
+) -> AdapterSummary {
+    if claim_status == ClaimStatus::CleanupFailed {
+        return AdapterSummary::CleanupFailed;
+    }
+    if !detected {
+        return AdapterSummary::Degraded;
+    }
+    match (marketplace, plugin) {
+        (ConditionStatus::True, ConditionStatus::True) => AdapterSummary::Healthy,
+        (ConditionStatus::False, _) | (_, ConditionStatus::False) => AdapterSummary::Degraded,
+        _ => AdapterSummary::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marketplace_name_is_component_scoped() {
+        assert_eq!(marketplace_name("tokenless"), "anolisa-tokenless");
+    }
+
+    #[test]
+    fn plugin_ref_combines_validated_parts() {
+        let layout = MarketplaceLayout {
+            root: PathBuf::from("/home/u/.local/share/anolisa/codex-marketplace"),
+            marketplace: "anolisa-tokenless".to_string(),
+            plugin: "tokenless".to_string(),
+        };
+        assert_eq!(layout.plugin_ref(), "tokenless@anolisa-tokenless");
+        assert_eq!(
+            layout.symlink(),
+            PathBuf::from("/home/u/.local/share/anolisa/codex-marketplace/tokenless")
+        );
+        assert_eq!(
+            layout.manifest(),
+            PathBuf::from(
+                "/home/u/.local/share/anolisa/codex-marketplace/.agents/plugins/marketplace.json"
+            )
+        );
+    }
+
+    #[test]
+    fn marketplace_json_is_valid_and_references_plugin() {
+        let layout = MarketplaceLayout {
+            root: PathBuf::from("/tmp/mkt"),
+            marketplace: "anolisa-tokenless".to_string(),
+            plugin: "tokenless".to_string(),
+        };
+        let json = marketplace_json(&layout);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(parsed["name"], "anolisa-tokenless");
+        assert_eq!(parsed["plugins"][0]["name"], "tokenless");
+        assert_eq!(parsed["plugins"][0]["source"]["path"], "./tokenless");
+    }
+
+    #[test]
+    fn add_and_plugin_cmd_shapes() {
+        let add = build_marketplace_add_cmd(Path::new("/tmp/mkt"));
+        assert_eq!(add.program, "codex");
+        assert_eq!(add.args, vec!["plugin", "marketplace", "add", "/tmp/mkt"]);
+        let plugin = build_plugin_add_cmd("tokenless@anolisa-tokenless");
+        assert_eq!(
+            plugin.args,
+            vec!["plugin", "add", "tokenless@anolisa-tokenless"]
+        );
+        let rm = build_plugin_remove_cmd("tokenless@anolisa-tokenless");
+        assert_eq!(
+            rm.args,
+            vec!["plugin", "remove", "tokenless@anolisa-tokenless"]
+        );
+        let mrm = build_marketplace_remove_cmd("anolisa-tokenless");
+        assert_eq!(
+            mrm.args,
+            vec!["plugin", "marketplace", "remove", "anolisa-tokenless"]
+        );
+    }
+
+    #[test]
+    fn list_contains_token_matches_whole_word() {
+        assert!(list_contains_token(
+            "anolisa-tokenless  local\n",
+            "anolisa-tokenless"
+        ));
+        assert!(!list_contains_token(
+            "anolisa-tokenless-x\n",
+            "anolisa-tokenless"
+        ));
+        assert!(!list_contains_token("", "anolisa-tokenless"));
+    }
+
+    #[test]
+    fn marketplace_base_fallback_without_xdg() {
+        // Only the fallback branch is asserted, and only when the ambient
+        // env would exercise it — mutating XDG_DATA_HOME here would race
+        // with parallel FsLayout tests in the same binary.
+        if std::env::var_os("XDG_DATA_HOME").is_some() {
+            return;
+        }
+        assert_eq!(
+            marketplace_base(Some(Path::new("/home/u"))),
+            Some(PathBuf::from("/home/u/.local/share/anolisa"))
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
@@ -1,0 +1,729 @@
+//! Cosh (copilot-shell) framework driver.
+//!
+//! Cosh discovers extensions by scanning well-known directories, so its
+//! adapter is *extension*-typed (`adapter_type = "extension"`), not a
+//! CLI-registered plugin: `enable` copies the component's extension tree
+//! into `<cosh_home>/extensions/<plugin_id>/` and `disable` removes only
+//! that directory. No framework CLI is spawned — enable/disable/status are
+//! pure filesystem operations mediated by the Manager's
+//! [`AdapterOps`](super::driver::AdapterOps).
+//!
+//! The per-user extension dir ANOLISA takes over is distinct from the
+//! system-level auto-discovery tree an RPM may ship under
+//! `/usr/share/anolisa/extensions/<component>/`; `disable` never touches
+//! the latter, which is package-owned, not receipt-owned.
+//!
+//! Env contract (used by detection and home resolution, and by tests to
+//! point at a scratch home): `COSH_BIN` overrides the detected binary name;
+//! `COSH_HOME` overrides the cosh home directory (default
+//! `<user_home>/.copilot-shell`).
+
+use std::path::{Path, PathBuf};
+
+use super::AdapterError;
+use super::claim::{
+    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus, CoshClaim,
+    DRIVER_SCHEMA_VERSION, DriverPayload,
+};
+use super::driver::{
+    AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
+    ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
+    FrameworkDriver, HostEnv, find_binary_in_path,
+};
+use super::util::{bool_status, digest_tree, now_iso8601};
+
+/// Candidate binary names that indicate cosh is installed. `co` and
+/// `copilot` are the short/legacy aliases of the `cosh` CLI.
+const COSH_BINARIES: &[&str] = &["cosh", "co", "copilot"];
+
+/// Native manifest inside a cosh extension bundle. Its presence is what
+/// makes a directory a valid cosh extension.
+const COSH_MANIFEST: &str = "cosh-extension.json";
+
+/// Ownership marker ANOLISA drops inside the delivered extension directory.
+/// Its presence proves the directory is ANOLISA-managed, so a re-enable may
+/// safely replace it and disable may safely remove it — without that proof,
+/// enable refuses to overwrite and disable leaves the directory alone, so a
+/// user-installed extension of the same name is never destroyed.
+const COSH_OWNERSHIP_MARKER: &str = ".anolisa-adapter";
+
+/// Resource id used in Cosh receipts.
+const RES_EXTENSION_DIR: &str = "cosh_extension_dir";
+
+/// Cosh driver. Stateless; all per-operation context arrives via
+/// [`DriverCtx`].
+pub struct CoshDriver;
+
+impl CoshDriver {
+    /// Construct the driver.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CoshDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameworkDriver for CoshDriver {
+    fn name(&self) -> &'static str {
+        "cosh"
+    }
+
+    fn detect(&self, env: &HostEnv) -> DetectResult {
+        // A cosh CLI on PATH is the strong signal. Because the extension
+        // model only drops files (no CLI needed to enable), an existing
+        // cosh home is accepted as a weaker signal so a user who installed
+        // cosh without leaving its launcher on PATH can still enable.
+        if let Some(path) = detect_cosh_binary() {
+            return DetectResult {
+                detected: true,
+                reason: format!("cosh CLI found at {}", path.display()),
+            };
+        }
+        match cosh_home(env.user_home.as_deref()).filter(|h| h.exists()) {
+            Some(home) => DetectResult {
+                detected: true,
+                reason: format!(
+                    "cosh CLI not on PATH, but home {} exists (extension can still be delivered)",
+                    home.display()
+                ),
+            },
+            None => DetectResult {
+                detected: false,
+                reason: "cosh not detected: no cosh/co/copilot on PATH and no ~/.copilot-shell"
+                    .to_string(),
+            },
+        }
+    }
+
+    fn allowed_external_roots(&self, ctx: &DriverCtx) -> Vec<PathBuf> {
+        // The only external root Cosh writes is its own home directory.
+        cosh_home(ctx.user_home.as_deref()).into_iter().collect()
+    }
+
+    fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError> {
+        let root = &ctx.resource_root;
+        if !root.is_dir() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: "resource root does not exist or is not a directory".to_string(),
+            });
+        }
+        let manifest = ctx
+            .declared_bundle_entry
+            .as_deref()
+            .unwrap_or(COSH_MANIFEST);
+        if !root.join(manifest).is_file() {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: format!("cosh extension manifest '{manifest}' missing from resource root"),
+            });
+        }
+        // Extension id used for the destination directory name. Falls back
+        // to the component name when the manifest declares no plugin id.
+        let plugin_id = Some(
+            ctx.declared_plugin_id
+                .clone()
+                .filter(|id| !id.is_empty())
+                .unwrap_or_else(|| ctx.component.clone()),
+        );
+        Ok(AdapterBundle {
+            resource_root: root.clone(),
+            digest: digest_tree(root),
+            plugin_id,
+        })
+    }
+
+    fn plan_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<DriverPlan, AdapterError> {
+        let dst = extension_dir(bundle, ctx)?;
+        let actions = vec![format!(
+            "deliver cosh extension from {} to {}",
+            bundle.resource_root.display(),
+            dst.display(),
+        )];
+        Ok(DriverPlan {
+            framework: self.name().to_string(),
+            component: ctx.component.clone(),
+            actions,
+            register_command: None,
+        })
+    }
+
+    fn prepare_enable(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterClaim, AdapterError> {
+        let dst = extension_dir(bundle, ctx)?;
+        let resources = vec![ClaimResource {
+            id: RES_EXTENSION_DIR.to_string(),
+            purpose: "cosh_extension_dir".to_string(),
+            kind: ClaimResourceKind::ExternalPath { path: dst },
+        }];
+        Ok(AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: ctx.component.clone(),
+            framework: self.name().to_string(),
+            plugin_id: bundle.plugin_id.clone(),
+            adapter_type: ctx.adapter_type.clone(),
+            enabled_at: now_iso8601(),
+            resource_root: bundle.resource_root.clone(),
+            bundle_digest: bundle.digest.clone(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources,
+            driver_payload: DriverPayload::Cosh(CoshClaim {
+                extension_dir_resource: RES_EXTENSION_DIR.to_string(),
+            }),
+        })
+    }
+
+    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+        let dst = claim_extension_dir(claim).ok_or_else(|| AdapterError::BundleInvalid {
+            root: claim.resource_root.clone(),
+            reason: "cosh receipt has no extension directory resource".to_string(),
+        })?;
+        // Never clobber a directory ANOLISA does not own. A first enable
+        // onto a user-installed extension of the same name would otherwise
+        // silently destroy the user's files (and a later disable would
+        // remove them as if ANOLISA had created them). Only replace when the
+        // directory is empty/absent or carries our ownership marker.
+        if dst.exists() && !is_anolisa_owned(&dst) && !dir_is_empty(&dst) {
+            return Err(AdapterError::InvalidAdapterInput {
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                reason: format!(
+                    "refusing to overwrite existing non-ANOLISA cosh extension at {} (no {COSH_OWNERSHIP_MARKER} marker); remove it manually to enable",
+                    dst.display()
+                ),
+            });
+        }
+        // Replace any prior ANOLISA contents so a re-enable after a bundle
+        // change does not leave stale files behind. The dir is inside the
+        // receipt-declared external root, so remove_tree is bounded.
+        ctx.ops.remove_tree(&dst)?;
+        // Write the ownership marker *before* copying the bundle: if the
+        // copy fails partway, the directory is already provably
+        // ANOLISA-owned, so a later disable will remove the partial tree
+        // instead of leaving it (and dropping the receipt). copy_tree
+        // tolerates the pre-existing marker in the destination.
+        ctx.ops.write_file(
+            &dst.join(COSH_OWNERSHIP_MARKER),
+            b"ANOLISA-managed cosh extension\n",
+        )?;
+        ctx.ops.copy_tree(&claim.resource_root, &dst)?;
+        Ok(())
+    }
+
+    fn status(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<AdapterStatusReport, AdapterError> {
+        let mut conditions = Vec::new();
+
+        // 1. Framework detectable?
+        let detect = self.detect(&HostEnv {
+            user_home: ctx.user_home.clone(),
+        });
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::FrameworkDetected,
+            status: bool_status(detect.detected),
+            reason: Some(detect.reason.clone()),
+            resource: None,
+        });
+
+        // 2. Resource bundle still matches the enable-time digest?
+        conditions.push(bundle_match_condition(claim));
+
+        // 3. Extension tree still present, carrying its manifest AND our
+        //    ownership marker? A dir/manifest without the marker is not
+        //    ANOLISA-managed (user replaced it, or a marker write failed),
+        //    which is a degraded state — not a healthy one. This is a
+        //    reliable, read-only filesystem check, so verification is always
+        //    supported for cosh.
+        let (tree_present, tree_reason) = match claim_extension_dir(claim) {
+            Some(dir) if !dir.is_dir() || !dir.join(COSH_MANIFEST).is_file() => (
+                false,
+                Some("cosh extension directory or manifest missing".to_string()),
+            ),
+            Some(dir) if !is_anolisa_owned(&dir) => (
+                false,
+                Some(format!(
+                    "cosh extension directory is not ANOLISA-managed ({COSH_OWNERSHIP_MARKER} marker missing)"
+                )),
+            ),
+            Some(_) => (true, None),
+            None => (
+                false,
+                Some("receipt has no extension directory".to_string()),
+            ),
+        };
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::TreePresent,
+            status: bool_status(tree_present),
+            reason: tree_reason,
+            resource: Some(ClaimResourceRef {
+                id: RES_EXTENSION_DIR.to_string(),
+            }),
+        });
+        conditions.push(AdapterCondition {
+            kind: AdapterConditionKind::VerificationSupported,
+            status: ConditionStatus::True,
+            reason: None,
+            resource: None,
+        });
+
+        let summary = summarize(claim.status, detect.detected, tree_present);
+        Ok(AdapterStatusReport {
+            summary,
+            conditions,
+        })
+    }
+
+    fn disable(
+        &self,
+        claim: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        let mut messages = Vec::new();
+        let mut cleanup_complete = true;
+
+        match claim_extension_dir(claim) {
+            Some(dir) if !dir.exists() => {
+                messages.push(format!(
+                    "cosh extension dir {} already absent",
+                    dir.display()
+                ));
+            }
+            // Only remove a directory we can prove ANOLISA created. If the
+            // marker is gone (e.g. the user replaced the extension after
+            // enable), leave the directory in place rather than deleting
+            // files ANOLISA does not own — but do NOT report success: the
+            // extension is still on disk (and may still be auto-discovered
+            // by cosh), so keep the receipt as cleanup_failed for the
+            // operator to resolve manually.
+            Some(dir) if !is_anolisa_owned(&dir) => {
+                cleanup_complete = false;
+                messages.push(format!(
+                    "cosh extension dir {} is not ANOLISA-managed ({COSH_OWNERSHIP_MARKER} marker missing); left in place — remove it manually, then re-run disable",
+                    dir.display()
+                ));
+            }
+            Some(dir) => match ctx.ops.remove_tree(&dir) {
+                Ok(true) => messages.push(format!("removed cosh extension dir {}", dir.display())),
+                Ok(false) => messages.push(format!(
+                    "cosh extension dir {} already absent",
+                    dir.display()
+                )),
+                Err(err) => {
+                    cleanup_complete = false;
+                    messages.push(format!(
+                        "failed to remove cosh extension dir {}: {err}",
+                        dir.display()
+                    ));
+                }
+            },
+            None => messages.push("receipt records no cosh extension directory".to_string()),
+        }
+
+        Ok(DisableReport {
+            cleanup_complete,
+            messages,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/// First cosh-family binary found on PATH, honoring the `COSH_BIN`
+/// override (which may name any executable, not only the defaults).
+fn detect_cosh_binary() -> Option<PathBuf> {
+    if let Some(bin) = std::env::var("COSH_BIN").ok().filter(|s| !s.is_empty()) {
+        return find_binary_in_path(&bin);
+    }
+    COSH_BINARIES
+        .iter()
+        .find_map(|name| find_binary_in_path(name))
+}
+
+/// True when `dir` carries ANOLISA's ownership marker, proving ANOLISA
+/// created (and may replace/remove) it.
+fn is_anolisa_owned(dir: &Path) -> bool {
+    dir.join(COSH_OWNERSHIP_MARKER).is_file()
+}
+
+/// True when `dir` has no entries (a fresh, safe-to-replace destination).
+/// A read error is treated as "not empty" so we fail closed and refuse to
+/// clobber a directory we could not inspect.
+fn dir_is_empty(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|mut entries| entries.next().is_none())
+        .unwrap_or(false)
+}
+
+/// Resolve the cosh home directory: `COSH_HOME`, else
+/// `<user_home>/.copilot-shell`. Trailing slashes are trimmed.
+fn cosh_home(user_home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(h) = std::env::var_os("COSH_HOME") {
+        let s = h.to_string_lossy();
+        let trimmed = s.trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    user_home.map(|h| h.join(".copilot-shell"))
+}
+
+/// Destination extension directory `<cosh_home>/extensions/<plugin_id>`.
+fn extension_dir(bundle: &AdapterBundle, ctx: &DriverCtx) -> Result<PathBuf, AdapterError> {
+    let home = cosh_home(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
+        program: "cosh".to_string(),
+        reason: "cannot resolve cosh home (no $HOME and no COSH_HOME)".to_string(),
+    })?;
+    let id = bundle
+        .plugin_id
+        .clone()
+        .unwrap_or_else(|| ctx.component.clone());
+    Ok(home.join("extensions").join(id))
+}
+
+/// Extract the extension directory path from a receipt's external-path
+/// resource.
+fn claim_extension_dir(claim: &AdapterClaim) -> Option<PathBuf> {
+    let id = match &claim.driver_payload {
+        DriverPayload::Cosh(c) => c.extension_dir_resource.as_str(),
+        _ => return None,
+    };
+    claim.resource(id).and_then(|res| match &res.kind {
+        ClaimResourceKind::ExternalPath { path } => Some(path.clone()),
+        _ => None,
+    })
+}
+
+/// Build the `ResourceBundleMatches` condition by re-digesting the resource
+/// root and comparing to the enable-time digest.
+fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
+    let kind = AdapterConditionKind::ResourceBundleMatches;
+    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
+        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+            kind,
+            status: ConditionStatus::True,
+            reason: None,
+            resource: None,
+        },
+        (Some(_), Some(_)) => AdapterCondition {
+            kind,
+            status: ConditionStatus::False,
+            reason: Some("resource bundle changed since enable".to_string()),
+            resource: None,
+        },
+        _ => AdapterCondition {
+            kind,
+            status: ConditionStatus::Unknown,
+            reason: Some("no digest recorded or resource root unavailable".to_string()),
+            resource: None,
+        },
+    }
+}
+
+/// Roll the detect and tree-present signals into a summary, honoring a
+/// `cleanup_failed` receipt.
+fn summarize(
+    claim_status: ClaimStatus,
+    framework_detected: bool,
+    tree_present: bool,
+) -> AdapterSummary {
+    if claim_status == ClaimStatus::CleanupFailed {
+        return AdapterSummary::CleanupFailed;
+    }
+    if !tree_present {
+        return AdapterSummary::Degraded;
+    }
+    if !framework_detected {
+        return AdapterSummary::Degraded;
+    }
+    AdapterSummary::Healthy
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::driver::{AdapterOps, CliOutput, FrameworkCommand};
+    use std::sync::{Mutex, MutexGuard};
+
+    /// Serializes cosh env mutation across tests in this module.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved_bin: Option<std::ffi::OsString>,
+        saved_home: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn acquire() -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let g = Self {
+                _lock: lock,
+                saved_bin: std::env::var_os("COSH_BIN"),
+                saved_home: std::env::var_os("COSH_HOME"),
+            };
+            // SAFETY: guard holds ENV_LOCK for the test's duration.
+            unsafe {
+                std::env::remove_var("COSH_BIN");
+                std::env::remove_var("COSH_HOME");
+            }
+            g
+        }
+        fn set_home(&self, home: &Path) {
+            // SAFETY: guard holds ENV_LOCK.
+            unsafe { std::env::set_var("COSH_HOME", home) }
+        }
+        /// Force binary detection to miss, isolating the test from any real
+        /// cosh-family CLI on the host PATH.
+        fn set_bin_absent(&self) {
+            // SAFETY: guard holds ENV_LOCK.
+            unsafe { std::env::set_var("COSH_BIN", "cosh-does-not-exist-xyz-123") }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: guard holds ENV_LOCK until restore completes.
+            unsafe {
+                match &self.saved_bin {
+                    Some(v) => std::env::set_var("COSH_BIN", v),
+                    None => std::env::remove_var("COSH_BIN"),
+                }
+                match &self.saved_home {
+                    Some(v) => std::env::set_var("COSH_HOME", v),
+                    None => std::env::remove_var("COSH_HOME"),
+                }
+            }
+        }
+    }
+
+    /// Recording ops that apply real filesystem effects for copy/remove
+    /// (so status/disable behavior can be asserted) but reject CLI/symlink
+    /// calls the cosh driver must never make.
+    struct FsOps;
+    impl AdapterOps for FsOps {
+        fn run_framework_cli(&self, _: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+            panic!("cosh driver must not spawn a framework CLI");
+        }
+        fn copy_tree(&self, src: &Path, dst: &Path) -> Result<(), AdapterError> {
+            copy_dir(src, dst).map_err(|source| AdapterError::Io {
+                path: dst.to_path_buf(),
+                source,
+            })
+        }
+        fn copy_file(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn remove_tree(&self, path: &Path) -> Result<bool, AdapterError> {
+            if !path.exists() {
+                return Ok(false);
+            }
+            std::fs::remove_dir_all(path).map_err(|source| AdapterError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            Ok(true)
+        }
+        fn write_file(&self, path: &Path, contents: &[u8]) -> Result<(), AdapterError> {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(|source| AdapterError::Io {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+            std::fs::write(path, contents).map_err(|source| AdapterError::Io {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+        fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+            panic!("cosh driver must not create symlinks");
+        }
+    }
+
+    fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let s = entry.path();
+            let d = dst.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                copy_dir(&s, &d)?;
+            } else {
+                std::fs::copy(&s, &d)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn staged_resource_root(dir: &Path) -> PathBuf {
+        let root = dir.join("common");
+        std::fs::create_dir_all(root.join("hooks")).expect("mkdir");
+        std::fs::write(root.join(COSH_MANIFEST), br#"{"name":"tokenless"}"#).expect("manifest");
+        std::fs::write(root.join("hooks/run-hook.sh"), b"#!/bin/sh\n").expect("hook");
+        root
+    }
+
+    fn ctx<'a>(
+        resource_root: &Path,
+        user_home: &Path,
+        ops: &'a FsOps,
+        layout: &'a anolisa_platform::fs_layout::FsLayout,
+    ) -> DriverCtx<'a> {
+        DriverCtx {
+            component: "tokenless".to_string(),
+            framework: "cosh".to_string(),
+            layout,
+            resource_root: resource_root.to_path_buf(),
+            user_home: Some(user_home.to_path_buf()),
+            declared_plugin_id: Some("tokenless".to_string()),
+            adapter_type: Some("extension".to_string()),
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            dry_run: false,
+            ops,
+        }
+    }
+
+    #[test]
+    fn enable_status_disable_copies_and_removes_only_extension_dir() {
+        let guard = EnvGuard::acquire();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let user_home = tmp.path().join("home");
+        std::fs::create_dir_all(&user_home).expect("home");
+        let cosh = tmp.path().join("cosh-home");
+        guard.set_home(&cosh);
+        // A pre-existing sibling extension must survive disable.
+        let sibling = cosh.join("extensions").join("other");
+        std::fs::create_dir_all(&sibling).expect("sibling");
+        std::fs::write(sibling.join("keep.txt"), b"keep").expect("keep");
+
+        let resource_root = staged_resource_root(tmp.path());
+        let ops = FsOps;
+        let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
+        let ctx = ctx(&resource_root, &user_home, &ops, &layout);
+        let driver = CoshDriver::new();
+
+        let bundle = driver.read_bundle(&ctx).expect("read bundle");
+        assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
+
+        let claim = driver.prepare_enable(&bundle, &ctx).expect("claim");
+        driver.apply_enable(&claim, &ctx).expect("apply");
+
+        let ext_dir = cosh.join("extensions").join("tokenless");
+        assert!(ext_dir.join(COSH_MANIFEST).is_file(), "manifest copied");
+        assert!(ext_dir.join("hooks/run-hook.sh").is_file(), "tree copied");
+
+        let report = driver.status(&claim, &ctx).expect("status");
+        assert_eq!(report.summary, AdapterSummary::Healthy);
+        assert!(
+            report
+                .conditions
+                .iter()
+                .any(|c| c.kind == AdapterConditionKind::TreePresent
+                    && c.status == ConditionStatus::True)
+        );
+
+        let disabled = driver.disable(&claim, &ctx).expect("disable");
+        assert!(disabled.cleanup_complete);
+        assert!(!ext_dir.exists(), "extension dir removed");
+        assert!(
+            sibling.join("keep.txt").is_file(),
+            "disable must not touch other extensions"
+        );
+    }
+
+    #[test]
+    fn enable_refuses_to_overwrite_non_anolisa_extension() {
+        let guard = EnvGuard::acquire();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let user_home = tmp.path().join("home");
+        std::fs::create_dir_all(&user_home).expect("home");
+        let cosh = tmp.path().join("cosh-home");
+        guard.set_home(&cosh);
+        // A user-installed extension of the same name, WITHOUT our marker.
+        let ext_dir = cosh.join("extensions").join("tokenless");
+        std::fs::create_dir_all(&ext_dir).expect("ext dir");
+        std::fs::write(ext_dir.join("user-file"), b"precious user data").expect("user file");
+
+        let resource_root = staged_resource_root(tmp.path());
+        let ops = FsOps;
+        let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
+        let ctx = ctx(&resource_root, &user_home, &ops, &layout);
+        let driver = CoshDriver::new();
+
+        let bundle = driver.read_bundle(&ctx).expect("read bundle");
+        let claim = driver.prepare_enable(&bundle, &ctx).expect("claim");
+        let err = driver
+            .apply_enable(&claim, &ctx)
+            .expect_err("must refuse to clobber non-ANOLISA extension");
+        assert!(
+            matches!(err, AdapterError::InvalidAdapterInput { .. }),
+            "got {err:?}"
+        );
+        // The user's file must be untouched.
+        assert_eq!(
+            std::fs::read_to_string(ext_dir.join("user-file")).expect("user file kept"),
+            "precious user data"
+        );
+    }
+
+    #[test]
+    fn read_bundle_rejects_missing_manifest() {
+        let _guard = EnvGuard::acquire();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("common");
+        std::fs::create_dir_all(&root).expect("mkdir");
+        std::fs::write(root.join("stray.txt"), b"x").expect("write");
+        let user_home = tmp.path().join("home");
+        let ops = FsOps;
+        let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
+        let ctx = ctx(&root, &user_home, &ops, &layout);
+        let err = CoshDriver::new()
+            .read_bundle(&ctx)
+            .expect_err("missing manifest must fail");
+        assert!(matches!(err, AdapterError::BundleInvalid { .. }));
+    }
+
+    #[test]
+    fn detect_uses_home_when_cli_absent() {
+        let guard = EnvGuard::acquire();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join(".copilot-shell");
+        std::fs::create_dir_all(&home).expect("home");
+        guard.set_home(&home);
+        guard.set_bin_absent();
+        let result = CoshDriver::new().detect(&HostEnv {
+            user_home: Some(tmp.path().to_path_buf()),
+        });
+        assert!(result.detected, "existing home is a weak detect signal");
+    }
+
+    #[test]
+    fn detect_false_without_cli_or_home() {
+        let guard = EnvGuard::acquire();
+        guard.set_bin_absent();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = CoshDriver::new().detect(&HostEnv {
+            user_home: Some(tmp.path().join("nonexistent-home")),
+        });
+        assert!(!result.detected);
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -271,10 +271,11 @@ impl CliOutput {
 /// The closed set of dangerous IO a driver may perform, mediated by the
 /// Manager.
 ///
-/// MVP exposes only [`run_framework_cli`](AdapterOps::run_framework_cli);
-/// the file/JSON/symlink helpers from the design land with the drivers
-/// that need them (Cosh, Qoder, Hermes), so the boundary grows one
-/// reviewed method at a time rather than shipping unused surface.
+/// The boundary grows one reviewed method at a time rather than shipping
+/// unused surface: `run_framework_cli` plus the tree-copy helpers landed
+/// with OpenClaw/Hermes, and [`write_file`](AdapterOps::write_file) /
+/// [`create_symlink`](AdapterOps::create_symlink) landed with the
+/// Codex/Claude Code drivers.
 pub trait AdapterOps {
     /// Spawn a framework CLI with a timeout, capture and truncate its
     /// output, and record the invocation in the central log. The argv is
@@ -317,6 +318,32 @@ pub trait AdapterOps {
     /// [`AdapterError::Io`] on filesystem failure;
     /// [`AdapterError::ClaimValidation`] if `path` fails boundary check.
     fn remove_tree(&self, path: &Path) -> Result<bool, AdapterError>;
+
+    /// Write `contents` to `path`, creating parent directories. The
+    /// Manager validates that `path` is under an allowed external root
+    /// before executing. An existing file is overwritten (idempotent
+    /// re-enable). The bytes are pure data built by the driver — never an
+    /// executable path or argv.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::Io`] on filesystem failure;
+    /// [`AdapterError::ClaimValidation`] if `path` fails boundary check.
+    fn write_file(&self, path: &Path, contents: &[u8]) -> Result<(), AdapterError>;
+
+    /// Create a symlink at `link` pointing to `target`, creating `link`'s
+    /// parent directories. The Manager validates that **both** `link` and
+    /// `target` are under an allowed external root before executing. When a
+    /// symlink already exists at `link`, it is replaced (idempotent
+    /// re-enable); a non-symlink at `link` is an error so ANOLISA never
+    /// clobbers a real file it did not create.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::Io`] on filesystem failure or when `link` exists and
+    /// is not a symlink; [`AdapterError::ClaimValidation`] if either path
+    /// fails boundary check.
+    fn create_symlink(&self, link: &Path, target: &Path) -> Result<(), AdapterError>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -960,6 +960,12 @@ mod tests {
         fn remove_tree(&self, _: &Path) -> Result<bool, AdapterError> {
             unimplemented!()
         }
+        fn write_file(&self, _: &Path, _: &[u8]) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -392,8 +392,8 @@ impl AdapterManager {
             self.load_visible_component_manifest(component, &state)?;
         let framework = self.resolve_framework(component, framework, &manifest)?;
 
-        // Fail-closed: only `plugin`, `skill_bundle`, or an absent value
-        // (legacy plugin default) is supported.
+        // Fail-closed in two steps. First reject a value no driver
+        // implements at all (`service`, typos, …).
         let adapter_type = declared_adapter_type(&manifest, &framework);
         if let Some(ref at) = adapter_type
             && !is_supported_adapter_type(at)
@@ -404,6 +404,10 @@ impl AdapterManager {
                 adapter_type: at.clone(),
             });
         }
+        // Then reject an implemented type used with a framework that does
+        // not support it (e.g. `openclaw` + `extension`, `cosh` + `plugin`),
+        // so the wrong driver code path can never run.
+        validate_adapter_type_for_framework(component, &framework, adapter_type.as_deref())?;
 
         let declared_plugin_id = declared_plugin_id(&manifest, &framework);
         let skill_specs = declared_skills(&manifest, &framework);
@@ -555,7 +559,11 @@ impl AdapterManager {
         let claim = driver.prepare_enable(&bundle, &ctx)?;
         // Defense in depth: the driver must not emit a claim that points
         // outside its own declared roots. Reject before persisting.
-        claim.validate(&self.layout, &driver.allowed_external_roots(&ctx))?;
+        claim.validate_with_owned_roots(
+            &self.layout,
+            &driver.allowed_external_roots(&ctx),
+            &self.all_datadir_roots,
+        )?;
 
         state.upsert_adapter_claim(claim.clone());
         state.save(&self.state_path)?;
@@ -736,7 +744,11 @@ impl AdapterManager {
         };
 
         // Re-validate the receipt before acting on it (forged-state guard).
-        claim.validate(&self.layout, &driver.allowed_external_roots(&ctx))?;
+        claim.validate_with_owned_roots(
+            &self.layout,
+            &driver.allowed_external_roots(&ctx),
+            &self.all_datadir_roots,
+        )?;
 
         if dry_run {
             let report = plan_disable_report(&claim);
@@ -841,7 +853,11 @@ impl AdapterManager {
                 ops: &ops,
             };
 
-            claim.validate(&self.layout, &driver.allowed_external_roots(&ctx))?;
+            claim.validate_with_owned_roots(
+                &self.layout,
+                &driver.allowed_external_roots(&ctx),
+                &self.all_datadir_roots,
+            )?;
             let report = driver.status(claim, &ctx)?;
             entries.push(StatusEntry {
                 component: claim.component.clone(),
@@ -1818,6 +1834,69 @@ fn is_supported_adapter_type(adapter_type: &str) -> bool {
     matches!(adapter_type, "plugin" | "skill_bundle" | "extension")
 }
 
+/// The adapter types each built-in framework accepts, in declaration order.
+///
+/// A framework whose list contains `"plugin"` also accepts an absent
+/// `adapter_type` (the legacy default). A framework without `"plugin"` (e.g.
+/// `cosh`, which is extension-only) requires an explicit `adapter_type`.
+///
+/// Returns `None` for frameworks with no built-in driver; enable resolves
+/// that into the more specific [`AdapterError::UnknownFramework`] later, so
+/// this gate stays silent for them.
+fn allowed_adapter_types(framework: &str) -> Option<&'static [&'static str]> {
+    match framework {
+        // Plugin frameworks that also deliver skills.
+        "openclaw" | "hermes" => Some(&["plugin", "skill_bundle"]),
+        // Marketplace-plugin frameworks: plugin only.
+        "codex" | "claude-code" => Some(&["plugin"]),
+        // Filesystem-extension framework: extension only, no plugin default.
+        "cosh" => Some(&["extension"]),
+        _ => None,
+    }
+}
+
+/// Reject a framework/`adapter_type` pair the framework does not support,
+/// even when the type is implemented by *some other* driver.
+///
+/// This is distinct from [`AdapterError::UnsupportedAdapterType`], which is
+/// reserved for a value no driver implements at all (e.g. `service`). Here
+/// the value is a real adapter type used with the wrong framework — for
+/// example `openclaw` + `extension` (which would otherwise silently run the
+/// plugin path) or `cosh` + `plugin` (which would mis-handle a filesystem
+/// extension as a CLI plugin).
+///
+/// # Errors
+///
+/// [`AdapterError::InvalidAdapterInput`] when the declared (or defaulted)
+/// type is not in the framework's allowed set.
+fn validate_adapter_type_for_framework(
+    component: &str,
+    framework: &str,
+    adapter_type: Option<&str>,
+) -> Result<(), AdapterError> {
+    let Some(allowed) = allowed_adapter_types(framework) else {
+        // No built-in driver; let enable surface UnknownFramework instead.
+        return Ok(());
+    };
+    let accepts_default = allowed.contains(&"plugin");
+    let ok = match adapter_type {
+        Some(at) => allowed.contains(&at),
+        None => accepts_default,
+    };
+    if ok {
+        return Ok(());
+    }
+    let declared = adapter_type.unwrap_or("<absent> (defaults to plugin)");
+    Err(AdapterError::InvalidAdapterInput {
+        component: component.to_string(),
+        framework: framework.to_string(),
+        reason: format!(
+            "framework '{framework}' does not support adapter_type '{declared}'; it accepts: {}",
+            allowed.join(", ")
+        ),
+    })
+}
+
 /// Whether a component status makes it visible to adapter scan/enable.
 /// Both fully-installed and adopted components should be adapter-visible.
 fn is_adapter_visible_status(status: ObjectStatus) -> bool {
@@ -2357,6 +2436,68 @@ mod tests {
         let at = declared_adapter_type(&manifest, "openclaw");
         let should_reject = at.as_ref().is_some_and(|t| !is_supported_adapter_type(t));
         assert!(!should_reject, "skill_bundle must pass the gate");
+    }
+
+    // -- validate_adapter_type_for_framework ---------------------------------
+
+    #[test]
+    fn framework_type_matrix_accepts_valid_pairs() {
+        let ok = |fw: &str, at: Option<&str>| {
+            validate_adapter_type_for_framework("tokenless", fw, at).is_ok()
+        };
+        assert!(ok("openclaw", Some("plugin")));
+        assert!(ok("openclaw", Some("skill_bundle")));
+        assert!(ok("openclaw", None), "openclaw defaults to plugin");
+        assert!(ok("hermes", Some("skill_bundle")));
+        assert!(ok("codex", Some("plugin")));
+        assert!(ok("codex", None), "codex defaults to plugin");
+        assert!(ok("claude-code", Some("plugin")));
+        assert!(ok("claude-code", None));
+        assert!(ok("cosh", Some("extension")));
+    }
+
+    #[test]
+    fn framework_type_matrix_rejects_extension_on_plugin_frameworks() {
+        for fw in ["openclaw", "hermes", "codex", "claude-code"] {
+            let err = validate_adapter_type_for_framework("tokenless", fw, Some("extension"))
+                .expect_err(&format!("{fw} + extension must be rejected"));
+            assert!(
+                matches!(err, AdapterError::InvalidAdapterInput { .. }),
+                "{fw}: got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn framework_type_matrix_rejects_skill_bundle_on_marketplace_frameworks() {
+        for fw in ["codex", "claude-code"] {
+            let err = validate_adapter_type_for_framework("tokenless", fw, Some("skill_bundle"))
+                .expect_err(&format!("{fw} + skill_bundle must be rejected"));
+            assert!(matches!(err, AdapterError::InvalidAdapterInput { .. }));
+        }
+    }
+
+    #[test]
+    fn cosh_requires_extension_type() {
+        // cosh + plugin, cosh + skill_bundle, and cosh with no adapter_type
+        // (which would default to plugin) must all be rejected.
+        for at in [Some("plugin"), Some("skill_bundle"), None] {
+            let err = validate_adapter_type_for_framework("tokenless", "cosh", at)
+                .expect_err(&format!("cosh + {at:?} must be rejected"));
+            assert!(
+                matches!(err, AdapterError::InvalidAdapterInput { .. }),
+                "cosh + {at:?}: got {err:?}"
+            );
+        }
+        validate_adapter_type_for_framework("tokenless", "cosh", Some("extension"))
+            .expect("cosh + extension must pass");
+    }
+
+    #[test]
+    fn framework_type_matrix_is_silent_for_unknown_framework() {
+        // No built-in driver: this gate defers to UnknownFramework.
+        validate_adapter_type_for_framework("tokenless", "qoder", Some("extension"))
+            .expect("unknown framework must not be rejected by the type gate");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -1464,15 +1464,101 @@ impl AdapterOps for ManagerOps {
 
     fn remove_tree(&self, path: &Path) -> Result<bool, AdapterError> {
         validate_ops_path(path, &self.allowed_roots)?;
-        if !path.exists() {
-            return Ok(false);
+        // Use symlink_metadata so a symlink at `path` is removed as a link
+        // rather than followed (remove_dir_all refuses a symlink, and
+        // following one could escape the allowed roots).
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                std::fs::remove_file(path).map_err(|source| AdapterError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                Ok(true)
+            }
+            Ok(_) => {
+                std::fs::remove_dir_all(path).map_err(|source| AdapterError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                Ok(true)
+            }
+            // Only a genuinely-absent path is a no-op. Permission or other
+            // IO errors must surface, not masquerade as "already removed"
+            // (which would let a driver mark cleanup complete and drop the
+            // receipt without having verified the target was gone).
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(source) => Err(AdapterError::Io {
+                path: path.to_path_buf(),
+                source,
+            }),
         }
-        std::fs::remove_dir_all(path).map_err(|source| AdapterError::Io {
+    }
+
+    fn write_file(&self, path: &Path, contents: &[u8]) -> Result<(), AdapterError> {
+        validate_ops_path(path, &self.allowed_roots)?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| AdapterError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        std::fs::write(path, contents).map_err(|source| AdapterError::Io {
             path: path.to_path_buf(),
             source,
-        })?;
-        Ok(true)
+        })
     }
+
+    fn create_symlink(&self, link: &Path, target: &Path) -> Result<(), AdapterError> {
+        validate_ops_path(link, &self.allowed_roots)?;
+        validate_ops_path(target, &self.allowed_roots)?;
+        if let Some(parent) = link.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| AdapterError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        // Replace an existing ANOLISA-created symlink (idempotent
+        // re-enable), but refuse to clobber a real file/dir we did not
+        // create.
+        match std::fs::symlink_metadata(link) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                std::fs::remove_file(link).map_err(|source| AdapterError::Io {
+                    path: link.to_path_buf(),
+                    source,
+                })?;
+            }
+            Ok(_) => {
+                return Err(AdapterError::Io {
+                    path: link.to_path_buf(),
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::AlreadyExists,
+                        "refusing to replace a non-symlink at the adapter link path",
+                    ),
+                });
+            }
+            Err(_) => {}
+        }
+        symlink_file(target, link).map_err(|source| AdapterError::Io {
+            path: link.to_path_buf(),
+            source,
+        })
+    }
+}
+
+/// Create a symlink at `link` pointing to `target`. Unix-only; on other
+/// platforms this returns an unsupported error so the boundary never
+/// silently degrades.
+#[cfg(unix)]
+fn symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(not(unix))]
+fn symlink_file(_target: &Path, _link: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "symlink adapters are only supported on Unix",
+    ))
 }
 
 /// Spawn `cmd` as a direct argv (no shell), enforce its timeout, and return
@@ -1729,7 +1815,7 @@ fn declared_adapter_type(manifest: &ComponentManifest, framework: &str) -> Optio
 }
 
 fn is_supported_adapter_type(adapter_type: &str) -> bool {
-    matches!(adapter_type, "plugin" | "skill_bundle")
+    matches!(adapter_type, "plugin" | "skill_bundle" | "extension")
 }
 
 /// Whether a component status makes it visible to adapter scan/enable.
@@ -1959,6 +2045,32 @@ fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
                 Some(h.plugin_resource.as_str())
             }
         }
+        DriverPayload::Cosh(c) => {
+            cleanup_ids.push(&c.extension_dir_resource);
+            None
+        }
+        DriverPayload::Codex(c) => {
+            // Real disable order: plugin remove, marketplace remove, then
+            // remove the marketplace directory (which contains the symlink).
+            cleanup_ids.push(&c.plugin_resource);
+            cleanup_ids.push(&c.marketplace_resource);
+            cleanup_ids.push(&c.symlink_resource);
+            cleanup_ids.push(&c.marketplace_dir_resource);
+            None
+        }
+        DriverPayload::ClaudeCode(c) => {
+            cleanup_ids.push(&c.plugin_resource);
+            cleanup_ids.push(&c.marketplace_resource);
+            None
+        }
+    };
+
+    // Whether disable uninstalls (Claude Code semantics) rather than
+    // unregisters (registry-only). Purely cosmetic for the plan text.
+    let plugin_verb = if matches!(claim.driver_payload, DriverPayload::ClaudeCode(_)) {
+        "uninstall"
+    } else {
+        "unregister"
     };
 
     for resource in &claim.resources {
@@ -1975,7 +2087,20 @@ fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
                 framework,
                 plugin_id,
             } => {
-                messages.push(format!("would unregister {framework} plugin '{plugin_id}'"));
+                messages.push(format!(
+                    "would {plugin_verb} {framework} plugin '{plugin_id}'"
+                ));
+            }
+            ClaimResourceKind::FrameworkMarketplace {
+                framework,
+                marketplace,
+            } => {
+                messages.push(format!(
+                    "would remove {framework} marketplace '{marketplace}'"
+                ));
+            }
+            ClaimResourceKind::Symlink { link, .. } => {
+                messages.push(format!("would remove symlink {}", link.display()));
             }
             ClaimResourceKind::ExternalPath { path } => {
                 // Hermes stores its plugin as a directory (ExternalPath) but
@@ -2186,19 +2311,16 @@ mod tests {
         assert!(msg.contains("service"));
         assert!(msg.contains("tokenless"));
         assert!(msg.contains("openclaw"));
-        assert!(msg.contains("'plugin' and 'skill_bundle'"));
+        assert!(msg.contains("'plugin', 'skill_bundle', and 'extension'"));
     }
 
     #[test]
-    fn unsupported_adapter_type_extension() {
-        let err = AdapterError::UnsupportedAdapterType {
-            component: "agentsight".to_string(),
-            framework: "openclaw".to_string(),
-            adapter_type: "extension".to_string(),
-        };
-        let msg = err.to_string();
-        assert!(msg.contains("extension"));
-        assert!(msg.contains("agentsight"));
+    fn supported_adapter_types_include_extension() {
+        assert!(is_supported_adapter_type("plugin"));
+        assert!(is_supported_adapter_type("skill_bundle"));
+        assert!(is_supported_adapter_type("extension"));
+        assert!(!is_supported_adapter_type("service"));
+        assert!(!is_supported_adapter_type("magic"));
     }
 
     #[test]
@@ -2210,7 +2332,7 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(msg.contains("magic"));
-        assert!(msg.contains("'plugin' and 'skill_bundle'"));
+        assert!(msg.contains("'plugin', 'skill_bundle', and 'extension'"));
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -1420,6 +1420,12 @@ mod tests {
             fn remove_tree(&self, _: &Path) -> Result<bool, AdapterError> {
                 unimplemented!()
             }
+            fn write_file(&self, _: &Path, _: &[u8]) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
         }
 
         let dir = tempfile::tempdir().expect("tempdir");

--- a/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/registry.rs
@@ -2,8 +2,11 @@
 //!
 //! The set of supported frameworks is closed and compiled in: a framework
 //! is supported only if an ANOLISA release ships a driver for it. There is
-//! no runtime plugin loading. MVP registers only the OpenClaw driver.
+//! no runtime plugin loading.
 
+use super::claude_code::ClaudeCodeDriver;
+use super::codex::CodexDriver;
+use super::cosh::CoshDriver;
 use super::driver::FrameworkDriver;
 use super::hermes::HermesDriver;
 use super::openclaw::OpenClawDriver;
@@ -20,6 +23,9 @@ impl DriverRegistry {
             drivers: vec![
                 Box::new(OpenClawDriver::new()),
                 Box::new(HermesDriver::new()),
+                Box::new(CoshDriver::new()),
+                Box::new(CodexDriver::new()),
+                Box::new(ClaudeCodeDriver::new()),
             ],
         }
     }
@@ -54,17 +60,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn builtin_registers_openclaw_and_hermes() {
+    fn builtin_registers_all_shipped_drivers() {
         let reg = DriverRegistry::builtin();
         assert!(reg.contains("openclaw"));
         assert!(reg.contains("hermes"));
-        assert!(!reg.contains("cosh"), "cosh driver not yet shipped");
-        assert_eq!(reg.names(), vec!["openclaw", "hermes"]);
+        assert!(reg.contains("cosh"));
+        assert!(reg.contains("codex"));
+        assert!(reg.contains("claude-code"));
+        assert_eq!(
+            reg.names(),
+            vec!["openclaw", "hermes", "cosh", "codex", "claude-code"]
+        );
     }
 
     #[test]
     fn get_unknown_framework_is_none() {
         let reg = DriverRegistry::builtin();
+        // `qoder` ships an adapter bundle but no built-in driver yet.
         assert!(reg.get("qoder").is_none());
+        assert!(reg.get("qwencode").is_none());
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/util.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/util.rs
@@ -1,0 +1,98 @@
+//! Pure, side-effect-free helpers shared by the built-in framework
+//! drivers.
+//!
+//! These never spawn a process or mutate the filesystem beyond reading for
+//! a digest, so they are safe to call from `plan`/`status`/`prepare` paths.
+//! The Cosh/Codex/Claude Code drivers share them here rather than each
+//! re-declaring the same digest/timestamp/formatting logic.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use super::driver::{CliOutput, ConditionStatus, FrameworkCommand};
+
+/// SHA-256 digest of a directory tree, stable across runs: files are hashed
+/// in sorted relative-path order as `path\0len\0bytes`. Returns `None` on
+/// any IO error so callers fall back to `Unknown` rather than a wrong
+/// verdict.
+pub(crate) fn digest_tree(root: &Path) -> Option<String> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    collect_files(root, &mut files).ok()?;
+    files.sort();
+    let mut hasher = Sha256::new();
+    for path in &files {
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        let bytes = std::fs::read(path).ok()?;
+        hasher.update(rel.to_string_lossy().as_bytes());
+        hasher.update([0u8]);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update([0u8]);
+        hasher.update(&bytes);
+    }
+    Some(format!("sha256:{:x}", hasher.finalize()))
+}
+
+/// Recursively collect regular-file paths under `dir`. Symlinks are not
+/// followed into directories (their link path is recorded as a file).
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            collect_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// ISO 8601 UTC timestamp, second precision.
+pub(crate) fn now_iso8601() -> String {
+    use chrono::{SecondsFormat, Utc};
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+/// Map a bool to a [`ConditionStatus`] (`true` -> `True`, `false` -> `False`).
+pub(crate) fn bool_status(b: bool) -> ConditionStatus {
+    if b {
+        ConditionStatus::True
+    } else {
+        ConditionStatus::False
+    }
+}
+
+/// Compose a failure reason string from a non-success [`CliOutput`].
+pub(crate) fn cli_failure_reason(verb: &str, output: &CliOutput) -> String {
+    if output.timed_out {
+        return format!("'{verb}' timed out");
+    }
+    let code = output
+        .status
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "killed".to_string());
+    let mut reason = format!("'{verb}' exited with {code}");
+    let stderr = output.stderr.trim();
+    if !stderr.is_empty() {
+        reason.push_str(": ");
+        reason.push_str(stderr);
+    }
+    reason
+}
+
+/// Human-readable form of a command for dry-run/preview output. Display
+/// only — never parsed back into an argv.
+pub(crate) fn display_command(cmd: &FrameworkCommand) -> String {
+    let mut s = String::new();
+    for (k, v) in &cmd.env_set {
+        s.push_str(&format!("{k}={v} "));
+    }
+    s.push_str(&cmd.program);
+    for a in &cmd.args {
+        s.push(' ');
+        s.push_str(a);
+    }
+    s
+}

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -1,0 +1,827 @@
+//! End-to-end adapter manager tests for the Cosh, Codex, and Claude Code
+//! drivers.
+//!
+//! Each test drives the real [`AdapterManager`] against a staged component
+//! contract + resource bundle. Codex and Claude Code use shell-script fake
+//! CLIs that record their argv (so we can assert the exact framework
+//! commands ANOLISA issues) and keep enough state for `status` to verify.
+//! Cosh is CLI-less: its enable/disable are pure filesystem operations, so
+//! the test asserts it copies and removes only its own extension directory.
+//!
+//! All three drivers read process-global env (`CODEX_BIN`, `CLAUDE_BIN`,
+//! `COSH_HOME`, `XDG_DATA_HOME`, …), so every test serializes on
+//! [`ENV_LOCK`], starts from a cleared env, and restores it on exit.
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use anolisa_core::adapter::AdapterError;
+use anolisa_core::adapter::claim::{ClaimResourceKind, ClaimStatus};
+use anolisa_core::adapter::driver::{AdapterConditionKind, AdapterSummary, ConditionStatus};
+use anolisa_core::adapter::manager::{AdapterManager, EnableOutcome};
+use anolisa_platform::fs_layout::FsLayout;
+
+const COMPONENT: &str = "tokenless";
+
+/// Serializes process-global env mutation across tests.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Env keys every test clears on entry and restores on drop, so a test
+/// never observes another test's half-applied contract.
+const MANAGED_ENV: &[&str] = &[
+    "CODEX_BIN",
+    "CLAUDE_BIN",
+    "COSH_BIN",
+    "COSH_HOME",
+    "XDG_DATA_HOME",
+    "FAKE_CODEX_LOG",
+    "FAKE_CODEX_STATE",
+    "FAKE_CODEX_FAIL",
+    "FAKE_CLAUDE_LOG",
+    "FAKE_CLAUDE_STATE",
+];
+
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    fn acquire() -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = MANAGED_ENV
+            .iter()
+            .map(|k| (*k, std::env::var_os(k)))
+            .collect();
+        let guard = Self { _lock: lock, saved };
+        for k in MANAGED_ENV {
+            // SAFETY: guard holds ENV_LOCK for the whole test.
+            unsafe { std::env::remove_var(k) };
+        }
+        guard
+    }
+
+    fn set(&self, key: &str, value: &Path) {
+        // SAFETY: guard holds ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.saved {
+            // SAFETY: guard holds ENV_LOCK until restore completes.
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+}
+
+/// A staged world: system-mode layout under a temp prefix, a seeded
+/// `installed.toml` + component contract for one framework, and the
+/// framework's resource bundle.
+struct World {
+    _root: tempfile::TempDir,
+    prefix: PathBuf,
+    layout: FsLayout,
+    user_home: PathBuf,
+    resource_root: PathBuf,
+}
+
+impl World {
+    fn manager(&self) -> AdapterManager {
+        AdapterManager::new(
+            self.layout.clone(),
+            Some(self.user_home.clone()),
+            "tester".to_string(),
+        )
+    }
+
+    fn load_state(&self) -> anolisa_core::state::InstalledState {
+        anolisa_core::state::InstalledState::load(&self.layout.state_dir.join("installed.toml"))
+            .expect("load state")
+    }
+}
+
+/// Stage a component contract declaring `framework`/`adapter_type` with the
+/// given `dest`, plus the resource bundle written by `stage_bundle`.
+fn stage(framework: &str, adapter_type: &str, dest: &str, stage_bundle: impl Fn(&Path)) -> World {
+    let root = tempfile::tempdir().expect("tempdir");
+    let prefix = root.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+    let user_home = prefix.join("home");
+    std::fs::create_dir_all(&user_home).expect("home");
+
+    // Resolve the resource root the same way the manager will (expand the
+    // dest against the system datadir) and populate it.
+    let resource_root = expand_dest(dest, &layout.datadir);
+    std::fs::create_dir_all(&resource_root).expect("resource root");
+    stage_bundle(&resource_root);
+
+    // Seed installed.toml + component contract.
+    let state_path = layout.state_dir.join("installed.toml");
+    std::fs::create_dir_all(state_path.parent().unwrap()).expect("state dir");
+    std::fs::write(
+        &state_path,
+        format!(
+            r#"schema_version = 2
+updated_at = "2026-07-04T00:00:00Z"
+install_mode = "system"
+prefix = "{prefix}"
+anolisa_version = "0.1.20"
+
+[[objects]]
+kind = "component"
+name = "{COMPONENT}"
+version = "0.6.0"
+status = "installed"
+installed_at = "2026-07-04T00:00:00Z"
+"#,
+            prefix = prefix.display(),
+        ),
+    )
+    .expect("seed state");
+
+    let manifest_path = layout
+        .state_dir
+        .join("component-manifests")
+        .join(COMPONENT)
+        .join("component.toml");
+    std::fs::create_dir_all(manifest_path.parent().unwrap()).expect("manifest dir");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"[component]
+name = "{COMPONENT}"
+version = "0.6.0"
+
+[component.layout]
+modes = ["system"]
+
+[[adapters]]
+framework = "{framework}"
+adapter_type = "{adapter_type}"
+plugin_id = "{COMPONENT}"
+dest = "{dest}"
+"#
+        ),
+    )
+    .expect("seed contract");
+
+    World {
+        _root: root,
+        prefix,
+        layout,
+        user_home,
+        resource_root,
+    }
+}
+
+/// Minimal `{datadir}`/`{component}` expansion for staging (the manager's
+/// real expansion is exercised separately).
+fn expand_dest(dest: &str, datadir: &Path) -> PathBuf {
+    let expanded = dest
+        .replace("{datadir}", &datadir.to_string_lossy())
+        .replace("{component}", COMPONENT);
+    PathBuf::from(expanded)
+}
+
+fn write_exec(path: &Path, body: &str) {
+    std::fs::write(path, body).expect("write script");
+    let mut perms = std::fs::metadata(path).expect("meta").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).expect("chmod");
+}
+
+// ---------------------------------------------------------------------------
+// Cosh
+// ---------------------------------------------------------------------------
+
+fn stage_cosh_bundle(root: &Path) {
+    std::fs::create_dir_all(root.join("hooks")).expect("hooks");
+    std::fs::write(root.join("cosh-extension.json"), br#"{"name":"tokenless"}"#).expect("manifest");
+    std::fs::write(root.join("hooks/run-hook.sh"), b"#!/bin/sh\n").expect("hook");
+}
+
+#[test]
+fn cosh_enable_status_disable_touches_only_extension_dir() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "cosh",
+        "extension",
+        "{datadir}/adapters/{component}/common/",
+        stage_cosh_bundle,
+    );
+    let cosh_home = world.prefix.join("cosh-home");
+    std::fs::create_dir_all(&cosh_home).expect("cosh home");
+    guard.set("COSH_HOME", &cosh_home);
+    // A sibling extension owned by someone else must survive disable.
+    let sibling = cosh_home.join("extensions").join("other");
+    std::fs::create_dir_all(&sibling).expect("sibling");
+    std::fs::write(sibling.join("keep.txt"), b"keep").expect("keep");
+
+    let manager = world.manager();
+    let claim = match manager
+        .enable(COMPONENT, Some("cosh"), false)
+        .expect("enable")
+    {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned(_) => panic!("expected enabled"),
+    };
+    assert_eq!(claim.adapter_type.as_deref(), Some("extension"));
+
+    let ext_dir = cosh_home.join("extensions").join("tokenless");
+    assert!(
+        ext_dir.join("cosh-extension.json").is_file(),
+        "extension copied"
+    );
+    assert!(ext_dir.join("hooks/run-hook.sh").is_file(), "tree copied");
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+    assert!(
+        status.entries[0]
+            .report
+            .conditions
+            .iter()
+            .any(|c| c.kind == AdapterConditionKind::TreePresent
+                && c.status == ConditionStatus::True)
+    );
+
+    let disabled = manager
+        .disable(COMPONENT, Some("cosh"), false)
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    assert!(!ext_dir.exists(), "extension dir removed");
+    assert!(
+        sibling.join("keep.txt").is_file(),
+        "disable must not touch sibling extensions"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "cosh")
+            .is_none(),
+        "receipt gone after disable"
+    );
+}
+
+#[test]
+fn cosh_dry_run_enable_writes_nothing() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "cosh",
+        "extension",
+        "{datadir}/adapters/{component}/common/",
+        stage_cosh_bundle,
+    );
+    let cosh_home = world.prefix.join("cosh-home");
+    std::fs::create_dir_all(&cosh_home).expect("cosh home");
+    guard.set("COSH_HOME", &cosh_home);
+
+    let manager = world.manager();
+    let outcome = manager
+        .enable(COMPONENT, Some("cosh"), true)
+        .expect("dry-run");
+    match outcome {
+        EnableOutcome::Planned(plan) => {
+            assert_eq!(plan.framework, "cosh");
+            assert!(
+                plan.actions
+                    .iter()
+                    .any(|a| a.contains("deliver cosh extension"))
+            );
+        }
+        EnableOutcome::Enabled(_) => panic!("dry-run must not enable"),
+    }
+    assert!(
+        !cosh_home.join("extensions").join("tokenless").exists(),
+        "dry-run must not write the extension dir"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "cosh")
+            .is_none(),
+        "dry-run must not persist a receipt"
+    );
+}
+
+#[test]
+fn cosh_disable_keeps_receipt_when_ownership_marker_missing() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "cosh",
+        "extension",
+        "{datadir}/adapters/{component}/common/",
+        stage_cosh_bundle,
+    );
+    let cosh_home = world.prefix.join("cosh-home");
+    std::fs::create_dir_all(&cosh_home).expect("cosh home");
+    guard.set("COSH_HOME", &cosh_home);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("cosh"), false)
+        .expect("enable");
+    let ext_dir = cosh_home.join("extensions").join("tokenless");
+
+    // Simulate the ownership marker going missing (user replaced the
+    // extension, or a marker write failed after copy).
+    std::fs::remove_file(ext_dir.join(".anolisa-adapter")).expect("remove marker");
+
+    // Status must degrade, not report healthy, when ownership is unprovable.
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
+
+    // Disable must NOT delete a dir it cannot prove it owns, and must NOT
+    // report success (the extension is still on disk / auto-discoverable),
+    // so the receipt is kept as cleanup_failed.
+    let disabled = manager
+        .disable(COMPONENT, Some("cosh"), false)
+        .expect("disable runs");
+    assert!(
+        !disabled.claim_removed,
+        "receipt kept when ownership unprovable"
+    );
+    assert!(!disabled.report.cleanup_complete);
+    assert!(
+        ext_dir.exists(),
+        "non-ANOLISA-owned dir must be left in place"
+    );
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "cosh")
+        .cloned()
+        .expect("receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+// ---------------------------------------------------------------------------
+// Codex
+// ---------------------------------------------------------------------------
+
+fn stage_codex_bundle(root: &Path) {
+    std::fs::create_dir_all(root.join(".codex-plugin")).expect("codex-plugin");
+    std::fs::write(
+        root.join(".codex-plugin/plugin.json"),
+        br#"{"name":"tokenless"}"#,
+    )
+    .expect("plugin.json");
+    std::fs::write(root.join("README.md"), b"codex plugin\n").expect("readme");
+}
+
+/// Fake `codex` CLI: appends each argv line to `$FAKE_CODEX_LOG` and keeps
+/// marketplace/plugin registries under `$FAKE_CODEX_STATE` so `list`
+/// reflects prior `add`/`remove` calls.
+fn write_fake_codex(dir: &Path) -> PathBuf {
+    let path = dir.join("codex");
+    write_exec(
+        &path,
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_CODEX_LOG"
+st="$FAKE_CODEX_STATE"; mkdir -p "$st" 2>/dev/null
+if [ "$1" = "plugin" ] && [ "$2" = "marketplace" ]; then
+  case "$3" in
+    add)
+      name=$(sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$4/.agents/plugins/marketplace.json" | head -n1)
+      echo "$name" >> "$st/marketplaces" ;;
+    remove)
+      [ "$FAKE_CODEX_FAIL" = "remove" ] && { echo "remove boom" >&2; exit 1; }
+      [ -f "$st/marketplaces" ] && { grep -vx "$4" "$st/marketplaces" > "$st/m.tmp" 2>/dev/null || true; mv "$st/m.tmp" "$st/marketplaces" 2>/dev/null || true; } ;;
+    list) cat "$st/marketplaces" 2>/dev/null || true ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "plugin" ]; then
+  case "$2" in
+    add) echo "$3" >> "$st/plugins" ;;
+    remove)
+      # FAKE_CODEX_FAIL=remove: fail without removing, so the driver's
+      # post-remove verification still finds the plugin registered.
+      [ "$FAKE_CODEX_FAIL" = "remove" ] && { echo "remove boom" >&2; exit 1; }
+      [ -f "$st/plugins" ] && { grep -vx "$3" "$st/plugins" > "$st/p.tmp" 2>/dev/null || true; mv "$st/p.tmp" "$st/plugins" 2>/dev/null || true; } ;;
+    list) cat "$st/plugins" 2>/dev/null || true ;;
+  esac
+  exit 0
+fi
+exit 0
+"#,
+    );
+    path
+}
+
+fn apply_codex_env(guard: &EnvGuard, world: &World, fake_bin: &Path) -> (PathBuf, PathBuf) {
+    let xdg = world.prefix.join("xdg-data");
+    std::fs::create_dir_all(&xdg).expect("xdg");
+    let log = world.prefix.join("codex.log");
+    let state = world.prefix.join("codex-state");
+    guard.set("CODEX_BIN", fake_bin);
+    guard.set("XDG_DATA_HOME", &xdg);
+    guard.set("FAKE_CODEX_LOG", &log);
+    guard.set("FAKE_CODEX_STATE", &state);
+    let marketplace_root = xdg.join("anolisa").join("codex-marketplace");
+    (log, marketplace_root)
+}
+
+#[test]
+fn codex_enable_records_argv_and_builds_marketplace() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    let (log, marketplace_root) = apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    let claim = match manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable")
+    {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned(_) => panic!("expected enabled"),
+    };
+
+    // Marketplace layout on disk.
+    let manifest = marketplace_root.join(".agents/plugins/marketplace.json");
+    assert!(manifest.is_file(), "marketplace.json written");
+    let symlink = marketplace_root.join("tokenless");
+    assert_eq!(
+        std::fs::read_link(&symlink).expect("symlink"),
+        world.resource_root,
+        "symlink points at the resource root"
+    );
+
+    // Recorded argv: exactly the marketplace-add and plugin-add commands.
+    let log_text = std::fs::read_to_string(&log).expect("codex log");
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == format!("plugin marketplace add {}", marketplace_root.display())),
+        "must run `plugin marketplace add <root>`: {log_text}"
+    );
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == "plugin add tokenless@anolisa-tokenless"),
+        "must run `plugin add tokenless@anolisa-tokenless`: {log_text}"
+    );
+
+    // Receipt carries the marketplace + symlink + plugin resources.
+    assert!(claim.resources.iter().any(|r| matches!(
+        &r.kind,
+        ClaimResourceKind::FrameworkMarketplace { marketplace, .. } if marketplace == "anolisa-tokenless"
+    )));
+    assert!(
+        claim
+            .resources
+            .iter()
+            .any(|r| matches!(&r.kind, ClaimResourceKind::Symlink { .. }))
+    );
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    let disabled = manager
+        .disable(COMPONENT, Some("codex"), false)
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    assert!(
+        !marketplace_root.exists(),
+        "marketplace dir removed on disable"
+    );
+    let log_text = std::fs::read_to_string(&log).expect("codex log");
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == "plugin remove tokenless@anolisa-tokenless"),
+        "disable must run `plugin remove`: {log_text}"
+    );
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == "plugin marketplace remove anolisa-tokenless"),
+        "disable must run `plugin marketplace remove`: {log_text}"
+    );
+}
+
+#[test]
+fn codex_dry_run_enable_writes_nothing() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    let (log, marketplace_root) = apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    let outcome = manager
+        .enable(COMPONENT, Some("codex"), true)
+        .expect("dry-run");
+    assert!(matches!(outcome, EnableOutcome::Planned(_)));
+    assert!(
+        !marketplace_root.exists(),
+        "dry-run must not create marketplace dir"
+    );
+    assert!(
+        !log.exists(),
+        "dry-run must not invoke the codex CLI (no log file)"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "codex")
+            .is_none(),
+        "dry-run must not persist a receipt"
+    );
+}
+
+#[test]
+fn codex_forged_symlink_target_rejected_by_status() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+
+    // Tamper: repoint the symlink resource's target at /etc.
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    {
+        let claim = state
+            .adapter_claims
+            .iter_mut()
+            .find(|c| c.component == COMPONENT)
+            .expect("claim");
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::Symlink { target, .. } = &mut res.kind {
+                *target = PathBuf::from("/etc/cron.d/evil");
+            }
+        }
+    }
+    state.save(&state_path).expect("save tampered state");
+
+    let err = manager
+        .status(Some(COMPONENT))
+        .expect_err("forged symlink target must be rejected");
+    assert!(
+        matches!(err, AdapterError::ClaimValidation(_)),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn codex_forged_resource_root_and_symlink_target_rejected() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+
+    // Forge BOTH the receipt's resource_root and the symlink target to
+    // /etc. The symlink target is validated against the trusted layout, not
+    // the receipt, so this must still be rejected.
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    {
+        let claim = state
+            .adapter_claims
+            .iter_mut()
+            .find(|c| c.component == COMPONENT)
+            .expect("claim");
+        claim.resource_root = PathBuf::from("/etc");
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::Symlink { target, .. } = &mut res.kind {
+                *target = PathBuf::from("/etc/cron.d/evil");
+            }
+        }
+    }
+    state.save(&state_path).expect("save tampered state");
+
+    let err = manager
+        .status(Some(COMPONENT))
+        .expect_err("forged resource_root must not authorize a forged symlink target");
+    assert!(
+        matches!(err, AdapterError::ClaimValidation(_)),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn codex_disable_keeps_receipt_when_cli_removal_fails() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+
+    // Force the codex CLI removal commands to fail without deregistering.
+    guard.set("FAKE_CODEX_FAIL", Path::new("remove"));
+    let disabled = manager
+        .disable(COMPONENT, Some("codex"), false)
+        .expect("disable runs");
+    assert!(
+        !disabled.claim_removed,
+        "receipt must be kept when CLI deregistration fails"
+    );
+    assert!(!disabled.report.cleanup_complete);
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "codex")
+        .cloned()
+        .expect("receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code
+// ---------------------------------------------------------------------------
+
+fn stage_claude_bundle(root: &Path) {
+    std::fs::create_dir_all(root.join(".claude-plugin")).expect("claude-plugin");
+    std::fs::write(
+        root.join(".claude-plugin/marketplace.json"),
+        br#"{"name":"anolisa","plugins":[{"name":"tokenless","source":"./"}]}"#,
+    )
+    .expect("marketplace.json");
+    std::fs::write(
+        root.join(".claude-plugin/plugin.json"),
+        br#"{"name":"tokenless","version":"0.6.0"}"#,
+    )
+    .expect("plugin.json");
+}
+
+/// Fake `claude` CLI: records argv and keeps marketplace/plugin registries.
+fn write_fake_claude(dir: &Path) -> PathBuf {
+    let path = dir.join("claude");
+    write_exec(
+        &path,
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_CLAUDE_LOG"
+st="$FAKE_CLAUDE_STATE"; mkdir -p "$st" 2>/dev/null
+if [ "$1" = "plugin" ]; then
+  case "$2" in
+    validate) exit 0 ;;
+    marketplace)
+      case "$3" in
+        add) echo "anolisa" >> "$st/marketplaces" ;;
+        remove) [ -f "$st/marketplaces" ] && { grep -vx "$4" "$st/marketplaces" > "$st/m.tmp" 2>/dev/null || true; mv "$st/m.tmp" "$st/marketplaces" 2>/dev/null || true; } ;;
+        list) cat "$st/marketplaces" 2>/dev/null || true ;;
+      esac ;;
+    install) echo "$3" >> "$st/plugins" ;;
+    uninstall) [ -f "$st/plugins" ] && { grep -vx "$3" "$st/plugins" > "$st/p.tmp" 2>/dev/null || true; mv "$st/p.tmp" "$st/plugins" 2>/dev/null || true; } ;;
+    list) cat "$st/plugins" 2>/dev/null || true ;;
+  esac
+  exit 0
+fi
+exit 0
+"#,
+    );
+    path
+}
+
+fn apply_claude_env(guard: &EnvGuard, world: &World, fake_bin: &Path) -> PathBuf {
+    let log = world.prefix.join("claude.log");
+    let state = world.prefix.join("claude-state");
+    guard.set("CLAUDE_BIN", fake_bin);
+    guard.set("FAKE_CLAUDE_LOG", &log);
+    guard.set("FAKE_CLAUDE_STATE", &state);
+    log
+}
+
+#[test]
+fn claude_code_enable_records_validate_marketplace_and_install() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "claude-code",
+        "plugin",
+        "{datadir}/adapters/{component}/claude-code/",
+        stage_claude_bundle,
+    );
+    let fake = write_fake_claude(&world.prefix);
+    let log = apply_claude_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    let claim = match manager
+        .enable(COMPONENT, Some("claude-code"), false)
+        .expect("enable")
+    {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned(_) => panic!("expected enabled"),
+    };
+    assert_eq!(claim.plugin_id.as_deref(), Some("tokenless"));
+
+    let log_text = std::fs::read_to_string(&log).expect("claude log");
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == format!("plugin validate {}", world.resource_root.display())),
+        "must validate the bundle: {log_text}"
+    );
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == format!("plugin marketplace add {}", world.resource_root.display())),
+        "must add the marketplace: {log_text}"
+    );
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == "plugin install tokenless@anolisa"),
+        "must install the plugin: {log_text}"
+    );
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    let disabled = manager
+        .disable(COMPONENT, Some("claude-code"), false)
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    let log_text = std::fs::read_to_string(&log).expect("claude log");
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == "plugin uninstall tokenless@anolisa"),
+        "disable must uninstall the plugin: {log_text}"
+    );
+    assert!(
+        log_text
+            .lines()
+            .any(|l| l == "plugin marketplace remove anolisa"),
+        "disable must remove the marketplace: {log_text}"
+    );
+}
+
+#[test]
+fn claude_code_disable_without_cli_keeps_receipt() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "claude-code",
+        "plugin",
+        "{datadir}/adapters/{component}/claude-code/",
+        stage_claude_bundle,
+    );
+    let fake = write_fake_claude(&world.prefix);
+    apply_claude_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("claude-code"), false)
+        .expect("enable");
+
+    // Point CLAUDE_BIN at a missing path: disable cannot run the CLI and
+    // must NOT hand-edit settings.json, so it keeps the receipt.
+    guard.set("CLAUDE_BIN", &world.prefix.join("no-such-claude"));
+    let disabled = manager
+        .disable(COMPONENT, Some("claude-code"), false)
+        .expect("disable runs");
+    assert!(!disabled.claim_removed, "receipt kept when CLI absent");
+    assert!(!disabled.report.cleanup_complete);
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "claude-code")
+        .cloned()
+        .expect("receipt kept");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -125,7 +125,26 @@ fn stage(framework: &str, adapter_type: &str, dest: &str, stage_bundle: impl Fn(
     std::fs::create_dir_all(&resource_root).expect("resource root");
     stage_bundle(&resource_root);
 
-    // Seed installed.toml + component contract.
+    seed_component(&layout, &prefix, framework, adapter_type, dest);
+
+    World {
+        _root: root,
+        prefix,
+        layout,
+        user_home,
+        resource_root,
+    }
+}
+
+/// Seed `installed.toml` (component installed) plus the component contract
+/// declaring one adapter with the given `framework`/`adapter_type`/`dest`.
+fn seed_component(
+    layout: &FsLayout,
+    prefix: &Path,
+    framework: &str,
+    adapter_type: &str,
+    dest: &str,
+) {
     let state_path = layout.state_dir.join("installed.toml");
     std::fs::create_dir_all(state_path.parent().unwrap()).expect("state dir");
     std::fs::write(
@@ -174,14 +193,6 @@ dest = "{dest}"
         ),
     )
     .expect("seed contract");
-
-    World {
-        _root: root,
-        prefix,
-        layout,
-        user_home,
-        resource_root,
-    }
 }
 
 /// Minimal `{datadir}`/`{component}` expansion for staging (the manager's
@@ -673,15 +684,84 @@ fn codex_disable_keeps_receipt_when_cli_removal_fails() {
     assert_eq!(claim.status, ClaimStatus::CleanupFailed);
 }
 
+/// Regression: when the resource bundle is resolved from a packaged datadir
+/// registered via `push_primary_datadir_root` (exe-sibling `/usr/share`
+/// differing from the install prefix's `{datadir}`), the codex plugin
+/// symlink target lives outside the primary layout roots. Enable must still
+/// succeed — the Manager trusts its configured datadir roots for symlink
+/// target validation.
+#[test]
+fn codex_enable_succeeds_with_bundle_under_packaged_datadir() {
+    let guard = EnvGuard::acquire();
+    let root = tempfile::tempdir().expect("tempdir");
+    let prefix = root.path().to_path_buf();
+    // Install prefix layout (its datadir is prefix/usr/local/share/anolisa).
+    let layout = FsLayout::system(Some(prefix.join("install")));
+    let user_home = prefix.join("home");
+    std::fs::create_dir_all(&user_home).expect("home");
+
+    // Packaged datadir distinct from layout.datadir — where the bundle lives.
+    let packaged_datadir = prefix.join("pkg").join("usr").join("share").join("anolisa");
+    let resource_root = packaged_datadir
+        .join("adapters")
+        .join(COMPONENT)
+        .join("codex");
+    std::fs::create_dir_all(&resource_root).expect("resource root");
+    stage_codex_bundle(&resource_root);
+
+    // Contract dest expands against {datadir}; the bundle exists only under
+    // the packaged datadir, so resolution lands there.
+    seed_component(
+        &layout,
+        &prefix,
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+    );
+
+    let fake = write_fake_codex(&prefix);
+    let xdg = prefix.join("xdg-data");
+    std::fs::create_dir_all(&xdg).expect("xdg");
+    guard.set("CODEX_BIN", &fake);
+    guard.set("XDG_DATA_HOME", &xdg);
+    guard.set("FAKE_CODEX_LOG", &prefix.join("codex.log"));
+    guard.set("FAKE_CODEX_STATE", &prefix.join("codex-state"));
+
+    let mut manager = AdapterManager::new(layout, Some(user_home), "tester".to_string());
+    manager.push_primary_datadir_root(packaged_datadir);
+
+    let claim = match manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable must succeed with bundle under a packaged datadir")
+    {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned(_) => panic!("expected enabled"),
+    };
+    // The symlink target points at the packaged-datadir bundle, outside the
+    // install-prefix layout roots — the very case that previously failed.
+    assert!(claim.resources.iter().any(|r| matches!(
+        &r.kind,
+        ClaimResourceKind::Symlink { target, .. } if target == &resource_root
+    )));
+
+    // status re-validates the receipt; it must not reject the packaged-datadir
+    // symlink target either.
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+}
+
 // ---------------------------------------------------------------------------
 // Claude Code
 // ---------------------------------------------------------------------------
 
 fn stage_claude_bundle(root: &Path) {
     std::fs::create_dir_all(root.join(".claude-plugin")).expect("claude-plugin");
+    // Written multi-line with the top-level name on its own line so the
+    // fake CLI's line-based `sed` reads the marketplace name (not the nested
+    // plugin name) — mirrors the real multi-line manifest.
     std::fs::write(
         root.join(".claude-plugin/marketplace.json"),
-        br#"{"name":"anolisa","plugins":[{"name":"tokenless","source":"./"}]}"#,
+        b"{\n  \"name\": \"anolisa-tokenless\",\n  \"plugins\": [{ \"name\": \"tokenless\", \"source\": \"./\" }]\n}\n",
     )
     .expect("marketplace.json");
     std::fs::write(
@@ -704,7 +784,9 @@ if [ "$1" = "plugin" ]; then
     validate) exit 0 ;;
     marketplace)
       case "$3" in
-        add) echo "anolisa" >> "$st/marketplaces" ;;
+        add)
+          name=$(sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$4/.claude-plugin/marketplace.json" | head -n1)
+          echo "$name" >> "$st/marketplaces" ;;
         remove) [ -f "$st/marketplaces" ] && { grep -vx "$4" "$st/marketplaces" > "$st/m.tmp" 2>/dev/null || true; mv "$st/m.tmp" "$st/marketplaces" 2>/dev/null || true; } ;;
         list) cat "$st/marketplaces" 2>/dev/null || true ;;
       esac ;;
@@ -767,7 +849,7 @@ fn claude_code_enable_records_validate_marketplace_and_install() {
     assert!(
         log_text
             .lines()
-            .any(|l| l == "plugin install tokenless@anolisa"),
+            .any(|l| l == "plugin install tokenless@anolisa-tokenless"),
         "must install the plugin: {log_text}"
     );
 
@@ -782,13 +864,13 @@ fn claude_code_enable_records_validate_marketplace_and_install() {
     assert!(
         log_text
             .lines()
-            .any(|l| l == "plugin uninstall tokenless@anolisa"),
+            .any(|l| l == "plugin uninstall tokenless@anolisa-tokenless"),
         "disable must uninstall the plugin: {log_text}"
     );
     assert!(
         log_text
             .lines()
-            .any(|l| l == "plugin marketplace remove anolisa"),
+            .any(|l| l == "plugin marketplace remove anolisa-tokenless"),
         "disable must remove the marketplace: {log_text}"
     );
 }
@@ -824,4 +906,66 @@ fn claude_code_disable_without_cli_keeps_receipt() {
         .cloned()
         .expect("receipt kept");
     assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+/// A receipt missing its marketplace resource (malformed/forged) must not
+/// drive `plugin uninstall` / `marketplace remove` against a name derived
+/// from context: status degrades and disable keeps the receipt without
+/// running any CLI.
+#[test]
+fn claude_code_fails_closed_without_marketplace_resource() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "claude-code",
+        "plugin",
+        "{datadir}/adapters/{component}/claude-code/",
+        stage_claude_bundle,
+    );
+    let fake = write_fake_claude(&world.prefix);
+    let log = apply_claude_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("claude-code"), false)
+        .expect("enable");
+
+    // Tamper: drop the FrameworkMarketplace resource, leaving the payload's
+    // dangling reference — as a forged/malformed receipt would.
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    {
+        let claim = state
+            .adapter_claims
+            .iter_mut()
+            .find(|c| c.component == COMPONENT)
+            .expect("claim");
+        claim
+            .resources
+            .retain(|r| !matches!(r.kind, ClaimResourceKind::FrameworkMarketplace { .. }));
+    }
+    state.save(&state_path).expect("save tampered state");
+
+    // status must not report healthy, and must not run the CLI.
+    let log_before = std::fs::read_to_string(&log).unwrap_or_default();
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
+
+    // disable must keep the receipt and run no CLI removal.
+    let disabled = manager
+        .disable(COMPONENT, Some("claude-code"), false)
+        .expect("disable runs");
+    assert!(!disabled.claim_removed, "malformed receipt must be kept");
+    assert!(!disabled.report.cleanup_complete);
+    let log_after = std::fs::read_to_string(&log).unwrap_or_default();
+    assert_eq!(
+        log_before, log_after,
+        "no framework CLI must run for a receipt with no marketplace resource"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "claude-code")
+            .is_some(),
+        "receipt kept for manual resolution"
+    );
 }

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -279,7 +279,7 @@ The plugin registers hooks at two Claude Code events, covering four strategies:
 | Response compression | `PostToolUse` | Compresses tool responses and encodes to TOON format | ✅ Active |
 | TOON encoding | `PostToolUse` | Pipeline step after response compression — encodes JSON to TOON format | ✅ Active |
 
-Claude Code v2 requires plugins to be sourced from a registered marketplace. We expose the adapter's `claude-code/` directory as a single-plugin marketplace (`anolisa`), then install `tokenless@anolisa` from it.
+Claude Code v2 requires plugins to be sourced from a registered marketplace. We expose the adapter's `claude-code/` directory as a single-plugin marketplace (`anolisa-tokenless`), then install `tokenless@anolisa-tokenless` from it. The marketplace name is component-scoped so multiple ANOLISA components can each register their own without colliding.
 
 ### Install
 

--- a/src/tokenless/adapters/tokenless/claude-code/.claude-plugin/marketplace.json
+++ b/src/tokenless/adapters/tokenless/claude-code/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "anolisa",
+  "name": "anolisa-tokenless",
   "description": "ANOLISA local marketplace — bundles the Token-Less plugin for Claude Code",
   "owner": {
     "name": "ANOLISA"

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -10,7 +10,7 @@ COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
 AGENT="${ANOLISA_TARGET:-claude-code}"
 ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
-PLUGIN_ID="tokenless@anolisa"
+PLUGIN_ID="${COMPONENT}@anolisa-${COMPONENT}"
 PLUGIN_SRC="$ADAPTER_DIR/claude-code"
 
 CLAUDE_BIN="${CLAUDE_BIN:-}"

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/install.sh
@@ -13,7 +13,9 @@
 #
 # Claude Code v2 requires plugins to be sourced from a registered marketplace.
 # We expose the adapter's claude-code/ directory itself as a single-plugin
-# marketplace ("anolisa"), then install tokenless@anolisa from it.
+# marketplace ("anolisa-tokenless"), then install tokenless@anolisa-tokenless
+# from it. The marketplace name is component-scoped so multiple ANOLISA
+# components can each register their own without colliding.
 set -euo pipefail
 
 AGENT="${ANOLISA_TARGET:-claude-code}"
@@ -21,8 +23,8 @@ COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
 ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 PLUGIN_SRC="$ADAPTER_DIR/claude-code"
-MARKETPLACE_NAME="anolisa"
-PLUGIN_ID="tokenless@${MARKETPLACE_NAME}"
+MARKETPLACE_NAME="anolisa-${COMPONENT}"
+PLUGIN_ID="${COMPONENT}@${MARKETPLACE_NAME}"
 
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/uninstall.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/uninstall.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 AGENT="${ANOLISA_TARGET:-claude-code}"
 COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
 
-MARKETPLACE_NAME="anolisa"
-PLUGIN_ID="tokenless@${MARKETPLACE_NAME}"
+MARKETPLACE_NAME="anolisa-${COMPONENT}"
+PLUGIN_ID="${COMPONENT}@${MARKETPLACE_NAME}"
 
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"

--- a/src/tokenless/adapters/tokenless/manifest.json.in
+++ b/src/tokenless/adapters/tokenless/manifest.json.in
@@ -63,8 +63,8 @@
     "claude-code": {
       "compatibleVersions": ">=2.0.0",
       "method": "plugin",
-      "marketplace": "anolisa",
-      "pluginId": "tokenless@anolisa",
+      "marketplace": "anolisa-tokenless",
+      "pluginId": "tokenless@anolisa-tokenless",
       "capabilities": {
         "hooks": [
           "rewrite",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -443,7 +443,7 @@ if [ $1 -eq 0 ]; then
     if [ -f "$CLAUDE_CODE_SCRIPT" ]; then
         bash "$CLAUDE_CODE_SCRIPT" || true
         echo "WARN: per-user Claude Code plugin entries are not removed by RPM %preun." >&2
-        echo "WARN: each user running claude should run: claude plugin uninstall tokenless@anolisa" >&2
+        echo "WARN: each user running claude should run: claude plugin uninstall tokenless@anolisa-tokenless" >&2
     fi
 fi
 


### PR DESCRIPTION
## Description

Adds first-class ANOLISA adapter support for cosh (copilot-shell), Codex, and
Claude Code, implemented entirely as built-in Rust `FrameworkDriver`s — no
delegation to component-side install/uninstall shell scripts. Extends the
receipt security boundary with two new claim-resource kinds (`Symlink`,
`FrameworkMarketplace`), two controlled IO ops (`write_file`, `create_symlink`),
and the `extension` adapter type. Cosh uses a filesystem extension model with an
ownership marker so it never destroys user-installed extensions; Codex/Claude
Code drive their official marketplace CLIs and keep the receipt as
`cleanup_failed` when deregistration cannot complete.

## Related Issue

no-issue: internal adapter roadmap (design in ANOLISA-design/docs/anolisa/cli)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `tokenless` (tokenless)
- [x] `anolisa` (anolisa-cli)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`,
      `cargo fmt --all --check`, and `cargo test --locked` pass

## Testing

- `cargo test --workspace --locked` — all 11 test binaries pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo doc --workspace --no-deps` — clean
- New unit tests per driver + `tests/adapter_frameworks.rs` integration suite
  (fake codex/claude CLIs asserting exact argv; cosh copy/remove-only-own-dir;
  dry-run writes nothing; forged symlink target / resource_root rejected;
  CLI-removal-failure and ownership-marker-missing keep the receipt)