### PR TITLE
fix(cosh): pass session ID to subprocesses

### DIFF
--- a/src/copilot-shell/packages/cli/src/config/config.test.ts
+++ b/src/copilot-shell/packages/cli/src/config/config.test.ts
@@ -606,6 +606,10 @@ describe('loadCliConfig', () => {
     // Discriminating: without the env-adopt block, sessionId stays undefined and
     // Config mints a random uuid, so this exact-match assertion fails.
     expect(config.getSessionId()).toBe('sight-corr-abc-123');
+    expect(config.getChildProcessEnv()['COSH_SESSION_ID']).toBe(
+      'sight-corr-abc-123',
+    );
+    expect(process.env['COSH_SESSION_ID']).toBe('sight-corr-abc-123');
   });
 
   it('ignores an empty COSH_SESSION_ID and mints a fresh id', async () => {
@@ -617,6 +621,30 @@ describe('loadCliConfig', () => {
     // Empty value must be treated as absent (guards the `.length > 0` check).
     expect(config.getSessionId()).not.toBe('');
     expect(config.getSessionId().length).toBeGreaterThan(0);
+    expect(config.getChildProcessEnv()['COSH_SESSION_ID']).toBe(
+      config.getSessionId(),
+    );
+    expect(process.env['COSH_SESSION_ID']).toBe('');
+  });
+
+  it('keeps ACP chat sessions distinct from launcher correlation', async () => {
+    vi.stubEnv('COSH_SESSION_ID', 'launcher-correlation');
+    process.argv = ['node', 'script.js', '--acp'];
+    const argv = await parseArguments();
+
+    const firstConfig = await loadCliConfig({}, argv);
+    const secondConfig = await loadCliConfig({}, argv);
+
+    expect(firstConfig.getSessionId()).not.toBe('launcher-correlation');
+    expect(secondConfig.getSessionId()).not.toBe('launcher-correlation');
+    expect(firstConfig.getSessionId()).not.toBe(secondConfig.getSessionId());
+    expect(firstConfig.getChildProcessEnv()['COSH_SESSION_ID']).toBe(
+      'launcher-correlation',
+    );
+    expect(secondConfig.getChildProcessEnv()['COSH_SESSION_ID']).toBe(
+      'launcher-correlation',
+    );
+    expect(process.env['COSH_SESSION_ID']).toBe('launcher-correlation');
   });
 
   describe('Proxy configuration', () => {

--- a/src/copilot-shell/packages/cli/src/config/config.ts
+++ b/src/copilot-shell/packages/cli/src/config/config.ts
@@ -956,22 +956,23 @@ export async function loadCliConfig(
     }
   }
 
-  // Adopt a launcher-provided correlation id (exported as COSH_SESSION_ID
-  // by the cosh wrapper) so this run's own session id matches what AgentSight
-  // scrapes from /proc/<pid>/environ, enabling per-run cross-plane correlation.
-  // Precedence: --continue/--resume > COSH_SESSION_ID env > minted uuid
-  // (Config mints one when sessionId is left undefined). Unauthenticated hint.
-  if (!sessionId) {
-    const envSessionId = process.env['COSH_SESSION_ID'];
-    if (envSessionId && envSessionId.length > 0) {
-      sessionId = envSessionId;
-    }
+  // COSH_SESSION_ID identifies the launcher process, not an ACP chat. ACP can
+  // host multiple chats, so only non-ACP sessions adopt it; child processes
+  // retain it for AgentSight correlation.
+  const envSessionId = process.env['COSH_SESSION_ID'];
+  const launcherSessionId =
+    envSessionId && envSessionId.length > 0 ? envSessionId : undefined;
+  const subprocessSessionId = launcherSessionId ?? sessionId;
+
+  if (!sessionId && !isAcpMode && launcherSessionId) {
+    sessionId = launcherSessionId;
   }
 
   const modelProvidersConfig = settings.modelProviders;
 
   const config = new Config({
     sessionId,
+    subprocessSessionId,
     sessionData,
     embeddingModel: DEFAULT_QWEN_EMBEDDING_MODEL,
     targetDir: cwd,

--- a/src/copilot-shell/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/src/copilot-shell/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -71,6 +71,9 @@ describe('ShellProcessor', () => {
       getTargetDir: vi.fn().mockReturnValue('/test/dir'),
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getShouldUseNodePtyShell: vi.fn().mockReturnValue(false),
+      getChildProcessEnv: vi
+        .fn()
+        .mockReturnValue({ COSH_SESSION_ID: 'test-session-id' }),
       getShellExecutionConfig: vi.fn().mockReturnValue({}),
       getAllowedTools: vi.fn().mockReturnValue([]),
     };
@@ -150,6 +153,7 @@ describe('ShellProcessor', () => {
       expect.any(Object),
       false,
       expect.any(Object),
+      { COSH_SESSION_ID: 'test-session-id' },
     );
     expect(result).toEqual([{ text: 'The current status is: On branch main' }]);
   });
@@ -222,6 +226,7 @@ describe('ShellProcessor', () => {
       expect.any(Object),
       false,
       expect.any(Object),
+      { COSH_SESSION_ID: 'test-session-id' },
     );
     expect(result).toEqual([{ text: 'Do something dangerous: deleted' }]);
   });
@@ -251,6 +256,7 @@ describe('ShellProcessor', () => {
       expect.any(Object),
       false,
       expect.any(Object),
+      { COSH_SESSION_ID: 'test-session-id' },
     );
     expect(result).toEqual([{ text: 'Do something dangerous: deleted' }]);
   });
@@ -444,6 +450,7 @@ describe('ShellProcessor', () => {
       expect.any(Object),
       false,
       expect.any(Object),
+      { COSH_SESSION_ID: 'test-session-id' },
     );
   });
 
@@ -609,6 +616,7 @@ describe('ShellProcessor', () => {
         expect.any(Object),
         false,
         expect.any(Object),
+        { COSH_SESSION_ID: 'test-session-id' },
       );
 
       expect(result).toEqual([{ text: 'Command: match found' }]);
@@ -634,6 +642,7 @@ describe('ShellProcessor', () => {
         expect.any(Object),
         false,
         expect.any(Object),
+        { COSH_SESSION_ID: 'test-session-id' },
       );
 
       expect(result).toEqual([
@@ -705,6 +714,7 @@ describe('ShellProcessor', () => {
         expect.any(Object),
         false,
         expect.any(Object),
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
 
@@ -735,6 +745,7 @@ describe('ShellProcessor', () => {
         expect.any(Object),
         false,
         expect.any(Object),
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
   });

--- a/src/copilot-shell/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/src/copilot-shell/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -191,6 +191,7 @@ export class ShellProcessor implements IPromptProcessor {
           new AbortController().signal,
           config.getShouldUseNodePtyShell(),
           shellExecutionConfig,
+          config.getChildProcessEnv(),
         );
 
         const executionResult = await result;

--- a/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -70,11 +70,12 @@ describe('useShellCommandProcessor', () => {
     mockConfig = {
       getTargetDir: () => '/test/dir',
       getShouldUseNodePtyShell: () => false,
+      getChildProcessEnv: () => ({ COSH_SESSION_ID: 'test-session-id' }),
       getShellExecutionConfig: () => ({
         terminalHeight: 20,
         terminalWidth: 80,
       }),
-    } as Config;
+    } as unknown as Config;
     mockGeminiClient = { addHistory: vi.fn() } as unknown as GeminiClient;
 
     vi.mocked(os.platform).mockReturnValue('linux');
@@ -152,6 +153,7 @@ describe('useShellCommandProcessor', () => {
       expect.any(Object),
       false,
       expect.any(Object),
+      { COSH_SESSION_ID: 'test-session-id' },
     );
     expect(onExecMock).toHaveBeenCalledWith(expect.any(Promise));
   });
@@ -274,6 +276,7 @@ describe('useShellCommandProcessor', () => {
         expect.any(Object),
         false, // enableInteractiveShell
         expect.any(Object),
+        { COSH_SESSION_ID: 'test-session-id' },
       );
 
       // Wait for the async PID update to happen.
@@ -416,6 +419,7 @@ describe('useShellCommandProcessor', () => {
       expect.any(Object),
       false,
       expect.any(Object),
+      { COSH_SESSION_ID: 'test-session-id' },
     );
   });
 

--- a/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/src/copilot-shell/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -233,6 +233,7 @@ export const useShellCommandProcessor = (
             abortSignal,
             config.getShouldUseNodePtyShell(),
             shellExecutionConfig,
+            config.getChildProcessEnv(),
           );
 
           console.log(terminalHeight, terminalWidth);

--- a/src/copilot-shell/packages/core/src/config/config.test.ts
+++ b/src/copilot-shell/packages/core/src/config/config.test.ts
@@ -328,6 +328,46 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('child process environment', () => {
+    it('pins the correlation id across chat session changes', () => {
+      const config = new Config({
+        ...baseParams,
+        sessionId: 'chat-session',
+        subprocessSessionId: 'launcher-correlation',
+      });
+
+      expect(
+        config.getChildProcessEnv({
+          CUSTOM_ENV: 'custom-value',
+          COSH_SESSION_ID: 'server-override',
+        }),
+      ).toEqual(
+        expect.objectContaining({
+          CUSTOM_ENV: 'custom-value',
+          COSH_SESSION_ID: 'launcher-correlation',
+        }),
+      );
+
+      config.startNewSession('new-chat-session');
+
+      expect(config.getSessionId()).toBe('new-chat-session');
+      expect(config.getChildProcessEnv()['COSH_SESSION_ID']).toBe(
+        'launcher-correlation',
+      );
+    });
+
+    it('defaults the correlation id to the initial chat session id', () => {
+      const config = new Config({
+        ...baseParams,
+        sessionId: 'initial-session',
+      });
+
+      expect(config.getChildProcessEnv()['COSH_SESSION_ID']).toBe(
+        'initial-session',
+      );
+    });
+  });
+
   describe('model switching with different credentials (OpenAI)', () => {
     it('should refresh auth when switching to model with different envKey', async () => {
       // This test verifies the fix for switching between modelProvider models

--- a/src/copilot-shell/packages/core/src/config/config.ts
+++ b/src/copilot-shell/packages/core/src/config/config.ts
@@ -305,6 +305,8 @@ export interface AutoMemoryConfig {
 
 export interface ConfigParameters {
   sessionId?: string;
+  /** Correlation ID pinned to child process environments. */
+  subprocessSessionId?: string;
   sessionData?: ResumedSessionData;
   embeddingModel?: string;
   targetDir: string;
@@ -450,6 +452,7 @@ export interface ConfigInitializeOptions {
 
 export class Config {
   private sessionId: string;
+  private readonly subprocessSessionId: string;
   private sessionData?: ResumedSessionData;
   private toolRegistry!: ToolRegistry;
   private promptRegistry!: PromptRegistry;
@@ -572,6 +575,7 @@ export class Config {
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId ?? randomUUID();
+    this.subprocessSessionId = params.subprocessSessionId ?? this.sessionId;
     this.sessionData = params.sessionData;
     this.embeddingModel = params.embeddingModel ?? DEFAULT_QWEN_EMBEDDING_MODEL;
     this.fileSystemService = new StandardFileSystemService();
@@ -952,6 +956,17 @@ export class Config {
 
   getSessionId(): string {
     return this.sessionId;
+  }
+
+  /** Builds a child environment pinned to this config's launcher correlation. */
+  getChildProcessEnv(
+    overrides: Record<string, string> = {},
+  ): Record<string, string> {
+    return {
+      ...process.env,
+      ...overrides,
+      COSH_SESSION_ID: this.subprocessSessionId,
+    } as Record<string, string>;
   }
 
   private currentRunId: string | undefined = undefined;

--- a/src/copilot-shell/packages/core/src/services/shellExecutionService.test.ts
+++ b/src/copilot-shell/packages/core/src/services/shellExecutionService.test.ts
@@ -904,6 +904,7 @@ describe('ShellExecutionService execution method selection', () => {
 
   it('should use node-pty when shouldUseNodePty is true and pty is available', async () => {
     const abortController = new AbortController();
+    const childProcessEnv = { COSH_SESSION_ID: 'launcher-correlation' };
     const handle = await ShellExecutionService.execute(
       'test command',
       '/test/dir',
@@ -911,6 +912,7 @@ describe('ShellExecutionService execution method selection', () => {
       abortController.signal,
       true, // shouldUseNodePty
       shellExecutionConfig,
+      childProcessEnv,
     );
 
     // Simulate exit to allow promise to resolve
@@ -918,13 +920,20 @@ describe('ShellExecutionService execution method selection', () => {
     const result = await handle.result;
 
     expect(mockGetPty).toHaveBeenCalled();
-    expect(mockPtySpawn).toHaveBeenCalled();
+    expect(mockPtySpawn).toHaveBeenCalledWith(
+      'bash',
+      ['-c', 'test command'],
+      expect.objectContaining({
+        env: expect.objectContaining(childProcessEnv),
+      }),
+    );
     expect(mockCpSpawn).not.toHaveBeenCalled();
     expect(result.executionMethod).toBe('mock-pty');
   });
 
   it('should use child_process when shouldUseNodePty is false', async () => {
     const abortController = new AbortController();
+    const childProcessEnv = { COSH_SESSION_ID: 'launcher-correlation' };
     const handle = await ShellExecutionService.execute(
       'test command',
       '/test/dir',
@@ -932,6 +941,7 @@ describe('ShellExecutionService execution method selection', () => {
       abortController.signal,
       false, // shouldUseNodePty
       {},
+      childProcessEnv,
     );
 
     // Simulate exit to allow promise to resolve
@@ -940,7 +950,13 @@ describe('ShellExecutionService execution method selection', () => {
 
     expect(mockGetPty).not.toHaveBeenCalled();
     expect(mockPtySpawn).not.toHaveBeenCalled();
-    expect(mockCpSpawn).toHaveBeenCalled();
+    expect(mockCpSpawn).toHaveBeenCalledWith(
+      'bash',
+      ['-c', 'test command'],
+      expect.objectContaining({
+        env: expect.objectContaining(childProcessEnv),
+      }),
+    );
     expect(result.executionMethod).toBe('child_process');
   });
 

--- a/src/copilot-shell/packages/core/src/services/shellExecutionService.ts
+++ b/src/copilot-shell/packages/core/src/services/shellExecutionService.ts
@@ -196,6 +196,7 @@ export class ShellExecutionService {
     abortSignal: AbortSignal,
     shouldUseNodePty: boolean,
     shellExecutionConfig: ShellExecutionConfig,
+    env: Record<string, string> = process.env as Record<string, string>,
   ): Promise<ShellExecutionHandle> {
     if (shouldUseNodePty) {
       const ptyInfo = await getPty();
@@ -211,6 +212,7 @@ export class ShellExecutionService {
             abortSignal,
             shellExecutionConfig,
             ptyInfo,
+            env,
           );
         } catch (_e) {
           console.warn(
@@ -231,6 +233,7 @@ export class ShellExecutionService {
       onOutputEvent,
       abortSignal,
       shouldUseNodePty,
+      env,
     );
   }
 
@@ -240,6 +243,7 @@ export class ShellExecutionService {
     onOutputEvent: (event: ShellOutputEvent) => void,
     abortSignal: AbortSignal,
     requestedPty: boolean = false,
+    env: Record<string, string> = process.env as Record<string, string>,
   ): ShellExecutionHandle {
     try {
       const isWindows = os.platform() === 'win32';
@@ -273,7 +277,7 @@ export class ShellExecutionService {
         detached: needsStdin ? false : !isWindows,
         windowsHide: isWindows,
         env: {
-          ...process.env,
+          ...env,
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
           PAGER: 'cat',
@@ -447,6 +451,7 @@ export class ShellExecutionService {
     abortSignal: AbortSignal,
     shellExecutionConfig: ShellExecutionConfig,
     ptyInfo: PtyImplementation,
+    env: Record<string, string> = process.env as Record<string, string>,
   ): ShellExecutionHandle {
     if (!ptyInfo) {
       // This should not happen, but as a safeguard...
@@ -467,7 +472,7 @@ export class ShellExecutionService {
         cols,
         rows,
         env: {
-          ...process.env,
+          ...env,
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
           PAGER: shellExecutionConfig.pager ?? 'cat',

--- a/src/copilot-shell/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/mcp-client-manager.test.ts
@@ -43,9 +43,20 @@ describe('McpClientManager', () => {
       getPromptRegistry: () => ({}),
       getWorkspaceContext: () => ({}),
       getDebugMode: () => false,
+      getChildProcessEnv: () => ({ COSH_SESSION_ID: 'test-session-id' }),
     } as unknown as Config;
     const manager = new McpClientManager(mockConfig, {} as ToolRegistry);
     await manager.discoverAllMcpTools(mockConfig);
+    expect(McpClient).toHaveBeenCalledWith(
+      'test-server',
+      {},
+      {},
+      {},
+      {},
+      false,
+      undefined,
+      { COSH_SESSION_ID: 'test-session-id' },
+    );
     expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
     expect(mockedMcpClient.discover).toHaveBeenCalledOnce();
   });

--- a/src/copilot-shell/packages/core/src/tools/mcp-client-manager.ts
+++ b/src/copilot-shell/packages/core/src/tools/mcp-client-manager.ts
@@ -76,6 +76,7 @@ export class McpClientManager {
           this.cliConfig.getWorkspaceContext(),
           this.cliConfig.getDebugMode(),
           sdkCallback,
+          this.cliConfig.getChildProcessEnv(config.env),
         );
         this.clients.set(name, client);
 

--- a/src/copilot-shell/packages/core/src/tools/mcp-client.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/mcp-client.test.ts
@@ -301,6 +301,35 @@ describe('mcp-client', () => {
       });
     });
 
+    it('should use a config-scoped environment for command transport', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+      const childProcessEnv = {
+        FOO: 'bar',
+        COSH_SESSION_ID: 'launcher-correlation',
+      };
+
+      await createTransport(
+        'test-server',
+        {
+          command: 'test-command',
+          env: { COSH_SESSION_ID: 'server-override' },
+        },
+        false,
+        undefined,
+        childProcessEnv,
+      );
+
+      expect(mockedTransport).toHaveBeenCalledWith({
+        command: 'test-command',
+        args: [],
+        cwd: undefined,
+        env: childProcessEnv,
+        stderr: 'pipe',
+      });
+    });
+
     describe('useGoogleCredentialProvider', () => {
       it('should use GoogleCredentialProvider when specified', async () => {
         const transport = await createTransport(

--- a/src/copilot-shell/packages/core/src/tools/mcp-client.ts
+++ b/src/copilot-shell/packages/core/src/tools/mcp-client.ts
@@ -103,6 +103,7 @@ export class McpClient {
     private readonly workspaceContext: WorkspaceContext,
     private readonly debugMode: boolean,
     private readonly sendSdkMcpMessage?: SendSdkMcpMessage,
+    private readonly childProcessEnv?: Record<string, string>,
   ) {
     this.client = new Client({
       name: `qwen-cli-mcp-client-${this.serverName}`,
@@ -205,6 +206,7 @@ export class McpClient {
       this.serverConfig,
       this.debugMode,
       this.sendSdkMcpMessage,
+      this.childProcessEnv,
     );
   }
 
@@ -540,6 +542,7 @@ export async function connectAndDiscover(
       debugMode,
       workspaceContext,
       sendSdkMcpMessage,
+      cliConfig.getChildProcessEnv(mcpServerConfig.env),
     );
 
     mcpClient.onerror = (error) => {
@@ -773,6 +776,7 @@ export async function connectToMcpServer(
   debugMode: boolean,
   workspaceContext: WorkspaceContext,
   sendSdkMcpMessage?: SendSdkMcpMessage,
+  childProcessEnv?: Record<string, string>,
 ): Promise<Client> {
   const mcpClient = new Client({
     name: 'qwen-code-mcp-client',
@@ -830,6 +834,7 @@ export async function connectToMcpServer(
       mcpServerConfig,
       debugMode,
       sendSdkMcpMessage,
+      childProcessEnv,
     );
     try {
       await mcpClient.connect(transport, {
@@ -1191,6 +1196,7 @@ export async function createTransport(
   mcpServerConfig: MCPServerConfig,
   debugMode: boolean,
   sendSdkMcpMessage?: SendSdkMcpMessage,
+  childProcessEnv?: Record<string, string>,
 ): Promise<Transport> {
   if (isSdkMcpServerConfig(mcpServerConfig)) {
     if (!sendSdkMcpMessage) {
@@ -1346,10 +1352,12 @@ export async function createTransport(
     const transport = new StdioClientTransport({
       command: mcpServerConfig.command,
       args: mcpServerConfig.args || [],
-      env: {
-        ...process.env,
-        ...(mcpServerConfig.env || {}),
-      } as Record<string, string>,
+      env:
+        childProcessEnv ??
+        ({
+          ...process.env,
+          ...(mcpServerConfig.env || {}),
+        } as Record<string, string>),
       cwd: mcpServerConfig.cwd,
       stderr: 'pipe',
     });

--- a/src/copilot-shell/packages/core/src/tools/shell.test.ts
+++ b/src/copilot-shell/packages/core/src/tools/shell.test.ts
@@ -55,6 +55,9 @@ describe('ShellTool', () => {
       getExcludeTools: vi.fn().mockReturnValue([]),
       getDebugMode: vi.fn().mockReturnValue(false),
       getTargetDir: vi.fn().mockReturnValue('/test/dir'),
+      getChildProcessEnv: vi
+        .fn()
+        .mockReturnValue({ COSH_SESSION_ID: 'test-session-id' }),
       getSummarizeToolOutputConfig: vi.fn().mockReturnValue(undefined),
       getWorkspaceContext: vi
         .fn()
@@ -329,6 +332,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
       expect(result.llmContent).toContain('Background PIDs: 54322');
       expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith(tmpFile);
@@ -356,6 +360,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
 
@@ -381,6 +386,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
 
@@ -406,6 +412,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
 
@@ -431,6 +438,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
 
@@ -459,6 +467,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
 
@@ -661,6 +670,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -691,6 +701,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -721,6 +732,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -751,6 +763,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -780,6 +793,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -809,6 +823,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -839,6 +854,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -875,6 +891,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -912,6 +929,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -942,6 +960,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
 
@@ -975,6 +994,7 @@ describe('ShellTool', () => {
           expect.any(AbortSignal),
           false,
           {},
+          { COSH_SESSION_ID: 'test-session-id' },
         );
       });
     });
@@ -1074,6 +1094,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
   });
@@ -1195,6 +1216,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
 
       // The signal passed should be different from the original signal
@@ -1233,6 +1255,7 @@ describe('ShellTool', () => {
         mockAbortSignal,
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
 
@@ -1318,6 +1341,7 @@ describe('ShellTool', () => {
         expect.any(AbortSignal),
         false,
         {},
+        { COSH_SESSION_ID: 'test-session-id' },
       );
     });
   });

--- a/src/copilot-shell/packages/core/src/tools/shell.ts
+++ b/src/copilot-shell/packages/core/src/tools/shell.ts
@@ -260,6 +260,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           combinedSignal,
           shouldUsePty,
           shellExecutionConfig ?? {},
+          this.config.getChildProcessEnv(),
         );
 
       if (pid && setPidCallback) {


### PR DESCRIPTION
## Description

Propagate `COSH_SESSION_ID` explicitly to child processes created by shell execution and stdio MCP transports. The correlation ID is kept Config-scoped and pinned to the launcher ID instead of mutating global `process.env`, which prevents independently addressable ACP chats from reusing one internal session ID. When no launcher ID exists, the initial Config session ID is used as the fallback correlation ID.

## Related Issue

closes #1489

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm test --workspace=packages/core -- --reporter=dot`
  - 3,783 passed, 2 skipped
- `npm test --workspace=packages/cli -- --reporter=dot`
  - Full CLI suite passed with no failures or errors
- Targeted session propagation tests
  - 424 passed, 2 skipped

Verified the following edge cases:

- A regular TUI session adopts the launcher-provided correlation ID.
- ACP chat sessions retain unique internal session IDs.
- Loading Config does not mutate global `process.env`.
- Shell tool, `!cmd`, prompt shell injection, PTY, and fallback execution receive `COSH_SESSION_ID`.
- Stdio MCP servers receive the Config-scoped environment.
- MCP server configuration cannot override the correlation ID.

## Additional Notes

This intentionally avoids the global `process.env` mutation proposed in #1490. A global mutation would cause subsequent ACP session configurations to re-adopt the same ID, breaking ACP session isolation.

No dependency or documentation files were changed.
