### PR TITLE
fix(anolisa): recover fresh rpm installs

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
@@ -10,6 +10,7 @@ pub mod list;
 pub mod logs;
 pub mod repair;
 pub mod restart;
+pub(crate) mod rpm_install;
 pub mod status;
 pub mod uninstall;
 pub mod update;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -17,6 +17,7 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::{RpmSituation, execute_adopt, probe_rpm_situation};
+use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
 use crate::resolution::{ResolutionUse, load_optional_component_index};
 use crate::response::CliError;
@@ -105,6 +106,11 @@ pub(crate) fn adopt_with_query(
     }
 
     let layout = common::resolve_layout(ctx);
+    let mut claims = vec![target];
+    if let Some(package) = cli_override {
+        claims.push(package);
+    }
+    rpm_install::reject_pending_claim(&layout, &installed, &claims, &command)?;
     // repo.toml locates the RPM backend and raw-hosted component index. Both
     // are supplementary to the explicit --package input, installed Provides
     // contract, and default name candidate, so unreadable config degrades to
@@ -671,6 +677,20 @@ mod tests {
             !layout.state_dir.join("installed.toml").exists(),
             "dry-run must not write state",
         );
+    }
+
+    #[test]
+    fn adopt_refuses_pending_rpm_install_claim() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("begin pending install");
+        let q = FakeQuery::default();
+
+        let err = adopt_with_query("cosh", Some("copilot-shell"), &c, &q)
+            .expect_err("adopt must not bypass a pending managed install");
+        assert!(err.reason().contains("repair cosh"));
     }
 
     /// `--package` pins the RPM name, bypassing the candidate chain.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -10,6 +10,7 @@ use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
+use crate::commands::tier1::rpm_install;
 use crate::context::{CliContext, InstallMode};
 use crate::repo_config::{
     BackendConfig, HostVars, RepoConfig, RepoConfigError, normalize_override_url,
@@ -97,6 +98,11 @@ fn handle_one_with_config(
         installed,
     } = identity;
     let command = format!("install {requested_component}");
+    let mut initial_claims = vec![requested_component.as_str(), component.as_str()];
+    if let Some(package) = args.package.as_deref() {
+        initial_claims.push(package);
+    }
+    rpm_install::reject_pending_claim(&layout, &installed, &initial_claims, &command)?;
 
     let mut rpm_component_index: Option<ComponentIndex> = None;
 
@@ -352,6 +358,13 @@ pub(crate) fn handle_raw_install(
             version: args.version.as_deref(),
             warnings,
         },
+    )?;
+
+    rpm_install::reject_pending_claim(
+        layout,
+        installed,
+        &[resolved.component.as_str(), resolved.package.as_str()],
+        command,
     )?;
 
     if ctx.dry_run {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -26,6 +26,7 @@ use anolisa_platform::fs_layout::FsLayout;
 use chrono::Utc;
 
 use crate::commands::common;
+use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
 use crate::repo_config::{
     HostVars, RepoConfig, raw_artifact_url, raw_index_url, raw_relative_root,
@@ -1011,6 +1012,12 @@ pub(crate) fn execute_raw(
             command: command.to_string(),
             reason: format!("failed to load installed state: {err}"),
         })?;
+    rpm_install::reject_pending_claim(
+        layout,
+        &state,
+        &[resolution.component.as_str(), resolution.package.as_str()],
+        command,
+    )?;
     ensure_component_backend_compatible(
         &state,
         &resolution.component,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
@@ -15,6 +15,7 @@ use chrono::Utc;
 
 use crate::color::Palette;
 use crate::commands::common;
+use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
 use crate::repo_config::{BackendConfig, RepoConfig};
 use crate::resolution::{
@@ -543,6 +544,19 @@ pub(crate) fn execute_adopt(
     query: &dyn PackageQuery,
 ) -> Result<InstallOutcome, CliError> {
     let mut warnings: Vec<String> = Vec::new();
+    let preview_state =
+        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to load installed state: {err}"),
+        })?;
+    rpm_install::reject_pending_claim(
+        layout,
+        &preview_state,
+        &[component, package.as_str()],
+        command,
+    )?;
+    refuse_observed_repoint(&preview_state, component, &info.name, command)?;
+
     // source_repo is supplementary metadata: a failed origin lookup degrades
     // to `None` with a warning and never fails the adopt (§7.2).
     let source_repo = match query.installed_origin(&package) {
@@ -575,13 +589,6 @@ pub(crate) fn execute_adopt(
     // rpm-observed component must target the same RPM; `--package` pointing at a
     // different one is a migration, not a refresh. This non-locked read is the
     // preview / pre-lock fast-fail; the locked path below re-checks for TOCTOU.
-    let preview_state =
-        common::load_installed_state(ctx, command).map_err(|err| CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("failed to load installed state: {err}"),
-        })?;
-    refuse_observed_repoint(&preview_state, component, &info.name, command)?;
-
     if ctx.dry_run {
         render_adopt(ctx, command, &payload);
         return Ok(InstallOutcome::Adopted);
@@ -598,6 +605,7 @@ pub(crate) fn execute_adopt(
             command: command.to_string(),
             reason: format!("failed to load installed state: {err}"),
         })?;
+    rpm_install::reject_pending_claim(layout, &state, &[component, package.as_str()], command)?;
 
     // Re-validate against the freshly-reloaded state, mirroring execute_raw's
     // post-lock guard. Layer 1 may have decided "adopt" from a pre-lock read
@@ -925,6 +933,8 @@ pub(crate) fn execute_delegated_install(
     // Dry-run: preview the dnf transaction with best-effort repo candidates.
     // Never needs root, never writes state.
     if ctx.dry_run {
+        let preview_state = common::load_installed_state(ctx, command)?;
+        rpm_install::reject_pending_claim(layout, &preview_state, &[component, package], command)?;
         let candidates = match exec.query.query_available(package) {
             Ok(infos) => {
                 let mut evrs: Vec<String> =
@@ -983,11 +993,69 @@ pub(crate) fn execute_delegated_install(
     })?;
     expectation.verify_locked(&state, command)?;
     ensure_component_backend_compatible(&state, component, "rpm", command)?;
+    rpm_install::reject_pending_claim(layout, &state, &[component, package], command)?;
+
+    let mut pending = if matches!(disposition, DelegatedInstallDisposition::Fresh) {
+        Some(rpm_install::begin_fresh_install(
+            layout, component, package, command,
+        )?)
+    } else {
+        None
+    };
+    let audit = match pending.as_ref() {
+        Some(pending) => InstallAudit {
+            operation_id: pending.transaction.operation_id.clone(),
+            started_at: pending.transaction.started_at.clone(),
+        },
+        None => new_install_audit(),
+    };
 
     // dnf install — delegate the file transaction while retaining the lock.
-    exec.txn
-        .install(package)
-        .map_err(|err| txn_install_err(err, command))?;
+    if let Err(err) = exec.txn.install(package) {
+        let install_error = txn_install_err(err, command);
+        if let Some(pending) = pending.as_mut() {
+            match exec.query.query_installed(package) {
+                Ok(None) => {
+                    if let Err(journal_err) = pending.finish_failed(
+                        pending.install_step,
+                        &install_error.reason(),
+                        command,
+                    ) {
+                        return Err(pending_retry_blocked_error(
+                            command,
+                            pending,
+                            &install_error.reason(),
+                            &journal_err,
+                        ));
+                    }
+                    return Err(install_error);
+                }
+                Ok(Some(_)) | Err(_) => {
+                    return Err(finish_partial_recovery_error(
+                        pending,
+                        pending.install_step,
+                        &install_error.reason(),
+                        command,
+                        &format!(
+                            "{}; RPM installation state is not safely known",
+                            install_error.reason()
+                        ),
+                    ));
+                }
+            }
+        }
+        return Err(install_error);
+    }
+    if let Some(pending) = pending.as_mut() {
+        if let Err(err) = pending.mark_install_done(command) {
+            return Err(pending_recovery_error(
+                command,
+                pending,
+                "dnf completed, but ANOLISA could not record the completed RPM install",
+                Some(&err),
+            ));
+        }
+    }
 
     // Refresh from rpmdb: the authoritative installed EVR/arch.
     let info = match exec.query.query_installed(package) {
@@ -995,22 +1063,54 @@ pub(crate) fn execute_delegated_install(
         // dnf reported success, so the package should be present; a miss here is
         // anomalous (a no-op transaction?). Refuse rather than record a phantom.
         Ok(None) => {
+            let reason = format!(
+                "dnf install of '{package}' reported success but rpmdb has no such package"
+            );
+            if let Some(pending) = pending.as_mut() {
+                return Err(finish_partial_recovery_error(
+                    pending,
+                    pending.state_step,
+                    &reason,
+                    command,
+                    &reason,
+                ));
+            }
             return Err(CliError::Runtime {
                 command: command.to_string(),
-                reason: format!(
-                    "dnf install of '{package}' reported success but rpmdb has no such package; the transaction may have been a no-op — run `anolisa status {component}`"
-                ),
+                reason,
             });
         }
         Err(PackageQueryError::UnexpectedOutput { .. }) => {
+            let reason = format!(
+                "RPM package '{package}' has multiple installed versions after install; refusing to record an ambiguous version"
+            );
+            if let Some(pending) = pending.as_mut() {
+                return Err(finish_partial_recovery_error(
+                    pending,
+                    pending.state_step,
+                    &reason,
+                    command,
+                    &reason,
+                ));
+            }
             return Err(CliError::Runtime {
                 command: command.to_string(),
-                reason: format!(
-                    "RPM package '{package}' has multiple installed versions after install; refusing to record an ambiguous version"
-                ),
+                reason,
             });
         }
-        Err(err) => return Err(pkg_query_err(err, command)),
+        Err(err) => {
+            let query_error = pkg_query_err(err, command);
+            if let Some(pending) = pending.as_mut() {
+                return Err(finish_partial_recovery_error(
+                    pending,
+                    pending.state_step,
+                    &query_error.reason(),
+                    command,
+                    &query_error.reason(),
+                ));
+            }
+            return Err(query_error);
+        }
     };
 
     // source_repo is supplementary metadata: a failed origin lookup degrades to
@@ -1025,7 +1125,7 @@ pub(crate) fn execute_delegated_install(
         }
     };
 
-    let (operation_id, snapshot_warnings) = persist_delegated_install_locked(
+    let (operation_id, snapshot_warnings) = match persist_delegated_install_locked(
         ctx,
         layout,
         state,
@@ -1033,11 +1133,42 @@ pub(crate) fn execute_delegated_install(
         component,
         package,
         disposition,
+        &audit,
         &info,
         source_repo.as_deref(),
         &warnings,
-    )?;
+    ) {
+        Ok(result) => result,
+        Err(err) => {
+            if let Some(pending) = pending.as_mut() {
+                return Err(finish_partial_recovery_error(
+                    pending,
+                    pending.state_step,
+                    &err.reason(),
+                    command,
+                    &err.reason(),
+                ));
+            }
+            return Err(err);
+        }
+    };
     warnings.extend(snapshot_warnings);
+
+    // State and its successful operation record are authoritative once saved.
+    // Journal finalisation failures are warnings: the scanner ignores the stale
+    // journal by operation ID, so reporting the completed install as failed
+    // would incorrectly invite a retry.
+    if let Some(pending) = pending.as_mut() {
+        if let Err(err) = pending
+            .mark_state_done(command)
+            .and_then(|()| pending.finish_ok(command))
+        {
+            warnings.push(format!(
+                "installed state was saved, but the RPM recovery journal could not be finalised: {}",
+                err.reason()
+            ));
+        }
+    }
 
     let payload = DelegatedInstallPayload {
         component: component.to_string(),
@@ -1057,6 +1188,81 @@ pub(crate) fn execute_delegated_install(
     Ok(InstallOutcome::Installed)
 }
 
+struct InstallAudit {
+    operation_id: String,
+    started_at: String,
+}
+
+fn new_install_audit() -> InstallAudit {
+    let lock_ts = Utc::now();
+    InstallAudit {
+        operation_id: format!(
+            "op-install-{}-{}",
+            lock_ts.format("%Y%m%d%H%M%S"),
+            lock_ts.timestamp_subsec_nanos()
+        ),
+        started_at: now_iso8601(),
+    }
+}
+
+fn finish_partial_recovery_error(
+    pending: &mut rpm_install::PendingRpmInstall,
+    failed_step: usize,
+    journal_reason: &str,
+    command: &str,
+    detail: &str,
+) -> CliError {
+    let journal_error = pending
+        .finish_partial(failed_step, journal_reason, command)
+        .err();
+    pending_recovery_error(command, pending, detail, journal_error.as_ref())
+}
+
+fn pending_recovery_error(
+    command: &str,
+    pending: &rpm_install::PendingRpmInstall,
+    detail: &str,
+    journal_error: Option<&CliError>,
+) -> CliError {
+    let (journal_detail, write_guidance) = match journal_error {
+        Some(err) => (
+            pending.journal_update_failure_detail(err),
+            "restore write access to ANOLISA state storage, then ",
+        ),
+        None => (
+            format!(
+                "recovery journal operation '{}' is at '{}'",
+                pending.transaction.operation_id,
+                pending.transaction.journal_path.display()
+            ),
+            "",
+        ),
+    };
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "{detail}; RPM package '{}' may be installed while ANOLISA state is incomplete; {journal_detail} — {write_guidance}run `anolisa repair {}` before retrying",
+            pending.package, pending.component
+        ),
+    }
+}
+
+fn pending_retry_blocked_error(
+    command: &str,
+    pending: &rpm_install::PendingRpmInstall,
+    detail: &str,
+    journal_error: &CliError,
+) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "{detail}; the RPM package was not observed as installed, but {}; restore write access to ANOLISA state storage and run `anolisa repair {}` to clear the pending claim before retrying",
+            pending.journal_update_failure_detail(journal_error),
+            pending.component
+        ),
+    }
+}
+
 /// Persist a delegated install as `rpm-managed` state under the install lock,
 /// then append an audit record. Returns the operation id.
 ///
@@ -1072,53 +1278,25 @@ fn persist_delegated_install_locked(
     component: &str,
     package: &str,
     disposition: DelegatedInstallDisposition,
+    audit: &InstallAudit,
     info: &PackageInfo,
     source_repo: Option<&str>,
     warnings: &[String],
 ) -> Result<(String, Vec<String>), CliError> {
     let evr = info.version.to_string();
-    let started_at = now_iso8601();
-
-    let lock_ts = Utc::now();
-    let operation_id = format!(
-        "op-install-{}-{}",
-        lock_ts.format("%Y%m%d%H%M%S"),
-        lock_ts.timestamp_subsec_nanos()
-    );
+    let started_at = audit.started_at.clone();
+    let operation_id = audit.operation_id.clone();
 
     state.install_mode = StateInstallMode::System;
     state.prefix = layout.prefix.clone();
     match disposition {
-        DelegatedInstallDisposition::Fresh => state.upsert_object(InstalledObject {
-            kind: ObjectKind::Component,
-            name: component.to_string(),
-            version: evr.clone(),
-            status: ObjectStatus::Installed,
-            manifest_digest: None,
-            // Not an ANOLISA-delivered raw artifact; dnf resolved the source.
-            distribution_source: None,
-            raw_package: None,
-            install_backend: Some("rpm".to_string()),
-            ownership: Some(Ownership::RpmManaged),
-            rpm_metadata: Some(RpmMetadata {
-                package_name: info.name.clone(),
-                evr: Some(evr.clone()),
-                arch: Some(info.arch.clone()),
-                source_repo: source_repo.map(str::to_string),
-            }),
-            installed_at: started_at.clone(),
-            last_operation_id: Some(operation_id.clone()),
-            managed: true,
-            adopted: false,
-            subscription_scope: Default::default(),
-            enabled_features: Vec::new(),
-            component_refs: Vec::new(),
-            files: Vec::new(),
-            external_modified_files: Vec::new(),
-            services: Vec::new(),
-            health: Vec::new(),
-            provisioned_packages: Vec::new(),
-        }),
+        DelegatedInstallDisposition::Fresh => state.upsert_object(rpm_install::fresh_rpm_object(
+            component,
+            info,
+            source_repo,
+            &operation_id,
+            &started_at,
+        )),
         DelegatedInstallDisposition::ReinstallManaged => {
             let object = state
                 .find_object_mut(ObjectKind::Component, component)
@@ -1149,13 +1327,12 @@ fn persist_delegated_install_locked(
             }
         }
     }
-    state.operations.push(OperationRecord {
-        id: operation_id.clone(),
-        command: command.to_string(),
-        status: "ok".to_string(),
-        started_at: started_at.clone(),
-        finished_at: Some(now_iso8601()),
-    });
+    state.operations.push(rpm_install::install_operation(
+        &operation_id,
+        command,
+        &started_at,
+        now_iso8601(),
+    ));
 
     let state_path = layout.state_dir.join("installed.toml");
     state.save(&state_path).map_err(|err| CliError::Runtime {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -624,11 +624,18 @@ pub struct FakeInstaller {
     pub available: Vec<PackageInfo>,
     /// `false` makes the dnf install transaction fail.
     pub install_succeeds: bool,
+    /// Make the authoritative rpmdb read fail after dnf has run.
+    pub post_install_query_fails: bool,
     pub installed: RefCell<Option<PackageInfo>>,
     pub install_calls: Cell<usize>,
     /// Optional lock path probed from inside `install`.
     pub lock_probe: Option<PathBuf>,
     pub lock_was_held: Cell<bool>,
+    /// Optional installed.toml path replaced with a directory after dnf.
+    pub block_state_save: Option<PathBuf>,
+    /// Optional journal directory replaced with a file during the post-install query.
+    pub block_journal_update: Option<PathBuf>,
+    pub journal_was_blocked: Cell<bool>,
 }
 
 impl FakeInstaller {
@@ -639,10 +646,14 @@ impl FakeInstaller {
             origin: None,
             available: Vec::new(),
             install_succeeds: true,
+            post_install_query_fails: false,
             installed: RefCell::new(None),
             install_calls: Cell::new(0),
             lock_probe: None,
             lock_was_held: Cell::new(false),
+            block_state_save: None,
+            block_journal_update: None,
+            journal_was_blocked: Cell::new(false),
         }
     }
     pub fn with_origin(mut self, repo: &str) -> Self {
@@ -653,8 +664,20 @@ impl FakeInstaller {
         self.install_succeeds = false;
         self
     }
+    pub fn failing_post_install_query(mut self) -> Self {
+        self.post_install_query_fails = true;
+        self
+    }
     pub fn expect_lock_held(mut self, path: PathBuf) -> Self {
         self.lock_probe = Some(path);
+        self
+    }
+    pub fn failing_state_save(mut self, path: PathBuf) -> Self {
+        self.block_state_save = Some(path);
+        self
+    }
+    pub fn failing_journal_update(mut self, path: PathBuf) -> Self {
+        self.block_journal_update = Some(path);
         self
     }
 
@@ -667,6 +690,21 @@ impl PackageQuery for FakeInstaller {
     fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
         if package != self.package {
             return Ok(None);
+        }
+        if self.post_install_query_fails && self.install_calls.get() > 0 {
+            if let Some(path) = &self.block_journal_update
+                && !self.journal_was_blocked.replace(true)
+            {
+                let backup = path.with_extension("before-write-failure");
+                std::fs::rename(path, &backup).expect("move journal directory");
+                std::fs::write(path, b"block journal updates")
+                    .expect("replace journal directory with file");
+            }
+            return Err(PackageQueryError::QueryFailed {
+                command: "rpm".to_string(),
+                code: Some(1),
+                stderr: "rpmdb unavailable".to_string(),
+            });
         }
         Ok(self.installed.borrow().clone())
     }
@@ -744,6 +782,9 @@ impl PackageTransaction for FakeInstaller {
         }
         // rpmdb now holds the package, modelling dnf placing it.
         *self.installed.borrow_mut() = Some(self.installs_to.clone());
+        if let Some(path) = &self.block_state_save {
+            std::fs::create_dir_all(path).expect("block installed.toml save");
+        }
         Ok(())
     }
     fn update(&self, _package: &str) -> Result<(), PackageTransactionError> {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -6,9 +6,11 @@ use anolisa_core::state::{
     InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
     Ownership, RpmMetadata,
 };
+use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus, TransactionStepStatus};
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::commands::common;
+use crate::commands::tier1::rpm_install;
 use crate::context::InstallMode;
 use crate::repo_config::RepoConfig;
 use crate::resolution::ResolutionUse;
@@ -622,7 +624,7 @@ fn delegated_install_writes_rpm_managed_state() {
         pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
     )
     .with_origin("anolisa")
-    .expect_lock_held(layout.lock_file);
+    .expect_lock_held(layout.lock_file.clone());
     let exec = RpmExec {
         query: &fake,
         txn: &fake,
@@ -657,6 +659,19 @@ fn delegated_install_writes_rpm_managed_state() {
     assert_eq!(meta.arch.as_deref(), Some("x86_64"));
     assert_eq!(meta.source_repo.as_deref(), Some("anolisa"));
     assert!(state.operations[0].id.starts_with("op-install-"));
+    assert_eq!(obj.last_operation_id, Some(state.operations[0].id.clone()));
+
+    let journals = load_journals(&layout);
+    assert_eq!(journals.len(), 1);
+    assert_eq!(journals[0].status, TransactionOutcomeStatus::Ok);
+    assert_eq!(journals[0].operation_id, state.operations[0].id);
+    assert_eq!(journals[0].steps.len(), 2);
+    assert!(
+        journals[0]
+            .steps
+            .iter()
+            .all(|step| step.status == TransactionStepStatus::Done)
+    );
 }
 
 fn tracked_rpm_component(component: &str, ownership: Ownership) -> InstalledObject {
@@ -837,6 +852,7 @@ fn delegated_install_reinstalls_managed_rpm_without_erasing_metadata() {
     assert_eq!(metadata.arch.as_deref(), Some("aarch64"));
     assert_eq!(metadata.source_repo.as_deref(), Some("old-repo"));
     assert_ne!(after.last_operation_id, before.last_operation_id);
+    assert!(load_journals(&common::resolve_layout(&ctx)).is_empty());
 }
 
 #[test]
@@ -1088,6 +1104,159 @@ fn delegated_install_dnf_failure_surfaces() {
             .is_none(),
         "failed install must not write state"
     );
+    let journals = load_journals(&common::resolve_layout(&ctx));
+    assert_eq!(journals.len(), 1);
+    assert_eq!(journals[0].status, TransactionOutcomeStatus::Failed);
+}
+
+#[test]
+fn delegated_install_query_failure_leaves_repairable_journal() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    )
+    .failing_post_install_query();
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let mut install_args = args("copilot-shell");
+    install_args.backend = Some("rpm".to_string());
+
+    let err = handle_one_with_exec("copilot-shell".to_string(), install_args, &ctx, &exec)
+        .expect_err("rpmdb failure after dnf must require repair");
+    assert!(err.reason().contains("repair copilot-shell"));
+    assert!(
+        load_state(&ctx)
+            .find_object(ObjectKind::Component, "copilot-shell")
+            .is_none()
+    );
+    let journals = load_journals(&common::resolve_layout(&ctx));
+    assert_eq!(journals.len(), 1);
+    assert_eq!(journals[0].status, TransactionOutcomeStatus::Partial);
+    assert_eq!(journals[0].steps[0].status, TransactionStepStatus::Done);
+    assert_eq!(journals[0].steps[1].status, TransactionStepStatus::Failed);
+}
+
+#[test]
+fn delegated_install_journal_failure_preserves_repair_guidance() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    )
+    .failing_post_install_query()
+    .failing_journal_update(layout.state_dir.join("journal"));
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let expectation =
+        DelegatedInstallExpectation::capture(&InstalledState::default(), "copilot-shell");
+
+    let err = execute_delegated_install(
+        &exec,
+        &ctx,
+        &layout,
+        "install copilot-shell",
+        "copilot-shell",
+        expectation,
+    )
+    .expect_err("journal failure must not hide recovery guidance");
+    assert!(
+        err.reason().contains("rpm query failed"),
+        "got: {}",
+        err.reason()
+    );
+    assert!(
+        err.reason().contains("could not be updated"),
+        "got: {}",
+        err.reason()
+    );
+    assert!(err.reason().contains("may remain live"));
+    assert!(err.reason().contains("recovery journal operation"));
+    assert!(err.reason().contains("repair copilot-shell"));
+}
+
+#[test]
+fn delegated_install_state_save_failure_leaves_repairable_journal() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    )
+    .failing_state_save(layout.state_dir.join("installed.toml"));
+    let exec = RpmExec {
+        query: &fake,
+        txn: &fake,
+        is_root: true,
+    };
+    let expectation =
+        DelegatedInstallExpectation::capture(&InstalledState::default(), "copilot-shell");
+
+    let err = execute_delegated_install(
+        &exec,
+        &ctx,
+        &layout,
+        "install copilot-shell",
+        "copilot-shell",
+        expectation,
+    )
+    .expect_err("state save failure after dnf must require repair");
+    assert!(err.reason().contains("repair copilot-shell"));
+    let journals = load_journals(&layout);
+    assert_eq!(journals.len(), 1);
+    assert_eq!(journals[0].status, TransactionOutcomeStatus::Partial);
+    assert_eq!(journals[0].steps[0].status, TransactionStepStatus::Done);
+    assert_eq!(journals[0].steps[1].status, TransactionStepStatus::Failed);
+}
+
+#[test]
+fn pending_claim_blocks_install_before_dnf() {
+    for dry_run in [false, true] {
+        let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(dry_run);
+        let layout = common::resolve_layout(&ctx);
+        rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("begin pending install");
+        let fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        let exec = RpmExec {
+            query: &fake,
+            txn: &fake,
+            is_root: true,
+        };
+        let mut install_args = args("cosh");
+        install_args.backend = Some("rpm".to_string());
+        install_args.package = Some("copilot-shell".to_string());
+
+        let err = handle_one_with_exec("cosh".to_string(), install_args, &ctx, &exec)
+            .expect_err("pending component/package claim must block routing");
+        assert!(err.reason().contains("repair cosh"));
+        assert_eq!(fake.install_calls.get(), 0);
+    }
+}
+
+fn load_journals(layout: &FsLayout) -> Vec<Transaction> {
+    let dir = layout.state_dir.join("journal");
+    let mut paths = match std::fs::read_dir(dir) {
+        Ok(entries) => entries
+            .map(|entry| entry.expect("journal entry").path())
+            .collect::<Vec<_>>(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(err) => panic!("read journals: {err}"),
+    };
+    paths.sort();
+    paths
+        .into_iter()
+        .map(|path| Transaction::load_journal(&path).expect("valid journal"))
+        .collect()
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -17,14 +17,17 @@ use serde::Serialize;
 
 use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
 use anolisa_core::lock::InstallLock;
-use anolisa_core::state::{ObjectKind, OperationRecord, Ownership, RpmMetadata};
+use anolisa_core::state::{InstalledState, ObjectKind, OperationRecord, Ownership, RpmMetadata};
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
-use crate::commands::tier1::install::rpm_package_candidates_with_index;
+use crate::commands::tier1::install::{
+    rpm_package_candidates_with_index, snapshot_datadir_contract,
+};
+use crate::commands::tier1::rpm_install::{self, PendingRpmInstall};
 use crate::context::CliContext;
 use crate::resolution::{ResolutionUse, load_optional_component_index};
 use crate::response::{CliError, render_json};
@@ -98,6 +101,16 @@ fn repair_with_query(
     let installed = common::load_installed_state(ctx, COMMAND)?;
 
     let component = common::lookup_component_name(target, &installed, ctx, COMMAND);
+
+    let layout = common::resolve_layout(ctx);
+    if let Some(pending) = rpm_install::find_pending_claim(
+        &layout,
+        &installed,
+        &[target, component.as_str()],
+        &command,
+    )? {
+        return repair_pending_rpm(ctx, &layout, &installed, pending, query, &command);
+    }
 
     let obj = installed
         .find_object(ObjectKind::Component, &component)
@@ -221,6 +234,304 @@ fn repair_with_query(
     };
     render_repair(ctx, &payload);
     Ok(())
+}
+
+fn repair_pending_rpm(
+    ctx: &CliContext,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    preview_state: &InstalledState,
+    pending: PendingRpmInstall,
+    query: &dyn PackageQuery,
+    command: &str,
+) -> Result<(), CliError> {
+    // Preview must reject the same ownership conflicts as execution; otherwise
+    // dry-run could promise a recovery that the locked path will refuse.
+    reject_pending_state_owner(preview_state, &pending, command)?;
+
+    if ctx.dry_run {
+        let info = query_pending_package(query, &pending.package, command)?
+            .ok_or_else(|| CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "pending RPM package '{}' for component '{}' is not installed; a real repair would mark the recovery journal Failed and clear its pending claim, then return an error so installation can be retried — run `anolisa repair {}` without --dry-run to perform that cleanup",
+                    pending.package, pending.component, pending.component
+                ),
+            })?;
+        let warnings = Vec::new();
+        let payload = RepairPayload {
+            component: pending.component,
+            package: pending.package,
+            backend: "rpm",
+            ownership: "rpm-managed",
+            install_mode: ctx.install_mode.as_str().to_string(),
+            from_version: None,
+            to_version: info.version.to_string(),
+            refreshed: false,
+            changed: true,
+            dry_run: true,
+            operation_id: None,
+            warnings,
+        };
+        render_repair(ctx, &payload);
+        return Ok(());
+    }
+
+    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut state = common::load_installed_state(ctx, command)?;
+    let mut pending = rpm_install::find_pending_claim(
+        layout,
+        &state,
+        &[pending.component.as_str(), pending.package.as_str()],
+        command,
+    )?
+    .ok_or_else(|| pending_claim_changed_error(&pending, command))?;
+
+    // The unlocked check is only a fast-fail. State may change before lock
+    // acquisition, so ownership must be validated again before any write.
+    reject_pending_state_owner(&state, &pending, command)?;
+
+    let info = match query_pending_package(query, &pending.package, command) {
+        Ok(info) => info,
+        Err(err) => {
+            let journal_error = pending
+                .finish_partial(pending.state_step, &err.reason(), command)
+                .err();
+            return Err(pending_repair_error(
+                &pending,
+                command,
+                &err.reason(),
+                journal_error.as_ref(),
+            ));
+        }
+    };
+    let Some(info) = info else {
+        let reason = format!("RPM package '{}' is not installed", pending.package);
+        if let Err(journal_err) = pending.finish_failed(pending.state_step, &reason, command) {
+            return Err(pending_repair_error(
+                &pending,
+                command,
+                &reason,
+                Some(&journal_err),
+            ));
+        }
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "pending RPM install for component '{}' was terminated because package '{}' is not installed; its journal is now Failed and no longer participates in recovery, and installed.toml was left unchanged — retry `anolisa install {}`",
+                pending.component, pending.package, pending.component
+            ),
+        });
+    };
+
+    let mut warnings = Vec::new();
+    let source_repo = match query.installed_origin(&pending.package) {
+        Ok(origin) => origin,
+        Err(err) => {
+            warnings.push(format!(
+                "could not determine source repo for '{}': {err}",
+                pending.package
+            ));
+            None
+        }
+    };
+    let operation_id = pending.transaction.operation_id.clone();
+    let started_at = pending.transaction.started_at.clone();
+    state.install_mode = anolisa_core::state::InstallMode::System;
+    state.prefix = layout.prefix.clone();
+    state.upsert_object(rpm_install::fresh_rpm_object(
+        &pending.component,
+        &info,
+        source_repo.as_deref(),
+        &operation_id,
+        &started_at,
+    ));
+    let install_command = format!("install {}", pending.component);
+    state.operations.push(rpm_install::install_operation(
+        &operation_id,
+        &install_command,
+        &started_at,
+        now_iso8601(),
+    ));
+    let state_path = layout.state_dir.join("installed.toml");
+    if let Err(err) = state.save(&state_path) {
+        let reason = format!("failed to save recovered RPM state: {err}");
+        let journal_error = pending
+            .finish_partial(pending.state_step, &reason, command)
+            .err();
+        return Err(pending_repair_error(
+            &pending,
+            command,
+            &reason,
+            journal_error.as_ref(),
+        ));
+    }
+
+    if let Err(err) = pending
+        .mark_install_done(command)
+        .and_then(|()| pending.mark_state_done(command))
+        .and_then(|()| pending.finish_ok(command))
+    {
+        warnings.push(format!(
+            "recovered state was saved, but the RPM recovery journal could not be finalised: {}",
+            err.reason()
+        ));
+    }
+    warnings.extend(snapshot_datadir_contract(
+        layout,
+        &pending.component,
+        command,
+    ));
+    if let Err(warning) = append_pending_repair_log(
+        ctx,
+        layout,
+        &pending,
+        &info,
+        &operation_id,
+        &started_at,
+        &warnings,
+    ) {
+        warnings.push(warning);
+    }
+
+    let payload = RepairPayload {
+        component: pending.component,
+        package: pending.package,
+        backend: "rpm",
+        ownership: "rpm-managed",
+        install_mode: ctx.install_mode.as_str().to_string(),
+        from_version: None,
+        to_version: info.version.to_string(),
+        refreshed: true,
+        changed: true,
+        dry_run: false,
+        operation_id: Some(operation_id),
+        warnings,
+    };
+    render_repair(ctx, &payload);
+    Ok(())
+}
+
+fn pending_claim_changed_error(pending: &PendingRpmInstall, command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "pending RPM install '{}' for component '{}' (package '{}', journal {}) no longer matches after the install lock was acquired; it may have completed, moved, or changed — reload installed.toml and cross-check the journal with rpmdb before retrying repair",
+            pending.transaction.operation_id,
+            pending.component,
+            pending.package,
+            pending.transaction.journal_path.display()
+        ),
+    }
+}
+
+fn pending_repair_error(
+    pending: &PendingRpmInstall,
+    command: &str,
+    detail: &str,
+    journal_error: Option<&CliError>,
+) -> CliError {
+    let (journal_detail, write_guidance) = match journal_error {
+        Some(err) => (
+            pending.journal_update_failure_detail(err),
+            "restore write access to ANOLISA state storage, then ",
+        ),
+        None => (
+            format!(
+                "recovery journal operation '{}' is at '{}'",
+                pending.transaction.operation_id,
+                pending.transaction.journal_path.display()
+            ),
+            "",
+        ),
+    };
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "{detail}; {journal_detail} — {write_guidance}run `anolisa repair {}` again",
+            pending.component,
+        ),
+    }
+}
+
+fn reject_pending_state_owner(
+    state: &InstalledState,
+    pending: &PendingRpmInstall,
+    command: &str,
+) -> Result<(), CliError> {
+    let Some(owner) = rpm_install::state_claim_owner(state, &pending.component, &pending.package)
+    else {
+        return Ok(());
+    };
+    Err(CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "pending RPM install for component '{}' (package '{}') conflicts with existing state component '{}'; refusing to overwrite either owner",
+            pending.component, pending.package, owner.name
+        ),
+    })
+}
+
+fn query_pending_package(
+    query: &dyn PackageQuery,
+    package: &str,
+    command: &str,
+) -> Result<Option<PackageInfo>, CliError> {
+    match query.query_installed(package) {
+        Ok(info) => Ok(info),
+        Err(PackageQueryError::CommandMissing { .. }) => Err(rpm_tooling_missing_error(command)),
+        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "rpm returned unexpected output for pending package '{package}': {detail}; recovery marker was preserved"
+            ),
+        }),
+        Err(err) => Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "failed to query pending RPM package '{package}': {err}; recovery marker was preserved"
+            ),
+        }),
+    }
+}
+
+fn append_pending_repair_log(
+    ctx: &CliContext,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    pending: &PendingRpmInstall,
+    info: &PackageInfo,
+    operation_id: &str,
+    started_at: &str,
+    warnings: &[String],
+) -> Result<(), String> {
+    let record = LogRecord {
+        kind: LogKind::Operation,
+        operation_id: Some(operation_id.to_string()),
+        command: format!("repair {}", pending.component),
+        source: "anolisa-cli".to_string(),
+        component: Some(pending.component.clone()),
+        severity: Severity::Info,
+        message: format!(
+            "recovered pending RPM package {} ({}) as rpm-managed for component {}",
+            pending.package, info.version, pending.component
+        ),
+        actor: "cli".to_string(),
+        install_mode: Some(ctx.install_mode.as_str().to_string()),
+        started_at: started_at.to_string(),
+        finished_at: Some(now_iso8601()),
+        status: Some(LogStatus::Ok),
+        objects: vec![pending.component.clone()],
+        backup_ids: Vec::new(),
+        warnings: warnings.to_vec(),
+        details: serde_json::Value::Null,
+    };
+    CentralLog::open(layout.central_log.clone())
+        .append(&record)
+        .map_err(|err| {
+            format!("recovered state was saved, but the central log was not written: {err}")
+        })
 }
 
 /// Resolve the RPM package name `repair` should reconcile against.
@@ -530,11 +841,12 @@ mod tests {
     use super::*;
     use crate::context::InstallMode;
 
-    use std::{fs, path::PathBuf};
+    use std::{cell::Cell, fs, path::PathBuf};
 
     use anolisa_core::state::{
         InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
     };
+    use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus};
     use anolisa_platform::pkg_query::PackageVersion;
 
     /// Configurable in-memory [`PackageQuery`] for the repair tests. Repair runs
@@ -545,6 +857,8 @@ mod tests {
         origin: Option<String>,
         multi_version: bool,
         command_missing: bool,
+        block_journal_update: Option<PathBuf>,
+        journal_was_blocked: Cell<bool>,
     }
 
     impl FakeQuery {
@@ -555,6 +869,8 @@ mod tests {
                 origin: None,
                 multi_version: false,
                 command_missing: false,
+                block_journal_update: None,
+                journal_was_blocked: Cell::new(false),
             }
         }
         fn with_origin(mut self, origin: &str) -> Self {
@@ -569,10 +885,22 @@ mod tests {
             self.command_missing = true;
             self
         }
+        fn failing_journal_update(mut self, path: PathBuf) -> Self {
+            self.block_journal_update = Some(path);
+            self
+        }
     }
 
     impl PackageQuery for FakeQuery {
         fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            if let Some(path) = &self.block_journal_update
+                && !self.journal_was_blocked.replace(true)
+            {
+                let backup = path.with_extension("before-write-failure");
+                fs::rename(path, &backup).expect("move journal directory");
+                fs::write(path, b"block journal updates")
+                    .expect("replace journal directory with file");
+            }
             if self.command_missing {
                 return Err(PackageQueryError::CommandMissing {
                     command: "rpm".to_string(),
@@ -1118,6 +1446,247 @@ name = "copilot-shell"
         assert_eq!(meta.package_name, "legacy-rpm");
         assert_eq!(meta.evr.as_deref(), Some("1.0.0-1.al8"));
         assert_eq!(obj.version, "1.0.0-1.al8");
+    }
+
+    #[test]
+    fn repair_recovers_fresh_rpm_install_by_package_alias() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        let mut pending =
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin pending install");
+        pending
+            .mark_install_done("install cosh")
+            .expect("record dnf success");
+        pending
+            .finish_partial(
+                pending.state_step,
+                "simulated crash before state commit",
+                "install cosh",
+            )
+            .expect("mark partial");
+        let operation_id = pending.transaction.operation_id.clone();
+        let journal_path = pending.transaction.journal_path.clone();
+        let rpm = FakeQuery::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
+        )
+        .with_origin("anolisa");
+
+        repair_with_query("copilot-shell", &c, &rpm).expect("recover pending install");
+
+        let state = load_state(&c);
+        let object = state
+            .find_object(ObjectKind::Component, "cosh")
+            .expect("recovered component");
+        assert_eq!(object.ownership, Some(Ownership::RpmManaged));
+        assert_eq!(
+            object.last_operation_id.as_deref(),
+            Some(operation_id.as_str())
+        );
+        assert!(state.operations.iter().any(|op| op.id == operation_id));
+        let journal = Transaction::load_journal(&journal_path).expect("load journal");
+        assert_eq!(journal.status, TransactionOutcomeStatus::Ok);
+        assert!(
+            journal.steps.iter().all(|step| {
+                step.status == anolisa_core::transaction::TransactionStepStatus::Done
+            })
+        );
+    }
+
+    #[test]
+    fn pending_repair_log_failure_returns_warning() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        let pending =
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin pending install");
+        let log_parent = layout.central_log.parent().expect("central log parent");
+        fs::create_dir_all(log_parent.parent().expect("log root")).expect("create log root");
+        fs::write(log_parent, b"block central log directory").expect("block central log");
+        let info = pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64");
+
+        let warning = append_pending_repair_log(
+            &c,
+            &layout,
+            &pending,
+            &info,
+            &pending.transaction.operation_id,
+            &pending.transaction.started_at,
+            &[],
+        )
+        .expect_err("central log failure must be returned to the caller");
+
+        assert!(warning.contains("recovered state was saved"));
+        assert!(warning.contains("central log was not written"));
+        assert!(warning.contains(&log_parent.display().to_string()));
+    }
+
+    #[test]
+    fn repair_clears_pending_install_when_package_is_absent() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        let pending =
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin pending install");
+        let journal_path = pending.transaction.journal_path.clone();
+        let rpm = FakeQuery::new("copilot-shell", None);
+
+        let err = repair_with_query("cosh", &c, &rpm)
+            .expect_err("absent package must clear pending marker and report retry");
+        assert!(err.reason().contains("retry `anolisa install cosh`"));
+        assert!(err.reason().contains("journal is now Failed"));
+        assert!(err.reason().contains("no longer participates in recovery"));
+        assert!(err.reason().contains("installed.toml was left unchanged"));
+        let journal = Transaction::load_journal(&journal_path).expect("load journal");
+        assert_eq!(journal.status, TransactionOutcomeStatus::Failed);
+        assert!(
+            rpm_install::find_pending_claim(&layout, &InstalledState::default(), &["cosh"], "test")
+                .expect("scan journals")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn repair_pending_absent_dry_run_previews_cleanup_without_mutation() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        let layout = common::resolve_layout(&c);
+        let pending =
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin pending install");
+        let journal_path = pending.transaction.journal_path.clone();
+        let rpm = FakeQuery::new("copilot-shell", None);
+
+        let err = repair_with_query("cosh", &c, &rpm)
+            .expect_err("dry-run must preview cleanup without reporting recovery success");
+        assert!(
+            err.reason()
+                .contains("would mark the recovery journal Failed")
+        );
+        assert!(err.reason().contains("clear its pending claim"));
+        let journal = Transaction::load_journal(&journal_path).expect("load journal");
+        assert_eq!(journal.status, TransactionOutcomeStatus::InFlight);
+    }
+
+    #[test]
+    fn repair_query_failure_marks_pending_install_partial() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        let pending =
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin pending install");
+        let journal_path = pending.transaction.journal_path.clone();
+        let rpm = FakeQuery::new("copilot-shell", None).command_missing();
+
+        repair_with_query("cosh", &c, &rpm).expect_err("query failure must preserve recovery");
+
+        let journal = Transaction::load_journal(&journal_path).expect("load journal");
+        assert_eq!(journal.status, TransactionOutcomeStatus::Partial);
+        assert!(
+            rpm_install::find_pending_claim(&layout, &InstalledState::default(), &["cosh"], "test")
+                .expect("scan pending")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn repair_journal_failure_preserves_retry_guidance() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        let pending =
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin pending install");
+        let operation_id = pending.transaction.operation_id.clone();
+        let journal_path = pending.transaction.journal_path.clone();
+        let rpm = FakeQuery::new("copilot-shell", None)
+            .failing_journal_update(layout.state_dir.join("journal"));
+
+        let err = repair_with_query("cosh", &c, &rpm)
+            .expect_err("journal failure must not hide repair retry guidance");
+        assert!(
+            err.reason().contains("not installed"),
+            "got: {}",
+            err.reason()
+        );
+        assert!(err.reason().contains("could not be updated"));
+        assert!(err.reason().contains("may remain live"));
+        assert!(err.reason().contains(&operation_id));
+        assert!(err.reason().contains(&journal_path.display().to_string()));
+        assert!(err.reason().contains("repair cosh` again"));
+    }
+
+    #[test]
+    fn repair_pending_install_refuses_existing_state_owner() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("begin pending install");
+        seed(&c, raw_object("copilot-shell", "1.0.0"));
+        let rpm = FakeQuery::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
+        );
+
+        let err = repair_with_query("cosh", &c, &rpm)
+            .expect_err("pending recovery must not overwrite a state owner");
+        assert!(
+            err.reason()
+                .contains("conflicts with existing state component")
+        );
+        assert_eq!(
+            load_state(&c)
+                .find_object(ObjectKind::Component, "copilot-shell")
+                .expect("raw owner remains")
+                .ownership,
+            Some(Ownership::RawManaged)
+        );
+    }
+
+    #[test]
+    fn repair_pending_dry_run_refuses_existing_state_owner() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        let layout = common::resolve_layout(&c);
+        rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("begin pending install");
+        seed(&c, raw_object("copilot-shell", "1.0.0"));
+        let rpm = FakeQuery::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")),
+        );
+
+        let err = repair_with_query("cosh", &c, &rpm)
+            .expect_err("dry-run must report the same ownership conflict");
+        assert!(
+            err.reason()
+                .contains("conflicts with existing state component")
+        );
+    }
+
+    #[test]
+    fn changed_pending_claim_error_identifies_original_transaction() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&c);
+        let pending =
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin pending install");
+
+        let err = pending_claim_changed_error(&pending, "repair cosh");
+        assert!(err.reason().contains(&pending.transaction.operation_id));
+        assert!(
+            err.reason()
+                .contains(&pending.transaction.journal_path.display().to_string())
+        );
+        assert!(err.reason().contains("installed.toml"));
+        assert!(err.reason().contains("rpmdb"));
     }
 
     /// CLI surface: `repair <component>` parses to the positional.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_install.rs
@@ -1,0 +1,500 @@
+//! Durable intent and recovery helpers for fresh delegated RPM installs.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anolisa_core::state::{
+    InstalledObject, InstalledState, ObjectKind, ObjectStatus, OperationRecord, Ownership,
+    RpmMetadata,
+};
+use anolisa_core::transaction::{
+    Transaction, TransactionError, TransactionOutcomeStatus, TransactionStep, TransactionStepStatus,
+};
+use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::PackageInfo;
+
+use crate::response::CliError;
+
+const INSTALL_PHASE: &str = "rpm-install";
+const INSTALL_ACTION: &str = "dnf-install";
+const STATE_PHASE: &str = "rpm-state";
+const STATE_ACTION: &str = "commit-rpm-managed";
+
+/// Validated pending intent for a fresh RPM install.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingRpmInstall {
+    pub(crate) transaction: Transaction,
+    pub(crate) component: String,
+    pub(crate) package: String,
+    pub(crate) install_step: usize,
+    pub(crate) state_step: usize,
+}
+
+impl PendingRpmInstall {
+    pub(crate) fn mark_install_done(&mut self, command: &str) -> Result<(), CliError> {
+        if self.transaction.steps[self.install_step].status != TransactionStepStatus::Done {
+            self.transaction
+                .mark_done(self.install_step)
+                .map_err(|err| journal_error(command, "record completed dnf install", err))?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn mark_state_done(&mut self, command: &str) -> Result<(), CliError> {
+        if self.transaction.steps[self.state_step].status != TransactionStepStatus::Done {
+            self.transaction
+                .mark_done(self.state_step)
+                .map_err(|err| journal_error(command, "record committed RPM state", err))?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn finish_ok(&mut self, command: &str) -> Result<(), CliError> {
+        self.transaction
+            .finish(TransactionOutcomeStatus::Ok)
+            .map_err(|err| journal_error(command, "finish RPM install journal", err))
+    }
+
+    pub(crate) fn finish_partial(
+        &mut self,
+        failed_step: usize,
+        reason: &str,
+        command: &str,
+    ) -> Result<(), CliError> {
+        self.transaction
+            .mark_failed(failed_step, reason)
+            .map_err(|err| journal_error(command, "record incomplete RPM install", err))?;
+        self.transaction
+            .finish(TransactionOutcomeStatus::Partial)
+            .map_err(|err| journal_error(command, "finish incomplete RPM install", err))
+    }
+
+    pub(crate) fn finish_failed(
+        &mut self,
+        failed_step: usize,
+        reason: &str,
+        command: &str,
+    ) -> Result<(), CliError> {
+        self.transaction
+            .mark_failed(failed_step, reason)
+            .map_err(|err| journal_error(command, "record failed RPM install", err))?;
+        self.transaction
+            .finish(TransactionOutcomeStatus::Failed)
+            .map_err(|err| journal_error(command, "finish failed RPM install", err))
+    }
+
+    pub(crate) fn journal_update_failure_detail(&self, err: &CliError) -> String {
+        format!(
+            "recovery journal operation '{}' at '{}' could not be updated: {}; it may remain live (InFlight or Partial)",
+            self.transaction.operation_id,
+            self.transaction.journal_path.display(),
+            err.reason()
+        )
+    }
+}
+
+pub(crate) fn journal_dir(layout: &FsLayout) -> PathBuf {
+    layout.state_dir.join("journal")
+}
+
+pub(crate) fn begin_fresh_install(
+    layout: &FsLayout,
+    component: &str,
+    package: &str,
+    command: &str,
+) -> Result<PendingRpmInstall, CliError> {
+    let state_path = layout.state_dir.join("installed.toml");
+    let mut transaction = Transaction::begin("install", state_path, &journal_dir(layout))
+        .map_err(|err| journal_error(command, "create pending RPM install", err))?;
+    // Component and package together define the recovery claim. Persist both
+    // steps in one revision so a crash cannot expose a half-formed contract
+    // that neither repair nor a later install can interpret safely.
+    if let Err(err) = transaction.record_steps([
+        TransactionStep::planned(INSTALL_PHASE, package, INSTALL_ACTION, None),
+        TransactionStep::planned(STATE_PHASE, component, STATE_ACTION, None),
+    ]) {
+        let _ = transaction.finish(TransactionOutcomeStatus::Failed);
+        return Err(journal_error(
+            command,
+            "record pending RPM install steps",
+            err,
+        ));
+    }
+    Ok(PendingRpmInstall {
+        transaction,
+        component: component.to_string(),
+        package: package.to_string(),
+        install_step: 0,
+        state_step: 1,
+    })
+}
+
+/// Find one live RPM claim matching a component or package alias.
+pub(crate) fn find_pending_claim(
+    layout: &FsLayout,
+    state: &InstalledState,
+    claims: &[&str],
+    command: &str,
+) -> Result<Option<PendingRpmInstall>, CliError> {
+    let dir = journal_dir(layout);
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "failed to scan RPM recovery journals in {}: {err}",
+                    dir.display()
+                ),
+            });
+        }
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "failed to read an RPM recovery journal entry in {}: {err}",
+                dir.display()
+            ),
+        })?;
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".journal.toml"))
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    let mut matches = Vec::new();
+    for path in paths {
+        let transaction = Transaction::load_journal(&path).map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "cannot read recovery journal {}: {err}; automatic recovery is unsafe — inspect the journal and cross-check installed.toml with rpmdb before removing any recovery marker",
+                path.display()
+            ),
+        })?;
+        let Some(pending) = parse_pending(transaction, &path, layout, state, command)? else {
+            continue;
+        };
+        if claims.is_empty()
+            || claims
+                .iter()
+                .any(|claim| *claim == pending.component || *claim == pending.package)
+        {
+            matches.push(pending);
+        }
+    }
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        _ => {
+            let journals = matches
+                .iter()
+                .map(|pending| {
+                    format!(
+                        "{} (component '{}', package '{}', path {})",
+                        pending.transaction.operation_id,
+                        pending.component,
+                        pending.package,
+                        pending.transaction.journal_path.display()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "multiple pending RPM installs match '{}': {journals}; refusing to choose an owner automatically — verify each package in rpmdb and inspect the listed journals before removing any recovery marker",
+                    claims.join("', '")
+                ),
+            })
+        }
+    }
+}
+
+pub(crate) fn reject_pending_claim(
+    layout: &FsLayout,
+    state: &InstalledState,
+    claims: &[&str],
+    command: &str,
+) -> Result<(), CliError> {
+    if let Some(pending) = find_pending_claim(layout, state, claims, command)? {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "a previous RPM install for component '{}' (package '{}') is pending recovery; run `anolisa repair {}` before retrying",
+                pending.component, pending.package, pending.component
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn state_claim_owner<'a>(
+    state: &'a InstalledState,
+    component: &str,
+    package: &str,
+) -> Option<&'a InstalledObject> {
+    state.objects.iter().find(|object| {
+        object.kind == ObjectKind::Component
+            && (object.name == component
+                || object.name == package
+                || object
+                    .rpm_metadata
+                    .as_ref()
+                    .is_some_and(|metadata| metadata.package_name.trim() == package))
+    })
+}
+
+fn parse_pending(
+    transaction: Transaction,
+    path: &Path,
+    layout: &FsLayout,
+    state: &InstalledState,
+    command: &str,
+) -> Result<Option<PendingRpmInstall>, CliError> {
+    let install_steps = transaction
+        .steps
+        .iter()
+        .enumerate()
+        .filter(|(_, step)| step.phase == INSTALL_PHASE || step.action == INSTALL_ACTION)
+        .collect::<Vec<_>>();
+    let state_steps = transaction
+        .steps
+        .iter()
+        .enumerate()
+        .filter(|(_, step)| step.phase == STATE_PHASE || step.action == STATE_ACTION)
+        .collect::<Vec<_>>();
+    // `Transaction::begin` persists an empty revision before the initial step
+    // batch. An interruption in that window is known to precede dnf, so the
+    // empty journal owns nothing and is safe to ignore.
+    if install_steps.is_empty() && state_steps.is_empty() {
+        return Ok(None);
+    }
+    if state
+        .operations
+        .iter()
+        .any(|operation| operation.id == transaction.operation_id && operation.status == "ok")
+    {
+        return Ok(None);
+    }
+    if !matches!(
+        transaction.status,
+        TransactionOutcomeStatus::InFlight | TransactionOutcomeStatus::Partial
+    ) {
+        return Ok(None);
+    }
+    if transaction.operation != "install"
+        || install_steps.len() != 1
+        || state_steps.len() != 1
+        || install_steps[0].1.phase != INSTALL_PHASE
+        || install_steps[0].1.action != INSTALL_ACTION
+        || state_steps[0].1.phase != STATE_PHASE
+        || state_steps[0].1.action != STATE_ACTION
+        || install_steps[0].0 >= state_steps[0].0
+        || install_steps[0].1.target.trim().is_empty()
+        || !valid_component_name(state_steps[0].1.target.trim())
+    {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "malformed live RPM recovery journal {} (operation '{}'); automatic recovery is unsafe — cross-check this operation in installed.toml and verify the package in rpmdb before removing or editing the recovery marker",
+                path.display(),
+                transaction.operation_id
+            ),
+        });
+    }
+    let expected_state = layout.state_dir.join("installed.toml");
+    if transaction.state_path != expected_state || transaction.journal_path != path {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "pending RPM journal {} references an unexpected state or journal path",
+                path.display()
+            ),
+        });
+    }
+
+    let component = state_steps[0].1.target.trim().to_string();
+    let package = install_steps[0].1.target.trim().to_string();
+    let install_step = install_steps[0].0;
+    let state_step = state_steps[0].0;
+    drop(install_steps);
+    drop(state_steps);
+
+    Ok(Some(PendingRpmInstall {
+        component,
+        package,
+        install_step,
+        state_step,
+        transaction,
+    }))
+}
+
+fn valid_component_name(component: &str) -> bool {
+    !component.is_empty()
+        && component != "."
+        && component != ".."
+        && !component.contains('/')
+        && !component.contains('\\')
+}
+
+pub(crate) fn fresh_rpm_object(
+    component: &str,
+    info: &PackageInfo,
+    source_repo: Option<&str>,
+    operation_id: &str,
+    installed_at: &str,
+) -> InstalledObject {
+    let evr = info.version.to_string();
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        version: evr.clone(),
+        status: ObjectStatus::Installed,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("rpm".to_string()),
+        ownership: Some(Ownership::RpmManaged),
+        rpm_metadata: Some(RpmMetadata {
+            package_name: info.name.clone(),
+            evr: Some(evr),
+            arch: Some(info.arch.clone()),
+            source_repo: source_repo.map(str::to_string),
+        }),
+        installed_at: installed_at.to_string(),
+        last_operation_id: Some(operation_id.to_string()),
+        managed: true,
+        adopted: false,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
+pub(crate) fn install_operation(
+    operation_id: &str,
+    command: &str,
+    started_at: &str,
+    finished_at: String,
+) -> OperationRecord {
+    OperationRecord {
+        id: operation_id.to_string(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: started_at.to_string(),
+        finished_at: Some(finished_at),
+    }
+}
+
+pub(crate) fn journal_error(command: &str, action: &str, err: TransactionError) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to {action}: {err}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn layout() -> (tempfile::TempDir, FsLayout) {
+        let tmp = tempdir().expect("tmpdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        (tmp, layout)
+    }
+
+    #[test]
+    fn claim_lookup_matches_component_and_package_alias() {
+        let (_tmp, layout) = layout();
+        let pending = begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("begin journal");
+
+        for claim in ["cosh", "copilot-shell"] {
+            let found = find_pending_claim(&layout, &InstalledState::default(), &[claim], "test")
+                .expect("find claim")
+                .expect("pending claim");
+            assert_eq!(
+                found.transaction.operation_id,
+                pending.transaction.operation_id
+            );
+        }
+    }
+
+    #[test]
+    fn claim_lookup_rejects_multiple_matching_journals() {
+        let (_tmp, layout) = layout();
+        let first = begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("first journal");
+        let second = begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("second journal");
+
+        let err = find_pending_claim(&layout, &InstalledState::default(), &["cosh"], "test")
+            .expect_err("ambiguous claim must fail");
+        assert!(err.reason().contains("multiple pending RPM installs"));
+        assert!(err.reason().contains(&first.transaction.operation_id));
+        assert!(err.reason().contains(&second.transaction.operation_id));
+        assert!(err.reason().contains("verify each package in rpmdb"));
+    }
+
+    #[test]
+    fn committed_operation_makes_malformed_stale_journal_ignorable() {
+        let (_tmp, layout) = layout();
+        let mut pending = begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("begin journal");
+        pending.transaction.steps.pop();
+        fs::write(
+            &pending.transaction.journal_path,
+            toml::to_string_pretty(&pending.transaction).expect("serialize journal"),
+        )
+        .expect("rewrite journal");
+        let mut state = InstalledState::default();
+        state.operations.push(OperationRecord {
+            id: pending.transaction.operation_id,
+            command: "install cosh".to_string(),
+            status: "ok".to_string(),
+            started_at: "2026-07-14T00:00:00Z".to_string(),
+            finished_at: Some("2026-07-14T00:00:01Z".to_string()),
+        });
+
+        assert!(
+            find_pending_claim(&layout, &state, &["cosh"], "test")
+                .expect("scan stale journal")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn malformed_live_journal_reports_safe_inspection_steps() {
+        let (_tmp, layout) = layout();
+        let mut pending = begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+            .expect("begin journal");
+        pending.transaction.steps.pop();
+        fs::write(
+            &pending.transaction.journal_path,
+            toml::to_string_pretty(&pending.transaction).expect("serialize journal"),
+        )
+        .expect("rewrite journal");
+
+        let err = find_pending_claim(&layout, &InstalledState::default(), &["cosh"], "test")
+            .expect_err("live malformed journal must fail closed");
+        assert!(err.reason().contains(&pending.transaction.operation_id));
+        assert!(err.reason().contains("installed.toml"));
+        assert!(err.reason().contains("rpmdb"));
+        assert!(err.reason().contains("before removing or editing"));
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -50,6 +50,7 @@ use super::update::check::{
 use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
+use crate::commands::tier1::rpm_install;
 use crate::context::{CliContext, InstallMode};
 use crate::progress::{self, Activity, ProgressReporter};
 use crate::response::{self, CliError};
@@ -626,6 +627,9 @@ fn run_upgrade_with_deps(
     command: &str,
     reporter: &dyn ProgressReporter,
 ) -> Result<UpgradeResult, CliError> {
+    let preview_state = common::load_installed_state(ctx, command)?;
+    reject_upgrade_pending_claims(layout, &preview_state, plan, command)?;
+
     if dry_run {
         // Dry-run only planned; it never applies a transaction, so it reports no
         // apply-phase progress (planning feedback is handled by the caller).
@@ -661,6 +665,7 @@ fn run_upgrade_with_deps(
             reason: format!("failed to acquire install lock: {err}"),
         })?;
         let mut state = common::load_installed_state(ctx, command)?;
+        reject_upgrade_pending_claims(layout, &state, plan, command)?;
         let audit = new_upgrade_audit();
 
         // Upgrade only runs in system mode; keep the state scope consistent with
@@ -877,6 +882,39 @@ fn run_upgrade_with_deps(
         errors,
         warnings,
     })
+}
+
+fn reject_upgrade_pending_claims(
+    layout: &FsLayout,
+    state: &InstalledState,
+    plan: &UpgradePlan,
+    command: &str,
+) -> Result<(), CliError> {
+    for update in &plan.updates {
+        rpm_install::reject_pending_claim(
+            layout,
+            state,
+            &[update.name.as_str(), update.package.as_str()],
+            command,
+        )?;
+    }
+    for install in &plan.installs {
+        rpm_install::reject_pending_claim(
+            layout,
+            state,
+            &[install.name.as_str(), install.package.as_str()],
+            command,
+        )?;
+    }
+    for observed in &plan.observed_defaults {
+        rpm_install::reject_pending_claim(
+            layout,
+            state,
+            &[observed.name.as_str(), observed.package.as_str()],
+            command,
+        )?;
+    }
+    Ok(())
 }
 
 /// Status for a completed real run: `ok` when nothing errored, `partial` when

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -377,6 +377,46 @@ fn upgrade_dry_run_apply_runs_without_root_and_touches_nothing() {
     );
 }
 
+#[test]
+fn upgrade_rejects_pending_rpm_claim_before_any_transaction() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+        .expect("begin pending install");
+    let host = FakeHost::default();
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        )],
+    );
+
+    for dry_run in [true, false] {
+        let err = run_upgrade_with_deps(
+            &ctx,
+            &layout,
+            &plan,
+            &host,
+            &host,
+            true,
+            dry_run,
+            COMMAND,
+            &NoopReporter,
+        )
+        .expect_err("pending install must block the whole upgrade");
+        assert!(err.reason().contains("repair cosh"));
+    }
+    assert!(host.txn_calls().is_empty());
+}
+
 // ── plan conversion ──────────────────────────────────────────────────────────
 
 #[test]

--- a/src/anolisa/crates/anolisa-core/src/transaction.rs
+++ b/src/anolisa/crates/anolisa-core/src/transaction.rs
@@ -350,6 +350,19 @@ impl Transaction {
         self.persist()
     }
 
+    /// Append several steps and persist them as one journal revision.
+    ///
+    /// Use this when recovery requires the complete initial step contract to
+    /// become visible atomically. If the process exits during persistence,
+    /// readers observe either the previous journal or the complete batch.
+    pub fn record_steps(
+        &mut self,
+        steps: impl IntoIterator<Item = TransactionStep>,
+    ) -> Result<(), TransactionError> {
+        self.steps.extend(steps);
+        self.persist()
+    }
+
     /// Mark `idx` as [`TransactionStepStatus::Done`] and persist.
     pub fn mark_done(&mut self, idx: usize) -> Result<(), TransactionError> {
         self.set_step_status(idx, TransactionStepStatus::Done, None)
@@ -763,6 +776,23 @@ mod tests {
         assert_eq!(reloaded.steps.len(), 1);
         assert_eq!(reloaded.steps[0].action, "install_file");
         assert_eq!(reloaded.steps[0].status, TransactionStepStatus::Planned);
+    }
+
+    #[test]
+    fn record_steps_persists_complete_batch() {
+        let tmp = tempdir().expect("tempdir");
+        let (state_path, journal_dir) = fresh(&tmp);
+        let mut tx = Transaction::begin("install", state_path, &journal_dir).expect("begin");
+
+        tx.record_steps([
+            TransactionStep::planned("rpm-install", "pkg", "dnf-install", None),
+            TransactionStep::planned("rpm-state", "component", "commit-state", None),
+        ])
+        .expect("record step batch");
+
+        let reloaded = Transaction::load_journal(&tx.journal_path).expect("load");
+        assert_eq!(reloaded.steps, tx.steps);
+        assert_eq!(reloaded.steps.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes the remaining recovery gap in delegated RPM installs after the install-lock ordering was corrected. A fresh RPM install now persists a typed pending journal before invoking dnf, uses the journal operation ID when committing `rpm-managed` state, and directs incomplete installs to `anolisa repair <component>` instead of leaving an untracked package with no recovery path.

The recovery claim is enforced by both canonical component name and RPM package alias across install, raw install, adopt, repair, and upgrade preflight. Tracked `rpm-managed` reinstalls continue to use their existing state object as the recovery authority and do not create a fresh-install journal.

## Related Issue

closes #1451

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Design Note

The journal is deliberately limited to fresh installs where neither the component nor its RPM package has an ANOLISA state owner. Its two identity-bearing steps—the dnf install and the `rpm-managed` state commit—are written as one atomic journal revision before dnf starts. If state later commits but journal finalization fails, the successful operation ID in `installed.toml` is authoritative and makes the stale journal ignorable.

`anolisa repair` checks pending fresh-install claims before ordinary tracked-object repair:

- If rpmdb contains the package and the state slot is still unowned, repair commits the complete `rpm-managed` object with the original install operation ID.
- If the package is absent, repair marks the journal failed and allows installation to be retried.
- If rpmdb is unavailable or ambiguous, repair preserves a partial journal instead of guessing.
- If state already owns the component or package, both dry-run and real repair refuse to overwrite that owner.

Pending claims are checked once for dry-run and early diagnostics, then checked again under `InstallLock` before any mutation. The lock remains held across dnf, rpmdb verification, state persistence, and journal finalization.

## Ship Note

- No CLI arguments, JSON response shapes, or `installed.toml` schema are changed.
- No automatic `dnf remove` rollback is attempted because dnf may have installed shared dependencies.
- Existing tracked `rpm-managed` reinstalls remain recoverable from their state object and preserve component metadata.
- Upgrade rejects pre-existing pending claims in this PR; making each missing upgrade default its own recoverable child transaction remains separate work.

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- Real-host validation on an authorized Alibaba Cloud Linux 4 test machine using the official `copilot-shell` RPM:
  - normal fresh install produced matching rpmdb, `installed.toml`, operation ID, and terminal journal state;
  - terminating ANOLISA after successful dnf but before state commit left a pending claim that blocked conflicting mutation;
  - `anolisa repair` recovered the package by both component and package alias;
  - repair marked an absent-package pending claim failed so install could be retried;
  - test RPMs, prefixes, wrappers, journals, and ANOLISA test state were removed afterwards.

## Additional Notes

The initial lock-contention reproduction is already fixed by the preceding lock-ordering change. This PR closes #1451 by covering the distinct crash and state-finalization window that begins after dnf has been allowed to run.
