### PR TITLE
fix(ci): use GitHub token for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           COMPONENT="${{ needs.package.outputs.component }}"
           VERSION="${{ needs.package.outputs.version }}"


### PR DESCRIPTION
## Summary

Use the built-in `github.token` when creating GitHub Releases.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yaml')"`\n- `git diff --check`