### PR TITLE
fix(skillfs): preserve SLS logs on panic

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -344,6 +344,18 @@ async fn main() {
     let cli = Cli::parse();
 
     let pid = std::process::id();
+
+    // Arm the SLS ops guard before any logging output so a broken stdout /
+    // stderr pipe that closes before the first write still yields exactly one
+    // ops record via Drop. Stop / Supervise are internal and left unlogged.
+    let sls_guard = match &cli.command {
+        Commands::Mount { .. } => Some(SlsOpsGuard::new("mount")),
+        Commands::Classify { .. } => Some(SlsOpsGuard::new("classify")),
+        Commands::Validate { .. } => Some(SlsOpsGuard::new("validate")),
+        Commands::List { .. } => Some(SlsOpsGuard::new("list")),
+        Commands::Stop { .. } | Commands::Supervise { .. } => None,
+    };
+
     let max_level = if cli.verbose {
         tracing::Level::DEBUG
     } else {
@@ -400,13 +412,17 @@ async fn main() {
 
     info!(pid, "starting skillfs CLI");
 
-    if let Err(e) = run(cli, raw_args).await {
+    if let Err(e) = run(cli, raw_args, sls_guard).await {
         error!(error = %e, "command failed");
         std::process::exit(1);
     }
 }
 
-async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+async fn run(
+    cli: Cli,
+    raw_args: Vec<String>,
+    guard: Option<SlsOpsGuard>,
+) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Mount {
             source,
@@ -441,15 +457,13 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
                 // as a foreground worker using the preserved raw arguments.
                 // Log this public mount invocation too — the detached worker's
                 // own mount record is separate.
-                let start = std::time::Instant::now();
                 let result = managed::run_client(&raw_args, &source, &mountpoint);
-                sls_ops::log_command("mount", start, err_reason(&result));
+                finish_sls(guard, err_reason(&result));
                 return result;
             }
             // Log the mount startup attempt as a best-effort ops record. The
             // mount may be long-running, so this captures startup success or
             // failure; the mount-session summary writer remains untouched.
-            let start = std::time::Instant::now();
             let result = cmd_mount(
                 source,
                 mountpoint,
@@ -477,7 +491,7 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
                 skill_layout,
             )
             .await;
-            sls_ops::log_command("mount", start, err_reason(&result));
+            finish_sls(guard, err_reason(&result));
             result
         }
         Commands::Classify {
@@ -485,13 +499,11 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
             primary_count,
             dry_run,
         } => {
-            let start = std::time::Instant::now();
             let result = cmd_classify(source, primary_count, dry_run).await;
-            sls_ops::log_command("classify", start, err_reason(&result));
+            finish_sls(guard, err_reason(&result));
             result
         }
         Commands::Validate { source, format } => {
-            let start = std::time::Instant::now();
             let (result, validation_failed) = cmd_validate(source, format).await;
             // A validation failure exits non-zero but is not a command error;
             // record it with a concise err_reason before exiting.
@@ -500,7 +512,9 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
                 None if validation_failed => Some("validation failed".to_string()),
                 None => None,
             };
-            sls_ops::log_command("validate", start, reason);
+            // Write now, not on drop: process::exit below skips destructors, so
+            // the validation-failure record must land before the exit.
+            finish_sls(guard, reason);
             if result.is_ok() && validation_failed {
                 std::process::exit(1);
             }
@@ -510,9 +524,8 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
             source,
             enabled_only,
         } => {
-            let start = std::time::Instant::now();
             let result = cmd_list(source, enabled_only).await;
-            sls_ops::log_command("list", start, err_reason(&result));
+            finish_sls(guard, err_reason(&result));
             result
         }
         Commands::Stop { mountpoint } => managed::run_stop(&mountpoint),
@@ -523,6 +536,58 @@ async fn run(cli: Cli, raw_args: Vec<String>) -> Result<(), Box<dyn std::error::
 /// Extract a concise error string from a command result for the SLS ops log.
 fn err_reason<T>(result: &Result<T, Box<dyn std::error::Error>>) -> Option<String> {
     result.as_ref().err().map(|e| e.to_string())
+}
+
+/// Guarantees each CLI command emits exactly one SLS ops record on every exit
+/// path. It is armed in `main` before logging is initialized, so the `Drop`
+/// fallback is live if tracing's internal error report panics after an early
+/// EPIPE. The same fallback handles later `println!`/`eprintln!` broken-pipe
+/// panics. `finish` writes the record immediately and disarms the guard; if the
+/// command unwinds first, `Drop` writes a single `err_reason="panic"` record
+/// instead.
+///
+/// `finish` writes eagerly rather than deferring to `Drop` because
+/// `process::exit` (used by `validate` on validation failure) skips
+/// destructors — the record must already be on disk before any explicit exit.
+/// Covers panic unwinding only, not `abort`/SIGKILL, which never run drops.
+struct SlsOpsGuard {
+    ops_name: &'static str,
+    start: std::time::Instant,
+    // `true` until `finish` runs; gates the panic fallback in `Drop`.
+    armed: bool,
+}
+
+impl SlsOpsGuard {
+    fn new(ops_name: &'static str) -> Self {
+        Self {
+            ops_name,
+            start: std::time::Instant::now(),
+            armed: true,
+        }
+    }
+
+    /// Write the ops record now and disarm the panic fallback.
+    fn finish(mut self, reason: Option<String>) {
+        self.armed = false;
+        sls_ops::log_command(self.ops_name, self.start, reason);
+    }
+}
+
+impl Drop for SlsOpsGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            // Reached only when the command unwound before `finish`.
+            sls_ops::log_command(self.ops_name, self.start, Some("panic".to_string()));
+        }
+    }
+}
+
+/// Finish the command's SLS guard, if any, writing exactly one ops record. A
+/// no-op for the internal Stop/Supervise commands, which carry no guard.
+fn finish_sls(guard: Option<SlsOpsGuard>, reason: Option<String>) {
+    if let Some(guard) = guard {
+        guard.finish(reason);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
@@ -4,8 +4,9 @@
 //! ops log. Tests point the writer at a temp file via `SKILLFS_SLS_OPS_PATH`
 //! (validated to live under `/tmp/`) and assert the appended record.
 
+use std::os::fd::{FromRawFd, OwnedFd};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn bin_path() -> &'static str {
     env!("CARGO_BIN_EXE_skillfs")
@@ -60,6 +61,56 @@ fn run_skillfs(args: &[&str], ops_log: &Path) -> std::process::Output {
         .env("SKILLFS_SLS_OPS_PATH", ops_log)
         .output()
         .expect("invoke skillfs")
+}
+
+/// Spawn `skillfs` and close the read end of the child's stdout pipe before it
+/// prints, so the first `println!` fails with EPIPE and the process panics —
+/// the broken-pipe scenario from issue #1506 (`skillfs list | head -5`).
+/// Dropping `ChildStdout` closes the fd; stderr is discarded so tracing and the
+/// panic message never block.
+fn run_with_broken_stdout(args: &[&str], ops_log: &Path) -> std::process::ExitStatus {
+    let mut child = Command::new(bin_path())
+        .args(args)
+        .env("SKILLFS_SLS_OPS_PATH", ops_log)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn skillfs");
+    drop(child.stdout.take());
+    child.wait().expect("wait for skillfs")
+}
+
+/// Reproduce `skillfs <cmd> 2>&1 | <reader that closes immediately>` (the
+/// issue's own repro). Creates a pipe and closes its read end *before*
+/// spawning, so the child inherits a reader-less pipe on both stdout and
+/// stderr. The first tracing write in `main` hits EPIPE; tracing's default
+/// internal error report then writes to the closed stderr and panics before
+/// the command body runs. This has no dependence on scheduling or output size
+/// and covers both the earliest possible close and the guard armed before
+/// logging. Close-on-exec prevents subprocesses spawned by parallel tests
+/// from accidentally inheriting either endpoint during setup.
+fn run_with_merged_output_closed(args: &[&str], ops_log: &Path) -> std::process::ExitStatus {
+    let mut fds = [0_i32; 2];
+    // SAFETY: `pipe2` writes two fresh, close-on-exec fds into `fds` on success.
+    let rc = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+    assert_eq!(rc, 0, "pipe2() failed: {}", std::io::Error::last_os_error());
+    // SAFETY: a successful `pipe2` returned two fresh fds owned by this test.
+    let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+    let write_dup = write_fd.try_clone().expect("clone pipe write fd");
+
+    // Close the read end now: the child inherits a reader-less pipe, so its
+    // first write is guaranteed to hit EPIPE regardless of timing.
+    drop(read_fd);
+
+    let mut child = Command::new(bin_path())
+        .args(args)
+        .env("SKILLFS_SLS_OPS_PATH", ops_log)
+        .stdout(Stdio::from(write_fd))
+        .stderr(Stdio::from(write_dup))
+        .spawn()
+        .expect("spawn skillfs");
+    child.wait().expect("wait for skillfs")
 }
 
 #[test]
@@ -164,4 +215,245 @@ fn missing_ops_log_is_not_created_and_command_succeeds() {
         !ops_log.exists(),
         "CLI must not create the missing ops log file"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Broken-pipe regression tests (issue #1506)
+//
+// When a downstream reader closes early (`skillfs list | head -5` or the
+// issue's own `skillfs list 2>&1 | head -5`), the CLI's `println!`/`eprintln!`
+// panics on EPIPE and unwinds. The SLS ops record must still be written exactly
+// once via the drop guard, with `err_reason="panic"`.
+//
+// Two channels are covered: stdout-only (panic in the command body, after the
+// guard) and merged stdout+stderr closed before any output (panic at the first
+// logging write in `main`, exercising the guard armed before logging).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_writes_one_record_when_stdout_reader_closes_early() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let status = run_with_broken_stdout(&["list", source.path().to_str().unwrap()], &ops_log);
+    assert!(
+        !status.success(),
+        "list must not exit 0 once its stdout pipe breaks"
+    );
+
+    let records = read_records(&ops_log);
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly one list ops record must survive the broken pipe"
+    );
+    assert_eq!(records[0]["ops_name"], "list");
+    assert_eq!(records[0]["err_reason"], "panic");
+}
+
+#[test]
+fn classify_dry_run_writes_one_record_when_stdout_reader_closes_early() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let status = run_with_broken_stdout(
+        &["classify", source.path().to_str().unwrap(), "--dry-run"],
+        &ops_log,
+    );
+    assert!(
+        !status.success(),
+        "classify must not exit 0 once its stdout pipe breaks"
+    );
+
+    let records = read_records(&ops_log);
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly one classify ops record must survive the broken pipe"
+    );
+    assert_eq!(records[0]["ops_name"], "classify");
+    assert_eq!(records[0]["err_reason"], "panic");
+    // --dry-run must not persist a config even when it panics mid-print.
+    assert!(
+        !source.path().join("skillfs-views.toml").exists(),
+        "classify --dry-run must not write skillfs-views.toml"
+    );
+}
+
+#[test]
+fn validate_writes_one_record_when_stdout_reader_closes_early() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let status = run_with_broken_stdout(&["validate", source.path().to_str().unwrap()], &ops_log);
+    assert!(
+        !status.success(),
+        "validate must not exit 0 once its stdout pipe breaks"
+    );
+
+    let records = read_records(&ops_log);
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly one validate ops record must survive the broken pipe"
+    );
+    assert_eq!(records[0]["ops_name"], "validate");
+    assert_eq!(records[0]["err_reason"], "panic");
+}
+
+#[test]
+fn mount_writes_one_record_through_guard_on_fast_failure() {
+    // `mount` routes through the same `SlsOpsGuard` as the other subcommands. A
+    // fast configuration error returns before any FUSE mount, so the guard's
+    // `finish` path emits exactly one "mount" record without a live mount. The
+    // broken-pipe Drop path for `mount` is covered separately by
+    // `mount_writes_one_record_when_merged_output_closes_early`.
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+    let mountpoint = tempfile::tempdir_in("/tmp").expect("mountpoint tempdir");
+
+    // An invalid --activation-mode fails inside cmd_mount before mounting.
+    let out = run_skillfs(
+        &[
+            "mount",
+            source.path().to_str().unwrap(),
+            mountpoint.path().to_str().unwrap(),
+            "--activation-mode",
+            "bogus",
+        ],
+        &ops_log,
+    );
+    assert!(
+        !out.status.success(),
+        "an invalid --activation-mode must exit non-zero"
+    );
+
+    let records = read_records(&ops_log);
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly one mount ops record on a fast startup failure"
+    );
+    assert_eq!(records[0]["ops_name"], "mount");
+    assert_ne!(
+        records[0]["err_reason"], "none",
+        "a startup failure must set a non-none err_reason"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Merged stdout+stderr (`2>&1`) closed before any output.
+//
+// The consumer closes before the first tracing write in `main`; that write
+// gets EPIPE, then tracing's internal error report panics on the closed stderr.
+// Because the guard is armed before logging, exactly one record must still be
+// written with `err_reason="panic"`. This is the strict form of the
+// contract: logging must not depend on when the downstream closes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_writes_one_record_when_merged_output_closes_early() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let status =
+        run_with_merged_output_closed(&["list", source.path().to_str().unwrap()], &ops_log);
+    assert!(!status.success(), "list must not exit 0 on a broken pipe");
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1, "exactly one list ops record");
+    assert_eq!(records[0]["ops_name"], "list");
+    assert_eq!(records[0]["err_reason"], "panic");
+}
+
+#[test]
+fn classify_dry_run_writes_one_record_when_merged_output_closes_early() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let status = run_with_merged_output_closed(
+        &["classify", source.path().to_str().unwrap(), "--dry-run"],
+        &ops_log,
+    );
+    assert!(
+        !status.success(),
+        "classify must not exit 0 on a broken pipe"
+    );
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1, "exactly one classify ops record");
+    assert_eq!(records[0]["ops_name"], "classify");
+    assert_eq!(records[0]["err_reason"], "panic");
+    assert!(
+        !source.path().join("skillfs-views.toml").exists(),
+        "classify --dry-run must not write skillfs-views.toml"
+    );
+}
+
+#[test]
+fn validate_writes_one_record_when_merged_output_closes_early() {
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+
+    let status =
+        run_with_merged_output_closed(&["validate", source.path().to_str().unwrap()], &ops_log);
+    assert!(
+        !status.success(),
+        "validate must not exit 0 on a broken pipe"
+    );
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1, "exactly one validate ops record");
+    assert_eq!(records[0]["ops_name"], "validate");
+    assert_eq!(records[0]["err_reason"], "panic");
+}
+
+#[test]
+fn mount_writes_one_record_when_merged_output_closes_early() {
+    // The first tracing write gets EPIPE, then tracing's internal error report
+    // panics on the closed stderr. This happens before the command body and any
+    // FUSE mount attempt; the guard records the panic and the test leaves no
+    // mount.
+    let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+    let ops_log = make_ops_log(dir.path());
+
+    let source = tempfile::tempdir_in("/tmp").expect("source tempdir");
+    create_skill_dir(source.path(), "good-skill", VALID_SKILL);
+    let mountpoint = tempfile::tempdir_in("/tmp").expect("mountpoint tempdir");
+
+    let status = run_with_merged_output_closed(
+        &[
+            "mount",
+            source.path().to_str().unwrap(),
+            mountpoint.path().to_str().unwrap(),
+        ],
+        &ops_log,
+    );
+    assert!(!status.success(), "mount must not exit 0 on a broken pipe");
+
+    let records = read_records(&ops_log);
+    assert_eq!(records.len(), 1, "exactly one mount ops record");
+    assert_eq!(records[0]["ops_name"], "mount");
+    assert_eq!(records[0]["err_reason"], "panic");
 }


### PR DESCRIPTION
## Description

SkillFS `list`, `classify`, `validate`, and `mount` can lose their SLS ops
records when a downstream pipe closes before `log_command` is reached. This
change arms a single RAII `SlsOpsGuard` immediately after CLI parsing, before
tracing emits output, and finishes it eagerly on normal or error returns.
Panic unwinding records `err_reason="panic"`, while `validate` preserves its
record before `process::exit`. Deterministic reader-less pipe tests cover both
stdout-only and merged stdout/stderr failure paths.

## Related Issue

closes #1506

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Executed on Linux with Rust 1.86.0 and the system FUSE 3 development package:

```shell
cargo +1.86.0 test -p skillfs --test sls_ops_cli_tests
# 13 passed, 0 failed

cargo +1.86.0 fmt --all -- --check
cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
cargo +1.86.0 test --workspace
cargo +1.86.0 doc --workspace --no-deps
scripts/test.sh
```

The FUSE smoke suite performed real mounts and verified unmounting, managed
supervisor recovery, orphan cleanup, and fast-failure cleanup. No FUSE checks
were skipped.

## Additional Notes

- The guard covers panic unwinding; `abort` and `SIGKILL` cannot run destructors.
- `Stop` and `Supervise` remain internal commands without SLS ops records.
- No dependencies, lock files, public APIs, or user documentation changed.
- Existing unrelated rustdoc warnings remain unchanged.