### PR TITLE
feat(anolisa): add scoped installed state view

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -6,6 +6,7 @@
 //!   / runtime / osbase). Each surface uses its own appropriate vocabulary.
 
 pub mod common;
+pub(crate) mod state_view;
 pub mod tier1;
 
 // Tier 2 surfaces
@@ -45,7 +46,7 @@ pub struct Cli {
     #[arg(long, global = true, value_enum)]
     pub install_mode: Option<InstallMode>,
 
-    /// Custom install prefix (system-mode only)
+    /// Custom system install prefix, including user-mode system visibility
     #[arg(long, global = true, value_name = "PATH")]
     pub prefix: Option<PathBuf>,
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
@@ -1,0 +1,202 @@
+use std::path::{Path, PathBuf};
+
+use anolisa_core::{InstalledObject, InstalledState, ObjectKind};
+use anolisa_platform::fs_layout::FsLayout;
+
+use crate::commands::common;
+use crate::context::{CliContext, InstallMode};
+use crate::response::CliError;
+
+const INSTALLED_STATE_FILE: &str = "installed.toml";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StateScope {
+    User,
+    System,
+}
+
+impl StateScope {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::System => "system",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StateVisibility {
+    UserPlusSystem,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScopedStateRoot {
+    pub(crate) scope: StateScope,
+    pub(crate) state_path: PathBuf,
+    pub(crate) writable: bool,
+    pub(crate) state: InstalledState,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StateView {
+    pub(crate) writable: ScopedStateRoot,
+    pub(crate) visible_roots: Vec<ScopedStateRoot>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RootSpec {
+    scope: StateScope,
+    writable: bool,
+}
+
+impl StateView {
+    pub(crate) fn load(
+        ctx: &CliContext,
+        command: &str,
+        visibility: StateVisibility,
+    ) -> Result<Self, CliError> {
+        let current_layout = common::resolve_layout(ctx);
+        let current_scope = scope_for_mode(ctx.install_mode);
+        let mut roots = Vec::new();
+        roots.push((
+            current_layout,
+            RootSpec {
+                scope: current_scope,
+                writable: true,
+            },
+        ));
+
+        if ctx.install_mode == InstallMode::User && visibility == StateVisibility::UserPlusSystem {
+            roots.push((
+                FsLayout::system(ctx.prefix.clone()),
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ));
+        }
+
+        Self::from_layouts(command, roots)
+    }
+
+    pub(crate) fn visible_components(&self) -> Vec<ScopedInstalledObject<'_>> {
+        let mut records = Vec::new();
+        for root in &self.visible_roots {
+            for object in root
+                .state
+                .objects
+                .iter()
+                .filter(|object| object.kind == ObjectKind::Component)
+            {
+                let shadowed_by = records
+                    .iter()
+                    .find(|record: &&ScopedInstalledObject<'_>| record.object.name == object.name)
+                    .map(ScopedInstalledObject::scope);
+                records.push(ScopedInstalledObject {
+                    root,
+                    object,
+                    active: shadowed_by.is_none(),
+                    shadowed_by,
+                    mutable_by_current_invocation: root.writable,
+                });
+            }
+        }
+        records
+    }
+
+    fn from_layouts(command: &str, roots: Vec<(FsLayout, RootSpec)>) -> Result<Self, CliError> {
+        let mut visible_roots = Vec::new();
+        let mut writable = None;
+        let mut warnings = Vec::new();
+
+        for (layout, spec) in roots {
+            let state_path = layout.state_dir.join(INSTALLED_STATE_FILE);
+            let loaded = load_root_state(command, &state_path, spec.writable);
+            let state = match loaded {
+                Ok(state) => state,
+                Err(RootLoad::Fatal(err)) => return Err(err),
+                Err(RootLoad::Warning(warning)) => {
+                    warnings.push(warning);
+                    continue;
+                }
+            };
+            let root = ScopedStateRoot {
+                scope: spec.scope,
+                state_path,
+                writable: spec.writable,
+                state,
+            };
+            if spec.writable {
+                writable = Some(root.clone());
+            }
+            visible_roots.push(root);
+        }
+
+        let Some(writable) = writable else {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: "state view has no writable root".to_string(),
+            });
+        };
+
+        Ok(Self {
+            writable,
+            visible_roots,
+            warnings,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ScopedInstalledObject<'a> {
+    pub(crate) root: &'a ScopedStateRoot,
+    pub(crate) object: &'a InstalledObject,
+    pub(crate) active: bool,
+    pub(crate) shadowed_by: Option<StateScope>,
+    pub(crate) mutable_by_current_invocation: bool,
+}
+
+impl ScopedInstalledObject<'_> {
+    pub(crate) const fn scope(&self) -> StateScope {
+        self.root.scope
+    }
+}
+
+enum RootLoad {
+    Fatal(CliError),
+    Warning(String),
+}
+
+fn load_root_state(
+    command: &str,
+    state_path: &Path,
+    writable: bool,
+) -> Result<InstalledState, RootLoad> {
+    InstalledState::load(state_path).map_err(|err| {
+        if writable {
+            RootLoad::Fatal(CliError::InvalidArgument {
+                command: command.to_string(),
+                reason: format!(
+                    "failed to load installed state at {}: {err}",
+                    state_path.display()
+                ),
+            })
+        } else {
+            RootLoad::Warning(format!(
+                "failed to load visible system state at {}: {err}",
+                state_path.display()
+            ))
+        }
+    })
+}
+
+const fn scope_for_mode(mode: InstallMode) -> StateScope {
+    match mode {
+        InstallMode::User => StateScope::User,
+        InstallMode::System => StateScope::System,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests.rs
@@ -1,0 +1,232 @@
+use anolisa_platform::fs_layout::FsLayout;
+use tempfile::tempdir;
+
+use crate::context::{CliContext, InstallMode};
+
+use super::*;
+use support::{component, user_layout, write_state};
+
+mod support;
+
+#[test]
+fn user_plus_system_orders_user_before_system() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    let system_layout = FsLayout::system(Some(tmp.path().join("system")));
+    write_state(&user_layout, vec![component("user-tool")]);
+    write_state(&system_layout, vec![component("system-tool")]);
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                user_layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+            (
+                system_layout,
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+
+    assert_eq!(view.visible_roots[0].scope, StateScope::User);
+    assert_eq!(view.visible_roots[1].scope, StateScope::System);
+    assert!(view.visible_components().iter().any(|record| {
+        record.scope() == StateScope::System && record.object.name == "system-tool"
+    }));
+}
+
+#[test]
+fn user_record_shadows_system_record() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    let system_layout = FsLayout::system(Some(tmp.path().join("system")));
+    write_state(&user_layout, vec![component("shared")]);
+    write_state(&system_layout, vec![component("shared")]);
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                user_layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+            (
+                system_layout,
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+    let records = view.visible_components();
+
+    assert!(records.iter().any(|record| {
+        record.scope() == StateScope::User && record.object.name == "shared" && record.active
+    }));
+    assert!(records.iter().any(|record| {
+        record.scope() == StateScope::System
+            && record.object.name == "shared"
+            && !record.active
+            && record.shadowed_by == Some(StateScope::User)
+    }));
+}
+
+#[test]
+fn mutability_uses_writable_flag_not_state_path() {
+    let tmp = tempdir().expect("tempdir");
+    let layout = user_layout(tmp.path().join("home"));
+    write_state(&layout, vec![component("shared-path")]);
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                layout.clone(),
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+            (
+                layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+    let records = view.visible_components();
+
+    let system_record = records
+        .iter()
+        .find(|record| record.scope() == StateScope::System)
+        .expect("system record");
+    assert!(!system_record.mutable_by_current_invocation);
+
+    let user_record = records
+        .iter()
+        .find(|record| record.scope() == StateScope::User)
+        .expect("user record");
+    assert!(user_record.mutable_by_current_invocation);
+}
+
+#[test]
+fn system_mode_visibility_does_not_load_user_state() {
+    let tmp = tempdir().expect("tempdir");
+    let system_prefix = tmp.path().join("system");
+    let system_layout = FsLayout::system(Some(system_prefix.clone()));
+    write_state(&system_layout, vec![component("system-tool")]);
+
+    let home = tmp.path().join("home");
+    let xdg_state = tmp.path().join("xdg-state");
+    let user_layout = FsLayout::user_with_overrides(home, None, None, Some(xdg_state), None, None);
+    write_state(&user_layout, vec![component("user-only")]);
+    let ctx = CliContext {
+        install_mode: InstallMode::System,
+        prefix: Some(system_prefix),
+        json: true,
+        dry_run: false,
+        verbose: false,
+        quiet: true,
+        no_color: true,
+    };
+
+    let view =
+        StateView::load(&ctx, "test", StateVisibility::UserPlusSystem).expect("system state view");
+    let records = view.visible_components();
+
+    assert_eq!(view.visible_roots.len(), 1);
+    assert_eq!(view.visible_roots[0].scope, StateScope::System);
+    assert!(
+        records
+            .iter()
+            .any(|record| record.object.name == "system-tool")
+    );
+    assert!(
+        records
+            .iter()
+            .all(|record| record.object.name != "user-only"),
+        "system mode must not inspect ordinary user state"
+    );
+}
+
+#[test]
+fn malformed_visible_system_state_records_warning() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    let system_layout = FsLayout::system(Some(tmp.path().join("system")));
+    write_state(&user_layout, vec![component("user-tool")]);
+    std::fs::create_dir_all(&system_layout.state_dir).expect("state dir");
+    std::fs::write(
+        system_layout.state_dir.join(INSTALLED_STATE_FILE),
+        "not toml = [",
+    )
+    .expect("write malformed state");
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                user_layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+            (
+                system_layout,
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+
+    assert_eq!(view.visible_roots.len(), 1);
+    assert_eq!(view.warnings.len(), 1);
+    assert!(view.warnings[0].contains("visible system state"));
+}
+
+#[test]
+fn malformed_writable_state_is_fatal() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    std::fs::create_dir_all(&user_layout.state_dir).expect("state dir");
+    std::fs::write(
+        user_layout.state_dir.join(INSTALLED_STATE_FILE),
+        "not toml = [",
+    )
+    .expect("write malformed state");
+
+    let err = StateView::from_layouts(
+        "test",
+        vec![(
+            user_layout,
+            RootSpec {
+                scope: StateScope::User,
+                writable: true,
+            },
+        )],
+    )
+    .expect_err("writable malformed state must fail");
+
+    assert!(err.to_string().contains("failed to load installed state"));
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests/support.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests/support.rs
@@ -1,0 +1,48 @@
+use anolisa_core::{
+    InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership, SubscriptionScope,
+};
+use anolisa_platform::fs_layout::FsLayout;
+use std::path::PathBuf;
+
+use super::super::INSTALLED_STATE_FILE;
+
+pub(super) fn user_layout(home: PathBuf) -> FsLayout {
+    FsLayout::user_with_overrides(home, None, None, None, None, None)
+}
+
+pub(super) fn write_state(layout: &FsLayout, objects: Vec<InstalledObject>) {
+    let state = InstalledState {
+        objects,
+        ..InstalledState::default()
+    };
+    state
+        .save(&layout.state_dir.join(INSTALLED_STATE_FILE))
+        .expect("save state");
+}
+
+pub(super) fn component(name: &str) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("raw".to_string()),
+        ownership: Some(Ownership::RawManaged),
+        rpm_metadata: None,
+        installed_at: "2026-01-01T00:00:00Z".to_string(),
+        last_operation_id: None,
+        managed: true,
+        adopted: false,
+        subscription_scope: SubscriptionScope::None,
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -10,6 +10,7 @@ mod state_view;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
 use anolisa_core::state::InstalledState;
 use anolisa_platform::pkg_query::PackageQuery;
 use anolisa_platform::rpm_query::RpmPackageQuery;
@@ -18,6 +19,7 @@ use serde::Serialize;
 
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
+use crate::commands::state_view::{StateScope, StateView, StateVisibility};
 use crate::context::{CliContext, InstallMode};
 use crate::resolution::{ComponentIndex, ComponentIndexEntry, load_component_index};
 use crate::response::{CliError, render_json};
@@ -45,6 +47,13 @@ pub struct Row {
     pub status: String,
     pub local_state: String,
     pub ownership: String,
+    pub scope: String,
+    pub active: bool,
+    pub mutable_by_current_invocation: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadowed_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_path: Option<String>,
     pub action: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rpm_package: Option<String>,
@@ -59,6 +68,8 @@ pub struct Row {
 #[derive(Serialize)]
 struct ListPayload {
     components: Vec<Row>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
 }
 
 // ── Handler ────────────────────────────────────────────────────────
@@ -75,28 +86,36 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
             reason: format!("failed to load component index: {err}"),
         })?;
 
-    let state = common::load_installed_state(ctx, COMMAND)?;
+    let view = StateView::load(ctx, COMMAND, StateVisibility::UserPlusSystem)?;
     let rpm_query = match ctx.install_mode {
         InstallMode::System => Some(RpmPackageQuery::system()),
         InstallMode::User => None,
     };
-    let rows = build_rows(
+    let rows = build_rows_from_view(
         &index,
         &args,
-        &state,
+        &view,
         rpm_query.as_ref().map(|query| query as &dyn PackageQuery),
     );
 
     if ctx.json {
-        return render_json(COMMAND, ListPayload { components: rows });
+        return render_json(
+            COMMAND,
+            ListPayload {
+                components: rows,
+                warnings: view.warnings,
+            },
+        );
     }
 
     if !ctx.quiet {
+        render_warnings(&view.warnings);
         render_human(&rows, ctx.no_color);
     }
     Ok(())
 }
 
+#[cfg(test)]
 fn build_rows(
     index: &ComponentIndex,
     args: &ListArgs,
@@ -111,12 +130,95 @@ fn build_rows(
             if args.installed && !projection.local_state.matches_installed_filter() {
                 return None;
             }
-            Some(entry_to_row(entry, projection))
+            Some(entry_to_row(
+                entry,
+                projection,
+                RowScope {
+                    scope: "none".to_string(),
+                    active: false,
+                    mutable_by_current_invocation: false,
+                    shadowed_by: None,
+                    state_path: None,
+                },
+            ))
         })
         .collect()
 }
 
-fn entry_to_row(entry: &ComponentIndexEntry, projection: LocalProjection) -> Row {
+fn build_rows_from_view(
+    index: &ComponentIndex,
+    args: &ListArgs,
+    view: &StateView,
+    rpm_query: Option<&dyn PackageQuery>,
+) -> Vec<Row> {
+    let visible_components = view.visible_components();
+    index
+        .components
+        .iter()
+        .filter_map(|entry| {
+            let active = visible_components
+                .iter()
+                .find(|record| record.object.name == entry.name && record.active);
+            let (projection, row_scope) = match active {
+                Some(record) => (
+                    project_component(entry, &record.root.state, rpm_query),
+                    RowScope {
+                        scope: record.scope().label().to_string(),
+                        active: true,
+                        mutable_by_current_invocation: record.mutable_by_current_invocation,
+                        shadowed_by: record
+                            .shadowed_by
+                            .map(StateScope::label)
+                            .map(str::to_string),
+                        state_path: Some(record.root.state_path.display().to_string()),
+                    },
+                ),
+                None => {
+                    let projection = project_component(entry, &view.writable.state, rpm_query);
+                    let scope = match projection.local_state {
+                        self::state_view::LocalState::Observed => view.writable.scope.label(),
+                        self::state_view::LocalState::Tracked
+                        | self::state_view::LocalState::Installed
+                        | self::state_view::LocalState::Drifted
+                        | self::state_view::LocalState::Missing
+                        | self::state_view::LocalState::Failed
+                        | self::state_view::LocalState::Degraded
+                        | self::state_view::LocalState::Disabled
+                        | self::state_view::LocalState::NotInstalled => "none",
+                    };
+                    (
+                        projection,
+                        RowScope {
+                            scope: scope.to_string(),
+                            active: false,
+                            mutable_by_current_invocation: false,
+                            shadowed_by: None,
+                            state_path: None,
+                        },
+                    )
+                }
+            };
+            if args.installed && !projection.local_state.matches_installed_filter() {
+                return None;
+            }
+            Some(entry_to_row(entry, projection, row_scope))
+        })
+        .collect()
+}
+
+struct RowScope {
+    scope: String,
+    active: bool,
+    mutable_by_current_invocation: bool,
+    shadowed_by: Option<String>,
+    state_path: Option<String>,
+}
+
+fn entry_to_row(
+    entry: &ComponentIndexEntry,
+    projection: LocalProjection,
+    row_scope: RowScope,
+) -> Row {
     let backends: Vec<String> = entry.backends.iter().map(|b| b.kind.clone()).collect();
     let local_state = projection.local_state.label().to_string();
     let ownership = projection.ownership_label().to_string();
@@ -132,10 +234,21 @@ fn entry_to_row(entry: &ComponentIndexEntry, projection: LocalProjection) -> Row
         status: projection.status,
         local_state,
         ownership,
+        scope: row_scope.scope,
+        active: row_scope.active,
+        mutable_by_current_invocation: row_scope.mutable_by_current_invocation,
+        shadowed_by: row_scope.shadowed_by,
+        state_path: row_scope.state_path,
         action,
         rpm_package: projection.rpm_package,
         rpm_evr: projection.rpm_evr,
         rpm_arch: projection.rpm_arch,
         rpm_source_repo: projection.rpm_source_repo,
+    }
+}
+
+fn render_warnings(warnings: &[String]) {
+    for warning in warnings {
+        eprintln!("warning: {warning}");
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
@@ -4,14 +4,16 @@ use crate::commands::tier1::list::Row;
 pub(super) fn human_header(rows: &[Row]) -> String {
     let widths = HumanWidths::for_rows(rows);
     format!(
-        "{:<name_width$}{:<backends_width$}{:<local_state_width$}{:<ownership_width$}{}",
+        "{:<name_width$}{:<backends_width$}{:<scope_width$}{:<local_state_width$}{:<ownership_width$}{}",
         "NAME",
         "BACKENDS",
+        "SCOPE",
         "LOCAL STATE",
         "OWNERSHIP",
         "ACTION",
         name_width = widths.name,
         backends_width = widths.backends,
+        scope_width = widths.scope,
         local_state_width = widths.local_state,
         ownership_width = widths.ownership,
     )
@@ -20,6 +22,7 @@ pub(super) fn human_header(rows: &[Row]) -> String {
 struct HumanWidths {
     name: usize,
     backends: usize,
+    scope: usize,
     local_state: usize,
     ownership: usize,
 }
@@ -41,6 +44,7 @@ impl HumanWidths {
                 .unwrap_or(8)
                 .max(8)
                 + 4,
+            scope: rows.iter().map(|r| r.scope.len()).max().unwrap_or(5).max(5) + 4,
             local_state: rows
                 .iter()
                 .map(|r| r.local_state.len())
@@ -76,14 +80,16 @@ pub(super) fn render_human(rows: &[Row], no_color: bool) {
             row.backends.join(",")
         };
         println!(
-            "{:<name_width$}{:<backends_width$}{}{:<ownership_width$}{}",
+            "{:<name_width$}{:<backends_width$}{:<scope_width$}{}{:<ownership_width$}{}",
             row.name,
             backend_str,
+            row.scope,
             pad_right(color.status(&row.local_state), widths.local_state),
             row.ownership,
             row.action,
             name_width = widths.name,
             backends_width = widths.backends,
+            scope_width = widths.scope,
             ownership_width = widths.ownership,
         );
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests.rs
@@ -3,4 +3,5 @@ mod output;
 mod projection;
 mod projection_tracked;
 mod rows;
+mod scoped_rows;
 mod support;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
@@ -143,7 +143,10 @@ fn json_payload_uses_components_key() {
     let args = ListArgs { installed: false };
     let state = empty_state();
     let rows = build_rows(&index, &args, &state, None);
-    let payload = ListPayload { components: rows };
+    let payload = ListPayload {
+        components: rows,
+        warnings: Vec::new(),
+    };
     let json_str = serde_json::to_string(&payload).expect("serialize");
     let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
     assert!(val.get("components").is_some());
@@ -155,7 +158,10 @@ fn json_payload_status_reflects_install_state() {
     let args = ListArgs { installed: false };
     let state = state_with_object(ObjectKind::Component, "agentsight", ObjectStatus::Installed);
     let rows = build_rows(&index, &args, &state, None);
-    let payload = ListPayload { components: rows };
+    let payload = ListPayload {
+        components: rows,
+        warnings: Vec::new(),
+    };
     let json_str = serde_json::to_string(&payload).expect("serialize");
     let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
     let components = val["components"].as_array().unwrap();

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
@@ -19,7 +19,10 @@ fn row_json_retains_status_and_adds_local_fields() {
         what_provides: Vec::new(),
     };
     let rows = build_rows(&index, &args, &state, Some(&query));
-    let payload = ListPayload { components: rows };
+    let payload = ListPayload {
+        components: rows,
+        warnings: Vec::new(),
+    };
 
     let json_str = serde_json::to_string(&payload).expect("serialize");
     let val: serde_json::Value = serde_json::from_str(&json_str).expect("reparse");
@@ -33,6 +36,9 @@ fn row_json_retains_status_and_adds_local_fields() {
     assert_eq!(sight["status"], "not_installed");
     assert_eq!(sight["local_state"], "observed");
     assert_eq!(sight["ownership"], "rpm");
+    assert_eq!(sight["scope"], "none");
+    assert_eq!(sight["active"], false);
+    assert_eq!(sight["mutable_by_current_invocation"], false);
     assert_eq!(sight["action"], "install");
 }
 
@@ -46,6 +52,11 @@ fn human_header_contains_local_state() {
         status: "not_installed".to_string(),
         local_state: "observed".to_string(),
         ownership: "none".to_string(),
+        scope: "system".to_string(),
+        active: true,
+        mutable_by_current_invocation: false,
+        shadowed_by: None,
+        state_path: Some("/var/lib/anolisa/installed.toml".to_string()),
         action: "install".to_string(),
         rpm_package: Some("agentsight".to_string()),
         rpm_evr: Some("1.2.3-1.al8".to_string()),
@@ -53,7 +64,9 @@ fn human_header_contains_local_state() {
         rpm_source_repo: Some("@System".to_string()),
     }];
 
-    assert!(human_header(&rows).contains("LOCAL STATE"));
+    let header = human_header(&rows);
+    assert!(header.contains("SCOPE"));
+    assert!(header.contains("LOCAL STATE"));
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/scoped_rows.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/scoped_rows.rs
@@ -1,0 +1,80 @@
+use std::path::PathBuf;
+
+use anolisa_core::state::{InstalledState, ObjectStatus, Ownership};
+
+use crate::commands::state_view::{ScopedStateRoot, StateScope, StateView};
+use crate::commands::tier1::list::{ListArgs, build_rows_from_view};
+
+use super::support::{component_object, sample_index, state_with_component_object};
+
+#[test]
+fn user_view_installed_filter_keeps_system_provided_component() {
+    let index = sample_index();
+    let args = ListArgs { installed: true };
+    let view = user_plus_system_view(
+        InstalledState::default(),
+        state_with_component_object(component_object(
+            "agentsight",
+            ObjectStatus::Installed,
+            Ownership::RawManaged,
+        )),
+    );
+
+    let rows = build_rows_from_view(&index, &args, &view, None);
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "agentsight");
+    assert_eq!(rows[0].local_state, "installed");
+    assert_eq!(rows[0].scope, "system");
+    assert_eq!(
+        rows[0].state_path.as_deref(),
+        Some("/tmp/anolisa-system-state/installed.toml")
+    );
+    assert!(rows[0].active);
+    assert!(!rows[0].mutable_by_current_invocation);
+}
+
+#[test]
+fn user_record_shadows_system_record_in_list_rows() {
+    let index = sample_index();
+    let args = ListArgs { installed: true };
+    let view = user_plus_system_view(
+        state_with_component_object(component_object(
+            "agentsight",
+            ObjectStatus::Installed,
+            Ownership::RawManaged,
+        )),
+        state_with_component_object(component_object(
+            "agentsight",
+            ObjectStatus::Installed,
+            Ownership::RpmManaged,
+        )),
+    );
+
+    let rows = build_rows_from_view(&index, &args, &view, None);
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "agentsight");
+    assert_eq!(rows[0].scope, "user");
+    assert!(rows[0].mutable_by_current_invocation);
+}
+
+fn user_plus_system_view(user_state: InstalledState, system_state: InstalledState) -> StateView {
+    let user_root = ScopedStateRoot {
+        scope: StateScope::User,
+        state_path: PathBuf::from("/tmp/anolisa-user-state/installed.toml"),
+        writable: true,
+        state: user_state,
+    };
+    let system_root = ScopedStateRoot {
+        scope: StateScope::System,
+        state_path: PathBuf::from("/tmp/anolisa-system-state/installed.toml"),
+        writable: false,
+        state: system_state,
+    };
+    StateView {
+        writable: user_root.clone(),
+        visible_roots: vec![user_root, system_root],
+        warnings: Vec::new(),
+    }
+}


### PR DESCRIPTION
## Description

Add a shared CLI `StateView` for scoped installed-state reads. User-mode read
views now load the current user state plus readable system state, while system
mode reads only system state. The `list` command uses this projection so a
normal user can discover system-provided components without implying ownership.

List rows now expose:

- `scope`: `user`, `system`, or `none`
- `active`: whether the row is the selected visible lifecycle record
- `mutable_by_current_invocation`: whether the current command may mutate it
- `state_path`: the physical `installed.toml` backing active rows

This is the first PR in the dual-scope installed-state plan. It intentionally
keeps mutation behavior unchanged: lifecycle writes still go only to the
current install mode's physical state file. `status`, `doctor`, adapter source
health, orphaned adapter receipts, and lifecycle wrong-scope guards are left to
later PRs.

## Related Issue

N/A

## Ship Note

`anolisa list --installed` in user mode can now show system-provided installed
components. System rows are marked as system scope and immutable for the user
invocation, while user rows remain user-scoped and mutable. Malformed writable
state remains fatal; malformed visible system state is surfaced as a warning for
read-only list output.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Testing

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli state_view` (6 tests)
- `cargo test -p anolisa-cli list` (40 tests)
- `cargo test -p anolisa-cli` (423 tests)
- `cargo doc --no-deps`
- Local CLI QA: temp user/system `installed.toml` files, verifying system mode
  does not read user state, user mode shows system rows as immutable, and
  malformed visible system state returns a warning.
- Remote QA on `Alinux 4`: root/system mode sees only the system row;
  `nobody`/user mode sees both the system row and the user row with correct
  scope, mutability, and `state_path` fields.