### PR TITLE
fix(anolisa): guard read-only lifecycle targets

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -185,6 +185,26 @@ pub fn load_installed_state(ctx: &CliContext, command: &str) -> Result<Installed
     })
 }
 
+/// Refuse lifecycle mutation of a visible component that is not writable by
+/// the current install mode. Missing visible records are left to the caller's
+/// existing "not installed" error path.
+pub(crate) fn reject_visible_non_writable_component(
+    ctx: &CliContext,
+    command: &str,
+    component: &str,
+) -> Result<(), CliError> {
+    let view = StateView::load(ctx, command, StateVisibility::UserPlusSystem)?;
+    reject_visible_non_writable_component_from_view(&view, command, component)
+}
+
+fn reject_visible_non_writable_component_from_view(
+    view: &StateView,
+    command: &str,
+    component: &str,
+) -> Result<(), CliError> {
+    view.reject_non_writable_component_mutation(command, component)
+}
+
 /// Resolve a user-supplied component name to the stable state key.
 ///
 /// Commands that address existing state (uninstall, forget, update, restart,
@@ -633,6 +653,114 @@ pub fn migrate_v3_symlinks(state: &mut InstalledState, layout: &FsLayout) -> usi
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use anolisa_core::state::{InstalledObject, Ownership, SubscriptionScope};
+
+    use crate::commands::state_view::{ScopedStateRoot, StateScope};
+
+    fn test_component(name: &str) -> InstalledObject {
+        InstalledObject {
+            kind: ObjectKind::Component,
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: None,
+            raw_package: None,
+            install_backend: Some("raw".to_string()),
+            ownership: Some(Ownership::RawManaged),
+            rpm_metadata: None,
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: true,
+            adopted: false,
+            subscription_scope: SubscriptionScope::None,
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+            provisioned_packages: Vec::new(),
+        }
+    }
+
+    fn state_with_objects(objects: Vec<InstalledObject>) -> InstalledState {
+        let mut state = InstalledState::default();
+        for object in objects {
+            state.upsert_object(object);
+        }
+        state
+    }
+
+    fn scoped_view(user_state: InstalledState, system_state: InstalledState) -> StateView {
+        let user_root = ScopedStateRoot {
+            scope: StateScope::User,
+            layout: FsLayout::user_with_overrides(
+                PathBuf::from("/tmp/anolisa-home"),
+                None,
+                None,
+                Some(PathBuf::from("/tmp/anolisa-user-state")),
+                None,
+                None,
+            ),
+            state_path: PathBuf::from("/tmp/anolisa-user-state/installed.toml"),
+            writable: true,
+            state: user_state,
+        };
+        let system_root = ScopedStateRoot {
+            scope: StateScope::System,
+            layout: FsLayout::system(Some(PathBuf::from("/tmp/anolisa-system"))),
+            state_path: PathBuf::from("/tmp/anolisa-system-state/installed.toml"),
+            writable: false,
+            state: system_state,
+        };
+        StateView {
+            writable: user_root.clone(),
+            visible_roots: vec![user_root, system_root],
+            warnings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn reject_visible_non_writable_component_blocks_read_only_system_view() {
+        let view = scoped_view(
+            InstalledState::default(),
+            state_with_objects(vec![test_component("system-tool")]),
+        );
+
+        let err = reject_visible_non_writable_component_from_view(
+            &view,
+            "uninstall system-tool",
+            "system-tool",
+        )
+        .expect_err("system component must be visible but read-only");
+
+        match err {
+            CliError::PermissionDenied { reason, hint, .. } => {
+                assert!(reason.contains("system-tool"), "reason: {reason}");
+                assert!(reason.contains("system-scope"), "reason: {reason}");
+                assert!(
+                    hint.as_deref()
+                        .is_some_and(|h| h.contains("--install-mode system")),
+                    "hint: {hint:?}",
+                );
+            }
+            other => panic!("expected permission error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reject_visible_non_writable_component_keeps_missing_targets_unchanged() {
+        let view = scoped_view(InstalledState::default(), InstalledState::default());
+
+        reject_visible_non_writable_component_from_view(
+            &view,
+            "forget missing-tool",
+            "missing-tool",
+        )
+        .expect("missing targets should continue into the existing not-installed path");
+    }
 
     /// Verify that `package_datadir()` is wired into the system-mode
     /// manager: an RPM-installed contract under `{prefix}/usr/share/anolisa`

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
@@ -106,6 +106,36 @@ impl StateView {
         records
     }
 
+    pub(crate) fn reject_non_writable_component_mutation(
+        &self,
+        command: &str,
+        component: &str,
+    ) -> Result<(), CliError> {
+        if let Some(record) = self.visible_components().into_iter().find(|record| {
+            record.active
+                && !record.mutable_by_current_invocation
+                && (record.object.name == component
+                    || record.object.raw_package.as_deref() == Some(component)
+                    || record
+                        .object
+                        .rpm_metadata
+                        .as_ref()
+                        .is_some_and(|metadata| metadata.package_name == component))
+        }) {
+            let scope = record.scope();
+            return Err(CliError::PermissionDenied {
+                command: command.to_string(),
+                reason: format!(
+                    "component '{component}' is {}-scope and read-only from the current {}-mode invocation",
+                    scope.label(),
+                    self.writable.scope.label(),
+                ),
+                hint: Some(scope_mutation_hint(scope, command)),
+            });
+        }
+        Ok(())
+    }
+
     fn from_layouts(command: &str, roots: Vec<(FsLayout, RootSpec)>) -> Result<Self, CliError> {
         let mut visible_roots = Vec::new();
         let mut writable = None;
@@ -197,6 +227,17 @@ const fn scope_for_mode(mode: InstallMode) -> StateScope {
     match mode {
         InstallMode::User => StateScope::User,
         InstallMode::System => StateScope::System,
+    }
+}
+
+fn scope_mutation_hint(scope: StateScope, command: &str) -> String {
+    match scope {
+        StateScope::System => {
+            format!("run `sudo anolisa --install-mode system {command}` to mutate system state")
+        }
+        StateScope::User => {
+            format!("run `anolisa --install-mode user {command}` to mutate user state")
+        }
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests.rs
@@ -6,6 +6,7 @@ use crate::context::{CliContext, InstallMode};
 use super::*;
 use support::{component, user_layout, write_state};
 
+mod mutation_guard;
 mod support;
 
 #[test]
@@ -83,6 +84,39 @@ fn user_record_shadows_system_record() {
             && !record.active
             && record.shadowed_by == Some(StateScope::User)
     }));
+}
+
+#[test]
+fn shadowed_system_record_does_not_block_user_lifecycle_mutation() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    let system_layout = FsLayout::system(Some(tmp.path().join("system")));
+    write_state(&user_layout, vec![component("shared")]);
+    write_state(&system_layout, vec![component("shared")]);
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                user_layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+            (
+                system_layout,
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+
+    view.reject_non_writable_component_mutation("forget shared", "shared")
+        .expect("writable user record owns the active mutation target");
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests/mutation_guard.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests/mutation_guard.rs
@@ -1,0 +1,165 @@
+use anolisa_platform::fs_layout::FsLayout;
+use tempfile::tempdir;
+
+use super::super::{RootSpec, StateScope, StateView};
+use super::support::{component, rpm_component, user_layout, write_state};
+
+#[test]
+fn read_only_system_record_blocks_lifecycle_mutation() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    let system_layout = FsLayout::system(Some(tmp.path().join("system")));
+    write_state(&user_layout, Vec::new());
+    write_state(&system_layout, vec![component("system-tool")]);
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                user_layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+            (
+                system_layout,
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+
+    let err = view
+        .reject_non_writable_component_mutation(
+            "uninstall --remove-system-package system-tool",
+            "system-tool",
+        )
+        .expect_err("system-only component must be read-only in user mode");
+
+    match err {
+        crate::response::CliError::PermissionDenied { reason, hint, .. } => {
+            assert!(reason.contains("system-tool"), "reason: {reason}");
+            assert!(reason.contains("system"), "reason: {reason}");
+            assert!(
+                hint.as_deref()
+                    .is_some_and(|h| h.contains("--install-mode system")),
+                "hint: {hint:?}"
+            );
+            assert!(
+                hint.as_deref()
+                    .is_some_and(|h| h.contains("uninstall --remove-system-package system-tool")),
+                "hint must preserve the original uninstall intent: {hint:?}"
+            );
+        }
+        other => panic!("expected permission error, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_only_system_record_blocks_lifecycle_mutation_by_rpm_package_name() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    let system_layout = FsLayout::system(Some(tmp.path().join("system")));
+    write_state(&user_layout, Vec::new());
+    write_state(&system_layout, vec![rpm_component("cosh", "copilot-shell")]);
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                user_layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+            (
+                system_layout,
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+
+    let err = view
+        .reject_non_writable_component_mutation("uninstall copilot-shell", "copilot-shell")
+        .expect_err("system RPM package alias must be read-only in user mode");
+
+    match err {
+        crate::response::CliError::PermissionDenied { reason, hint, .. } => {
+            assert!(reason.contains("copilot-shell"), "reason: {reason}");
+            assert!(reason.contains("system"), "reason: {reason}");
+            assert!(
+                hint.as_deref()
+                    .is_some_and(|h| h.contains("--install-mode system")),
+                "hint: {hint:?}"
+            );
+            assert!(
+                hint.as_deref()
+                    .is_some_and(|h| h.contains("uninstall copilot-shell")),
+                "hint must preserve the original alias input: {hint:?}"
+            );
+        }
+        other => panic!("expected permission error, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_only_system_record_blocks_lifecycle_mutation_by_raw_package_name() {
+    let tmp = tempdir().expect("tempdir");
+    let user_layout = user_layout(tmp.path().join("home"));
+    let system_layout = FsLayout::system(Some(tmp.path().join("system")));
+    let mut object = component("foo");
+    object.raw_package = Some("altpkg".to_string());
+    write_state(&user_layout, Vec::new());
+    write_state(&system_layout, vec![object]);
+
+    let view = StateView::from_layouts(
+        "test",
+        vec![
+            (
+                user_layout,
+                RootSpec {
+                    scope: StateScope::User,
+                    writable: true,
+                },
+            ),
+            (
+                system_layout,
+                RootSpec {
+                    scope: StateScope::System,
+                    writable: false,
+                },
+            ),
+        ],
+    )
+    .expect("state view");
+
+    let err = view
+        .reject_non_writable_component_mutation("update altpkg", "altpkg")
+        .expect_err("system raw package alias must be read-only in user mode");
+
+    match err {
+        crate::response::CliError::PermissionDenied { reason, hint, .. } => {
+            assert!(reason.contains("altpkg"), "reason: {reason}");
+            assert!(reason.contains("system"), "reason: {reason}");
+            assert!(
+                hint.as_deref()
+                    .is_some_and(|h| h.contains("--install-mode system")),
+                "hint: {hint:?}"
+            );
+            assert!(
+                hint.as_deref().is_some_and(|h| h.contains("update altpkg")),
+                "hint must preserve the original alias input: {hint:?}"
+            );
+        }
+        other => panic!("expected permission error, got {other:?}"),
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests/support.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests/support.rs
@@ -1,5 +1,6 @@
 use anolisa_core::{
-    InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership, SubscriptionScope,
+    InstalledObject, InstalledState, ObjectKind, ObjectStatus, Ownership, RpmMetadata,
+    SubscriptionScope,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use std::path::PathBuf;
@@ -45,4 +46,19 @@ pub(super) fn component(name: &str) -> InstalledObject {
         health: Vec::new(),
         provisioned_packages: Vec::new(),
     }
+}
+
+pub(super) fn rpm_component(name: &str, package: &str) -> InstalledObject {
+    let mut object = component(name);
+    object.install_backend = Some("rpm".to_string());
+    object.ownership = Some(Ownership::RpmObserved);
+    object.rpm_metadata = Some(RpmMetadata {
+        package_name: package.to_string(),
+        evr: None,
+        arch: None,
+        source_repo: None,
+    });
+    object.managed = false;
+    object.adopted = true;
+    object
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -64,6 +64,13 @@ pub fn handle(args: ForgetArgs, ctx: &CliContext) -> Result<(), CliError> {
     let resolved = common::lookup_component_name(input, &installed, ctx, COMMAND);
     let target = resolved.as_str();
 
+    if installed
+        .find_object(ObjectKind::Component, target)
+        .is_none()
+    {
+        common::reject_visible_non_writable_component(ctx, &command, target)?;
+    }
+
     let obj = installed
         .find_object(ObjectKind::Component, target)
         .ok_or_else(|| CliError::InvalidArgument {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -124,6 +124,7 @@ pub(crate) fn handle_with_deps(
     };
     let input = args.component.as_str();
     let command = format!("{} {}", operation.as_str(), input);
+    let scope_command = scope_guard_command(&args, input);
 
     // Load installed state to plan against. Missing state is the same
     // as "target not installed" — surface that as INVALID_ARGUMENT so
@@ -155,6 +156,12 @@ pub(crate) fn handle_with_deps(
                  on the next install/uninstall; use `anolisa list` to see components"
             ),
         });
+    }
+    if installed
+        .find_object(ObjectKind::Component, target)
+        .is_none()
+    {
+        common::reject_visible_non_writable_component(ctx, &scope_command, target)?;
     }
     // Adapter receipts must be released before the component is removed.
     // Uninstall does not auto-cascade into framework state (a framework CLI
@@ -302,6 +309,19 @@ pub(crate) fn handle_with_deps(
         render_outcome_human(&outcome, ctx.no_color);
     }
     Ok(())
+}
+
+fn scope_guard_command(args: &UninstallArgs, input: &str) -> String {
+    let mut command = COMMAND.to_string();
+    if args.purge {
+        command.push_str(" --purge");
+    }
+    if args.remove_system_package {
+        command.push_str(" --remove-system-package");
+    }
+    command.push(' ');
+    command.push_str(input);
+    command
 }
 
 fn lifecycle_err_to_cli(command: &str, err: LifecycleError) -> CliError {
@@ -1750,6 +1770,29 @@ mod tests {
             remove_system_package: true,
             force: false,
         }
+    }
+
+    #[test]
+    fn scope_guard_command_preserves_uninstall_flags() {
+        assert_eq!(
+            scope_guard_command(&args("system-tool", false), "system-tool"),
+            "uninstall system-tool"
+        );
+        assert_eq!(
+            scope_guard_command(&args("system-tool", true), "system-tool"),
+            "uninstall --purge system-tool"
+        );
+        assert_eq!(
+            scope_guard_command(&args_rm("system-tool"), "system-tool"),
+            "uninstall --remove-system-package system-tool"
+        );
+
+        let mut both = args_rm("system-tool");
+        both.purge = true;
+        assert_eq!(
+            scope_guard_command(&both, "system-tool"),
+            "uninstall --purge --remove-system-package system-tool"
+        );
     }
 
     fn run(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -307,6 +307,12 @@ fn resolve_update_target(
     command: &str,
 ) -> Result<UpdateTarget, CliError> {
     let installed = common::load_installed_state(ctx, COMMAND)?;
+    if installed
+        .find_object(ObjectKind::Component, target)
+        .is_none()
+    {
+        common::reject_visible_non_writable_component(ctx, command, target)?;
+    }
     let obj = installed
         .find_object(ObjectKind::Component, target)
         .ok_or_else(|| CliError::InvalidArgument {

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -1091,6 +1091,58 @@ fn now_iso8601() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static OPENCLAW_BIN_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct OpenClawBinEnvGuard {
+        previous: Option<OsString>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl OpenClawBinEnvGuard {
+        fn unset() -> Self {
+            Self::apply(None)
+        }
+
+        fn set(value: &str) -> Self {
+            Self::apply(Some(value))
+        }
+
+        fn apply(value: Option<&str>) -> Self {
+            let lock = OPENCLAW_BIN_ENV_LOCK.lock().expect("openclaw env lock");
+            let previous = std::env::var_os("OPENCLAW_BIN");
+            // SAFETY: these tests serialize every OPENCLAW_BIN mutation and
+            // every command-builder read behind the same process-wide lock.
+            unsafe {
+                if let Some(value) = value {
+                    std::env::set_var("OPENCLAW_BIN", value);
+                } else {
+                    std::env::remove_var("OPENCLAW_BIN");
+                }
+            }
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for OpenClawBinEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: the lock is still held while restoring the process
+            // environment, so no sibling OpenClaw test can observe a partial
+            // OPENCLAW_BIN transition.
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var("OPENCLAW_BIN", previous);
+                } else {
+                    std::env::remove_var("OPENCLAW_BIN");
+                }
+            }
+        }
+    }
 
     #[test]
     fn list_contains_plugin_matches_whole_token() {
@@ -1219,6 +1271,7 @@ mod tests {
 
     #[test]
     fn install_cmd_mirrors_script_contract() {
+        let _env = OpenClawBinEnvGuard::unset();
         let cmd = build_install_cmd(
             Path::new("/data/adapters/tokenless/openclaw"),
             Path::new("/home/u/.openclaw"),
@@ -1248,6 +1301,7 @@ mod tests {
 
     #[test]
     fn uninstall_cmd_uses_force() {
+        let _env = OpenClawBinEnvGuard::unset();
         let cmd = build_uninstall_cmd(
             "tokenless",
             Path::new("/home/u/.openclaw"),
@@ -1322,6 +1376,7 @@ mod tests {
 
     #[test]
     fn config_set_cmd_string_value() {
+        let _env = OpenClawBinEnvGuard::unset();
         let cmd = build_config_set_cmd(
             "plugins.entries.sec.enabled",
             &toml::Value::String("true".to_string()),
@@ -1337,6 +1392,7 @@ mod tests {
 
     #[test]
     fn config_set_cmd_boolean_value() {
+        let _env = OpenClawBinEnvGuard::unset();
         let cmd = build_config_set_cmd(
             "debug.enabled",
             &toml::Value::Boolean(true),
@@ -1348,6 +1404,7 @@ mod tests {
 
     #[test]
     fn config_set_cmd_integer_value() {
+        let _env = OpenClawBinEnvGuard::unset();
         let cmd = build_config_set_cmd(
             "limits.max_plugins",
             &toml::Value::Integer(42),
@@ -1475,20 +1532,8 @@ mod tests {
         );
         assert_eq!(claim_skill_resources(&claim), vec!["install-openclaw"]);
 
-        let previous_bin = std::env::var_os("OPENCLAW_BIN");
-        // SAFETY: test-only; restored before the test returns.
-        unsafe {
-            std::env::set_var("OPENCLAW_BIN", "/bin/sh");
-        }
+        let _env = OpenClawBinEnvGuard::set("/bin/sh");
         let report = driver.status(&claim, &ctx).expect("status");
-        // SAFETY: test-only; restore the process environment.
-        unsafe {
-            if let Some(value) = previous_bin {
-                std::env::set_var("OPENCLAW_BIN", value);
-            } else {
-                std::env::remove_var("OPENCLAW_BIN");
-            }
-        }
 
         assert_eq!(report.summary, AdapterSummary::Healthy);
         assert!(


### PR DESCRIPTION
## Description

This PR makes lifecycle mutations scope-aware when user mode can see a
system-scope component but cannot write its physical state. `uninstall`,
`forget`, and component `update` now consult the shared visible state view
before falling through to the existing not-installed error, so a system-only
target reports `PERMISSION_DENIED` with a system-mode hint instead of looking
absent.

The guard is centralized in `StateView` and exposed through a small command
helper so mutation commands share one dual-state lookup path. The change keeps
missing invisible targets on the existing error path and preserves the user
shadow semantics for components installed in both scopes. This PR also fixes
an OpenClaw test flake by serializing test-only `OPENCLAW_BIN` overrides.

## Related Issue

no-issue: split implementation from the scoped installed-state design work.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `OPENCLAW_BIN=/bin/sh cargo test -p anolisa-core adapter::openclaw::tests::install_cmd_mirrors_script_contract --locked`
- `cargo test -p anolisa-core adapter::openclaw::tests --locked`
- `cargo test -p anolisa-cli lifecycle_mutation`
- `cargo test -p anolisa-cli reject_visible_non_writable_component`
- `cargo test -p anolisa-cli commands::tier1::forget::tests`
- `cargo test -p anolisa-cli commands::tier1::uninstall::tests`
- `cargo test -p anolisa-cli commands::tier1::update::tests`
- `cargo test -p anolisa-cli`
- `cargo test --workspace --locked`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo doc --workspace --no-deps`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

Manual CLI QA:

- Local debug binary with isolated user/system state roots:
  - user-mode `uninstall system-tool`, `forget system-tool`, and
    `update system-tool` returned `PERMISSION_DENIED`.
  - user-mode `forget --dry-run shared` succeeded for the user shadow record.
  - system-mode `forget --dry-run system-tool` succeeded.
  - system-mode `forget --dry-run user-only` returned not installed.
  - bad input and `uninstall --help` behaved as expected.
  - system and user state file checksums stayed unchanged.
- Remote host `Alinux 4` with root plus `nobody`:
  - `nobody` user-mode `uninstall`, `forget`, and `update` of a system-only
    component returned `PERMISSION_DENIED`.
  - root system-mode could dry-run mutate system state.
  - root system-mode could not see user-only state.
  - state file checksums stayed unchanged.

## Additional Notes

`install` and `adopt` ownership semantics are unchanged. A user install may
still create or mutate a user-scope record that shadows a system-scope record.
