### PR TITLE
fix(cosh-ng): prioritize aliyun auth option

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod ecs;
 pub(crate) mod providers;
 pub(crate) mod runtime;
+
+#[cfg(test)]
+mod runtime_tests;

--- a/src/cosh-ng/crates/cosh-shell/src/auth/providers.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/providers.rs
@@ -1,8 +1,47 @@
 use crate::runtime::prelude::{AuthFieldInfo, AuthProviderInfo};
 
+/// Display label for the Aliyun provider, highlighting that it is free to use.
+///
+/// Kept as a single constant so the builtin template, the control-protocol
+/// normalizer, and `label_for_provider_type` all present identical text.
+pub(crate) const ALIYUN_PROVIDER_LABEL: &str = "Aliyun Authentication（免费可用）";
+
 /// Builtin provider templates (mirroring cosh-core's auth.rs).
+///
+/// Aliyun is listed first so the free option is the default choice on first-run
+/// authentication; DashScope and OpenAI Compatible follow.
 pub(crate) fn builtin_auth_providers() -> Vec<AuthProviderInfo> {
     vec![
+        AuthProviderInfo {
+            id: "aliyun".into(),
+            label: ALIYUN_PROVIDER_LABEL.into(),
+            fields: vec![
+                AuthFieldInfo {
+                    name: "access_key_id".into(),
+                    label: "Access Key ID".into(),
+                    hint: Some("https://ram.console.aliyun.com/manage/ak".into()),
+                    secret: true,
+                    required: true,
+                    placeholder: None,
+                },
+                AuthFieldInfo {
+                    name: "access_key_secret".into(),
+                    label: "Access Key Secret".into(),
+                    hint: None,
+                    secret: true,
+                    required: true,
+                    placeholder: None,
+                },
+                AuthFieldInfo {
+                    name: "model".into(),
+                    label: "Model".into(),
+                    hint: Some("默认: qwen3.7-plus".into()),
+                    secret: false,
+                    required: false,
+                    placeholder: Some("qwen3.7-plus".into()),
+                },
+            ],
+        },
         AuthProviderInfo {
             id: "dashscope".into(),
             label: "DashScope (百炼)".into(),
@@ -55,37 +94,27 @@ pub(crate) fn builtin_auth_providers() -> Vec<AuthProviderInfo> {
                 },
             ],
         },
-        AuthProviderInfo {
-            id: "aliyun".into(),
-            label: "Aliyun Authentication".into(),
-            fields: vec![
-                AuthFieldInfo {
-                    name: "access_key_id".into(),
-                    label: "Access Key ID".into(),
-                    hint: Some("https://ram.console.aliyun.com/manage/ak".into()),
-                    secret: true,
-                    required: true,
-                    placeholder: None,
-                },
-                AuthFieldInfo {
-                    name: "access_key_secret".into(),
-                    label: "Access Key Secret".into(),
-                    hint: None,
-                    secret: true,
-                    required: true,
-                    placeholder: None,
-                },
-                AuthFieldInfo {
-                    name: "model".into(),
-                    label: "Model".into(),
-                    hint: Some("默认: qwen3.7-plus".into()),
-                    secret: false,
-                    required: false,
-                    placeholder: Some("qwen3.7-plus".into()),
-                },
-            ],
-        },
     ]
+}
+
+/// Normalize a provider list arriving from cosh-core's control protocol so the
+/// shell always presents Aliyun first with the free-availability hint.
+///
+/// cosh-core may still emit the legacy order (dashscope / openai_compat /
+/// aliyun); rather than change cosh-core this round, the shell reorders the list
+/// (stable — non-Aliyun providers keep their relative order) and patches the
+/// Aliyun label. Ordering keys on the stable `aliyun` provider id, never the
+/// label text.
+pub(crate) fn normalize_provider_order(
+    mut providers: Vec<AuthProviderInfo>,
+) -> Vec<AuthProviderInfo> {
+    for provider in providers.iter_mut() {
+        if provider.id == "aliyun" {
+            provider.label = ALIYUN_PROVIDER_LABEL.to_string();
+        }
+    }
+    providers.sort_by_key(|provider| u8::from(provider.id != "aliyun"));
+    providers
 }
 
 /// Returns the builtin base URL for a given provider id, if any.
@@ -103,5 +132,51 @@ pub(crate) fn default_model_for_provider(provider_id: &str) -> Option<&'static s
         "dashscope" => Some("qwen3.7-plus"),
         "aliyun" => Some("qwen3.7-plus"),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(id: &str, label: &str) -> AuthProviderInfo {
+        AuthProviderInfo {
+            id: id.into(),
+            label: label.into(),
+            fields: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn builtin_lists_aliyun_first_with_free_hint() {
+        let providers = builtin_auth_providers();
+        assert_eq!(providers[0].id, "aliyun");
+        assert!(
+            providers[0].label.contains("免费可用"),
+            "aliyun label should advertise free availability, got {:?}",
+            providers[0].label
+        );
+    }
+
+    #[test]
+    fn builtin_keeps_dashscope_and_openai_compat() {
+        let providers = builtin_auth_providers();
+        let ids: Vec<&str> = providers.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, ["aliyun", "dashscope", "openai_compat"]);
+    }
+
+    #[test]
+    fn normalize_reorders_legacy_list_aliyun_first() {
+        // Legacy order emitted by cosh-core's control protocol.
+        let legacy = vec![
+            provider("dashscope", "DashScope (百炼)"),
+            provider("openai_compat", "OpenAI Compatible"),
+            provider("aliyun", "Aliyun Authentication"),
+        ];
+        let normalized = normalize_provider_order(legacy);
+        let ids: Vec<&str> = normalized.iter().map(|p| p.id.as_str()).collect();
+        // Aliyun promoted to front; other providers keep their relative order.
+        assert_eq!(ids, ["aliyun", "dashscope", "openai_compat"]);
+        assert!(normalized[0].label.contains("免费可用"));
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use crate::auth::ecs;
 use crate::auth::providers::{
     builtin_auth_providers, builtin_base_url_for_provider, default_model_for_provider,
+    normalize_provider_order, ALIYUN_PROVIDER_LABEL,
 };
 use crate::runtime::dispatcher::stable_event_key;
 use crate::runtime::prelude::{
@@ -60,7 +61,7 @@ pub(crate) struct ExistingProvider {
 fn label_for_provider_type(provider_type: &str) -> &'static str {
     match provider_type {
         "dashscope" => "DashScope (\u{767e}\u{70bc})",
-        "aliyun" => "Aliyun Authentication",
+        "aliyun" => ALIYUN_PROVIDER_LABEL,
         _ => "OpenAI Compatible",
     }
 }
@@ -202,7 +203,7 @@ pub(crate) fn record_auth_required(
                 id: id.clone(),
                 request_id: request_id.clone(),
                 phase: AuthPhase::SelectingProvider,
-                providers: providers.clone(),
+                providers: normalize_provider_order(providers.clone()),
                 selected_provider: 0,
                 current_field: 0,
                 collected_values: HashMap::new(),

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -1,0 +1,49 @@
+use super::runtime::*;
+use crate::runtime::prelude::{
+    AgentEvent, AuthProviderInfo, GovernanceDecision, GovernancePolicyDecision, GovernedEvent,
+    InlineState,
+};
+
+fn provider(id: &str, label: &str) -> AuthProviderInfo {
+    AuthProviderInfo {
+        id: id.into(),
+        label: label.into(),
+        fields: Vec::new(),
+    }
+}
+
+fn governed_auth_required(providers: Vec<AuthProviderInfo>) -> GovernedEvent {
+    GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::AuthRequired {
+            run_id: "run-1".into(),
+            request_id: "req-1".into(),
+            reason: "test".into(),
+            error_message: None,
+            providers,
+        },
+        reason: "test".into(),
+        display_text: "test".into(),
+        auto_execute: false,
+    }
+}
+
+#[test]
+fn record_auth_required_promotes_aliyun_from_legacy_order() {
+    // cosh-core's control protocol still emits the legacy provider order.
+    let legacy = vec![
+        provider("dashscope", "DashScope (百炼)"),
+        provider("openai_compat", "OpenAI Compatible"),
+        provider("aliyun", "Aliyun Authentication"),
+    ];
+    let mut state = InlineState::default();
+    let ids = record_auth_required(&mut state, &[governed_auth_required(legacy)]);
+    assert_eq!(ids, vec!["auth-req-1".to_string()]);
+
+    let stored = state.auth.state.expect("auth state recorded");
+    let ids: Vec<&str> = stored.providers.iter().map(|p| p.id.as_str()).collect();
+    // Aliyun promoted to front; other providers keep their original relative order.
+    assert_eq!(ids, ["aliyun", "dashscope", "openai_compat"]);
+    assert!(stored.providers[0].label.contains("免费可用"));
+}


### PR DESCRIPTION
## Description

This PR makes Aliyun Authentication the first option in the cosh-shell authentication provider menu and marks it as free to use. It keeps provider selection keyed by the stable `aliyun` id, while normalizing provider lists received through the control protocol so cosh-shell presents the same Aliyun-first order even when cosh-core still sends the legacy order.

No CHANGELOG entry is included because daily feature/fix PRs do not update changelogs under the current documentation standard.

## Related Issue

closes #1351

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cd src/cosh-ng && crates/cosh-shell/scripts/check-layout.sh`
- `cd src/cosh-ng && cargo test --package cosh-shell --bin cosh-shell`
- `cd src/cosh-ng && cargo clippy --package cosh-shell --all-targets`

## Additional Notes

The fix is confined to `src/cosh-ng/crates/cosh-shell/`. Provider ids, Aliyun ECS detection, AK/SK input, field filling, and auth response behavior remain unchanged.
