### PR TITLE
fix(skillfs): stop test mount leaks

### DIFF
--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -1796,8 +1796,13 @@ fn hermes_security_activation_file_passes_gate() {
         .expect("spawn skillfs");
 
     std::thread::sleep(std::time::Duration::from_secs(2));
-    let _ = child.kill();
+    stop_mount_child(&mut child, mount.path());
     let output = child.wait_with_output().expect("wait");
+    assert!(
+        !is_mounted(mount.path()),
+        "test mount must be removed after child shutdown: {}",
+        mount.path().display()
+    );
     let combined = format!(
         "{}{}",
         String::from_utf8_lossy(&output.stdout),
@@ -1895,8 +1900,13 @@ fn hermes_layout_without_security_passes_gate() {
         .expect("spawn skillfs");
 
     std::thread::sleep(std::time::Duration::from_secs(2));
-    let _ = child.kill();
+    stop_mount_child(&mut child, mount.path());
     let output = child.wait_with_output().expect("wait");
+    assert!(
+        !is_mounted(mount.path()),
+        "test mount must be removed after child shutdown: {}",
+        mount.path().display()
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !stderr.contains("incompatible"),


### PR DESCRIPTION
## Description

Two Hermes CLI startup tests terminated foreground SkillFS mounts with
`Child::kill()`, bypassing graceful shutdown and leaving dead FUSE endpoints
behind. This change routes both teardown paths through the existing bounded
shutdown helper and verifies that each test mountpoint disappears from
`/proc/mounts`. Cleanup remains scoped to the mountpoint created by the test,
and no production behavior changes.

## Related Issue

closes #1483

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

The original teardown was first reproduced with:

```bash
cargo +1.86.0 test -p skillfs \
  --test cli_startup_tests \
  hermes_security_activation_file_passes_gate \
  -- --exact --nocapture
# The test passed but left one new FUSE mount owned by the test user.
# After the fix, both affected tests pass independently and leave no new mount:
cargo +1.86.0 test -p skillfs \
  --test cli_startup_tests \
  hermes_security_activation_file_passes_gate \
  -- --exact --nocapture

cargo +1.86.0 test -p skillfs \
  --test cli_startup_tests \
  hermes_layout_without_security_passes_gate \
  -- --exact --nocapture

# The complete CLI startup target also passed with no mount-count change:
cargo +1.86.0 test -p skillfs --test cli_startup_tests
# Full Linux validation with real FUSE:
cargo +1.86.0 fmt --all -- --check
cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
cargo +1.86.0 test --workspace
cargo +1.86.0 doc --workspace --no-deps
scripts/test.sh
```
All commands passed. cargo doc reported only existing non-fatal rustdoc
warnings.
## Additional Notes
Only test teardown code is changed.
Cleanup targets the exact temporary mountpoint created by each test.
The fix does not scan or unmount arbitrary /tmp/.tmp* paths.
Mounts owned by other users are not inspected or modified.
No production mount, unmount, or signal-handling behavior changes.
Documentation is unchanged because this is a test-only correction.