### PR TITLE
fix(anolisa): recover delegated rpm installs

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
@@ -10,6 +10,7 @@ pub mod list;
 pub mod logs;
 pub mod repair;
 pub mod restart;
+pub(crate) mod rpm_recovery;
 pub mod status;
 pub mod uninstall;
 pub mod update;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -24,7 +24,9 @@ use super::InstallArgs;
 use super::raw::{build_install_preview, execute_raw, prepare_raw_execution, resolve_raw};
 use super::render::render_plan;
 use super::render::repo_config_err;
-use super::rpm::{RpmExec, RpmSituation, probe_rpm_situation, route_rpm_adopt};
+use super::rpm::{
+    RpmExec, RpmSituation, probe_rpm_situation, reject_pending_rpm_install, route_rpm_adopt,
+};
 use super::types::*;
 
 use super::{ANOLISA_RPM_REPO_ID, COMMAND};
@@ -91,6 +93,12 @@ fn handle_one_with_config(
     // backend selection, so ExistingState detection and compatibility checks
     // use the canonical component name stored in state.
     let component = common::lookup_component_name(&component, &installed, ctx, COMMAND);
+
+    // A pending delegated RPM transaction owns this component until repair
+    // resolves it. Check before backend selection so explicit/default raw and
+    // every dry-run path cannot bypass that recovery contract. Mutating
+    // executors repeat this check under the install lock for TOCTOU safety.
+    reject_pending_rpm_install(&layout, &installed, &component, &command)?;
 
     let mut rpm_component_index: Option<ComponentIndex> = None;
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -40,7 +40,7 @@ use super::provision::{resolver_env_from_facts, retained_packages_note, run_prov
 use super::render::{artifact_ext, artifact_type_wire, render_result, repo_config_err};
 use super::types::*;
 
-use super::{COMMAND, ensure_component_backend_compatible};
+use super::{COMMAND, ensure_component_backend_compatible, reject_pending_rpm_install};
 pub(crate) fn resolve_raw(
     ctx: &CliContext,
     layout: &FsLayout,
@@ -1011,6 +1011,7 @@ pub(crate) fn execute_raw(
             command: command.to_string(),
             reason: format!("failed to load installed state: {err}"),
         })?;
+    reject_pending_rpm_install(layout, &state, &resolution.component, command)?;
     ensure_component_backend_compatible(
         &state,
         &resolution.component,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
@@ -8,6 +8,7 @@ use anolisa_core::state::{
     InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
     OperationRecord, Ownership, RpmMetadata,
 };
+use anolisa_core::transaction::TransactionOutcomeStatus;
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
@@ -15,6 +16,9 @@ use chrono::Utc;
 
 use crate::color::Palette;
 use crate::commands::common;
+use crate::commands::tier1::rpm_recovery::{
+    RpmInstallRecovery, begin_rpm_install, find_pending_rpm_install, record_rpm_managed_install,
+};
 use crate::context::CliContext;
 use crate::repo_config::{BackendConfig, RepoConfig};
 use crate::resolution::{
@@ -350,6 +354,7 @@ pub(crate) fn route_rpm_adopt(
                 command,
                 &target.component,
                 &target.package,
+                installed.find_object(ObjectKind::Component, &target.component),
             )
         }
         RpmSituation::NotAnolisaComponent => Err(CliError::InvalidArgument {
@@ -485,6 +490,7 @@ pub(crate) fn execute_adopt(
             command: command.to_string(),
             reason: format!("failed to load installed state: {err}"),
         })?;
+    reject_pending_rpm_install(layout, &preview_state, component, command)?;
     refuse_observed_repoint(&preview_state, component, &info.name, command)?;
 
     if ctx.dry_run {
@@ -503,6 +509,7 @@ pub(crate) fn execute_adopt(
             command: command.to_string(),
             reason: format!("failed to load installed state: {err}"),
         })?;
+    reject_pending_rpm_install(layout, &state, component, command)?;
 
     // Re-validate against the freshly-reloaded state, mirroring execute_raw's
     // post-lock guard. Layer 1 may have decided "adopt" from a pre-lock read
@@ -725,13 +732,14 @@ pub(crate) struct DelegatedInstallPayload {
 /// (`owns_removal=true`). ANOLISA never fetches bytes itself — dnf owns the
 /// file transaction. Gated on root for the real run; `--dry-run` previews the
 /// `dnf install` without touching the host.
-fn execute_delegated_install(
+pub(crate) fn execute_delegated_install(
     exec: &RpmExec,
     ctx: &CliContext,
     layout: &FsLayout,
     command: &str,
     component: &str,
     package: &str,
+    expected_component: Option<&InstalledObject>,
 ) -> Result<InstallOutcome, CliError> {
     let mut warnings: Vec<String> = Vec::new();
 
@@ -783,10 +791,100 @@ fn execute_delegated_install(
         });
     }
 
-    // dnf install — delegate the file transaction.
-    exec.txn
-        .install(package)
-        .map_err(|err| txn_install_err(err, command))?;
+    // Serialize the whole delegated transaction. The lock must be acquired
+    // before dnf mutates rpmdb, not only when installed.toml is finalized:
+    // otherwise another ANOLISA writer can win between those two commits.
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state =
+        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to load installed state: {err}"),
+        })?;
+
+    // Compare the object used for routing with the freshly locked state. An
+    // unchanged tracked RPM whose package disappeared may be reinstalled, but
+    // any concurrent addition, removal, or mutation invalidates the decision
+    // that led here and must not be overwritten by a second dnf transaction.
+    if state.find_object(ObjectKind::Component, component) != expected_component {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' changed while this RPM install was being prepared; dnf was not run — inspect it with `anolisa status {component}` and retry"
+            ),
+        });
+    }
+    ensure_component_backend_compatible(&state, component, "rpm", command)?;
+
+    let state_path = layout.state_dir.join("installed.toml");
+    let journal_dir = layout.state_dir.join("journal");
+    reject_pending_rpm_install(layout, &state, component, command)?;
+
+    // Persist both planned steps before invoking dnf. If the process exits at
+    // any later point, repair can identify both the component and package from
+    // this journal without trusting a partial installed-state object.
+    let mut recovery = begin_rpm_install(state_path.clone(), &journal_dir, component, package)
+        .map_err(|err| rpm_recovery_error(command, err))?;
+    let operation_id = recovery.operation_id().to_string();
+    let started_at = recovery.started_at().to_string();
+
+    if let Err(err) = exec.txn.install(package) {
+        let dnf_error = txn_install_err(err, command);
+        let dnf_reason = dnf_error.reason();
+        match exec.query.query_installed(package) {
+            // The failed dnf transaction made no observable package change, so
+            // the marker can be closed and the original package-manager error
+            // remains the useful result.
+            Ok(None) => {
+                let _ = recovery.mark_install_failed(&dnf_reason);
+                let _ = recovery.finish(TransactionOutcomeStatus::Failed);
+                return Err(dnf_error);
+            }
+            // A non-zero dnf exit can still leave a package installed. Preserve
+            // that fact for repair instead of pretending the transaction was
+            // cleanly rolled back.
+            Ok(Some(_)) => {
+                let _ = recovery.mark_install_done();
+                mark_rpm_install_partial(
+                    &mut recovery,
+                    "dnf returned an error but rpmdb reports the package installed",
+                );
+                return Err(rpm_install_needs_repair(
+                    command,
+                    component,
+                    package,
+                    &format!(
+                        "dnf reported failure ({dnf_reason}) but rpmdb now contains the package"
+                    ),
+                ));
+            }
+            Err(query_err) => {
+                let _ = recovery.mark_install_failed(&dnf_reason);
+                let _ = recovery.finish(TransactionOutcomeStatus::Partial);
+                return Err(rpm_install_needs_repair(
+                    command,
+                    component,
+                    package,
+                    &format!(
+                        "dnf reported failure ({dnf_reason}) and rpmdb verification also failed ({query_err})"
+                    ),
+                ));
+            }
+        }
+    }
+
+    if let Err(err) = recovery.mark_install_done() {
+        return Err(rpm_install_needs_repair(
+            command,
+            component,
+            package,
+            &format!(
+                "dnf succeeded but recording that result in the recovery journal failed ({err})"
+            ),
+        ));
+    }
 
     // Refresh from rpmdb: the authoritative installed EVR/arch.
     let info = match exec.query.query_installed(package) {
@@ -794,22 +892,41 @@ fn execute_delegated_install(
         // dnf reported success, so the package should be present; a miss here is
         // anomalous (a no-op transaction?). Refuse rather than record a phantom.
         Ok(None) => {
-            return Err(CliError::Runtime {
-                command: command.to_string(),
-                reason: format!(
-                    "dnf install of '{package}' reported success but rpmdb has no such package; the transaction may have been a no-op — run `anolisa status {component}`"
-                ),
-            });
+            mark_rpm_install_partial(
+                &mut recovery,
+                "dnf succeeded but rpmdb did not return the installed package",
+            );
+            return Err(rpm_install_needs_repair(
+                command,
+                component,
+                package,
+                "dnf succeeded but rpmdb has no package under that name",
+            ));
         }
         Err(PackageQueryError::UnexpectedOutput { .. }) => {
-            return Err(CliError::Runtime {
-                command: command.to_string(),
-                reason: format!(
-                    "RPM package '{package}' has multiple installed versions after install; refusing to record an ambiguous version"
-                ),
-            });
+            mark_rpm_install_partial(
+                &mut recovery,
+                "rpmdb reports multiple installed versions after dnf succeeded",
+            );
+            return Err(rpm_install_needs_repair(
+                command,
+                component,
+                package,
+                "dnf succeeded but rpmdb reports multiple installed versions",
+            ));
         }
-        Err(err) => return Err(pkg_query_err(err, command)),
+        Err(err) => {
+            mark_rpm_install_partial(
+                &mut recovery,
+                &format!("reading rpmdb after dnf succeeded failed: {err}"),
+            );
+            return Err(rpm_install_needs_repair(
+                command,
+                component,
+                package,
+                &format!("dnf succeeded but reading rpmdb failed ({err})"),
+            ));
+        }
     };
 
     // source_repo is supplementary metadata: a failed origin lookup degrades to
@@ -824,17 +941,45 @@ fn execute_delegated_install(
         }
     };
 
-    let (operation_id, snapshot_warnings) = persist_delegated_install(
+    let snapshot_warnings = match persist_delegated_install(
         ctx,
         layout,
+        &mut state,
         command,
         component,
         package,
         &info,
         source_repo.as_deref(),
         &warnings,
-    )?;
+        &operation_id,
+        &started_at,
+    ) {
+        Ok(snapshot_warnings) => snapshot_warnings,
+        Err(err) => {
+            let reason = err.reason();
+            mark_rpm_install_partial(&mut recovery, &reason);
+            return Err(rpm_install_needs_repair(
+                command,
+                component,
+                package,
+                &format!("dnf succeeded but ANOLISA state finalization failed ({reason})"),
+            ));
+        }
+    };
     warnings.extend(snapshot_warnings);
+
+    // installed.toml is authoritative once saved. A journal-finalization
+    // failure after that point is diagnostic only: the committed operation id
+    // lets future scans recognize and ignore the stale marker.
+    if let Err(err) = recovery.mark_persist_done() {
+        warnings.push(format!(
+            "installed state was saved but the RPM recovery journal could not mark state persistence complete: {err}"
+        ));
+    } else if let Err(err) = recovery.finish(TransactionOutcomeStatus::Ok) {
+        warnings.push(format!(
+            "installed state was saved but the RPM recovery journal could not be finalized: {err}"
+        ));
+    }
 
     let payload = DelegatedInstallPayload {
         component: component.to_string(),
@@ -855,7 +1000,7 @@ fn execute_delegated_install(
 }
 
 /// Persist a delegated install as `rpm-managed` state under the install lock,
-/// then append an audit record. Returns the operation id.
+/// then append an audit record. Returns datadir snapshot warnings.
 ///
 /// Mirrors [`execute_adopt`]'s state write but records ANOLISA ownership
 /// (`managed=true`, `adopted=false`, [`Ownership::RpmManaged`]) — the file
@@ -864,84 +1009,28 @@ fn execute_delegated_install(
 fn persist_delegated_install(
     ctx: &CliContext,
     layout: &FsLayout,
+    state: &mut InstalledState,
     command: &str,
     component: &str,
     package: &str,
     info: &PackageInfo,
     source_repo: Option<&str>,
     warnings: &[String],
-) -> Result<(String, Vec<String>), CliError> {
+    operation_id: &str,
+    started_at: &str,
+) -> Result<Vec<String>, CliError> {
     let evr = info.version.to_string();
-    let started_at = now_iso8601();
-
-    // Acquire the lock, then load state inside it so a concurrent writer is not
-    // clobbered — mirrors `execute_adopt`/`execute_raw` ordering.
-    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("failed to acquire install lock: {err}"),
-    })?;
-    let mut state =
-        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("failed to load installed state: {err}"),
-        })?;
-
-    // Re-validate against the freshly-reloaded state: a concurrent raw install
-    // may have won the lock and recorded the component first. Refuse rather than
-    // overwrite its provenance with rpm-managed.
-    ensure_component_backend_compatible(&state, component, "rpm", command)?;
-
-    let lock_ts = Utc::now();
-    let operation_id = format!(
-        "op-install-{}-{}",
-        lock_ts.format("%Y%m%d%H%M%S"),
-        lock_ts.timestamp_subsec_nanos()
+    record_rpm_managed_install(
+        state,
+        layout,
+        component,
+        info,
+        source_repo,
+        operation_id,
+        started_at,
+        command,
+        &now_iso8601(),
     );
-
-    // Delegated install is system-scope by construction (route_rpm_adopt
-    // rejects user mode before reaching the Absent branch).
-    state.install_mode = StateInstallMode::System;
-    state.prefix = layout.prefix.clone();
-    state.upsert_object(InstalledObject {
-        kind: ObjectKind::Component,
-        name: component.to_string(),
-        version: evr.clone(),
-        status: ObjectStatus::Installed,
-        manifest_digest: None,
-        // Not an ANOLISA-delivered raw artifact; dnf resolved the source.
-        distribution_source: None,
-        raw_package: None,
-        install_backend: Some("rpm".to_string()),
-        ownership: Some(Ownership::RpmManaged),
-        rpm_metadata: Some(RpmMetadata {
-            package_name: info.name.clone(),
-            evr: Some(evr.clone()),
-            arch: Some(info.arch.clone()),
-            source_repo: source_repo.map(str::to_string),
-        }),
-        installed_at: started_at.clone(),
-        last_operation_id: Some(operation_id.clone()),
-        // ANOLISA delegated the install and owns the removal (owns_removal=true).
-        managed: true,
-        // Not an adoption: ANOLISA drove the install.
-        adopted: false,
-        subscription_scope: Default::default(),
-        enabled_features: Vec::new(),
-        component_refs: Vec::new(),
-        // dnf owns the file transaction; RPM-owned files stay out of state.
-        files: Vec::new(),
-        external_modified_files: Vec::new(),
-        services: Vec::new(),
-        health: Vec::new(),
-        provisioned_packages: Vec::new(),
-    });
-    state.operations.push(OperationRecord {
-        id: operation_id.clone(),
-        command: command.to_string(),
-        status: "ok".to_string(),
-        started_at: started_at.clone(),
-        finished_at: Some(now_iso8601()),
-    });
 
     let state_path = layout.state_dir.join("installed.toml");
     state.save(&state_path).map_err(|err| CliError::Runtime {
@@ -961,7 +1050,7 @@ fn persist_delegated_install(
     let log = CentralLog::open(layout.central_log.clone());
     let record = LogRecord {
         kind: LogKind::Operation,
-        operation_id: Some(operation_id.clone()),
+        operation_id: Some(operation_id.to_string()),
         command: command.to_string(),
         source: "anolisa-cli".to_string(),
         component: Some(component.to_string()),
@@ -971,7 +1060,7 @@ fn persist_delegated_install(
         ),
         actor: "cli".to_string(),
         install_mode: Some(ctx.install_mode.as_str().to_string()),
-        started_at,
+        started_at: started_at.to_string(),
         finished_at: Some(now_iso8601()),
         status: Some(LogStatus::Ok),
         objects: vec![component.to_string()],
@@ -983,7 +1072,59 @@ fn persist_delegated_install(
         eprintln!("warning: failed to write central log: {err}");
     }
 
-    Ok((operation_id, snapshot_warnings))
+    Ok(snapshot_warnings)
+}
+
+fn rpm_recovery_error(
+    command: &str,
+    err: crate::commands::tier1::rpm_recovery::RpmRecoveryError,
+) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("RPM install recovery journal failure: {err}"),
+    }
+}
+
+pub(crate) fn reject_pending_rpm_install(
+    layout: &FsLayout,
+    state: &InstalledState,
+    component: &str,
+    command: &str,
+) -> Result<(), CliError> {
+    let state_path = layout.state_dir.join("installed.toml");
+    let journal_dir = layout.state_dir.join("journal");
+    let Some(pending) = find_pending_rpm_install(&journal_dir, &state_path, state, component)
+        .map_err(|err| rpm_recovery_error(command, err))?
+    else {
+        return Ok(());
+    };
+    Err(CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "component '{component}' has an unfinished RPM install {} for package '{}'; no install or adopt changes were made — recover it with `anolisa repair {component}`",
+            pending.operation_id(),
+            pending.package()
+        ),
+    })
+}
+
+fn mark_rpm_install_partial(recovery: &mut RpmInstallRecovery, reason: &str) {
+    let _ = recovery.mark_persist_failed(reason);
+    let _ = recovery.finish(TransactionOutcomeStatus::Partial);
+}
+
+fn rpm_install_needs_repair(
+    command: &str,
+    component: &str,
+    package: &str,
+    reason: &str,
+) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "{reason}; RPM package '{package}' may already be installed while ANOLISA state is incomplete — run `anolisa repair {component}`"
+        ),
+    }
 }
 
 /// Render a delegated-install result (JSON envelope or human text). Silent in

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -625,6 +625,10 @@ pub struct FakeInstaller {
     pub install_succeeds: bool,
     pub installed: RefCell<Option<PackageInfo>>,
     pub install_calls: Cell<usize>,
+    /// Fail rpmdb reads after dnf has populated the in-memory package.
+    pub fail_post_install_query: bool,
+    /// Create this directory after dnf succeeds to make state-file saving fail.
+    pub state_save_blocker: Option<PathBuf>,
 }
 
 impl FakeInstaller {
@@ -637,6 +641,8 @@ impl FakeInstaller {
             install_succeeds: true,
             installed: RefCell::new(None),
             install_calls: Cell::new(0),
+            fail_post_install_query: false,
+            state_save_blocker: None,
         }
     }
     pub fn with_origin(mut self, repo: &str) -> Self {
@@ -645,6 +651,14 @@ impl FakeInstaller {
     }
     pub fn failing_install(mut self) -> Self {
         self.install_succeeds = false;
+        self
+    }
+    pub fn failing_post_install_query(mut self) -> Self {
+        self.fail_post_install_query = true;
+        self
+    }
+    pub fn blocking_state_save(mut self, path: PathBuf) -> Self {
+        self.state_save_blocker = Some(path);
         self
     }
 
@@ -657,6 +671,12 @@ impl PackageQuery for FakeInstaller {
     fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
         if package != self.package {
             return Ok(None);
+        }
+        if self.fail_post_install_query && self.installed.borrow().is_some() {
+            return Err(PackageQueryError::UnexpectedOutput {
+                command: "rpm".to_string(),
+                detail: "simulated post-install rpmdb failure".to_string(),
+            });
         }
         Ok(self.installed.borrow().clone())
     }
@@ -728,6 +748,9 @@ impl PackageTransaction for FakeInstaller {
         }
         // rpmdb now holds the package, modelling dnf placing it.
         *self.installed.borrow_mut() = Some(self.installs_to.clone());
+        if let Some(path) = &self.state_save_blocker {
+            std::fs::create_dir_all(path).expect("create state-save blocker");
+        }
         Ok(())
     }
     fn update(&self, _package: &str) -> Result<(), PackageTransactionError> {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -9,6 +9,7 @@ use anolisa_core::state::{
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::commands::common;
+use crate::commands::tier1::rpm_recovery::begin_rpm_install;
 use tempfile::tempdir;
 
 #[test]
@@ -48,6 +49,44 @@ fn install_dry_run_resolves_without_writing_files() {
             .all(|name| !name.ends_with("agentsight.tar.gz")),
         "dry-run must not download the install artifact; cache entries: {cached_names:?}"
     );
+}
+
+#[test]
+fn raw_executor_rechecks_pending_rpm_journal_under_lock() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let env = anolisa_env::EnvService::detect();
+    let resolution = resolve_raw(
+        &ctx,
+        &layout,
+        &env,
+        ResolveInputs {
+            component: "agentsight".to_string(),
+            package: "agentsight".to_string(),
+            backend: "raw".to_string(),
+            base_url: repo_url,
+            version: None,
+            warnings: Vec::new(),
+        },
+    )
+    .expect("resolve raw artifact");
+    let prepared = prepare_raw_execution(&ctx, &layout, resolution).expect("prepare raw install");
+
+    begin_rpm_install(
+        layout.state_dir.join("installed.toml"),
+        &layout.state_dir.join("journal"),
+        "agentsight",
+        "agentsight",
+    )
+    .expect("seed marker after the dispatch-time check");
+
+    let err = execute_raw(&ctx, &layout, "install agentsight", prepared)
+        .expect_err("locked raw executor must recheck RPM recovery ownership");
+    assert!(err.reason().contains("repair agentsight"));
+    assert!(!layout.bin_dir.join("agentsight").exists());
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -6,9 +6,11 @@ use anolisa_core::state::{
     InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
     Ownership, RpmMetadata,
 };
+use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus, TransactionStepStatus};
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::commands::common;
+use crate::commands::tier1::rpm_recovery::begin_rpm_install;
 use crate::context::InstallMode;
 use crate::repo_config::RepoConfig;
 use crate::resolution::ResolutionUse;
@@ -614,6 +616,67 @@ fn adopt_origin_failure_degrades_to_none() {
     );
 }
 
+fn rpm_journals(ctx: &CliContext) -> Vec<Transaction> {
+    let journal_dir = common::resolve_layout(ctx).state_dir.join("journal");
+    let entries = match std::fs::read_dir(journal_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(err) => panic!("read journal dir: {err}"),
+    };
+    let mut paths = entries
+        .map(|entry| entry.expect("journal entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".journal.toml"))
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+        .into_iter()
+        .map(|path| Transaction::load_journal(&path).expect("load journal"))
+        .collect()
+}
+
+fn only_rpm_journal(ctx: &CliContext) -> Transaction {
+    let mut journals = rpm_journals(ctx);
+    assert_eq!(journals.len(), 1, "expected exactly one journal");
+    journals.pop().expect("journal")
+}
+
+fn tracked_component(component: &str, ownership: Ownership) -> InstalledObject {
+    let rpm = ownership == Ownership::RpmManaged;
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        version: "1.0.0".to_string(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: (!rpm).then(|| "file:///tmp/component.tar.gz".to_string()),
+        raw_package: None,
+        install_backend: Some(if rpm { "rpm" } else { "raw" }.to_string()),
+        ownership: Some(ownership),
+        rpm_metadata: rpm.then(|| RpmMetadata {
+            package_name: component.to_string(),
+            evr: Some("1.0.0".to_string()),
+            arch: Some("x86_64".to_string()),
+            source_repo: None,
+        }),
+        installed_at: "2026-06-01T10:00:00Z".to_string(),
+        last_operation_id: Some("op-concurrent".to_string()),
+        managed: true,
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
 #[test]
 fn delegated_install_writes_rpm_managed_state() {
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
@@ -652,6 +715,272 @@ fn delegated_install_writes_rpm_managed_state() {
     assert_eq!(meta.arch.as_deref(), Some("x86_64"));
     assert_eq!(meta.source_repo.as_deref(), Some("anolisa"));
     assert!(state.operations[0].id.starts_with("op-install-"));
+
+    let journal = only_rpm_journal(&ctx);
+    assert_eq!(journal.operation_id, state.operations[0].id);
+    assert_eq!(journal.status, TransactionOutcomeStatus::Ok);
+    assert_eq!(journal.steps.len(), 2);
+    assert_eq!(
+        (
+            journal.steps[0].phase.as_str(),
+            journal.steps[0].action.as_str(),
+            journal.steps[0].target.as_str(),
+        ),
+        ("rpm_install", "dnf_install", "copilot-shell")
+    );
+    assert_eq!(
+        (
+            journal.steps[1].phase.as_str(),
+            journal.steps[1].action.as_str(),
+            journal.steps[1].target.as_str(),
+        ),
+        ("persist_state", "record_rpm_managed", "copilot-shell")
+    );
+    assert!(
+        journal
+            .steps
+            .iter()
+            .all(|step| step.status == TransactionStepStatus::Done),
+        "both dnf and state-persistence steps must be complete"
+    );
+}
+
+#[test]
+fn delegated_install_lock_failure_precedes_journal_and_dnf() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    let _held = anolisa_core::lock::InstallLock::acquire(&layout.lock_file).expect("hold lock");
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+        .expect_err("held lock must fail before dnf");
+    assert!(err.reason().contains("install lock"));
+    assert_eq!(fake.install_calls.get(), 0);
+    assert!(rpm_journals(&ctx).is_empty(), "no marker before lock");
+}
+
+#[test]
+fn delegated_install_rechecks_concurrent_state_before_dnf() {
+    for ownership in [Ownership::RawManaged, Ownership::RpmManaged] {
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        let mut state = InstalledState {
+            install_mode: StateInstallMode::System,
+            prefix: layout.prefix.clone(),
+            ..Default::default()
+        };
+        state.upsert_object(tracked_component("copilot-shell", ownership));
+        state
+            .save(&layout.state_dir.join("installed.toml"))
+            .expect("seed concurrent state");
+        let fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
+
+        let err = execute_delegated_install(
+            &exec,
+            &ctx,
+            &layout,
+            "install copilot-shell",
+            "copilot-shell",
+            "copilot-shell",
+            None,
+        )
+        .expect_err("concurrent state must block delegated install");
+        assert!(err.reason().contains("changed"));
+        assert_eq!(fake.install_calls.get(), 0);
+        assert!(rpm_journals(&ctx).is_empty());
+    }
+}
+
+#[test]
+fn delegated_install_pending_journal_blocks_dnf() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    begin_rpm_install(
+        layout.state_dir.join("installed.toml"),
+        &layout.state_dir.join("journal"),
+        "copilot-shell",
+        "copilot-shell",
+    )
+    .expect("seed marker");
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+        .expect_err("pending marker must block a second dnf transaction");
+    assert!(err.reason().contains("repair"));
+    assert_eq!(fake.install_calls.get(), 0);
+}
+
+#[test]
+fn pending_journal_blocks_explicit_and_default_raw_routes() {
+    for backend in [Some("raw"), None] {
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+        let layout = common::resolve_layout(&ctx);
+        begin_rpm_install(
+            layout.state_dir.join("installed.toml"),
+            &layout.state_dir.join("journal"),
+            "copilot-shell",
+            "copilot-shell",
+        )
+        .expect("seed marker");
+        let fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
+        let mut a = args("copilot-shell");
+        a.backend = backend.map(str::to_string);
+
+        let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+            .expect_err("pending RPM marker must own the component across backends");
+        assert!(err.reason().contains("repair copilot-shell"));
+        assert_eq!(fake.install_calls.get(), 0);
+        assert!(
+            load_state(&ctx)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .is_none()
+        );
+    }
+}
+
+#[test]
+fn pending_journal_blocks_delegated_install_dry_run() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(true);
+    let layout = common::resolve_layout(&ctx);
+    begin_rpm_install(
+        layout.state_dir.join("installed.toml"),
+        &layout.state_dir.join("journal"),
+        "copilot-shell",
+        "copilot-shell",
+    )
+    .expect("seed marker");
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: false,
+    };
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+        .expect_err("dry-run must not preview an install blocked on RPM recovery");
+    assert!(err.reason().contains("repair copilot-shell"));
+    assert_eq!(fake.install_calls.get(), 0);
+}
+
+#[test]
+fn pending_journal_blocks_retry_from_becoming_rpm_observed() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    begin_rpm_install(
+        layout.state_dir.join("installed.toml"),
+        &layout.state_dir.join("journal"),
+        "copilot-shell",
+        "copilot-shell",
+    )
+    .expect("seed marker");
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    *fake.installed.borrow_mut() = Some(fake.installs_to.clone());
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+        .expect_err("pending marker must block the adopt route on retry");
+    assert!(err.reason().contains("repair copilot-shell"));
+    assert_eq!(fake.install_calls.get(), 0);
+    assert!(
+        load_state(&ctx)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .is_none(),
+        "retry must not downgrade the interrupted install to rpm-observed"
+    );
+    assert_eq!(
+        only_rpm_journal(&ctx).status,
+        TransactionOutcomeStatus::InFlight
+    );
+}
+
+#[test]
+fn delegated_install_reinstalls_tracked_rpm_missing_from_rpmdb() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    let mut state = InstalledState {
+        install_mode: StateInstallMode::System,
+        prefix: layout.prefix.clone(),
+        ..Default::default()
+    };
+    state.upsert_object(tracked_component("copilot-shell", Ownership::RpmManaged));
+    state
+        .save(&layout.state_dir.join("installed.toml"))
+        .expect("seed tracked RPM state");
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+
+    let outcome = handle_one_with_exec(
+        "copilot-shell".to_string(),
+        args("copilot-shell"),
+        &ctx,
+        &exec,
+    )
+    .expect("unchanged tracked RPM may be reinstalled when rpmdb is missing it");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 1);
+    let state = load_state(&ctx);
+    let object = state
+        .find_object(ObjectKind::Component, "copilot-shell")
+        .expect("tracked component remains recorded");
+    assert_eq!(object.ownership, Some(Ownership::RpmManaged));
+    assert_eq!(object.version, "2.3.0-1.al8");
 }
 
 #[test]
@@ -711,6 +1040,7 @@ fn delegated_install_dry_run_previews_without_txn_or_state() {
             .is_none(),
         "dry-run must not persist state"
     );
+    assert!(rpm_journals(&ctx).is_empty(), "dry-run must not journal");
 }
 
 #[test]
@@ -744,6 +1074,62 @@ fn delegated_install_dnf_failure_surfaces() {
             .is_none(),
         "failed install must not write state"
     );
+    let journal = only_rpm_journal(&ctx);
+    assert_eq!(journal.status, TransactionOutcomeStatus::Failed);
+    assert_eq!(journal.steps[0].status, TransactionStepStatus::Failed);
+}
+
+#[test]
+fn delegated_install_post_dnf_query_failure_stays_repairable() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    )
+    .failing_post_install_query();
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+        .expect_err("rpmdb failure after dnf must require repair");
+    assert!(err.reason().contains("repair copilot-shell"));
+    assert_eq!(fake.install_calls.get(), 1);
+    assert_eq!(
+        only_rpm_journal(&ctx).status,
+        TransactionOutcomeStatus::Partial,
+    );
+}
+
+#[test]
+fn delegated_install_state_save_failure_stays_repairable() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    )
+    .blocking_state_save(layout.state_dir.join("installed.toml"));
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+        .expect_err("state save failure after dnf must require repair");
+    assert!(err.reason().contains("repair copilot-shell"));
+    assert_eq!(fake.install_calls.get(), 1);
+    let journal = only_rpm_journal(&ctx);
+    assert_eq!(journal.status, TransactionOutcomeStatus::Partial);
+    assert_eq!(journal.steps[0].status, TransactionStepStatus::Done);
+    assert_eq!(journal.steps[1].status, TransactionStepStatus::Failed);
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -7,9 +7,10 @@
 //! dnf/rpm transaction and never switches backend — only rpmdb reads plus a
 //! state write.
 //!
-//! A package that has been `rpm -e`'d cannot be repaired: there is nothing to
-//! refresh from, so `repair` refuses and points at `anolisa forget`. Raw
-//! components have no rpmdb to reconcile against and are not handled yet.
+//! A pending delegated install can also be completed from its transaction
+//! journal when dnf committed the RPM but `installed.toml` was not saved. A
+//! tracked package that has since been `rpm -e`'d still cannot be repaired;
+//! raw components have no rpmdb to reconcile against and are not handled yet.
 
 use chrono::{SecondsFormat, Utc};
 use clap::Parser;
@@ -18,13 +19,21 @@ use serde::Serialize;
 use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
 use anolisa_core::lock::InstallLock;
 use anolisa_core::state::{ObjectKind, OperationRecord, Ownership, RpmMetadata};
+use anolisa_core::transaction::TransactionOutcomeStatus;
+use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
-use crate::commands::tier1::install::rpm_package_candidates_with_index;
+use crate::commands::tier1::install::{
+    rpm_package_candidates_with_index, snapshot_datadir_contract,
+};
+use crate::commands::tier1::rpm_recovery::{
+    RpmInstallRecovery, find_pending_rpm_install, load_pending_rpm_install,
+    record_rpm_managed_install,
+};
 use crate::context::CliContext;
 use crate::resolution::{ResolutionUse, load_optional_component_index};
 use crate::response::{CliError, render_json};
@@ -71,9 +80,9 @@ struct RepairPayload {
 ///
 /// # Errors
 ///
-/// Returns [`CliError`] when the component is absent, raw-backed (unsupported),
-/// the package is gone from rpmdb, the rpmdb read is ambiguous, or the state
-/// write fails.
+/// Returns [`CliError`] when neither state nor a recovery journal identifies
+/// the component, the component is raw-backed (unsupported), the package is
+/// gone from rpmdb, the rpmdb read is ambiguous, or the state write fails.
 pub fn handle(args: RepairArgs, ctx: &CliContext) -> Result<(), CliError> {
     let query = RpmPackageQuery::system();
     repair_with_query(&args.component, ctx, &query)
@@ -99,14 +108,28 @@ fn repair_with_query(
 
     let component = common::lookup_component_name(target, &installed, ctx, COMMAND);
 
-    let obj = installed
-        .find_object(ObjectKind::Component, &component)
-        .ok_or_else(|| CliError::InvalidArgument {
-            command: command.clone(),
-            reason: format!(
-                "component '{target}' is not installed — nothing to repair (run `anolisa status` to see what is installed)"
-            ),
-        })?;
+    let obj = match installed.find_object(ObjectKind::Component, &component) {
+        Some(obj) => obj,
+        None => {
+            let layout = common::resolve_layout(ctx);
+            let state_path = layout.state_dir.join("installed.toml");
+            let journal_dir = layout.state_dir.join("journal");
+            let pending = find_pending_rpm_install(
+                &journal_dir,
+                &state_path,
+                &installed,
+                &component,
+            )
+                .map_err(|err| rpm_recovery_error(&command, err))?
+                .ok_or_else(|| CliError::InvalidArgument {
+                    command: command.clone(),
+                    reason: format!(
+                        "component '{target}' is not installed — nothing to repair (run `anolisa status` to see what is installed)"
+                    ),
+                })?;
+            return repair_pending_rpm_install(ctx, query, &command, pending);
+        }
+    };
 
     let ownership = obj.effective_ownership();
     // Raw components have no rpmdb to reconcile against. Keep them on the same
@@ -221,6 +244,373 @@ fn repair_with_query(
     };
     render_repair(ctx, &payload);
     Ok(())
+}
+
+/// Recover an RPM install whose dnf transaction outlived its state commit.
+fn repair_pending_rpm_install(
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    command: &str,
+    pending: RpmInstallRecovery,
+) -> Result<(), CliError> {
+    if ctx.dry_run {
+        return preview_pending_rpm_repair(ctx, query, command, pending);
+    }
+
+    let layout = common::resolve_layout(ctx);
+    let state_path = layout.state_dir.join("installed.toml");
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state = common::load_installed_state(ctx, command)?;
+    if let Some(existing) = state.find_object(ObjectKind::Component, pending.component()) {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{}' appeared in state while RPM recovery was being prepared and is now tracked as {}; refusing to overwrite it",
+                pending.component(),
+                existing.effective_ownership().label()
+            ),
+        });
+    }
+
+    // Reload the exact marker and rescan under the lock. The path check guards
+    // against replacement, while the scan also rejects a newly-created second
+    // marker for the same component.
+    let expected_path = pending.journal_path().to_path_buf();
+    let expected_operation_id = pending.operation_id().to_string();
+    let expected_component = pending.component().to_string();
+    let expected_package = pending.package().to_string();
+    let exact = load_pending_rpm_install(&expected_path, &state_path)
+        .map_err(|err| rpm_recovery_error(command, err))?
+        .ok_or_else(|| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "RPM recovery journal {} is no longer pending; no state was changed",
+                expected_path.display()
+            ),
+        })?;
+    validate_pending_identity(
+        command,
+        &exact,
+        &expected_operation_id,
+        &expected_component,
+        &expected_package,
+    )?;
+    let mut recovery = find_pending_rpm_install(
+        &layout.state_dir.join("journal"),
+        &state_path,
+        &state,
+        &expected_component,
+    )
+    .map_err(|err| rpm_recovery_error(command, err))?
+    .ok_or_else(|| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "RPM recovery journal for component '{expected_component}' is no longer pending; no state was changed"
+        ),
+    })?;
+    validate_pending_identity(
+        command,
+        &recovery,
+        &expected_operation_id,
+        &expected_component,
+        &expected_package,
+    )?;
+
+    let info = match query.query_installed(&expected_package) {
+        Ok(Some(info)) => info,
+        Ok(None) => {
+            let reason = format!(
+                "rpmdb does not contain pending package '{expected_package}'; no ANOLISA state was committed"
+            );
+            recovery
+                .mark_install_failed(&reason)
+                .map_err(|err| pending_journal_update_error(command, &expected_component, err))?;
+            recovery
+                .mark_persist_failed(&reason)
+                .map_err(|err| pending_journal_update_error(command, &expected_component, err))?;
+            recovery
+                .finish(TransactionOutcomeStatus::Failed)
+                .map_err(|err| pending_journal_update_error(command, &expected_component, err))?;
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "pending RPM install for component '{expected_component}' was cleared because package '{expected_package}' is not installed; re-run `anolisa install --backend rpm {expected_component}`"
+                ),
+            });
+        }
+        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => {
+            let reason = format!("rpm returned unexpected output: {detail}");
+            mark_pending_query_partial(&mut recovery, &reason);
+            return Err(pending_rpm_query_error(
+                command,
+                &expected_component,
+                &expected_package,
+                &reason,
+            ));
+        }
+        Err(PackageQueryError::CommandMissing { .. }) => {
+            let reason = "rpm/dnf was not found";
+            mark_pending_query_partial(&mut recovery, reason);
+            return Err(pending_rpm_query_error(
+                command,
+                &expected_component,
+                &expected_package,
+                reason,
+            ));
+        }
+        Err(err) => {
+            let reason = format!("rpm query failed: {err}");
+            mark_pending_query_partial(&mut recovery, &reason);
+            return Err(pending_rpm_query_error(
+                command,
+                &expected_component,
+                &expected_package,
+                &reason,
+            ));
+        }
+    };
+
+    let mut warnings = Vec::new();
+    let source_repo = match query.installed_origin(&expected_package) {
+        Ok(origin) => origin,
+        Err(err) => {
+            warnings.push(format!(
+                "could not determine source repo for '{expected_package}': {err}"
+            ));
+            None
+        }
+    };
+    recovery
+        .mark_install_done()
+        .map_err(|err| pending_journal_update_error(command, &expected_component, err))?;
+
+    let finished_at = now_iso8601();
+    let install_command = format!("install {expected_component}");
+    record_rpm_managed_install(
+        &mut state,
+        &layout,
+        &expected_component,
+        &info,
+        source_repo.as_deref(),
+        &expected_operation_id,
+        recovery.started_at(),
+        &install_command,
+        &finished_at,
+    );
+    if let Err(err) = state.save(&state_path) {
+        let reason = format!("failed to save recovered RPM state: {err}");
+        let _ = recovery.mark_persist_failed(&reason);
+        let _ = recovery.finish(TransactionOutcomeStatus::Partial);
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "{reason}; pending install remains recoverable — run `anolisa repair {expected_component}` after fixing the state path"
+            ),
+        });
+    }
+
+    warnings.extend(snapshot_datadir_contract(
+        &layout,
+        &expected_component,
+        command,
+    ));
+    if let Err(err) = recovery.mark_persist_done() {
+        warnings.push(format!(
+            "recovered state was saved but the RPM recovery journal could not mark persistence complete: {err}"
+        ));
+    } else if let Err(err) = recovery.finish(TransactionOutcomeStatus::Ok) {
+        warnings.push(format!(
+            "recovered state was saved but the RPM recovery journal could not be finalized: {err}"
+        ));
+    }
+
+    append_pending_repair_log(
+        ctx,
+        &layout,
+        command,
+        &expected_component,
+        &expected_package,
+        &info,
+        &expected_operation_id,
+        recovery.started_at(),
+        &finished_at,
+        &warnings,
+    );
+    let payload = RepairPayload {
+        component: expected_component,
+        package: expected_package,
+        backend: "rpm",
+        ownership: Ownership::RpmManaged.label(),
+        install_mode: ctx.install_mode.as_str().to_string(),
+        from_version: None,
+        to_version: info.version.to_string(),
+        refreshed: true,
+        changed: true,
+        dry_run: false,
+        operation_id: Some(expected_operation_id),
+        warnings,
+    };
+    render_repair(ctx, &payload);
+    Ok(())
+}
+
+fn preview_pending_rpm_repair(
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    command: &str,
+    pending: RpmInstallRecovery,
+) -> Result<(), CliError> {
+    let package = pending.package().to_string();
+    let component = pending.component().to_string();
+    let info = match query.query_installed(&package) {
+        Ok(Some(info)) => info,
+        Ok(None) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "pending RPM package '{package}' is not installed; dry-run left the recovery marker unchanged — run `anolisa repair {component}` without --dry-run to clear it, then reinstall"
+                ),
+            });
+        }
+        Err(err) => {
+            return Err(pending_rpm_query_error(
+                command,
+                &component,
+                &package,
+                &err.to_string(),
+            ));
+        }
+    };
+    let mut warnings = Vec::new();
+    match query.installed_origin(&package) {
+        Ok(_) => {}
+        Err(err) => {
+            warnings.push(format!(
+                "could not determine source repo for '{package}': {err}"
+            ));
+        }
+    }
+    let payload = RepairPayload {
+        component,
+        package,
+        backend: "rpm",
+        ownership: Ownership::RpmManaged.label(),
+        install_mode: ctx.install_mode.as_str().to_string(),
+        from_version: None,
+        to_version: info.version.to_string(),
+        refreshed: false,
+        changed: true,
+        dry_run: true,
+        operation_id: None,
+        warnings,
+    };
+    render_repair(ctx, &payload);
+    Ok(())
+}
+
+fn validate_pending_identity(
+    command: &str,
+    pending: &RpmInstallRecovery,
+    operation_id: &str,
+    component: &str,
+    package: &str,
+) -> Result<(), CliError> {
+    if pending.operation_id() == operation_id
+        && pending.component() == component
+        && pending.package() == package
+    {
+        return Ok(());
+    }
+    Err(CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "RPM recovery journal changed while repair was being prepared; expected operation '{operation_id}' for component '{component}' and package '{package}', so no state was changed"
+        ),
+    })
+}
+
+fn mark_pending_query_partial(recovery: &mut RpmInstallRecovery, reason: &str) {
+    let _ = recovery.mark_persist_failed(reason);
+    let _ = recovery.finish(TransactionOutcomeStatus::Partial);
+}
+
+fn rpm_recovery_error(
+    command: &str,
+    err: crate::commands::tier1::rpm_recovery::RpmRecoveryError,
+) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("RPM install recovery journal failure: {err}"),
+    }
+}
+
+fn pending_journal_update_error(
+    command: &str,
+    component: &str,
+    err: anolisa_core::transaction::TransactionError,
+) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "failed to update the RPM recovery journal for component '{component}': {err}; no ANOLISA state was committed"
+        ),
+    }
+}
+
+fn pending_rpm_query_error(
+    command: &str,
+    component: &str,
+    package: &str,
+    reason: &str,
+) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "could not determine whether pending RPM package '{package}' for component '{component}' is installed ({reason}); recovery marker was retained and ANOLISA state was not changed"
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_pending_repair_log(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    command: &str,
+    component: &str,
+    package: &str,
+    info: &PackageInfo,
+    operation_id: &str,
+    started_at: &str,
+    finished_at: &str,
+    warnings: &[String],
+) {
+    let evr = info.version.to_string();
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.to_string()),
+        command: command.to_string(),
+        source: "anolisa-cli".to_string(),
+        component: Some(component.to_string()),
+        severity: Severity::Info,
+        message: format!(
+            "recovered rpm-managed state for component {component} from installed RPM package {package} ({evr})"
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at: started_at.to_string(),
+        finished_at: Some(finished_at.to_string()),
+        status: Some(LogStatus::Ok),
+        objects: vec![component.to_string()],
+        backup_ids: Vec::new(),
+        warnings: warnings.to_vec(),
+        details: serde_json::Value::Null,
+    };
+    if let Err(err) = CentralLog::open(layout.central_log.clone()).append(&record) {
+        eprintln!("warning: failed to write central log: {err}");
+    }
 }
 
 /// Resolve the RPM package name `repair` should reconcile against.
@@ -528,6 +918,7 @@ fn now_iso8601() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::tier1::rpm_recovery::begin_rpm_install;
     use crate::context::InstallMode;
 
     use std::{fs, path::PathBuf};
@@ -535,6 +926,7 @@ mod tests {
     use anolisa_core::state::{
         InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
     };
+    use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus, TransactionStepStatus};
     use anolisa_platform::pkg_query::PackageVersion;
 
     /// Configurable in-memory [`PackageQuery`] for the repair tests. Repair runs
@@ -743,6 +1135,182 @@ mod tests {
     fn load_state(ctx: &CliContext) -> InstalledState {
         let layout = common::resolve_layout(ctx);
         InstalledState::load(&layout.state_dir.join("installed.toml")).expect("load state")
+    }
+
+    fn seed_pending_rpm_install(
+        ctx: &CliContext,
+        component: &str,
+        package: &str,
+    ) -> (String, PathBuf) {
+        let layout = common::resolve_layout(ctx);
+        let mut recovery = begin_rpm_install(
+            layout.state_dir.join("installed.toml"),
+            &layout.state_dir.join("journal"),
+            component,
+            package,
+        )
+        .expect("begin pending install");
+        let operation_id = recovery.operation_id().to_string();
+        let journal_path = recovery.journal_path().to_path_buf();
+        recovery.mark_install_done().expect("dnf done marker");
+        recovery
+            .mark_persist_failed("simulated state commit failure")
+            .expect("persist failure marker");
+        recovery
+            .finish(TransactionOutcomeStatus::Partial)
+            .expect("partial marker");
+        (operation_id, journal_path)
+    }
+
+    #[test]
+    fn repair_recovers_installed_rpm_from_pending_journal() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        let contract_source = FsLayout::component_contract_path(&layout.datadir, "cosh");
+        fs::create_dir_all(contract_source.parent().expect("contract parent"))
+            .expect("create contract dir");
+        fs::write(
+            &contract_source,
+            "[component]\nname = \"cosh\"\nversion = \"2.3.0\"\n",
+        )
+        .expect("write contract");
+        let (operation_id, journal_path) = seed_pending_rpm_install(&c, "cosh", "copilot-shell");
+        let rpm = FakeQuery::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "aarch64")),
+        )
+        .with_origin("anolisa");
+
+        repair_with_query("cosh", &c, &rpm).expect("recover pending install");
+
+        let state = load_state(&c);
+        let obj = state
+            .find_object(ObjectKind::Component, "cosh")
+            .expect("recovered component");
+        assert_eq!(obj.version, "2.3.0-1.al8");
+        assert_eq!(obj.status, ObjectStatus::Installed);
+        assert_eq!(obj.ownership, Some(Ownership::RpmManaged));
+        assert_eq!(obj.install_backend.as_deref(), Some("rpm"));
+        assert!(obj.managed);
+        assert!(!obj.adopted);
+        assert_eq!(
+            obj.last_operation_id.as_deref(),
+            Some(operation_id.as_str())
+        );
+        let metadata = obj.rpm_metadata.as_ref().expect("rpm metadata");
+        assert_eq!(metadata.package_name, "copilot-shell");
+        assert_eq!(metadata.evr.as_deref(), Some("2.3.0-1.al8"));
+        assert_eq!(metadata.arch.as_deref(), Some("aarch64"));
+        assert_eq!(metadata.source_repo.as_deref(), Some("anolisa"));
+        let operation = state
+            .operations
+            .iter()
+            .find(|operation| operation.id == operation_id)
+            .expect("original install operation committed");
+        assert_eq!(operation.command, "install cosh");
+
+        let journal = Transaction::load_journal(&journal_path).expect("load finalized journal");
+        assert_eq!(journal.status, TransactionOutcomeStatus::Ok);
+        assert!(
+            journal
+                .steps
+                .iter()
+                .all(|step| step.status == TransactionStepStatus::Done)
+        );
+        let snapshot = common::installed_component_manifest_path(&layout, "cosh", "repair cosh")
+            .expect("snapshot path");
+        assert_eq!(
+            fs::read_to_string(snapshot).expect("read snapshot"),
+            fs::read_to_string(contract_source).expect("read source contract")
+        );
+    }
+
+    #[test]
+    fn repair_clears_pending_marker_when_rpm_is_absent() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let (_operation_id, journal_path) = seed_pending_rpm_install(&c, "cosh", "copilot-shell");
+        let rpm = FakeQuery::new("copilot-shell", None);
+
+        let err = repair_with_query("cosh", &c, &rpm)
+            .expect_err("absent pending package must clear marker and error");
+        assert!(err.reason().contains("was cleared"));
+        assert!(err.reason().contains("install --backend rpm cosh"));
+        let journal = Transaction::load_journal(&journal_path).expect("load failed journal");
+        assert_eq!(journal.status, TransactionOutcomeStatus::Failed);
+        assert!(
+            journal
+                .steps
+                .iter()
+                .all(|step| step.status == TransactionStepStatus::Failed)
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "cosh")
+                .is_none()
+        );
+        let layout = common::resolve_layout(&c);
+        assert!(
+            find_pending_rpm_install(
+                &layout.state_dir.join("journal"),
+                &layout.state_dir.join("installed.toml"),
+                &load_state(&c),
+                "cosh",
+            )
+            .expect("scan markers")
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn repair_keeps_pending_marker_partial_when_rpmdb_is_ambiguous() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let (_operation_id, journal_path) = seed_pending_rpm_install(&c, "cosh", "copilot-shell");
+        let rpm = FakeQuery::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1"), "x86_64")),
+        )
+        .multi_version();
+
+        let err = repair_with_query("cosh", &c, &rpm)
+            .expect_err("ambiguous rpmdb must preserve pending recovery");
+        assert!(err.reason().contains("marker was retained"));
+        assert_eq!(
+            Transaction::load_journal(&journal_path)
+                .expect("load partial journal")
+                .status,
+            TransactionOutcomeStatus::Partial
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "cosh")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn repair_pending_dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        let (_operation_id, journal_path) = seed_pending_rpm_install(&c, "cosh", "copilot-shell");
+        let before = fs::read(&journal_path).expect("read marker before dry-run");
+        let rpm = FakeQuery::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1"), "x86_64")),
+        );
+
+        repair_with_query("cosh", &c, &rpm).expect("dry-run preview");
+        assert_eq!(
+            fs::read(&journal_path).expect("read marker after dry-run"),
+            before
+        );
+        assert!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "cosh")
+                .is_none()
+        );
     }
 
     /// A drifted rpm-observed component refreshes its EVR/arch/source from rpmdb

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_recovery.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_recovery.rs
@@ -1,0 +1,593 @@
+//! Durable recovery markers for delegated RPM installs.
+//!
+//! RPM file transactions cannot be atomically committed with
+//! `installed.toml`. This module gives install and repair a shared journal
+//! contract so a completed dnf transaction can be reconciled after a crash or
+//! state-write failure without guessing package ownership.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anolisa_core::state::{
+    InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
+    OperationRecord, Ownership, RpmMetadata,
+};
+use anolisa_core::transaction::{
+    Transaction, TransactionError, TransactionOutcomeStatus, TransactionStep,
+};
+use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::PackageInfo;
+
+const OPERATION: &str = "install";
+const INSTALL_PHASE: &str = "rpm_install";
+const INSTALL_ACTION: &str = "dnf_install";
+const PERSIST_PHASE: &str = "persist_state";
+const PERSIST_ACTION: &str = "record_rpm_managed";
+
+/// Errors raised while creating or discovering RPM install recovery journals.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RpmRecoveryError {
+    /// A journal directory could not be read.
+    #[error("failed to read RPM recovery journals at {path}: {source}")]
+    Io {
+        /// Directory or entry path involved in the failure.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        #[source]
+        source: io::Error,
+    },
+    /// A transaction journal could not be loaded or updated.
+    #[error("RPM recovery journal error at {path}: {source}")]
+    Journal {
+        /// Journal file involved in the failure.
+        path: PathBuf,
+        /// Underlying transaction error.
+        #[source]
+        source: TransactionError,
+    },
+    /// More than one live journal claims the same component.
+    #[error(
+        "multiple pending RPM installs exist for component '{component}': {operation_ids}; refusing ambiguous recovery"
+    )]
+    Ambiguous {
+        /// Component named by the conflicting journals.
+        component: String,
+        /// Sorted operation ids for diagnostics.
+        operation_ids: String,
+    },
+    /// A live journal resembles the RPM contract but violates its invariants.
+    #[error("invalid RPM recovery journal at {path}: {reason}")]
+    InvalidContract {
+        /// Journal whose contract could not be trusted.
+        path: PathBuf,
+        /// Violated contract invariant.
+        reason: String,
+    },
+}
+
+/// Parsed journal contract for one delegated RPM install.
+#[derive(Debug)]
+pub(crate) struct RpmInstallRecovery {
+    transaction: Transaction,
+    component: String,
+    package: String,
+    install_step: usize,
+    persist_step: usize,
+}
+
+impl RpmInstallRecovery {
+    /// Component whose ANOLISA state must be finalized.
+    pub(crate) fn component(&self) -> &str {
+        &self.component
+    }
+
+    /// Backend-native RPM package passed to dnf.
+    pub(crate) fn package(&self) -> &str {
+        &self.package
+    }
+
+    /// Operation id shared by the journal and installed state.
+    pub(crate) fn operation_id(&self) -> &str {
+        &self.transaction.operation_id
+    }
+
+    /// Timestamp captured before dnf was invoked.
+    pub(crate) fn started_at(&self) -> &str {
+        &self.transaction.started_at
+    }
+
+    /// On-disk journal path used to revalidate recovery under the lock.
+    pub(crate) fn journal_path(&self) -> &Path {
+        &self.transaction.journal_path
+    }
+
+    /// Mark the dnf transaction as durably completed.
+    pub(crate) fn mark_install_done(&mut self) -> Result<(), TransactionError> {
+        self.transaction.mark_done(self.install_step)
+    }
+
+    /// Record that the dnf step failed before its result could be committed.
+    pub(crate) fn mark_install_failed(&mut self, reason: &str) -> Result<(), TransactionError> {
+        self.transaction.mark_failed(self.install_step, reason)
+    }
+
+    /// Mark the state-persistence step as durably completed.
+    pub(crate) fn mark_persist_done(&mut self) -> Result<(), TransactionError> {
+        self.transaction.mark_done(self.persist_step)
+    }
+
+    /// Record why the state-persistence step requires repair.
+    pub(crate) fn mark_persist_failed(&mut self, reason: &str) -> Result<(), TransactionError> {
+        self.transaction.mark_failed(self.persist_step, reason)
+    }
+
+    /// Finish the journal with the supplied aggregate outcome.
+    pub(crate) fn finish(
+        &mut self,
+        status: TransactionOutcomeStatus,
+    ) -> Result<(), TransactionError> {
+        self.transaction.finish(status)
+    }
+}
+
+/// Create and persist both planned steps before dnf may mutate the host.
+pub(crate) fn begin_rpm_install(
+    state_path: PathBuf,
+    journal_dir: &Path,
+    component: &str,
+    package: &str,
+) -> Result<RpmInstallRecovery, RpmRecoveryError> {
+    let mut transaction =
+        Transaction::begin(OPERATION, state_path, journal_dir).map_err(|source| {
+            RpmRecoveryError::Journal {
+                path: journal_dir.to_path_buf(),
+                source,
+            }
+        })?;
+    let journal_path = transaction.journal_path.clone();
+
+    let install_step = transaction.steps.len();
+    if let Err(source) = transaction.record_step(TransactionStep::planned(
+        INSTALL_PHASE,
+        package,
+        INSTALL_ACTION,
+        None,
+    )) {
+        let _ = transaction.finish(TransactionOutcomeStatus::Failed);
+        return Err(RpmRecoveryError::Journal {
+            path: journal_path,
+            source,
+        });
+    }
+
+    let persist_step = transaction.steps.len();
+    if let Err(source) = transaction.record_step(TransactionStep::planned(
+        PERSIST_PHASE,
+        component,
+        PERSIST_ACTION,
+        None,
+    )) {
+        let _ = transaction.finish(TransactionOutcomeStatus::Failed);
+        return Err(RpmRecoveryError::Journal {
+            path: journal_path,
+            source,
+        });
+    }
+
+    Ok(RpmInstallRecovery {
+        transaction,
+        component: component.to_string(),
+        package: package.to_string(),
+        install_step,
+        persist_step,
+    })
+}
+
+/// Find the unique live RPM install journal for `component`.
+///
+/// Journals whose operation id is already committed as `ok` in installed
+/// state are ignored. This prevents a post-commit journal-write failure from
+/// blocking a later reinstall after the original component is removed.
+pub(crate) fn find_pending_rpm_install(
+    journal_dir: &Path,
+    state_path: &Path,
+    state: &InstalledState,
+    component: &str,
+) -> Result<Option<RpmInstallRecovery>, RpmRecoveryError> {
+    let entries = match fs::read_dir(journal_dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(RpmRecoveryError::Io {
+                path: journal_dir.to_path_buf(),
+                source,
+            });
+        }
+    };
+
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| RpmRecoveryError::Io {
+            path: journal_dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".journal.toml"))
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    let mut matches = Vec::new();
+    for path in paths {
+        let transaction = load_validated_journal(&path, state_path)?;
+        let committed = state
+            .operations
+            .iter()
+            .any(|operation| operation.id == transaction.operation_id && operation.status == "ok");
+        if committed {
+            continue;
+        }
+        let Some(recovery) = parse_pending(transaction)? else {
+            continue;
+        };
+        if recovery.component() == component {
+            matches.push(recovery);
+        }
+    }
+
+    if matches.len() > 1 {
+        let operation_ids = matches
+            .iter()
+            .map(|recovery| recovery.operation_id().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(RpmRecoveryError::Ambiguous {
+            component: component.to_string(),
+            operation_ids,
+        });
+    }
+    Ok(matches.pop())
+}
+
+/// Reload one pending journal by path for lock-protected revalidation.
+pub(crate) fn load_pending_rpm_install(
+    path: &Path,
+    state_path: &Path,
+) -> Result<Option<RpmInstallRecovery>, RpmRecoveryError> {
+    let transaction = load_validated_journal(path, state_path)?;
+    parse_pending(transaction)
+}
+
+fn load_validated_journal(
+    path: &Path,
+    expected_state_path: &Path,
+) -> Result<Transaction, RpmRecoveryError> {
+    let transaction =
+        Transaction::load_journal(path).map_err(|source| RpmRecoveryError::Journal {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if transaction.journal_path != path {
+        return Err(RpmRecoveryError::InvalidContract {
+            path: path.to_path_buf(),
+            reason: format!(
+                "embedded journal_path '{}' does not match the loaded file",
+                transaction.journal_path.display()
+            ),
+        });
+    }
+    if transaction.state_path != expected_state_path {
+        return Err(RpmRecoveryError::InvalidContract {
+            path: path.to_path_buf(),
+            reason: format!(
+                "embedded state_path '{}' does not match current state '{}'; refusing recovery across state roots",
+                transaction.state_path.display(),
+                expected_state_path.display()
+            ),
+        });
+    }
+    let expected_name = format!("{}.journal.toml", transaction.operation_id);
+    if path.file_name().and_then(|name| name.to_str()) != Some(expected_name.as_str()) {
+        return Err(RpmRecoveryError::InvalidContract {
+            path: path.to_path_buf(),
+            reason: format!(
+                "file name does not match operation id '{}'",
+                transaction.operation_id
+            ),
+        });
+    }
+    Ok(transaction)
+}
+
+/// Add the state object and operation shared by install and journal recovery.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_rpm_managed_install(
+    state: &mut InstalledState,
+    layout: &FsLayout,
+    component: &str,
+    info: &PackageInfo,
+    source_repo: Option<&str>,
+    operation_id: &str,
+    started_at: &str,
+    command: &str,
+    finished_at: &str,
+) {
+    let evr = info.version.to_string();
+    state.install_mode = StateInstallMode::System;
+    state.prefix = layout.prefix.clone();
+    state.upsert_object(InstalledObject {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        version: evr.clone(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("rpm".to_string()),
+        ownership: Some(Ownership::RpmManaged),
+        rpm_metadata: Some(RpmMetadata {
+            package_name: info.name.clone(),
+            evr: Some(evr),
+            arch: Some(info.arch.clone()),
+            source_repo: source_repo.map(str::to_string),
+        }),
+        installed_at: started_at.to_string(),
+        last_operation_id: Some(operation_id.to_string()),
+        managed: true,
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    });
+    state.operations.push(OperationRecord {
+        id: operation_id.to_string(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: started_at.to_string(),
+        finished_at: Some(finished_at.to_string()),
+    });
+}
+
+fn parse_pending(transaction: Transaction) -> Result<Option<RpmInstallRecovery>, RpmRecoveryError> {
+    if transaction.operation != OPERATION
+        || !matches!(
+            transaction.status,
+            TransactionOutcomeStatus::InFlight | TransactionOutcomeStatus::Partial
+        )
+    {
+        return Ok(None);
+    }
+
+    let resembles_rpm_contract = transaction.steps.iter().any(|step| {
+        step.phase == INSTALL_PHASE
+            || step.action == INSTALL_ACTION
+            || step.action == PERSIST_ACTION
+    });
+    if !resembles_rpm_contract {
+        return Ok(None);
+    }
+    let invalid = |reason: &str| RpmRecoveryError::InvalidContract {
+        path: transaction.journal_path.clone(),
+        reason: reason.to_string(),
+    };
+    if transaction.steps.len() != 2 {
+        return Err(invalid("expected exactly two ordered steps"));
+    }
+    let install = &transaction.steps[0];
+    if install.phase != INSTALL_PHASE
+        || install.action != INSTALL_ACTION
+        || install.target.is_empty()
+    {
+        return Err(invalid(
+            "first step must identify a non-empty dnf package target",
+        ));
+    }
+    let persist = &transaction.steps[1];
+    if persist.phase != PERSIST_PHASE
+        || persist.action != PERSIST_ACTION
+        || persist.target.is_empty()
+    {
+        return Err(invalid(
+            "second step must identify a non-empty component state target",
+        ));
+    }
+    let install_step = 0;
+    let persist_step = 1;
+    let package = transaction.steps[install_step].target.clone();
+    let component = transaction.steps[persist_step].target.clone();
+
+    Ok(Some(RpmInstallRecovery {
+        transaction,
+        component,
+        package,
+        install_step,
+        persist_step,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anolisa_core::state::OperationRecord;
+    use tempfile::tempdir;
+
+    #[test]
+    fn pending_round_trip_preserves_component_and_package() {
+        let tmp = tempdir().expect("tmpdir");
+        let state_path = tmp.path().join("installed.toml");
+        let journal_dir = tmp.path().join("journal");
+        let recovery = begin_rpm_install(state_path.clone(), &journal_dir, "cosh", "copilot-shell")
+            .expect("begin");
+
+        let found = find_pending_rpm_install(
+            &journal_dir,
+            &state_path,
+            &InstalledState::default(),
+            "cosh",
+        )
+        .expect("scan")
+        .expect("pending journal");
+        assert_eq!(found.operation_id(), recovery.operation_id());
+        assert_eq!(found.component(), "cosh");
+        assert_eq!(found.package(), "copilot-shell");
+    }
+
+    #[test]
+    fn committed_operation_suppresses_stale_pending_journal() {
+        let tmp = tempdir().expect("tmpdir");
+        let state_path = tmp.path().join("installed.toml");
+        let journal_dir = tmp.path().join("journal");
+        let recovery = begin_rpm_install(state_path.clone(), &journal_dir, "cosh", "copilot-shell")
+            .expect("begin");
+        let mut state = InstalledState::default();
+        state.operations.push(OperationRecord {
+            id: recovery.operation_id().to_string(),
+            command: "install cosh".to_string(),
+            status: "ok".to_string(),
+            started_at: recovery.started_at().to_string(),
+            finished_at: Some(recovery.started_at().to_string()),
+        });
+
+        assert!(
+            find_pending_rpm_install(&journal_dir, &state_path, &state, "cosh")
+                .expect("scan")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn multiple_pending_journals_are_rejected() {
+        let tmp = tempdir().expect("tmpdir");
+        let state_path = tmp.path().join("installed.toml");
+        let journal_dir = tmp.path().join("journal");
+        begin_rpm_install(state_path.clone(), &journal_dir, "cosh", "copilot-shell")
+            .expect("first marker");
+        begin_rpm_install(state_path.clone(), &journal_dir, "cosh", "copilot-shell")
+            .expect("second marker");
+
+        let err = find_pending_rpm_install(
+            &journal_dir,
+            &state_path,
+            &InstalledState::default(),
+            "cosh",
+        )
+        .expect_err("ambiguous markers must fail closed");
+        assert!(matches!(err, RpmRecoveryError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn corrupt_journal_is_reported_deterministically() {
+        let tmp = tempdir().expect("tmpdir");
+        let journal_dir = tmp.path().join("journal");
+        let state_path = tmp.path().join("installed.toml");
+        fs::create_dir_all(&journal_dir).expect("journal dir");
+        fs::write(
+            journal_dir.join("broken.journal.toml"),
+            "this is not valid toml = [",
+        )
+        .expect("write corrupt marker");
+
+        let err = find_pending_rpm_install(
+            &journal_dir,
+            &state_path,
+            &InstalledState::default(),
+            "cosh",
+        )
+        .expect_err("corrupt marker must fail closed");
+        assert!(matches!(err, RpmRecoveryError::Journal { .. }));
+    }
+
+    #[test]
+    fn partial_rpm_contract_is_not_silently_ignored() {
+        let tmp = tempdir().expect("tmpdir");
+        let state_path = tmp.path().join("installed.toml");
+        let journal_dir = tmp.path().join("journal");
+        let recovery = begin_rpm_install(state_path.clone(), &journal_dir, "cosh", "copilot-shell")
+            .expect("marker");
+        let path = recovery.journal_path().to_path_buf();
+        let mut transaction = Transaction::load_journal(&path).expect("load marker");
+        transaction.steps.pop();
+        fs::write(
+            &path,
+            toml::to_string_pretty(&transaction).expect("serialize malformed marker"),
+        )
+        .expect("write malformed marker");
+
+        let err = find_pending_rpm_install(
+            &journal_dir,
+            &state_path,
+            &InstalledState::default(),
+            "cosh",
+        )
+        .expect_err("partial contract must fail closed");
+        assert!(matches!(err, RpmRecoveryError::InvalidContract { .. }));
+    }
+
+    #[test]
+    fn embedded_journal_path_cannot_redirect_recovery_writes() {
+        let tmp = tempdir().expect("tmpdir");
+        let state_path = tmp.path().join("installed.toml");
+        let journal_dir = tmp.path().join("journal");
+        let recovery = begin_rpm_install(state_path.clone(), &journal_dir, "cosh", "copilot-shell")
+            .expect("marker");
+        let path = recovery.journal_path().to_path_buf();
+        let redirected = tmp.path().join("redirected.journal.toml");
+        let mut transaction = Transaction::load_journal(&path).expect("load marker");
+        transaction.journal_path = redirected.clone();
+        fs::write(
+            &path,
+            toml::to_string_pretty(&transaction).expect("serialize tampered marker"),
+        )
+        .expect("write tampered marker");
+
+        let err = find_pending_rpm_install(
+            &journal_dir,
+            &state_path,
+            &InstalledState::default(),
+            "cosh",
+        )
+        .expect_err("embedded path mismatch must fail closed");
+        assert!(matches!(err, RpmRecoveryError::InvalidContract { .. }));
+        assert!(
+            !redirected.exists(),
+            "scanner must not follow embedded path"
+        );
+    }
+
+    #[test]
+    fn journal_from_another_state_root_is_rejected() {
+        let tmp = tempdir().expect("tmpdir");
+        let state_path = tmp.path().join("installed.toml");
+        let journal_dir = tmp.path().join("journal");
+        let recovery = begin_rpm_install(state_path.clone(), &journal_dir, "cosh", "copilot-shell")
+            .expect("marker");
+        let path = recovery.journal_path().to_path_buf();
+        let mut transaction = Transaction::load_journal(&path).expect("load marker");
+        transaction.state_path = tmp.path().join("other-state/installed.toml");
+        fs::write(
+            &path,
+            toml::to_string_pretty(&transaction).expect("serialize tampered marker"),
+        )
+        .expect("write tampered marker");
+
+        let err = find_pending_rpm_install(
+            &journal_dir,
+            &state_path,
+            &InstalledState::default(),
+            "cosh",
+        )
+        .expect_err("foreign state root must fail closed");
+        assert!(matches!(err, RpmRecoveryError::InvalidContract { .. }));
+    }
+}


### PR DESCRIPTION
## Description

Moves install locking and journal intent ahead of delegated dnf execution, then commits `rpm-managed` state with the same operation ID. Extends `repair` to recover an RPM that reached rpmdb when state finalization failed, while leaving ambiguous transactions partial and never automatically removing packages or shared dependencies. Pending RPM journals also block install/adopt retries and are path-bound before any recovery mutation.

## Related Issue

closes #1451

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`

Tests cover lock contention, concurrent ownership changes, post-dnf rpmdb and state-save failures, recovery for present and missing packages, duplicate/corrupt/tampered journals, and retry attempts that would otherwise be adopted as `rpm-observed`.

## Additional Notes

This does not change the installed-state schema, public CLI types, or RPM update behavior. Documentation is unchanged because the repair command and its successful JSON shape remain compatible.