### PR TITLE
feat(anolisa): report orphaned adapter receipts

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -39,7 +39,8 @@ use anolisa_core::adapter::AdapterError;
 use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus};
 use anolisa_core::adapter::driver::{AdapterStatusReport, DriverPlan};
 use anolisa_core::adapter::manager::{
-    AdapterManager, DisableOutcome, EnableOutcome, ScanEntry, ScanReport, StatusReport,
+    AdapterManager, AdapterSourceStatus, DisableOutcome, EnableOutcome, ScanEntry, ScanReport,
+    StatusReport,
 };
 
 use crate::commands::common;
@@ -103,6 +104,15 @@ struct ScanRow {
     enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     claim_status: Option<ClaimStatus>,
+    /// Receipt source health. Present only when a receipt exists, so JSON
+    /// consumers can distinguish a disabled declaration from an orphaned
+    /// enabled receipt whose source component disappeared.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_status: Option<&'static str>,
+    /// Human-readable explanation for [`Self::source_status`] when the source
+    /// is unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_reason: Option<String>,
 }
 
 /// `adapter scan` JSON output.
@@ -208,12 +218,12 @@ fn handle_scan(ctx: &CliContext) -> Result<(), CliError> {
         return Ok(());
     }
     println!(
-        "{:<16} {:<10} {:<14} {:<9} {:<9} {:<9} {:<8} STATE",
-        "COMPONENT", "FRAMEWORK", "TYPE", "DECLARED", "RESOURCE", "DRIVER", "DETECTED"
+        "{:<16} {:<10} {:<14} {:<9} {:<9} {:<9} {:<8} {:<9} STATE",
+        "COMPONENT", "FRAMEWORK", "TYPE", "DECLARED", "RESOURCE", "DRIVER", "DETECTED", "SOURCE"
     );
     for row in &report.entries {
         println!(
-            "{:<16} {:<10} {:<14} {:<9} {:<9} {:<9} {:<8} {}",
+            "{:<16} {:<10} {:<14} {:<9} {:<9} {:<9} {:<8} {:<9} {}",
             row.component,
             row.framework,
             row.adapter_type.as_deref().unwrap_or("-"),
@@ -225,8 +235,12 @@ fn handle_scan(ctx: &CliContext) -> Result<(), CliError> {
             },
             yes_no(row.driver_available),
             yes_no(row.framework_detected),
+            source_status_label(row.source_status),
             scan_state_label(row),
         );
+        if let Some(reason) = &row.source_reason {
+            println!("  source: {reason}");
+        }
     }
     Ok(())
 }
@@ -246,16 +260,23 @@ fn scan_row_from_entry(row: &ScanEntry) -> ScanRow {
         adapter_type: row.adapter_type.clone(),
         enabled: row.enabled,
         claim_status: row.claim_status,
+        source_status: row.source_status.map(AdapterSourceStatus::label),
+        source_reason: row.source_reason.clone(),
     }
 }
 
 fn scan_state_label(row: &ScanEntry) -> &'static str {
-    match (row.enabled, row.claim_status) {
-        (true, Some(ClaimStatus::Enabled)) => "enabled",
-        (true, Some(ClaimStatus::CleanupFailed)) => "cleanup_failed",
-        (true, None) => "enabled",
-        (false, _) => "-",
+    match (row.enabled, row.claim_status, row.source_status) {
+        (true, Some(ClaimStatus::CleanupFailed), _) => "cleanup_failed",
+        (true, _, Some(AdapterSourceStatus::Missing)) => "orphaned",
+        (true, Some(ClaimStatus::Enabled), _) => "enabled",
+        (true, None, _) => "enabled",
+        (false, _, _) => "-",
     }
+}
+
+fn source_status_label(status: Option<AdapterSourceStatus>) -> &'static str {
+    status.map(AdapterSourceStatus::label).unwrap_or("-")
 }
 
 // ---------------------------------------------------------------------------
@@ -633,6 +654,8 @@ mod tests {
             adapter_type: Some("plugin".to_string()),
             enabled: false,
             claim_status: None,
+            source_status: None,
+            source_reason: None,
         };
         let row = scan_row_from_entry(&entry);
         assert_eq!(row.adapter_type.as_deref(), Some("plugin"));
@@ -650,8 +673,36 @@ mod tests {
             adapter_type: None,
             enabled: false,
             claim_status: None,
+            source_status: None,
+            source_reason: None,
         };
         let row = scan_row_from_entry(&entry);
         assert!(row.adapter_type.is_none());
+    }
+
+    #[test]
+    fn scan_row_includes_source_health_for_receipt() {
+        let entry = ScanEntry {
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            declared: false,
+            resource_root: None,
+            driver_available: true,
+            framework_detected: true,
+            adapter_type: Some("plugin".to_string()),
+            enabled: true,
+            claim_status: Some(ClaimStatus::Enabled),
+            source_status: Some(AdapterSourceStatus::Missing),
+            source_reason: Some("no visible installed component".to_string()),
+        };
+
+        let row = scan_row_from_entry(&entry);
+
+        assert_eq!(row.source_status, Some("missing"));
+        assert_eq!(
+            row.source_reason.as_deref(),
+            Some("no visible installed component")
+        );
+        assert_eq!(scan_state_label(&entry), "orphaned");
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -6,11 +6,12 @@
 
 use std::path::{Path, PathBuf};
 
-use anolisa_core::adapter::manager::AdapterManager;
+use anolisa_core::adapter::manager::{AdapterManager, VisibleRoot};
 use anolisa_core::{Catalog, CatalogLayers, InstalledState, ObjectKind, ObjectStatus};
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::color::Palette;
+use crate::commands::state_view::{StateView, StateVisibility};
 use crate::context::{CliContext, InstallMode};
 use crate::packaged;
 use crate::repo_config::{RepoConfig, RepoConfigProvisioning};
@@ -393,12 +394,38 @@ pub(crate) fn status_is_enabled(status_label: &str) -> bool {
 /// Build an [`AdapterManager`] for the active layout, shared between
 /// `adapter` and `status` handlers.
 pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
-    use anolisa_core::adapter::manager::VisibleRoot;
-
     let layout = resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
     let mut manager = AdapterManager::new(layout.clone(), Some(env.home), env.user);
 
+    match StateView::load(ctx, "adapter", StateVisibility::UserPlusSystem) {
+        Ok(view) => {
+            let roots = view
+                .visible_roots
+                .iter()
+                .map(|root| visible_root_for_adapter(&root.layout))
+                .collect();
+            manager.set_visible_roots(roots);
+            for warning in view.warnings {
+                manager.push_visibility_warning(warning);
+            }
+        }
+        Err(_) => {
+            manager.set_visible_roots(vec![visible_root_for_adapter(&layout)]);
+        }
+    }
+
+    manager
+}
+
+fn visible_root_for_adapter(layout: &FsLayout) -> VisibleRoot {
+    VisibleRoot {
+        state_dir: layout.state_dir.clone(),
+        contract_datadir_roots: adapter_contract_datadir_roots(layout),
+    }
+}
+
+fn adapter_contract_datadir_roots(layout: &FsLayout) -> Vec<PathBuf> {
     // Two independent datadir-discovery mechanisms are layered here:
     //
     //   packaged_datadir_root()  — runtime probe: env override → exe-sibling
@@ -407,44 +434,25 @@ pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
     //                              packaged tree actually lives on disk.
     //
     //   layout.package_datadir() — FHS constant: `/usr/share/anolisa` (rebased
-    //                              under prefix). Always present in system mode
-    //                              so RPM-installed contracts are found even
-    //                              when the binary is at `/usr/local/bin/`.
+    //                              under prefix). System roots use it so
+    //                              RPM-installed contracts are found even when
+    //                              the binary is at `/usr/local/bin/`.
     //
-    // Both are added (deduped by push_primary_datadir_root / contains-check)
-    // because they cover different scenarios: the exe-sibling probe handles
-    // relocated installs; the FHS constant handles cross-install-method
-    // discovery (raw binary + RPM components).
-
-    if ctx.install_mode == InstallMode::User {
-        let system_layout = FsLayout::system(ctx.prefix.clone());
-        let mut system_datadirs = vec![system_layout.datadir.clone()];
-        if let Some(packaged) = packaged::packaged_datadir_root(&system_layout)
-            && !system_datadirs.contains(&packaged)
-        {
-            system_datadirs.push(packaged);
-        }
-        if let Some(pkg_dd) = system_layout.package_datadir()
-            && !system_datadirs.contains(&pkg_dd)
-        {
-            system_datadirs.push(pkg_dd);
-        }
-        manager.push_visible_root(VisibleRoot {
-            state_dir: system_layout.state_dir,
-            contract_datadir_roots: system_datadirs,
-        });
-    } else {
-        if let Some(packaged) = packaged::packaged_datadir_root(&layout)
-            && packaged != layout.datadir
-        {
-            manager.push_primary_datadir_root(packaged);
-        }
-        if let Some(pkg_dd) = layout.package_datadir() {
-            manager.push_primary_datadir_root(pkg_dd);
-        }
+    // Both are added (deduped) because they cover different scenarios: the
+    // exe-sibling probe handles relocated installs; the FHS constant handles
+    // cross-install-method discovery (raw binary + RPM components).
+    let mut roots = vec![layout.datadir.clone()];
+    if let Some(packaged) = packaged::packaged_datadir_root(layout)
+        && !roots.contains(&packaged)
+    {
+        roots.push(packaged);
     }
-
-    manager
+    if let Some(pkg_dd) = layout.package_datadir()
+        && !roots.contains(&pkg_dd)
+    {
+        roots.push(pkg_dd);
+    }
+    roots
 }
 
 /// In-memory migration of pre-v4 symlink entries.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -20,6 +20,8 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anolisa_core::adapter::claim::ClaimStatus;
+#[cfg(test)]
+use anolisa_core::adapter::manager::AdapterSourceStatus;
 use anolisa_core::adapter::manager::ScanEntry;
 use anolisa_core::path_safety::{PathBoundaryError, validate_owned_path};
 use anolisa_core::{
@@ -87,6 +89,14 @@ pub(crate) struct AdapterSummaryRecord {
     pub(crate) enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) claim_status: Option<ClaimStatus>,
+    /// Source health for enabled adapter receipts. Present only for receipt
+    /// rows so JSON consumers can identify orphaned user receipts separately
+    /// from adapters that are simply not enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) source_status: Option<String>,
+    /// Explanation for a missing adapter source, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) source_reason: Option<String>,
 }
 
 /// JSON-shaped record for a single component, used in both the wire
@@ -607,6 +617,8 @@ fn adapter_summaries_for(component: &str, scan: Option<&[ScanEntry]>) -> Vec<Ada
             framework_detected: e.framework_detected,
             enabled: e.enabled,
             claim_status: e.claim_status,
+            source_status: e.source_status.map(|status| status.label().to_string()),
+            source_reason: e.source_reason.clone(),
         })
         .collect()
 }
@@ -1291,11 +1303,16 @@ fn render_warnings(warnings: &[String]) {
 }
 
 fn adapter_state_label(adapter: &AdapterSummaryRecord) -> &'static str {
-    match (adapter.enabled, adapter.claim_status) {
-        (_, Some(ClaimStatus::CleanupFailed)) => "cleanup_failed",
-        (true, Some(ClaimStatus::Enabled)) => "enabled",
-        (true, None) => "enabled",
-        (false, _) => "not enabled",
+    match (
+        adapter.enabled,
+        adapter.claim_status,
+        adapter.source_status.as_deref(),
+    ) {
+        (_, Some(ClaimStatus::CleanupFailed), _) => "cleanup_failed",
+        (true, _, Some("missing")) => "orphaned",
+        (true, Some(ClaimStatus::Enabled), _) => "enabled",
+        (true, None, _) => "enabled",
+        (false, _, _) => "not enabled",
     }
 }
 
@@ -2637,6 +2654,8 @@ mod tests {
             } else {
                 None
             },
+            source_status: enabled.then_some(AdapterSourceStatus::Available),
+            source_reason: None,
         }
     }
 
@@ -2740,6 +2759,8 @@ mod tests {
             framework_detected: true,
             enabled: true,
             claim_status: Some(ClaimStatus::Enabled),
+            source_status: Some("available".to_string()),
+            source_reason: None,
         };
         let json = serde_json::to_value(&record).expect("serialize");
         assert_eq!(json["component"], "tokenless");
@@ -2829,6 +2850,8 @@ mod tests {
             framework_detected: true,
             enabled: true,
             claim_status: Some(ClaimStatus::Enabled),
+            source_status: Some("available".to_string()),
+            source_reason: None,
         };
 
         assert_eq!(adapter_state_label(&base), "enabled");
@@ -2843,7 +2866,13 @@ mod tests {
 
         let mut not_enabled = base.clone();
         not_enabled.enabled = false;
+        not_enabled.source_status = None;
         assert_eq!(adapter_state_label(&not_enabled), "not enabled");
+
+        let mut orphaned = base.clone();
+        orphaned.source_status = Some("missing".to_string());
+        orphaned.source_reason = Some("no visible installed component".to_string());
+        assert_eq!(adapter_state_label(&orphaned), "orphaned");
     }
 
     // ── rpm-observed status (#958) ──────────────────────────────────

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -187,6 +187,11 @@ pub struct ClaimResourceRef {
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AdapterConditionKind {
+    /// The component/adapter source that originally supplied this receipt is
+    /// still visible through ANOLISA's installed-state view. This manager-level
+    /// condition lets automation distinguish a broken framework registration
+    /// from an orphaned receipt whose system/user component source disappeared.
+    SourceAvailable,
     /// The framework itself is detectable on the host.
     FrameworkDetected,
     /// The installed resource bundle still matches the enable-time digest.

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -36,8 +36,8 @@ use anolisa_platform::fs_layout::{FsLayout, InstallMode};
 use super::AdapterError;
 use super::claim::{AdapterClaim, ClaimStatus};
 use super::driver::{
-    AdapterOps, AdapterStatusReport, CliOutput, DisableReport, DriverCtx, DriverPlan,
-    FrameworkCommand, HostEnv,
+    AdapterCondition, AdapterConditionKind, AdapterOps, AdapterStatusReport, AdapterSummary,
+    CliOutput, ConditionStatus, DisableReport, DriverCtx, DriverPlan, FrameworkCommand, HostEnv,
 };
 use super::registry::DriverRegistry;
 use crate::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
@@ -102,6 +102,41 @@ pub struct ScanEntry {
     pub enabled: bool,
     /// Lifecycle status of the receipt, when one exists.
     pub claim_status: Option<ClaimStatus>,
+    /// Availability of the component/adapter source behind an enabled
+    /// receipt. `None` means this row has no receipt, so source health is not
+    /// a persisted-state concern.
+    pub source_status: Option<AdapterSourceStatus>,
+    /// Human-readable reason for [`Self::source_status`], present when source
+    /// health is missing or otherwise needs operator explanation.
+    pub source_reason: Option<String>,
+}
+
+/// Source availability for an adapter receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdapterSourceStatus {
+    /// The component is still installed in a visible scope and its adapter
+    /// resource root can be resolved.
+    Available,
+    /// The receipt remains, but the visible component source or adapter
+    /// resource root is gone.
+    Missing,
+}
+
+impl AdapterSourceStatus {
+    /// Stable wire/human label for scan JSON and table output.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::Missing => "missing",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SourceProbe {
+    status: AdapterSourceStatus,
+    resource_root: Option<PathBuf>,
+    reason: Option<String>,
 }
 
 /// Full result of [`AdapterManager::scan`].
@@ -177,6 +212,10 @@ pub struct AdapterManager {
     /// Resource discovery is scope-independent: a user-mode enable may
     /// use adapter resources from a system-installed package.
     all_datadir_roots: Vec<PathBuf>,
+    /// Warnings discovered by the caller while deriving visible roots. Scan
+    /// returns these with manager-local manifest/state warnings so read-only
+    /// adapter surfaces do not lose StateView visibility diagnostics.
+    visibility_warnings: Vec<String>,
     user_home: Option<PathBuf>,
     /// Identity recorded as the central-log actor.
     actor: String,
@@ -200,9 +239,28 @@ impl AdapterManager {
             state_path,
             visible_roots: vec![primary],
             all_datadir_roots,
+            visibility_warnings: Vec::new(),
             user_home,
             actor,
         }
+    }
+
+    /// Replace the visible root set. Receipts still read/write only the
+    /// manager's primary state path; this controls read-only source discovery.
+    pub fn set_visible_roots(&mut self, roots: Vec<VisibleRoot>) {
+        if roots.is_empty() {
+            return;
+        }
+        self.visible_roots.clear();
+        self.all_datadir_roots.clear();
+        for root in roots {
+            self.push_visible_root(root);
+        }
+    }
+
+    /// Preserve a non-fatal root-visibility warning for the next scan report.
+    pub fn push_visibility_warning(&mut self, warning: String) {
+        self.visibility_warnings.push(warning);
     }
 
     /// Add a visible root with explicit contract-scope datadir pairing.
@@ -268,16 +326,7 @@ impl AdapterManager {
         let state = InstalledState::load(&self.state_path)?;
         let mut entries: BTreeMap<(String, String), ScanEntry> = BTreeMap::new();
         for (component, framework, resource_root) in self.discover_all() {
-            let driver = self.registry.get(&framework);
-            let driver_available = driver.is_some();
-            let framework_detected = driver
-                .map(|d| {
-                    d.detect(&HostEnv {
-                        user_home: self.user_home.clone(),
-                    })
-                    .detected
-                })
-                .unwrap_or(false);
+            let (driver_available, framework_detected) = self.driver_scan_facts(&framework);
             let claim = state.find_adapter_claim(&component, &framework);
             entries.insert(
                 (component.clone(), framework.clone()),
@@ -291,11 +340,13 @@ impl AdapterManager {
                     adapter_type: None,
                     enabled: claim.is_some(),
                     claim_status: claim.map(|c| c.status),
+                    source_status: None,
+                    source_reason: None,
                 },
             );
         }
 
-        let (declarations, warnings) = self.load_visible_adapter_declarations(&state);
+        let (declarations, declaration_warnings) = self.load_visible_adapter_declarations(&state);
         for declaration in declarations {
             let key = (declaration.component.clone(), declaration.framework.clone());
             if let Some(entry) = entries.get_mut(&key) {
@@ -328,16 +379,8 @@ impl AdapterManager {
                 )
             });
 
-            let driver = self.registry.get(&declaration.framework);
-            let driver_available = driver.is_some();
-            let framework_detected = driver
-                .map(|d| {
-                    d.detect(&HostEnv {
-                        user_home: self.user_home.clone(),
-                    })
-                    .detected
-                })
-                .unwrap_or(false);
+            let (driver_available, framework_detected) =
+                self.driver_scan_facts(&declaration.framework);
             let claim = state.find_adapter_claim(&declaration.component, &declaration.framework);
             entries.insert(
                 key,
@@ -351,10 +394,43 @@ impl AdapterManager {
                     adapter_type: declaration.adapter_type,
                     enabled: claim.is_some(),
                     claim_status: claim.map(|c| c.status),
+                    source_status: None,
+                    source_reason: None,
                 },
             );
         }
 
+        for claim in &state.adapter_claims {
+            let source = self.source_probe_for_claim(claim, &state);
+            let (driver_available, framework_detected) = self.driver_scan_facts(&claim.framework);
+            let key = (claim.component.clone(), claim.framework.clone());
+            let entry = entries.entry(key).or_insert_with(|| ScanEntry {
+                component: claim.component.clone(),
+                framework: claim.framework.clone(),
+                declared: false,
+                resource_root: source.resource_root.clone(),
+                driver_available,
+                framework_detected,
+                adapter_type: claim.adapter_type.clone(),
+                enabled: false,
+                claim_status: None,
+                source_status: None,
+                source_reason: None,
+            });
+            entry.enabled = true;
+            entry.claim_status = Some(claim.status);
+            if entry.adapter_type.is_none() {
+                entry.adapter_type = claim.adapter_type.clone();
+            }
+            if entry.resource_root.is_none() {
+                entry.resource_root = source.resource_root.clone();
+            }
+            entry.source_status = Some(source.status);
+            entry.source_reason = source.reason;
+        }
+
+        let mut warnings = self.visibility_warnings.clone();
+        warnings.extend(declaration_warnings);
         Ok(ScanReport {
             entries: entries.into_values().collect(),
             warnings,
@@ -811,6 +887,7 @@ impl AdapterManager {
                 continue;
             }
             let framework = claim.framework.clone();
+            let source = self.source_probe_for_claim(claim, &state);
             let driver = match self.registry.get(&framework) {
                 Some(d) => d,
                 None => {
@@ -819,15 +896,22 @@ impl AdapterManager {
                     entries.push(StatusEntry {
                         component: claim.component.clone(),
                         framework,
-                        report: unverified_report("no built-in driver for framework"),
+                        report: with_source_condition(
+                            unverified_report("no built-in driver for framework"),
+                            &source,
+                        ),
                     });
                     continue;
                 }
             };
 
-            let resource_root = self
-                .discover_resource_root(&claim.component, &framework)
-                .map(|(path, _)| path)
+            let resource_root = source
+                .resource_root
+                .clone()
+                .or_else(|| {
+                    self.discover_resource_root(&claim.component, &framework)
+                        .map(|(path, _)| path)
+                })
                 .unwrap_or_else(|| claim.resource_root.clone());
             let label = format!("adapter status {} {framework}", claim.component);
             // Two-phase ops mirroring enable/disable: probe to learn the
@@ -890,7 +974,7 @@ impl AdapterManager {
                 &driver.allowed_external_roots(&ctx),
                 &self.all_datadir_roots,
             )?;
-            let report = driver.status(claim, &ctx)?;
+            let report = with_source_condition(driver.status(claim, &ctx)?, &source);
             entries.push(StatusEntry {
                 component: claim.component.clone(),
                 framework,
@@ -902,6 +986,99 @@ impl AdapterManager {
     }
 
     // -- discovery helpers --------------------------------------------------
+
+    fn driver_scan_facts(&self, framework: &str) -> (bool, bool) {
+        let driver = self.registry.get(framework);
+        let driver_available = driver.is_some();
+        let framework_detected = driver
+            .map(|d| {
+                d.detect(&HostEnv {
+                    user_home: self.user_home.clone(),
+                })
+                .detected
+            })
+            .unwrap_or(false);
+        (driver_available, framework_detected)
+    }
+
+    fn source_probe_for_claim(
+        &self,
+        claim: &AdapterClaim,
+        current_state: &InstalledState,
+    ) -> SourceProbe {
+        self.source_probe(&claim.component, &claim.framework, current_state)
+    }
+
+    fn source_probe(
+        &self,
+        component: &str,
+        framework: &str,
+        current_state: &InstalledState,
+    ) -> SourceProbe {
+        let vr = match self.find_component_visible_root(component, current_state) {
+            Ok(Some(vr)) => vr,
+            Ok(None) => {
+                return source_missing(format!(
+                    "no visible installed component '{component}' supplies this adapter"
+                ));
+            }
+            Err(err) => {
+                return source_missing(format!(
+                    "failed to inspect visible component source for '{component}': {err}"
+                ));
+            }
+        };
+
+        let resolved = match super::contract::resolve_component_contract_with_source(
+            component,
+            std::slice::from_ref(&vr.state_dir),
+            &vr.contract_datadir_roots,
+        ) {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                return source_missing(format!(
+                    "component contract unavailable for '{component}': {err}"
+                ));
+            }
+        };
+        let manifest = resolved.manifest;
+        if manifest.component.name != component {
+            return source_missing(format!(
+                "component contract declares '{}', expected '{component}'",
+                manifest.component.name
+            ));
+        }
+        if !declared_frameworks(&manifest)
+            .iter()
+            .any(|fw| fw == framework)
+        {
+            return source_missing(format!(
+                "component '{component}' no longer declares adapter framework '{framework}'"
+            ));
+        }
+
+        let contract_datadir_root = contract_datadir_root_from_source(
+            component,
+            &resolved.path,
+            &vr.contract_datadir_roots,
+        );
+        match self.resolve_resource_root(
+            component,
+            framework,
+            &manifest,
+            &vr.contract_datadir_roots,
+            contract_datadir_root.as_deref(),
+        ) {
+            Ok((resource_root, _)) => SourceProbe {
+                status: AdapterSourceStatus::Available,
+                resource_root: Some(resource_root),
+                reason: None,
+            },
+            Err(err) => source_missing(format!(
+                "adapter source unavailable for '{component}/{framework}': {err}"
+            )),
+        }
+    }
 
     /// Resolve the framework for an operation from the installed manifest:
     /// use the explicit one when declared, else the single declared
@@ -2417,7 +2594,6 @@ fn plan_disable_report(claim: &AdapterClaim) -> DisableReport {
 /// A status report for a receipt that cannot be verified at all (e.g. no
 /// driver). Reports `Unknown` rather than faking a healthy/absent verdict.
 fn unverified_report(reason: &str) -> AdapterStatusReport {
-    use super::driver::{AdapterCondition, AdapterConditionKind, AdapterSummary, ConditionStatus};
     AdapterStatusReport {
         summary: AdapterSummary::Unknown,
         conditions: vec![AdapterCondition {
@@ -2427,6 +2603,39 @@ fn unverified_report(reason: &str) -> AdapterStatusReport {
             resource: None,
         }],
     }
+}
+
+fn source_missing(reason: String) -> SourceProbe {
+    SourceProbe {
+        status: AdapterSourceStatus::Missing,
+        resource_root: None,
+        reason: Some(reason),
+    }
+}
+
+fn source_condition(source: &SourceProbe) -> AdapterCondition {
+    AdapterCondition {
+        kind: AdapterConditionKind::SourceAvailable,
+        status: match source.status {
+            AdapterSourceStatus::Available => ConditionStatus::True,
+            AdapterSourceStatus::Missing => ConditionStatus::False,
+        },
+        reason: source.reason.clone(),
+        resource: None,
+    }
+}
+
+fn with_source_condition(
+    mut report: AdapterStatusReport,
+    source: &SourceProbe,
+) -> AdapterStatusReport {
+    if source.status == AdapterSourceStatus::Missing
+        && report.summary != AdapterSummary::CleanupFailed
+    {
+        report.summary = AdapterSummary::Degraded;
+    }
+    report.conditions.insert(0, source_condition(source));
+    report
 }
 
 /// Reorder datadir roots so `preferred` is tried first, then the remaining
@@ -2982,6 +3191,155 @@ source = "adapters/openclaw"
         let dir = datadir.join("components").join(component);
         std::fs::create_dir_all(&dir).expect("mkdir contract");
         std::fs::write(dir.join("component.toml"), content).expect("write contract");
+    }
+
+    fn openclaw_claim(component: &str, resource_root: PathBuf) -> AdapterClaim {
+        use crate::adapter::claim::{
+            CLAIM_SCHEMA_VERSION, DRIVER_SCHEMA_VERSION, DriverPayload, OpenClawClaim,
+        };
+
+        AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: component.to_string(),
+            framework: "openclaw".to_string(),
+            plugin_id: Some(component.to_string()),
+            adapter_type: Some("plugin".to_string()),
+            enabled_at: "2026-07-09T00:00:00Z".to_string(),
+            resource_root,
+            bundle_digest: None,
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: Vec::new(),
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "openclaw_state".to_string(),
+                plugin_resource: "openclaw_plugin".to_string(),
+                skill_resources: Vec::new(),
+                config_resources: Vec::new(),
+            }),
+        }
+    }
+
+    fn seed_adapter_claim(state_dir: &std::path::Path, claim: AdapterClaim) {
+        let mut state = InstalledState::default();
+        state.upsert_adapter_claim(claim);
+        std::fs::create_dir_all(state_dir).expect("mkdir state");
+        state
+            .save(&state_dir.join("installed.toml"))
+            .expect("save state");
+    }
+
+    #[test]
+    fn scan_surfaces_orphaned_receipt_when_source_component_is_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let missing_resource = tmp
+            .path()
+            .join("data")
+            .join("adapters")
+            .join("tokenless")
+            .join("openclaw");
+        seed_adapter_claim(&state_dir, openclaw_claim("tokenless", missing_resource));
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![tmp.path().join("data")],
+        }];
+        manager.all_datadir_roots = vec![tmp.path().join("data")];
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|entry| entry.component == "tokenless" && entry.framework == "openclaw")
+            .expect("orphaned receipt should be listed");
+
+        assert!(entry.enabled);
+        assert_eq!(entry.source_status, Some(AdapterSourceStatus::Missing));
+        assert!(
+            entry
+                .source_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("no visible installed component")),
+            "source reason should explain missing component, got: {:?}",
+            entry.source_reason
+        );
+    }
+
+    #[test]
+    fn status_marks_receipt_degraded_when_source_component_is_missing() {
+        use crate::adapter::driver::{AdapterConditionKind, AdapterSummary, ConditionStatus};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let missing_resource = tmp
+            .path()
+            .join("data")
+            .join("adapters")
+            .join("tokenless")
+            .join("openclaw");
+        seed_adapter_claim(&state_dir, openclaw_claim("tokenless", missing_resource));
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![tmp.path().join("data")],
+        }];
+        manager.all_datadir_roots = vec![tmp.path().join("data")];
+
+        let report = manager.status(Some("tokenless")).expect("status");
+        let entry = report.entries.first().expect("receipt status");
+
+        assert_eq!(entry.report.summary, AdapterSummary::Degraded);
+        let source_condition = entry
+            .report
+            .conditions
+            .iter()
+            .find(|condition| condition.kind == AdapterConditionKind::SourceAvailable)
+            .expect("source availability condition");
+        assert_eq!(source_condition.status, ConditionStatus::False);
+        assert!(
+            source_condition
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("no visible installed component")),
+            "source condition should explain missing component, got: {:?}",
+            source_condition.reason
+        );
+    }
+
+    #[test]
+    fn disable_dry_run_works_when_adapter_source_is_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let missing_resource = tmp
+            .path()
+            .join("data")
+            .join("adapters")
+            .join("tokenless")
+            .join("openclaw");
+        seed_adapter_claim(&state_dir, openclaw_claim("tokenless", missing_resource));
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![tmp.path().join("data")],
+        }];
+        manager.all_datadir_roots = vec![tmp.path().join("data")];
+
+        let outcome = manager
+            .disable("tokenless", Some("openclaw"), true)
+            .expect("disable dry-run should not require source root");
+
+        assert!(outcome.dry_run);
+        assert!(!outcome.claim_removed);
+        assert!(outcome.report.cleanup_complete);
     }
 
     // -- contract-driven resource root discovery --------------------------------


### PR DESCRIPTION
## Description

This PR adds adapter source-health reporting for persisted adapter receipts.
Adapter scan/status now keep enabled receipts visible after the source
component disappears, mark those receipts as orphaned/degraded, and preserve
receipt-only disable cleanup paths.

The CLI adapter manager now derives visible roots from the scoped StateView
model. User-mode read paths can inspect system-installed adapter sources,
while receipt mutation remains tied to the current install mode's physical
state file.

## Related Issue

no-issue: follow-up PR slice for scoped adapter visibility/source-health work

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo doc --no-deps`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-core source_component_is_missing`
- `cargo test -p anolisa-core disable_dry_run_works_when_adapter_source_is_missing`
- `cargo test -p anolisa-cli adapter::tests`
- `cargo test -p anolisa-cli adapter_state_label_values`
- LSP diagnostics on changed Rust files: no errors or warnings
- Local isolated CLI QA: user-mode sees system adapter source; deleted source
  becomes orphaned/degraded; dry-run disable, bad input, and help paths pass
- Remote QA on `Alinux 4`: root/system-mode and nobody/user-mode
  pass; system-mode does not see user receipts; user-mode sees system sources;
  orphan status and dry-run cleanup pass

## Additional Notes

This PR intentionally reports `source_status` only for rows backed by a
receipt. Plain adapter declarations without a receipt remain source-neutral.
