### PR TITLE
feat(anolisa): implement component-level mutual exclusion for raw backend

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -329,7 +329,7 @@ pub(crate) fn handle_raw_install(
     )?;
 
     if ctx.dry_run {
-        let preview = build_install_preview(ctx, layout, resolved)?;
+        let preview = build_install_preview(ctx, layout, installed, resolved)?;
         render_plan(ctx, &preview)?;
         return Ok(InstallOutcome::Installed);
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -254,6 +254,7 @@ impl InstallContractSource {
 pub(crate) fn build_install_preview(
     ctx: &CliContext,
     layout: &FsLayout,
+    installed: &anolisa_core::state::InstalledState,
     mut resolution: RawResolution,
 ) -> Result<InstallPreview, CliError> {
     if resolution.entry.sha256.is_none() {
@@ -277,6 +278,10 @@ pub(crate) fn build_install_preview(
             provision_plan: None,
         });
     };
+
+    // Conflict check: surface the same mutual-exclusion error that execute_raw
+    // would produce, so `--dry-run` never shows a plan that cannot succeed.
+    check_component_conflicts(&contract.manifest, installed, COMMAND)?;
 
     let (files, services, capabilities) = match resolve_manifest_contract(
         &contract.manifest,
@@ -951,6 +956,37 @@ pub(crate) fn resolve_install_hooks(
     })
 }
 
+/// Check that no component declared in the manifest's `conflicts` list is
+/// already installed. Returns `Ok(())` when no conflict exists, or an
+/// actionable error with a remediation hint otherwise.
+///
+/// This is the raw-backend equivalent of RPM's `Conflicts:` tag. Because the
+/// conflict declaration lives in the embedded manifest (published alongside
+/// the artifact), it is authoritative for the *incoming* component's view of
+/// mutual exclusion. A symmetric declaration on the *installed* component's
+/// manifest is NOT required — a one-sided `conflicts` suffices.
+fn check_component_conflicts(
+    manifest: &ComponentManifest,
+    state: &anolisa_core::state::InstalledState,
+    command: &str,
+) -> Result<(), CliError> {
+    use anolisa_core::state::ObjectKind;
+
+    for conflict_name in &manifest.component.conflicts {
+        if let Some(installed) = state.find_object(ObjectKind::Component, conflict_name) {
+            return Err(CliError::InvalidArgument {
+                command: command.to_string(),
+                reason: format!(
+                    "component '{}' conflicts with installed component '{}' (v{}) — \
+                     uninstall '{}' first, then retry",
+                    manifest.component.name, conflict_name, installed.version, conflict_name,
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Execute the resolved install: download+verify, copy files under the
 /// install lock, persist state, and append the audit record. Files already
 /// on disk are rolled back when a later step fails, so no phantom install
@@ -1007,6 +1043,14 @@ pub(crate) fn execute_raw(
             command: command.to_string(),
             reason: format!("failed to parse component manifest for hook resolution: {err}"),
         })?;
+
+    // Component-level mutual exclusion: refuse to install when a declared
+    // conflicting component is already present. This check runs before any
+    // host mutation (provisioning, hooks, file layout) so the user gets a
+    // clear actionable error without side effects. The RPM backend handles
+    // this via its native `Conflicts:` tag; the raw backend must enforce it
+    // here explicitly.
+    check_component_conflicts(&manifest, &state, command)?;
 
     // Validate hook declarations before any host mutation (contract authoring
     // errors must be caught before provisioning installs system packages).

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -66,12 +66,26 @@ pub fn toml_string_array(values: &[&str]) -> String {
 }
 
 pub fn component_manifest_toml(component: &str, version: &str, modes: &[&str]) -> String {
+    component_manifest_toml_with_conflicts(component, version, modes, &[])
+}
+
+pub fn component_manifest_toml_with_conflicts(
+    component: &str,
+    version: &str,
+    modes: &[&str],
+    conflicts: &[&str],
+) -> String {
     let modes = toml_string_array(modes);
+    let conflicts_line = if conflicts.is_empty() {
+        String::new()
+    } else {
+        format!("conflicts = {}\n", toml_string_array(conflicts))
+    };
     format!(
         r#"[component]
 name = "{component}"
 version = "{version}"
-
+{conflicts_line}
 [component.layout]
 modes = {modes}
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -79,7 +79,8 @@ fn install_dry_run_reads_version_meta_without_downloading_artifact() {
         },
     )
     .expect("resolve");
-    let preview = build_install_preview(&ctx, &layout, resolution).expect("preview");
+    let preview =
+        build_install_preview(&ctx, &layout, &Default::default(), resolution).expect("preview");
 
     assert_eq!(preview.files.len(), 1);
     assert_eq!(preview.files[0].dest, layout.bin_dir.join("remote-only"));
@@ -647,4 +648,162 @@ fn install_unpublished_version_is_invalid_argument() {
         .expect_err("must fail to resolve");
     assert_eq!(err.code(), "INVALID_ARGUMENT");
     assert!(err.reason().contains("9.9.9"), "got: {}", err.reason());
+}
+
+// ---------------------------------------------------------------------------
+// Component-level mutual-exclusion (conflicts) tests
+// ---------------------------------------------------------------------------
+
+/// Build a local file:// repo with a single component whose manifest declares
+/// `conflicts = [...]`. Returns the repo URL.
+fn write_local_repo_with_conflicts(
+    root: &std::path::Path,
+    component: &str,
+    version: &str,
+    modes: &[&str],
+    conflicts: &[&str],
+) -> String {
+    let v1 = root.join("v1");
+    std::fs::create_dir_all(&v1).expect("create repo dirs");
+
+    let manifest = component_manifest_toml_with_conflicts(component, version, modes, conflicts);
+    let bin_path = format!("bin/{component}");
+    let payload = format!("#!/bin/sh\necho {component}\n");
+    let artifact = build_tar_gz(&[
+        (".anolisa/component.toml", manifest.as_bytes()),
+        (bin_path.as_str(), payload.as_bytes()),
+    ]);
+    let artifact_name = format!("{component}.tar.gz");
+    std::fs::write(v1.join(&artifact_name), &artifact).expect("write artifact");
+    let sha = format!("{:x}", Sha256::digest(&artifact));
+    let modes_str = toml_string_array(modes);
+
+    let env = anolisa_env::EnvService::detect();
+    let index = format!(
+        r#"schema_version = 1
+channel = "stable"
+publisher = "test"
+
+[[entries]]
+component = "{component}"
+version = "{version}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "{artifact_name}"
+os = "{os}"
+arch = "{arch}"
+install_modes = {modes_str}
+sha256 = "{sha}"
+"#,
+        os = env.os,
+        arch = env.arch,
+    );
+    std::fs::write(v1.join("index.toml"), index).expect("write index");
+    format!("file://{}", v1.display())
+}
+
+#[test]
+fn install_conflict_blocks_when_conflicting_component_is_installed() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let layout = FsLayout::system(Some(prefix.clone()));
+
+    // Pre-seed state: cosh v2.6.0 is already installed.
+    std::fs::create_dir_all(&layout.state_dir).expect("create state dir");
+    let mut state = anolisa_core::InstalledState {
+        install_mode: StateInstallMode::System,
+        prefix: layout.prefix.clone(),
+        ..Default::default()
+    };
+    state.upsert_object(InstalledObject {
+        kind: ObjectKind::Component,
+        name: "cosh".to_string(),
+        version: "2.6.0".to_string(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: Some("file:///repo/v1/cosh.tar.gz".to_string()),
+        raw_package: Some("cosh".to_string()),
+        install_backend: Some("raw".to_string()),
+        ownership: None,
+        rpm_metadata: None,
+        installed_at: "2026-06-01T10:00:00Z".to_string(),
+        last_operation_id: Some("op-prior".to_string()),
+        managed: true,
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    });
+    state
+        .save(&layout.state_dir.join("installed.toml"))
+        .expect("save state");
+
+    // Write a repo with cosh-ng that declares conflicts = ["cosh"].
+    let repo_url = write_local_repo_with_conflicts(
+        &tmp.path().join("repo"),
+        "cosh-ng",
+        "0.11.0",
+        &["system"],
+        &["cosh"],
+    );
+
+    let mut a = args("cosh-ng");
+    a.repo = Some(repo_url);
+    let err = handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix)))
+        .expect_err("install must fail due to conflict");
+
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(
+        err.reason()
+            .contains("conflicts with installed component 'cosh'"),
+        "error must identify the conflicting component: {}",
+        err.reason()
+    );
+    assert!(
+        err.reason().contains("v2.6.0"),
+        "error must show the installed version: {}",
+        err.reason()
+    );
+    assert!(
+        err.reason().contains("uninstall 'cosh' first"),
+        "error must provide remediation: {}",
+        err.reason()
+    );
+}
+
+#[test]
+fn install_no_conflict_when_conflicting_component_not_installed() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+
+    // Write a repo with cosh-ng that declares conflicts = ["cosh"], but cosh
+    // is NOT installed — install should succeed.
+    let repo_url = write_local_repo_with_conflicts(
+        &tmp.path().join("repo"),
+        "cosh-ng",
+        "0.11.0",
+        &["system"],
+        &["cosh"],
+    );
+
+    let mut a = args("cosh-ng");
+    a.repo = Some(repo_url);
+    handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix.clone())))
+        .expect("install must succeed when no conflict");
+
+    // Verify cosh-ng is recorded in state.
+    let layout = FsLayout::system(Some(prefix));
+    let state = anolisa_core::InstalledState::load(&layout.state_dir.join("installed.toml"))
+        .expect("state must load");
+    let obj = state
+        .find_object(ObjectKind::Component, "cosh-ng")
+        .expect("cosh-ng must be recorded");
+    assert_eq!(obj.version, "0.11.0");
+    assert_eq!(obj.status, ObjectStatus::Installed);
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -2123,6 +2123,7 @@ mod tests {
                 owner: None,
                 license: None,
                 repository: None,
+                conflicts: Vec::new(),
             },
             contract: ContractSpec::default(),
             artifact: ArtifactSpec::default(),

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -162,6 +162,14 @@ pub struct ComponentMeta {
     /// Upstream repository URL (minimal schema `repository`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<String>,
+    /// Component names that cannot coexist with this component.
+    ///
+    /// The raw backend checks this list against the installed state before
+    /// laying files. If any listed component is already installed, the
+    /// install is refused with a diagnostic pointing at the conflict. The
+    /// RPM backend ignores this field — rpm `Conflicts:` handles it natively.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conflicts: Vec<String>,
 }
 
 /// `[component.contract]` — schema/version compatibility envelope (minimal
@@ -864,6 +872,10 @@ struct ComponentMetaRaw {
     license: Option<String>,
     #[serde(default)]
     repository: Option<String>,
+    /// Component-level mutual exclusion list. Names listed here cannot
+    /// coexist with this component when installed via the raw backend.
+    #[serde(default)]
+    conflicts: Vec<String>,
     // Minimal-schema nested sub-tables (`[component.contract]`, etc.). When
     // present they take precedence over the legacy top-level sections.
     #[serde(default)]
@@ -1146,6 +1158,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             owner,
             license,
             repository,
+            conflicts,
             contract: contract_raw,
             platform: platform_raw,
             artifact: artifact_raw,
@@ -1166,6 +1179,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
             owner,
             license,
             repository,
+            conflicts,
         };
 
         let contract = contract_raw


### PR DESCRIPTION
## Description

Add a `conflicts` field to the component manifest schema so components can declare mutual exclusion. The raw backend checks this list against `InstalledState` before any host mutation and refuses to install when a conflicting component is already present, providing an actionable error with the installed version and an uninstall hint.

This implements the raw-backend equivalent of RPM's `Conflicts:` tag. The RPM backend ignores this field — rpm handles it natively.

**Manifest declaration:**
```toml
[component]
name = "cosh-ng"
conflicts = ["cosh"]
```

**Error output when conflict is detected:**
```
error[INVALID_ARGUMENT]: component 'cosh-ng' conflicts with installed component 'cosh' (v2.6.1) — uninstall 'cosh' first, then retry
```

## Related Issue

Closes #1381

## Ship Note

Components can now declare mutual exclusion via `conflicts = ["other-component"]` in their manifest. The raw backend enforces this before any filesystem mutation; `--dry-run` also reports the conflict. The RPM backend is unaffected.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)
- [x] `anolisa-core`

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p anolisa-cli -- install_conflict` (2 new e2e tests)
- `cargo test -p anolisa-cli -- raw_e2e` (18 tests, 0 regressions)
- `cargo test` (1141 tests total, all pass)
- End-to-end on remote environment: install cosh → install cosh-ng (blocked) → uninstall cosh → install cosh-ng (succeeds) → install cosh (blocked)