### PR TITLE
chore(ci): relax commit body line-length to warning

### DIFF
--- a/.github/commitlint.config.json
+++ b/.github/commitlint.config.json
@@ -33,6 +33,11 @@
       2,
       "always",
       120
+    ],
+    "body-max-line-length": [
+      1,
+      "always",
+      100
     ]
   }
 }


### PR DESCRIPTION
## Description

The `config-conventional` preset inherited by `.github/commitlint.config.json` enforces `body-max-line-length` at 100 as a hard error, which blocked commits that legitimately need long single lines (pasted URLs, stack traces). This change adds an explicit override downgrading the rule to a warning (level 1) at the same 100-char limit, so contributors get nudged without being blocked. `header-max-length` and the scope rules remain hard errors.

## Related Issue

no-issue: minor CI lint config tweak

## Type / Scope

- [x] ci

## Testing

Config-only change. Verified `body-max-line-length` is now level 1 (warning) in `.github/commitlint.config.json`; `wagoid/commitlint-github-action` defaults to `failOnWarnings: false`, so warnings no longer fail the lint job.