### PR TITLE
fix(tokenless): sync adapter contracts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -752,6 +752,9 @@ jobs:
         with:
           workspaces: src/tokenless
 
+      - name: Check component contract
+        run: make -C src/tokenless check-component-contract
+
       - name: Check formatting
         run: |
           cd src/tokenless

--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -51,3 +51,33 @@ dest = "{datadir}/adapters/{component}/qoder/"
 # uninstall.sh ship in the same bundle as publishing assets, but the ANOLISA
 # driver never invokes them — enable/disable behavior is built into Rust.
 entry = ".qoder-plugin/plugin.json"
+
+[[adapters]]
+framework = "claude-code"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/claude-code"
+dest = "{datadir}/adapters/{component}/claude-code/"
+
+[adapters.bundle]
+entry = ".claude-plugin/marketplace.json"
+
+[[adapters]]
+framework = "codex"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/codex"
+dest = "{datadir}/adapters/{component}/codex/"
+
+[adapters.bundle]
+entry = ".codex-plugin/plugin.json"
+
+[[adapters]]
+framework = "cosh"
+adapter_type = "extension"
+plugin_id = "tokenless"
+source = "adapters/common"
+dest = "{datadir}/extensions/{component}/"
+
+[adapters.bundle]
+entry = "cosh-extension.json"

--- a/src/tokenless/.anolisa/component.toml.in
+++ b/src/tokenless/.anolisa/component.toml.in
@@ -36,3 +36,48 @@ dest = "{datadir}/adapters/{component}/hermes/"
 # so the contract names the platform entry manifest (matches the file
 # shipped at the dest root: adapters/<component>/hermes/plugin.yaml).
 entry = "plugin.yaml"
+
+[[adapters]]
+framework = "qoder"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/qoder"
+dest = "{datadir}/adapters/{component}/qoder/"
+
+[adapters.bundle]
+# Qoder-native plugin manifest inside the bundle directory. The built-in
+# qoder driver reads this to confirm the bundle is a valid Qoder plugin and
+# requires hooks.json beside it. The legacy scripts/install.sh and
+# uninstall.sh ship in the same bundle as publishing assets, but the ANOLISA
+# driver never invokes them — enable/disable behavior is built into Rust.
+entry = ".qoder-plugin/plugin.json"
+
+[[adapters]]
+framework = "claude-code"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/claude-code"
+dest = "{datadir}/adapters/{component}/claude-code/"
+
+[adapters.bundle]
+entry = ".claude-plugin/marketplace.json"
+
+[[adapters]]
+framework = "codex"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/codex"
+dest = "{datadir}/adapters/{component}/codex/"
+
+[adapters.bundle]
+entry = ".codex-plugin/plugin.json"
+
+[[adapters]]
+framework = "cosh"
+adapter_type = "extension"
+plugin_id = "tokenless"
+source = "adapters/common"
+dest = "{datadir}/extensions/{component}/"
+
+[adapters.bundle]
+entry = "cosh-extension.json"

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -37,7 +37,7 @@ TOON_VER := 0.5.0
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
 .PHONY: build build-tokenless build-toon build-openclaw-plugin \
-        stamp-adapter-templates \
+        stamp-adapter-templates check-component-contract \
         install uninstall test lint clean \
         install-binaries install-helpers install-adapter-resources install-cosh-extension \
         adapter-install adapter-uninstall adapter-scan \
@@ -77,6 +77,16 @@ $(ADAPTER_SRC_DIR)/manifest.json: $(ADAPTER_SRC_DIR)/manifest.json.in Cargo.toml
 $(COMPONENT_CONTRACT): $(COMPONENT_CONTRACT).in Cargo.toml
 	@echo "==> Generating component contract (version=$(VERSION))..."
 	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
+check-component-contract:
+	@tmp=$$(mktemp); \
+		cp "$(COMPONENT_CONTRACT)" "$$tmp"; \
+		trap 'cp "$$tmp" "$(COMPONENT_CONTRACT)"; rm -f "$$tmp"' EXIT; \
+		$(MAKE) -B "$(COMPONENT_CONTRACT)"; \
+		cmp -s "$$tmp" "$(COMPONENT_CONTRACT)" || { \
+			diff -u "$$tmp" "$(COMPONENT_CONTRACT)"; \
+			exit 1; \
+		}
 
 $(ADAPTER_SRC_DIR)/openclaw/package.json: $(ADAPTER_SRC_DIR)/openclaw/package.json.in Cargo.toml
 	@echo "==> Generating openclaw/package.json (version=$(VERSION))..."


### PR DESCRIPTION
## Description

Synchronizes the Tokenless component contract with its built-in adapter
drivers. The authoritative template now declares qoder, Claude Code, Codex,
and cosh; the checked-in generated contract is regenerated from it.

The Tokenless CI job now regenerates and compares the contract, preventing
future template/generated-file drift. `qwencode` remains undeclared because
ANOLISA does not ship a qwencode driver.

## Related Issue

no-issue: targeted contract synchronization fix

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD or build changes

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass

## Testing

- `make -C src/tokenless check-component-contract`
- `cargo +1.89.0 clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --workspace` (four macOS-incompatible Linux-path tests skipped)

## Additional Notes

No RPM build or release metadata changes are included.
