### PR TITLE
feat(anolisa): fix uninstall dry-run JSON

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -242,7 +242,11 @@ pub(crate) fn handle_with_deps(
 
     if ctx.dry_run {
         if ctx.json {
-            return render_json(COMMAND, &plan);
+            let payload = PlanDryRunPayload {
+                dry_run: true,
+                plan: &plan,
+            };
+            return render_json(COMMAND, &payload);
         }
         if !ctx.quiet {
             render_plan_human(&plan, ctx.no_color);
@@ -897,6 +901,26 @@ fn render_uninstall_rpm(ctx: &CliContext, payload: &UninstallRpmPayload) {
     if let Some(id) = &payload.operation_id {
         println!("{} {}", color.label("operation_id:"), color.id(id));
     }
+}
+
+/// JSON wire wrapper for a `--dry-run` [`LifecyclePlan`] (the generic
+/// uninstall/purge plan view).
+///
+/// [`LifecyclePlan`] is a render-context-free planning model and deliberately
+/// carries no `dry_run` field — the plan is identical whether or not the caller
+/// asked to preview it. The CLI only serializes it on the `--dry-run` path, so
+/// the flag is stamped here at the same `data` level as the RPM view's
+/// [`UninstallRpmPayload::dry_run`]. That gives clients a single `data.dry_run`
+/// field to detect a dry-run across both views without a per-view schema branch.
+///
+/// `#[serde(flatten)]` keeps every plan field at the top of `data` (rather than
+/// nesting it under a `plan` key), so the plan's existing wire shape is
+/// preserved and only augmented with `dry_run`.
+#[derive(serde::Serialize)]
+struct PlanDryRunPayload<'a> {
+    dry_run: bool,
+    #[serde(flatten)]
+    plan: &'a LifecyclePlan,
 }
 
 #[derive(serde::Serialize)]
@@ -2559,6 +2583,163 @@ name = "copilot-shell"
         assert!(
             after.find_object(ObjectKind::Component, "cosh").is_none(),
             "ANOLISA state record for 'cosh' must be dropped",
+        );
+    }
+
+    // ── #1471: generic plan-view dry-run JSON contract ──────────────────
+
+    /// #1471: the generic plan view's dry-run JSON must carry
+    /// `data.dry_run == true` and keep every plan field flattened at the
+    /// `data` top level (never nested under a `plan` key), so a client
+    /// detects a dry-run with one field across both the plan and RPM
+    /// views. For an absent component the flattened `phases` must be empty.
+    #[test]
+    fn plan_dry_run_payload_flattens_plan_and_stamps_dry_run() {
+        let empty = InstalledState::default();
+        let plan = LifecyclePlan::for_component_uninstall("agentsight", &empty);
+        let payload = PlanDryRunPayload {
+            dry_run: true,
+            plan: &plan,
+        };
+        let value = serde_json::to_value(&payload).expect("serialize payload");
+        let obj = value
+            .as_object()
+            .expect("payload serializes to a JSON object");
+
+        assert_eq!(
+            obj.get("dry_run"),
+            Some(&serde_json::Value::Bool(true)),
+            "data.dry_run must be true: {value}",
+        );
+        assert!(
+            obj.get("plan").is_none(),
+            "flatten must not introduce a nested 'plan' key: {value}",
+        );
+        assert_eq!(
+            obj.get("operation").and_then(|v| v.as_str()),
+            Some("uninstall"),
+            "flattened plan field 'operation' must sit at the data top level: {value}",
+        );
+        assert_eq!(
+            obj.get("component").and_then(|v| v.as_str()),
+            Some("agentsight"),
+            "flattened plan field 'component' must sit at the data top level: {value}",
+        );
+        assert_eq!(
+            obj.get("phases"),
+            Some(&serde_json::Value::Array(Vec::new())),
+            "absent-component phases must be empty: {value}",
+        );
+    }
+
+    /// #1471: a dry-run over an *installed* raw-managed component keeps the
+    /// legitimate phase `mode == "execute"` — that value describes the real
+    /// execute-time behavior and must not be relabeled for the dry-run
+    /// context — while the payload still reports `dry_run == true`.
+    #[test]
+    fn plan_dry_run_payload_installed_keeps_execute_mode() {
+        use anolisa_core::{FileOwner, OwnedFile, OwnedFileKind};
+
+        let owned = PathBuf::from("/usr/local/bin/agentsight");
+        let mut state = InstalledState::default();
+        state.upsert_object(InstalledObject {
+            kind: ObjectKind::Component,
+            name: "agentsight".to_string(),
+            version: "0.2.0".to_string(),
+            status: ObjectStatus::Installed,
+            manifest_digest: None,
+            distribution_source: Some("file:///fake".to_string()),
+            raw_package: None,
+            install_backend: Some("raw".to_string()),
+            ownership: None,
+            rpm_metadata: None,
+            installed_at: "2026-06-01T10:00:00Z".to_string(),
+            last_operation_id: None,
+            managed: true,
+            adopted: false,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            component_refs: Vec::new(),
+            files: vec![OwnedFile {
+                path: owned.clone(),
+                owner: FileOwner::Anolisa,
+                sha256: Some("0".repeat(64)),
+                kind: OwnedFileKind::File,
+                referent: None,
+            }],
+            external_modified_files: Vec::new(),
+            services: Vec::new(),
+            health: Vec::new(),
+            provisioned_packages: Vec::new(),
+        });
+
+        let plan = LifecyclePlan::for_component_uninstall("agentsight", &state);
+        let payload = PlanDryRunPayload {
+            dry_run: true,
+            plan: &plan,
+        };
+        let value = serde_json::to_value(&payload).expect("serialize payload");
+        let obj = value
+            .as_object()
+            .expect("payload serializes to a JSON object");
+
+        assert_eq!(
+            obj.get("dry_run"),
+            Some(&serde_json::Value::Bool(true)),
+            "installed dry-run must still stamp dry_run: {value}",
+        );
+        let phases = obj
+            .get("phases")
+            .and_then(|v| v.as_array())
+            .expect("phases array present");
+        let remove_file = phases
+            .iter()
+            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("remove_file"))
+            .expect("owned-file removal phase present for installed component");
+        assert_eq!(
+            remove_file.get("mode").and_then(|v| v.as_str()),
+            Some("execute"),
+            "the owned-file removal phase keeps mode=execute: {value}",
+        );
+        let remove_state = phases
+            .iter()
+            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("remove_state"))
+            .expect("remove_state phase present for installed component");
+        assert_eq!(
+            remove_state.get("mode").and_then(|v| v.as_str()),
+            Some("execute"),
+            "the remove_state phase keeps mode=execute: {value}",
+        );
+    }
+
+    /// #1471: `--purge --dry-run` shares the same wrapper, so its JSON also
+    /// carries `data.dry_run == true` with the plan flattened at the top.
+    #[test]
+    fn plan_dry_run_payload_covers_purge() {
+        let empty = InstalledState::default();
+        let plan = LifecyclePlan::for_component_purge("agentsight", &empty);
+        let payload = PlanDryRunPayload {
+            dry_run: true,
+            plan: &plan,
+        };
+        let value = serde_json::to_value(&payload).expect("serialize payload");
+        let obj = value
+            .as_object()
+            .expect("payload serializes to a JSON object");
+
+        assert_eq!(
+            obj.get("dry_run"),
+            Some(&serde_json::Value::Bool(true)),
+            "purge dry-run must stamp dry_run: {value}",
+        );
+        assert_eq!(
+            obj.get("operation").and_then(|v| v.as_str()),
+            Some("purge"),
+            "purge operation must sit flattened at the data top level: {value}",
+        );
+        assert!(
+            obj.get("plan").is_none(),
+            "purge payload must also stay flat: {value}",
         );
     }
 }

--- a/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
@@ -1,0 +1,115 @@
+//! Subprocess wire-contract coverage for the generic lifecycle plan view of
+//! `uninstall --dry-run --json` (#1471).
+//!
+//! The in-crate payload unit tests serialize [`PlanDryRunPayload`] directly, so
+//! they cannot catch a regression that reverts the handler to `render_json(&plan)`
+//! (which would drop `data.dry_run`). These tests drive the real
+//! `handle → render_json` routing through the compiled binary and assert the
+//! full envelope, closing that gap.
+
+use std::process::Output;
+
+mod common;
+
+/// Run the CLI and parse its stdout as a JSON envelope, asserting a clean exit.
+fn run_json(arguments: &[&str]) -> serde_json::Value {
+    let output: Output = common::run(arguments);
+    assert_eq!(
+        Some(0),
+        output.status.code(),
+        "dry-run uninstall of an absent component must exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout must be a JSON envelope: {error}; stdout: {}",
+            String::from_utf8_lossy(&output.stdout),
+        )
+    })
+}
+
+/// The #1471 contract every generic plan-view dry-run must satisfy: a unified
+/// `data.dry_run`, a genuinely empty `phases` for an absent target, and plan
+/// fields kept flat under `data` (never nested behind a `plan` key).
+fn assert_plan_dry_run_contract(data: &serde_json::Value) {
+    assert_eq!(
+        data.get("dry_run"),
+        Some(&serde_json::Value::Bool(true)),
+        "data.dry_run must be true across the plan view: {data}",
+    );
+    assert_eq!(
+        data.get("phases"),
+        Some(&serde_json::Value::Array(Vec::new())),
+        "absent-component phases must be empty: {data}",
+    );
+    assert!(
+        data.get("plan").is_none(),
+        "plan fields must stay flat under data, not nested under 'plan': {data}",
+    );
+}
+
+/// A temp prefix + system mode isolates the run from real state; a name that
+/// is neither installed nor visible falls through to the absent-plan branch.
+fn absent_uninstall_args<'a>(prefix: &'a str, extra: &[&'a str]) -> Vec<&'a str> {
+    let mut args = vec![
+        "--json",
+        "--dry-run",
+        "--install-mode",
+        "system",
+        "--prefix",
+        prefix,
+        "uninstall",
+    ];
+    args.extend_from_slice(extra);
+    args.push("definitely-missing");
+    args
+}
+
+#[test]
+fn uninstall_dry_run_json_absent_component_carries_dry_run_and_empty_phases() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let prefix = tmp.path().to_str().expect("utf-8 prefix");
+    let value = run_json(&absent_uninstall_args(prefix, &[]));
+
+    assert_eq!(
+        value.get("ok"),
+        Some(&serde_json::Value::Bool(true)),
+        "absent-component dry-run is a successful preview: {value}",
+    );
+    assert_eq!(
+        value.get("command").and_then(|v| v.as_str()),
+        Some("uninstall"),
+    );
+    let data = value.get("data").expect("envelope must carry data");
+    assert_eq!(
+        data.get("operation").and_then(|v| v.as_str()),
+        Some("uninstall"),
+    );
+    assert_plan_dry_run_contract(data);
+
+    let warnings = data
+        .get("warnings")
+        .and_then(|v| v.as_array())
+        .expect("plan carries its own warnings list");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().is_some_and(|s| s.contains("not installed"))),
+        "the not-installed warning must remain: {data}",
+    );
+}
+
+#[test]
+fn uninstall_purge_dry_run_json_uses_same_contract() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let prefix = tmp.path().to_str().expect("utf-8 prefix");
+    let value = run_json(&absent_uninstall_args(prefix, &["--purge"]));
+
+    let data = value.get("data").expect("envelope must carry data");
+    assert_eq!(
+        data.get("operation").and_then(|v| v.as_str()),
+        Some("purge"),
+        "purge shares the generic plan view: {data}",
+    );
+    assert_plan_dry_run_contract(data);
+}

--- a/src/anolisa/crates/anolisa-core/src/lifecycle.rs
+++ b/src/anolisa/crates/anolisa-core/src/lifecycle.rs
@@ -622,13 +622,20 @@ fn build_phases(
             }
         }
     }
-    phases.push(LifecyclePhase {
-        name: "remove_state".to_string(),
-        action: "remove_object".to_string(),
-        target: component.to_string(),
-        mode: LifecycleMode::Execute,
-        rollback_hint: Some("anolisa install <component> (reinstall)".to_string()),
-    });
+    // State-record removal is the one phase every *installed* target ends
+    // with. When the target is absent, `components` is empty and the plan is
+    // genuinely empty (see the "not installed — plan is empty" warning in
+    // `build`); appending `remove_state` here would report a phantom removal
+    // that contradicts that warning, so gate it on a present component.
+    if !components.is_empty() {
+        phases.push(LifecyclePhase {
+            name: "remove_state".to_string(),
+            action: "remove_object".to_string(),
+            target: component.to_string(),
+            mode: LifecycleMode::Execute,
+            rollback_hint: Some("anolisa install <component> (reinstall)".to_string()),
+        });
+    }
 
     phases
 }
@@ -2728,6 +2735,33 @@ mod tests {
             other => panic!("expected ComponentNotInstalled, got {other:?}"),
         }
         assert!(!layout.central_log.exists());
+    }
+
+    /// #1471: an absent target must yield a *genuinely* empty plan — the
+    /// "not installed" warning present, and neither a component slice nor
+    /// any phase emitted. Guards the self-contradiction where the warning
+    /// said "plan is empty" while a phantom `remove_state` phase remained.
+    #[test]
+    fn uninstall_absent_component_yields_empty_components_and_phases() {
+        let empty = InstalledState::default();
+        let plan = LifecyclePlan::for_component_uninstall("agentsight", &empty);
+
+        assert!(
+            plan.components.is_empty(),
+            "absent component must produce no component slice",
+        );
+        assert!(
+            plan.phases.is_empty(),
+            "absent component must produce no phases (not even remove_state): {:?}",
+            plan.phases,
+        );
+        assert!(
+            plan.warnings
+                .iter()
+                .any(|w| w.contains("is not installed") && w.contains("plan is empty")),
+            "the not-installed warning must be retained: {:?}",
+            plan.warnings,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Adds `dry_run: true` to generic lifecycle-plan JSON without coupling the core
plan model to CLI rendering context. It also omits the phantom `remove_state`
phase for absent components, making the existing “plan is empty” warning
truthful. Lifecycle phase modes, RPM output, and schema version remain
unchanged.

## Related Issue

closes #1471

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa/` on macOS arm64:

```bash
cargo fmt --all -- --check
cargo check --locked
cargo clippy --all-targets --locked -- -D warnings
cargo test --locked
cargo doc --workspace --no-deps
```

The test suite covers:

- Absent-component uninstall JSON through the compiled CLI binary.
- Absent-component purge JSON through the same subprocess path.
- Flattened `data.dry_run: true` without a nested `plan` field.
- Empty `phases` for absent components.
- Preserved `mode: "execute"` phases for installed raw-managed components.
- No filesystem, RPM database, or ANOLISA state mutation during dry-run.

### Ship Note

- Changed: Generic uninstall and purge dry-runs now expose
  `data.dry_run: true`; absent targets return genuinely empty phase lists.
- Known limitations: Generic plan and RPM payload structures remain distinct;
  absent-plan risk levels are unchanged.
- Not covered: Full raw/RPM schema unification and risk-level normalization.
- Verification: `cargo fmt`, check, Clippy, tests, and rustdoc gates passed;
  subprocess tests validate the complete CLI JSON envelope.

## Additional Notes

No dependencies, lock files, or documentation were changed. The new subprocess
tests fail if the handler regresses to serializing `LifecyclePlan` directly.
