### PR TITLE
chore(anolisa): bump version to 0.2.3

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-12
+
+### Changed
+
+- Package installation and removal progress now uses stderr, keeping command output safe for redirection.
+
+### Fixed
+
+- ANOLISA commands now exit cleanly when a downstream pipeline closes standard output early.
+- ANOLISA commands now report standard output write failures instead of silently succeeding.
+
 ## [0.2.2] - 2026-07-09
 
 ### Added
@@ -470,6 +481,17 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.3] - 2026-07-12
+
+### 变更
+
+- 软件包安装和卸载进度现输出至标准错误，避免干扰重定向结果。
+
+### 修复
+
+- 下游管道提前关闭标准输出时，ANOLISA 命令现可正常退出。
+- 标准输出写入失败时，ANOLISA 命令现会报错而非静默成功。
 
 ## [0.2.2] - 2026-07-09
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -124,7 +124,12 @@ install -m 0644 manifests/repo.toml %{buildroot}%{_sysconfdir}/anolisa/repo.toml
 #%%doc %%{_docdir}/%%{name}/README.md
 
 %changelog
-* Thu Jul 09 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Sun Jul 12 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Package installation and removal progress now uses stderr, keeping command output safe for redirection.
+- ANOLISA commands now exit cleanly when a downstream pipeline closes standard output early.
+- ANOLISA commands now report standard output write failures instead of silently succeeding.
+
+* Thu Jul 09 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.2-1
 - `anolisa update --check` now reports RPM upgrade opportunities without changing state.
 - `anolisa update --check --motd` now prints a short login-friendly upgrade summary.
 - `anolisa upgrade` now applies RPM image upgrades for RPM-managed toolchains.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.2",
-    "@anolisa/cli-linux-arm64": "0.2.2"
+    "@anolisa/cli-linux-x64": "0.2.3",
+    "@anolisa/cli-linux-arm64": "0.2.3"
   }
 }

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

Bumps ANOLISA release metadata from 0.2.2 to 0.2.3 across Cargo, npm, and RPM packaging. The bilingual changelog aggregates user-visible output fixes since 0.2.2, including clean pipeline exits, explicit stdout failures, and stderr package progress. Keeping every release surface synchronized prevents published artifacts from reporting inconsistent versions.

## Related Issue

no-issue: release metadata update for v0.2.3

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `cargo run --quiet --locked -p anolisa-cli -- --version`

## Additional Notes

This release commit introduces no runtime code changes. The underlying output-handling fixes are already present on `main` in `d140c888` and include regression coverage.
