### PR TITLE
feat(anolisa): show update and upgrade progress

### DIFF
--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "console",
  "dirs",
  "flate2",
+ "nix",
  "semver",
  "serde",
  "serde_json",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -45,7 +45,7 @@ chrono = { version = "0.4", default-features = false, features = [
 
 # Linux / System
 dirs = "6"
-nix = { version = "0.29", default-features = false, features = ["user", "fs", "socket"] }
+nix = { version = "0.29", default-features = false, features = ["user", "fs", "socket", "signal"] }
 
 # File integrity
 sha2 = "0.10"

--- a/src/anolisa/crates/anolisa-cli/Cargo.toml
+++ b/src/anolisa/crates/anolisa-cli/Cargo.toml
@@ -24,6 +24,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 console.workspace = true
 dirs.workspace = true
+nix.workspace = true
 ureq.workspace = true
 semver.workspace = true
 sha2.workspace = true

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -90,7 +90,10 @@ fn render_repo_config_provisioning(ctx: &CliContext, provisioning: &RepoConfigPr
         return;
     }
     let color = Palette::new(ctx.no_color);
-    match provisioning {
+    // Routed through `suspend_output` so these persistent lines cannot
+    // interleave with a live activity spinner (issue #1452); a no-op when no
+    // spinner is running, which is the case for most callers.
+    crate::progress::suspend_output(|| match provisioning {
         RepoConfigProvisioning::Existing => {}
         RepoConfigProvisioning::Downloaded { url, dest } => {
             println!(
@@ -115,7 +118,7 @@ fn render_repo_config_provisioning(ctx: &CliContext, provisioning: &RepoConfigPr
                 reason,
             );
         }
-    }
+    });
 }
 
 /// Controls whether a failed persistence of downloaded repo config is fatal.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -53,6 +53,7 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 use super::UpdateArgs;
 use crate::commands::common;
 use crate::context::CliContext;
+use crate::progress;
 use crate::repo_config::{BackendConfig, RepoConfig};
 use crate::resolution::{
     BackendKind, ComponentIndex, ComponentResolver, ResolutionSet, ResolutionUse, ResolveOptions,
@@ -258,15 +259,27 @@ pub(super) fn handle_update_check(args: &UpdateArgs, ctx: &CliContext) -> Result
         return Ok(());
     }
 
-    let report = match compute_update_check_report(args.target.as_deref(), ctx, &layout) {
-        Ok(report) => report,
-        Err(err) => {
-            // MOTD must stay quiet and low-noise on failure; a JSON/human check
-            // surfaces the error as usual.
-            if args.motd {
-                return Ok(());
+    // Show activity while the (potentially blocking) repo queries run, so a slow
+    // repository does not look like a hung process. The MOTD path stays
+    // low-noise and never animates. The guard cleans up on every exit path via
+    // RAII, including the error return below.
+    let feedback = if args.motd {
+        progress::FeedbackMode::Disabled
+    } else {
+        progress::feedback_for_stderr(ctx.json, ctx.quiet)
+    };
+    let report = {
+        let _activity = progress::Activity::start(feedback, "Checking for updates...");
+        match compute_update_check_report(args.target.as_deref(), ctx, &layout) {
+            Ok(report) => report,
+            Err(err) => {
+                // MOTD must stay quiet and low-noise on failure; a JSON/human
+                // check surfaces the error as usual.
+                if args.motd {
+                    return Ok(());
+                }
+                return Err(err);
             }
-            return Err(err);
         }
     };
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -51,6 +51,7 @@ use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
 use crate::context::{CliContext, InstallMode};
+use crate::progress::{self, Activity, ProgressReporter};
 use crate::response::{self, CliError};
 
 /// Command label for JSON envelopes and error routing.
@@ -112,6 +113,13 @@ pub fn handle(args: UpgradeArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     let layout = common::resolve_layout(ctx);
 
+    // A single activity spinner spans both planning and the apply transactions,
+    // so a slow repo query or `dnf` transaction never looks like a hung process.
+    // It is dropped (clearing the line) before `render_result` prints the final
+    // structured output, and on every early-return path via RAII.
+    let feedback = progress::feedback_for_stderr(ctx.json, ctx.quiet);
+    let activity = Activity::start(feedback, "Planning upgrade...");
+
     // Reuse the read-only planner behind `update --check`. This performs only
     // rpm/dnf *queries* — no transaction, no state write.
     let report = check::compute_update_check_report(args.target.as_deref(), ctx, &layout)?;
@@ -140,8 +148,11 @@ pub fn handle(args: UpgradeArgs, ctx: &CliContext) -> Result<(), CliError> {
         privilege::is_root(),
         ctx.dry_run,
         COMMAND,
+        &activity,
     )?;
 
+    // Clear the spinner before the final result is rendered to stdout.
+    drop(activity);
     render_result(ctx, &result);
 
     // A non-`ok` status has already been rendered (human or JSON); propagate a
@@ -613,8 +624,11 @@ fn run_upgrade_with_deps(
     is_root: bool,
     dry_run: bool,
     command: &str,
+    reporter: &dyn ProgressReporter,
 ) -> Result<UpgradeResult, CliError> {
     if dry_run {
+        // Dry-run only planned; it never applies a transaction, so it reports no
+        // apply-phase progress (planning feedback is handled by the caller).
         return Ok(render_plan_preview(plan));
     }
 
@@ -657,6 +671,15 @@ fn run_upgrade_with_deps(
         let authorized = authorize_plan(&state, plan);
         errors.extend(authorized.errors);
 
+        // Reliable total for the `i/total` counter: only the items that actually
+        // run a `dnf` transaction (CLI update + authorized component updates and
+        // installs). Observed-default recording touches no transaction and is
+        // folded into the finalize phase, so it is deliberately excluded — the
+        // counter never advertises work that has no `dnf` step.
+        let transaction_total =
+            plan.cli.is_some() as usize + authorized.updates.len() + authorized.installs.len();
+        let mut transaction_step = 0usize;
+
         // The CLI update is applied first and reported, but is never an ANOLISA
         // component object (the binary is rpm-owned). Held separately so the
         // audit step can count it toward the outcome even on a CLI-only upgrade.
@@ -669,6 +692,11 @@ fn run_upgrade_with_deps(
         // 1. CLI package (rpm-owned binary). Reported but never recorded as a
         //    component object, so it is not gated on component state.
         if let Some(cli) = &plan.cli {
+            transaction_step += 1;
+            reporter.report(&format!(
+                "Upgrading {} ({transaction_step}/{transaction_total})...",
+                cli.name
+            ));
             match txn.update(&cli.package) {
                 Ok(()) => match refresh_evr(query, &cli.package) {
                     Ok(to) => {
@@ -693,6 +721,11 @@ fn run_upgrade_with_deps(
 
         // 2. Already-installed RPM-backed components authorized by locked state.
         for update in authorized.updates {
+            transaction_step += 1;
+            reporter.report(&format!(
+                "Upgrading {} ({transaction_step}/{transaction_total})...",
+                update.name
+            ));
             match txn.update(&update.package) {
                 Ok(()) => match query.query_installed(&update.package) {
                     Ok(Some(info)) => {
@@ -732,6 +765,11 @@ fn run_upgrade_with_deps(
 
         // 3. Missing default components authorized by locked state.
         for install in authorized.installs {
+            transaction_step += 1;
+            reporter.report(&format!(
+                "Installing {} ({transaction_step}/{transaction_total})...",
+                install.name
+            ));
             match txn.install(&install.package) {
                 Ok(()) => match query.query_installed(&install.package) {
                     Ok(Some(info)) => {
@@ -802,6 +840,7 @@ fn run_upgrade_with_deps(
 
         // Refresh ANOLISA state and write the durable audit while the same lock
         // that authorized the RPM work is still held.
+        reporter.report("Finalizing ANOLISA state...");
         let outcome = finalize_upgrade(FinalizeUpgrade {
             ctx,
             layout,
@@ -1244,7 +1283,11 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
     if let Err(err) = log.append(&record)
         && !ctx.quiet
     {
-        eprintln!("warning: failed to write central log: {err}");
+        // Routed through `suspend_output` so this warning never collides with
+        // the "Finalizing ANOLISA state..." spinner frame (issue #1452).
+        progress::suspend_output(|| {
+            eprintln!("warning: failed to write central log: {err}");
+        });
     }
 
     Ok(outcome)

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -13,6 +13,11 @@ use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion
 
 use anolisa_core::state::{InstalledObject, InstalledState, RpmMetadata, SubscriptionScope};
 
+// `Activity` and `ProgressReporter` reach the tests through the module glob
+// (`use super::*`); `NoopReporter` is the only progress item not re-imported by
+// the upgrade module, so it is brought in explicitly here.
+use crate::progress::NoopReporter;
+
 // ── fake host ────────────────────────────────────────────────────────────────
 
 /// In-memory host: `query_installed` returns the configured post-transaction
@@ -304,8 +309,18 @@ fn upgrade_real_execution_without_root_is_rejected_with_sudo_hint() {
     let host = FakeHost::default();
     let plan = build_plan(None, &cli_noop(), &[]);
 
-    let err = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, false, false, COMMAND)
-        .expect_err("non-root real execution must be rejected");
+    let err = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        false,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect_err("non-root real execution must be rejected");
     assert_eq!(err.code(), "EXECUTION_FAILED");
     assert!(err.reason().contains("sudo anolisa upgrade"));
     assert!(host.txn_calls().is_empty(), "no dnf on a rejected run");
@@ -337,8 +352,18 @@ fn upgrade_dry_run_apply_runs_without_root_and_touches_nothing() {
         )],
     );
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, false, true, COMMAND)
-        .expect("dry-run is allowed without root");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        false,
+        true,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("dry-run is allowed without root");
     assert!(result.dry_run);
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(result.updated.len(), 1);
@@ -475,8 +500,18 @@ fn plan_errors_block_real_execution_before_dnf() {
     );
     assert!(plan.has_errors());
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("blocked plan renders rather than erroring");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("blocked plan renders rather than erroring");
     assert_eq!(result.status, STATUS_BLOCKED);
     assert!(!result.dry_run);
     assert!(
@@ -511,8 +546,18 @@ fn raw_managed_component_is_skipped_and_never_transacted() {
         )],
     );
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(result.skipped.len(), 1);
     assert_eq!(result.skipped[0].reason, RAW_SKIP_REASON);
@@ -576,8 +621,18 @@ fn transaction_order_is_cli_then_updates_then_installs() {
     ];
     let plan = build_plan(None, &cli, &components);
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(
         host.txn_calls(),
@@ -614,8 +669,18 @@ fn installed_default_is_recorded_as_rpm_managed_after_refresh() {
         )],
     );
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(result.installed.len(), 1);
     assert_eq!(result.installed[0].version.as_deref(), Some("1.0.0-1.al4"));
@@ -663,8 +728,18 @@ fn origin_lookup_failure_is_warning_not_apply_failure() {
         )],
     );
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(result.warnings.len(), 1);
     assert!(result.warnings[0].contains("could not determine source repo"));
@@ -714,8 +789,18 @@ fn origin_lookup_failure_preserves_existing_source_repo() {
         )],
     );
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(result.warnings.len(), 1);
 
@@ -778,8 +863,18 @@ fn partial_transaction_failure_is_reported_and_not_claimed_as_success() {
     ];
     let plan = build_plan(None, &cli_noop(), &components);
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(
         result.status, STATUS_PARTIAL,
         "must not claim clean success"
@@ -835,8 +930,18 @@ fn install_does_not_overwrite_existing_raw_managed_component() {
         )],
     );
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_FAILED, "nothing landed cleanly");
     assert!(result.installed.is_empty());
     assert_eq!(result.errors.len(), 1);
@@ -884,8 +989,18 @@ fn update_state_drift_missing_object_is_reported_as_error() {
         )],
     );
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(
         result.status, STATUS_FAILED,
         "a dnf success with no state refresh must not be reported as ok"
@@ -925,8 +1040,18 @@ fn observed_default_update_missing_from_state_is_recorded_as_rpm_observed() {
     observed_default.absent_from_state = true;
     let plan = build_plan(None, &cli_noop(), &[observed_default]);
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(result.updated.len(), 1);
     assert!(result.errors.is_empty());
@@ -973,8 +1098,18 @@ fn observed_default_noop_missing_from_state_is_recorded_without_dnf() {
     observed_default.absent_from_state = true;
     let plan = build_plan(None, &cli_noop(), &[observed_default]);
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert!(result.updated.is_empty(), "no package update happened");
     assert_eq!(result.recorded.len(), 1);
@@ -1019,8 +1154,18 @@ fn cli_only_upgrade_records_durable_audit() {
     );
     let plan = build_plan(None, &cli, &[]);
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_OK);
     assert_eq!(result.updated.len(), 1);
     assert_eq!(result.updated[0].name, "anolisa");
@@ -1069,8 +1214,18 @@ fn cli_success_with_component_failure_records_partial_audit() {
     )];
     let plan = build_plan(None, &cli, &components);
 
-    let result = run_upgrade_with_deps(&ctx, &layout, &plan, &host, &host, true, false, COMMAND)
-        .expect("apply");
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("apply");
     assert_eq!(result.status, STATUS_PARTIAL);
     assert_eq!(result.updated.len(), 1);
     assert_eq!(result.updated[0].name, "anolisa");
@@ -1082,5 +1237,236 @@ fn cli_success_with_component_failure_records_partial_audit() {
         state.operations.last().map(|op| op.status.as_str()),
         Some("partial"),
         "CLI success + component failure must record a partial operation"
+    );
+}
+
+// ── progress reporting (issue #1452) ─────────────────────────────────────────
+
+/// Records the phase messages emitted during the apply loop so tests can assert
+/// the exact sequence without a TTY or animated-frame timing.
+#[derive(Default)]
+struct RecordingReporter {
+    messages: RefCell<Vec<String>>,
+}
+
+impl RecordingReporter {
+    fn messages(&self) -> Vec<String> {
+        self.messages.borrow().clone()
+    }
+}
+
+impl ProgressReporter for RecordingReporter {
+    fn report(&self, message: &str) {
+        self.messages.borrow_mut().push(message.to_string());
+    }
+}
+
+/// A real apply reports each transaction item with a reliable `i/total`, then a
+/// finalize phase, in order: CLI → component update → install → finalizing.
+#[test]
+fn apply_reports_each_phase_with_reliable_counts() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default()
+        .with_installed("anolisa", info("anolisa", "1.0.0", Some("1.al4")))
+        .with_installed(
+            "copilot-shell",
+            info("copilot-shell", "1.1.0", Some("1.al4")),
+        )
+        .with_installed("agent-memory", info("agent-memory", "1.0.0", Some("1.al4")));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        )],
+    );
+
+    let cli = cli_check(
+        ACTION_UPDATE,
+        Some("anolisa"),
+        Some("0.5.0-1.al4"),
+        Some("1.0.0-1.al4"),
+        None,
+    );
+    let components = vec![
+        component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        ),
+        component_check(
+            "agent-memory",
+            Some("agent-memory"),
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        ),
+    ];
+    let plan = build_plan(None, &cli, &components);
+    let reporter = RecordingReporter::default();
+
+    let result = run_upgrade_with_deps(
+        &ctx, &layout, &plan, &host, &host, true, false, COMMAND, &reporter,
+    )
+    .expect("apply");
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(
+        reporter.messages(),
+        vec![
+            "Upgrading anolisa (1/3)...".to_string(),
+            "Upgrading cosh (2/3)...".to_string(),
+            "Installing agent-memory (3/3)...".to_string(),
+            "Finalizing ANOLISA state...".to_string(),
+        ],
+        "each transaction reports a reliable i/total, then finalizing"
+    );
+}
+
+/// A dry-run plans only; it must not report any apply-phase progress.
+#[test]
+fn dry_run_reports_no_apply_phase() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(
+        Some("agentic_os-latest".to_string()),
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+    let reporter = RecordingReporter::default();
+
+    let result = run_upgrade_with_deps(
+        &ctx, &layout, &plan, &host, &host, false, true, COMMAND, &reporter,
+    )
+    .expect("dry-run");
+    assert!(result.dry_run);
+    assert!(
+        reporter.messages().is_empty(),
+        "dry-run must not report an apply phase that never happens"
+    );
+}
+
+/// A per-item transaction failure still reports the item (its message is emitted
+/// before the failing `dnf` call) and still reaches the finalize phase, so the
+/// reporter contract holds on the error path.
+#[test]
+fn apply_reports_phases_even_when_an_item_fails() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "1.1.0", Some("1.al4")),
+    );
+    host.fail_update.insert("agent-sec-core".to_string());
+    // Both components are seeded so they are authorized against locked state and
+    // both reach the `dnf` layer; only the second one's transaction fails there.
+    seed_state(
+        &layout,
+        vec![
+            rpm_component(
+                "cosh",
+                "copilot-shell",
+                "1.0.0-1.al4",
+                Ownership::RpmManaged,
+            ),
+            rpm_component(
+                "sec-core",
+                "agent-sec-core",
+                "1.0.0-1.al4",
+                Ownership::RpmManaged,
+            ),
+        ],
+    );
+    let components = vec![
+        component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        ),
+        component_check(
+            "sec-core",
+            Some("agent-sec-core"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        ),
+    ];
+    let plan = build_plan(None, &cli_noop(), &components);
+    let reporter = RecordingReporter::default();
+
+    let result = run_upgrade_with_deps(
+        &ctx, &layout, &plan, &host, &host, true, false, COMMAND, &reporter,
+    )
+    .expect("apply");
+    assert_eq!(result.status, STATUS_PARTIAL);
+    assert_eq!(
+        reporter.messages(),
+        vec![
+            "Upgrading cosh (1/2)...".to_string(),
+            "Upgrading sec-core (2/2)...".to_string(),
+            "Finalizing ANOLISA state...".to_string(),
+        ],
+        "a failing item is still announced and the finalize phase still runs"
+    );
+}
+
+/// A blocked plan (planning error) never reaches the apply loop, so no phase is
+/// reported — real execution aborts before any `dnf` transaction.
+#[test]
+fn blocked_plan_reports_no_apply_phase() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "mystery",
+            None,
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        )],
+    );
+    assert!(plan.has_errors());
+    let reporter = RecordingReporter::default();
+
+    let result = run_upgrade_with_deps(
+        &ctx, &layout, &plan, &host, &host, true, false, COMMAND, &reporter,
+    )
+    .expect("blocked plan renders");
+    assert_eq!(result.status, STATUS_BLOCKED);
+    assert!(
+        reporter.messages().is_empty(),
+        "a blocked plan must not report an apply phase"
     );
 }

--- a/src/anolisa/crates/anolisa-cli/src/main.rs
+++ b/src/anolisa/crates/anolisa-cli/src/main.rs
@@ -5,6 +5,7 @@ mod color;
 mod commands;
 mod context;
 mod packaged;
+mod progress;
 mod repo_config;
 mod resolution;
 mod response;

--- a/src/anolisa/crates/anolisa-cli/src/progress.rs
+++ b/src/anolisa/crates/anolisa-cli/src/progress.rs
@@ -1,0 +1,761 @@
+//! Transient interactive activity feedback for long-running human-readable
+//! commands (issue #1452).
+//!
+//! Repository queries, upgrade planning, and `dnf` transactions can each block
+//! for a long time with no visible output, so a healthy run is
+//! indistinguishable from a hung process. This module provides an injectable
+//! [`ProgressReporter`] plus an [`Activity`] guard that renders feedback in one
+//! of two ways, chosen by [`feedback_mode`], without ever touching the
+//! structured stdout/JSON contract:
+//!
+//! - **Animated** (interactive, ANSI-capable terminal): a background spinner on
+//!   stderr, repainted in place.
+//! - **Static** (interactive terminal that cannot animate — `TERM=dumb`, an
+//!   unknown/zero width, or a spinner thread that failed to spawn): a single
+//!   plain stderr line per phase, no ANSI and no repaint. This keeps a feedback
+//!   channel for users the animated path cannot serve, instead of going silent
+//!   and reintroducing the "looks hung" problem.
+//!
+//! `--json`, `--quiet`, and a non-TTY stderr all resolve to **Disabled**: no
+//! thread, no writes, no control sequences.
+//!
+//! Other design points:
+//! - **Never wrap**: an animated frame is painted only when the terminal width
+//!   is known and the frame fits one physical line ([`fit_line`]); otherwise the
+//!   painter falls back to a one-time static line for that message, so a frame
+//!   `clear_line` could not fully erase is never emitted.
+//! - **No competing output**: while an animated spinner is live, occasional
+//!   persistent lines (repo-config deprecation, provisioning result,
+//!   central-log warning) go through [`suspend_output`], which parks the painter
+//!   and clears the frame so the two never interleave.
+//! - **Injectable phases**: the apply loop takes a `&dyn `[`ProgressReporter`]
+//!   so tests can record the exact phase messages with a fake sink.
+//! - **Reliable cleanup**: the animated painter owns *every* terminal write,
+//!   including the final clear it performs as its last action before publishing
+//!   [`SIG_DONE`]. On Ctrl+C the scoped SIGINT handler ([`on_sigint`]) never
+//!   writes itself — it only asks the painter to stop and waits for that final
+//!   clear — so an in-flight frame can never overwrite the cleanup. The cursor
+//!   is never hidden.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use console::{Term, measure_text_width};
+use nix::libc;
+use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, SigmaskHow, Signal, sigaction};
+
+/// Braille spinner frames. Unicode is already used elsewhere in the CLI (see
+/// `color.rs`), so no ASCII fallback is needed for the animated path (which only
+/// runs on ANSI-capable terminals anyway).
+const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Interval between spinner frames.
+const TICK: Duration = Duration::from_millis(100);
+
+/// Granularity at which the painter polls the stop flags while waiting out a
+/// [`TICK`], so shutdown (drop or Ctrl+C) is observed promptly.
+const STOP_POLL: Duration = Duration::from_millis(10);
+
+/// Upper bound on the SIGINT handler's spin-wait for the painter to finish its
+/// final clear. This is only a hang-guard for a painter that is wedged or
+/// starved; in the normal case the wait ends in well under a tick. It does not
+/// weaken correctness: the handler never writes to the terminal, so timing out
+/// cannot cause a clear to be overwritten — at worst a wedged painter leaves its
+/// last frame, which no design could safely erase while that write is stuck.
+const SIGINT_SPIN_LIMIT: u32 = 20_000_000;
+
+/// The active animated spinner's shared state, published while it is live so
+/// [`suspend_output`] can coordinate with the painter from another call path.
+/// At most one spinner is live at a time in this CLI (never nested).
+static ACTIVE: Mutex<Option<Arc<SpinnerState>>> = Mutex::new(None);
+
+/// Set by the SIGINT handler to tell the painter to stop. Global (not a field)
+/// because the async-signal-safe handler cannot reach the `Arc` state.
+static SIG_STOP: AtomicBool = AtomicBool::new(false);
+
+/// Published by the painter after it has performed its final clear and will not
+/// write again. The SIGINT handler waits on this so it never re-raises before
+/// the terminal has been cleaned up.
+static SIG_DONE: AtomicBool = AtomicBool::new(false);
+
+/// Report transient phase messages during a long operation.
+///
+/// Production code uses [`Activity`]; tests use a recording fake to assert the
+/// exact phase sequence without a TTY.
+pub(crate) trait ProgressReporter {
+    /// Replace the currently displayed activity message.
+    fn report(&self, message: &str);
+}
+
+/// A [`ProgressReporter`] that discards every message.
+///
+/// Production code always passes a live [`Activity`] (which is itself inert when
+/// disabled), so this exists only for tests that exercise the apply path without
+/// asserting on progress output.
+#[cfg(test)]
+pub(crate) struct NoopReporter;
+
+#[cfg(test)]
+impl ProgressReporter for NoopReporter {
+    fn report(&self, _message: &str) {}
+}
+
+/// How a command should surface transient activity feedback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FeedbackMode {
+    /// No feedback: `--json`, `--quiet`, or a non-interactive stderr.
+    Disabled,
+    /// In-place stderr spinner on an ANSI-capable interactive terminal.
+    Animated,
+    /// One plain stderr line per phase when the terminal cannot animate.
+    Static,
+}
+
+/// Decide the feedback mode from the output-mode flags and terminal facts.
+///
+/// Kept pure so the policy is unit-testable without a real TTY. Machine output
+/// (`--json`), silence (`--quiet`), and a non-TTY stderr all suppress feedback;
+/// an interactive terminal animates when ANSI-capable and otherwise falls back
+/// to static lines rather than going silent.
+pub(crate) fn feedback_mode(
+    json: bool,
+    quiet: bool,
+    stderr_is_tty: bool,
+    ansi_capable: bool,
+) -> FeedbackMode {
+    if json || quiet || !stderr_is_tty {
+        FeedbackMode::Disabled
+    } else if ansi_capable {
+        FeedbackMode::Animated
+    } else {
+        FeedbackMode::Static
+    }
+}
+
+/// Resolve [`feedback_mode`] against the live stderr terminal.
+pub(crate) fn feedback_for_stderr(json: bool, quiet: bool) -> FeedbackMode {
+    feedback_mode(json, quiet, stderr_is_tty(), terminal_ansi_capable())
+}
+
+/// Whether the process's stderr is an interactive terminal.
+fn stderr_is_tty() -> bool {
+    Term::stderr().is_term()
+}
+
+/// Whether `$TERM` denotes a terminal that can interpret ANSI control
+/// sequences. A `dumb` (or empty/unset) terminal cannot, so the animated path
+/// is not used there.
+fn terminal_ansi_capable() -> bool {
+    ansi_capable_for(std::env::var("TERM").ok().as_deref())
+}
+
+fn ansi_capable_for(term: Option<&str>) -> bool {
+    matches!(term, Some(t) if !t.is_empty() && t != "dumb")
+}
+
+/// Run `f`, parking the active animated spinner (if any) and clearing its frame
+/// for the duration so a persistent line written by `f` cannot interleave with,
+/// or be erased by, spinner repaints. A no-op wrapper when no animated spinner
+/// is live (including static mode), so it is safe to route every occasional CLI
+/// line through it unconditionally.
+pub(crate) fn suspend_output<T>(f: impl FnOnce() -> T) -> T {
+    let Some(state) = active_state() else {
+        return f();
+    };
+    // The SIGINT handler waits for the painter. Keep it from interrupting this
+    // thread while it owns the paint lock the painter needs for its final clear.
+    // Locals drop in reverse order, so `_paint` unlocks before the mask restores.
+    let _sigint_block = ScopedSigintBlock::block().ok();
+    // Hold the paint lock for the whole of `f`: the painter also takes it each
+    // tick, so it cannot repaint until `f` returns and its output is flushed.
+    let _paint = state.lock_paint();
+    let _ = Term::stderr().clear_line();
+    f()
+}
+
+/// Emit a single plain stderr line (no ANSI, no repaint) — the static-feedback
+/// primitive, safe on terminals that cannot interpret control sequences.
+fn emit_static_line(message: &str) {
+    let _ = Term::stderr().write_line(message);
+}
+
+/// A transient activity guard.
+///
+/// Construct with [`Activity::start`]; the mode decides whether it animates,
+/// prints static lines, or does nothing. Dropping it tears down the animated
+/// spinner (join the worker, restore SIGINT); the other modes need no cleanup.
+pub(crate) struct Activity {
+    inner: ActivityInner,
+}
+
+enum ActivityInner {
+    Disabled,
+    Static(StaticHint),
+    Animated(AnimatedSpinner),
+}
+
+impl Activity {
+    /// Start feedback for `message` in the given [`FeedbackMode`].
+    ///
+    /// An `Animated` request whose worker thread cannot be spawned degrades to
+    /// `Static` — a non-critical progress hint must never crash the command, and
+    /// falling back keeps a feedback channel rather than going silent.
+    pub(crate) fn start(mode: FeedbackMode, message: &str) -> Self {
+        let inner = match mode {
+            FeedbackMode::Disabled => ActivityInner::Disabled,
+            FeedbackMode::Static => ActivityInner::Static(StaticHint::new(message)),
+            FeedbackMode::Animated => match AnimatedSpinner::start(message) {
+                Some(spinner) => ActivityInner::Animated(spinner),
+                None => ActivityInner::Static(StaticHint::new(message)),
+            },
+        };
+        Self { inner }
+    }
+
+    /// Replace the displayed message. A no-op when disabled.
+    pub(crate) fn set_message(&self, message: &str) {
+        match &self.inner {
+            ActivityInner::Disabled => {}
+            ActivityInner::Static(hint) => hint.report(message),
+            ActivityInner::Animated(spinner) => {
+                // Avoid pausing this thread in the handler while it owns the
+                // message lock the painter may need before its final clear.
+                let _sigint_block = ScopedSigintBlock::block().ok();
+                set_shared_message(&spinner.state.message, message);
+            }
+        }
+    }
+}
+
+impl ProgressReporter for Activity {
+    fn report(&self, message: &str) {
+        self.set_message(message);
+    }
+}
+
+/// Static feedback: one plain line per distinct message, deduplicated so an
+/// unchanged phase is not reprinted.
+struct StaticHint {
+    last: Mutex<Option<String>>,
+}
+
+impl StaticHint {
+    fn new(message: &str) -> Self {
+        emit_static_line(message);
+        Self {
+            last: Mutex::new(Some(message.to_string())),
+        }
+    }
+
+    fn report(&self, message: &str) {
+        let mut last = self
+            .last
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if last.as_deref() != Some(message) {
+            emit_static_line(message);
+            *last = Some(message.to_string());
+        }
+    }
+}
+
+/// Animated feedback: a background worker repaints frames on stderr.
+struct AnimatedSpinner {
+    state: Arc<SpinnerState>,
+    handle: Option<JoinHandle<()>>,
+    /// SIGINT disposition to restore on drop; `None` when the scoped handler
+    /// could not be installed.
+    prev_sigint: Option<SigAction>,
+}
+
+impl AnimatedSpinner {
+    /// Spawn the painter, or `None` if the worker thread cannot be created.
+    fn start(message: &str) -> Option<Self> {
+        // Block before installing the handler and spawning. The painter inherits
+        // this mask, closing the window where it could handle SIGINT itself and
+        // wait for its own `SIG_DONE`. Failure degrades to static feedback.
+        let sigint_block = ScopedSigintBlock::block().ok()?;
+
+        // Fresh interrupt-handshake state for this spinner.
+        SIG_STOP.store(false, Ordering::Release);
+        SIG_DONE.store(false, Ordering::Release);
+
+        let state = Arc::new(SpinnerState {
+            message: Mutex::new(message.to_string()),
+            stop: AtomicBool::new(false),
+            paint: Mutex::new(()),
+        });
+        set_active(Some(Arc::clone(&state)));
+        let prev_sigint = install_sigint_cleanup();
+
+        let worker_state = Arc::clone(&state);
+        match thread::Builder::new()
+            .name("anolisa-activity".to_string())
+            .spawn(move || run_spinner(&worker_state))
+        {
+            Ok(handle) => {
+                // The worker now exists with SIGINT blocked, so a pending signal
+                // can safely run the handler when the parent mask is restored.
+                drop(sigint_block);
+                Some(Self {
+                    state,
+                    handle: Some(handle),
+                    prev_sigint,
+                })
+            }
+            Err(_) => {
+                // Restore the prior disposition before unblocking so a pending
+                // signal cannot enter our handler without a painter to finish.
+                restore_sigint(prev_sigint);
+                set_active(None);
+                drop(sigint_block);
+                None
+            }
+        }
+    }
+}
+
+impl Drop for AnimatedSpinner {
+    fn drop(&mut self) {
+        self.state.stop.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            // A worker panic must not poison the drop path; the defensive clear
+            // below still runs.
+            let _ = handle.join();
+        }
+        // The painter clears as its last act; this is a belt-and-suspenders
+        // clear in case the worker panicked before it could.
+        let _ = Term::stderr().clear_line();
+        restore_sigint(self.prev_sigint.take());
+        set_active(None);
+    }
+}
+
+/// Shared spinner state driven by the worker thread and updated by
+/// [`Activity::set_message`].
+struct SpinnerState {
+    message: Mutex<String>,
+    stop: AtomicBool,
+    /// Serializes terminal repaints against [`suspend_output`].
+    paint: Mutex<()>,
+}
+
+impl SpinnerState {
+    fn lock_paint(&self) -> MutexGuard<'_, ()> {
+        self.paint
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Whether the painter should stop, for either a normal drop
+    /// (`stop`) or an interrupt ([`SIG_STOP`]).
+    fn should_stop(&self) -> bool {
+        self.stop.load(Ordering::Acquire) || SIG_STOP.load(Ordering::Acquire)
+    }
+}
+
+/// Worker loop: repaint the spinner until a stop flag is set, then perform the
+/// one and only final clear.
+///
+/// The painter is the *sole* terminal writer, which is what lets the SIGINT
+/// handler stay write-free: the last thing written here is always the final
+/// clear, after which [`SIG_DONE`] is published and the thread exits.
+fn run_spinner(state: &SpinnerState) {
+    let term = Term::stderr();
+    let mut frame = 0usize;
+    let mut render_state = RenderState::default();
+
+    while !state.should_stop() {
+        {
+            let _paint = state.lock_paint();
+            if !state.should_stop() {
+                let message = read_shared_message(&state.message);
+                match fit_to_width(
+                    &term,
+                    &format!("{} {message}", FRAMES[frame % FRAMES.len()]),
+                ) {
+                    Some(line) => {
+                        // Best-effort paint: a transient stderr write error must
+                        // not abort the whole command.
+                        let _ = term.clear_line();
+                        let _ = term.write_str(&line);
+                        let _ = term.flush();
+                        render_state.record_animated();
+                    }
+                    None => {
+                        // Width unknown/degenerate: fall back to a one-time
+                        // static line so the user still sees activity rather
+                        // than a frozen-looking terminal (issue #1452 P2).
+                        let (clear_frame, emit_line) = render_state.enter_static(&message);
+                        if clear_frame {
+                            let _ = term.clear_line();
+                        }
+                        if emit_line {
+                            let _ = term.write_line(&message);
+                        }
+                    }
+                }
+            }
+        }
+        sleep_until_stop(state);
+        frame = frame.wrapping_add(1);
+    }
+
+    // Final clear is the painter's last write; the SIGINT handler relies on this
+    // (it never writes the terminal itself).
+    {
+        let _paint = state.lock_paint();
+        let _ = term.clear_line();
+        let _ = term.flush();
+    }
+    SIG_DONE.store(true, Ordering::Release);
+}
+
+/// Restores the calling thread's prior signal mask when it leaves scope.
+struct ScopedSigintBlock {
+    previous: SigSet,
+}
+
+impl ScopedSigintBlock {
+    fn block() -> nix::Result<Self> {
+        let mut sigint = SigSet::empty();
+        sigint.add(Signal::SIGINT);
+        let previous = sigint.thread_swap_mask(SigmaskHow::SIG_BLOCK)?;
+        Ok(Self { previous })
+    }
+}
+
+impl Drop for ScopedSigintBlock {
+    fn drop(&mut self) {
+        let _ = self.previous.thread_set_mask();
+    }
+}
+
+/// Tracks transitions between in-place frames and persistent fallback lines.
+#[derive(Default)]
+struct RenderState {
+    animated_visible: bool,
+    static_shown: Option<String>,
+}
+
+impl RenderState {
+    fn record_animated(&mut self) {
+        self.animated_visible = true;
+        // Feedback from before a resumed animated period must not suppress a
+        // later transition back to the persistent fallback.
+        self.static_shown = None;
+    }
+
+    /// Returns whether to clear an animated frame and emit the static message.
+    fn enter_static(&mut self, message: &str) -> (bool, bool) {
+        let clear_frame = std::mem::take(&mut self.animated_visible);
+        let emit_line = self.static_shown.as_deref() != Some(message);
+        if emit_line {
+            self.static_shown = Some(message.to_string());
+        }
+        (clear_frame, emit_line)
+    }
+}
+
+/// Sleep out one [`TICK`], waking early (within [`STOP_POLL`]) when a stop flag
+/// is set so shutdown latency stays low.
+fn sleep_until_stop(state: &SpinnerState) {
+    let mut elapsed = Duration::ZERO;
+    while elapsed < TICK {
+        if state.should_stop() {
+            return;
+        }
+        let step = STOP_POLL.min(TICK - elapsed);
+        thread::sleep(step);
+        elapsed += step;
+    }
+}
+
+/// Fit `line` to the terminal width, or `None` when it cannot be shown on a
+/// single physical line (width unknown, zero, or too narrow). Delegates the
+/// pure decision to [`fit_line`] so it is testable without a terminal.
+fn fit_to_width(term: &Term, line: &str) -> Option<String> {
+    fit_line(term.size_checked().map(|(_rows, cols)| cols), line)
+}
+
+/// Pure width-fitting: `Some(truncated)` when `cols` is known and greater than
+/// one (leaving one spare column), else `None`. Returning `None` for an unknown
+/// or degenerate width lets the painter fall back to a static line rather than
+/// risk a wrapped frame that `clear_line` could only partially erase.
+fn fit_line(cols: Option<u16>, line: &str) -> Option<String> {
+    match cols {
+        Some(cols) if cols > 1 => {
+            let max = cols as usize - 1;
+            if measure_text_width(line) <= max {
+                Some(line.to_string())
+            } else {
+                Some(truncate_to_width(line, max))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Take the longest prefix of `s` whose display width does not exceed `max`.
+fn truncate_to_width(s: &str, max: usize) -> String {
+    let mut out = String::new();
+    let mut width = 0usize;
+    for ch in s.chars() {
+        let w = measure_text_width(&ch.to_string());
+        if width + w > max {
+            break;
+        }
+        out.push(ch);
+        width += w;
+    }
+    out
+}
+
+// ── global active-spinner registry ───────────────────────────────────────────
+
+fn active_state() -> Option<Arc<SpinnerState>> {
+    match ACTIVE.lock() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+fn set_active(state: Option<Arc<SpinnerState>>) {
+    match ACTIVE.lock() {
+        Ok(mut guard) => *guard = state,
+        Err(poisoned) => *poisoned.into_inner() = state,
+    }
+}
+
+/// Read the shared message, recovering from a poisoned lock rather than
+/// panicking (a worker/main panic must not take down the reporter).
+fn read_shared_message(message: &Mutex<String>) -> String {
+    match message.lock() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+/// Update the shared message, recovering from a poisoned lock.
+fn set_shared_message(message: &Mutex<String>, next: &str) {
+    match message.lock() {
+        Ok(mut guard) => *guard = next.to_string(),
+        Err(poisoned) => *poisoned.into_inner() = next.to_string(),
+    }
+}
+
+// ── scoped SIGINT cleanup ─────────────────────────────────────────────────────
+
+/// Async-signal-safe SIGINT handler.
+///
+/// It never writes the terminal itself. Instead it asks the painter to stop
+/// ([`SIG_STOP`]) and waits for the painter's own final clear to complete
+/// ([`SIG_DONE`]) before restoring the default disposition and re-raising. Since
+/// the painter is the sole writer and its last write is a clear, an in-flight
+/// frame can never overwrite the cleanup. The spin is bounded only as a
+/// hang-guard for a wedged painter; timing out is still write-free and therefore
+/// cannot corrupt output.
+///
+/// Only atomics, `signal`, and `raise` are used — all async-signal-safe.
+extern "C" fn on_sigint(_sig: libc::c_int) {
+    SIG_STOP.store(true, Ordering::Release);
+    let mut spins = 0u32;
+    while !SIG_DONE.load(Ordering::Acquire) && spins < SIGINT_SPIN_LIMIT {
+        std::hint::spin_loop();
+        spins += 1;
+    }
+    // SAFETY: both calls are async-signal-safe and act only on the process's own
+    // SIGINT disposition.
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_DFL);
+        libc::raise(libc::SIGINT);
+    }
+}
+
+/// Install the scoped SIGINT cleanup handler, returning the previous
+/// disposition to restore later. Best-effort: a failure yields `None` and the
+/// spinner simply falls back to "leftover frame on Ctrl+C".
+fn install_sigint_cleanup() -> Option<SigAction> {
+    let action = SigAction::new(
+        SigHandler::Handler(on_sigint),
+        SaFlags::empty(),
+        SigSet::empty(),
+    );
+    // SAFETY: `on_sigint` is async-signal-safe (see its docs); installing a
+    // SIGINT handler has no memory-safety obligations beyond that.
+    unsafe { sigaction(Signal::SIGINT, &action) }.ok()
+}
+
+/// Restore a previously saved SIGINT disposition, if one was captured.
+fn restore_sigint(prev: Option<SigAction>) {
+    if let Some(prev) = prev {
+        // SAFETY: `prev` was produced by a prior successful `sigaction` call.
+        let _ = unsafe { sigaction(Signal::SIGINT, &prev) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// Recording reporter used by command tests to assert the exact phase
+    /// sequence without a TTY or timing on animated frames.
+    struct RecordingReporter {
+        messages: RefCell<Vec<String>>,
+    }
+
+    #[test]
+    fn feedback_mode_animates_on_ansi_tty() {
+        assert_eq!(
+            feedback_mode(false, false, true, true),
+            FeedbackMode::Animated
+        );
+    }
+
+    #[test]
+    fn feedback_mode_static_on_non_ansi_tty() {
+        // Interactive but cannot interpret ANSI (e.g. TERM=dumb): still give a
+        // static hint rather than going silent.
+        assert_eq!(
+            feedback_mode(false, false, true, false),
+            FeedbackMode::Static
+        );
+    }
+
+    #[test]
+    fn feedback_mode_disabled_for_json_quiet_and_non_tty() {
+        assert_eq!(
+            feedback_mode(true, false, true, true),
+            FeedbackMode::Disabled
+        );
+        assert_eq!(
+            feedback_mode(false, true, true, true),
+            FeedbackMode::Disabled
+        );
+        assert_eq!(
+            feedback_mode(false, false, false, true),
+            FeedbackMode::Disabled
+        );
+    }
+
+    #[test]
+    fn ansi_capability_rejects_dumb_and_empty_and_unset() {
+        assert!(ansi_capable_for(Some("xterm-256color")));
+        assert!(ansi_capable_for(Some("screen")));
+        assert!(!ansi_capable_for(Some("dumb")));
+        assert!(!ansi_capable_for(Some("")));
+        assert!(!ansi_capable_for(None));
+    }
+
+    /// Width fitting truncates an over-long frame, keeps a fitting one, and
+    /// refuses to paint (returns `None`) when the width is unknown or degenerate
+    /// — the branch that hands off to the static fallback.
+    #[test]
+    fn fit_line_bounds_or_skips() {
+        assert_eq!(fit_line(Some(80), "short"), Some("short".to_string()));
+        // A 10-column terminal leaves a 9-column budget.
+        assert_eq!(
+            fit_line(Some(10), "Checking for updates..."),
+            Some("Checking ".to_string())
+        );
+        assert_eq!(fit_line(None, "Checking for updates..."), None);
+        assert_eq!(fit_line(Some(0), "x"), None);
+        assert_eq!(fit_line(Some(1), "x"), None);
+    }
+
+    #[test]
+    fn truncate_to_width_bounds_display_width() {
+        assert_eq!(truncate_to_width("hello world", 5), "hello");
+        assert_eq!(truncate_to_width("hi", 5), "hi");
+        assert_eq!(truncate_to_width("anything", 0), "");
+    }
+
+    #[test]
+    fn render_state_clears_and_reemits_across_mode_transitions() {
+        let mut state = RenderState::default();
+
+        state.record_animated();
+        assert_eq!(state.enter_static("Checking for updates..."), (true, true));
+        assert_eq!(
+            state.enter_static("Checking for updates..."),
+            (false, false)
+        );
+
+        state.record_animated();
+        assert_eq!(state.enter_static("Checking for updates..."), (true, true));
+    }
+
+    #[test]
+    fn scoped_sigint_block_is_inherited_and_restored() {
+        let previous = SigSet::thread_get_mask().expect("read initial signal mask");
+        let block = ScopedSigintBlock::block().expect("block SIGINT");
+        assert!(
+            SigSet::thread_get_mask()
+                .expect("read blocked signal mask")
+                .contains(Signal::SIGINT)
+        );
+
+        let child_blocked = thread::spawn(|| {
+            SigSet::thread_get_mask()
+                .expect("read child signal mask")
+                .contains(Signal::SIGINT)
+        })
+        .join()
+        .expect("join signal mask probe");
+        assert!(child_blocked);
+
+        drop(block);
+        assert_eq!(
+            SigSet::thread_get_mask().expect("read restored signal mask"),
+            previous
+        );
+    }
+
+    /// A disabled activity does nothing: it never registers as the active
+    /// spinner, and `report` is a no-op.
+    #[test]
+    fn disabled_activity_is_inert() {
+        let activity = Activity::start(FeedbackMode::Disabled, "Checking for updates...");
+        assert!(matches!(activity.inner, ActivityInner::Disabled));
+        assert!(active_state().is_none());
+        activity.report("still inert");
+    }
+
+    /// With no active animated spinner, `suspend_output` is a transparent
+    /// passthrough that runs the closure exactly once and returns its value.
+    #[test]
+    fn suspend_output_without_spinner_is_passthrough() {
+        let ran = RefCell::new(0);
+        let value = suspend_output(|| {
+            *ran.borrow_mut() += 1;
+            42
+        });
+        assert_eq!(value, 42);
+        assert_eq!(*ran.borrow(), 1);
+    }
+
+    #[test]
+    fn noop_reporter_discards_messages() {
+        let reporter = NoopReporter;
+        reporter.report("ignored");
+    }
+
+    #[test]
+    fn recording_reporter_preserves_order() {
+        let reporter = RecordingReporter {
+            messages: RefCell::new(Vec::new()),
+        };
+        reporter.report("first");
+        reporter.report("second");
+        assert_eq!(reporter.messages.borrow().as_slice(), ["first", "second"]);
+    }
+
+    impl ProgressReporter for RecordingReporter {
+        fn report(&self, message: &str) {
+            self.messages.borrow_mut().push(message.to_string());
+        }
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -440,7 +440,11 @@ impl RepoConfig {
 
     fn emit_deprecation_warnings(&self, path: &Path) {
         if let Some(warning) = self.deprecation_warning() {
-            eprintln!("warning: repo config at {} {warning}", path.display());
+            // Routed through `suspend_output` so this persistent line cannot
+            // interleave with a live activity spinner (issue #1452).
+            crate::progress::suspend_output(|| {
+                eprintln!("warning: repo config at {} {warning}", path.display());
+            });
         }
     }
 


### PR DESCRIPTION
## Description

Adds interactive activity feedback to `anolisa update --check` and
`anolisa upgrade`, so slow repository queries and RPM transactions no longer
appear frozen. Human-readable TTY sessions use a stderr spinner, while
non-ANSI terminals, unknown terminal widths, and thread-spawn failures fall
back to plain static feedback.

Upgrade execution reports the current phase and reliable item counts through
an injected progress reporter without changing RPM transaction order, state
persistence, or read-only update-check behavior. JSON, quiet, MOTD, and
non-TTY output contracts remain unchanged, while scoped SIGINT cleanup avoids
leaving stale animated frames.

## Related Issue

closes #1452

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa`:

```bash
cargo fmt --all -- --check
cargo check --locked
cargo clippy --all-targets --locked -- -D warnings
cargo test --locked
cargo doc --workspace --no-deps
git diff --check
```

Verified edge cases:

- Interactive stderr renders animated progress.
- `TERM=dumb` uses static feedback without spinner control sequences.
- Unknown and zero terminal widths use static feedback.
- Animated-to-static width transitions clear the previous frame before
  printing the fallback line.
- `--json`, `--quiet`, MOTD, and non-TTY paths remain inert.
- Upgrade phase messages preserve transaction order and reliable item counts.
- Normal SIGINT clears the animated frame and exits with status 130.

### Ship Note

- Changed: Added interactive activity feedback for update checks, upgrade
  planning, RPM transactions, and state finalization.
- Known limitations: A completely wedged painter may leave its last frame after
  the bounded SIGINT wait expires.
- Not covered: Real RPM upgrades, repeated Ctrl+C stress, and slow repository
  timing in an isolated Linux environment.
- Verification: `cargo fmt --all -- --check`, `cargo check --locked`,
  `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked`,
  and `cargo doc --workspace --no-deps`.

## Additional Notes

The implementation reuses the workspace `console` and `nix` dependencies; no
new third-party package version was introduced. User documentation and the
changelog are unchanged because changelog entries are added by the release
version-bump PR.
