### PR TITLE
fix(anolisa): reconcile rpm state after upgrade

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -91,6 +91,7 @@ const PROFILES_SUBDIR: &str = "profiles";
 // items against the same vocabulary the check produces.
 pub(crate) const ACTION_UPDATE: &str = "update";
 pub(crate) const ACTION_NOOP: &str = "noop";
+pub(crate) const ACTION_RECONCILE: &str = "reconcile";
 pub(crate) const ACTION_INSTALL: &str = "install";
 pub(crate) const ACTION_UNSUPPORTED: &str = "unsupported";
 pub(crate) const ACTION_UNSUPPORTED_RPM: &str = "unsupported_in_rpm_upgrade";
@@ -113,10 +114,10 @@ pub(crate) struct UpdateCheckReport {
     /// narrow: a missing default is an *install*, not an upgrade, so it does not
     /// set this — see [`action_required`](Self::action_required).
     upgrade_available: bool,
-    /// True when there is anything to do: an upgrade **or** a missing default to
-    /// install. This is the signal machine callers should gate on when driving
-    /// `anolisa upgrade`; `upgrade_available` alone would report
-    /// "nothing to upgrade" on a fresh image that is only missing defaults.
+    /// True when there is anything to do: an upgrade, a missing default to
+    /// install, or RPM state to reconcile. This is the signal machine callers
+    /// should gate on when driving `anolisa upgrade`; `upgrade_available` alone
+    /// intentionally covers only package version updates.
     action_required: bool,
     pub(crate) cli: CliCheck,
     pub(crate) components: Vec<ComponentCheck>,
@@ -173,6 +174,10 @@ pub(crate) struct ComponentCheck {
 struct CheckSummary {
     /// Upgrades found (CLI plus components).
     updates: usize,
+    /// Legacy RPM rows whose resolved package metadata needs reconciliation.
+    /// Defaults to zero when reading caches written before this field existed.
+    #[serde(default)]
+    reconciliations: usize,
     /// Profile default components absent from state.
     missing_defaults: usize,
     /// Items outside the RPM upgrade scope (raw-managed, non-RPM CLI).
@@ -424,7 +429,8 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
     }
 
     let upgrade_available = summary.updates > 0;
-    let action_required = upgrade_available || summary.missing_defaults > 0;
+    let action_required =
+        upgrade_available || summary.reconciliations > 0 || summary.missing_defaults > 0;
     UpdateCheckReport {
         target: inputs.target_name,
         backend: "rpm".to_string(),
@@ -646,17 +652,25 @@ fn check_component(
                 backfill_rpm_metadata,
             }
         }
-        Ok(None) => ComponentCheck {
-            component,
-            package: Some(package),
-            ownership: Some(ownership_label),
-            installed: Some(installed_evr),
-            available: None,
-            action: ACTION_NOOP.to_string(),
-            error: None,
-            absent_from_state: false,
-            backfill_rpm_metadata,
-        },
+        Ok(None) => {
+            let action = if backfill_rpm_metadata {
+                summary.reconciliations += 1;
+                ACTION_RECONCILE
+            } else {
+                ACTION_NOOP
+            };
+            ComponentCheck {
+                component,
+                package: Some(package),
+                ownership: Some(ownership_label),
+                installed: Some(installed_evr),
+                available: None,
+                action: action.to_string(),
+                error: None,
+                absent_from_state: false,
+                backfill_rpm_metadata,
+            }
+        }
         Err(err) => {
             summary.errors += 1;
             component_error(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -162,6 +162,10 @@ pub(crate) struct ComponentCheck {
     /// absent from ANOLISA state. It is intentionally not part of JSON/cache.
     #[serde(skip)]
     pub(crate) absent_from_state: bool,
+    /// Internal planner hint: the RPM package was resolved for a legacy state
+    /// row whose package metadata needs to be backfilled by `upgrade`.
+    #[serde(skip)]
+    pub(crate) backfill_rpm_metadata: bool,
 }
 
 /// Aggregate counts used by the summary line, MOTD, and exit signalling.
@@ -386,6 +390,8 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
         }
         components.push(check_component(
             inputs.query,
+            inputs.component_index,
+            inputs.rpm_backend,
             obj,
             inputs.arch,
             &mut summary,
@@ -526,6 +532,8 @@ fn build_cli_check(
 /// Evaluate one installed component against the RPM upgrade scope.
 fn check_component(
     query: &dyn PackageQuery,
+    component_index: Option<&ComponentIndex>,
+    rpm_backend: Option<&BackendConfig>,
     obj: &InstalledObject,
     arch: &str,
     summary: &mut CheckSummary,
@@ -546,26 +554,33 @@ fn check_component(
             action: ACTION_UNSUPPORTED_RPM.to_string(),
             error: None,
             absent_from_state: false,
+            backfill_rpm_metadata: false,
         };
     }
 
     let ownership_label = ownership.label().to_string();
-    let package = match obj
+    let (package, backfill_rpm_metadata) = match obj
         .rpm_metadata
         .as_ref()
         .map(|m| m.package_name.clone())
         .filter(|p| !p.is_empty())
     {
-        Some(package) => package,
+        Some(package) => (package, false),
         None => {
-            summary.errors += 1;
-            return component_error(
-                component,
-                None,
-                ownership_label,
-                Some(obj.version.clone()),
-                "component is recorded as RPM-backed but has no package metadata; run `anolisa repair` to refresh it".to_string(),
-            );
+            match resolve_legacy_component_package(query, component_index, rpm_backend, &component)
+            {
+                Ok(package) => (package, true),
+                Err(reason) => {
+                    summary.errors += 1;
+                    return component_error(
+                        component,
+                        None,
+                        ownership_label,
+                        Some(obj.version.clone()),
+                        reason,
+                    );
+                }
+            }
         }
     };
 
@@ -628,6 +643,7 @@ fn check_component(
                 action: ACTION_UPDATE.to_string(),
                 error: None,
                 absent_from_state: false,
+                backfill_rpm_metadata,
             }
         }
         Ok(None) => ComponentCheck {
@@ -639,6 +655,7 @@ fn check_component(
             action: ACTION_NOOP.to_string(),
             error: None,
             absent_from_state: false,
+            backfill_rpm_metadata,
         },
         Err(err) => {
             summary.errors += 1;
@@ -695,6 +712,7 @@ fn check_default_component(
                         action: ACTION_ERROR.to_string(),
                         error: Some(reason),
                         absent_from_state: true,
+                        backfill_rpm_metadata: false,
                     };
                 }
             };
@@ -716,6 +734,7 @@ fn check_default_component(
                             "cannot query installed version of resolved package for default component '{name}': {err}"
                         )),
                         absent_from_state: true,
+                        backfill_rpm_metadata: false,
                     };
                 }
             }
@@ -729,6 +748,7 @@ fn check_default_component(
                 action: ACTION_INSTALL.to_string(),
                 error: None,
                 absent_from_state: true,
+                backfill_rpm_metadata: false,
             }
         }
         // Could not determine presence (query failure, ambiguous providers).
@@ -746,6 +766,7 @@ fn check_default_component(
                 action: ACTION_ERROR.to_string(),
                 error: Some(reason),
                 absent_from_state: true,
+                backfill_rpm_metadata: false,
             }
         }
     }
@@ -785,6 +806,37 @@ fn resolve_default_install_package(
         }
         Err(err) => Err(format!(
             "cannot resolve RPM package for default component '{name}': {err}"
+        )),
+    }
+}
+
+fn resolve_legacy_component_package(
+    query: &dyn PackageQuery,
+    index: Option<&ComponentIndex>,
+    rpm_backend: Option<&BackendConfig>,
+    name: &str,
+) -> Result<String, String> {
+    let resolver = ComponentResolver::new(index, rpm_backend, Some(query));
+    match resolver.resolve(
+        name,
+        BackendKind::Rpm,
+        ResolutionUse::RepairLegacy,
+        ResolveOptions::default(),
+    ) {
+        Ok(ResolutionSet::Unique(target)) => Ok(target.package),
+        Ok(ResolutionSet::None) => Err(format!(
+            "component '{name}' is recorded as RPM-backed without package metadata, and no RPM package could be resolved; run `anolisa repair {name}`"
+        )),
+        Ok(ResolutionSet::Ambiguous(targets)) => Err(format!(
+            "component '{name}' is recorded as RPM-backed without package metadata, and multiple RPM packages were resolved ({}); run `anolisa repair {name}`",
+            targets
+                .iter()
+                .map(|target| target.package.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+        Err(err) => Err(format!(
+            "cannot resolve the RPM package for legacy component '{name}': {err}"
         )),
     }
 }
@@ -938,6 +990,7 @@ fn check_present_default(
                 action: ACTION_UPDATE.to_string(),
                 error: None,
                 absent_from_state: true,
+                backfill_rpm_metadata: false,
             }
         }
         Ok(None) => ComponentCheck {
@@ -949,6 +1002,7 @@ fn check_present_default(
             action: ACTION_NOOP.to_string(),
             error: None,
             absent_from_state: true,
+            backfill_rpm_metadata: false,
         },
         Err(err) => {
             summary.errors += 1;
@@ -1028,6 +1082,7 @@ fn component_error(
         action: ACTION_ERROR.to_string(),
         error: Some(reason),
         absent_from_state: false,
+        backfill_rpm_metadata: false,
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/render.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/render.rs
@@ -4,8 +4,8 @@
 
 use super::super::UpdateArgs;
 use super::{
-    ACTION_ERROR, ACTION_INSTALL, ACTION_NOOP, ACTION_UNSUPPORTED_RPM, ACTION_UPDATE,
-    CHECK_COMMAND, CliCheck, ComponentCheck, UpdateCheckReport,
+    ACTION_ERROR, ACTION_INSTALL, ACTION_NOOP, ACTION_RECONCILE, ACTION_UNSUPPORTED_RPM,
+    ACTION_UPDATE, CHECK_COMMAND, CliCheck, ComponentCheck, UpdateCheckReport,
 };
 use crate::color::Palette;
 use crate::context::CliContext;
@@ -38,10 +38,10 @@ pub(super) fn render_motd(ctx: &CliContext, report: &UpdateCheckReport) {
     }
 }
 
-/// Build the MOTD text, or `None` when nothing can be upgraded or installed.
+/// Build the MOTD text, or `None` when no upgrade action is required.
 pub(super) fn build_motd(report: &UpdateCheckReport) -> Option<String> {
     let summary = &report.summary;
-    if summary.updates == 0 && summary.missing_defaults == 0 {
+    if summary.updates == 0 && summary.reconciliations == 0 && summary.missing_defaults == 0 {
         return None;
     }
     let mut parts = Vec::new();
@@ -59,8 +59,20 @@ pub(super) fn build_motd(report: &UpdateCheckReport) -> Option<String> {
             plural(summary.missing_defaults)
         ));
     }
+    if summary.reconciliations > 0 {
+        parts.push(format!(
+            "{} component{} requires state reconciliation",
+            summary.reconciliations,
+            plural(summary.reconciliations)
+        ));
+    }
+    let headline = if summary.updates == 0 && summary.missing_defaults == 0 {
+        "ANOLISA state reconciliation is required."
+    } else {
+        "ANOLISA toolchain update is available."
+    };
     Some(format!(
-        "ANOLISA toolchain update is available.\n{}.\nRun: sudo anolisa upgrade to apply, or anolisa update --check for details",
+        "{headline}\n{}.\nRun: sudo anolisa upgrade to apply, or anolisa update --check for details",
         parts.join("; ")
     ))
 }
@@ -85,9 +97,10 @@ fn render_human(ctx: &CliContext, report: &UpdateCheckReport) {
 
     let summary = &report.summary;
     println!(
-        "{} {} update(s), {} new default(s), {} unsupported, {} error(s)",
+        "{} {} update(s), {} reconciliation(s), {} new default(s), {} unsupported, {} error(s)",
         color.label("summary:"),
         summary.updates,
+        summary.reconciliations,
         summary.missing_defaults,
         summary.unsupported,
         summary.errors,
@@ -148,6 +161,12 @@ fn render_component_line(component: &ComponentCheck, color: &Palette) {
             "  {} {}",
             component.component,
             color.warn("(new default — can be installed)"),
+        ),
+        ACTION_RECONCILE => println!(
+            "  {}{} {}",
+            component.component,
+            meta,
+            color.warn("(state reconciliation required)"),
         ),
         ACTION_UNSUPPORTED_RPM => println!(
             "  {}{} {}",

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -855,6 +855,34 @@ fn update_check_repo_query_failure_is_item_error() {
 }
 
 #[test]
+fn update_check_resolves_legacy_rpm_component_without_metadata() {
+    let mut host = FakeHost::with_cli_noop();
+    host.installed.insert(
+        "copilot-shell".to_string(),
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    let backend = rpm_backend_with_package_map("cosh", "copilot-shell");
+    let mut component = rpm_component(
+        "cosh",
+        "copilot-shell",
+        "2.6.1-1.alnx4",
+        Ownership::RpmManaged,
+    );
+    component.rpm_metadata = None;
+    let state = state_with(vec![component]);
+
+    let report = run_with_index_and_backend(&host, &state, None, None, None, Some(&backend));
+
+    let item = &report.components[0];
+    assert_eq!(item.action, ACTION_NOOP);
+    assert_eq!(item.package.as_deref(), Some("copilot-shell"));
+    assert_eq!(item.installed.as_deref(), Some("2.7.0-1.alnx4"));
+    assert!(item.backfill_rpm_metadata);
+    assert!(serde_json::to_value(item).expect("serialize item")["backfill_rpm_metadata"].is_null());
+    assert_eq!(report.summary.errors, 0);
+}
+
+#[test]
 fn update_check_component_missing_from_rpmdb_is_item_error() {
     let host = FakeHost::with_cli_noop();
     // No installed entry for the package → rpmdb miss.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -874,12 +874,31 @@ fn update_check_resolves_legacy_rpm_component_without_metadata() {
     let report = run_with_index_and_backend(&host, &state, None, None, None, Some(&backend));
 
     let item = &report.components[0];
-    assert_eq!(item.action, ACTION_NOOP);
+    assert_eq!(item.action, ACTION_RECONCILE);
     assert_eq!(item.package.as_deref(), Some("copilot-shell"));
     assert_eq!(item.installed.as_deref(), Some("2.7.0-1.alnx4"));
     assert!(item.backfill_rpm_metadata);
-    assert!(serde_json::to_value(item).expect("serialize item")["backfill_rpm_metadata"].is_null());
+    let json = serde_json::to_value(&report).expect("serialize report");
+    assert_eq!(json["components"][0]["action"], ACTION_RECONCILE);
+    assert!(json["components"][0]["backfill_rpm_metadata"].is_null());
+    assert_eq!(json["summary"]["reconciliations"], 1);
+    assert!(report.action_required);
+    assert_eq!(report.summary.reconciliations, 1);
     assert_eq!(report.summary.errors, 0);
+
+    let motd = build_motd(&report).expect("reconciliation appears in MOTD");
+    assert!(motd.contains("ANOLISA state reconciliation is required."));
+    assert!(motd.contains("1 component requires state reconciliation"));
+
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let path = cache_path(&layout);
+    write_cache(&path, &report).expect("write cache");
+    let cached = read_cache(&path).expect("read cache");
+    assert!(cached.report.action_required);
+    assert_eq!(cached.report.summary.reconciliations, 1);
+    assert_eq!(cached.report.components[0].action, ACTION_RECONCILE);
+    assert!(build_motd(&cached.report).is_some());
 }
 
 #[test]
@@ -948,6 +967,7 @@ fn update_check_motd_text_lists_upgrades_and_installs() {
         components: Vec::new(),
         summary: CheckSummary {
             updates: 1,
+            reconciliations: 0,
             missing_defaults: 1,
             unsupported: 0,
             errors: 0,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -9,8 +9,8 @@
 //! 1. Update the RPM-owned `anolisa` CLI package, if a newer candidate exists.
 //! 2. Update already-installed RPM-backed components.
 //! 3. Install target-profile default components that are missing.
-//! 4. Re-read rpmdb and refresh ANOLISA state so `anolisa status` reflects the
-//!    result.
+//! 4. Re-read rpmdb, refresh planned changes, and reconcile recorded RPM state
+//!    so `anolisa status` reflects package-manager truth.
 //!
 //! Scope is deliberately narrow (first phase):
 //! - RPM / system-image scenario only; user mode is rejected. `--dry-run` waives
@@ -26,6 +26,8 @@
 //! and both commands share it, so `upgrade` and `update --check` can never
 //! disagree about what is upgradable.
 
+use std::collections::HashSet;
+
 use chrono::{SecondsFormat, Utc};
 use clap::Parser;
 use serde::Serialize;
@@ -37,7 +39,7 @@ use anolisa_core::state::{
     OperationRecord, Ownership, RpmMetadata,
 };
 use anolisa_platform::fs_layout::FsLayout;
-use anolisa_platform::pkg_query::{PackageInfo, PackageQuery};
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
 use anolisa_platform::privilege;
 use anolisa_platform::rpm_query::RpmPackageQuery;
@@ -419,6 +421,8 @@ struct UpgradeResult {
     dry_run: bool,
     updated: Vec<UpdatedItem>,
     installed: Vec<InstalledItem>,
+    /// RPM-backed state rows refreshed from rpmdb without a package transaction.
+    reconciled: Vec<ReconciledItem>,
     recorded: Vec<RecordedItem>,
     skipped: Vec<SkippedResult>,
     errors: Vec<ErrorResult>,
@@ -440,6 +444,14 @@ struct InstalledItem {
     /// Installed EVR after `dnf install`; `None` on a dry-run preview.
     #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReconciledItem {
+    name: String,
+    package: String,
+    from: String,
+    to: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -494,12 +506,28 @@ struct PendingInstall {
     source_repo: Option<String>,
 }
 
+/// A drifted RPM-backed state row awaiting the caller's single state save.
+struct PendingReconciliation {
+    name: String,
+    package: String,
+    from: String,
+    refreshed: PackageInfo,
+    source_repo: Option<String>,
+}
+
+#[derive(Default)]
+struct ReconciliationInspection {
+    pending: Vec<PendingReconciliation>,
+    errors: Vec<ErrorResult>,
+}
+
 /// Outcome of the single state save: the items it actually recorded (reported as
 /// updated/installed) plus per-item drift errors for changes it refused to make.
 #[derive(Default)]
 struct PersistOutcome {
     updated: Vec<UpdatedItem>,
     installed: Vec<InstalledItem>,
+    reconciled: Vec<ReconciledItem>,
     recorded: Vec<RecordedItem>,
     errors: Vec<ErrorResult>,
 }
@@ -523,11 +551,12 @@ struct FinalizeUpgrade<'a> {
     command: &'a str,
     state: &'a mut InstalledState,
     audit: &'a UpgradeAudit,
+    query: &'a dyn PackageQuery,
     cli_updated: Option<&'a UpdatedItem>,
     updates: &'a [PendingUpdate],
     installs: &'a [PendingInstall],
-    prior_errors: usize,
-    warnings: &'a [String],
+    prior_errors: &'a [ErrorResult],
+    warnings: &'a mut Vec<String>,
 }
 
 fn new_upgrade_audit() -> UpgradeAudit {
@@ -627,9 +656,10 @@ fn run_upgrade_with_deps(
     reporter: &dyn ProgressReporter,
 ) -> Result<UpgradeResult, CliError> {
     if dry_run {
-        // Dry-run only planned; it never applies a transaction, so it reports no
-        // apply-phase progress (planning feedback is handled by the caller).
-        return Ok(render_plan_preview(plan));
+        // Dry-run reads state/rpmdb without taking the install lock, applying a
+        // transaction, or constructing an operation to persist.
+        let state = common::load_installed_state(ctx, command)?;
+        return Ok(render_plan_preview(plan, &state, query));
     }
 
     // Real execution needs root for the dnf transactions. Check up front so the
@@ -650,12 +680,12 @@ fn run_upgrade_with_deps(
     let mut warnings: Vec<String> = Vec::new();
     let mut updated: Vec<UpdatedItem> = Vec::new();
     let mut installed: Vec<InstalledItem> = Vec::new();
+    let mut reconciled: Vec<ReconciledItem> = Vec::new();
     let mut recorded: Vec<RecordedItem> = Vec::new();
-    let needs_finalize = plan.cli.is_some()
-        || !plan.updates.is_empty()
-        || !plan.installs.is_empty()
-        || !plan.observed_defaults.is_empty();
-    if needs_finalize {
+    // An empty transaction plan can still carry RPM state drift caused by an
+    // external yum/dnf run, so every real invocation enters the same locked
+    // finalize boundary. A true no-op returns before save/audit below.
+    {
         let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
             command: command.to_string(),
             reason: format!("failed to acquire install lock: {err}"),
@@ -847,22 +877,24 @@ fn run_upgrade_with_deps(
             command,
             state: &mut state,
             audit: &audit,
+            query,
             cli_updated: cli_updated.as_ref(),
             updates: &pending_updates,
             installs: &pending_installs,
-            prior_errors: errors.len(),
-            warnings: &warnings,
+            prior_errors: &errors,
+            warnings: &mut warnings,
         })?;
         if let Some(item) = cli_updated {
             updated.push(item);
         }
         updated.extend(outcome.updated);
         installed.extend(outcome.installed);
+        reconciled.extend(outcome.reconciled);
         recorded.extend(outcome.recorded);
         errors.extend(outcome.errors);
     }
 
-    let succeeded = updated.len() + installed.len() + recorded.len();
+    let succeeded = updated.len() + installed.len() + reconciled.len() + recorded.len();
     let status = apply_status(succeeded, errors.len());
 
     Ok(UpgradeResult {
@@ -872,6 +904,7 @@ fn run_upgrade_with_deps(
         dry_run: false,
         updated,
         installed,
+        reconciled,
         recorded,
         skipped: skipped_results(plan),
         errors,
@@ -921,6 +954,94 @@ fn installed_origin_or_warn(
     }
 }
 
+/// Inspect existing RPM-backed component rows against rpmdb without mutating
+/// state. Callers decide whether to preview or apply the returned changes.
+fn inspect_rpm_reconciliations(
+    state: &InstalledState,
+    query: &dyn PackageQuery,
+    excluded: &HashSet<String>,
+    warnings: &mut Vec<String>,
+) -> ReconciliationInspection {
+    let mut inspection = ReconciliationInspection::default();
+
+    for object in &state.objects {
+        if object.kind != ObjectKind::Component
+            || !object.effective_ownership().is_rpm()
+            || excluded.contains(&object.name)
+        {
+            continue;
+        }
+        let Some(metadata) = object.rpm_metadata.as_ref() else {
+            continue;
+        };
+        let package = metadata.package_name.as_str();
+        if package.trim().is_empty() {
+            continue;
+        }
+
+        let refreshed = match query.query_installed(package) {
+            Ok(Some(info)) => info,
+            Ok(None) => {
+                inspection.errors.push(ErrorResult {
+                    name: object.name.clone(),
+                    reason: format!(
+                        "RPM package '{package}' recorded for component '{}' is not present in rpmdb; state was not reconciled",
+                        object.name
+                    ),
+                });
+                continue;
+            }
+            Err(PackageQueryError::UnexpectedOutput { detail, .. }) => {
+                inspection.errors.push(ErrorResult {
+                    name: object.name.clone(),
+                    reason: format!(
+                        "rpm returned unexpected output for package '{package}' recorded for component '{}': {detail}; refusing to reconcile without one installed version",
+                        object.name
+                    ),
+                });
+                continue;
+            }
+            Err(err) => {
+                inspection.errors.push(ErrorResult {
+                    name: object.name.clone(),
+                    reason: format!(
+                        "failed to query RPM package '{package}' recorded for component '{}': {err}; state was not reconciled",
+                        object.name
+                    ),
+                });
+                continue;
+            }
+        };
+
+        let to = refreshed.version.to_string();
+        let drifted = object.version != to
+            || metadata.evr.as_deref() != Some(to.as_str())
+            || metadata.arch.as_deref() != Some(refreshed.arch.as_str());
+        if !drifted {
+            continue;
+        }
+        let source_repo = installed_origin_or_warn(query, package, warnings);
+        inspection.pending.push(PendingReconciliation {
+            name: object.name.clone(),
+            package: package.to_string(),
+            from: object.version.clone(),
+            refreshed,
+            source_repo,
+        });
+    }
+
+    inspection
+}
+
+fn reconciliation_result(pending: &PendingReconciliation) -> ReconciledItem {
+    ReconciledItem {
+        name: pending.name.clone(),
+        package: pending.package.clone(),
+        from: pending.from.clone(),
+        to: pending.refreshed.version.to_string(),
+    }
+}
+
 /// Human-readable reason for a failed `dnf` transaction.
 fn txn_error_reason(err: PackageTransactionError) -> String {
     match err {
@@ -944,15 +1065,20 @@ fn txn_error_reason(err: PackageTransactionError) -> String {
     }
 }
 
-/// Build the dry-run preview result from the plan (no host access).
-fn render_plan_preview(plan: &UpgradePlan) -> UpgradeResult {
+/// Build the dry-run preview from the transaction plan plus read-only rpmdb
+/// reconciliation detection.
+fn render_plan_preview(
+    plan: &UpgradePlan,
+    state: &InstalledState,
+    query: &dyn PackageQuery,
+) -> UpgradeResult {
     let mut updated: Vec<UpdatedItem> = Vec::new();
     if let Some(cli) = &plan.cli {
         updated.push(planned_to_updated(cli));
     }
     updated.extend(plan.updates.iter().map(planned_to_updated));
 
-    let installed = plan
+    let installed: Vec<InstalledItem> = plan
         .installs
         .iter()
         .map(|install| InstalledItem {
@@ -961,7 +1087,7 @@ fn render_plan_preview(plan: &UpgradePlan) -> UpgradeResult {
             version: None,
         })
         .collect();
-    let recorded = plan
+    let recorded: Vec<RecordedItem> = plan
         .observed_defaults
         .iter()
         .map(|observed| RecordedItem {
@@ -971,12 +1097,34 @@ fn render_plan_preview(plan: &UpgradePlan) -> UpgradeResult {
         })
         .collect();
 
+    // Planned component work will refresh these rows during finalize, so a
+    // preview must not report the same component as both updated and reconciled.
+    let excluded: HashSet<String> = plan
+        .updates
+        .iter()
+        .map(|item| item.name.clone())
+        .chain(plan.installs.iter().map(|item| item.name.clone()))
+        .chain(plan.observed_defaults.iter().map(|item| item.name.clone()))
+        .collect();
+    let mut warnings = Vec::new();
+    let inspection = inspect_rpm_reconciliations(state, query, &excluded, &mut warnings);
+    let reconciled = inspection
+        .pending
+        .iter()
+        .map(reconciliation_result)
+        .collect::<Vec<_>>();
+    let mut errors = plan_errors(plan);
+    errors.extend(inspection.errors);
+
     // A dry-run whose plan carries errors would be blocked if applied for real;
-    // report that so automation can gate on it, otherwise `ok`.
+    // otherwise report reconcile query failures with normal apply semantics.
     let status = if plan.has_errors() {
         STATUS_BLOCKED
     } else {
-        STATUS_OK
+        apply_status(
+            updated.len() + installed.len() + recorded.len() + reconciled.len(),
+            errors.len(),
+        )
     };
 
     UpgradeResult {
@@ -986,10 +1134,11 @@ fn render_plan_preview(plan: &UpgradePlan) -> UpgradeResult {
         dry_run: true,
         updated,
         installed,
+        reconciled,
         recorded,
         skipped: skipped_results(plan),
-        errors: plan_errors(plan),
-        warnings: Vec::new(),
+        errors,
+        warnings,
     }
 }
 
@@ -1002,6 +1151,7 @@ fn blocked_result(plan: &UpgradePlan) -> UpgradeResult {
         dry_run: false,
         updated: Vec::new(),
         installed: Vec::new(),
+        reconciled: Vec::new(),
         recorded: Vec::new(),
         skipped: skipped_results(plan),
         errors: plan_errors(plan),
@@ -1076,6 +1226,7 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         command,
         state,
         audit,
+        query,
         cli_updated,
         updates,
         installs,
@@ -1213,14 +1364,79 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         }
     }
 
+    // Pending update/install/default changes are already reflected in memory.
+    // Excluding their names makes the reporting invariant explicit: one
+    // component cannot be both transaction-updated and reconciled in this run.
+    let excluded: HashSet<String> = outcome
+        .updated
+        .iter()
+        .map(|item| item.name.clone())
+        .chain(outcome.installed.iter().map(|item| item.name.clone()))
+        .chain(outcome.recorded.iter().map(|item| item.name.clone()))
+        .collect();
+    let inspection = inspect_rpm_reconciliations(state, query, &excluded, warnings);
+    // Apply errors do not exclude a component from the sweep: a transient
+    // post-transaction query may recover here and still reconcile state. If
+    // the retry fails again, keep the original item error instead of counting
+    // the same component twice in the result and durable operation summary.
+    let prior_error_names: HashSet<&str> = prior_errors
+        .iter()
+        .map(|error| error.name.as_str())
+        .collect();
+    outcome.errors.extend(
+        inspection
+            .errors
+            .into_iter()
+            .filter(|error| !prior_error_names.contains(error.name.as_str())),
+    );
+
+    for reconciliation in inspection.pending {
+        let Some(object) = state.find_object_mut(ObjectKind::Component, &reconciliation.name)
+        else {
+            outcome.errors.push(ErrorResult {
+                name: reconciliation.name.clone(),
+                reason: format!(
+                    "component '{}' disappeared from ANOLISA state during RPM reconciliation for package '{}'; state was not changed",
+                    reconciliation.name, reconciliation.package
+                ),
+            });
+            continue;
+        };
+        if !is_matching_rpm_object(object, &reconciliation.package) {
+            outcome.errors.push(ErrorResult {
+                name: reconciliation.name.clone(),
+                reason: format!(
+                    "component '{}' changed ownership/package during RPM reconciliation for package '{}'; state was not changed",
+                    reconciliation.name, reconciliation.package
+                ),
+            });
+            continue;
+        }
+
+        let to = reconciliation.refreshed.version.to_string();
+        object.version = to.clone();
+        object.last_operation_id = Some(audit.operation_id.clone());
+        if let Some(metadata) = object.rpm_metadata.as_mut() {
+            metadata.evr = Some(to.clone());
+            metadata.arch = Some(reconciliation.refreshed.arch.clone());
+            if let Some(source_repo) = &reconciliation.source_repo {
+                metadata.source_repo = Some(source_repo.clone());
+            }
+        }
+        outcome
+            .reconciled
+            .push(reconciliation_result(&reconciliation));
+    }
+
     // Count the whole command's outcome, not just component state: the CLI
     // update (not an ANOLISA object) and the transaction-phase errors are folded
     // in so the durable record shows the true `ok` / `partial` / `failed`.
     let total_success = cli_updated.is_some() as usize
         + outcome.updated.len()
         + outcome.installed.len()
+        + outcome.reconciled.len()
         + outcome.recorded.len();
-    let total_errors = prior_errors + outcome.errors.len();
+    let total_errors = prior_errors.len() + outcome.errors.len();
 
     if total_success == 0 && total_errors == 0 {
         // No transaction actually happened (e.g. only skips/noops reached here);
@@ -1235,9 +1451,10 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         _ => (LogStatus::Failed, Severity::Error),
     };
 
-    // Always append the operation record and save, even when no component object
-    // changed (a CLI-only upgrade, or a run where every component drifted): the
-    // record is what makes a real system mutation auditable via `anolisa logs`.
+    // Always append the operation record and save when real work or an item
+    // error occurred, even if no component object changed (for example a
+    // CLI-only upgrade or failed rpmdb query). The record keeps the attempt
+    // auditable via `anolisa logs`.
     state.operations.push(OperationRecord {
         id: audit.operation_id.clone(),
         command: command.to_string(),
@@ -1254,11 +1471,15 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
 
     // Audit log is best-effort: state already persisted, so a log failure
     // downgrades to a stderr warning rather than unwinding.
-    let recorded = outcome.updated.len() + outcome.installed.len() + outcome.recorded.len();
+    let recorded = outcome.updated.len()
+        + outcome.installed.len()
+        + outcome.reconciled.len()
+        + outcome.recorded.len();
     let log = CentralLog::open(layout.central_log.clone());
     let mut objects: Vec<String> = cli_updated.map(|c| c.package.clone()).into_iter().collect();
     objects.extend(outcome.updated.iter().map(|u| u.name.clone()));
     objects.extend(outcome.installed.iter().map(|i| i.name.clone()));
+    objects.extend(outcome.reconciled.iter().map(|i| i.name.clone()));
     objects.extend(outcome.recorded.iter().map(|i| i.name.clone()));
     let record = LogRecord {
         kind: LogKind::Operation,
@@ -1467,6 +1688,21 @@ fn render_result(ctx: &CliContext, result: &UpgradeResult) {
             color.muted(format!("({})", item.package)),
         );
     }
+    for item in &result.reconciled {
+        let verb = if result.dry_run {
+            "would reconcile"
+        } else {
+            "reconciled"
+        };
+        println!(
+            "  {} {} {} → {} {}",
+            color.ok(format!("✓ {verb}")),
+            item.name,
+            item.from,
+            item.to,
+            color.muted(format!("({})", item.package)),
+        );
+    }
     for item in &result.recorded {
         let verb = if result.dry_run {
             "would record".to_string()
@@ -1498,10 +1734,11 @@ fn render_result(ctx: &CliContext, result: &UpgradeResult) {
     }
 
     println!(
-        "{} {} updated, {} installed, {} recorded, {} skipped, {} error(s) [{}]",
+        "{} {} updated, {} installed, {} reconciled, {} recorded, {} skipped, {} error(s) [{}]",
         color.label("summary:"),
         result.updated.len(),
         result.installed.len(),
+        result.reconciled.len(),
         result.recorded.len(),
         result.skipped.len(),
         result.errors.len(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -184,6 +184,8 @@ struct PlannedUpdate {
     to: String,
     /// Whether a missing state row should be recorded as an observed RPM default.
     adopt_if_missing: bool,
+    /// Whether this package was resolved for a legacy RPM row without metadata.
+    backfill_rpm_metadata: bool,
 }
 
 /// A missing default component the upgrade will `dnf install`.
@@ -200,6 +202,13 @@ struct PlannedObservedDefault {
     name: String,
     package: String,
     installed: String,
+}
+
+/// Resolved RPM identity for a legacy state row that the final sweep may repair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedLegacyReconciliation {
+    name: String,
+    package: String,
 }
 
 /// An item deliberately left untouched (raw-managed, non-RPM CLI).
@@ -227,6 +236,7 @@ struct UpgradePlan {
     updates: Vec<PlannedUpdate>,
     installs: Vec<PlannedInstall>,
     observed_defaults: Vec<PlannedObservedDefault>,
+    legacy_reconciliations: Vec<PlannedLegacyReconciliation>,
     skipped: Vec<SkippedItem>,
     errors: Vec<PlanError>,
 }
@@ -285,6 +295,16 @@ fn build_plan(
 
     // ── components ──
     for component in components {
+        if component.backfill_rpm_metadata
+            && matches!(component.action.as_str(), ACTION_UPDATE | ACTION_NOOP)
+            && let Some(package) = &component.package
+        {
+            plan.legacy_reconciliations
+                .push(PlannedLegacyReconciliation {
+                    name: component.component.clone(),
+                    package: package.clone(),
+                });
+        }
         match component.action.as_str() {
             ACTION_UPDATE => match component_update(component) {
                 Ok(update) => plan.updates.push(update),
@@ -364,6 +384,7 @@ fn cli_update(cli: &CliCheck) -> Result<PlannedUpdate, String> {
         from,
         to,
         adopt_if_missing: false,
+        backfill_rpm_metadata: false,
     })
 }
 
@@ -388,6 +409,7 @@ fn component_update(component: &ComponentCheck) -> Result<PlannedUpdate, String>
         from,
         to,
         adopt_if_missing: component.absent_from_state,
+        backfill_rpm_metadata: component.backfill_rpm_metadata,
     })
 }
 
@@ -492,6 +514,8 @@ struct PendingUpdate {
     source_repo: Option<String>,
     /// True for a target default that was present in rpmdb but absent from state.
     adopt_if_missing: bool,
+    /// True when the locked legacy row may still lack RPM package metadata.
+    backfill_rpm_metadata: bool,
     /// True when no package update occurred and the item should be reported as a
     /// state recording rather than an update.
     record_only: bool,
@@ -513,6 +537,7 @@ struct PendingReconciliation {
     from: String,
     refreshed: PackageInfo,
     source_repo: Option<String>,
+    allow_metadata_backfill: bool,
 }
 
 #[derive(Default)]
@@ -555,6 +580,7 @@ struct FinalizeUpgrade<'a> {
     cli_updated: Option<&'a UpdatedItem>,
     updates: &'a [PendingUpdate],
     installs: &'a [PendingInstall],
+    legacy_reconciliations: &'a [PlannedLegacyReconciliation],
     prior_errors: &'a [ErrorResult],
     warnings: &'a mut Vec<String>,
 }
@@ -578,7 +604,13 @@ fn authorize_plan<'a>(state: &InstalledState, plan: &'a UpgradePlan) -> Authoriz
 
     for update in &plan.updates {
         match state.find_object(ObjectKind::Component, &update.name) {
-            Some(obj) if is_matching_rpm_object(obj, &update.package) => {
+            Some(obj)
+                if is_matching_or_legacy_rpm_object(
+                    obj,
+                    &update.package,
+                    update.backfill_rpm_metadata,
+                ) =>
+            {
                 authorized.updates.push(update);
             }
             Some(obj) => authorized.errors.push(ErrorResult {
@@ -768,6 +800,7 @@ fn run_upgrade_with_deps(
                             refreshed: info,
                             source_repo,
                             adopt_if_missing: update.adopt_if_missing,
+                            backfill_rpm_metadata: update.backfill_rpm_metadata,
                             record_only: false,
                         });
                     }
@@ -848,6 +881,7 @@ fn run_upgrade_with_deps(
                         refreshed: info,
                         source_repo,
                         adopt_if_missing: true,
+                        backfill_rpm_metadata: false,
                         record_only: true,
                     });
                 }
@@ -881,6 +915,7 @@ fn run_upgrade_with_deps(
             cli_updated: cli_updated.as_ref(),
             updates: &pending_updates,
             installs: &pending_installs,
+            legacy_reconciliations: &plan.legacy_reconciliations,
             prior_errors: &errors,
             warnings: &mut warnings,
         })?;
@@ -960,6 +995,7 @@ fn inspect_rpm_reconciliations(
     state: &InstalledState,
     query: &dyn PackageQuery,
     excluded: &HashSet<String>,
+    legacy_reconciliations: &[PlannedLegacyReconciliation],
     warnings: &mut Vec<String>,
 ) -> ReconciliationInspection {
     let mut inspection = ReconciliationInspection::default();
@@ -971,15 +1007,23 @@ fn inspect_rpm_reconciliations(
         {
             continue;
         }
-        let Some(metadata) = object.rpm_metadata.as_ref() else {
-            continue;
+        let (package, allow_metadata_backfill) = match object
+            .rpm_metadata
+            .as_ref()
+            .map(|metadata| metadata.package_name.trim())
+            .filter(|package| !package.is_empty())
+        {
+            Some(package) => (package.to_string(), false),
+            None => match legacy_reconciliations
+                .iter()
+                .find(|candidate| candidate.name == object.name)
+            {
+                Some(candidate) => (candidate.package.clone(), true),
+                None => continue,
+            },
         };
-        let package = metadata.package_name.as_str();
-        if package.trim().is_empty() {
-            continue;
-        }
 
-        let refreshed = match query.query_installed(package) {
+        let refreshed = match query.query_installed(&package) {
             Ok(Some(info)) => info,
             Ok(None) => {
                 inspection.errors.push(ErrorResult {
@@ -1014,19 +1058,23 @@ fn inspect_rpm_reconciliations(
         };
 
         let to = refreshed.version.to_string();
-        let drifted = object.version != to
-            || metadata.evr.as_deref() != Some(to.as_str())
-            || metadata.arch.as_deref() != Some(refreshed.arch.as_str());
+        let metadata_current = object.rpm_metadata.as_ref().is_some_and(|metadata| {
+            metadata.package_name == package
+                && metadata.evr.as_deref() == Some(to.as_str())
+                && metadata.arch.as_deref() == Some(refreshed.arch.as_str())
+        });
+        let drifted = object.version != to || !metadata_current;
         if !drifted {
             continue;
         }
-        let source_repo = installed_origin_or_warn(query, package, warnings);
+        let source_repo = installed_origin_or_warn(query, &package, warnings);
         inspection.pending.push(PendingReconciliation {
             name: object.name.clone(),
-            package: package.to_string(),
+            package,
             from: object.version.clone(),
             refreshed,
             source_repo,
+            allow_metadata_backfill,
         });
     }
 
@@ -1097,6 +1145,22 @@ fn render_plan_preview(
         })
         .collect();
 
+    if plan.has_errors() {
+        return UpgradeResult {
+            target: plan.target.clone(),
+            backend: BACKEND,
+            status: STATUS_BLOCKED,
+            dry_run: true,
+            updated,
+            installed,
+            reconciled: Vec::new(),
+            recorded,
+            skipped: skipped_results(plan),
+            errors: plan_errors(plan),
+            warnings: Vec::new(),
+        };
+    }
+
     // Planned component work will refresh these rows during finalize, so a
     // preview must not report the same component as both updated and reconciled.
     let excluded: HashSet<String> = plan
@@ -1107,7 +1171,13 @@ fn render_plan_preview(
         .chain(plan.observed_defaults.iter().map(|item| item.name.clone()))
         .collect();
     let mut warnings = Vec::new();
-    let inspection = inspect_rpm_reconciliations(state, query, &excluded, &mut warnings);
+    let inspection = inspect_rpm_reconciliations(
+        state,
+        query,
+        &excluded,
+        &plan.legacy_reconciliations,
+        &mut warnings,
+    );
     let reconciled = inspection
         .pending
         .iter()
@@ -1116,16 +1186,10 @@ fn render_plan_preview(
     let mut errors = plan_errors(plan);
     errors.extend(inspection.errors);
 
-    // A dry-run whose plan carries errors would be blocked if applied for real;
-    // otherwise report reconcile query failures with normal apply semantics.
-    let status = if plan.has_errors() {
-        STATUS_BLOCKED
-    } else {
-        apply_status(
-            updated.len() + installed.len() + recorded.len() + reconciled.len(),
-            errors.len(),
-        )
-    };
+    let status = apply_status(
+        updated.len() + installed.len() + recorded.len() + reconciled.len(),
+        errors.len(),
+    );
 
     UpgradeResult {
         target: plan.target.clone(),
@@ -1230,6 +1294,7 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         cli_updated,
         updates,
         installs,
+        legacy_reconciliations,
         prior_errors,
         warnings,
     } = req;
@@ -1276,7 +1341,7 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         // Refuse to graft the new EVR onto a row that is no longer this RPM
         // package (a concurrent backend change), mirroring the single-component
         // update guard.
-        if !is_matching_rpm_object(obj, &update.package) {
+        if !is_matching_or_legacy_rpm_object(obj, &update.package, update.backfill_rpm_metadata) {
             outcome.errors.push(ErrorResult {
                 name: update.name.clone(),
                 reason: format!(
@@ -1288,13 +1353,13 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         }
         obj.version = evr.clone();
         obj.last_operation_id = Some(audit.operation_id.clone());
-        if let Some(meta) = obj.rpm_metadata.as_mut() {
-            meta.evr = Some(evr.clone());
-            meta.arch = Some(update.refreshed.arch.clone());
-            if let Some(source_repo) = &update.source_repo {
-                meta.source_repo = Some(source_repo.clone());
-            }
-        }
+        refresh_rpm_metadata(
+            obj,
+            &update.package,
+            &evr,
+            &update.refreshed.arch,
+            update.source_repo.as_deref(),
+        );
         if update.record_only {
             outcome.recorded.push(RecordedItem {
                 name: update.name.clone(),
@@ -1374,7 +1439,8 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         .chain(outcome.installed.iter().map(|item| item.name.clone()))
         .chain(outcome.recorded.iter().map(|item| item.name.clone()))
         .collect();
-    let inspection = inspect_rpm_reconciliations(state, query, &excluded, warnings);
+    let inspection =
+        inspect_rpm_reconciliations(state, query, &excluded, legacy_reconciliations, warnings);
     // Apply errors do not exclude a component from the sweep: a transient
     // post-transaction query may recover here and still reconcile state. If
     // the retry fails again, keep the original item error instead of counting
@@ -1402,7 +1468,11 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
             });
             continue;
         };
-        if !is_matching_rpm_object(object, &reconciliation.package) {
+        if !is_matching_or_legacy_rpm_object(
+            object,
+            &reconciliation.package,
+            reconciliation.allow_metadata_backfill,
+        ) {
             outcome.errors.push(ErrorResult {
                 name: reconciliation.name.clone(),
                 reason: format!(
@@ -1416,13 +1486,13 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         let to = reconciliation.refreshed.version.to_string();
         object.version = to.clone();
         object.last_operation_id = Some(audit.operation_id.clone());
-        if let Some(metadata) = object.rpm_metadata.as_mut() {
-            metadata.evr = Some(to.clone());
-            metadata.arch = Some(reconciliation.refreshed.arch.clone());
-            if let Some(source_repo) = &reconciliation.source_repo {
-                metadata.source_repo = Some(source_repo.clone());
-            }
-        }
+        refresh_rpm_metadata(
+            object,
+            &reconciliation.package,
+            &to,
+            &reconciliation.refreshed.arch,
+            reconciliation.source_repo.as_deref(),
+        );
         outcome
             .reconciled
             .push(reconciliation_result(&reconciliation));
@@ -1539,6 +1609,41 @@ fn is_matching_rpm_object(obj: &InstalledObject, package: &str) -> bool {
         .as_ref()
         .is_some_and(|m| m.package_name == package)
         && obj.effective_ownership().is_rpm()
+}
+
+fn is_matching_or_legacy_rpm_object(
+    obj: &InstalledObject,
+    package: &str,
+    allow_metadata_backfill: bool,
+) -> bool {
+    is_matching_rpm_object(obj, package)
+        || (allow_metadata_backfill
+            && obj.effective_ownership().is_rpm()
+            && obj
+                .rpm_metadata
+                .as_ref()
+                .is_none_or(|metadata| metadata.package_name.trim().is_empty()))
+}
+
+fn refresh_rpm_metadata(
+    obj: &mut InstalledObject,
+    package: &str,
+    evr: &str,
+    arch: &str,
+    source_repo: Option<&str>,
+) {
+    let metadata = obj.rpm_metadata.get_or_insert_with(|| RpmMetadata {
+        package_name: package.to_string(),
+        evr: None,
+        arch: None,
+        source_repo: None,
+    });
+    metadata.package_name = package.to_string();
+    metadata.evr = Some(evr.to_string());
+    metadata.arch = Some(arch.to_string());
+    if let Some(source_repo) = source_repo {
+        metadata.source_repo = Some(source_repo.to_string());
+    }
 }
 
 /// Build an rpm-observed component object for a target default that was already

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -46,8 +46,8 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use super::update::check::{
-    self, ACTION_ERROR, ACTION_INSTALL, ACTION_NOOP, ACTION_UNSUPPORTED, ACTION_UNSUPPORTED_RPM,
-    ACTION_UPDATE, CliCheck, ComponentCheck,
+    self, ACTION_ERROR, ACTION_INSTALL, ACTION_NOOP, ACTION_RECONCILE, ACTION_UNSUPPORTED,
+    ACTION_UNSUPPORTED_RPM, ACTION_UPDATE, CliCheck, ComponentCheck,
 };
 use crate::color::Palette;
 use crate::commands::common;
@@ -295,19 +295,18 @@ fn build_plan(
 
     // ── components ──
     for component in components {
-        if component.backfill_rpm_metadata
-            && matches!(component.action.as_str(), ACTION_UPDATE | ACTION_NOOP)
-            && let Some(package) = &component.package
-        {
-            plan.legacy_reconciliations
-                .push(PlannedLegacyReconciliation {
-                    name: component.component.clone(),
-                    package: package.clone(),
-                });
-        }
         match component.action.as_str() {
             ACTION_UPDATE => match component_update(component) {
-                Ok(update) => plan.updates.push(update),
+                Ok(update) => {
+                    if component.backfill_rpm_metadata {
+                        plan.legacy_reconciliations
+                            .push(PlannedLegacyReconciliation {
+                                name: update.name.clone(),
+                                package: update.package.clone(),
+                            });
+                    }
+                    plan.updates.push(update);
+                }
                 Err(reason) => plan.errors.push(PlanError {
                     name: component.component.clone(),
                     reason,
@@ -333,6 +332,18 @@ fn build_plan(
                 name: component.component.clone(),
                 reason: RAW_SKIP_REASON.to_string(),
             }),
+            ACTION_RECONCILE => match component.package.clone() {
+                Some(package) => plan.legacy_reconciliations.push(
+                    PlannedLegacyReconciliation {
+                        name: component.component.clone(),
+                        package,
+                    },
+                ),
+                None => plan.errors.push(PlanError {
+                    name: component.component.clone(),
+                    reason: "state reconciliation reported without an RPM package".to_string(),
+                }),
+            },
             ACTION_NOOP => {
                 if component.absent_from_state {
                     match observed_default(component) {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -1365,16 +1365,15 @@ fn empty_plan_reconciles_legacy_rpm_component_and_backfills_metadata() {
             info("copilot-shell", "2.7.0", Some("1.alnx4")),
         )
         .with_origin("copilot-shell", "anolisa");
-    let mut check = component_check(
+    let check = component_check(
         "cosh",
         Some("copilot-shell"),
         Some("rpm-managed"),
         Some("2.7.0-1.alnx4"),
         None,
-        ACTION_NOOP,
+        ACTION_RECONCILE,
         None,
     );
-    check.backfill_rpm_metadata = true;
     let plan = build_plan(None, &cli_noop(), &[check]);
 
     let result = run_upgrade_with_deps(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -206,6 +206,7 @@ fn component_check(
         action: action.to_string(),
         error: error.map(str::to_string),
         absent_from_state: false,
+        backfill_rpm_metadata: false,
     }
 }
 
@@ -1345,6 +1346,124 @@ fn empty_plan_reconciles_all_drifted_rpm_components() {
 }
 
 #[test]
+fn empty_plan_reconciles_legacy_rpm_component_and_backfills_metadata() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut legacy = rpm_component(
+        "cosh",
+        "copilot-shell",
+        "2.6.1-1.alnx4",
+        Ownership::RpmManaged,
+    );
+    legacy.rpm_metadata = None;
+    seed_state(&layout, vec![legacy]);
+
+    let host = FakeHost::default()
+        .with_installed(
+            "copilot-shell",
+            info("copilot-shell", "2.7.0", Some("1.alnx4")),
+        )
+        .with_origin("copilot-shell", "anolisa");
+    let mut check = component_check(
+        "cosh",
+        Some("copilot-shell"),
+        Some("rpm-managed"),
+        Some("2.7.0-1.alnx4"),
+        None,
+        ACTION_NOOP,
+        None,
+    );
+    check.backfill_rpm_metadata = true;
+    let plan = build_plan(None, &cli_noop(), &[check]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("reconcile legacy component");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.reconciled.len(), 1);
+    assert_eq!(result.reconciled[0].name, "cosh");
+    assert!(host.txn_calls().is_empty());
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let object = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("cosh");
+    let metadata = object.rpm_metadata.as_ref().expect("backfilled metadata");
+    assert_eq!(object.version, "2.7.0-1.alnx4");
+    assert_eq!(metadata.package_name, "copilot-shell");
+    assert_eq!(metadata.evr.as_deref(), Some("2.7.0-1.alnx4"));
+    assert_eq!(metadata.arch.as_deref(), Some("x86_64"));
+    assert_eq!(metadata.source_repo.as_deref(), Some("anolisa"));
+}
+
+#[test]
+fn planned_update_backfills_legacy_rpm_metadata() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut legacy = rpm_component(
+        "cosh",
+        "copilot-shell",
+        "2.6.1-1.alnx4",
+        Ownership::RpmManaged,
+    );
+    legacy.rpm_metadata = None;
+    seed_state(&layout, vec![legacy]);
+
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    let mut check = component_check(
+        "cosh",
+        Some("copilot-shell"),
+        Some("rpm-managed"),
+        Some("2.6.1-1.alnx4"),
+        Some("2.7.0-1.alnx4"),
+        ACTION_UPDATE,
+        None,
+    );
+    check.backfill_rpm_metadata = true;
+    let plan = build_plan(None, &cli_noop(), &[check]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("update legacy component");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.updated.len(), 1);
+    assert!(result.reconciled.is_empty());
+    assert_eq!(host.txn_calls(), vec!["update:copilot-shell"]);
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let object = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("cosh");
+    let metadata = object.rpm_metadata.as_ref().expect("backfilled metadata");
+    assert_eq!(object.version, "2.7.0-1.alnx4");
+    assert_eq!(metadata.package_name, "copilot-shell");
+    assert_eq!(metadata.evr.as_deref(), Some("2.7.0-1.alnx4"));
+}
+
+#[test]
 fn empty_plan_without_drift_is_true_noop() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let ctx = system_ctx(tmp.path().to_path_buf());
@@ -1852,6 +1971,58 @@ fn reconcile_origin_failure_preserves_prior_source() {
             .and_then(|metadata| metadata.source_repo.as_deref()),
         Some("@System"),
     );
+}
+
+#[test]
+fn blocked_dry_run_does_not_inspect_rpm_reconciliation() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "2.6.1-1.alnx4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "broken",
+            None,
+            Some("rpm-managed"),
+            None,
+            None,
+            ACTION_ERROR,
+            Some("planning failed"),
+        )],
+    );
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        false,
+        true,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("blocked dry-run renders");
+
+    assert_eq!(result.status, STATUS_BLOCKED);
+    assert!(result.reconciled.is_empty());
+    assert_eq!(result.errors.len(), 1);
+    assert!(host.query_calls().is_empty());
+    assert!(host.txn_calls().is_empty());
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -33,12 +33,20 @@ struct FakeHost {
     fail_install: HashSet<String>,
     /// packages whose `query_installed` returns `Ok(None)` (rpmdb miss).
     missing_after: HashSet<String>,
+    /// packages whose installed query reports multiple/unparseable rows.
+    ambiguous_after: HashSet<String>,
+    /// packages whose installed query fails.
+    fail_query: HashSet<String>,
+    /// packages whose next installed query fails once, then recovers.
+    fail_query_once: RefCell<HashSet<String>>,
     /// package -> source repo returned by `installed_origin`.
     origins: HashMap<String, String>,
     /// packages whose `installed_origin` returns an error.
     fail_origin: HashSet<String>,
     /// ordered transaction log (`"update:<pkg>"` / `"install:<pkg>"`).
     calls: RefCell<Vec<String>>,
+    /// package names inspected through `query_installed`.
+    query_calls: RefCell<Vec<String>>,
 }
 
 impl FakeHost {
@@ -55,10 +63,28 @@ impl FakeHost {
     fn txn_calls(&self) -> Vec<String> {
         self.calls.borrow().clone()
     }
+
+    fn query_calls(&self) -> Vec<String> {
+        self.query_calls.borrow().clone()
+    }
 }
 
 impl PackageQuery for FakeHost {
     fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+        self.query_calls.borrow_mut().push(package.to_string());
+        if self.ambiguous_after.contains(package) {
+            return Err(PackageQueryError::UnexpectedOutput {
+                command: "rpm".to_string(),
+                detail: "2 installed versions".to_string(),
+            });
+        }
+        if self.fail_query.contains(package) || self.fail_query_once.borrow_mut().remove(package) {
+            return Err(PackageQueryError::QueryFailed {
+                command: "rpm".to_string(),
+                code: Some(1),
+                stderr: "rpmdb read failed".to_string(),
+            });
+        }
         if self.missing_after.contains(package) {
             return Ok(None);
         }
@@ -128,6 +154,12 @@ fn info(name: &str, version: &str, release: Option<&str>) -> PackageInfo {
         arch: "x86_64".to_string(),
         origin: None,
     }
+}
+
+fn info_with_arch(name: &str, version: &str, release: Option<&str>, arch: &str) -> PackageInfo {
+    let mut package = info(name, version, release);
+    package.arch = arch.to_string();
+    package
 }
 
 fn cli_check(
@@ -1237,6 +1269,648 @@ fn cli_success_with_component_failure_records_partial_audit() {
         state.operations.last().map(|op| op.status.as_str()),
         Some("partial"),
         "CLI success + component failure must record a partial operation"
+    );
+}
+
+// ── batch RPM state reconciliation (issue #1472) ───────────────────────────
+
+#[test]
+fn empty_plan_reconciles_all_drifted_rpm_components() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let components = [
+        ("sec-core", "agent-sec-core", "0.7.1", "0.8.0"),
+        ("agentsight", "agentsight", "0.7.1", "0.8.0"),
+        ("tokenless", "tokenless", "0.6.1", "0.7.0"),
+        ("agent-memory", "agent-memory", "0.2.1", "0.2.3"),
+        ("cosh", "copilot-shell", "2.6.1", "2.7.0"),
+        ("skillfs", "skillfs", "0.3.2", "0.3.3"),
+    ];
+    let objects = components
+        .iter()
+        .map(|(name, package, old, _)| {
+            rpm_component(
+                name,
+                package,
+                &format!("{old}-1.alnx4"),
+                Ownership::RpmManaged,
+            )
+        })
+        .collect();
+    seed_state(&layout, objects);
+
+    let mut host = FakeHost::default();
+    for (_, package, _, new) in components {
+        host.installed
+            .insert(package.to_string(), info(package, new, Some("1.alnx4")));
+    }
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("reconcile empty plan");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert!(result.updated.is_empty());
+    assert_eq!(result.reconciled.len(), 6);
+    assert!(host.txn_calls().is_empty(), "reconcile must not call dnf");
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(state.operations.len(), 1, "one upgrade operation");
+    let operation_id = &state.operations[0].id;
+    for (name, _package, _old, new) in components {
+        let expected = format!("{new}-1.alnx4");
+        let object = state
+            .find_object(ObjectKind::Component, name)
+            .expect("reconciled component");
+        let metadata = object.rpm_metadata.as_ref().expect("rpm metadata");
+        assert_eq!(object.version, expected);
+        assert_eq!(metadata.evr.as_deref(), Some(expected.as_str()));
+        assert_eq!(metadata.arch.as_deref(), Some("x86_64"));
+        assert_eq!(
+            object.last_operation_id.as_deref(),
+            Some(operation_id.as_str())
+        );
+    }
+}
+
+#[test]
+fn empty_plan_without_drift_is_true_noop() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut object = rpm_component(
+        "cosh",
+        "copilot-shell",
+        "2.7.0-1.alnx4",
+        Ownership::RpmManaged,
+    );
+    object.last_operation_id = Some("op-before".to_string());
+    seed_state(&layout, vec![object]);
+    let before = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("before");
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("true noop");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert!(result.reconciled.is_empty());
+    assert!(result.errors.is_empty());
+    assert!(host.txn_calls().is_empty());
+    let after = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("after");
+    assert_eq!(after, before, "a drift-free run must not save state");
+}
+
+#[test]
+fn planned_update_is_not_reported_as_reconciled() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![
+            rpm_component(
+                "cosh",
+                "copilot-shell",
+                "2.6.1-1.alnx4",
+                Ownership::RpmManaged,
+            ),
+            rpm_component(
+                "sec-core",
+                "agent-sec-core",
+                "0.7.1-1.alnx4",
+                Ownership::RpmManaged,
+            ),
+        ],
+    );
+    let host = FakeHost::default()
+        .with_installed(
+            "copilot-shell",
+            info("copilot-shell", "2.7.0", Some("1.alnx4")),
+        )
+        .with_installed(
+            "agent-sec-core",
+            info("agent-sec-core", "0.8.0", Some("1.alnx4")),
+        );
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("2.6.1-1.alnx4"),
+            Some("2.7.0-1.alnx4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("update and reconcile");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].name, "cosh");
+    assert_eq!(result.reconciled.len(), 1);
+    assert_eq!(result.reconciled[0].name, "sec-core");
+    assert_eq!(host.txn_calls(), vec!["update:copilot-shell"]);
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(state.operations.len(), 1, "one operation and one save path");
+    let operation_id = &state.operations[0].id;
+    for name in ["cosh", "sec-core"] {
+        assert_eq!(
+            state
+                .find_object(ObjectKind::Component, name)
+                .and_then(|object| object.last_operation_id.as_deref()),
+            Some(operation_id.as_str()),
+            "all state changes share the upgrade operation",
+        );
+    }
+}
+
+#[test]
+fn post_transaction_query_failure_is_not_double_counted() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "2.6.1-1.alnx4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let mut host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    host.fail_query.insert("copilot-shell".to_string());
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("2.6.1-1.alnx4"),
+            Some("2.7.0-1.alnx4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("post-transaction query failure");
+
+    assert_eq!(host.txn_calls(), vec!["update:copilot-shell"]);
+    assert_eq!(host.query_calls(), vec!["copilot-shell", "copilot-shell"]);
+    assert_eq!(result.status, STATUS_FAILED);
+    assert!(result.updated.is_empty());
+    assert!(result.reconciled.is_empty());
+    assert_eq!(result.errors.len(), 1, "one component yields one error");
+    assert_eq!(result.errors[0].name, "cosh");
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(
+        state
+            .find_object(ObjectKind::Component, "cosh")
+            .expect("cosh")
+            .version,
+        "2.6.1-1.alnx4",
+    );
+    assert_eq!(state.operations.len(), 1);
+    assert_eq!(state.operations[0].status, STATUS_FAILED);
+}
+
+#[test]
+fn post_transaction_query_retry_can_reconcile() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "2.6.1-1.alnx4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    host.fail_query_once
+        .borrow_mut()
+        .insert("copilot-shell".to_string());
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("2.6.1-1.alnx4"),
+            Some("2.7.0-1.alnx4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("reconcile after query recovery");
+
+    assert_eq!(host.txn_calls(), vec!["update:copilot-shell"]);
+    assert_eq!(host.query_calls(), vec!["copilot-shell", "copilot-shell"]);
+    assert_eq!(result.status, STATUS_PARTIAL);
+    assert!(result.updated.is_empty());
+    assert_eq!(result.reconciled.len(), 1);
+    assert_eq!(result.reconciled[0].name, "cosh");
+    assert_eq!(result.errors.len(), 1, "the original apply error remains");
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let object = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("cosh");
+    assert_eq!(object.version, "2.7.0-1.alnx4");
+    assert_eq!(state.operations.len(), 1);
+    assert_eq!(state.operations[0].status, STATUS_PARTIAL);
+    assert_eq!(
+        object.last_operation_id.as_deref(),
+        Some(state.operations[0].id.as_str())
+    );
+}
+
+#[test]
+fn reconcile_preserves_rpm_ownership_and_metadata() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let mut managed = rpm_component(
+        "cosh",
+        "copilot-shell",
+        "2.6.1-1.alnx4",
+        Ownership::RpmManaged,
+    );
+    managed.manifest_digest = Some("sha256:managed".to_string());
+    managed.enabled_features = vec!["shell-hooks".to_string()];
+    let mut observed = rpm_component(
+        "os-skills",
+        "os-skills",
+        "0.6.1-1.alnx4",
+        Ownership::RpmObserved,
+    );
+    observed.status = ObjectStatus::Adopted;
+    observed.installed_at = "2026-05-01T00:00:00Z".to_string();
+    observed.manifest_digest = Some("sha256:observed".to_string());
+    if let Some(metadata) = observed.rpm_metadata.as_mut() {
+        metadata.evr = None;
+        metadata.arch = None;
+    }
+    let mut raw = rpm_component("local-tool", "local-tool", "1.0.0", Ownership::RawManaged);
+    raw.enabled_features = vec!["local".to_string()];
+    let managed_before = managed.clone();
+    let observed_before = observed.clone();
+    let raw_before = raw.clone();
+    seed_state(&layout, vec![managed, observed, raw]);
+    let host = FakeHost::default()
+        .with_installed(
+            "copilot-shell",
+            info_with_arch("copilot-shell", "2.7.0", Some("1.alnx4"), "aarch64"),
+        )
+        .with_origin("copilot-shell", "anolisa-updates")
+        .with_installed(
+            "os-skills",
+            info_with_arch("os-skills", "0.6.1", Some("1.alnx4"), "noarch"),
+        )
+        .with_origin("os-skills", "anolisa-updates");
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("preserving reconcile");
+
+    assert_eq!(result.reconciled.len(), 2);
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let mut expected_managed = managed_before;
+    let actual_managed = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("managed");
+    expected_managed.version = "2.7.0-1.alnx4".to_string();
+    expected_managed.last_operation_id = actual_managed.last_operation_id.clone();
+    let managed_meta = expected_managed.rpm_metadata.as_mut().expect("metadata");
+    managed_meta.evr = Some("2.7.0-1.alnx4".to_string());
+    managed_meta.arch = Some("aarch64".to_string());
+    managed_meta.source_repo = Some("anolisa-updates".to_string());
+    assert_eq!(actual_managed, &expected_managed);
+
+    let mut expected_observed = observed_before;
+    let actual_observed = state
+        .find_object(ObjectKind::Component, "os-skills")
+        .expect("observed");
+    expected_observed.version = "0.6.1-1.alnx4".to_string();
+    expected_observed.last_operation_id = actual_observed.last_operation_id.clone();
+    let observed_meta = expected_observed.rpm_metadata.as_mut().expect("metadata");
+    observed_meta.evr = Some("0.6.1-1.alnx4".to_string());
+    observed_meta.arch = Some("noarch".to_string());
+    observed_meta.source_repo = Some("anolisa-updates".to_string());
+    assert_eq!(actual_observed, &expected_observed);
+    assert_eq!(
+        state
+            .find_object(ObjectKind::Component, "local-tool")
+            .expect("raw"),
+        &raw_before,
+        "raw-managed state is untouched",
+    );
+    assert_eq!(
+        host.query_calls().into_iter().collect::<HashSet<_>>(),
+        HashSet::from(["copilot-shell".to_string(), "os-skills".to_string()]),
+        "raw-managed components are not queried",
+    );
+}
+
+#[test]
+fn reconcile_missing_or_ambiguous_rpm_is_not_written() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let objects = vec![
+        rpm_component(
+            "missing",
+            "missing-pkg",
+            "1.0.0-1.alnx4",
+            Ownership::RpmManaged,
+        ),
+        rpm_component(
+            "ambiguous",
+            "ambiguous-pkg",
+            "1.0.0-1.alnx4",
+            Ownership::RpmManaged,
+        ),
+        rpm_component(
+            "broken",
+            "broken-pkg",
+            "1.0.0-1.alnx4",
+            Ownership::RpmManaged,
+        ),
+    ];
+    seed_state(&layout, objects.clone());
+    let mut host = FakeHost::default();
+    host.missing_after.insert("missing-pkg".to_string());
+    host.ambiguous_after.insert("ambiguous-pkg".to_string());
+    host.fail_query.insert("broken-pkg".to_string());
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("failed reconciliation audit");
+
+    assert_eq!(result.status, STATUS_FAILED);
+    assert!(result.reconciled.is_empty());
+    assert_eq!(result.errors.len(), 3);
+    for (name, package) in [
+        ("missing", "missing-pkg"),
+        ("ambiguous", "ambiguous-pkg"),
+        ("broken", "broken-pkg"),
+    ] {
+        let error = result
+            .errors
+            .iter()
+            .find(|error| error.name == name)
+            .expect("item error");
+        assert!(
+            error.reason.contains(package),
+            "package identity is visible"
+        );
+    }
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(
+        state.objects, objects,
+        "failed items remain byte-for-byte facts"
+    );
+    assert_eq!(state.operations.len(), 1);
+    assert_eq!(state.operations[0].status, STATUS_FAILED);
+
+    let partial_tmp = tempfile::tempdir().expect("partial tmpdir");
+    let partial_ctx = system_ctx(partial_tmp.path().to_path_buf());
+    let partial_layout = FsLayout::system(Some(partial_tmp.path().to_path_buf()));
+    seed_state(
+        &partial_layout,
+        vec![
+            rpm_component("good", "good-pkg", "1.0.0-1.alnx4", Ownership::RpmManaged),
+            rpm_component(
+                "missing",
+                "missing-pkg",
+                "1.0.0-1.alnx4",
+                Ownership::RpmManaged,
+            ),
+        ],
+    );
+    let mut partial_host =
+        FakeHost::default().with_installed("good-pkg", info("good-pkg", "2.0.0", Some("1.alnx4")));
+    partial_host.missing_after.insert("missing-pkg".to_string());
+    let partial_result = run_upgrade_with_deps(
+        &partial_ctx,
+        &partial_layout,
+        &plan,
+        &partial_host,
+        &partial_host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("partial reconciliation");
+    assert_eq!(partial_result.status, STATUS_PARTIAL);
+    assert_eq!(partial_result.reconciled.len(), 1);
+    assert_eq!(partial_result.errors.len(), 1);
+}
+
+#[test]
+fn reconcile_origin_failure_preserves_prior_source() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "2.6.1-1.alnx4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let mut host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    host.fail_origin.insert("copilot-shell".to_string());
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("origin warning");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.reconciled.len(), 1);
+    assert_eq!(result.warnings.len(), 1);
+    assert!(result.warnings[0].contains("copilot-shell"));
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    let object = state
+        .find_object(ObjectKind::Component, "cosh")
+        .expect("cosh");
+    assert_eq!(object.version, "2.7.0-1.alnx4");
+    assert_eq!(
+        object
+            .rpm_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.source_repo.as_deref()),
+        Some("@System"),
+    );
+}
+
+#[test]
+fn upgrade_dry_run_reports_reconcile_without_writes() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "2.6.1-1.alnx4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let state_path = layout.state_dir.join("installed.toml");
+    let before = std::fs::read(&state_path).expect("state bytes");
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "2.7.0", Some("1.alnx4")),
+    );
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        false,
+        true,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("dry-run reconcile preview");
+
+    assert!(result.dry_run);
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.reconciled.len(), 1);
+    assert_eq!(result.reconciled[0].name, "cosh");
+    assert_eq!(result.reconciled[0].from, "2.6.1-1.alnx4");
+    assert_eq!(result.reconciled[0].to, "2.7.0-1.alnx4");
+    let json = serde_json::to_value(&result).expect("serialize result");
+    assert_eq!(json["reconciled"][0]["package"], "copilot-shell");
+    assert!(host.txn_calls().is_empty());
+    assert_eq!(std::fs::read(&state_path).expect("state bytes"), before);
+    assert!(
+        !layout.lock_file.exists(),
+        "dry-run must not acquire the install lock"
+    );
+    let state = InstalledState::load(&state_path).expect("state");
+    assert!(state.operations.is_empty());
+    assert!(
+        state
+            .find_object(ObjectKind::Component, "cosh")
+            .expect("cosh")
+            .last_operation_id
+            .is_none()
     );
 }
 


### PR DESCRIPTION
## Description

`anolisa upgrade` now reconciles recorded rpm-managed and rpm-observed component
state with rpmdb after applying the upgrade plan, including when the plan has no
package transactions. Previously, yum/dnf could update the packages while
`installed.toml` remained stale because an empty upgrade plan skipped state
finalization. The new sweep runs inside the existing install lock, batches all
drifted changes under one operation ID, and persists state at most once. Dry-run
previews reconciliation without locking, package transactions, or state writes.

## Related Issue

closes #1472

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test -p anolisa-cli upgrade --locked` — 39 passed
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- `git diff --check`

Regression coverage includes empty-plan batch reconciliation, true no-op,
planned-update de-duplication, persistent and transient rpmdb query failures,
metadata preservation, origin warnings, and dry-run behavior.

## Additional Notes

This PR does not add `repair --all` or change `update --check`. Documentation,
CHANGELOG, dependencies, and `Cargo.lock` are unchanged.

### Ship Note

- Changed: `anolisa upgrade` now batch-reconciles drifted RPM component state.
- Known limitations: `repair --all` and drift reporting in `update --check` remain unchanged.
- Verification: `cargo test --workspace --locked` and the ANOLISA Rust gates.
