### PR TITLE
fix(anolisa): lock delegated rpm installs

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -36,7 +36,13 @@ pub(crate) fn handle_one(
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
     let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
-    let rpm_repo = if rpm_repo_required(&component, &args, ctx, &repo_config)? {
+    let identity = load_install_identity(component, ctx)?;
+    let rpm_repo = if rpm_repo_required(
+        &identity.component,
+        &args,
+        &identity.installed,
+        &repo_config,
+    ) {
         configured_rpm_repo_source(&repo_config, &env)?
     } else {
         None
@@ -55,7 +61,7 @@ pub(crate) fn handle_one(
         None => RpmTransaction::system(),
     };
     let exec = RpmExec::new(&query, &txn, privilege::is_root());
-    handle_one_with_config(component, args, ctx, &exec, layout, env, repo_config)
+    handle_one_with_config(identity, args, ctx, &exec, layout, env, repo_config)
 }
 
 /// Core of [`handle_one`] with the RPM execution dependencies injected, so
@@ -72,11 +78,12 @@ pub(crate) fn handle_one_with_exec(
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
     let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
-    handle_one_with_config(component, args, ctx, exec, layout, env, repo_config)
+    let identity = load_install_identity(component, ctx)?;
+    handle_one_with_config(identity, args, ctx, exec, layout, env, repo_config)
 }
 
 fn handle_one_with_config(
-    component: String,
+    identity: InstallIdentity,
     args: InstallArgs,
     ctx: &CliContext,
     exec: &RpmExec,
@@ -84,13 +91,12 @@ fn handle_one_with_config(
     env: anolisa_env::EnvFacts,
     repo_config: RepoConfig,
 ) -> Result<InstallOutcome, CliError> {
-    let command = format!("install {component}");
-    let installed = common::load_installed_state(ctx, COMMAND)?;
-
-    // Resolve package aliases (e.g., "copilot-shell" → "cosh") before Layer 1
-    // backend selection, so ExistingState detection and compatibility checks
-    // use the canonical component name stored in state.
-    let component = common::lookup_component_name(&component, &installed, ctx, COMMAND);
+    let InstallIdentity {
+        requested_component,
+        component,
+        installed,
+    } = identity;
+    let command = format!("install {requested_component}");
 
     let mut rpm_component_index: Option<ComponentIndex> = None;
 
@@ -185,6 +191,27 @@ fn handle_one_with_config(
     )
 }
 
+/// Load the routing snapshot and resolve package aliases before constructing
+/// backend clients, so repository selection and execution use one identity.
+struct InstallIdentity {
+    requested_component: String,
+    component: String,
+    installed: InstalledState,
+}
+
+fn load_install_identity(
+    requested_component: String,
+    ctx: &CliContext,
+) -> Result<InstallIdentity, CliError> {
+    let installed = common::load_installed_state(ctx, COMMAND)?;
+    let component = common::lookup_component_name(&requested_component, &installed, ctx, COMMAND);
+    Ok(InstallIdentity {
+        requested_component,
+        component,
+        installed,
+    })
+}
+
 pub(crate) fn configured_rpm_repo_source(
     repo_config: &RepoConfig,
     env: &anolisa_env::EnvFacts,
@@ -226,25 +253,24 @@ pub(crate) fn require_configured_rpm_backend(
 pub(crate) fn rpm_repo_required(
     component: &str,
     args: &InstallArgs,
-    ctx: &CliContext,
+    installed: &InstalledState,
     repo_config: &RepoConfig,
-) -> Result<bool, CliError> {
+) -> bool {
     if args
         .backend
         .as_deref()
         .map(RepoConfig::canonical_backend_name)
         == Some("rpm")
     {
-        return Ok(true);
+        return true;
     }
     if args.backend.is_none() && repo_config.default_backend == "rpm" {
-        return Ok(true);
+        return true;
     }
-    let installed = common::load_installed_state(ctx, COMMAND)?;
-    Ok(installed
+    installed
         .find_object(ObjectKind::Component, component)
         .and_then(installed_backend_label)
-        == Some("rpm"))
+        == Some("rpm")
 }
 
 /// Existing raw-backend trunk: repo.toml → base_url → package → resolve →
@@ -589,9 +615,93 @@ base_url = "https://repo.example/alinux/$releasever/agentic-os/$basearch/os/"
         )
         .expect("parse repo without resolving rpm variables");
         let a = args("copilot-shell");
+        let installed = common::load_installed_state(&ctx, COMMAND).expect("load state");
         assert!(
-            !rpm_repo_required("copilot-shell", &a, &ctx, &repo).expect("check requirement"),
+            !rpm_repo_required("copilot-shell", &a, &installed, &repo),
             "raw default with no rpm state must not resolve the rpm backend"
+        );
+    }
+
+    #[test]
+    fn managed_rpm_package_alias_requires_configured_repo() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("install-root");
+        let layout = FsLayout::system(Some(prefix.clone()));
+        let raw_root = tmp.path().join("raw-repo");
+        std::fs::create_dir_all(raw_root.join("v1")).expect("create raw repo");
+        std::fs::create_dir_all(&layout.etc_dir).expect("create etc dir");
+        std::fs::create_dir_all(&layout.state_dir).expect("create state dir");
+        std::fs::write(
+            raw_root.join("v1/components.toml"),
+            r#"schema_version = 1
+
+[[components]]
+name = "cosh"
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+
+[[components.aliases]]
+kind = "rpm-package"
+name = "copilot-shell"
+"#,
+        )
+        .expect("write component index");
+        std::fs::write(
+            layout.etc_dir.join("repo.toml"),
+            format!(
+                r#"schema_version = 1
+default_backend = "raw"
+
+[backends.raw]
+base_url = "file://{}"
+
+[backends.rpm]
+base_url = "https://repo.example/anolisa"
+"#,
+                raw_root.display()
+            ),
+        )
+        .expect("write repo config");
+
+        std::fs::write(
+            layout.state_dir.join("installed.toml"),
+            format!(
+                r#"schema_version = 4
+updated_at = "2026-07-14T00:00:00Z"
+install_mode = "system"
+prefix = "{}"
+anolisa_version = "test"
+
+[[objects]]
+kind = "component"
+name = "cosh"
+version = "2.2.0-1.al8"
+status = "installed"
+install_backend = "rpm"
+ownership = "rpm_managed"
+installed_at = "2026-07-14T00:00:00Z"
+"#,
+                layout.prefix.display()
+            ),
+        )
+        .expect("write state");
+
+        let ctx = ctx_with_prefix(false, Some(prefix));
+        let repo = RepoConfig::load(&layout, false).expect("load repo").config;
+        let identity = load_install_identity("copilot-shell".to_string(), &ctx)
+            .expect("resolve package alias");
+
+        assert_eq!(identity.component, "cosh");
+        assert!(
+            rpm_repo_required(
+                &identity.component,
+                &args("copilot-shell"),
+                &identity.installed,
+                &repo
+            ),
+            "an existing rpm-managed component must select the configured RPM repo even when addressed by package alias"
         );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
@@ -82,6 +82,15 @@ impl RpmTarget {
         }
     }
 
+    fn from_installed_state(component: &str, package: &str) -> Self {
+        Self {
+            component: component.to_string(),
+            package: package.to_string(),
+            source: ResolutionSource::InstalledState,
+            legacy_adopt: false,
+        }
+    }
+
     pub(crate) fn label(&self) -> String {
         if self.component == self.package {
             self.package.clone()
@@ -255,6 +264,7 @@ fn rpm_installed_target_allowed(
     if matches!(
         target.source,
         ResolutionSource::RepoPackageMap
+            | ResolutionSource::InstalledState
             | ResolutionSource::InstalledRpmProvides
             | ResolutionSource::AvailableRpmProvides
     ) || target.legacy_adopt
@@ -266,6 +276,67 @@ fn rpm_installed_target_allowed(
         .provided_capabilities_installed(&target.package)?
         .iter()
         .any(|capability| rpm_capability_matches_component(capability, &expected)))
+}
+
+enum TrackedRpmSituation {
+    ManagedAbsent(RpmTarget),
+    ManagedPresent(RpmTarget),
+    ObservedAbsent(RpmTarget),
+    ObservedPresent {
+        target: RpmTarget,
+        info: PackageInfo,
+    },
+}
+
+fn probe_tracked_rpm(
+    state: &InstalledState,
+    component: &str,
+    package_override: Option<&str>,
+    query: &dyn PackageQuery,
+    command: &str,
+) -> Result<Option<TrackedRpmSituation>, CliError> {
+    let Some(existing) = state.find_object(ObjectKind::Component, component) else {
+        return Ok(None);
+    };
+    let ownership = existing.effective_ownership();
+    let observed = match ownership {
+        Ownership::RpmManaged => false,
+        Ownership::RpmObserved => true,
+        Ownership::RawManaged => return Ok(None),
+    };
+    let Some(recorded_package) = existing
+        .rpm_metadata
+        .as_ref()
+        .map(|metadata| metadata.package_name.trim())
+        .filter(|package| !package.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    if let Some(requested_package) = package_override {
+        if observed {
+            refuse_observed_repoint(state, component, requested_package, command)?;
+        } else if requested_package != recorded_package {
+            return Err(CliError::InvalidArgument {
+                command: command.to_string(),
+                reason: format!(
+                    "component '{component}' is managed through RPM package '{recorded_package}', not '{requested_package}'; refusing to reinstall a different package"
+                ),
+            });
+        }
+    }
+
+    let target = RpmTarget::from_installed_state(component, recorded_package);
+    match query.query_installed(recorded_package) {
+        Ok(Some(info)) if observed => {
+            Ok(Some(TrackedRpmSituation::ObservedPresent { target, info }))
+        }
+        Ok(Some(_)) => Ok(Some(TrackedRpmSituation::ManagedPresent(target))),
+        Ok(None) if observed => Ok(Some(TrackedRpmSituation::ObservedAbsent(target))),
+        Ok(None) => Ok(Some(TrackedRpmSituation::ManagedAbsent(target))),
+        Err(PackageQueryError::CommandMissing { .. }) => Err(rpm_tooling_missing_error(command)),
+        Err(err) => Err(pkg_query_err(err, command)),
+    }
 }
 
 pub(crate) fn rpm_capability_matches_component(capability: &str, expected: &str) -> bool {
@@ -312,15 +383,45 @@ pub(crate) fn route_rpm_adopt(
 
     let situation = match situation {
         Some(s) => s,
-        None => probe_rpm_situation(
+        None => match probe_tracked_rpm(
+            installed,
             component,
             args.package.as_deref(),
-            repo_config.backends.get("rpm"),
-            component_index,
-            ResolutionUse::Install,
             exec.query,
             command,
-        )?,
+        )? {
+            Some(TrackedRpmSituation::ManagedAbsent(target)) => RpmSituation::Absent { target },
+            Some(TrackedRpmSituation::ManagedPresent(target)) => {
+                return Err(CliError::InvalidArgument {
+                    command: command.to_string(),
+                    reason: format!(
+                        "component '{}' is already tracked as rpm-managed and RPM package '{}' is installed; use `anolisa status {}` to inspect it or `anolisa repair {}` to reconcile its metadata",
+                        target.component, target.package, target.component, target.component
+                    ),
+                });
+            }
+            Some(TrackedRpmSituation::ObservedAbsent(target)) => {
+                return Err(CliError::InvalidArgument {
+                    command: command.to_string(),
+                    reason: format!(
+                        "component '{}' is rpm-observed and package '{}' is missing; ANOLISA does not own its installation — run `anolisa forget {}` first, then install it as rpm-managed",
+                        target.component, target.package, target.component
+                    ),
+                });
+            }
+            Some(TrackedRpmSituation::ObservedPresent { target, info }) => {
+                RpmSituation::Adoptable { target, info }
+            }
+            None => probe_rpm_situation(
+                component,
+                args.package.as_deref(),
+                repo_config.backends.get("rpm"),
+                component_index,
+                ResolutionUse::Install,
+                exec.query,
+                command,
+            )?,
+        },
     };
 
     match situation {
@@ -343,14 +444,8 @@ pub(crate) fn route_rpm_adopt(
             if source == BackendSource::Explicit {
                 ensure_component_backend_compatible(installed, &target.component, "rpm", command)?;
             }
-            execute_delegated_install(
-                exec,
-                ctx,
-                layout,
-                command,
-                &target.component,
-                &target.package,
-            )
+            let expectation = DelegatedInstallExpectation::capture(installed, &target.component);
+            execute_delegated_install(exec, ctx, layout, command, &target.package, expectation)
         }
         RpmSituation::NotAnolisaComponent => Err(CliError::InvalidArgument {
             command: command.to_string(),
@@ -420,7 +515,7 @@ fn refuse_observed_repoint(
     if let Some(prev) = existing
         .rpm_metadata
         .as_ref()
-        .map(|m| m.package_name.as_str())
+        .map(|m| m.package_name.trim())
         && !prev.is_empty()
         && prev != new_package
     {
@@ -716,8 +811,97 @@ pub(crate) struct DelegatedInstallPayload {
     warnings: Vec<String>,
 }
 
-/// Install a not-yet-present RPM component by delegating to `dnf install`, then
-/// record it as ANOLISA-managed `rpm-managed` state.
+/// State authority used when an absent RPM package is installed through dnf.
+#[derive(Debug, Clone, Copy)]
+enum DelegatedInstallDisposition {
+    /// No ANOLISA object exists; installation creates a new managed record.
+    Fresh,
+    /// A managed object exists but its RPM is missing; preserve and refresh it.
+    ReinstallManaged,
+}
+
+/// Canonical component identity and object snapshot selected by RPM routing.
+///
+/// Capturing both together prevents callers from pairing a package alias with
+/// an object from a different component. The locked execution path compares
+/// the complete object because any concurrent metadata write invalidates the
+/// route decision; the command fails before dnf instead of guessing whether a
+/// changed field is benign.
+#[derive(Debug, Clone)]
+pub(crate) struct DelegatedInstallExpectation {
+    component: String,
+    object: Option<InstalledObject>,
+}
+
+impl DelegatedInstallExpectation {
+    /// Captures the canonical component from the state snapshot used to route
+    /// the delegated install.
+    pub(crate) fn capture(state: &InstalledState, component: &str) -> Self {
+        Self {
+            component: component.to_string(),
+            object: state.find_object(ObjectKind::Component, component).cloned(),
+        }
+    }
+
+    fn verify_locked(&self, state: &InstalledState, command: &str) -> Result<(), CliError> {
+        if state.find_object(ObjectKind::Component, &self.component) == self.object.as_ref() {
+            return Ok(());
+        }
+        Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "component '{}' changed while this RPM install was being prepared; dnf was not run — inspect it with `anolisa status {}` and retry",
+                self.component, self.component
+            ),
+        })
+    }
+}
+
+fn classify_delegated_install(
+    existing: Option<&InstalledObject>,
+    component: &str,
+    package: &str,
+    command: &str,
+) -> Result<DelegatedInstallDisposition, CliError> {
+    let Some(existing) = existing else {
+        return Ok(DelegatedInstallDisposition::Fresh);
+    };
+    match existing.effective_ownership() {
+        Ownership::RpmManaged => {
+            if let Some(recorded_package) = existing
+                .rpm_metadata
+                .as_ref()
+                .map(|metadata| metadata.package_name.trim())
+                && !recorded_package.is_empty()
+                && recorded_package != package
+            {
+                return Err(CliError::InvalidArgument {
+                    command: command.to_string(),
+                    reason: format!(
+                        "component '{component}' is managed through RPM package '{recorded_package}', not '{package}'; refusing to reinstall a different package"
+                    ),
+                });
+            }
+            Ok(DelegatedInstallDisposition::ReinstallManaged)
+        }
+        Ownership::RpmObserved => Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' is rpm-observed and package '{package}' is missing; ANOLISA does not own its installation — run `anolisa forget {component}` first, then install it as rpm-managed"
+            ),
+        }),
+        ownership => Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "component '{component}' is tracked as {} and cannot be reinstalled through RPM",
+                ownership.label()
+            ),
+        }),
+    }
+}
+
+/// Install a missing RPM by delegating to dnf, then create or refresh its
+/// ANOLISA-managed state.
 ///
 /// This is the write-side mirror of [`execute_adopt`]: where adopt only
 /// observes an already-installed package, delegated install drives the package
@@ -725,15 +909,18 @@ pub(crate) struct DelegatedInstallPayload {
 /// (`owns_removal=true`). ANOLISA never fetches bytes itself — dnf owns the
 /// file transaction. Gated on root for the real run; `--dry-run` previews the
 /// `dnf install` without touching the host.
-fn execute_delegated_install(
+pub(crate) fn execute_delegated_install(
     exec: &RpmExec,
     ctx: &CliContext,
     layout: &FsLayout,
     command: &str,
-    component: &str,
     package: &str,
+    expectation: DelegatedInstallExpectation,
 ) -> Result<InstallOutcome, CliError> {
+    let component = expectation.component.as_str();
     let mut warnings: Vec<String> = Vec::new();
+    let disposition =
+        classify_delegated_install(expectation.object.as_ref(), component, package, command)?;
 
     // Dry-run: preview the dnf transaction with best-effort repo candidates.
     // Never needs root, never writes state.
@@ -783,7 +970,21 @@ fn execute_delegated_install(
         });
     }
 
-    // dnf install — delegate the file transaction.
+    // The package transaction and state commit share one lock. The route into
+    // this function used an unlocked state snapshot, so reload and compare it
+    // before dnf can mutate rpmdb.
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let state = common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: err.reason(),
+    })?;
+    expectation.verify_locked(&state, command)?;
+    ensure_component_backend_compatible(&state, component, "rpm", command)?;
+
+    // dnf install — delegate the file transaction while retaining the lock.
     exec.txn
         .install(package)
         .map_err(|err| txn_install_err(err, command))?;
@@ -824,12 +1025,14 @@ fn execute_delegated_install(
         }
     };
 
-    let (operation_id, snapshot_warnings) = persist_delegated_install(
+    let (operation_id, snapshot_warnings) = persist_delegated_install_locked(
         ctx,
         layout,
+        state,
         command,
         component,
         package,
+        disposition,
         &info,
         source_repo.as_deref(),
         &warnings,
@@ -861,35 +1064,20 @@ fn execute_delegated_install(
 /// (`managed=true`, `adopted=false`, [`Ownership::RpmManaged`]) — the file
 /// transaction was ANOLISA-driven, so a later uninstall delegates back to dnf.
 #[allow(clippy::too_many_arguments)]
-fn persist_delegated_install(
+fn persist_delegated_install_locked(
     ctx: &CliContext,
     layout: &FsLayout,
+    mut state: InstalledState,
     command: &str,
     component: &str,
     package: &str,
+    disposition: DelegatedInstallDisposition,
     info: &PackageInfo,
     source_repo: Option<&str>,
     warnings: &[String],
 ) -> Result<(String, Vec<String>), CliError> {
     let evr = info.version.to_string();
     let started_at = now_iso8601();
-
-    // Acquire the lock, then load state inside it so a concurrent writer is not
-    // clobbered — mirrors `execute_adopt`/`execute_raw` ordering.
-    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("failed to acquire install lock: {err}"),
-    })?;
-    let mut state =
-        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("failed to load installed state: {err}"),
-        })?;
-
-    // Re-validate against the freshly-reloaded state: a concurrent raw install
-    // may have won the lock and recorded the component first. Refuse rather than
-    // overwrite its provenance with rpm-managed.
-    ensure_component_backend_compatible(&state, component, "rpm", command)?;
 
     let lock_ts = Utc::now();
     let operation_id = format!(
@@ -898,43 +1086,69 @@ fn persist_delegated_install(
         lock_ts.timestamp_subsec_nanos()
     );
 
-    // Delegated install is system-scope by construction (route_rpm_adopt
-    // rejects user mode before reaching the Absent branch).
     state.install_mode = StateInstallMode::System;
     state.prefix = layout.prefix.clone();
-    state.upsert_object(InstalledObject {
-        kind: ObjectKind::Component,
-        name: component.to_string(),
-        version: evr.clone(),
-        status: ObjectStatus::Installed,
-        manifest_digest: None,
-        // Not an ANOLISA-delivered raw artifact; dnf resolved the source.
-        distribution_source: None,
-        raw_package: None,
-        install_backend: Some("rpm".to_string()),
-        ownership: Some(Ownership::RpmManaged),
-        rpm_metadata: Some(RpmMetadata {
-            package_name: info.name.clone(),
-            evr: Some(evr.clone()),
-            arch: Some(info.arch.clone()),
-            source_repo: source_repo.map(str::to_string),
+    match disposition {
+        DelegatedInstallDisposition::Fresh => state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: component.to_string(),
+            version: evr.clone(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            // Not an ANOLISA-delivered raw artifact; dnf resolved the source.
+            distribution_source: None,
+            raw_package: None,
+            install_backend: Some("rpm".to_string()),
+            ownership: Some(Ownership::RpmManaged),
+            rpm_metadata: Some(RpmMetadata {
+                package_name: info.name.clone(),
+                evr: Some(evr.clone()),
+                arch: Some(info.arch.clone()),
+                source_repo: source_repo.map(str::to_string),
+            }),
+            installed_at: started_at.clone(),
+            last_operation_id: Some(operation_id.clone()),
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: Vec::new(),
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+            provisioned_packages: Vec::new(),
         }),
-        installed_at: started_at.clone(),
-        last_operation_id: Some(operation_id.clone()),
-        // ANOLISA delegated the install and owns the removal (owns_removal=true).
-        managed: true,
-        // Not an adoption: ANOLISA drove the install.
-        adopted: false,
-        subscription_scope: Default::default(),
-        enabled_features: Vec::new(),
-        component_refs: Vec::new(),
-        // dnf owns the file transaction; RPM-owned files stay out of state.
-        files: Vec::new(),
-        external_modified_files: Vec::new(),
-        services: Vec::new(),
-        health: Vec::new(),
-        provisioned_packages: Vec::new(),
-    });
+        DelegatedInstallDisposition::ReinstallManaged => {
+            let object = state
+                .find_object_mut(ObjectKind::Component, component)
+                .ok_or_else(|| CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!(
+                        "component '{component}' vanished while its RPM was being reinstalled"
+                    ),
+                })?;
+            object.version = evr.clone();
+            object.status = ObjectStatus::Installed;
+            object.install_backend = Some("rpm".to_string());
+            object.ownership = Some(Ownership::RpmManaged);
+            object.managed = true;
+            object.adopted = false;
+            object.last_operation_id = Some(operation_id.clone());
+            let metadata = object.rpm_metadata.get_or_insert_with(|| RpmMetadata {
+                package_name: info.name.clone(),
+                evr: None,
+                arch: None,
+                source_repo: None,
+            });
+            metadata.package_name = info.name.clone();
+            metadata.evr = Some(evr.clone());
+            metadata.arch = Some(info.arch.clone());
+            if source_repo.is_some() {
+                metadata.source_repo = source_repo.map(str::to_string);
+            }
+        }
+    }
     state.operations.push(OperationRecord {
         id: operation_id.clone(),
         command: command.to_string(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -6,6 +6,7 @@
 
 use super::*;
 
+use anolisa_core::lock::{InstallLock, LockError};
 use anolisa_core::state::InstalledState;
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
@@ -625,6 +626,9 @@ pub struct FakeInstaller {
     pub install_succeeds: bool,
     pub installed: RefCell<Option<PackageInfo>>,
     pub install_calls: Cell<usize>,
+    /// Optional lock path probed from inside `install`.
+    pub lock_probe: Option<PathBuf>,
+    pub lock_was_held: Cell<bool>,
 }
 
 impl FakeInstaller {
@@ -637,6 +641,8 @@ impl FakeInstaller {
             install_succeeds: true,
             installed: RefCell::new(None),
             install_calls: Cell::new(0),
+            lock_probe: None,
+            lock_was_held: Cell::new(false),
         }
     }
     pub fn with_origin(mut self, repo: &str) -> Self {
@@ -645,6 +651,10 @@ impl FakeInstaller {
     }
     pub fn failing_install(mut self) -> Self {
         self.install_succeeds = false;
+        self
+    }
+    pub fn expect_lock_held(mut self, path: PathBuf) -> Self {
+        self.lock_probe = Some(path);
         self
     }
 
@@ -718,6 +728,12 @@ impl PackageTransaction for FakeInstaller {
     fn install(&self, package: &str) -> Result<(), PackageTransactionError> {
         self.install_calls.set(self.install_calls.get() + 1);
         assert_eq!(package, self.package, "install targeted the wrong package");
+        if let Some(path) = &self.lock_probe {
+            self.lock_was_held.set(matches!(
+                InstallLock::acquire(path),
+                Err(LockError::Held { .. })
+            ));
+        }
         if !self.install_succeeds {
             return Err(PackageTransactionError::TransactionFailed {
                 command: "dnf".to_string(),
@@ -746,6 +762,7 @@ pub struct FakeQuery {
     pub available_provides: Vec<(String, Vec<String>)>,
     pub package_provides: Vec<(String, Vec<String>)>,
     pub available_package_provides: Vec<(String, Vec<String>)>,
+    pub unexpected_installed: Vec<(String, String)>,
     pub multi_version: Vec<String>,
     pub origin_fails: bool,
     /// Simulate a host with no rpm/dnf: every rpmdb-touching query returns
@@ -759,6 +776,16 @@ impl PackageQuery for FakeQuery {
         if self.command_missing {
             return Err(PackageQueryError::CommandMissing {
                 command: "rpm".to_string(),
+            });
+        }
+        if let Some((_, detail)) = self
+            .unexpected_installed
+            .iter()
+            .find(|(name, _)| name == package)
+        {
+            return Err(PackageQueryError::UnexpectedOutput {
+                command: "rpm".to_string(),
+                detail: detail.clone(),
             });
         }
         if self.multi_version.iter().any(|p| p == package) {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -512,11 +512,9 @@ fn adopt_refuses_to_downgrade_concurrent_rpm_managed_install() {
 }
 
 #[test]
-fn reinstall_of_rpm_managed_refuses_instead_of_downgrading() {
-    // Full install entrypoint (not execute_adopt directly): re-running
-    // `install` on an already rpm-managed component routes ExistingState ->
-    // route_rpm_adopt -> execute_adopt. The downgrade guard must refuse here
-    // too, rather than silently overwriting the managed record with observed.
+fn install_of_present_rpm_managed_component_refuses_without_dnf() {
+    // The full entrypoint must classify this as Present and stop before the
+    // NoTxn transaction double, which panics if dnf is invoked.
     let (_tmp, ctx) = system_ctx_with_raw_repo(false);
     let layout = common::resolve_layout(&ctx);
     let mut state = InstalledState {
@@ -557,7 +555,7 @@ fn reinstall_of_rpm_managed_refuses_instead_of_downgrading() {
         .save(&layout.state_dir.join("installed.toml"))
         .expect("seed rpm-managed record");
 
-    // rpmdb still has the package, so the re-probe yields Adoptable.
+    // rpmdb still has the package, so the managed-state probe yields Present.
     let q = FakeQuery {
         installed: vec![(
             "copilot-shell".to_string(),
@@ -568,6 +566,7 @@ fn reinstall_of_rpm_managed_refuses_instead_of_downgrading() {
     let err = handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
         .expect_err("re-install of rpm-managed must refuse");
     assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(err.reason().contains("status"), "got: {}", err.reason());
     assert!(err.reason().contains("repair"), "got: {}", err.reason());
 
     let obj = load_state(&ctx)
@@ -617,11 +616,13 @@ fn adopt_origin_failure_degrades_to_none() {
 #[test]
 fn delegated_install_writes_rpm_managed_state() {
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
     let fake = FakeInstaller::new(
         "copilot-shell",
         pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
     )
-    .with_origin("anolisa");
+    .with_origin("anolisa")
+    .expect_lock_held(layout.lock_file);
     let exec = RpmExec {
         query: &fake,
         txn: &fake,
@@ -634,6 +635,10 @@ fn delegated_install_writes_rpm_managed_state() {
         .expect("delegated install ok");
     assert_eq!(outcome, InstallOutcome::Installed);
     assert_eq!(fake.install_calls.get(), 1, "dnf install must run once");
+    assert!(
+        fake.lock_was_held.get(),
+        "install lock must remain held while dnf runs"
+    );
 
     let state = load_state(&ctx);
     let obj = state
@@ -652,6 +657,345 @@ fn delegated_install_writes_rpm_managed_state() {
     assert_eq!(meta.arch.as_deref(), Some("x86_64"));
     assert_eq!(meta.source_repo.as_deref(), Some("anolisa"));
     assert!(state.operations[0].id.starts_with("op-install-"));
+}
+
+fn tracked_rpm_component(component: &str, ownership: Ownership) -> InstalledObject {
+    let observed = ownership == Ownership::RpmObserved;
+    let rpm = ownership != Ownership::RawManaged;
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        version: "2.2.0-1.al8".to_string(),
+        status: if observed {
+            ObjectStatus::Adopted
+        } else {
+            ObjectStatus::Installed
+        },
+        manifest_digest: Some("preserve-manifest-digest".to_string()),
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some(if rpm { "rpm" } else { "raw" }.to_string()),
+        ownership: Some(ownership),
+        rpm_metadata: rpm.then(|| RpmMetadata {
+            package_name: "copilot-shell".to_string(),
+            evr: Some("2.2.0-1.al8".to_string()),
+            arch: Some("x86_64".to_string()),
+            source_repo: Some("old-repo".to_string()),
+        }),
+        installed_at: "2026-06-01T10:00:00Z".to_string(),
+        last_operation_id: Some("op-prior".to_string()),
+        managed: !observed,
+        adopted: observed,
+        subscription_scope: Default::default(),
+        enabled_features: vec!["feature-a".to_string()],
+        component_refs: vec!["legacy-ref".to_string()],
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: vec!["dependency-a".to_string()],
+    }
+}
+
+fn seed_tracked_rpm(ctx: &CliContext, component: &str, ownership: Ownership) -> InstalledObject {
+    let layout = common::resolve_layout(ctx);
+    let object = tracked_rpm_component(component, ownership);
+    let mut state = InstalledState {
+        install_mode: StateInstallMode::System,
+        prefix: layout.prefix.clone(),
+        ..Default::default()
+    };
+    state.upsert_object(object.clone());
+    state
+        .save(&layout.state_dir.join("installed.toml"))
+        .expect("seed tracked RPM state");
+    object
+}
+
+#[test]
+fn delegated_install_lock_failure_precedes_dnf() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    let _held = anolisa_core::lock::InstallLock::acquire(&layout.lock_file).expect("hold lock");
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), a, &ctx, &exec)
+        .expect_err("held lock must fail before dnf");
+    assert!(err.reason().contains("install lock"));
+    assert_eq!(fake.install_calls.get(), 0, "dnf must not run before lock");
+}
+
+#[test]
+fn delegated_install_corrupt_locked_state_is_runtime_error_before_dnf() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    std::fs::write(layout.state_dir.join("installed.toml"), "not = [valid toml")
+        .expect("write corrupt state");
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let expectation =
+        DelegatedInstallExpectation::capture(&InstalledState::default(), "copilot-shell");
+
+    let err = execute_delegated_install(
+        &exec,
+        &ctx,
+        &layout,
+        "install copilot-shell",
+        "copilot-shell",
+        expectation,
+    )
+    .expect_err("corrupt state must fail before dnf");
+    assert_eq!(err.code(), "EXECUTION_FAILED");
+    assert!(err.reason().contains("failed to load installed state"));
+    assert_eq!(fake.install_calls.get(), 0, "dnf must not run");
+}
+
+#[test]
+fn delegated_install_rechecks_state_under_lock() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    seed_tracked_rpm(&ctx, "copilot-shell", Ownership::RawManaged);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let expectation =
+        DelegatedInstallExpectation::capture(&InstalledState::default(), "copilot-shell");
+
+    let err = execute_delegated_install(
+        &exec,
+        &ctx,
+        &layout,
+        "install copilot-shell",
+        "copilot-shell",
+        expectation,
+    )
+    .expect_err("state added after routing must block dnf");
+    assert!(err.reason().contains("changed"));
+    assert_eq!(fake.install_calls.get(), 0);
+}
+
+#[test]
+fn delegated_install_reinstalls_managed_rpm_without_erasing_metadata() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let before = seed_tracked_rpm(&ctx, "copilot-shell", Ownership::RpmManaged);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "aarch64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+
+    let outcome = handle_one_with_exec(
+        "copilot-shell".to_string(),
+        args("copilot-shell"),
+        &ctx,
+        &exec,
+    )
+    .expect("tracked managed RPM may be reinstalled");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 1);
+
+    let state = load_state(&ctx);
+    let after = state
+        .find_object(ObjectKind::Component, "copilot-shell")
+        .expect("tracked object remains");
+    assert_eq!(after.version, "2.3.0-1.al8");
+    assert_eq!(after.status, ObjectStatus::Installed);
+    assert_eq!(after.ownership, Some(Ownership::RpmManaged));
+    assert_eq!(after.installed_at, before.installed_at);
+    assert_eq!(after.manifest_digest, before.manifest_digest);
+    assert_eq!(after.enabled_features, before.enabled_features);
+    assert_eq!(after.component_refs, before.component_refs);
+    assert_eq!(after.provisioned_packages, before.provisioned_packages);
+    let metadata = after.rpm_metadata.as_ref().expect("rpm metadata");
+    assert_eq!(metadata.arch.as_deref(), Some("aarch64"));
+    assert_eq!(metadata.source_repo.as_deref(), Some("old-repo"));
+    assert_ne!(after.last_operation_id, before.last_operation_id);
+}
+
+#[test]
+fn delegated_install_refuses_missing_observed_rpm() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    seed_tracked_rpm(&ctx, "copilot-shell", Ownership::RpmObserved);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+
+    let err = handle_one_with_exec(
+        "copilot-shell".to_string(),
+        args("copilot-shell"),
+        &ctx,
+        &exec,
+    )
+    .expect_err("observed package must not become managed implicitly");
+    assert!(err.reason().contains("rpm-observed"));
+    assert!(err.reason().contains("forget copilot-shell"));
+    assert_eq!(fake.install_calls.get(), 0);
+}
+
+#[test]
+fn delegated_install_refuses_missing_observed_rpm_without_current_resolution() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    seed_tracked_rpm(&ctx, "cosh", Ownership::RpmObserved);
+    let query = FakeQuery::default();
+
+    let err = handle_one_with_query("cosh".to_string(), args("cosh"), &ctx, &query)
+        .expect_err("observed state must provide a deterministic forget path");
+
+    assert!(err.reason().contains("rpm-observed"));
+    assert!(err.reason().contains("copilot-shell"));
+    assert!(err.reason().contains("forget cosh"));
+    assert!(!err.reason().contains("not an ANOLISA RPM component"));
+}
+
+#[test]
+fn delegated_install_uses_recorded_package_for_managed_component_alias() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    seed_tracked_rpm(&ctx, "cosh", Ownership::RpmManaged);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+
+    let outcome = handle_one_with_exec("cosh".to_string(), args("cosh"), &ctx, &exec)
+        .expect("state package identity must allow alias reinstall");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 1);
+
+    let state = load_state(&ctx);
+    let object = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("managed alias remains canonical");
+    assert_eq!(object.version, "2.3.0-1.al8");
+    assert_eq!(
+        object
+            .rpm_metadata
+            .as_ref()
+            .map(|metadata| metadata.package_name.as_str()),
+        Some("copilot-shell")
+    );
+}
+
+#[test]
+fn delegated_install_normalizes_recorded_managed_package() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    seed_tracked_rpm(&ctx, "cosh", Ownership::RpmManaged);
+    let layout = common::resolve_layout(&ctx);
+    let mut state = load_state(&ctx);
+    state
+        .find_object_mut(ObjectKind::Component, "cosh")
+        .and_then(|object| object.rpm_metadata.as_mut())
+        .expect("rpm metadata")
+        .package_name = " copilot-shell ".to_string();
+    state
+        .save(&layout.state_dir.join("installed.toml"))
+        .expect("save normalized-state fixture");
+
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+
+    let outcome = handle_one_with_exec("cosh".to_string(), args("cosh"), &ctx, &exec)
+        .expect("persisted package whitespace must be normalized consistently");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 1);
+    assert_eq!(
+        load_state(&ctx)
+            .find_object(ObjectKind::Component, "cosh")
+            .and_then(|object| object.rpm_metadata.as_ref())
+            .map(|metadata| metadata.package_name.as_str()),
+        Some("copilot-shell")
+    );
+}
+
+#[test]
+fn delegated_install_rejects_package_override_different_from_managed_state() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    seed_tracked_rpm(&ctx, "cosh", Ownership::RpmManaged);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut install_args = args("cosh");
+    install_args.package = Some("replacement-shell".to_string());
+
+    let err = handle_one_with_exec("cosh".to_string(), install_args, &ctx, &exec)
+        .expect_err("managed package identity must not be repointed");
+    assert!(err.reason().contains("copilot-shell"));
+    assert!(err.reason().contains("replacement-shell"));
+    assert_eq!(fake.install_calls.get(), 0);
+}
+
+#[test]
+fn managed_rpm_query_parse_error_is_not_reported_as_multi_version() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    seed_tracked_rpm(&ctx, "copilot-shell", Ownership::RpmManaged);
+    let query = FakeQuery {
+        unexpected_installed: vec![(
+            "copilot-shell".to_string(),
+            "expected 5 fields, got 4".to_string(),
+        )],
+        ..Default::default()
+    };
+
+    let err = handle_one_with_query(
+        "copilot-shell".to_string(),
+        args("copilot-shell"),
+        &ctx,
+        &query,
+    )
+    .expect_err("malformed rpm output must remain a query error");
+    assert_eq!(err.code(), "EXECUTION_FAILED");
+    assert!(err.reason().contains("expected 5 fields, got 4"));
+    assert!(!err.reason().contains("multiple installed versions"));
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -156,6 +156,8 @@ pub(crate) enum ResolutionSource {
     ComponentIndex,
     /// Site-local `[backends.rpm.package_map]`.
     RepoPackageMap,
+    /// Package identity retained by an existing managed component record.
+    InstalledState,
     /// RPM metadata declares or provides `anolisa-component(...)` on host.
     InstalledRpmProvides,
     /// RPM repository metadata declares or provides `anolisa-component(...)`.


### PR DESCRIPTION
## Description

Serializes delegated RPM installs by holding the ANOLISA install lock across dnf, rpmdb verification, and the atomic state commit. Missing tracked `rpm-managed` packages now reinstall from the package identity retained in state without erasing component metadata, while missing `rpm-observed` packages remain non-owning and require `forget` before a managed install. This is the first change in the split recovery design; fresh-install crash recovery remains a separate follow-up.

## Related Issue

Part of #1451. This PR fixes the lock-contention and tracked reinstall behavior without closing the remaining crash-recovery work.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project code style
- [x] I have added tests that prove the fix is effective
- [ ] Documentation update is not applicable because this changes internal install transaction behavior
- [x] For `anolisa`: `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`, and `cargo test --workspace --locked` pass
- [x] Lock files are up to date

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- Remote Alibaba Cloud Linux 4 x86_64 integration testing with the real `copilot-shell` RPM verified lock contention before dnf, lock retention during dnf, fresh managed state, metadata-preserving managed reinstall, concurrent-state rejection, state-anchored package aliases, and observed-missing refusal in both real and dry-run modes.

## Additional Notes

Fresh installs can still leave rpmdb ahead of ANOLISA state if the process exits after dnf succeeds. Journal-backed fresh-install recovery and `repair` integration remain tracked by #1451 for the next PR in the series.