### PR TITLE
chore(release): publish 1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0] - Unreleased
+## [1.0] - 2026-07-06
 
 ### Component Versions
 

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -6,7 +6,7 @@
 
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，项目遵循[语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
 
-## [1.0] - 未发布
+## [1.0] - 2026-07-06
 
 ### 组件版本
 


### PR DESCRIPTION
## Description

Publish the Agentic OS 1.0 changelog in both English and Chinese.
This marks the 1.0 release date as 2026-07-06 and keeps the component
version table aligned with the agreed release.

## Related Issue

no-issue: release documentation update

## Type of Change

- [x] Documentation update

## Scope

- [x] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have updated the documentation accordingly

## Testing

- Ran `git diff --check` to verify changelog formatting.