### PR TITLE
feat(cosh): show loading when selecting auth provider

### DIFF
--- a/src/copilot-shell/packages/cli/src/i18n/locales/en.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/en.js
@@ -1047,6 +1047,8 @@ export default {
     'Configuration verification failed. Please check your API Key and model settings.',
   'Verifying and saving configuration...':
     'Verifying and saving configuration...',
+  'Initializing model configuration, please wait...':
+    'Initializing model configuration, please wait...',
   '{{authType}} configuration saved successfully, current model: {{model}}':
     '{{authType}} configuration saved successfully, current model: {{model}}',
   '{{authType}} credentials saved successfully.':

--- a/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
+++ b/src/copilot-shell/packages/cli/src/i18n/locales/zh.js
@@ -991,6 +991,8 @@ export default {
   'Configuration verification failed. Please check your API Key and model settings.':
     '配置验证失败。请检查您的 API Key 和模型设置。',
   'Verifying and saving configuration...': '正在验证并保存配置...',
+  'Initializing model configuration, please wait...':
+    '正在初始化模型配置,请稍候...',
   '{{authType}} configuration saved successfully, current model: {{model}}':
     '{{authType}} 配置已保存，当前模型：{{model}}',
   '{{authType}} credentials saved successfully.':

--- a/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -89,6 +89,40 @@ describe('AuthDialog', () => {
     throw new Error('waitFor timed out');
   };
 
+  const makeUnauthenticatedSettings = (): LoadedSettings =>
+    new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        originalSettings: {},
+        path: '',
+      },
+      {
+        settings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        originalSettings: {
+          security: { auth: { selectedType: undefined } },
+          ui: { customThemes: {} },
+          mcpServers: {},
+        },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+      new Set(),
+    );
+
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
@@ -930,6 +964,72 @@ describe('AuthDialog', () => {
 
     // Should call handleAuthSelect with undefined to exit
     expect(handleAuthSelect).toHaveBeenCalledWith(undefined);
+    unmount();
+  });
+
+  it('should show initializing loading after selecting Custom Provider', async () => {
+    const handleAuthSelect = vi.fn();
+    const settings = makeUnauthenticatedSettings();
+
+    const { lastFrame, stdin, unmount } = renderAuthDialog(
+      settings,
+      {},
+      { handleAuthSelect },
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('● Aliyun Authentication');
+    });
+    await wait(); // extra tick: ensure keypress handler re-registered
+
+    // Move to Custom Provider and select it
+    stdin.write('[B');
+    await wait();
+    expect(lastFrame()).toContain('● Custom Provider');
+
+    stdin.write('\r');
+    await wait();
+
+    expect(lastFrame()).toContain(
+      'Initializing model configuration, please wait...',
+    );
+    await waitFor(() => {
+      expect(handleAuthSelect).toHaveBeenCalledWith(AuthType.USE_OPENAI);
+    });
+    unmount();
+  });
+
+  it('should ignore repeated keypresses while initializing', async () => {
+    const handleAuthSelect = vi.fn();
+    const settings = makeUnauthenticatedSettings();
+
+    const { lastFrame, stdin, unmount } = renderAuthDialog(
+      settings,
+      {},
+      { handleAuthSelect },
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('● Aliyun Authentication');
+    });
+    await wait(); // extra tick: ensure keypress handler re-registered
+
+    stdin.write('\r');
+    await wait();
+
+    expect(lastFrame()).toContain(
+      'Initializing model configuration, please wait...',
+    );
+
+    // Any further input must be ignored while the loading indicator is shown
+    stdin.write('\r');
+    stdin.write('\r');
+    stdin.write('');
+    stdin.write('[B');
+    await wait();
+
+    expect(handleAuthSelect).toHaveBeenCalledTimes(1);
+    expect(handleAuthSelect).toHaveBeenCalledWith(AuthType.USE_ALIYUN);
     unmount();
   });
 });

--- a/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/src/copilot-shell/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { AuthType } from '@copilot-shell/core';
 import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
 import { Colors } from '../colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import type { Key } from '../hooks/useKeypress.js';
@@ -39,6 +40,13 @@ export function AuthDialog(): React.JSX.Element {
   const config = useConfig();
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // While a provider selection is being handed off to the auth flow (which may
+  // synchronously probe provider config before the next dialog renders), show a
+  // loading indicator and disable input so repeated keys cannot re-trigger it.
+  const [isSelectingAuth, setIsSelectingAuth] = useState(false);
+  const [pendingSelection, setPendingSelection] = useState<AuthType | null>(
+    null,
+  );
   const authItems = useMemo(
     () => [
       {
@@ -146,13 +154,39 @@ export function AuthDialog(): React.JSX.Element {
     lastAuthOption,
   ]);
 
-  const handleAuthSelect = useCallback(
-    async (authMethod: AuthType) => {
-      setErrorMessage(null);
-      await onAuthSelect(authMethod);
-    },
-    [onAuthSelect],
-  );
+  const handleAuthSelect = useCallback((authMethod: AuthType) => {
+    setErrorMessage(null);
+    // Enter loading state and defer the actual hand-off (see effect below) so the
+    // spinner paints before the auth flow's synchronous work blocks rendering.
+    setIsSelectingAuth(true);
+    setPendingSelection(authMethod);
+  }, []);
+
+  // Run the deferred provider selection once the loading indicator has rendered.
+  // If the hand-off rejects without unmounting this dialog, restore input so the
+  // user is not stuck on the spinner.
+  useEffect(() => {
+    if (!isSelectingAuth || pendingSelection === null) {
+      return;
+    }
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          await onAuthSelect(pendingSelection);
+        } catch {
+          if (!cancelled) {
+            setIsSelectingAuth(false);
+            setPendingSelection(null);
+          }
+        }
+      })();
+    }, 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [isSelectingAuth, pendingSelection, onAuthSelect]);
 
   const handleContinueToBash = useCallback(() => {
     setErrorMessage(null);
@@ -271,7 +305,24 @@ export function AuthDialog(): React.JSX.Element {
     ],
   );
 
-  useKeypress(handleDialogKeypress, { isActive: true });
+  useKeypress(handleDialogKeypress, { isActive: !isSelectingAuth });
+
+  if (isSelectingAuth) {
+    return (
+      <Box
+        borderStyle="round"
+        borderColor={Colors.Gray}
+        flexDirection="column"
+        padding={1}
+        width="100%"
+      >
+        <Text>
+          <Spinner type="dots" />{' '}
+          {t('Initializing model configuration, please wait...')}
+        </Text>
+      </Box>
+    );
+  }
 
   return (
     <Box


### PR DESCRIPTION
## Description

When first configuring cosh, selecting `Custom Provider` froze the UI for a
few seconds with no feedback, so users assumed it hung and kept pressing keys,
interrupting the flow. The `AuthDialog` now enters a loading state on
selection, rendering an `ink-spinner` with `Initializing model configuration,
please wait...` and disabling its keypress handler so repeated Enter/Esc/arrow
keys cannot re-trigger the hand-off. The actual `onAuthSelect` is deferred one
tick so the spinner paints before the auth flow's synchronous provider probing
blocks rendering.

## Related Issue

no-issue: user-reported UX papercut in the first-run auth flow

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass

## Testing

- `npx vitest run packages/cli/src/ui/auth/AuthDialog.test.tsx` → 19 passed
  (17 existing + 2 new: loading text appears after selecting Custom Provider;
  repeated keypresses while initializing trigger `handleAuthSelect` only once)
- `npx tsc --noEmit -p packages/cli/tsconfig.json` → passes
- `npx eslint` on changed files → passes
- `npx prettier --check` on the 4 changed files → passes

## Additional Notes

The pre-existing `Verifying and saving configuration...` behavior (after
submitting an API key) is unchanged. The `escape`-to-exit path bypasses the
new loading state, so exit behavior is preserved.
