### PR TITLE
feat(skillfs): add ledger live source resolver

### DIFF
--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -458,7 +458,9 @@ Agent or installer writes through SkillFS
 For in-place activation and notify mounts, set `--ledger-backing-root` to a
 daemon-visible backing source path and enable the authenticated resolver.
 Notify v2 carries canonical identity only, so startup rejects an in-place
-notify configuration that omits `--trusted-peer-exe`:
+notify configuration that omits `--trusted-peer-exe`. The same resolver
+requirement applies to an out-of-place notify mount whenever it explicitly
+configures `--ledger-backing-root`:
 
 ```bash
 skillfs mount /path/to/skills /path/to/skills \

--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -474,7 +474,7 @@ startup validation.
 ### Control Socket
 
 The trusted control socket is the preferred production path for activation
-writes:
+writes and for the read-only resolver query:
 
 ```bash
 skillfs mount /path/to/skills /mnt/skillfs \
@@ -488,6 +488,25 @@ The socket requires `--security --activation-mode file`, is mutually exclusive
 with `--decision-command`, and requires a pinned trusted peer executable. Peer
 validation uses Linux peer credentials and executable identity checks.
 
+#### Endpoint and priority
+
+The control plane is opt-in and authenticated. The endpoint is resolved by
+priority:
+
+1. CLI `--control-socket <PATH>`
+2. `[control_socket].path` in the config file
+3. the default per-user endpoint `/run/user/<uid>/skillfs/control.sock`
+
+A trusted peer with no explicit path uses the default endpoint; an explicit
+path with no trusted peer is a configuration error; neither leaves the control
+plane off. The default endpoint never falls back to `/tmp` or `/var/tmp` — if
+`/run/user/<uid>` is unavailable, startup fails with an actionable error and
+you must pass `--control-socket` explicitly. A second instance never unlinks an
+active endpoint; only a confirmed-stale socket that SkillFS owns is reclaimed.
+
+No `register`, `mountId`, or `generation` handshake is required — the endpoint
+is stable per UID and the resolver is queried directly.
+
 Supported JSONL request examples:
 
 ```json
@@ -495,7 +514,36 @@ Supported JSONL request examples:
 {"schemaVersion":"1","method":"status"}
 {"schemaVersion":"1","method":"meta.writeActivation","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
 {"schemaVersion":"1","method":"meta.setActivationXattr","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
+{"schemaVersion":"1","method":"skill.resolveLiveSource","canonicalSkillDir":"/path/to/skills/apple/apple-notes"}
 ```
+
+#### `skill.resolveLiveSource`
+
+A read-only query that maps a canonical Skill directory to its physical
+live/backing source. The only business parameter is `canonicalSkillDir`. It has
+three distinct outcomes:
+
+- **`managed=true`** — the path is inside the managed canonical root and
+  resolves to a valid live Skill directory. The response includes the derived
+  `skillId`, `relativeSkillDir`, the physical `liveSkillDir`, the live
+  directory's `identity` (`device`, `inode`), and `transport` (`shared_path`).
+  The query is read-only: it triggers no scan, manifest build, policy decision,
+  or activation write.
+- **`managed=false`** — the request is well-formed and `canonicalSkillDir` is a
+  valid absolute path outside the managed root (`reason: not_managed`). This is
+  a normal success; the caller may manage that directory directly.
+- **structured error** — a non-absolute path, an illegal `..` segment, a
+  symlink/path escape, a management/reserved directory, a missing Skill
+  directory, an invalid layout / missing `SKILL.md`, an unreadable live source,
+  or peer-authentication failure. These are never disguised as `managed=false`.
+
+The skill id is derived from the canonical relative path, so both flat
+(`my-skill`) and Hermes nested (`apple/apple-notes`) layouts resolve to full
+ids. S1 implements a single source runtime; the endpoint is shared across
+future multiple canonical roots.
+
+> Note: `skill.resolveLiveSource` (SkillFS S1) is a read-only resolver. notify
+> v2 and deletion-state semantics are not part of S1.
 
 ### Trusted Mount-path Writer
 
@@ -580,8 +628,8 @@ shares the same file for compatibility.
 | `--notify-socket <PATH>` | Send mutation events to an external daemon |
 | `--activation-events-log <PATH>` | Write activation protocol events as JSONL |
 | `--audit-log <PATH>` | Write filesystem audit events as JSONL |
-| `--control-socket <PATH>` | Accept trusted activation write requests |
-| `--trusted-peer-exe <PATH>` | Pin the trusted control socket peer |
+| `--control-socket <PATH>` | Override the control socket endpoint (default: `/run/user/<uid>/skillfs/control.sock`) |
+| `--trusted-peer-exe <PATH>` | Pin the trusted control socket peer (enables the control plane on the default endpoint if no path is given) |
 | `--trusted-writer-exe <PATH>` | Pin a trusted mount-path writer |
 | `--ledger-backing-root <PATH>` | Provide a daemon-visible source view |
 | `--decision-command <CMD>` | Use legacy external decision mode |

--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -456,7 +456,9 @@ Agent or installer writes through SkillFS
 `--activation-events-log`, because SkillFS needs a trigger source for polling.
 
 For in-place activation and notify mounts, set `--ledger-backing-root` to a
-daemon-visible backing source path:
+daemon-visible backing source path and enable the authenticated resolver.
+Notify v2 carries canonical identity only, so startup rejects an in-place
+notify configuration that omits `--trusted-peer-exe`:
 
 ```bash
 skillfs mount /path/to/skills /path/to/skills \
@@ -464,6 +466,7 @@ skillfs mount /path/to/skills /path/to/skills \
   --security \
   --activation-mode file \
   --notify-socket /run/skill-ledger.sock \
+  --trusted-peer-exe /usr/bin/python3.11 \
   --ledger-backing-root /run/user/$UID/skillfs-ledger/source
 ```
 
@@ -481,12 +484,27 @@ skillfs mount /path/to/skills /mnt/skillfs \
   --security \
   --activation-mode file \
   --control-socket /run/skillfs/control.sock \
-  --trusted-peer-exe /usr/bin/skill-ledger
+  --trusted-peer-exe /usr/bin/python3.11
 ```
 
 The socket requires `--security --activation-mode file`, is mutually exclusive
 with `--decision-command`, and requires a pinned trusted peer executable. Peer
 validation uses Linux peer credentials and executable identity checks.
+
+The packaged AgentSecCore daemon starts the Skill Ledger worker with
+`sys.executable`, which resolves to `/usr/bin/python3.11`; the worker is not a
+`/usr/bin/skill-ledger` executable. For a custom virtual environment, run the
+following with the exact interpreter that starts the daemon and configure the
+real path it prints:
+
+```bash
+/path/to/ledger/python -c 'import os, sys; print(os.path.realpath(sys.executable))'
+```
+
+This M1 executable gate trusts that Python interpreter, not a particular
+module. Keep SkillFS and the Ledger worker in the same UID/security domain and
+account for the fact that another process under that UID using the same
+interpreter also satisfies the executable identity check.
 
 #### Endpoint and priority
 
@@ -532,10 +550,11 @@ three distinct outcomes:
 - **`managed=false`** — the request is well-formed and `canonicalSkillDir` is a
   valid absolute path outside the managed root (`reason: not_managed`). This is
   a normal success; the caller may manage that directory directly.
-- **structured error** — a non-absolute path, an illegal `..` segment, a
-  symlink/path escape, a management/reserved directory, a missing Skill
-  directory, an invalid layout / missing `SKILL.md`, an unreadable live source,
-  or peer-authentication failure. These are never disguised as `managed=false`.
+- **structured error** — a non-absolute or non-normalized path (including
+  repeated or trailing `/`), an illegal `..` segment, a symlink/path escape, a
+  management/reserved directory, a missing Skill directory, an invalid layout /
+  missing `SKILL.md`, an unreadable live source, or peer-authentication failure.
+  These are never disguised as `managed=false`.
 
 The skill id is derived from the canonical relative path, so both flat
 (`my-skill`) and Hermes nested (`apple/apple-notes`) layouts resolve to full
@@ -554,11 +573,12 @@ both components (`category/weather`). SkillFS sorts and deduplicates paths; an
 empty array requests a whole-Skill rescan, including when the path limit is
 exceeded.
 
-The canonical directory is derived from the user-visible source root. The
-physical live/backing root remains private to activation and the S1 resolver,
-so backing paths never appear in notifications. The daemon must accept v2
-directly and return `schemaVersion=2` with `accepted=true`; there is no v1
-fallback or negotiation.
+The canonical directory is derived from the absolute, lexically normalized
+source identity without following a source-root symlink. The physical
+live/backing root remains private to activation and the S1 resolver, so backing
+paths never appear in notifications. The daemon must accept v2 directly and
+return `schemaVersion=2` with `accepted=true`; there is no v1 fallback or
+negotiation.
 
 ### Trusted Mount-path Writer
 

--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -545,6 +545,21 @@ future multiple canonical roots.
 > Note: `skill.resolveLiveSource` (SkillFS S1) is a read-only resolver. notify
 > v2 and deletion-state semantics are not part of S1.
 
+#### Notify v2
+
+`skill_ledger.skillfs_notify_change` uses schema version 2. Its business
+payload contains only `canonicalSkillDir`, the complete `skillId`, `eventKind`,
+and relative `paths`. Flat ids stay intact (`weather`), and Hermes ids retain
+both components (`category/weather`). SkillFS sorts and deduplicates paths; an
+empty array requests a whole-Skill rescan, including when the path limit is
+exceeded.
+
+The canonical directory is derived from the user-visible source root. The
+physical live/backing root remains private to activation and the S1 resolver,
+so backing paths never appear in notifications. The daemon must accept v2
+directly and return `schemaVersion=2` with `accepted=true`; there is no v1
+fallback or negotiation.
+
 ### Trusted Mount-path Writer
 
 `--trusted-writer-exe <PATH>` is a compatibility gate for trusted writers that

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -496,6 +496,17 @@ skillId 由 canonical 相对路径推导，因此 flat（`my-skill`）和 Hermes
 > 说明：`skill.resolveLiveSource`（SkillFS S1）是只读 resolver。notify v2 与删除态
 > 语义不属于 S1。
 
+#### Notify v2
+
+`skill_ledger.skillfs_notify_change` 使用 schema version 2。业务 payload 只包含
+`canonicalSkillDir`、完整 `skillId`、`eventKind` 和相对 `paths`。Flat id 保持完整
+（`weather`），Hermes id 保留两个分量（`category/weather`）。SkillFS 会排序、去重
+paths；空数组表示需要重新扫描整个 Skill，也用于超过路径数量上限的情况。
+
+canonical 目录由用户可见的 source root 推导。物理 live/backing root 只供 activation
+和 S1 resolver 使用，因此通知不会暴露 backing 路径。daemon 必须直接接受 v2，并返回
+`schemaVersion=2` 与 `accepted=true`；不提供 v1 fallback 或协商。
+
 ### Trusted Mount-path Writer
 
 `--trusted-writer-exe <PATH>` 是 mount path 可信写入兼容门禁。新生产集成优先使用

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -432,7 +432,8 @@ skillfs mount /path/to/skills /path/to/skills \
 
 ### Control Socket
 
-可信 control socket 是生产环境推荐的 activation 写入路径：
+可信 control socket 是生产环境推荐的 activation 写入路径，也承载只读的
+resolver 查询：
 
 ```bash
 skillfs mount /path/to/skills /mnt/skillfs \
@@ -446,6 +447,23 @@ skillfs mount /path/to/skills /mnt/skillfs \
 并且必须指定可信 peer executable。Peer 校验使用 Linux peer credential 和
 executable identity。
 
+#### Endpoint 与优先级
+
+control plane 是 opt-in 且需认证的。endpoint 按优先级解析：
+
+1. CLI `--control-socket <PATH>`
+2. 配置文件 `[control_socket].path`
+3. 默认的每用户 endpoint `/run/user/<uid>/skillfs/control.sock`
+
+仅配置可信 peer 而未给显式 path 时使用默认 endpoint；仅给显式 path 而未配置可信
+peer 为配置错误；两者都没有则 control plane 保持关闭。默认 endpoint 绝不 fallback
+到 `/tmp` 或 `/var/tmp`——若 `/run/user/<uid>` 不可用，启动会返回明确且可操作的
+错误，此时必须显式传入 `--control-socket`。第二个实例绝不会 unlink 处于活跃状态
+的 endpoint；只有确认属于 SkillFS 且为 stale 的 socket 才会被回收。
+
+无需 `register`、`mountId` 或 `generation` 握手——endpoint 按 UID 稳定，resolver
+可直接查询。
+
 支持的 JSONL 请求示例：
 
 ```json
@@ -453,7 +471,30 @@ executable identity。
 {"schemaVersion":"1","method":"status"}
 {"schemaVersion":"1","method":"meta.writeActivation","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
 {"schemaVersion":"1","method":"meta.setActivationXattr","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
+{"schemaVersion":"1","method":"skill.resolveLiveSource","canonicalSkillDir":"/path/to/skills/apple/apple-notes"}
 ```
+
+#### `skill.resolveLiveSource`
+
+只读查询，将 canonical Skill 目录映射到其物理 live/backing source。业务参数只有
+`canonicalSkillDir`，结果分三态：
+
+- **`managed=true`**——路径位于受管 canonical root 内且对应有效 live Skill 目录。
+  响应包含推导出的 `skillId`、`relativeSkillDir`、物理 `liveSkillDir`、live 目录的
+  `identity`（`device`、`inode`）以及 `transport`（`shared_path`）。查询是只读的：
+  不触发 scan、manifest、policy decide 或 activation write。
+- **`managed=false`**——请求格式合法且 `canonicalSkillDir` 是位于受管 root 之外的
+  合法绝对路径（`reason: not_managed`）。这是正常成功响应，调用方可直接管理该目录。
+- **structured error**——非绝对路径、非法 `..` 段、symlink/path 逃逸、管理/保留目录、
+  Skill 目录不存在、布局无效/缺少 `SKILL.md`、live source 不可安全访问，或 peer
+  认证失败。这些绝不会伪装成 `managed=false`。
+
+skillId 由 canonical 相对路径推导，因此 flat（`my-skill`）和 Hermes nested
+（`apple/apple-notes`）布局都会解析为完整 id。S1 只实现单 source runtime；该 endpoint
+在未来多 canonical root 场景下仍共享。
+
+> 说明：`skill.resolveLiveSource`（SkillFS S1）是只读 resolver。notify v2 与删除态
+> 语义不属于 S1。
 
 ### Trusted Mount-path Writer
 
@@ -530,8 +571,8 @@ mount-session summary 仍共享同一个文件。
 | `--notify-socket <PATH>` | 向外部 daemon 发送 mutation event |
 | `--activation-events-log <PATH>` | 写 activation protocol events JSONL |
 | `--audit-log <PATH>` | 写 filesystem audit events JSONL |
-| `--control-socket <PATH>` | 接收可信 activation 写请求 |
-| `--trusted-peer-exe <PATH>` | 固定可信 control socket peer |
+| `--control-socket <PATH>` | 覆盖 control socket endpoint（默认 `/run/user/<uid>/skillfs/control.sock`） |
+| `--trusted-peer-exe <PATH>` | 固定可信 control socket peer（未给 path 时在默认 endpoint 启用 control plane） |
 | `--trusted-writer-exe <PATH>` | 固定可信 mount-path writer |
 | `--ledger-backing-root <PATH>` | 提供 daemon 可见的 source view |
 | `--decision-command <CMD>` | 使用旧 external decision 模式 |

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -418,7 +418,8 @@ Agent 或 installer 通过 SkillFS 写入
 对于 in-place activation 和 notify mount，需要设置 `--ledger-backing-root`，给
 daemon 一个可见的 backing source path，并启用 authenticated resolver。Notify v2
 只携带 canonical identity，因此缺少 `--trusted-peer-exe` 的 in-place notify 配置会
-在启动阶段被拒绝：
+在启动阶段被拒绝。out-of-place notify mount 如果显式配置
+`--ledger-backing-root`，同样必须启用 resolver：
 
 ```bash
 skillfs mount /path/to/skills /path/to/skills \

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -416,7 +416,9 @@ Agent 或 installer 通过 SkillFS 写入
 `--activation-events-log`，因为 SkillFS 需要触发源来启动 polling。
 
 对于 in-place activation 和 notify mount，需要设置 `--ledger-backing-root`，给
-daemon 一个可见的 backing source path：
+daemon 一个可见的 backing source path，并启用 authenticated resolver。Notify v2
+只携带 canonical identity，因此缺少 `--trusted-peer-exe` 的 in-place notify 配置会
+在启动阶段被拒绝：
 
 ```bash
 skillfs mount /path/to/skills /path/to/skills \
@@ -424,6 +426,7 @@ skillfs mount /path/to/skills /path/to/skills \
   --security \
   --activation-mode file \
   --notify-socket /run/skill-ledger.sock \
+  --trusted-peer-exe /usr/bin/python3.11 \
   --ledger-backing-root /run/user/$UID/skillfs-ledger/source
 ```
 
@@ -440,12 +443,25 @@ skillfs mount /path/to/skills /mnt/skillfs \
   --security \
   --activation-mode file \
   --control-socket /run/skillfs/control.sock \
-  --trusted-peer-exe /usr/bin/skill-ledger
+  --trusted-peer-exe /usr/bin/python3.11
 ```
 
 该 socket 要求 `--security --activation-mode file`，与 `--decision-command` 互斥，
 并且必须指定可信 peer executable。Peer 校验使用 Linux peer credential 和
 executable identity。
+
+packaged AgentSecCore daemon 使用 `sys.executable` 启动 Skill Ledger worker，该路径
+解析为 `/usr/bin/python3.11`；worker 并不是 `/usr/bin/skill-ledger` executable。
+使用自定义 virtual environment 时，请用启动 daemon 的同一个 interpreter 执行以下
+命令，并配置它输出的真实路径：
+
+```bash
+/path/to/ledger/python -c 'import os, sys; print(os.path.realpath(sys.executable))'
+```
+
+这个 M1 executable gate 信任的是 Python interpreter，而不是某个特定 module。请让
+SkillFS 与 Ledger worker 运行在相同 UID/security domain，并注意同一 UID 下使用相同
+interpreter 的其他进程也会通过 executable identity 校验。
 
 #### Endpoint 与优先级
 
@@ -485,9 +501,9 @@ peer 为配置错误；两者都没有则 control plane 保持关闭。默认 en
   不触发 scan、manifest、policy decide 或 activation write。
 - **`managed=false`**——请求格式合法且 `canonicalSkillDir` 是位于受管 root 之外的
   合法绝对路径（`reason: not_managed`）。这是正常成功响应，调用方可直接管理该目录。
-- **structured error**——非绝对路径、非法 `..` 段、symlink/path 逃逸、管理/保留目录、
-  Skill 目录不存在、布局无效/缺少 `SKILL.md`、live source 不可安全访问，或 peer
-  认证失败。这些绝不会伪装成 `managed=false`。
+- **structured error**——非绝对或非规范路径（包括重复或末尾 `/`）、非法 `..` 段、
+  symlink/path 逃逸、管理/保留目录、Skill 目录不存在、布局无效/缺少 `SKILL.md`、
+  live source 不可安全访问，或 peer 认证失败。这些绝不会伪装成 `managed=false`。
 
 skillId 由 canonical 相对路径推导，因此 flat（`my-skill`）和 Hermes nested
 （`apple/apple-notes`）布局都会解析为完整 id。S1 只实现单 source runtime；该 endpoint
@@ -503,9 +519,10 @@ skillId 由 canonical 相对路径推导，因此 flat（`my-skill`）和 Hermes
 （`weather`），Hermes id 保留两个分量（`category/weather`）。SkillFS 会排序、去重
 paths；空数组表示需要重新扫描整个 Skill，也用于超过路径数量上限的情况。
 
-canonical 目录由用户可见的 source root 推导。物理 live/backing root 只供 activation
-和 S1 resolver 使用，因此通知不会暴露 backing 路径。daemon 必须直接接受 v2，并返回
-`schemaVersion=2` 与 `accepted=true`；不提供 v1 fallback 或协商。
+canonical 目录由不跟随 source-root symlink 的绝对、词法规范化 source identity
+推导。物理 live/backing root 只供 activation 和 S1 resolver 使用，因此通知不会暴露
+backing 路径。daemon 必须直接接受 v2，并返回 `schemaVersion=2` 与
+`accepted=true`；不提供 v1 fallback 或协商。
 
 ### Trusted Mount-path Writer
 

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -488,8 +488,9 @@ Related security surfaces:
 - `--notify-socket <PATH>` sends debounced skill mutation notifications to an
   external daemon. Notify v2 identifies the Skill with its canonical path and
   complete flat or Hermes `skillId`; live/backing paths are resolved separately.
-  In-place notify mounts require `--trusted-peer-exe` so the authenticated
-  resolver is available before the daemon accesses the source.
+  In-place notify mounts, and any notify mount with `--ledger-backing-root`,
+  require `--trusted-peer-exe` so the authenticated resolver is available
+  before the daemon accesses the source.
 - `--activation-events-log <PATH>` writes activation protocol events as JSONL.
 - `--activation-reload-mode poll` re-reads activation state after notify events
   and updates the resolver without a remount.

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -486,7 +486,8 @@ Related security surfaces:
   new skills; writes land in the source tree and completion can trigger the
   external security flow.
 - `--notify-socket <PATH>` sends debounced skill mutation notifications to an
-  external daemon.
+  external daemon. Notify v2 identifies the Skill with its canonical path and
+  complete flat or Hermes `skillId`; live/backing paths are resolved separately.
 - `--activation-events-log <PATH>` writes activation protocol events as JSONL.
 - `--activation-reload-mode poll` re-reads activation state after notify events
   and updates the resolver without a remount.
@@ -545,6 +546,9 @@ Related security surfaces:
 - [docs/design/control-socket-resolver.md](docs/design/control-socket-resolver.md)
   - Control socket default endpoint and the read-only
     `skill.resolveLiveSource` resolver (SkillFS S1).
+- [docs/design/notify-v2.md](docs/design/notify-v2.md) - Canonical Skill
+  identity and live-root separation for daemon change notifications (SkillFS
+  S2).
 - [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md)
   - Long-lived filesystem capability record.
 - [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX test matrix and

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -508,6 +508,21 @@ Related security surfaces:
   Unix socket control plane. Trusted peers can write activation JSON or xattr
   through methods such as `meta.writeActivation` and
   `meta.setActivationXattr`.
+- The control plane is opt-in and authenticated. The endpoint is resolved by
+  priority: CLI `--control-socket` > `[control_socket].path` in the config >
+  the default per-user endpoint `/run/user/<uid>/skillfs/control.sock`. A
+  trusted peer without an explicit path uses the default endpoint; an explicit
+  path without a trusted peer is a configuration error; neither leaves the
+  control plane off. The default never falls back to `/tmp` or `/var/tmp`, and
+  a second instance never unlinks an active endpoint.
+- `skill.resolveLiveSource` is a read-only query that maps a caller-supplied
+  canonical Skill directory to its physical live/backing source. It returns
+  `managed=true` (with the derived `skillId`, `relativeSkillDir`,
+  `liveSkillDir`, and the live directory's `(device, inode)` identity),
+  `managed=false` for a valid path outside the managed root, or a structured
+  error. Skill ids are derived from the canonical relative path, so both flat
+  (`my-skill`) and Hermes nested (`apple/apple-notes`) layouts resolve to full
+  ids. No `register`, `mountId`, or `generation` is required.
 
 ## Documentation
 
@@ -527,6 +542,9 @@ Related security surfaces:
   - Decision-command JSON protocol.
 - [docs/security/runtime-activation-implementation-plan.md](docs/security/runtime-activation-implementation-plan.md)
   - Activation, notify, reload, and backing-root integration.
+- [docs/design/control-socket-resolver.md](docs/design/control-socket-resolver.md)
+  - Control socket default endpoint and the read-only
+    `skill.resolveLiveSource` resolver (SkillFS S1).
 - [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md)
   - Long-lived filesystem capability record.
 - [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX test matrix and

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -488,6 +488,8 @@ Related security surfaces:
 - `--notify-socket <PATH>` sends debounced skill mutation notifications to an
   external daemon. Notify v2 identifies the Skill with its canonical path and
   complete flat or Hermes `skillId`; live/backing paths are resolved separately.
+  In-place notify mounts require `--trusted-peer-exe` so the authenticated
+  resolver is available before the daemon accesses the source.
 - `--activation-events-log <PATH>` writes activation protocol events as JSONL.
 - `--activation-reload-mode poll` re-reads activation state after notify events
   and updates the resolver without a remount.
@@ -508,7 +510,9 @@ Related security surfaces:
 - `--control-socket <PATH>` with `--trusted-peer-exe <PATH>` starts a trusted
   Unix socket control plane. Trusted peers can write activation JSON or xattr
   through methods such as `meta.writeActivation` and
-  `meta.setActivationXattr`.
+  `meta.setActivationXattr`. The packaged Skill Ledger worker's executable is
+  `/usr/bin/python3.11` because it starts through `sys.executable`, not a
+  `skill-ledger` launcher.
 - The control plane is opt-in and authenticated. The endpoint is resolved by
   priority: CLI `--control-socket` > `[control_socket].path` in the config >
   the default per-user endpoint `/run/user/<uid>/skillfs/control.sock`. A

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -458,6 +458,19 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 - `--control-socket <PATH>` 配合 `--trusted-peer-exe <PATH>` 启动可信 Unix
   socket control plane。可信 peer 可通过 `meta.writeActivation`、
   `meta.setActivationXattr` 等方法写 activation JSON 或 xattr。
+- control plane 是 opt-in 且需认证的。endpoint 按优先级解析：CLI
+  `--control-socket` > 配置 `[control_socket].path` > 默认的每用户 endpoint
+  `/run/user/<uid>/skillfs/control.sock`。仅配置 trusted peer 而未给显式
+  path 时使用默认 endpoint；仅给显式 path 而未配置 trusted peer 为配置错误；
+  两者都没有则 control plane 保持关闭。默认 endpoint 绝不 fallback 到 `/tmp`
+  或 `/var/tmp`，第二个实例也绝不 unlink 处于活跃状态的 endpoint。
+- `skill.resolveLiveSource` 是只读查询，将调用方给定的 canonical Skill 目录
+  映射到物理 live/backing source。返回 `managed=true`（含推导出的
+  `skillId`、`relativeSkillDir`、`liveSkillDir` 以及实际 live 目录的
+  `(device, inode)` identity）、对 managed root 之外的合法路径返回
+  `managed=false`，或返回 structured error。skillId 由 canonical 相对路径推导，
+  因此 flat（`my-skill`）和 Hermes nested（`apple/apple-notes`）布局都会解析
+  为完整 id。无需 `register`、`mountId` 或 `generation`。
 
 ## 文档
 
@@ -469,6 +482,7 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 - [docs/testing/posix-external-harness.md](docs/testing/posix-external-harness.md) - external POSIX harness 用法。
 - [docs/security/external-decision-protocol.md](docs/security/external-decision-protocol.md) - decision-command JSON 协议。
 - [docs/security/runtime-activation-implementation-plan.md](docs/security/runtime-activation-implementation-plan.md) - activation、notify、reload 与 backing-root 集成。
+- [docs/design/control-socket-resolver.md](docs/design/control-socket-resolver.md) - control socket 默认 endpoint 与只读 `skill.resolveLiveSource` resolver（SkillFS S1）。
 - [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md) - 长期维护的 filesystem capability record。
 - [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX 测试矩阵与当前覆盖。
 - [POSIX_FS_REFERENCES.md](POSIX_FS_REFERENCES.md) - POSIX、FUSE 和项目参考资料。

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -441,8 +441,9 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
   写入落到 source，完成信号可触发外部安全流程。
 - `--notify-socket <PATH>` 将 debounce 后的 skill mutation 通知发给外部 daemon。
   Notify v2 使用 canonical 路径和完整 flat/Hermes `skillId` 标识 Skill；
-  live/backing 路径通过独立 resolver 解析。in-place notify mount 要求配置
-  `--trusted-peer-exe`，确保 daemon 访问 source 前 authenticated resolver 已可用。
+  live/backing 路径通过独立 resolver 解析。in-place notify mount，以及任何配置了
+  `--ledger-backing-root` 的 notify mount，都要求配置 `--trusted-peer-exe`，
+  确保 daemon 访问 source 前 authenticated resolver 已可用。
 - `--activation-events-log <PATH>` 将 activation protocol events 写成 JSONL。
 - `--activation-reload-mode poll` 在 notify events 后重读 activation state，
   无需 remount 即可更新 resolver。

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -441,7 +441,8 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
   写入落到 source，完成信号可触发外部安全流程。
 - `--notify-socket <PATH>` 将 debounce 后的 skill mutation 通知发给外部 daemon。
   Notify v2 使用 canonical 路径和完整 flat/Hermes `skillId` 标识 Skill；
-  live/backing 路径通过独立 resolver 解析。
+  live/backing 路径通过独立 resolver 解析。in-place notify mount 要求配置
+  `--trusted-peer-exe`，确保 daemon 访问 source 前 authenticated resolver 已可用。
 - `--activation-events-log <PATH>` 将 activation protocol events 写成 JSONL。
 - `--activation-reload-mode poll` 在 notify events 后重读 activation state，
   无需 remount 即可更新 resolver。
@@ -459,7 +460,9 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
   进程名可伪造，不应用作生产可信依据。
 - `--control-socket <PATH>` 配合 `--trusted-peer-exe <PATH>` 启动可信 Unix
   socket control plane。可信 peer 可通过 `meta.writeActivation`、
-  `meta.setActivationXattr` 等方法写 activation JSON 或 xattr。
+  `meta.setActivationXattr` 等方法写 activation JSON 或 xattr。packaged Skill
+  Ledger worker 通过 `sys.executable` 启动，因此其 executable 是
+  `/usr/bin/python3.11`，不是 `skill-ledger` launcher。
 - control plane 是 opt-in 且需认证的。endpoint 按优先级解析：CLI
   `--control-socket` > 配置 `[control_socket].path` > 默认的每用户 endpoint
   `/run/user/<uid>/skillfs/control.sock`。仅配置 trusted peer 而未给显式

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -440,6 +440,8 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 - `/.skillfs-inbox/<skill>/...` 是 hidden 或 new skill 的安装/修复入口；
   写入落到 source，完成信号可触发外部安全流程。
 - `--notify-socket <PATH>` 将 debounce 后的 skill mutation 通知发给外部 daemon。
+  Notify v2 使用 canonical 路径和完整 flat/Hermes `skillId` 标识 Skill；
+  live/backing 路径通过独立 resolver 解析。
 - `--activation-events-log <PATH>` 将 activation protocol events 写成 JSONL。
 - `--activation-reload-mode poll` 在 notify events 后重读 activation state，
   无需 remount 即可更新 resolver。
@@ -483,6 +485,7 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 - [docs/security/external-decision-protocol.md](docs/security/external-decision-protocol.md) - decision-command JSON 协议。
 - [docs/security/runtime-activation-implementation-plan.md](docs/security/runtime-activation-implementation-plan.md) - activation、notify、reload 与 backing-root 集成。
 - [docs/design/control-socket-resolver.md](docs/design/control-socket-resolver.md) - control socket 默认 endpoint 与只读 `skill.resolveLiveSource` resolver（SkillFS S1）。
+- [docs/design/notify-v2.md](docs/design/notify-v2.md) - daemon change notification 的 canonical Skill 身份和 live-root 解耦（SkillFS S2）。
 - [docs/skillfs-filesystem-capability-record.md](docs/skillfs-filesystem-capability-record.md) - 长期维护的 filesystem capability record。
 - [POSIX_FS_TEST_MATRIX.csv](POSIX_FS_TEST_MATRIX.csv) - POSIX 测试矩阵与当前覆盖。
 - [POSIX_FS_REFERENCES.md](POSIX_FS_REFERENCES.md) - POSIX、FUSE 和项目参考资料。

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -226,18 +226,20 @@ enum Commands {
         ledger_backing_root: Option<PathBuf>,
 
         /// Unix domain socket path for the trusted peer control
-        /// channel. When set, SkillFS creates a control socket at this
-        /// path and accepts connections from trusted peers. Peer
-        /// identity is verified via `SO_PEERCRED` + executable identity.
-        /// Requires `--trusted-peer-exe`. Linux only.
+        /// channel. Overrides the default per-user endpoint
+        /// `/run/user/<uid>/skillfs/control.sock`. SkillFS creates a
+        /// control socket at this path and accepts connections from
+        /// trusted peers; peer identity is verified via `SO_PEERCRED` +
+        /// executable identity. Requires `--trusted-peer-exe`. Linux only.
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_TRUSTED_PEER)]
         control_socket: Option<PathBuf>,
 
         /// Trusted peer executable path for control socket
         /// authentication. The peer's `/proc/<pid>/exe` must match this
         /// canonical path and its on-disk `(dev, ino)` file identity.
-        /// Requires `--control-socket`. The path must exist and be a
-        /// regular file.
+        /// The path must exist and be a regular file. Enables the control
+        /// plane; with no `--control-socket` it binds the default per-user
+        /// endpoint `/run/user/<uid>/skillfs/control.sock`.
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_TRUSTED_PEER)]
         trusted_peer_exe: Option<PathBuf>,
 
@@ -264,8 +266,9 @@ enum Commands {
         /// top-level skill/SKILL.md).
         ///
         /// Hermes mode supports --security --activation-mode file
-        /// for nested skill activation and notify. Incompatible with
-        /// --decision-command and --control-socket.
+        /// for nested skill activation and notify, and the read-only
+        /// `skill.resolveLiveSource` control socket query. Incompatible
+        /// with --decision-command.
         #[arg(long, value_name = "MODE", help_heading = help_text::HEADING_MOUNT)]
         skill_layout: Option<String>,
     },
@@ -602,25 +605,54 @@ fn finish_sls(guard: Option<SlsOpsGuard>, reason: Option<String>) {
 /// out-of-band change happened.
 const DRIFT_DEBOUNCE_MS: u64 = 200;
 
-/// Compute the expected canonical path a daemon-facing directory will
-/// resolve to, without requiring the leaf to exist.
+/// Resolve the canonical path a daemon-facing path will occupy, resolving
+/// symlinks in **every** existing ancestor even when one or more trailing
+/// components do not exist yet.
 ///
-/// Mirrors the parent-canonicalize + leaf-join shape used by
-/// `LedgerBackingRoot::setup`: the parent must resolve, but the final
-/// component may be created later. Falls back to the input path when the
-/// parent cannot be canonicalized so the caller still gets a best-effort
-/// answer instead of silently skipping the check.
-fn expected_daemon_facing_path(p: &Path) -> PathBuf {
-    let parent = p
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    match parent.canonicalize() {
-        Ok(parent_canon) => match p.file_name() {
-            Some(leaf) => parent_canon.join(leaf),
-            None => parent_canon,
-        },
-        Err(_) => p.to_path_buf(),
+/// A plain parent-only canonicalize (used previously) resolves only the
+/// direct parent, and falls back to the raw input when that parent does not
+/// exist. That misses `link-to-tmp/missing/leaf`, where `link-to-tmp` is a
+/// symlink into `/tmp` but `missing` does not exist yet: the raw lexical
+/// path shows no `/tmp` prefix, yet the object is created under `/tmp`. This
+/// walk climbs to the deepest existing ancestor, canonicalizes it (resolving
+/// the whole symlink chain), and re-appends the remaining components.
+///
+/// Returns `None` when the path cannot be reliably resolved (no existing
+/// ancestor, or an ancestor cannot be canonicalized) so the caller can fail
+/// closed instead of trusting an unverified lexical prefix.
+fn resolve_daemon_facing_path(p: &Path) -> Option<PathBuf> {
+    let mut trailing: Vec<std::ffi::OsString> = Vec::new();
+    let mut cursor = p;
+    loop {
+        // `exists()` follows symlinks, which is exactly what we want for
+        // ancestors: a symlinked ancestor pointing at an existing directory
+        // is the deepest resolvable point, and `canonicalize` resolves it.
+        if cursor.exists() {
+            let base = cursor.canonicalize().ok()?;
+            let mut result = base;
+            for name in trailing.iter().rev() {
+                result.push(name);
+            }
+            return Some(result);
+        }
+        // No filename (e.g. a trailing `..`) means we cannot reason about
+        // the path safely — fail closed.
+        let name = cursor.file_name()?;
+        trailing.push(name.to_os_string());
+        match cursor.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => cursor = parent,
+            _ => {
+                // Reached the top with no existing ancestor. For an absolute
+                // path this only happens if `/` is missing; for a relative
+                // path, anchor at the current directory.
+                let base = Path::new(".").canonicalize().ok()?;
+                let mut result = base;
+                for name in trailing.iter().rev() {
+                    result.push(name);
+                }
+                return Some(result);
+            }
+        }
     }
 }
 
@@ -651,18 +683,15 @@ fn daemon_facing_path_under_private_tmp(candidate: &Path) -> bool {
 /// Return `true` when an operator-supplied daemon-facing argument resolves
 /// under a private-tmp root.
 ///
-/// Checks both the parent-canonicalize + leaf shape (so a not-yet-created
-/// leaf is still evaluated) and, when the path already exists, its fully
-/// canonicalized form. The latter closes a symlink bypass such as
-/// `/run/.../x -> /tmp/real`, which passes the shape check but is resolved
-/// to a PrivateTmp-invisible path once the daemon follows it.
+/// Resolution climbs to the deepest existing ancestor and canonicalizes it,
+/// so an ancestor symlink into `/tmp` is caught even when trailing
+/// components (e.g. a not-yet-created parent directory) do not exist. A path
+/// that cannot be reliably resolved is treated as unsafe (fail closed).
 fn daemon_facing_arg_under_private_tmp(path: &Path) -> bool {
-    daemon_facing_path_under_private_tmp(&expected_daemon_facing_path(path))
-        || path
-            .canonicalize()
-            .ok()
-            .as_deref()
-            .is_some_and(daemon_facing_path_under_private_tmp)
+    match resolve_daemon_facing_path(path) {
+        Some(resolved) => daemon_facing_path_under_private_tmp(&resolved),
+        None => true,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -841,40 +870,68 @@ async fn cmd_mount(
         );
     }
 
+    // ── Trusted peer control socket: merge CLI over config ──────────
+    //
+    // Merge CLI flags with the config file (CLI overrides config) here,
+    // BEFORE any control-plane validation, so the mutual-requirement,
+    // semantic, endpoint-classification, and backing-root checks all see a
+    // single merged view. This is the only place `control_socket` /
+    // `trusted_peer_exe` are resolved; there is no second merge later.
+    let control_socket = control_socket.or_else(|| {
+        file_config
+            .as_ref()
+            .and_then(|c| c.control_socket_path().map(PathBuf::from))
+    });
+    let trusted_peer_exe = trusted_peer_exe.or_else(|| {
+        file_config
+            .as_ref()
+            .and_then(|c| c.control_socket_trusted_peer_exe().map(PathBuf::from))
+    });
+    let trusted_peer_uid = trusted_peer_uid.or_else(|| {
+        file_config
+            .as_ref()
+            .and_then(|c| c.control_socket_trusted_peer_uid())
+    });
+    let trusted_peer_gid = trusted_peer_gid.or_else(|| {
+        file_config
+            .as_ref()
+            .and_then(|c| c.control_socket_trusted_peer_gid())
+    });
+
     // Control socket gates — mutual requirement first, then semantic
     // gates. Must fire before the generic security source check so the
-    // error message names the actual problem.
-    match (&control_socket, &trusted_peer_exe) {
-        (Some(p), None) => {
-            return Err(format!(
-                "--control-socket {} requires --trusted-peer-exe",
-                p.display()
-            )
-            .into());
-        }
-        (None, Some(p)) => {
-            return Err(format!(
-                "--trusted-peer-exe {} requires --control-socket",
-                p.display()
-            )
-            .into());
-        }
-        _ => {}
+    // error message names the actual problem. All operate on the merged
+    // values above.
+    //
+    // A trusted peer without an explicit socket path is valid: the
+    // control plane binds the default per-user endpoint (resolved below).
+    // Only an explicit socket path without a trusted peer is an error —
+    // the control plane is always authenticated.
+    if let (Some(p), None) = (&control_socket, &trusted_peer_exe) {
+        return Err(format!(
+            "--control-socket {} requires a trusted peer (--trusted-peer-exe \
+             or [control_socket].trusted_peer_exe)",
+            p.display()
+        )
+        .into());
     }
-    if control_socket.is_some() {
+    // The control plane is enabled by either an explicit socket path or a
+    // trusted peer (which selects the default endpoint).
+    let control_plane_enabled = control_socket.is_some() || trusted_peer_exe.is_some();
+    if control_plane_enabled {
         if !security {
-            return Err("--control-socket requires --security (the control socket \
+            return Err("control socket requires --security (the control socket \
                  writes activation state through the active resolver)"
                 .into());
         }
         if activation_mode != ActivationMode::File {
-            return Err("--control-socket requires --activation-mode file (the \
+            return Err("control socket requires --activation-mode file (the \
                  control socket writes activation files consumed by the \
                  file-based activation path)"
                 .into());
         }
         if parsed_decision_command.is_some() {
-            return Err("--control-socket and --decision-command are mutually \
+            return Err("control socket and --decision-command are mutually \
                  exclusive (control socket is the daemon-driven activation \
                  path; --decision-command is the CLI-driven refresh path)"
                 .into());
@@ -1149,26 +1206,35 @@ async fn cmd_mount(
             .map_err(|e| format!("{}", e))?;
     }
 
-    // #1262 PrivateTmp gate. When daemon-driven activation is enabled,
+    // #1262 PrivateTmp gate. When a daemon-facing operation is enabled,
     // agent-sec-core.service runs with PrivateTmp=true and therefore
     // cannot see the host /tmp or /var/tmp. Any daemon-facing path under
     // those roots makes the daemon reject notify, fail to tail the events
-    // log, or time out the activation reload, which hides the affected
-    // skills. Fail fast here — before the audit sink is opened, the
-    // mountpoint is auto-created, or any backing root bind mount runs — so
-    // a rejected config leaves no side effects behind. The pure
-    // inside-source guards above keep their own error ordering; this only
-    // adds a check, never a side effect.
+    // log, time out the activation reload, or be unable to reach the
+    // control socket / open the live source the resolver reports — all of
+    // which hide the affected skills. Fail fast here — before the audit
+    // sink is opened, the mountpoint is auto-created, or any backing root
+    // bind mount runs — so a rejected config leaves no side effects behind.
+    // The pure inside-source guards above keep their own error ordering;
+    // this only adds a check, never a side effect.
+    //
+    // This gate protects both the daemon-driven activation transport
+    // (notify / events log) and the resolver control plane (the control
+    // socket transport and the live source it resolves).
     //
     // Guarded paths (all daemon-facing):
-    //   * backing root, or the source fallback (the daemon's scan target);
+    //   * backing root, or the source fallback (the daemon's scan target
+    //     and the resolver's live root);
     //   * --activation-events-log (the daemon tails this JSONL file);
-    //   * --notify-socket (the daemon owns this Unix socket).
+    //   * --notify-socket (the daemon owns this Unix socket);
+    //   * --control-socket (the daemon connects to this Unix socket; the
+    //     default /run/user/<uid>/... endpoint is always daemon-visible and
+    //     is therefore not checked here).
     // A plain agent-visible mountpoint under /tmp is NOT guarded.
-    let daemon_driven_activation = security
+    let daemon_facing_ops = security
         && activation_mode == ActivationMode::File
-        && (notify_socket.is_some() || activation_events_log.is_some());
-    if daemon_driven_activation {
+        && (notify_socket.is_some() || activation_events_log.is_some() || control_plane_enabled);
+    if daemon_facing_ops {
         // Daemon-facing root: the backing root when set, otherwise the
         // source is what the daemon scans directly.
         if let Some(ref br_path) = ledger_backing_root {
@@ -1221,6 +1287,25 @@ async fn cmd_mount(
                      activation would break and the affected skills be hidden. Use a \
                      daemon-visible path such as /run/user/$UID/skillfs-ledger/... or \
                      /run/skillfs-ledger/... instead.",
+                    p.display()
+                )
+                .into());
+            }
+        }
+        // Explicit control socket. The daemon connects to this socket to
+        // issue resolver queries, so a path under /tmp or /var/tmp is
+        // invisible to it. Only an explicit path is checked: when the
+        // control plane uses the default endpoint (`control_socket` is
+        // None) the path is always under /run/user/<uid> and daemon-visible.
+        if let Some(ref p) = control_socket {
+            if daemon_facing_arg_under_private_tmp(p) {
+                return Err(format!(
+                    "--control-socket {} resolves under /tmp or /var/tmp, which the \
+                     agent-sec-core.service daemon cannot see because it runs with \
+                     PrivateTmp=true. The daemon connects to this socket, so the resolver \
+                     control plane would be unreachable. Use the default \
+                     /run/user/$UID/skillfs/control.sock endpoint (omit --control-socket) \
+                     or another daemon-visible /run/... path instead.",
                     p.display()
                 )
                 .into());
@@ -1288,9 +1373,15 @@ async fn cmd_mount(
     // In-place mount with daemon-facing operations requires a backing root.
     // Without it, daemon_root would fall back to source which becomes the
     // FUSE over-mount path — the daemon cannot scan through FUSE.
+    //
+    // The control plane (control socket / resolver) is a daemon-facing
+    // operation too: `skill.resolveLiveSource` must open the physical live
+    // source, not the FUSE current/fallback/hidden view. `control_plane_enabled`
+    // was computed above from the merged CLI+config values.
     let has_daemon_ops = notify_socket.is_some()
         || activation_events_log.is_some()
-        || reload_mode == ReloadMode::Poll;
+        || reload_mode == ReloadMode::Poll
+        || control_plane_enabled;
     if in_place
         && security
         && activation_mode == ActivationMode::File
@@ -1298,18 +1389,22 @@ async fn cmd_mount(
         && backing_root.is_none()
     {
         return Err(
-            "in-place mount with activation/notify requires --ledger-backing-root \
-             (the FUSE over-mount makes the source path inaccessible to the daemon)"
+            "in-place mount with activation/notify/control-socket requires \
+             --ledger-backing-root (the FUSE over-mount makes the source path \
+             inaccessible to the daemon and the resolver)"
                 .into(),
         );
     }
 
-    // daemon_root: the path used for all daemon-facing operations.
-    // When a backing root is set, use it; otherwise fall back to the source.
+    // daemon_root: the path used for all daemon-facing operations. When a
+    // backing root is set, use it; otherwise fall back to the canonical
+    // (absolute) source path so daemon-facing paths — including the
+    // resolver's live root — are always absolute regardless of the CWD the
+    // mount was launched from.
     let daemon_root: PathBuf = backing_root
         .as_ref()
         .map(|br| br.path().to_path_buf())
-        .unwrap_or_else(|| source.clone());
+        .unwrap_or_else(|| source_canon.clone());
 
     // Load skills into store
     info!("loading skills from source directory");
@@ -1719,69 +1814,53 @@ async fn cmd_mount(
             _ => None,
         };
 
-    // ── Trusted peer control socket ────────────────────────────────
+    // ── Trusted peer control socket: resolve the effective endpoint ──
     //
-    // Merge CLI flags with config file. CLI overrides config.
-    let control_socket = control_socket.or_else(|| {
-        file_config
-            .as_ref()
-            .and_then(|c| c.control_socket_path().map(PathBuf::from))
-    });
-    let trusted_peer_exe = trusted_peer_exe.or_else(|| {
-        file_config
-            .as_ref()
-            .and_then(|c| c.control_socket_trusted_peer_exe().map(PathBuf::from))
-    });
-    let trusted_peer_uid = trusted_peer_uid.or_else(|| {
-        file_config
-            .as_ref()
-            .and_then(|c| c.control_socket_trusted_peer_uid())
-    });
-    let trusted_peer_gid = trusted_peer_gid.or_else(|| {
-        file_config
-            .as_ref()
-            .and_then(|c| c.control_socket_trusted_peer_gid())
-    });
-
-    // Re-check mutual requirement after config merge (the early gate
-    // only covers CLI args; config-file values are merged above).
-    match (&control_socket, &trusted_peer_exe) {
-        (Some(p), None) => {
-            return Err(format!(
-                "--control-socket {} requires --trusted-peer-exe",
-                p.display()
-            )
-            .into());
+    // CLI/config values were merged and validated earlier (mutual
+    // requirement, semantic gates, backing-root gate). Here we only
+    // classify the endpoint by priority:
+    //   1. --control-socket / [control_socket].path (merged earlier)
+    //   2. the default per-user endpoint, when a trusted peer is set but
+    //      no explicit path is given.
+    let effective_socket_path: Option<PathBuf> = {
+        use skillfs_fuse::security::control_socket::{
+            EndpointResolution, classify_control_socket_endpoint,
+            resolve_default_control_socket_endpoint,
+        };
+        match classify_control_socket_endpoint(
+            control_socket.as_deref(),
+            trusted_peer_exe.is_some(),
+        ) {
+            EndpointResolution::Explicit(path) => Some(path),
+            EndpointResolution::UseDefault => {
+                // Trusted peer, no explicit path: bind the default per-user
+                // endpoint. Never falls back to /tmp or /var/tmp.
+                Some(resolve_default_control_socket_endpoint().map_err(|e| e.to_string())?)
+            }
+            // The mutual-requirement gate above already rejected an explicit
+            // path without a trusted peer.
+            EndpointResolution::MissingTrustedPeer(p) => {
+                return Err(format!(
+                    "--control-socket {} requires --trusted-peer-exe",
+                    p.display()
+                )
+                .into());
+            }
+            EndpointResolution::Disabled => None,
         }
-        (None, Some(p)) => {
-            return Err(format!(
-                "--trusted-peer-exe {} requires --control-socket",
-                p.display()
-            )
-            .into());
-        }
-        _ => {}
-    }
+    };
 
-    // Hermes + control-socket gate (post config merge).
+    // Build ControlSocketConfig when the control plane is enabled.
     //
-    // Control socket skill-name validation does not accept nested ids.
-    // This gate runs after both CLI and config-file values are merged.
-    if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) && control_socket.is_some() {
-        return Err("--skill-layout hermes is incompatible with \
-                 --control-socket (control socket skill-name validation \
-                 does not accept nested ids)"
-            .into());
-    }
-
-    // Build ControlSocketConfig when both are set.
+    // Hermes layout is compatible: the read-only resolver derives full
+    // nested skill ids from the canonical path. Nested activation *writes*
+    // still return an invalid-skill-name error inside the write methods —
+    // enabling the resolver does not widen the write protocol.
     let control_socket_config: Option<ControlSocketConfig> =
-        match (&control_socket, &trusted_peer_exe) {
+        match (&effective_socket_path, &trusted_peer_exe) {
             (Some(socket_path), Some(exe_path)) => {
                 #[cfg(not(target_os = "linux"))]
-                return Err(
-                    "--control-socket requires Linux (SO_PEERCRED, /proc/<pid>/exe)".into(),
-                );
+                return Err("control socket requires Linux (SO_PEERCRED, /proc/<pid>/exe)".into());
 
                 #[cfg(target_os = "linux")]
                 {
@@ -2102,7 +2181,13 @@ async fn cmd_mount(
     // Start control socket server before the FUSE mount.
     let control_socket_handle = if let Some(cs_config) = control_socket_config {
         let ctx = ControlSocketContext {
+            // Canonical root: the user-visible Skill root the ledger
+            // addresses. Live root (source_root): the physical backing
+            // tree that stays accessible under the FUSE over-mount.
+            canonical_root: source_canon.clone(),
             source_root: daemon_root.clone(),
+            // Layout drives the resolver's Flat / Hermes Skill boundary.
+            layout: skill_layout.unwrap_or_default(),
             resolver: active_resolver.clone(),
             protocol_event_writer: Some(protocol_event_writer.clone()),
         };

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -23,12 +23,13 @@ use skillfs_fuse::security::{
     ControlSocketServer, DEFAULT_NOTIFY_DEBOUNCE_MS, DEFAULT_NOTIFY_TIMEOUT_MS,
     DEFAULT_RELOAD_INTERVAL_MS, DEFAULT_RELOAD_TIMEOUT_MS, DecisionCommand,
     InstallerStagingController, JsonlProtocolEventWriter, JsonlSecurityEventWriter, LedgerAdapter,
-    LedgerBackingRoot, NoopProtocolEventWriter, NoopSecurityEventWriter, NotifyController,
-    ProtocolEventWriter, RefreshController, ReloadMode, RuntimeDecisionOutcome, RuntimeMetricsSink,
-    RuntimeMetricsWriter, SecurityConfig, SecurityEventWriter, SecurityModeConfig,
-    SessionStatsWriter, SkillfsSessionStats, SourceDriftObserver, StagingMatcher,
-    SummaryWriteOutcome, TrustedPeerConfig, TrustedWriterConfig, UnixSocketNotifyClient,
-    bootstrap_activation, resolve_events_path, resolve_protocol_events_path, spawn_drift_watcher,
+    LedgerBackingRoot, NoopProtocolEventWriter, NoopSecurityEventWriter, NotifyClient,
+    NotifyController, ProtocolEventWriter, RefreshController, ReloadMode, RuntimeDecisionOutcome,
+    RuntimeMetricsSink, RuntimeMetricsWriter, SecurityConfig, SecurityEventWriter,
+    SecurityModeConfig, SessionStatsWriter, SkillfsSessionStats, SourceDriftObserver,
+    StagingMatcher, SummaryWriteOutcome, TrustedPeerConfig, TrustedWriterConfig,
+    UnixSocketNotifyClient, bootstrap_activation, resolve_events_path,
+    resolve_protocol_events_path, spawn_drift_watcher,
 };
 use skillfs_fuse::{FuseError as FuseErr, MountConfig, MountOptions, mount_configured};
 use tokio::signal;
@@ -37,6 +38,60 @@ use tracing::{debug, error, info, warn};
 mod help_text;
 mod managed;
 mod sls_ops;
+
+#[derive(Clone, Debug)]
+struct MountRuntimeRoots {
+    notify_canonical_root: PathBuf,
+    daemon_root: PathBuf,
+}
+
+impl MountRuntimeRoots {
+    fn from_mount(canonical_source: &Path, ledger_backing_root: Option<&Path>) -> Self {
+        Self {
+            notify_canonical_root: canonical_source.to_path_buf(),
+            daemon_root: ledger_backing_root
+                .unwrap_or(canonical_source)
+                .to_path_buf(),
+        }
+    }
+
+    fn notify_canonical_root(&self) -> &Path {
+        &self.notify_canonical_root
+    }
+
+    fn daemon_root(&self) -> &Path {
+        &self.daemon_root
+    }
+}
+
+fn build_notify_controller(
+    client: Arc<dyn NotifyClient>,
+    roots: &MountRuntimeRoots,
+    notify_timeout_ms: u64,
+    protocol_event_writer: Arc<dyn ProtocolEventWriter>,
+    reload_controller: Option<Arc<ActivationReloadController>>,
+) -> Arc<NotifyController> {
+    if let Some(reload) = reload_controller {
+        NotifyController::new_with_reload(
+            client,
+            roots.notify_canonical_root().to_path_buf(),
+            roots.daemon_root().to_path_buf(),
+            std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
+            notify_timeout_ms,
+            protocol_event_writer,
+            reload,
+        )
+    } else {
+        NotifyController::new_with_protocol_writer(
+            client,
+            roots.notify_canonical_root().to_path_buf(),
+            roots.daemon_root().to_path_buf(),
+            std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
+            notify_timeout_ms,
+            protocol_event_writer,
+        )
+    }
+}
 
 // ---------------------------------------------------------------------------
 // CLI Arguments
@@ -1355,7 +1410,8 @@ async fn cmd_mount(
     //
     // When the operator provides --ledger-backing-root, SkillFS creates a
     // private source alias (bind mount) before the FUSE over-mount becomes
-    // active. All daemon-facing operations then use the backing root path.
+    // active. Daemon live-source operations and N3 protocol events then use
+    // the backing root path; socket notify v2 keeps canonical source identity.
     // Fail-closed: unsafe backing root rejects startup.
     let backing_root: Option<LedgerBackingRoot> = if let Some(ref br_path) = ledger_backing_root {
         let br = LedgerBackingRoot::setup(&source_canon, br_path, &mount_canon, in_place)
@@ -1363,7 +1419,7 @@ async fn cmd_mount(
         info!(
             backing_root = %br.path().display(),
             in_place,
-            "ledger backing root enabled — daemon-facing operations will use this path"
+            "ledger backing root enabled for live-source operations"
         );
         Some(br)
     } else {
@@ -1396,15 +1452,14 @@ async fn cmd_mount(
         );
     }
 
-    // daemon_root: the path used for all daemon-facing operations. When a
-    // backing root is set, use it; otherwise fall back to the canonical
-    // (absolute) source path so daemon-facing paths — including the
-    // resolver's live root — are always absolute regardless of the CWD the
-    // mount was launched from.
-    let daemon_root: PathBuf = backing_root
-        .as_ref()
-        .map(|br| br.path().to_path_buf())
-        .unwrap_or_else(|| source_canon.clone());
+    // Select the path contracts once for all later production wiring. Socket
+    // notify v2 keeps canonical source identity, while daemon live-source
+    // operations and N3 protocol events use the backing root when configured.
+    let runtime_roots = MountRuntimeRoots::from_mount(
+        &source_canon,
+        backing_root.as_ref().map(LedgerBackingRoot::path),
+    );
+    let daemon_root = runtime_roots.daemon_root().to_path_buf();
 
     // Load skills into store
     info!("loading skills from source directory");
@@ -1682,24 +1737,13 @@ async fn cmd_mount(
                 socket_path.clone(),
                 std::time::Duration::from_millis(notify_timeout_ms),
             ));
-            let ctrl = if let Some(ref reload) = reload_controller {
-                NotifyController::new_with_reload(
-                    client,
-                    source_canon.clone(),
-                    std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
-                    notify_timeout_ms,
-                    protocol_event_writer.clone(),
-                    reload.clone(),
-                )
-            } else {
-                NotifyController::new_with_protocol_writer(
-                    client,
-                    source_canon.clone(),
-                    std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
-                    notify_timeout_ms,
-                    protocol_event_writer.clone(),
-                )
-            };
+            let ctrl = build_notify_controller(
+                client,
+                &runtime_roots,
+                notify_timeout_ms,
+                protocol_event_writer.clone(),
+                reload_controller.clone(),
+            );
             info!(
                 socket = %socket_path.display(),
                 timeout_ms = notify_timeout_ms,
@@ -1709,24 +1753,13 @@ async fn cmd_mount(
             Some(ctrl)
         } else if activation_events_log.is_some() {
             let client = Arc::new(skillfs_fuse::security::NoopNotifyClient);
-            let ctrl = if let Some(ref reload) = reload_controller {
-                NotifyController::new_with_reload(
-                    client,
-                    source_canon.clone(),
-                    std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
-                    DEFAULT_NOTIFY_TIMEOUT_MS,
-                    protocol_event_writer.clone(),
-                    reload.clone(),
-                )
-            } else {
-                NotifyController::new_with_protocol_writer(
-                    client,
-                    source_canon.clone(),
-                    std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
-                    DEFAULT_NOTIFY_TIMEOUT_MS,
-                    protocol_event_writer.clone(),
-                )
-            };
+            let ctrl = build_notify_controller(
+                client,
+                &runtime_roots,
+                DEFAULT_NOTIFY_TIMEOUT_MS,
+                protocol_event_writer.clone(),
+                reload_controller.clone(),
+            );
             info!("notify: protocol event log only (no socket)");
             Some(ctrl)
         } else {
@@ -2897,4 +2930,197 @@ async fn cmd_list(source: PathBuf, enabled_only: bool) -> Result<(), Box<dyn std
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use parking_lot::Mutex;
+    use skillfs_fuse::security::{
+        ActiveSkillResolver, InMemoryProtocolEventWriter, MutationKind, NOTIFY_METHOD,
+        NotifyChangeEvent, NotifyClient, NotifyError,
+    };
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct CapturedNotify {
+        schema_version: u64,
+        method: &'static str,
+        canonical_skill_dir: String,
+        skill_id: String,
+        event_kind: String,
+        paths: Vec<String>,
+    }
+
+    struct ActivationWritingNotifyClient {
+        activation_path: PathBuf,
+        events: Mutex<Vec<CapturedNotify>>,
+    }
+
+    impl ActivationWritingNotifyClient {
+        fn new(activation_path: PathBuf) -> Self {
+            Self {
+                activation_path,
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn events(&self) -> Vec<CapturedNotify> {
+            self.events.lock().clone()
+        }
+    }
+
+    impl NotifyClient for ActivationWritingNotifyClient {
+        fn send(&self, event: &NotifyChangeEvent) -> Result<(), NotifyError> {
+            self.events.lock().push(CapturedNotify {
+                schema_version: event.params.schema_version,
+                method: event.method,
+                canonical_skill_dir: event.params.canonical_skill_dir.clone(),
+                skill_id: event.params.skill_id.clone(),
+                event_kind: event.params.event_kind.clone(),
+                paths: event.params.paths.clone(),
+            });
+            let before = std::fs::metadata(&self.activation_path)
+                .ok()
+                .and_then(|metadata| metadata.modified().ok());
+            for _ in 0..100 {
+                std::thread::sleep(Duration::from_millis(15));
+                std::fs::write(
+                    &self.activation_path,
+                    r#"{"schemaVersion": 1, "target": ".skill-meta/versions/v000001.snapshot"}"#,
+                )
+                .expect("write activation during notify");
+                let after = std::fs::metadata(&self.activation_path)
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok());
+                if before.map_or(after.is_some(), |before| {
+                    after.is_some_and(|after| after > before)
+                }) {
+                    return Ok(());
+                }
+            }
+            panic!("activation mtime did not advance");
+        }
+    }
+
+    fn seed_skill(root: &Path, skill_id: &str) -> PathBuf {
+        let skill_dir = root.join(skill_id);
+        let snapshot = skill_dir.join(".skill-meta/versions/v000001.snapshot");
+        std::fs::create_dir_all(&snapshot).expect("create snapshot");
+        std::fs::write(
+            snapshot.join("SKILL.md"),
+            format!("---\nname: {skill_id}\ndescription: fixture\n---\n"),
+        )
+        .expect("write snapshot skill");
+        skill_dir.join(".skill-meta/activation.json")
+    }
+
+    #[test]
+    fn mount_runtime_roots_preserve_notify_identity_and_select_live_root() {
+        let canonical_root = Path::new("/srv/skills");
+        let backing_root = Path::new("/run/skillfs-ledger/skills");
+
+        let direct = MountRuntimeRoots::from_mount(canonical_root, None);
+        assert_eq!(direct.notify_canonical_root(), canonical_root);
+        assert_eq!(direct.daemon_root(), canonical_root);
+
+        let backed = MountRuntimeRoots::from_mount(canonical_root, Some(backing_root));
+        assert_eq!(backed.notify_canonical_root(), canonical_root);
+        assert_eq!(backed.daemon_root(), backing_root);
+        assert_ne!(backed.notify_canonical_root(), backed.daemon_root());
+    }
+
+    #[test]
+    fn notify_controller_wiring_splits_canonical_and_event_roots() {
+        let canonical_root = tempfile::tempdir().unwrap();
+        let daemon_root = tempfile::tempdir().unwrap();
+        let skill_id = "category/alpha";
+        let activation_path = seed_skill(daemon_root.path(), skill_id);
+        seed_skill(canonical_root.path(), skill_id);
+
+        let client = Arc::new(ActivationWritingNotifyClient::new(activation_path));
+        let writer = Arc::new(InMemoryProtocolEventWriter::new());
+        let resolver = Arc::new(ActiveSkillResolver::new(
+            canonical_root.path().to_path_buf(),
+        ));
+        let reload_controller = Arc::new(ActivationReloadController::new(
+            daemon_root.path().to_path_buf(),
+            resolver,
+            Duration::from_millis(1),
+            Duration::from_millis(250),
+        ));
+        let runtime_roots =
+            MountRuntimeRoots::from_mount(canonical_root.path(), Some(daemon_root.path()));
+
+        assert_eq!(runtime_roots.notify_canonical_root(), canonical_root.path());
+        assert_eq!(runtime_roots.daemon_root(), daemon_root.path());
+
+        let ctrl = build_notify_controller(
+            client.clone(),
+            &runtime_roots,
+            DEFAULT_NOTIFY_TIMEOUT_MS,
+            writer.clone(),
+            Some(reload_controller),
+        );
+
+        let count = ctrl.emit_startup_reconcile(&[skill_id.to_string()]);
+        assert_eq!(count, 1);
+
+        ctrl.observe(skill_id, Some(Path::new("SKILL.md")), MutationKind::Write);
+        ctrl.flush_for_testing();
+
+        let notify_events = client.events();
+        assert_eq!(notify_events.len(), 2);
+        for event in &notify_events {
+            assert_eq!(event.method, NOTIFY_METHOD);
+            assert_eq!(event.schema_version, 2);
+            assert_eq!(event.skill_id, skill_id);
+            assert!(
+                event
+                    .canonical_skill_dir
+                    .starts_with(canonical_root.path().to_string_lossy().as_ref())
+            );
+            assert!(
+                !event
+                    .canonical_skill_dir
+                    .starts_with(daemon_root.path().to_string_lossy().as_ref()),
+                "notify canonicalSkillDir must not expose daemon root"
+            );
+        }
+        assert_eq!(notify_events[0].event_kind, "reconcile");
+        assert!(notify_events[0].paths.is_empty());
+        assert_eq!(notify_events[1].event_kind, "write");
+        assert_eq!(notify_events[1].paths, vec!["SKILL.md"]);
+
+        let protocol_events = writer.events();
+        assert_eq!(protocol_events.len(), 3);
+        assert_eq!(protocol_events[0].schema_version, 1);
+        assert_eq!(protocol_events[0].event_kind, "reconcile");
+        assert_eq!(protocol_events[1].event_kind, "write");
+        assert_eq!(
+            protocol_events[2].reload_outcome.as_deref(),
+            Some("activation_updated")
+        );
+        for event in &protocol_events {
+            assert_eq!(event.skill_name, skill_id);
+            assert!(
+                event
+                    .skill_dir
+                    .starts_with(daemon_root.path().to_string_lossy().as_ref()),
+                "protocol event skillDir must use daemon root"
+            );
+            assert!(
+                !event
+                    .skill_dir
+                    .starts_with(canonical_root.path().to_string_lossy().as_ref()),
+                "protocol event skillDir must not use canonical root"
+            );
+        }
+
+        ctrl.shutdown();
+    }
 }

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -1682,11 +1682,10 @@ async fn cmd_mount(
                 socket_path.clone(),
                 std::time::Duration::from_millis(notify_timeout_ms),
             ));
-            let source_for_notify = daemon_root.clone();
             let ctrl = if let Some(ref reload) = reload_controller {
                 NotifyController::new_with_reload(
                     client,
-                    source_for_notify,
+                    source_canon.clone(),
                     std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
                     notify_timeout_ms,
                     protocol_event_writer.clone(),
@@ -1695,7 +1694,7 @@ async fn cmd_mount(
             } else {
                 NotifyController::new_with_protocol_writer(
                     client,
-                    source_for_notify,
+                    source_canon.clone(),
                     std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
                     notify_timeout_ms,
                     protocol_event_writer.clone(),
@@ -1713,7 +1712,7 @@ async fn cmd_mount(
             let ctrl = if let Some(ref reload) = reload_controller {
                 NotifyController::new_with_reload(
                     client,
-                    daemon_root.clone(),
+                    source_canon.clone(),
                     std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
                     DEFAULT_NOTIFY_TIMEOUT_MS,
                     protocol_event_writer.clone(),
@@ -1722,7 +1721,7 @@ async fn cmd_mount(
             } else {
                 NotifyController::new_with_protocol_writer(
                     client,
-                    daemon_root.clone(),
+                    source_canon.clone(),
                     std::time::Duration::from_millis(DEFAULT_NOTIFY_DEBOUNCE_MS),
                     DEFAULT_NOTIFY_TIMEOUT_MS,
                     protocol_event_writer.clone(),

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -1281,17 +1281,21 @@ async fn cmd_mount(
     let source_roots = SourceRoots::resolve(&source)
         .map_err(|e| format!("failed to resolve source root '{}': {e}", source.display()))?;
 
-    // Compute mount identity before side-effecting setup. An in-place notify
-    // v2 deployment must expose the authenticated resolver because the
-    // canonical identity alone cannot reach the underlying live source after
-    // the FUSE over-mount.
+    // Compute mount identity before side-effecting setup. Notify v2 carries
+    // canonical identity only, so the daemon needs the authenticated resolver
+    // whenever the live root differs by contract: an in-place mount hides the
+    // physical source, while an explicit backing root replaces the canonical
+    // host path as the daemon-facing source.
     let mount_canon = mountpoint
         .canonicalize()
         .unwrap_or_else(|_| mountpoint.clone());
     let in_place = source_roots.physical_source_root() == mount_canon;
-    if in_place && notify_socket.is_some() && !control_plane_enabled {
+    let notify_requires_resolver =
+        notify_socket.is_some() && (in_place || ledger_backing_root.is_some());
+    if notify_requires_resolver && !control_plane_enabled {
         return Err(
-            "in-place --notify-socket requires the authenticated live-source resolver; \
+            "--notify-socket with an in-place mount or --ledger-backing-root requires the \
+             authenticated live-source resolver; \
              configure --trusted-peer-exe (and optionally --control-socket) so the daemon \
              can resolve canonicalSkillDir before accessing the source"
                 .into(),

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -1,6 +1,6 @@
 //! SkillFS CLI — AI agent skill management via virtual filesystem.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 fn cleanup_pid_file(pid_file: &Option<PathBuf>) {
@@ -40,23 +40,73 @@ mod managed;
 mod sls_ops;
 
 #[derive(Clone, Debug)]
+struct SourceRoots {
+    canonical_identity_root: PathBuf,
+    physical_source_root: PathBuf,
+}
+
+impl SourceRoots {
+    fn resolve(source: &Path) -> std::io::Result<Self> {
+        Ok(Self {
+            canonical_identity_root: lexical_absolute(source)?,
+            physical_source_root: source.canonicalize()?,
+        })
+    }
+
+    fn canonical_identity_root(&self) -> &Path {
+        &self.canonical_identity_root
+    }
+
+    fn physical_source_root(&self) -> &Path {
+        &self.physical_source_root
+    }
+}
+
+fn lexical_absolute(path: &Path) -> std::io::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(Path::new("/")),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(name) => normalized.push(name),
+        }
+    }
+    Ok(normalized)
+}
+
+#[derive(Clone, Debug)]
 struct MountRuntimeRoots {
     notify_canonical_root: PathBuf,
+    physical_source_root: PathBuf,
     daemon_root: PathBuf,
 }
 
 impl MountRuntimeRoots {
-    fn from_mount(canonical_source: &Path, ledger_backing_root: Option<&Path>) -> Self {
+    fn from_source(source: &SourceRoots, ledger_backing_root: Option<&Path>) -> Self {
         Self {
-            notify_canonical_root: canonical_source.to_path_buf(),
+            notify_canonical_root: source.canonical_identity_root().to_path_buf(),
+            physical_source_root: source.physical_source_root().to_path_buf(),
             daemon_root: ledger_backing_root
-                .unwrap_or(canonical_source)
+                .unwrap_or(source.physical_source_root())
                 .to_path_buf(),
         }
     }
 
     fn notify_canonical_root(&self) -> &Path {
         &self.notify_canonical_root
+    }
+
+    fn physical_source_root(&self) -> &Path {
+        &self.physical_source_root
     }
 
     fn daemon_root(&self) -> &Path {
@@ -1224,14 +1274,29 @@ async fn cmd_mount(
         .validate(&source, &mountpoint)
         .map_err(|e| format!("{}", e))?;
 
-    // Resolve the source canonical path once, up front. Several startup
-    // gates need it: the W1 audit-path-vs-source check below, the
-    // in-place detection further down, and the W1 drift watcher
-    // (which must observe canonical source events). Falls back to the
-    // user-supplied path on canonicalize failure so the existing CLI UX
-    // is preserved for callers who hand us a relative path that already
-    // resolves to a real directory.
-    let source_canon = source.canonicalize().unwrap_or_else(|_| source.clone());
+    // Keep external identity separate from physical I/O. The canonical
+    // identity is absolute and lexically normalized without following a
+    // source symlink; the physical root resolves that symlink for mount,
+    // backing-root, safety, and live-source operations.
+    let source_roots = SourceRoots::resolve(&source)
+        .map_err(|e| format!("failed to resolve source root '{}': {e}", source.display()))?;
+
+    // Compute mount identity before side-effecting setup. An in-place notify
+    // v2 deployment must expose the authenticated resolver because the
+    // canonical identity alone cannot reach the underlying live source after
+    // the FUSE over-mount.
+    let mount_canon = mountpoint
+        .canonicalize()
+        .unwrap_or_else(|_| mountpoint.clone());
+    let in_place = source_roots.physical_source_root() == mount_canon;
+    if in_place && notify_socket.is_some() && !control_plane_enabled {
+        return Err(
+            "in-place --notify-socket requires the authenticated live-source resolver; \
+             configure --trusted-peer-exe (and optionally --control-socket) so the daemon \
+             can resolve canonicalSkillDir before accessing the source"
+                .into(),
+        );
+    }
 
     // Build the runtime audit configuration. When `--audit-log` is omitted
     // the default `NoopEventSink` is preserved (Ok(None) below). When it is
@@ -1251,14 +1316,17 @@ async fn cmd_mount(
     // creates the audit log file on disk. Disabled audit configs always
     // pass.
     audit_runtime
-        .validate_audit_path_outside_source(&source_canon)
+        .validate_audit_path_outside_source(source_roots.physical_source_root())
         .map_err(|e| format!("{}", e))?;
     // N3 source-tree guard: reject --activation-events-log inside source,
     // same rationale as audit. Ordered before the file is opened so a
     // rejected path never creates the log file on disk.
     if let Some(ref p) = activation_events_log {
-        skillfs_fuse::security::validate_protocol_events_path_outside_source(p, &source_canon)
-            .map_err(|e| format!("{}", e))?;
+        skillfs_fuse::security::validate_protocol_events_path_outside_source(
+            p,
+            source_roots.physical_source_root(),
+        )
+        .map_err(|e| format!("{}", e))?;
     }
 
     // #1262 PrivateTmp gate. When a daemon-facing operation is enabled,
@@ -1304,14 +1372,14 @@ async fn cmd_mount(
                 )
                 .into());
             }
-        } else if daemon_facing_path_under_private_tmp(&source_canon) {
+        } else if daemon_facing_path_under_private_tmp(source_roots.physical_source_root()) {
             return Err(format!(
                 "the daemon-facing source root {} resolves under /tmp or /var/tmp, which the \
                  agent-sec-core.service daemon cannot see because it runs with PrivateTmp=true. \
                  Daemon-driven activation would be rejected and the affected skills hidden. \
                  Set --ledger-backing-root to a daemon-visible path such as \
                  /run/user/$UID/skillfs-ledger/... or /run/skillfs-ledger/... instead.",
-                source_canon.display()
+                source_roots.physical_source_root().display()
             )
             .into());
         }
@@ -1399,13 +1467,6 @@ async fn cmd_mount(
         return Err(format!("Mount point is not a directory: {}", mountpoint.display()).into());
     }
 
-    // Compute mount_canon and in_place early so the A6/B1 backing root
-    // setup can validate path shape before the FUSE over-mount.
-    let mount_canon = mountpoint
-        .canonicalize()
-        .unwrap_or_else(|_| mountpoint.clone());
-    let in_place = source_canon == mount_canon;
-
     // A6/B1: Ledger backing root setup.
     //
     // When the operator provides --ledger-backing-root, SkillFS creates a
@@ -1414,8 +1475,13 @@ async fn cmd_mount(
     // the backing root path; socket notify v2 keeps canonical source identity.
     // Fail-closed: unsafe backing root rejects startup.
     let backing_root: Option<LedgerBackingRoot> = if let Some(ref br_path) = ledger_backing_root {
-        let br = LedgerBackingRoot::setup(&source_canon, br_path, &mount_canon, in_place)
-            .map_err(|e| format!("--ledger-backing-root setup failed: {e}"))?;
+        let br = LedgerBackingRoot::setup(
+            source_roots.physical_source_root(),
+            br_path,
+            &mount_canon,
+            in_place,
+        )
+        .map_err(|e| format!("--ledger-backing-root setup failed: {e}"))?;
         info!(
             backing_root = %br.path().display(),
             in_place,
@@ -1455,8 +1521,8 @@ async fn cmd_mount(
     // Select the path contracts once for all later production wiring. Socket
     // notify v2 keeps canonical source identity, while daemon live-source
     // operations and N3 protocol events use the backing root when configured.
-    let runtime_roots = MountRuntimeRoots::from_mount(
-        &source_canon,
+    let runtime_roots = MountRuntimeRoots::from_source(
+        &source_roots,
         backing_root.as_ref().map(LedgerBackingRoot::path),
     );
     let daemon_root = runtime_roots.daemon_root().to_path_buf();
@@ -1465,7 +1531,7 @@ async fn cmd_mount(
     info!("loading skills from source directory");
     let mut store = SkillStore::new();
     let config = ParseConfig::default();
-    let errors = store.load_from_directory(&source, &config);
+    let errors = store.load_from_directory(runtime_roots.physical_source_root(), &config);
 
     if !errors.is_empty() {
         warn!(count = errors.len(), "some skills failed to load");
@@ -1477,7 +1543,7 @@ async fn cmd_mount(
     info!(count = store.len(), "skills loaded");
 
     // Auto-assign any skills that are not yet in any view to the default view.
-    if let Some(mut views) = ViewsConfig::load(&source) {
+    if let Some(mut views) = ViewsConfig::load(runtime_roots.physical_source_root()) {
         let assigned = views.all_assigned_skills();
         let new_skills: Vec<String> = store
             .list()
@@ -1490,7 +1556,9 @@ async fn cmd_mount(
                 count = new_skills.len(),
                 "auto-assigning new skills to default view"
             );
-            if let Err(e) = views.assign_to_default(&source, &new_skills) {
+            if let Err(e) =
+                views.assign_to_default(runtime_roots.physical_source_root(), &new_skills)
+            {
                 warn!(error = %e, "failed to save updated views config");
             }
         }
@@ -1528,7 +1596,7 @@ async fn cmd_mount(
         // `<skill_dir>/.skill-meta/activation.json` for every loaded
         // skill at startup and populates the resolver. Invalid or
         // missing activation files map to hidden (fail-safe).
-        let resolver = ActiveSkillResolver::new(source.clone());
+        let resolver = ActiveSkillResolver::new(runtime_roots.physical_source_root().to_path_buf());
         let skill_names: Vec<String> = if skill_layout == Some(skillfs_fuse::SkillLayout::Hermes) {
             skillfs_fuse::security::enumerate_hermes_skill_ids(&daemon_root)
         } else {
@@ -1573,7 +1641,7 @@ async fn cmd_mount(
             .expect("decision_command presence checked above")
             .clone();
         let adapter: Arc<dyn LedgerAdapter> = Arc::new(CliLedgerAdapter::new(cmd.clone()));
-        let resolver = ActiveSkillResolver::new(source.clone());
+        let resolver = ActiveSkillResolver::new(runtime_roots.physical_source_root().to_path_buf());
         let skill_names: Vec<String> = shared_store
             .read()
             .list()
@@ -1587,7 +1655,7 @@ async fn cmd_mount(
             "security: resolving active skill mapping via scan -> resolve"
         );
         for name in &skill_names {
-            let skill_dir = source.join(name);
+            let skill_dir = runtime_roots.physical_source_root().join(name);
             if let Err(e) = adapter.scan(&skill_dir) {
                 warn!(
                     skill = %name,
@@ -2046,11 +2114,12 @@ async fn cmd_mount(
     // operator already asked for. We log a warning and continue with the
     // sink-only audit pipeline that S2.1 delivered.
     let drift_handle = if let Some(ref sink) = audit_sink {
-        let observer = Arc::new(SourceDriftObserver::new(source_canon.clone(), sink.clone()));
-        match spawn_drift_watcher(source_canon.clone(), observer, DRIFT_DEBOUNCE_MS).await {
+        let drift_source = runtime_roots.daemon_root().to_path_buf();
+        let observer = Arc::new(SourceDriftObserver::new(drift_source.clone(), sink.clone()));
+        match spawn_drift_watcher(drift_source.clone(), observer, DRIFT_DEBOUNCE_MS).await {
             Ok(handle) => {
                 info!(
-                    source = %source_canon.display(),
+                    source = %drift_source.display(),
                     debounce_ms = DRIFT_DEBOUNCE_MS,
                     "source drift observation enabled"
                 );
@@ -2216,7 +2285,7 @@ async fn cmd_mount(
             // Canonical root: the user-visible Skill root the ledger
             // addresses. Live root (source_root): the physical backing
             // tree that stays accessible under the FUSE over-mount.
-            canonical_root: source_canon.clone(),
+            canonical_root: runtime_roots.notify_canonical_root().to_path_buf(),
             source_root: daemon_root.clone(),
             // Layout drives the resolver's Flat / Hermes Skill boundary.
             layout: skill_layout.unwrap_or_default(),
@@ -2254,7 +2323,7 @@ async fn cmd_mount(
         // Load ViewsConfig once; derive all metrics from a single canonical set.
         let store_guard = shared_store.read();
         let total_skills = store_guard.len() as u64;
-        let views_config = ViewsConfig::load(&source);
+        let views_config = ViewsConfig::load(runtime_roots.physical_source_root());
 
         // Build the canonical "real existing default-view skills" set.
         // Deduplicates and filters out stale/typo names not in the store.
@@ -2370,7 +2439,7 @@ async fn cmd_mount(
     let mount_task = tokio::task::spawn_blocking(move || {
         mount_configured(
             &mountpoint,
-            &source,
+            runtime_roots.physical_source_root(),
             shared_store,
             options,
             in_place,
@@ -3021,31 +3090,65 @@ mod tests {
 
     #[test]
     fn mount_runtime_roots_preserve_notify_identity_and_select_live_root() {
-        let canonical_root = Path::new("/srv/skills");
+        let source_roots = SourceRoots {
+            canonical_identity_root: PathBuf::from("/srv/skills"),
+            physical_source_root: PathBuf::from("/srv/skills"),
+        };
         let backing_root = Path::new("/run/skillfs-ledger/skills");
 
-        let direct = MountRuntimeRoots::from_mount(canonical_root, None);
-        assert_eq!(direct.notify_canonical_root(), canonical_root);
-        assert_eq!(direct.daemon_root(), canonical_root);
+        let direct = MountRuntimeRoots::from_source(&source_roots, None);
+        assert_eq!(
+            direct.notify_canonical_root(),
+            source_roots.canonical_identity_root()
+        );
+        assert_eq!(direct.daemon_root(), source_roots.physical_source_root());
 
-        let backed = MountRuntimeRoots::from_mount(canonical_root, Some(backing_root));
-        assert_eq!(backed.notify_canonical_root(), canonical_root);
+        let backed = MountRuntimeRoots::from_source(&source_roots, Some(backing_root));
+        assert_eq!(
+            backed.notify_canonical_root(),
+            source_roots.canonical_identity_root()
+        );
         assert_eq!(backed.daemon_root(), backing_root);
         assert_ne!(backed.notify_canonical_root(), backed.daemon_root());
     }
 
     #[test]
+    fn source_roots_preserve_symlink_identity_and_resolve_physical_source() {
+        let physical_root = tempfile::tempdir().unwrap();
+        let identity_parent = tempfile::tempdir().unwrap();
+        let identity_root = identity_parent.path().join("skills-link");
+        std::os::unix::fs::symlink(physical_root.path(), &identity_root).unwrap();
+
+        let source_roots = SourceRoots::resolve(&identity_root).unwrap();
+        assert_eq!(source_roots.canonical_identity_root(), identity_root);
+        assert_eq!(
+            source_roots.physical_source_root(),
+            physical_root.path().canonicalize().unwrap()
+        );
+
+        let runtime_roots = MountRuntimeRoots::from_source(&source_roots, None);
+        assert_eq!(runtime_roots.notify_canonical_root(), identity_root);
+        assert_eq!(
+            runtime_roots.daemon_root(),
+            physical_root.path().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
     fn notify_controller_wiring_splits_canonical_and_event_roots() {
-        let canonical_root = tempfile::tempdir().unwrap();
+        let physical_source_root = tempfile::tempdir().unwrap();
+        let identity_parent = tempfile::tempdir().unwrap();
+        let canonical_identity_root = identity_parent.path().join("skills-link");
+        std::os::unix::fs::symlink(physical_source_root.path(), &canonical_identity_root).unwrap();
         let daemon_root = tempfile::tempdir().unwrap();
         let skill_id = "category/alpha";
         let activation_path = seed_skill(daemon_root.path(), skill_id);
-        seed_skill(canonical_root.path(), skill_id);
+        seed_skill(physical_source_root.path(), skill_id);
 
         let client = Arc::new(ActivationWritingNotifyClient::new(activation_path));
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let resolver = Arc::new(ActiveSkillResolver::new(
-            canonical_root.path().to_path_buf(),
+            physical_source_root.path().to_path_buf(),
         ));
         let reload_controller = Arc::new(ActivationReloadController::new(
             daemon_root.path().to_path_buf(),
@@ -3053,10 +3156,17 @@ mod tests {
             Duration::from_millis(1),
             Duration::from_millis(250),
         ));
-        let runtime_roots =
-            MountRuntimeRoots::from_mount(canonical_root.path(), Some(daemon_root.path()));
+        let source_roots = SourceRoots::resolve(&canonical_identity_root).unwrap();
+        let runtime_roots = MountRuntimeRoots::from_source(&source_roots, Some(daemon_root.path()));
 
-        assert_eq!(runtime_roots.notify_canonical_root(), canonical_root.path());
+        assert_eq!(
+            runtime_roots.notify_canonical_root(),
+            canonical_identity_root
+        );
+        assert_eq!(
+            runtime_roots.physical_source_root(),
+            physical_source_root.path().canonicalize().unwrap()
+        );
         assert_eq!(runtime_roots.daemon_root(), daemon_root.path());
 
         let ctrl = build_notify_controller(
@@ -3082,7 +3192,13 @@ mod tests {
             assert!(
                 event
                     .canonical_skill_dir
-                    .starts_with(canonical_root.path().to_string_lossy().as_ref())
+                    .starts_with(canonical_identity_root.to_string_lossy().as_ref())
+            );
+            assert!(
+                !event
+                    .canonical_skill_dir
+                    .starts_with(physical_source_root.path().to_string_lossy().as_ref()),
+                "notify canonicalSkillDir must preserve symlink identity"
             );
             assert!(
                 !event
@@ -3116,7 +3232,7 @@ mod tests {
             assert!(
                 !event
                     .skill_dir
-                    .starts_with(canonical_root.path().to_string_lossy().as_ref()),
+                    .starts_with(canonical_identity_root.to_string_lossy().as_ref()),
                 "protocol event skillDir must not use canonical root"
             );
         }

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -80,6 +80,58 @@ fn empty_source() -> tempfile::TempDir {
     dir
 }
 
+/// Connect to a control socket, send `ping`, and return the one-line
+/// response. Proves the server is alive; the response is either a `pong`
+/// or a `permission_denied` (the test binary may fail peer verification),
+/// both of which carry the `schemaVersion` envelope.
+fn probe_control_socket(path: &Path) -> Option<String> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixStream;
+    let mut stream = UnixStream::connect(path).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(3))).ok()?;
+    writeln!(stream, r#"{{"schemaVersion":"1","method":"ping"}}"#).ok()?;
+    stream.flush().ok()?;
+    let mut reader = BufReader::new(&stream);
+    let mut response = String::new();
+    match reader.read_line(&mut response) {
+        Ok(n) if n > 0 => Some(response),
+        _ => None,
+    }
+}
+
+/// True when a control-socket response is an authenticated `pong` — proves
+/// both that the server is alive AND that the connecting peer passed
+/// verification. Requires the trusted peer to be the test binary itself.
+fn response_is_authenticated_pong(resp: &str) -> bool {
+    resp.contains("\"schemaVersion\"") && resp.contains("\"pong\":true")
+}
+
+/// Best-effort FUSE availability check for gating vs. failing. Mirrors the
+/// process-level gate in scripts/test.sh.
+fn fuse_available() -> bool {
+    Path::new("/dev/fuse").exists()
+        && Command::new("fusermount3")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+}
+
+/// Path of the running test binary — used as the trusted peer so the
+/// test's own probe connection authenticates and receives a real `pong`.
+fn test_exe() -> String {
+    std::env::current_exe()
+        .expect("current_exe")
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Serializes tests that bind the OS-global default endpoint
+/// `/run/user/<uid>/skillfs/control.sock`, which only one instance can hold
+/// at a time. cargo runs tests in parallel threads, so without this two
+/// default-endpoint tests would race for the same path.
+static DEFAULT_ENDPOINT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 fn security_without_decision_command_fails_startup() {
     let source = empty_source();
@@ -1168,6 +1220,386 @@ fn non_tmp_transport_paths_pass_gate() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #1262: PrivateTmp daemon-facing control-plane gates
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The resolver control plane is daemon-facing too: the daemon connects to
+// the control socket and the resolver opens the physical live source. With
+// PrivateTmp=true the daemon cannot see /tmp or /var/tmp, so a control-plane
+// source fallback, backing root, or explicit socket under those roots must
+// fail fast — even when notify / events-log are not configured.
+
+#[test]
+fn control_plane_only_source_under_tmp_fails_before_mount() {
+    // Control plane enabled via a trusted peer (default endpoint, no
+    // explicit socket) and no backing root: the resolver's live root falls
+    // back to the source. A source under /tmp must be rejected, pointing at
+    // --ledger-backing-root, even though notify/events-log are absent.
+    let source = empty_source(); // under /tmp
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--trusted-peer-exe",
+            &test_exe(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("source")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true")
+            && combined.contains("--ledger-backing-root"),
+        "expected PrivateTmp source-fallback rejection for control plane, got: {combined}"
+    );
+}
+
+#[test]
+fn control_plane_backing_root_under_tmp_fails_before_setup() {
+    // Control plane enabled with a backing root under /tmp must be rejected
+    // before any bind mount, naming --ledger-backing-root.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let backing = format!("/tmp/{}", unique_leaf("skillfs-privtmp-cp-backing"));
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--trusted-peer-exe",
+            &test_exe(),
+            "--ledger-backing-root",
+            &backing,
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--ledger-backing-root")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true"),
+        "expected PrivateTmp backing-root rejection for control plane, got: {combined}"
+    );
+    assert!(
+        !Path::new(&backing).exists(),
+        "backing root dir must not be created when the gate rejects it"
+    );
+}
+
+#[test]
+fn control_socket_under_tmp_fails_before_mount() {
+    // An explicit --control-socket under /tmp is daemon-facing: the daemon
+    // connects to it with PrivateTmp=true and could not see it. The source
+    // is non-tmp so the socket path is the one that trips the gate.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let socket = format!("/tmp/{}", unique_leaf("skillfs-privtmp-control.sock"));
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--control-socket",
+            &socket,
+            "--trusted-peer-exe",
+            &test_exe(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--control-socket")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true")
+            && combined.contains("/run/"),
+        "expected PrivateTmp control-socket rejection, got: {combined}"
+    );
+    assert!(
+        !Path::new(&socket).exists(),
+        "control socket must not be bound on a rejected startup"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn control_socket_symlink_to_tmp_fails_before_mount() {
+    // A control socket whose parent directory symlinks to a real /tmp
+    // directory canonicalizes to a PrivateTmp-invisible path and must be
+    // rejected, mirroring the backing-root / events-log symlink handling.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    // Real /tmp directory the symlink resolves through to.
+    let tmp_target = tempfile::tempdir().expect("tmp target");
+    // Symlink lives under a non-tmp parent so only canonicalization reveals
+    // the /tmp destination.
+    let parent = non_tmp_dir();
+    let link = parent.path().join("control-link");
+    std::os::unix::fs::symlink(tmp_target.path(), &link).expect("create symlink");
+    let socket = link.join("control.sock");
+
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--control-socket",
+            socket.to_str().unwrap(),
+            "--trusted-peer-exe",
+            &test_exe(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--control-socket")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true"),
+        "expected PrivateTmp rejection for symlinked control socket, got: {combined}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn control_socket_ancestor_symlink_missing_parent_to_tmp_fails() {
+    // The socket's direct parent (`missing-parent`) does not exist yet, and
+    // an ancestor (`link`) is a symlink into /tmp. A parent-only
+    // canonicalize would fall back to the raw lexical path (no /tmp prefix)
+    // and wrongly pass; resolution must climb to the deepest existing
+    // ancestor (`link` → /tmp) and still reject before any socket is bound.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let tmp_target = tempfile::tempdir().expect("tmp target");
+    let parent = non_tmp_dir();
+    let link = parent.path().join("cp-ancestor-link");
+    std::os::unix::fs::symlink(tmp_target.path(), &link).expect("create symlink");
+    // `missing-parent` does not exist under the symlink target.
+    let socket = link.join("missing-parent").join("control.sock");
+
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--control-socket",
+            socket.to_str().unwrap(),
+            "--trusted-peer-exe",
+            &test_exe(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--control-socket")
+            && combined.contains("/tmp or /var/tmp")
+            && combined.contains("PrivateTmp=true"),
+        "expected PrivateTmp rejection for ancestor-symlink socket, got: {combined}"
+    );
+    // The socket must not have been bound under the real /tmp target.
+    assert!(
+        !tmp_target
+            .path()
+            .join("missing-parent")
+            .join("control.sock")
+            .exists(),
+        "socket must not be bound under the /tmp symlink target on a rejected startup"
+    );
+}
+
+#[test]
+fn control_plane_cli_socket_with_config_trusted_peer_passes_gate() {
+    // Mixed configuration: --control-socket on the CLI, trusted peer from
+    // the config file. Both are daemon-visible (non-tmp), so the control
+    // plane comes up and answers an authenticated pong.
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot bring up the control socket");
+        return;
+    }
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
+    let config_dir = tempfile::tempdir().expect("config dir");
+    let config_path = config_dir.path().join("security.toml");
+    // Only the trusted peer comes from config; the socket path is CLI-only.
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+[activation]
+mode = "file"
+
+[control_socket]
+trusted_peer_exe = "{}"
+"#,
+            test_exe()
+        ),
+    )
+    .unwrap();
+
+    let mut child = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--control-socket",
+            sock_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let child_alive = matches!(child.try_wait(), Ok(None));
+    let socket_exists = sock_path.exists();
+    let probe = if socket_exists {
+        probe_control_socket(&sock_path)
+    } else {
+        None
+    };
+    stop_mount_child(&mut child, mount.path());
+    let output = child.wait_with_output();
+
+    assert!(
+        child_alive,
+        "child exited before binding the mixed CLI-socket/config-peer control socket: {:?}",
+        output.map(|o| String::from_utf8_lossy(&o.stderr).into_owned())
+    );
+    assert!(
+        socket_exists,
+        "FUSE is available but the mixed-config control socket {} was not created",
+        sock_path.display()
+    );
+    let resp = probe.expect("mixed-config control socket must respond");
+    assert!(
+        response_is_authenticated_pong(&resp),
+        "mixed-config control socket did not return an authenticated pong: {resp}"
+    );
+}
+
+#[test]
+fn control_plane_config_socket_with_cli_trusted_peer_passes_gate() {
+    // Reverse mixed configuration: socket path from the config file, trusted
+    // peer from the CLI. The config loader must NOT reject the path-only
+    // config, and the post-merge gate must accept the CLI-supplied peer, so
+    // the control plane comes up and answers an authenticated pong.
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot bring up the control socket");
+        return;
+    }
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
+    let config_dir = tempfile::tempdir().expect("config dir");
+    let config_path = config_dir.path().join("security.toml");
+    // Only the socket path comes from config; the trusted peer is CLI-only.
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+[activation]
+mode = "file"
+
+[control_socket]
+path = "{}"
+"#,
+            sock_path.display()
+        ),
+    )
+    .unwrap();
+
+    let mut child = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--trusted-peer-exe",
+            &test_exe(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let child_alive = matches!(child.try_wait(), Ok(None));
+    let socket_exists = sock_path.exists();
+    let probe = if socket_exists {
+        probe_control_socket(&sock_path)
+    } else {
+        None
+    };
+    stop_mount_child(&mut child, mount.path());
+    let output = child.wait_with_output();
+
+    assert!(
+        child_alive,
+        "child exited before binding the config-socket/CLI-peer control socket: {:?}",
+        output.map(|o| String::from_utf8_lossy(&o.stderr).into_owned())
+    );
+    assert!(
+        socket_exists,
+        "FUSE is available but the config-socket/CLI-peer control socket {} was not created",
+        sock_path.display()
+    );
+    let resp = probe.expect("config-socket/CLI-peer control socket must respond");
+    assert!(
+        response_is_authenticated_pong(&resp),
+        "config-socket/CLI-peer control socket did not return an authenticated pong: {resp}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // PID file cleanup tests
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -1436,13 +1868,17 @@ fn control_socket_without_trusted_peer_exe_fails_startup() {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(
-        combined.contains("--control-socket") && combined.contains("requires --trusted-peer-exe"),
-        "expected requires-trusted-peer-exe error, got: {combined}"
+        combined.contains("--control-socket") && combined.contains("requires a trusted peer"),
+        "expected requires-trusted-peer error, got: {combined}"
     );
 }
 
 #[test]
-fn trusted_peer_exe_without_control_socket_fails_startup() {
+fn trusted_peer_exe_without_security_fails_startup() {
+    // A trusted peer with no explicit --control-socket enables the control
+    // plane on the default per-user endpoint, so it is no longer rejected
+    // for "requires --control-socket". It still requires --security like
+    // any control-plane configuration.
     let source = empty_source();
     let mount = tempfile::tempdir().expect("mount tempdir");
     let out = Command::new(bin_path())
@@ -1462,15 +1898,23 @@ fn trusted_peer_exe_without_control_socket_fails_startup() {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(
-        combined.contains("--trusted-peer-exe") && combined.contains("requires --control-socket"),
-        "expected requires-control-socket error, got: {combined}"
+        combined.contains("requires --security"),
+        "expected requires-security error, got: {combined}"
+    );
+    assert!(
+        !combined.contains("requires --control-socket"),
+        "trusted-peer-exe alone must no longer require --control-socket: {combined}"
     );
 }
 
 #[test]
 fn control_socket_trusted_peer_exe_nonexistent_fails() {
-    let source = empty_source();
+    // Daemon-visible source and socket so the trusted-peer-exe validation
+    // is the gate that fires — not the PrivateTmp gate on a /tmp fixture.
+    let source = non_tmp_dir();
     let mount = tempfile::tempdir().expect("mount tempdir");
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
     let out = Command::new(bin_path())
         .args([
             "mount",
@@ -1480,7 +1924,7 @@ fn control_socket_trusted_peer_exe_nonexistent_fails() {
             "--activation-mode",
             "file",
             "--control-socket",
-            "/tmp/test-skillfs.sock",
+            sock_path.to_str().unwrap(),
             "--trusted-peer-exe",
             "/nonexistent/binary/path",
         ])
@@ -1500,8 +1944,12 @@ fn control_socket_trusted_peer_exe_nonexistent_fails() {
 
 #[test]
 fn control_socket_trusted_peer_exe_directory_fails() {
-    let source = empty_source();
+    // Daemon-visible source and socket so the trusted-peer-exe validation
+    // is the gate that fires — not the PrivateTmp gate on a /tmp fixture.
+    let source = non_tmp_dir();
     let mount = tempfile::tempdir().expect("mount tempdir");
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
     let dir = tempfile::tempdir().expect("directory for test");
     let out = Command::new(bin_path())
         .args([
@@ -1512,7 +1960,7 @@ fn control_socket_trusted_peer_exe_directory_fails() {
             "--activation-mode",
             "file",
             "--control-socket",
-            "/tmp/test-skillfs.sock",
+            sock_path.to_str().unwrap(),
             "--trusted-peer-exe",
             dir.path().to_str().unwrap(),
         ])
@@ -1553,7 +2001,7 @@ fn control_socket_without_security_fails_startup() {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(
-        combined.contains("--control-socket requires --security"),
+        combined.contains("control socket requires --security"),
         "expected requires-security error, got: {combined}"
     );
 }
@@ -1582,7 +2030,7 @@ fn control_socket_without_activation_mode_file_fails_startup() {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(
-        combined.contains("--control-socket requires --activation-mode file"),
+        combined.contains("control socket requires --activation-mode file"),
         "expected requires-activation-mode-file error, got: {combined}"
     );
 }
@@ -1701,11 +2149,21 @@ fn supervise_missing_instance_fails() {
 
 #[test]
 fn control_socket_created_and_accepts_ping() {
-    let source = empty_source();
+    // FUSE is required to bring up the mount and the control socket. Gate
+    // explicitly rather than silently passing when the socket never binds.
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot bring up the control socket");
+        return;
+    }
+    // Daemon-visible source and socket: with the control plane enabled the
+    // PrivateTmp gate rejects a daemon-facing source/socket under /tmp.
+    let source = non_tmp_dir();
     let mount = tempfile::tempdir().expect("mount tempdir");
-    let sock_dir = tempfile::tempdir().expect("socket dir");
+    let sock_dir = non_tmp_dir();
     let sock_path = sock_dir.path().join("skillfs.sock");
 
+    // Trusted peer = this test binary, so our own probe authenticates and
+    // must receive a real pong (not a permission_denied).
     let mut child = Command::new(bin_path())
         .args([
             "mount",
@@ -1717,7 +2175,7 @@ fn control_socket_created_and_accepts_ping() {
             "--control-socket",
             sock_path.to_str().unwrap(),
             "--trusted-peer-exe",
-            bin_path(),
+            &test_exe(),
         ])
         .stderr(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -1726,48 +2184,278 @@ fn control_socket_created_and_accepts_ping() {
 
     std::thread::sleep(std::time::Duration::from_secs(2));
 
+    // Capture state before teardown so the failure path never leaks the
+    // mount (all assertions run after stop_mount_child).
+    let child_alive = matches!(child.try_wait(), Ok(None));
     let socket_exists = sock_path.exists();
-
-    let server_responded = if socket_exists {
-        use std::io::{BufRead, BufReader};
-        use std::os::unix::net::UnixStream;
-        match UnixStream::connect(&sock_path) {
-            Ok(stream) => {
-                stream
-                    .set_read_timeout(Some(std::time::Duration::from_secs(3)))
-                    .ok();
-                // The server verifies peer identity before reading the
-                // request, so the test binary may be rejected with
-                // permission_denied. Either a pong or a permission_denied
-                // response proves the server is alive.
-                let mut reader = BufReader::new(&stream);
-                let mut response = String::new();
-                match reader.read_line(&mut response) {
-                    Ok(n) if n > 0 => {
-                        response.contains("\"schemaVersion\"")
-                            && (response.contains("\"pong\":true")
-                                || response.contains("\"permission_denied\""))
-                    }
-                    _ => false,
-                }
-            }
-            Err(_) => false,
-        }
+    let probe = if socket_exists {
+        probe_control_socket(&sock_path)
     } else {
-        false
+        None
     };
 
     stop_mount_child(&mut child, mount.path());
-    let _ = child.wait();
+    let output = child.wait_with_output();
 
-    if socket_exists {
-        assert!(
-            server_responded,
-            "control socket was created but server did not respond"
-        );
-    } else {
-        eprintln!("SKIP: control socket not created (FUSE mount likely unavailable)");
+    assert!(
+        child_alive,
+        "child exited before binding the control socket: {:?}",
+        output.map(|o| String::from_utf8_lossy(&o.stderr).into_owned())
+    );
+    assert!(
+        socket_exists,
+        "FUSE is available but the control socket {} was not created",
+        sock_path.display()
+    );
+    let resp = probe.expect("control socket must respond");
+    assert!(
+        response_is_authenticated_pong(&resp),
+        "control socket did not return an authenticated pong: {resp}"
+    );
+}
+
+#[test]
+fn control_socket_default_endpoint_used_when_no_path() {
+    // A trusted peer with no explicit --control-socket binds the default
+    // per-user endpoint /run/user/<uid>/skillfs/control.sock.
+    let _serial = DEFAULT_ENDPOINT_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let uid_out = Command::new("id").arg("-u").output().expect("id -u");
+    let uid = String::from_utf8_lossy(&uid_out.stdout).trim().to_string();
+    let runtime_dir = format!("/run/user/{uid}");
+    if !std::path::Path::new(&runtime_dir).is_dir() {
+        eprintln!("SKIP: {runtime_dir} unavailable; cannot test default endpoint");
+        return;
     }
+    let default_sock = format!("{runtime_dir}/skillfs/control.sock");
+
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot test default endpoint end-to-end");
+        return;
+    }
+    // Refuse to run if the default endpoint is already occupied — otherwise
+    // a pre-existing listener would make this test a false positive.
+    let sock_path = std::path::PathBuf::from(&default_sock);
+    if sock_path.exists() {
+        eprintln!("SKIP: default endpoint {default_sock} already in use");
+        return;
+    }
+
+    // Daemon-visible source: with the control plane enabled and no backing
+    // root, the resolver's live root falls back to the source, so a source
+    // under /tmp would be rejected by the PrivateTmp gate.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    // Trusted peer = this test binary, so our own probe authenticates and
+    // receives a real pong (not a permission_denied that could mask a
+    // different instance answering on a pre-existing socket).
+    let mut child = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            // No --control-socket: the default endpoint must be used.
+            "--trusted-peer-exe",
+            &test_exe(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // The child must still be running: a dead child means startup failed,
+    // which is a real failure now that FUSE is known available.
+    let child_alive = matches!(child.try_wait(), Ok(None));
+    let socket_exists = sock_path.exists();
+    let uid_ok = if socket_exists {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata(&sock_path).map(|m| m.uid()).ok()
+    } else {
+        None
+    };
+    let probe = if socket_exists {
+        probe_control_socket(&sock_path)
+    } else {
+        None
+    };
+
+    stop_mount_child(&mut child, mount.path());
+    let output = child.wait_with_output();
+
+    assert!(
+        child_alive,
+        "child exited before binding the default endpoint: {:?}",
+        output.map(|o| String::from_utf8_lossy(&o.stderr).into_owned())
+    );
+    assert!(
+        socket_exists,
+        "FUSE is available but the default endpoint {default_sock} was not created"
+    );
+    // Under /run/user, never a public temp directory.
+    assert!(
+        !default_sock.contains("/tmp") && !default_sock.contains("/var/tmp"),
+        "default endpoint must not use a public temp dir"
+    );
+    // Owned by the current uid.
+    let our_uid: u32 = uid.parse().expect("uid");
+    assert_eq!(
+        uid_ok,
+        Some(our_uid),
+        "default endpoint must be owned by us"
+    );
+    // An authenticated pong proves a live server that trusts this binary —
+    // not some other instance that pre-occupied the path.
+    let resp = probe.expect("default endpoint must respond");
+    assert!(
+        response_is_authenticated_pong(&resp),
+        "default endpoint did not return an authenticated pong: {resp}"
+    );
+}
+
+#[test]
+fn control_socket_config_only_default_endpoint() {
+    // Config-only trusted peer (no path, no CLI control-socket flags) must
+    // enable the control plane on the default per-user endpoint — the
+    // config loader no longer rejects a trusted_peer_exe without a path.
+    let _serial = DEFAULT_ENDPOINT_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let uid_out = Command::new("id").arg("-u").output().expect("id -u");
+    let uid = String::from_utf8_lossy(&uid_out.stdout).trim().to_string();
+    let runtime_dir = format!("/run/user/{uid}");
+    if !Path::new(&runtime_dir).is_dir() {
+        eprintln!("SKIP: {runtime_dir} unavailable; cannot test default endpoint");
+        return;
+    }
+    let default_sock = format!("{runtime_dir}/skillfs/control.sock");
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot test default endpoint end-to-end");
+        return;
+    }
+    let sock_path = std::path::PathBuf::from(&default_sock);
+    if sock_path.exists() {
+        eprintln!("SKIP: default endpoint {default_sock} already in use");
+        return;
+    }
+
+    // Daemon-visible source (see the sibling default-endpoint test): the
+    // PrivateTmp gate rejects a /tmp source-fallback when the control plane
+    // is enabled.
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let config_dir = tempfile::tempdir().expect("config dir");
+    let config_path = config_dir.path().join("security.toml");
+    // Only a trusted peer, no [control_socket].path.
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+[activation]
+mode = "file"
+
+[control_socket]
+trusted_peer_exe = "{}"
+"#,
+            test_exe()
+        ),
+    )
+    .unwrap();
+
+    let mut child = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--config",
+            config_path.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let child_alive = matches!(child.try_wait(), Ok(None));
+    let socket_exists = sock_path.exists();
+    let probe = if socket_exists {
+        probe_control_socket(&sock_path)
+    } else {
+        None
+    };
+
+    stop_mount_child(&mut child, mount.path());
+    let output = child.wait_with_output();
+
+    assert!(
+        child_alive,
+        "child exited before binding the config-only default endpoint: {:?}",
+        output.map(|o| String::from_utf8_lossy(&o.stderr).into_owned())
+    );
+    assert!(
+        socket_exists,
+        "FUSE is available but the config-only default endpoint was not created"
+    );
+    let resp = probe.expect("config-only default endpoint must respond");
+    assert!(
+        response_is_authenticated_pong(&resp),
+        "config-only default endpoint did not return an authenticated pong: {resp}"
+    );
+}
+
+#[test]
+fn control_socket_in_place_without_backing_root_fails_startup() {
+    // An in-place mount (source == mountpoint) with the control plane
+    // enabled must require --ledger-backing-root: the FUSE over-mount hides
+    // the physical source, so the resolver would otherwise read the
+    // current/fallback/hidden view instead of the live source. This must
+    // fail startup, not silently mount.
+    //
+    // Daemon-visible source and socket so the PrivateTmp gate passes and the
+    // in-place backing-root gate is the one that fires.
+    let source = non_tmp_dir();
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            // Same path → in-place mount.
+            source.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--control-socket",
+            sock_path.to_str().unwrap(),
+            "--trusted-peer-exe",
+            bin_path(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(
+        !out.status.success(),
+        "in-place control-socket mount without backing root must fail startup"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--ledger-backing-root"),
+        "error must require --ledger-backing-root, got: {combined}"
+    );
+    // The socket must not have been created — startup failed first.
+    assert!(
+        !sock_path.exists(),
+        "no control socket must be bound on a rejected startup"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1847,10 +2535,24 @@ fn hermes_decision_command_rejected() {
 }
 
 #[test]
-fn hermes_control_socket_rejected() {
-    let source = empty_source();
+fn hermes_control_socket_allowed() {
+    // The read-only resolver derives full nested skill ids from the
+    // canonical path, so Hermes layout is compatible with the control
+    // socket. The blanket incompatibility gate has been removed. Prove a
+    // live, authenticated server actually comes up — not merely that no
+    // "incompatible" text was printed (which an unrelated startup failure
+    // could mask).
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot bring up the Hermes control socket");
+        return;
+    }
+    // Daemon-visible source and socket so the PrivateTmp gate does not
+    // reject the control plane on a /tmp fixture.
+    let source = non_tmp_dir();
     let mount = tempfile::tempdir().expect("mount tempdir");
-    let out = Command::new(bin_path())
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
+    let mut child = Command::new(bin_path())
         .args([
             "mount",
             source.path().to_str().unwrap(),
@@ -1861,24 +2563,56 @@ fn hermes_control_socket_rejected() {
             "--activation-mode",
             "file",
             "--control-socket",
-            "/tmp/test-hermes.sock",
+            sock_path.to_str().unwrap(),
             "--trusted-peer-exe",
-            bin_path(),
+            &test_exe(),
+            "--foreground",
         ])
-        .output()
-        .expect("invoke skillfs");
-    assert!(
-        !out.status.success(),
-        "hermes + control-socket must fail startup"
-    );
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    // Capture all state before teardown so the failure path never leaks the
+    // mount (assertions run after stop_mount_child).
+    let child_alive = matches!(child.try_wait(), Ok(None));
+    let socket_exists = sock_path.exists();
+    let probe = if socket_exists {
+        probe_control_socket(&sock_path)
+    } else {
+        None
+    };
+    stop_mount_child(&mut child, mount.path());
+    let output = child.wait_with_output().expect("wait");
+    let still_mounted = is_mounted(mount.path());
     let combined = format!(
         "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert!(
+        !still_mounted,
+        "test mount must be removed after child shutdown: {}",
+        mount.path().display()
     );
     assert!(
-        combined.contains("incompatible"),
-        "error must mention incompatibility: {combined}"
+        !combined.contains("incompatible"),
+        "hermes + control-socket must not trigger an incompatibility gate: {combined}"
+    );
+    assert!(
+        child_alive,
+        "child exited before binding the Hermes control socket: {combined}"
+    );
+    assert!(
+        socket_exists,
+        "FUSE is available but the Hermes control socket was not created: {combined}"
+    );
+    let resp = probe.expect("hermes control socket must respond");
+    assert!(
+        response_is_authenticated_pong(&resp),
+        "hermes control socket server did not return an authenticated pong: {resp}"
     );
 }
 
@@ -1959,9 +2693,21 @@ command = "agent-sec-cli skill-ledger"
 }
 
 #[test]
-fn hermes_config_control_socket_rejected() {
-    let source = empty_source();
+fn hermes_config_control_socket_allowed() {
+    // Config-sourced Hermes + control socket is allowed: the read-only
+    // resolver derives full nested skill ids, so no incompatibility gate
+    // fires. Prove a live, authenticated server comes up rather than just
+    // asserting the absence of "incompatible".
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot bring up the Hermes control socket");
+        return;
+    }
+    // Daemon-visible source and socket so the PrivateTmp gate does not
+    // reject the control plane on a /tmp fixture.
+    let source = non_tmp_dir();
     let mount = tempfile::tempdir().expect("mount tempdir");
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
     let config_dir = tempfile::tempdir().expect("config dir");
     let config_path = config_dir.path().join("security.toml");
     std::fs::write(
@@ -1975,15 +2721,16 @@ layout = "hermes"
 mode = "file"
 
 [control_socket]
-path = "/tmp/test-hermes-config.sock"
+path = "{}"
 trusted_peer_exe = "{}"
 "#,
-            bin_path()
+            sock_path.display(),
+            test_exe()
         ),
     )
     .unwrap();
 
-    let out = Command::new(bin_path())
+    let mut child = Command::new(bin_path())
         .args([
             "mount",
             source.path().to_str().unwrap(),
@@ -1991,20 +2738,52 @@ trusted_peer_exe = "{}"
             "--security",
             "--config",
             config_path.to_str().unwrap(),
+            "--foreground",
         ])
-        .output()
-        .expect("invoke skillfs");
-    assert!(
-        !out.status.success(),
-        "hermes (config) + control-socket (config) must fail"
-    );
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    // Capture all state before teardown so the failure path never leaks the
+    // mount (assertions run after stop_mount_child).
+    let child_alive = matches!(child.try_wait(), Ok(None));
+    let socket_exists = sock_path.exists();
+    let probe = if socket_exists {
+        probe_control_socket(&sock_path)
+    } else {
+        None
+    };
+    stop_mount_child(&mut child, mount.path());
+    let output = child.wait_with_output().expect("wait");
+    let still_mounted = is_mounted(mount.path());
     let combined = format!(
         "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert!(
+        !still_mounted,
+        "test mount must be removed after child shutdown: {}",
+        mount.path().display()
     );
     assert!(
-        combined.contains("incompatible"),
-        "config-sourced hermes + control-socket must be rejected: {combined}"
+        !combined.contains("incompatible"),
+        "config-sourced hermes + control-socket must not trigger an incompatibility gate: {combined}"
+    );
+    assert!(
+        child_alive,
+        "child exited before binding the config-sourced Hermes control socket: {combined}"
+    );
+    assert!(
+        socket_exists,
+        "FUSE is available but the config-sourced Hermes control socket was not created: {combined}"
+    );
+    let resp = probe.expect("hermes (config) control socket must respond");
+    assert!(
+        response_is_authenticated_pong(&resp),
+        "hermes (config) control socket server did not return an authenticated pong: {resp}"
     );
 }

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -85,11 +85,15 @@ fn empty_source() -> tempfile::TempDir {
 /// or a `permission_denied` (the test binary may fail peer verification),
 /// both of which carry the `schemaVersion` envelope.
 fn probe_control_socket(path: &Path) -> Option<String> {
+    request_control_socket(path, r#"{"schemaVersion":"1","method":"ping"}"#)
+}
+
+fn request_control_socket(path: &Path, request: &str) -> Option<String> {
     use std::io::{BufRead, BufReader, Write};
     use std::os::unix::net::UnixStream;
     let mut stream = UnixStream::connect(path).ok()?;
     stream.set_read_timeout(Some(Duration::from_secs(3))).ok()?;
-    writeln!(stream, r#"{{"schemaVersion":"1","method":"ping"}}"#).ok()?;
+    writeln!(stream, "{request}").ok()?;
     stream.flush().ok()?;
     let mut reader = BufReader::new(&stream);
     let mut response = String::new();
@@ -2215,6 +2219,84 @@ fn control_socket_created_and_accepts_ping() {
 }
 
 #[test]
+fn control_socket_preserves_symlink_source_identity() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE unavailable; cannot test symlink source identity");
+        return;
+    }
+
+    let physical_source = non_tmp_dir();
+    let skill_dir = physical_source.path().join("my-skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: my-skill\ndescription: fixture\n---\n",
+    )
+    .unwrap();
+    let identity_parent = non_tmp_dir();
+    let identity_root = identity_parent.path().join("skills-link");
+    std::os::unix::fs::symlink(physical_source.path(), &identity_root).unwrap();
+
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let sock_dir = non_tmp_dir();
+    let sock_path = sock_dir.path().join("skillfs.sock");
+    let mut child = Command::new(bin_path())
+        .args([
+            "mount",
+            identity_root.to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--control-socket",
+            sock_path.to_str().unwrap(),
+            "--trusted-peer-exe",
+            &test_exe(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn skillfs");
+
+    std::thread::sleep(Duration::from_secs(2));
+    let child_alive = matches!(child.try_wait(), Ok(None));
+    let request_identity = identity_root.join("my-skill");
+    let request = serde_json::json!({
+        "schemaVersion": "1",
+        "method": "skill.resolveLiveSource",
+        "canonicalSkillDir": request_identity,
+    });
+    let response = request_control_socket(&sock_path, &request.to_string());
+
+    stop_mount_child(&mut child, mount.path());
+    let output = child.wait_with_output();
+
+    assert!(
+        child_alive,
+        "child exited before serving symlink identity: {:?}",
+        output.map(|o| String::from_utf8_lossy(&o.stderr).into_owned())
+    );
+    let response: serde_json::Value =
+        serde_json::from_str(&response.expect("control socket must respond")).unwrap();
+    assert_eq!(response["ok"], true);
+    assert_eq!(
+        response["result"]["canonicalSkillDir"],
+        request_identity.to_string_lossy().as_ref()
+    );
+    assert_eq!(response["result"]["skillId"], "my-skill");
+    assert_eq!(
+        response["result"]["liveSkillDir"],
+        physical_source
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("my-skill")
+            .to_string_lossy()
+            .as_ref()
+    );
+}
+
+#[test]
 fn control_socket_default_endpoint_used_when_no_path() {
     // A trusted peer with no explicit --control-socket binds the default
     // per-user endpoint /run/user/<uid>/skillfs/control.sock.
@@ -2455,6 +2537,73 @@ fn control_socket_in_place_without_backing_root_fails_startup() {
     assert!(
         !sock_path.exists(),
         "no control socket must be bound on a rejected startup"
+    );
+}
+
+#[test]
+fn in_place_notify_without_resolver_fails_startup() {
+    let source = non_tmp_dir();
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            source.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            "/run/skillfs-in-place-notify.sock",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("authenticated live-source resolver")
+            && combined.contains("--trusted-peer-exe"),
+        "in-place notify must require the resolver control plane, got: {combined}"
+    );
+    assert!(
+        !combined.contains("--ledger-backing-root"),
+        "resolver gate must run before backing-root setup, got: {combined}"
+    );
+}
+
+#[test]
+fn in_place_notify_with_resolver_reaches_backing_root_gate() {
+    let source = non_tmp_dir();
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            source.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            "/run/skillfs-in-place-notify.sock",
+            "--trusted-peer-exe",
+            bin_path(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--ledger-backing-root"),
+        "resolver-enabled in-place notify must reach backing-root gate, got: {combined}"
+    );
+    assert!(
+        !combined.contains("authenticated live-source resolver"),
+        "configured resolver must satisfy the notify gate, got: {combined}"
     );
 }
 

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -847,6 +847,8 @@ fn backing_root_under_tmp_fails_before_setup() {
             "/run/skillfs-privtmp-test.sock",
             "--ledger-backing-root",
             &backing,
+            "--trusted-peer-exe",
+            bin_path(),
         ])
         .output()
         .expect("invoke skillfs");
@@ -934,6 +936,8 @@ fn backing_root_symlink_to_tmp_fails_before_setup() {
             "/run/skillfs-privtmp-test.sock",
             "--ledger-backing-root",
             link.to_str().unwrap(),
+            "--trusted-peer-exe",
+            bin_path(),
         ])
         .output()
         .expect("invoke skillfs");
@@ -1037,10 +1041,14 @@ fn non_tmp_daemon_facing_root_passes_gate() {
             "/run/skillfs-privtmp-test.sock",
             "--ledger-backing-root",
             source.path().to_str().unwrap(),
+            "--trusted-peer-exe",
+            bin_path(),
         ],
     );
     assert!(
-        !combined.contains("PrivateTmp=true") && !combined.contains("resolves under /tmp"),
+        !combined.contains("PrivateTmp=true")
+            && !combined.contains("resolves under /tmp")
+            && !combined.contains("authenticated live-source resolver"),
         "PrivateTmp gate must not fire for a non-tmp backing root, got: {combined}"
     );
 }
@@ -2568,7 +2576,7 @@ fn in_place_notify_without_resolver_fails_startup() {
         "in-place notify must require the resolver control plane, got: {combined}"
     );
     assert!(
-        !combined.contains("--ledger-backing-root"),
+        !combined.contains("--ledger-backing-root setup failed"),
         "resolver gate must run before backing-root setup, got: {combined}"
     );
 }
@@ -2604,6 +2612,117 @@ fn in_place_notify_with_resolver_reaches_backing_root_gate() {
     assert!(
         !combined.contains("authenticated live-source resolver"),
         "configured resolver must satisfy the notify gate, got: {combined}"
+    );
+}
+
+#[test]
+fn out_of_place_notify_with_backing_root_without_resolver_fails_startup() {
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let backing = mount.path().join("backing");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            "/run/skillfs-out-of-place-notify.sock",
+            "--ledger-backing-root",
+            backing.to_str().unwrap(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("authenticated live-source resolver")
+            && combined.contains("--trusted-peer-exe")
+            && combined.contains("--ledger-backing-root"),
+        "backing-root notify must require the resolver control plane, got: {combined}"
+    );
+    assert!(
+        !backing.exists(),
+        "resolver gate must run before backing-root setup"
+    );
+}
+
+#[test]
+fn config_backing_root_with_notify_without_resolver_fails_startup() {
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let backing = mount.path().join("backing");
+    let config_dir = tempfile::tempdir().expect("config dir");
+    let config_path = config_dir.path().join("security.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[activation]\nmode = \"file\"\n[ledger]\nbacking_root = \"{}\"\n",
+            backing.display()
+        ),
+    )
+    .unwrap();
+
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--notify-socket",
+            "/run/skillfs-config-backing-notify.sock",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    assert!(!out.status.success(), "expected non-zero exit");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("authenticated live-source resolver")
+            && combined.contains("--ledger-backing-root"),
+        "merged config backing root must require the resolver, got: {combined}"
+    );
+    assert!(
+        !backing.exists(),
+        "resolver gate must run before config backing-root setup"
+    );
+}
+
+#[test]
+fn out_of_place_notify_with_backing_root_and_resolver_passes_gate() {
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let combined = run_briefly(
+        mount.path(),
+        &[
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--notify-socket",
+            "/run/skillfs-out-of-place-notify.sock",
+            "--ledger-backing-root",
+            source.path().to_str().unwrap(),
+            "--trusted-peer-exe",
+            bin_path(),
+        ],
+    );
+    assert!(
+        !combined.contains("authenticated live-source resolver"),
+        "configured resolver must satisfy backing-root notify gate, got: {combined}"
     );
 }
 

--- a/src/skillfs/crates/skillfs-core/src/store.rs
+++ b/src/skillfs/crates/skillfs-core/src/store.rs
@@ -74,8 +74,10 @@ impl SkillStore {
 
             let path = entry.path();
 
-            // Skip non-directories
-            if !path.is_dir() {
+            // Skip non-directories. No-follow entry type so a symlink to a
+            // directory is skipped: a symlinked Skill/category is not managed
+            // (the resolver rejects symlinked components with O_NOFOLLOW).
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                 continue;
             }
 
@@ -113,10 +115,10 @@ impl SkillStore {
                 errors.extend(cat_errors);
             } else {
                 // ---- Flat layout ----
-                let skill_md = path.join("SKILL.md");
-                if !skill_md.exists() {
+                if !has_regular_skill_md(&path) {
                     continue;
                 }
+                let skill_md = path.join("SKILL.md");
 
                 match parser::parse_skill_file_with_limit(&skill_md, config.max_skill_size) {
                     Ok(mut entry) => {
@@ -176,7 +178,9 @@ impl SkillStore {
             };
 
             let path = entry.path();
-            if !path.is_dir() {
+            // No-follow entry type: a symlinked child is never a managed
+            // nested Skill (resolver rejects symlinked components).
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                 continue;
             }
 
@@ -194,10 +198,10 @@ impl SkillStore {
                 continue;
             }
 
-            let skill_md = path.join("SKILL.md");
-            if !skill_md.exists() {
+            if !has_regular_skill_md(&path) {
                 continue;
             }
+            let skill_md = path.join("SKILL.md");
 
             match parser::parse_skill_file_with_limit(&skill_md, config.max_skill_size) {
                 Ok(mut entry) => {
@@ -303,17 +307,55 @@ impl Default for SkillStore {
 // Private helpers
 // ---------------------------------------------------------------------------
 
+/// Return `true` when `dir` is itself a **real directory** (not a symlink)
+/// and contains a `SKILL.md` that is a **regular file**, both classified
+/// **without following symlinks**.
+///
+/// This is the single, shared definition of "this directory is a Skill"
+/// used by store discovery, the FUSE readdir/read gating, Hermes activation
+/// enumeration, and the control-socket resolver. Keeping one predicate
+/// prevents the layers from disagreeing about what a Skill is:
+///
+/// * `dir` must be a real directory. A symlinked Skill directory
+///   (`<root>/linked-skill -> /outside`) is **not** a managed Skill: the
+///   resolver descends with `openat(O_NOFOLLOW)` and rejects any symlinked
+///   component, so store/FUSE discovery must reject it too rather than load,
+///   expose, and read a Skill the resolver refuses to resolve.
+/// * A `SKILL.md` that is a symlink, directory, FIFO, or any other
+///   non-regular object is **not** a valid marker — it is treated as absent
+///   (the directory is not a Skill), never followed.
+/// * A regular-file `SKILL.md` is a marker even when it is unreadable
+///   (mode `000`): discovery must not depend on read permission.
+///
+/// This matches the resolver's `openat(O_NOFOLLOW)` + `fstatat`
+/// classification (real directory with a regular-file marker → Skill;
+/// anything else → not a Skill).
+pub fn has_regular_skill_md(dir: &Path) -> bool {
+    // The directory itself must be a real directory, checked no-follow so a
+    // symlink is rejected even when its target is a directory.
+    match std::fs::symlink_metadata(dir) {
+        Ok(meta) if meta.file_type().is_dir() => {}
+        _ => return false,
+    }
+    match std::fs::symlink_metadata(dir.join("SKILL.md")) {
+        Ok(meta) => meta.file_type().is_file(),
+        Err(_) => false,
+    }
+}
+
 /// Returns `true` when `dir` looks like a category container:
-/// it has no `SKILL.md` of its own but contains at least one sub-directory
-/// that does have a `SKILL.md`.
+/// it has no `SKILL.md` of its own but contains at least one **real
+/// sub-directory** (not a symlink) that does have a `SKILL.md`.
 fn is_category_dir(dir: &Path) -> bool {
-    if dir.join("SKILL.md").exists() {
+    if has_regular_skill_md(dir) {
         return false;
     }
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
-            let p = entry.path();
-            if p.is_dir() && p.join("SKILL.md").exists() {
+            // No-follow entry type: a symlinked child is never a Skill
+            // directory, so it never makes `dir` a category.
+            let is_real_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            if is_real_dir && has_regular_skill_md(&entry.path()) {
                 return true;
             }
         }
@@ -539,5 +581,201 @@ mod tests {
 
         assert!(errors.is_empty());
         assert!(store.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // has_regular_skill_md predicate boundaries (shared Skill-marker rule)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn has_regular_skill_md_true_for_regular_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("SKILL.md"), "---\nname: x\n---\n").unwrap();
+        assert!(has_regular_skill_md(dir.path()));
+    }
+
+    #[test]
+    fn has_regular_skill_md_true_for_unreadable_mode_000_regular_file() {
+        // Discovery must not depend on read permission: a mode-000 regular
+        // SKILL.md is still a marker (stat succeeds without read access).
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let md = dir.path().join("SKILL.md");
+        std::fs::write(&md, "---\nname: x\n---\n").unwrap();
+        std::fs::set_permissions(&md, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let present = has_regular_skill_md(dir.path());
+        // Restore perms so the tempdir cleans up.
+        std::fs::set_permissions(&md, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(present, "mode-000 regular SKILL.md must be seen as present");
+    }
+
+    #[test]
+    fn has_regular_skill_md_false_for_symlink() {
+        // A symlink named SKILL.md is not a marker and is never followed.
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("real.md");
+        std::fs::write(&target, "---\nname: x\n---\n").unwrap();
+        std::os::unix::fs::symlink(&target, dir.path().join("SKILL.md")).unwrap();
+        assert!(!has_regular_skill_md(dir.path()));
+    }
+
+    #[test]
+    fn has_regular_skill_md_false_for_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("SKILL.md")).unwrap();
+        assert!(!has_regular_skill_md(dir.path()));
+    }
+
+    #[test]
+    fn has_regular_skill_md_false_when_absent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(!has_regular_skill_md(dir.path()));
+    }
+
+    #[test]
+    fn store_hermes_symlinked_top_level_skill_md_is_category_not_skill() {
+        // A top-level dir whose only SKILL.md is a symlink is a category:
+        // store must NOT load it as a flat skill, and its real nested child
+        // (regular SKILL.md) IS loaded as `category/child`. This is the same
+        // classification the resolver and FUSE layer now apply.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let top = temp_dir.path().join("top");
+        std::fs::create_dir(&top).unwrap();
+        let real = temp_dir.path().join("real.md");
+        std::fs::write(&real, "---\nname: r\n---\n").unwrap();
+        std::os::unix::fs::symlink(&real, top.join("SKILL.md")).unwrap();
+        let child = top.join("child");
+        std::fs::create_dir(&child).unwrap();
+        std::fs::write(child.join("SKILL.md"), "---\nname: child\n---\n").unwrap();
+
+        let mut store = SkillStore::new();
+        let config = ParseConfig {
+            strict: false,
+            max_skill_size: 1_048_576,
+            max_skills: 1000,
+        };
+        let errors = store.load_from_directory(temp_dir.path(), &config);
+        assert!(errors.is_empty(), "unexpected load errors: {errors:?}");
+
+        // `top` is a category, not a flat skill; `child` is the nested skill.
+        assert!(
+            store.get("top").is_none(),
+            "symlink-marker top must not load"
+        );
+        assert!(store.get("child").is_some(), "nested child must load");
+    }
+
+    #[test]
+    fn has_regular_skill_md_false_for_symlinked_directory() {
+        // `dir` itself is a symlink pointing at a real Skill directory. It is
+        // NOT a managed Skill: the resolver's O_NOFOLLOW descent rejects a
+        // symlinked component, so the predicate must reject it too.
+        let root = tempfile::TempDir::new().unwrap();
+        let real = root.path().join("real-skill");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("SKILL.md"), "---\nname: x\n---\n").unwrap();
+        let link = root.path().join("linked-skill");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert!(has_regular_skill_md(&real), "the real dir is a Skill");
+        assert!(
+            !has_regular_skill_md(&link),
+            "a symlinked Skill directory must not be classified as a Skill"
+        );
+    }
+
+    #[test]
+    fn store_flat_symlinked_skill_dir_not_loaded() {
+        // Flat layout: `<root>/linked-skill -> <outside>/real-skill`. The
+        // store must NOT load the symlinked directory as a Skill (the
+        // resolver rejects it), while a sibling real Skill loads normally.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let real = outside.path().join("real-skill");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("SKILL.md"), "---\nname: real\n---\n").unwrap();
+        std::os::unix::fs::symlink(&real, temp_dir.path().join("linked-skill")).unwrap();
+        // A genuine in-root Skill to prove loading still works.
+        let inroot = temp_dir.path().join("inroot");
+        std::fs::create_dir(&inroot).unwrap();
+        std::fs::write(inroot.join("SKILL.md"), "---\nname: inroot\n---\n").unwrap();
+
+        let mut store = SkillStore::new();
+        let config = ParseConfig {
+            strict: false,
+            max_skill_size: 1_048_576,
+            max_skills: 1000,
+        };
+        let errors = store.load_from_directory(temp_dir.path(), &config);
+        assert!(errors.is_empty(), "unexpected load errors: {errors:?}");
+        assert!(
+            store.get("linked-skill").is_none(),
+            "symlinked Skill directory must not be loaded"
+        );
+        assert!(store.get("inroot").is_some(), "real Skill must load");
+    }
+
+    #[test]
+    fn store_hermes_symlink_category_not_descended() {
+        // A symlinked category (`<root>/linkcat -> <outside>/cat`) must not be
+        // descended: its nested skills live outside the managed root and the
+        // resolver rejects the symlinked component. Skills under it must NOT
+        // load.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let cat = outside.path().join("cat");
+        let nested = cat.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("SKILL.md"), "---\nname: nested\n---\n").unwrap();
+        std::os::unix::fs::symlink(&cat, temp_dir.path().join("linkcat")).unwrap();
+
+        let mut store = SkillStore::new();
+        let config = ParseConfig {
+            strict: false,
+            max_skill_size: 1_048_576,
+            max_skills: 1000,
+        };
+        let errors = store.load_from_directory(temp_dir.path(), &config);
+        assert!(errors.is_empty(), "unexpected load errors: {errors:?}");
+        assert!(
+            store.get("nested").is_none(),
+            "skill under a symlinked category must not load"
+        );
+    }
+
+    #[test]
+    fn store_hermes_symlink_nested_skill_not_loaded() {
+        // Real category, but the nested skill entry is a symlink to a real
+        // Skill directory. The symlinked nested skill must NOT load.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let real = outside.path().join("real-nested");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("SKILL.md"), "---\nname: linked\n---\n").unwrap();
+
+        let cat = temp_dir.path().join("cat");
+        std::fs::create_dir(&cat).unwrap();
+        // A genuine nested skill so `cat` is recognized as a category.
+        let realnested = cat.join("realnested");
+        std::fs::create_dir(&realnested).unwrap();
+        std::fs::write(realnested.join("SKILL.md"), "---\nname: realnested\n---\n").unwrap();
+        // The symlinked nested skill.
+        std::os::unix::fs::symlink(&real, cat.join("linknested")).unwrap();
+
+        let mut store = SkillStore::new();
+        let config = ParseConfig {
+            strict: false,
+            max_skill_size: 1_048_576,
+            max_skills: 1000,
+        };
+        let errors = store.load_from_directory(temp_dir.path(), &config);
+        assert!(errors.is_empty(), "unexpected load errors: {errors:?}");
+        assert!(
+            store.get("realnested").is_some(),
+            "real nested skill must load"
+        );
+        assert!(
+            store.get("linknested").is_none(),
+            "symlinked nested skill must not load"
+        );
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -473,7 +473,9 @@ impl SkillFs {
                             if self.is_pending_install(&nested_id) {
                                 continue;
                             }
-                            if has_resolver && entry.path().join("SKILL.md").exists() {
+                            if has_resolver
+                                && skillfs_core::store::has_regular_skill_md(&entry.path())
+                            {
                                 let resolution = self.resolve_hermes_nested_read(category, &name);
                                 if matches!(resolution, ReadResolution::Hidden) {
                                     continue;
@@ -1126,7 +1128,8 @@ impl SkillFs {
                                 continue;
                             }
                             if has_resolver && entry.path().is_dir() {
-                                let is_skill_leaf = entry.path().join("SKILL.md").exists();
+                                let is_skill_leaf =
+                                    skillfs_core::store::has_regular_skill_md(&entry.path());
                                 if is_skill_leaf {
                                     let resolution =
                                         self.resolve_hermes_nested_read(category, &name);

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -58,6 +58,12 @@ impl SkillFs {
                 ];
                 if let Ok(dir_iter) = std::fs::read_dir(self.source_base()) {
                     for entry in dir_iter.flatten() {
+                        if entry
+                            .file_type()
+                            .is_ok_and(|file_type| file_type.is_symlink())
+                        {
+                            continue;
+                        }
                         let name = entry.file_name().to_string_lossy().to_string();
                         let kind = dir_entry_file_type(&entry);
                         let entry_path = self.skill_inode_path(&name);
@@ -457,6 +463,12 @@ impl SkillFs {
                 ];
                 if let Ok(dir_iter) = std::fs::read_dir(&phys_dir) {
                     for entry in dir_iter.flatten() {
+                        if entry
+                            .file_type()
+                            .is_ok_and(|file_type| file_type.is_symlink())
+                        {
+                            continue;
+                        }
                         let name = entry.file_name().to_string_lossy().to_string();
                         let is_dir = entry.path().is_dir();
                         // Activation gating applies only to real nested
@@ -683,6 +695,12 @@ impl SkillFs {
                         let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
                         phys_entries.sort_by_key(|e| e.file_name());
                         for entry in phys_entries {
+                            if entry
+                                .file_type()
+                                .is_ok_and(|file_type| file_type.is_symlink())
+                            {
+                                continue;
+                            }
                             let name = entry.file_name().to_string_lossy().to_string();
                             let kind = dir_entry_file_type(&entry);
                             let entry_path = self.skill_inode_path(&name);
@@ -1118,6 +1136,12 @@ impl SkillFs {
                         let mut phys_entries: Vec<_> = dir_iter.flatten().collect();
                         phys_entries.sort_by_key(|e| e.file_name());
                         for entry in phys_entries {
+                            if entry
+                                .file_type()
+                                .is_ok_and(|file_type| file_type.is_symlink())
+                            {
+                                continue;
+                            }
                             let name = entry.file_name().to_string_lossy().to_string();
                             // H3: staging roots inside category hidden from listing.
                             if entry.path().is_dir() && self.is_staging_skill_root(&name) {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -1053,6 +1053,85 @@ impl SkillFs {
             stat.f_frsize as u32,
         );
     }
+
+    fn check_activated_access_result(
+        &self,
+        read_path: &Path,
+        write_path: &Path,
+        mask: i32,
+        req: &Request,
+    ) -> i32 {
+        if mask == libc::F_OK {
+            return self.check_physical_access_result(read_path, mask, req);
+        }
+
+        let read_mask = mask & (libc::R_OK | libc::X_OK);
+        if read_mask != 0 {
+            let result = self.check_physical_access_result(read_path, read_mask, req);
+            if result != 0 {
+                return result;
+            }
+        }
+
+        if (mask & libc::W_OK) != 0 {
+            return self.check_physical_access_result(write_path, libc::W_OK, req);
+        }
+
+        0
+    }
+
+    fn flat_access_read_path(
+        &self,
+        skill_name: &str,
+        relative_path: Option<&Path>,
+    ) -> Option<std::path::PathBuf> {
+        let live_dir = self.source_base().join(skill_name);
+        if self.is_staging_skill_root(skill_name)
+            || self.is_pending_install(skill_name)
+            || relative_path.is_some_and(|relative| {
+                self.is_post_publish_grace_allowed(skill_name, Some(relative))
+            })
+        {
+            return Some(match relative_path {
+                Some(relative) => live_dir.join(relative),
+                None => live_dir,
+            });
+        }
+
+        self.skill_read_dir(skill_name)
+            .map(|dir| match relative_path {
+                Some(relative) => dir.join(relative),
+                None => dir,
+            })
+    }
+
+    fn nested_access_read_path(
+        &self,
+        category: &str,
+        skill_name: &str,
+        relative_path: Option<&Path>,
+    ) -> Option<std::path::PathBuf> {
+        let nested_id = Self::hermes_skill_id(category, skill_name);
+        let live_dir = self.source_base().join(category).join(skill_name);
+        if self.is_staging_skill_root(&nested_id)
+            || self.is_pending_install(&nested_id)
+            || relative_path.is_some_and(|relative| {
+                self.is_post_publish_grace_allowed(&nested_id, Some(relative))
+            })
+        {
+            return Some(match relative_path {
+                Some(relative) => live_dir.join(relative),
+                None => live_dir,
+            });
+        }
+
+        self.hermes_nested_skill_read_dir(category, skill_name)
+            .map(|dir| match relative_path {
+                Some(relative) => dir.join(relative),
+                None => dir,
+            })
+    }
+
     pub(in crate::fs) fn access_impl(
         &mut self,
         req: &Request,
@@ -1158,8 +1237,14 @@ impl SkillFs {
                         reply.ok();
                     }
                 } else {
-                    let file_path = self.source_base().join(skill_name).join("SKILL.md");
-                    let result = self.check_physical_access_result(&file_path, mask, req);
+                    let live_path = self.source_base().join(skill_name).join("SKILL.md");
+                    let read_path =
+                        match self.flat_access_read_path(skill_name, Some(Path::new("SKILL.md"))) {
+                            Some(path) => path,
+                            None => return reply.error(libc::ENOENT),
+                        };
+                    let result =
+                        self.check_activated_access_result(&read_path, &live_path, mask, req);
                     if result == 0 {
                         reply.ok();
                     } else {
@@ -1212,8 +1297,15 @@ impl SkillFs {
                             return;
                         }
                     }
-                    let file_path = self.source_base().join(skill_name).join(relative_path);
-                    let result = self.check_physical_access_result(&file_path, mask, req);
+                    let live_path = self.source_base().join(skill_name).join(relative_path);
+                    let read_path = match self
+                        .flat_access_read_path(skill_name, Some(relative_path.as_path()))
+                    {
+                        Some(path) => path,
+                        None => return reply.error(libc::ENOENT),
+                    };
+                    let result =
+                        self.check_activated_access_result(&read_path, &live_path, mask, req);
                     if result == 0 {
                         reply.ok();
                     } else {
@@ -1236,12 +1328,38 @@ impl SkillFs {
                     reply.error(result);
                 }
             }
-            PathType::NestedSkillDir { .. } | PathType::NestedSkillMd { .. } => {
-                let physical = match self.resolve_physical_path(&path) {
-                    Some(p) => p,
+            PathType::NestedSkillDir {
+                ref category,
+                ref skill_name,
+            } => {
+                let live_path = self.source_base().join(category).join(skill_name);
+                let read_path = match self.nested_access_read_path(category, skill_name, None) {
+                    Some(path) => path,
                     None => return reply.error(libc::ENOENT),
                 };
-                let result = self.check_physical_access_result(&physical, mask, req);
+                let result = self.check_activated_access_result(&read_path, &live_path, mask, req);
+                if result == 0 {
+                    reply.ok();
+                } else {
+                    reply.error(result);
+                }
+            }
+            PathType::NestedSkillMd {
+                ref category,
+                ref skill_name,
+            } => {
+                let relative_path = Path::new("SKILL.md");
+                let live_path = self
+                    .source_base()
+                    .join(category)
+                    .join(skill_name)
+                    .join(relative_path);
+                let read_path =
+                    match self.nested_access_read_path(category, skill_name, Some(relative_path)) {
+                        Some(path) => path,
+                        None => return reply.error(libc::ENOENT),
+                    };
+                let result = self.check_activated_access_result(&read_path, &live_path, mask, req);
                 if result == 0 {
                     reply.ok();
                 } else {
@@ -1288,11 +1406,20 @@ impl SkillFs {
                         return;
                     }
                 }
-                let physical = match self.resolve_physical_path(&path) {
-                    Some(p) => p,
+                let live_path = self
+                    .source_base()
+                    .join(category)
+                    .join(skill_name)
+                    .join(relative_path);
+                let read_path = match self.nested_access_read_path(
+                    category,
+                    skill_name,
+                    Some(relative_path.as_path()),
+                ) {
+                    Some(path) => path,
                     None => return reply.error(libc::ENOENT),
                 };
-                let result = self.check_physical_access_result(&physical, mask, req);
+                let result = self.check_activated_access_result(&read_path, &live_path, mask, req);
                 if result == 0 {
                     reply.ok();
                 } else {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
@@ -1059,9 +1059,9 @@ impl SkillFs {
 
                 // D1.3-demo: rename observes both old and new owning
                 // skill. If they're identical the controller's
-                // per-skill debounce coalesces them; if they differ
-                // the controller schedules independent refreshes for
-                // each side.
+                // per-skill debounce coalesces both relative paths; if
+                // they differ the controller schedules independent
+                // refreshes for each side.
                 // L1: cross-namespace renames between inbox and
                 // `/skills` were rejected above, so the old/new sides
                 // here are either both inbox or both non-inbox. Inbox
@@ -1172,13 +1172,7 @@ impl SkillFs {
                         observe_pair(self, skill, rel.as_deref(), *is_inbox);
                     }
                     if let Some((new_skill, new_rel, is_inbox)) = &new_skill_path {
-                        let same_as_old = old_skill_path
-                            .as_ref()
-                            .map(|(old_skill, _, _)| old_skill == new_skill)
-                            .unwrap_or(false);
-                        if !same_as_old {
-                            observe_pair(self, new_skill, new_rel.as_deref(), *is_inbox);
-                        }
+                        observe_pair(self, new_skill, new_rel.as_deref(), *is_inbox);
                     }
                 }
                 self.emit_event(

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -493,6 +493,9 @@ impl SkillFs {
         if self.skill_layout != SkillLayout::Hermes {
             return parsed;
         }
+        if self.hermes_has_symlinked_boundary(&parsed) {
+            return PathType::Invalid;
+        }
         match parsed {
             PathType::CategoryDir { category } if self.hermes_is_top_level_skill(&category) => {
                 PathType::SkillDir {
@@ -552,6 +555,47 @@ impl SkillFs {
             }
             other => other,
         }
+    }
+
+    fn hermes_has_symlinked_boundary(&self, path_type: &crate::path::PathType) -> bool {
+        use crate::path::PathType;
+
+        let (category, nested) = match path_type {
+            PathType::CategoryDir { category } => (category, None),
+            PathType::NestedSkillDir {
+                category,
+                skill_name,
+            }
+            | PathType::NestedSkillMd {
+                category,
+                skill_name,
+            }
+            | PathType::NestedPassthrough {
+                category,
+                skill_name,
+                ..
+            } => (category, Some(skill_name)),
+            _ => return false,
+        };
+
+        let category_path = self.source_base().join(category);
+        if std::fs::symlink_metadata(&category_path)
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            return true;
+        }
+
+        // A second Hermes component is structural only below a category.
+        // Below a real top-level Skill it is ordinary passthrough content,
+        // whose existing same-Skill symlink policy remains unchanged.
+        if self.hermes_is_top_level_skill(category) {
+            return false;
+        }
+
+        nested.is_some_and(|name| {
+            std::fs::symlink_metadata(category_path.join(name))
+                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        })
     }
 
     fn virtual_file_attr(&self, size: u64) -> FileAttr {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -409,10 +409,15 @@ impl SkillFs {
     /// never enter activation gating. The probe hits the physical source
     /// via `source_base()` so it bypasses the FUSE over-mount in in-place
     /// mode.
+    ///
+    /// Uses the shared no-follow regular-file `SKILL.md` predicate so path
+    /// classification, store discovery, activation enumeration, and the
+    /// resolver all agree on what a Skill is (a symlinked or non-regular
+    /// `SKILL.md` is not a marker).
     pub(super) fn hermes_nested_is_skill(&self, category: &str, skill_name: &str) -> bool {
-        self.hermes_skill_physical_dir(category, skill_name)
-            .join("SKILL.md")
-            .exists()
+        skillfs_core::store::has_regular_skill_md(
+            &self.hermes_skill_physical_dir(category, skill_name),
+        )
     }
 
     /// Whether the direct category child `<category>/<name>` physically
@@ -436,7 +441,13 @@ impl SkillFs {
     /// (`category/skill/SKILL.md`); the lexical parser classifies every
     /// top-level entry as a category container, so callers reclassify a
     /// top-level skill back into the flat skill path types.
+    ///
+    /// Uses the shared no-follow regular-file `SKILL.md` predicate: a
+    /// directory whose only `SKILL.md` is a symlink or other non-regular
+    /// object is a category (its real nested Skills resolve), consistent
+    /// with store discovery and the resolver — never a phantom top-level
+    /// Skill that has no activation key and would fail closed to hidden.
     pub(super) fn hermes_is_top_level_skill(&self, name: &str) -> bool {
-        self.source_base().join(name).join("SKILL.md").exists()
+        skillfs_core::store::has_regular_skill_md(&self.source_base().join(name))
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -82,7 +82,7 @@ impl SkillFs {
             return true;
         }
         match self.skill_read_dir(skill_name) {
-            Some(dir) => dir.join("SKILL.md").exists(),
+            Some(dir) => skillfs_core::store::has_regular_skill_md(&dir),
             None => false,
         }
     }

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -28,7 +28,9 @@ pub enum SkillLayout {
     /// hidden), `--notify-socket` mutation events, and installer
     /// transactions (staging rename, pending install, quiet timeout,
     /// post-publish grace). Incompatible with `--decision-command`
-    /// and `--control-socket` (rejected at startup).
+    /// (rejected at startup). The read-only `skill.resolveLiveSource`
+    /// control socket query is supported: it derives full nested skill
+    /// ids from the canonical path.
     ///
     /// **Parser model:** purely lexical. Every non-management
     /// top-level entry is classified as `CategoryDir`; every second-

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -110,6 +110,7 @@ pub mod path;
 pub mod policy;
 pub mod protocol_events;
 pub mod refresh;
+pub mod resolver;
 pub mod runtime_metrics;
 pub mod session_stats;
 pub mod session_stats_writer;

--- a/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/activation.rs
@@ -622,15 +622,20 @@ pub fn enumerate_hermes_skill_leaves(source_root: &Path) -> Vec<String> {
         if is_hermes_management_path(&name) || name.starts_with('.') {
             continue;
         }
-        if !entry.path().is_dir() {
+        // No-follow type: a symlinked category is not a managed category
+        // (the resolver rejects symlinked components with O_NOFOLLOW), and
+        // descending into it would register skills that live outside the
+        // managed root. Skip it so enumeration matches the resolver.
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             continue;
         }
         // A first-level directory that carries its own SKILL.md is a
         // top-level skill, not a category. The mount serves it (and its
         // whole subtree) as a flat skill, so descending into it here would
         // register `skill/subdir` as a phantom nested skill and diverge
-        // from mount discovery.
-        if entry.path().join("SKILL.md").exists() {
+        // from mount discovery. Uses the shared no-follow regular-file
+        // marker so store, mount, and resolver agree on what a Skill is.
+        if skillfs_core::store::has_regular_skill_md(&entry.path()) {
             continue;
         }
         let cat_entries = match std::fs::read_dir(entry.path()) {
@@ -639,10 +644,11 @@ pub fn enumerate_hermes_skill_leaves(source_root: &Path) -> Vec<String> {
         };
         for child in cat_entries.flatten() {
             let child_name = child.file_name().to_string_lossy().to_string();
-            if !child.path().is_dir() {
+            // No-follow: a symlinked nested entry is never a managed skill.
+            if !child.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                 continue;
             }
-            if child.path().join("SKILL.md").exists() {
+            if skillfs_core::store::has_regular_skill_md(&child.path()) {
                 leaves.push(format!("{}/{}", name, child_name));
             }
         }
@@ -669,10 +675,11 @@ pub fn enumerate_hermes_top_level_skills(source_root: &Path) -> Vec<String> {
         if is_hermes_management_path(&name) || name.starts_with('.') {
             continue;
         }
-        if !entry.path().is_dir() {
+        // No-follow: a symlinked top-level entry is not a managed skill.
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             continue;
         }
-        if entry.path().join("SKILL.md").exists() {
+        if skillfs_core::store::has_regular_skill_md(&entry.path()) {
             skills.push(name);
         }
     }
@@ -1087,6 +1094,63 @@ mod tests {
             vec!["apple/apple-music", "apple/apple-notes"],
             "must enumerate only dirs with SKILL.md, got: {:?}",
             leaves
+        );
+    }
+
+    #[test]
+    fn enumerate_hermes_rejects_symlink_category_and_nested_and_top_level() {
+        // Symlinked categories, symlinked nested skills, and symlinked
+        // top-level skills all live outside the managed root once resolved,
+        // and the resolver rejects symlinked components with O_NOFOLLOW.
+        // Enumeration must skip them so it never registers an activatable id
+        // the resolver would refuse to resolve.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let outside = tempfile::tempdir().unwrap();
+
+        // Real category + nested skill (must be enumerated).
+        let real_nested = root.join("cat/realnested");
+        std::fs::create_dir_all(&real_nested).unwrap();
+        std::fs::write(real_nested.join("SKILL.md"), "---\nname: rn\n---\n").unwrap();
+
+        // Symlinked nested skill under the real category (must be skipped).
+        let out_skill = outside.path().join("out-skill");
+        std::fs::create_dir(&out_skill).unwrap();
+        std::fs::write(out_skill.join("SKILL.md"), "---\nname: os\n---\n").unwrap();
+        std::os::unix::fs::symlink(&out_skill, root.join("cat/linknested")).unwrap();
+
+        // Symlinked category (must not be descended).
+        let out_cat = outside.path().join("out-cat");
+        let out_cat_child = out_cat.join("child");
+        std::fs::create_dir_all(&out_cat_child).unwrap();
+        std::fs::write(out_cat_child.join("SKILL.md"), "---\nname: oc\n---\n").unwrap();
+        std::os::unix::fs::symlink(&out_cat, root.join("linkcat")).unwrap();
+
+        // Symlinked top-level skill (must be skipped).
+        let out_top = outside.path().join("out-top");
+        std::fs::create_dir(&out_top).unwrap();
+        std::fs::write(out_top.join("SKILL.md"), "---\nname: ot\n---\n").unwrap();
+        std::os::unix::fs::symlink(&out_top, root.join("linktop")).unwrap();
+
+        let mut leaves = enumerate_hermes_skill_leaves(root);
+        leaves.sort();
+        assert_eq!(
+            leaves,
+            vec!["cat/realnested"],
+            "only the real nested skill may be enumerated, got: {leaves:?}"
+        );
+
+        let top = enumerate_hermes_top_level_skills(root);
+        assert!(
+            !top.iter().any(|s| s == "linktop"),
+            "a symlinked top-level skill must not be enumerated, got: {top:?}"
+        );
+
+        let ids = enumerate_hermes_skill_ids(root);
+        assert!(
+            !ids.iter()
+                .any(|i| i == "linktop" || i == "linkcat/child" || i == "cat/linknested"),
+            "no symlinked category/nested/top-level id may appear, got: {ids:?}"
         );
     }
 

--- a/src/skillfs/crates/skillfs-fuse/src/security/backing_root.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/backing_root.rs
@@ -14,9 +14,11 @@
 //! propagated into the backing root.  Without this isolation the daemon
 //! would see the FUSE hidden view instead of the real source tree.
 //!
-//! All daemon-facing operations — notify `skillDir`, activation bootstrap,
-//! activation reload, startup reconcile, and activation watching — use the
-//! backing root path. The agent-visible FUSE path is unchanged.
+//! Daemon live-source operations — activation bootstrap, reload, watching,
+//! and N3 protocol event `skillDir` — use the backing root path. Socket notify
+//! v2 keeps the canonical source identity, which the daemon resolves to this
+//! live path through the control socket. The agent-visible FUSE view is
+//! unchanged.
 //!
 //! Fail-closed: if the backing root exists but ownership, permissions, path
 //! shape, or mount setup is unsafe, startup is rejected.
@@ -428,9 +430,11 @@ impl LedgerBackingRoot {
         }
     }
 
-    /// The daemon-facing root path. All daemon-facing operations
-    /// (notify `skillDir`, activation bootstrap, activation reload, etc.)
-    /// join skill names onto this path.
+    /// The daemon-facing live root path.
+    ///
+    /// Activation bootstrap, reload, watching, and N3 protocol event
+    /// `skillDir` join skill names onto this path. Socket notify v2 uses the
+    /// separate canonical source root.
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/src/skillfs/crates/skillfs-fuse/src/security/config.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/config.rs
@@ -157,9 +157,9 @@ pub struct ActivationEventsSection {
 #[serde(deny_unknown_fields)]
 pub struct LedgerSection {
     /// Private source-side work path for external daemons.
-    /// When set, all daemon-facing operations (notify skillDir,
-    /// activation bootstrap, activation reload, startup reconcile,
-    /// activation watcher) use this path instead of the source.
+    /// When set, activation bootstrap, reload, watching, and N3 protocol
+    /// event `skillDir` use this path instead of the source. Socket notify v2
+    /// retains the canonical source root for `canonicalSkillDir`.
     pub backing_root: Option<String>,
 }
 

--- a/src/skillfs/crates/skillfs-fuse/src/security/config.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/config.rs
@@ -434,32 +434,13 @@ impl SecurityConfig {
         }
         self.parse_os_adapter_config()
             .map_err(ConfigError::OsAdapter)?;
-        if let Some(ref cs) = self.control_socket {
-            let has_path = cs
-                .path
-                .as_deref()
-                .map(|s| !s.trim().is_empty())
-                .unwrap_or(false);
-            let has_exe = cs
-                .trusted_peer_exe
-                .as_deref()
-                .map(|s| !s.trim().is_empty())
-                .unwrap_or(false);
-            if has_path && !has_exe {
-                return Err(ConfigError::InvalidValue {
-                    field: "control_socket.trusted_peer_exe",
-                    value: String::new(),
-                    allowed: "non-empty path when control_socket.path is set",
-                });
-            }
-            if !has_path && has_exe {
-                return Err(ConfigError::InvalidValue {
-                    field: "control_socket.path",
-                    value: String::new(),
-                    allowed: "non-empty path when control_socket.trusted_peer_exe is set",
-                });
-            }
-        }
+        // Cross-field control-socket integrity ("a socket path requires a
+        // trusted peer") is intentionally NOT validated here. Config values
+        // are merged with the CLI later (CLI overrides config, and either
+        // field may come from either source), so validating a single field
+        // in isolation at load time would reject valid combinations such as
+        // a config-file socket path completed by a CLI `--trusted-peer-exe`.
+        // The mutual-requirement gate runs once, after the merge, in the CLI.
         Ok(())
     }
 
@@ -1564,9 +1545,14 @@ path = "  "
     }
 
     #[test]
-    fn control_socket_path_without_exe_rejected() {
+    fn control_socket_path_without_exe_accepted_at_load() {
+        // Config load must NOT reject a socket path that lacks a trusted
+        // peer: the peer can still arrive from the CLI (`--trusted-peer-exe`)
+        // during the later merge. The "socket requires a peer" rule is
+        // enforced once, after merge, in the CLI — validating a single field
+        // in isolation here would break `config socket + CLI peer`.
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("bad.toml");
+        let path = dir.path().join("path-only.toml");
         std::fs::write(
             &path,
             r#"
@@ -1575,23 +1561,17 @@ path = "/run/skillfs/skillfs.sock"
 "#,
         )
         .unwrap();
-        let result = SecurityConfig::load(&path);
-        assert!(
-            matches!(
-                result,
-                Err(ConfigError::InvalidValue {
-                    field: "control_socket.trusted_peer_exe",
-                    ..
-                })
-            ),
-            "path without trusted_peer_exe must fail: {result:?}"
-        );
+        let cfg = SecurityConfig::load(&path).expect("path-only control_socket must load");
+        assert_eq!(cfg.control_socket_path(), Some("/run/skillfs/skillfs.sock"));
+        assert!(cfg.control_socket_trusted_peer_exe().is_none());
     }
 
     #[test]
-    fn control_socket_exe_without_path_rejected() {
+    fn control_socket_exe_without_path_uses_default_endpoint() {
+        // A trusted peer with no explicit path is valid: SkillFS binds the
+        // default per-user endpoint. Config loading must accept it.
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("bad.toml");
+        let path = dir.path().join("ok.toml");
         std::fs::write(
             &path,
             r#"
@@ -1600,16 +1580,11 @@ trusted_peer_exe = "/usr/local/bin/agent-sec-cli"
 "#,
         )
         .unwrap();
-        let result = SecurityConfig::load(&path);
-        assert!(
-            matches!(
-                result,
-                Err(ConfigError::InvalidValue {
-                    field: "control_socket.path",
-                    ..
-                })
-            ),
-            "trusted_peer_exe without path must fail: {result:?}"
+        let cfg = SecurityConfig::load(&path).expect("trusted_peer_exe without path is valid");
+        assert!(cfg.control_socket_path().is_none());
+        assert_eq!(
+            cfg.control_socket_trusted_peer_exe(),
+            Some("/usr/local/bin/agent-sec-cli")
         );
     }
 

--- a/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
@@ -103,8 +103,9 @@ pub struct TrustedPeerConfig {
 ///
 /// This context keeps the two skill roots explicit:
 ///
-/// * `canonical_root` — the user-visible Skill root the external ledger
-///   addresses. Incoming `canonicalSkillDir` paths are checked for
+/// * `canonical_root` — the absolute, lexically normalized user-visible
+///   Skill identity the external ledger addresses. It does not follow a
+///   source-root symlink. Incoming `canonicalSkillDir` paths are checked for
 ///   lexical containment against this root, and the relative skill id is
 ///   derived from it.
 /// * `source_root` — the live / backing root whose physical content stays
@@ -4050,6 +4051,31 @@ mod tests {
             let resp: ControlResponse = serde_json::from_str(&resp_str).unwrap();
             assert!(!resp.ok);
             assert_eq!(resp.error.unwrap().code, "invalid_canonical_path");
+
+            handle.shutdown();
+        }
+
+        #[test]
+        fn server_resolve_live_source_non_normalized_path_error() {
+            let dir = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
+
+            for canonical_skill_dir in [
+                format!("{}//my-skill", source.path().display()),
+                format!("//{}/my-skill", source.path().display()),
+                format!("{}/my-skill/", source.path().display()),
+            ] {
+                let req = serde_json::json!({
+                    "schemaVersion": "1",
+                    "method": "skill.resolveLiveSource",
+                    "canonicalSkillDir": canonical_skill_dir,
+                });
+                let resp_str = connect_and_send(&socket_path, &req.to_string());
+                let resp: ControlResponse = serde_json::from_str(&resp_str).unwrap();
+                assert!(!resp.ok);
+                assert_eq!(resp.error.unwrap().code, "invalid_canonical_path");
+            }
 
             handle.shutdown();
         }

--- a/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
@@ -17,6 +17,7 @@
 //! {"schemaVersion":"1","method":"status"}
 //! {"schemaVersion":"1","method":"meta.writeActivation","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
 //! {"schemaVersion":"1","method":"meta.setActivationXattr","skillName":"demo-weather","activation":{"schemaVersion":1,"target":null}}
+//! {"schemaVersion":"1","method":"skill.resolveLiveSource","canonicalSkillDir":"/canonical/skills/apple/apple-notes"}
 //! ```
 //!
 //! Response:
@@ -24,8 +25,18 @@
 //! {"schemaVersion":"1","ok":true,"result":{"pong":true}}
 //! {"schemaVersion":"1","ok":true,"result":{"status":"ready"}}
 //! {"schemaVersion":"1","ok":true,"result":{"outcome":"updated"}}
+//! {"schemaVersion":"1","ok":true,"result":{"managed":true,"canonicalSkillDir":"...","skillId":"apple/apple-notes","relativeSkillDir":"apple/apple-notes","liveSkillDir":"...","identity":{"device":42,"inode":1001},"transport":"shared_path"}}
+//! {"schemaVersion":"1","ok":true,"result":{"managed":false,"canonicalSkillDir":"...","reason":"not_managed"}}
 //! {"schemaVersion":"1","ok":false,"error":{"code":"permission_denied","message":"..."}}
 //! ```
+//!
+//! ## `skill.resolveLiveSource`
+//!
+//! A read-only query that maps a caller-supplied canonical Skill directory
+//! to its physical live/backing source. It is O(path depth): it opens the
+//! live Skill directory one path component at a time and never scans the
+//! whole Skill root. It has no side effects — no scan, manifest, policy
+//! decision, or activation write. See `dispatch_resolve_live_source`.
 //!
 //! ## Security
 //!
@@ -44,6 +55,8 @@ use std::os::unix::fs::FileTypeExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use crate::path::SkillLayout;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tracing::{debug, info, warn};
@@ -80,15 +93,40 @@ pub struct TrustedPeerConfig {
 }
 
 /// Runtime context for methods that need filesystem access
-/// (e.g. `meta.writeActivation`, `meta.setActivationXattr`).
+/// (e.g. `meta.writeActivation`, `meta.setActivationXattr`,
+/// `skill.resolveLiveSource`).
 ///
 /// Passed through `ControlSocketServer::new()` and threaded into
-/// `handle_connection()` so write methods can access the source root,
+/// `handle_connection()` so methods can access the canonical/live roots,
 /// active resolver, and protocol event writer. Read-only methods
 /// (`ping`, `status`) ignore the context.
+///
+/// This context keeps the two skill roots explicit:
+///
+/// * `canonical_root` — the user-visible Skill root the external ledger
+///   addresses. Incoming `canonicalSkillDir` paths are checked for
+///   lexical containment against this root, and the relative skill id is
+///   derived from it.
+/// * `source_root` — the live / backing root whose physical content stays
+///   accessible after the FUSE over-mount. Write methods `openat` against
+///   it, and `skill.resolveLiveSource` opens the live Skill directory
+///   under it to report the physical backing path and its identity.
+///
+/// In the common single-source in-place mount the two roots resolve to
+/// the same tree (or a bind-mount alias of it), but they are stored
+/// separately so a query never crosses the canonical / FUSE / live
+/// boundary implicitly.
 #[derive(Clone)]
 pub struct ControlSocketContext {
+    /// User-visible canonical Skill root used for containment checks and
+    /// relative skill-id derivation.
+    pub canonical_root: PathBuf,
+    /// Live / backing root whose physical content is opened for reads and
+    /// activation writes.
     pub source_root: PathBuf,
+    /// Skill layout of the mount. `skill.resolveLiveSource` uses it to
+    /// enforce the same Flat / Hermes Skill boundaries as the FUSE layer.
+    pub layout: SkillLayout,
     pub resolver: Option<Arc<ActiveSkillResolver>>,
     pub protocol_event_writer: Option<Arc<dyn ProtocolEventWriter>>,
 }
@@ -96,7 +134,9 @@ pub struct ControlSocketContext {
 impl std::fmt::Debug for ControlSocketContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ControlSocketContext")
+            .field("canonical_root", &self.canonical_root)
             .field("source_root", &self.source_root)
+            .field("layout", &self.layout)
             .field("resolver", &self.resolver.is_some())
             .field(
                 "protocol_event_writer",
@@ -447,6 +487,7 @@ pub fn dispatch_request(
         "status" => ControlResponse::ok(serde_json::json!({ "status": "ready" })),
         "meta.writeActivation" => dispatch_meta_write_activation(raw, ctx),
         "meta.setActivationXattr" => dispatch_meta_set_activation_xattr(raw, ctx),
+        "skill.resolveLiveSource" => dispatch_resolve_live_source(raw, ctx),
         other => ControlResponse::err("unknown_method", format!("unknown method '{other}'")),
     }
 }
@@ -896,14 +937,83 @@ fn set_activation_xattr_fd(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// skill.resolveLiveSource (read-only)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Dispatch `skill.resolveLiveSource`.
+///
+/// A read-only query mapping a caller-supplied canonical Skill directory to
+/// its physical live/backing source. The path/layout resolution and
+/// response construction live in [`super::resolver`]; this dispatcher only
+/// validates the request envelope, forwards the canonical/live roots and
+/// layout from the context, and maps the resolver outcome onto a control
+/// response. Three distinct outcomes:
+///
+/// * `managed = true` — the path resolves to a valid live Skill directory
+///   under the managed canonical root.
+/// * `managed = false` — a valid absolute path outside the managed root; a
+///   normal success the caller may fall back on.
+/// * structured error — never disguised as `managed = false`.
+fn dispatch_resolve_live_source(
+    raw: &serde_json::Value,
+    ctx: Option<&ControlSocketContext>,
+) -> ControlResponse {
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            return ControlResponse::err(
+                "not_configured",
+                "skill.resolveLiveSource requires a configured canonical and live root",
+            );
+        }
+    };
+
+    let canonical_skill_dir = match raw.get("canonicalSkillDir").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            return ControlResponse::err(
+                "invalid_request",
+                "missing or non-string 'canonicalSkillDir' field",
+            );
+        }
+    };
+
+    match super::resolver::resolve_live_source(
+        &ctx.canonical_root,
+        &ctx.source_root,
+        ctx.layout,
+        canonical_skill_dir,
+    ) {
+        Ok(result) => ControlResponse::ok(result),
+        Err(e) => ControlResponse::err(e.code, e.message),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Socket path preflight
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[derive(Debug)]
 pub enum SocketPreflightError {
     ParentDoesNotExist(PathBuf),
+    /// The existing path is a symlink, regular file, directory, or other
+    /// non-socket object. It is never deleted.
     ExistingPathNotSocket(PathBuf),
+    /// The existing socket is owned by a different uid. It is never
+    /// deleted.
+    ExistingSocketWrongOwner {
+        path: PathBuf,
+        uid: u32,
+    },
+    /// A live listener is accepting connections on the existing socket.
+    /// A second instance must not unlink an active endpoint.
+    ActiveListener(PathBuf),
+    /// The liveness probe could not prove the socket is stale (e.g.
+    /// `EACCES`, `EINTR`, resource exhaustion). Only a definitive
+    /// `ECONNREFUSED` is treated as stale; everything else fails closed.
+    ProbeInconclusive(PathBuf, std::io::Error),
     UnlinkFailed(PathBuf, std::io::Error),
+    Stat(PathBuf, std::io::Error),
 }
 
 impl std::fmt::Display for SocketPreflightError {
@@ -917,16 +1027,52 @@ impl std::fmt::Display for SocketPreflightError {
                 "path '{}' exists but is not a socket; refusing to overwrite",
                 p.display()
             ),
+            Self::ExistingSocketWrongOwner { path, uid } => write!(
+                f,
+                "socket '{}' is owned by uid {uid}; refusing to unlink a socket \
+                 we do not own",
+                path.display()
+            ),
+            Self::ActiveListener(p) => write!(
+                f,
+                "socket '{}' has an active listener; another instance owns this \
+                 endpoint",
+                p.display()
+            ),
+            Self::ProbeInconclusive(p, e) => write!(
+                f,
+                "cannot determine liveness of socket '{}' ({e}); refusing to \
+                 unlink",
+                p.display()
+            ),
             Self::UnlinkFailed(p, e) => {
-                write!(f, "failed to unlink existing socket '{}': {e}", p.display())
+                write!(f, "failed to unlink stale socket '{}': {e}", p.display())
             }
+            Self::Stat(p, e) => write!(f, "failed to stat '{}': {e}", p.display()),
         }
     }
 }
 
 impl std::error::Error for SocketPreflightError {}
 
+/// Preflight the socket path, safely reclaiming only a confirmed-stale
+/// socket that we own.
+///
+/// Called while the lifecycle lock is held, so no other lock-aware
+/// instance can be serving this endpoint. The checks are still defensive:
+///
+/// * A missing path is fine — the caller will bind.
+/// * A non-socket object (symlink, regular file, directory) is never
+///   deleted; startup fails closed.
+/// * A socket owned by a different uid is never deleted.
+/// * A socket is reclaimed only when a non-blocking connect probe returns
+///   a definitive `ECONNREFUSED` (no listener). A successful connect means
+///   a live listener (a non-lock-aware instance may still be serving it),
+///   and any other probe error (`EACCES`, `EINTR`, resource exhaustion, …)
+///   is inconclusive — both fail closed rather than unlink.
 pub fn preflight_socket_path(path: &Path) -> Result<(), SocketPreflightError> {
+    use std::os::unix::fs::MetadataExt;
+
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
             return Err(SocketPreflightError::ParentDoesNotExist(
@@ -935,32 +1081,237 @@ pub fn preflight_socket_path(path: &Path) -> Result<(), SocketPreflightError> {
         }
     }
 
-    if path.exists() {
-        let meta = std::fs::symlink_metadata(path)
-            .map_err(|e| SocketPreflightError::UnlinkFailed(path.to_path_buf(), e))?;
-        let file_type = meta.file_type();
-        if !file_type.is_socket() {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(SocketPreflightError::Stat(path.to_path_buf(), e)),
+    };
+
+    // `symlink_metadata` does not follow links, so a symlink reports its
+    // own type here. Classify the object; only an owned socket is a
+    // reclamation candidate.
+    let our_uid = unsafe { libc::geteuid() };
+    match classify_socket_object(meta.file_type().is_socket(), meta.uid(), our_uid) {
+        SocketObjectClass::NotSocket => {
             return Err(SocketPreflightError::ExistingPathNotSocket(
                 path.to_path_buf(),
             ));
         }
-        std::fs::remove_file(path)
-            .map_err(|e| SocketPreflightError::UnlinkFailed(path.to_path_buf(), e))?;
+        SocketObjectClass::WrongOwner(uid) => {
+            return Err(SocketPreflightError::ExistingSocketWrongOwner {
+                path: path.to_path_buf(),
+                uid,
+            });
+        }
+        SocketObjectClass::OwnedSocket => {}
     }
 
-    Ok(())
+    // Probe liveness while holding the lifecycle lock. Only a definitive
+    // ECONNREFUSED proves the socket is stale and safe to reclaim; a live
+    // listener or any inconclusive error fails closed. The probe retries a
+    // bounded number of times so a socket whose previous owner's listener is
+    // still finishing teardown (transiently EAGAIN/EINPROGRESS) settles to
+    // ECONNREFUSED rather than being misread as a live listener — which
+    // otherwise makes a fast restart fail to reclaim its own endpoint.
+    match probe_socket_liveness(path) {
+        SocketLiveness::Stale => {
+            std::fs::remove_file(path)
+                .map_err(|e| SocketPreflightError::UnlinkFailed(path.to_path_buf(), e))?;
+            Ok(())
+        }
+        SocketLiveness::Live => Err(SocketPreflightError::ActiveListener(path.to_path_buf())),
+        SocketLiveness::Inconclusive(e) => Err(SocketPreflightError::ProbeInconclusive(
+            path.to_path_buf(),
+            e,
+        )),
+    }
 }
 
-/// Ensure the socket parent directory exists with permissions `0o700`.
+/// Result of probing whether a socket path has a live listener.
+enum SocketLiveness {
+    /// A listener accepted, or was persistently unconnectable-but-present
+    /// (backlog full) across every retry — the endpoint is live and must
+    /// never be reclaimed.
+    Live,
+    /// The kernel returned `ECONNREFUSED` — no listener, the socket file is
+    /// stale and safe to reclaim.
+    Stale,
+    /// The probe never reached a definitive result; liveness is unknown.
+    Inconclusive(std::io::Error),
+}
+
+/// Outcome of a single non-blocking `connect(2)` attempt.
+enum ProbeOnce {
+    /// `connect` returned 0: a listener accepted — definitively live.
+    Connected,
+    /// `ECONNREFUSED`: no listener — definitively stale.
+    Refused,
+    /// A non-definitive result (`EAGAIN`/`EINPROGRESS` — backlog full or
+    /// pending — or a resource/other error). Ambiguous on a single attempt;
+    /// the caller retries before drawing a conclusion.
+    Ambiguous(std::io::Error),
+}
+
+/// Non-blocking `connect(2)` probe against an `AF_UNIX` socket path. Bounded
+/// (never blocks) and precise: only a definitive `ECONNREFUSED` is treated
+/// as stale.
+///
+/// A single connect is ambiguous while a previous owner's listener is
+/// mid-teardown: for a short window after the listener fd is closed, a stale
+/// socket transiently reports `EAGAIN`/`EINPROGRESS` before the kernel
+/// settles the endpoint to `ECONNREFUSED`. Classifying that transient state
+/// as a live listener would refuse to reclaim a genuinely stale socket and
+/// make a fast restart fail. The lifecycle flock guarantees mutual exclusion
+/// but not that teardown has completed, so the probe retries on any
+/// non-definitive result:
+///
+/// * a genuinely live listener connects (or is persistently backlog-full)
+///   across every retry, so it is reported `Live` and never unlinked;
+/// * a stale socket settles to `ECONNREFUSED` within the retry window and is
+///   reported `Stale`.
+///
+/// The common cases (immediate connect or immediate refusal) return on the
+/// first attempt with no delay; the retry budget is capped so the probe
+/// always terminates quickly.
+fn probe_socket_liveness(path: &Path) -> SocketLiveness {
+    const MAX_ATTEMPTS: u32 = 40;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
+
+    resolve_socket_liveness(
+        MAX_ATTEMPTS,
+        || probe_socket_liveness_once(path),
+        || std::thread::sleep(RETRY_DELAY),
+    )
+}
+
+/// Retry state machine over single-probe outcomes, factored out of the
+/// `connect(2)` syscall so it can be covered deterministically with injected
+/// outcomes (the real socket teardown almost always yields `ECONNREFUSED`
+/// immediately, so a live-socket test cannot reliably reach the retry path).
+///
+/// Returns `Stale` on the first `Refused` and `Live` on the first
+/// `Connected`; otherwise retries up to `max_attempts` on `Ambiguous`,
+/// invoking `wait` between attempts (a real sleep in production, a no-op in
+/// tests). If no definitive result ever appears, a persistent
+/// backlog-full/pending signal (`EAGAIN`/`EINPROGRESS`) is reported `Live`
+/// (never unlinked) and any other persistent error is `Inconclusive` (fail
+/// closed).
+fn resolve_socket_liveness(
+    max_attempts: u32,
+    mut probe: impl FnMut() -> ProbeOnce,
+    mut wait: impl FnMut(),
+) -> SocketLiveness {
+    let mut last_err: Option<std::io::Error> = None;
+    for attempt in 0..max_attempts {
+        match probe() {
+            ProbeOnce::Connected => return SocketLiveness::Live,
+            ProbeOnce::Refused => return SocketLiveness::Stale,
+            ProbeOnce::Ambiguous(e) => last_err = Some(e),
+        }
+        if attempt + 1 < max_attempts {
+            wait();
+        }
+    }
+
+    // Never observed a definitive result. A persistently backlog-full live
+    // listener lands here (EAGAIN/EINPROGRESS every attempt): keep it Live so
+    // it is never unlinked. Any other persistent error is inconclusive and
+    // fails closed.
+    match last_err {
+        Some(e) => match e.raw_os_error() {
+            Some(libc::EAGAIN) | Some(libc::EINPROGRESS) => SocketLiveness::Live,
+            _ => SocketLiveness::Inconclusive(e),
+        },
+        None => SocketLiveness::Inconclusive(std::io::Error::other("probe produced no result")),
+    }
+}
+
+/// One non-blocking `connect(2)` attempt; see [`probe_socket_liveness`].
+fn probe_socket_liveness_once(path: &Path) -> ProbeOnce {
+    use std::os::unix::ffi::OsStrExt;
+
+    let bytes = path.as_os_str().as_bytes();
+    // sun_path must be NUL-terminated and fit the sockaddr_un buffer.
+    let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    if bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
+        return ProbeOnce::Ambiguous(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "socket path too long for sockaddr_un",
+        ));
+    }
+    addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    for (i, b) in bytes.iter().enumerate() {
+        addr.sun_path[i] = *b as libc::c_char;
+    }
+
+    let fd = unsafe {
+        libc::socket(
+            libc::AF_UNIX,
+            libc::SOCK_STREAM | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC,
+            0,
+        )
+    };
+    if fd < 0 {
+        return ProbeOnce::Ambiguous(std::io::Error::last_os_error());
+    }
+    let _guard = FdGuard(fd);
+
+    let rc = unsafe {
+        libc::connect(
+            fd,
+            &addr as *const libc::sockaddr_un as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t,
+        )
+    };
+    if rc == 0 {
+        return ProbeOnce::Connected;
+    }
+    let err = std::io::Error::last_os_error();
+    match err.raw_os_error() {
+        // No listener bound to the path: stale.
+        Some(libc::ECONNREFUSED) => ProbeOnce::Refused,
+        // Backlog full / connection pending / resource or other error:
+        // ambiguous on a single attempt — let the caller retry.
+        _ => ProbeOnce::Ambiguous(err),
+    }
+}
+
+/// Classification of an existing object at the socket path, excluding the
+/// live-listener probe (which needs a connect attempt).
+#[derive(Debug, PartialEq, Eq)]
+enum SocketObjectClass {
+    /// Not a socket (symlink, regular file, directory, …): never delete.
+    NotSocket,
+    /// A socket owned by another uid: never delete.
+    WrongOwner(u32),
+    /// A socket owned by the current uid: a stale-reclamation candidate.
+    OwnedSocket,
+}
+
+/// Pure classification used by [`preflight_socket_path`]. Kept separate so
+/// the wrong-owner and non-socket branches are unit-testable without a
+/// second uid.
+fn classify_socket_object(is_socket: bool, owner_uid: u32, our_uid: u32) -> SocketObjectClass {
+    if !is_socket {
+        SocketObjectClass::NotSocket
+    } else if owner_uid != our_uid {
+        SocketObjectClass::WrongOwner(owner_uid)
+    } else {
+        SocketObjectClass::OwnedSocket
+    }
+}
+
+/// Ensure the socket parent directory exists, is a directory (not a
+/// symlink), is owned by the current uid, and has permissions `0o700`.
 ///
 /// - If the parent does not exist, creates it (and ancestors) and sets
 ///   permissions to `0o700`.
-/// - If the parent exists, verifies it is a directory (not a symlink)
-///   and sets permissions to `0o700`.
-/// - Fails closed if the parent is not a directory or permissions
-///   cannot be set.
+/// - If the parent exists, verifies it is a directory, owned by the
+///   current euid, and tightens permissions to `0o700`.
+/// - Fails closed if the parent is not a directory, is owned by another
+///   uid, or permissions cannot be set.
 pub fn secure_socket_parent(socket_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     let parent = match socket_path.parent() {
         Some(p) if !p.as_os_str().is_empty() => p,
@@ -983,10 +1334,199 @@ pub fn secure_socket_parent(socket_path: &Path) -> Result<(), Box<dyn std::error
         .into());
     }
 
+    let our_uid = unsafe { libc::geteuid() };
+    if meta.uid() != our_uid {
+        return Err(format!(
+            "socket parent '{}' is owned by uid {}; expected the current uid {our_uid}",
+            parent.display(),
+            meta.uid()
+        )
+        .into());
+    }
+
     let perms = std::fs::Permissions::from_mode(0o700);
     std::fs::set_permissions(parent, perms)?;
 
     Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Default endpoint
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Error resolving the default control socket endpoint.
+#[derive(Debug)]
+pub enum DefaultEndpointError {
+    /// The per-user runtime directory `/run/user/<uid>` does not exist.
+    RuntimeDirMissing(PathBuf),
+    /// `/run/user/<uid>` exists but is not a directory.
+    RuntimeDirNotDir(PathBuf),
+}
+
+impl std::fmt::Display for DefaultEndpointError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RuntimeDirMissing(p) => write!(
+                f,
+                "default control socket endpoint unavailable: '{}' does not exist; \
+                 pass --control-socket <PATH> explicitly (the default never falls \
+                 back to /tmp or /var/tmp)",
+                p.display()
+            ),
+            Self::RuntimeDirNotDir(p) => write!(
+                f,
+                "default control socket endpoint unavailable: '{}' is not a directory; \
+                 pass --control-socket <PATH> explicitly",
+                p.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DefaultEndpointError {}
+
+/// The default control socket endpoint path for `uid`:
+/// `/run/user/<uid>/skillfs/control.sock`.
+///
+/// Pure: does not touch the filesystem. Deliberately anchored on the
+/// per-user runtime directory and never on `/tmp` or `/var/tmp`.
+pub fn default_control_socket_path(uid: u32) -> PathBuf {
+    PathBuf::from(format!("/run/user/{uid}/skillfs/control.sock"))
+}
+
+/// Resolution of the effective control socket endpoint from the merged
+/// explicit path (CLI value already merged over the config value) and
+/// whether a trusted peer is configured.
+///
+/// Priority: an explicit path always wins; otherwise a trusted peer
+/// selects the default per-user endpoint; otherwise the control plane is
+/// disabled. An explicit path without a trusted peer is a configuration
+/// error — the control plane is always authenticated.
+#[derive(Debug, PartialEq, Eq)]
+pub enum EndpointResolution {
+    /// Neither an explicit path nor a trusted peer: control plane off.
+    Disabled,
+    /// Explicit path with a trusted peer: use the path verbatim.
+    Explicit(PathBuf),
+    /// Trusted peer with no explicit path: bind the default endpoint.
+    UseDefault,
+    /// Explicit path without a trusted peer: configuration error.
+    MissingTrustedPeer(PathBuf),
+}
+
+/// Classify the control socket endpoint from the merged explicit path and
+/// whether a trusted peer is configured. Pure: performs no filesystem
+/// access.
+pub fn classify_control_socket_endpoint(
+    explicit_path: Option<&Path>,
+    has_trusted_peer: bool,
+) -> EndpointResolution {
+    match (explicit_path, has_trusted_peer) {
+        (Some(p), true) => EndpointResolution::Explicit(p.to_path_buf()),
+        (Some(p), false) => EndpointResolution::MissingTrustedPeer(p.to_path_buf()),
+        (None, true) => EndpointResolution::UseDefault,
+        (None, false) => EndpointResolution::Disabled,
+    }
+}
+
+/// Resolve the default control socket endpoint for the current user,
+/// validating that the per-user runtime directory `/run/user/<uid>` exists
+/// and is a directory.
+///
+/// The `skillfs/` leaf under it is created (0700) at bind time by
+/// [`secure_socket_parent`]; this function refuses to invent a
+/// `/run/user/<uid>` that the system did not provide, and never falls back
+/// to a public temporary directory.
+pub fn resolve_default_control_socket_endpoint() -> Result<PathBuf, DefaultEndpointError> {
+    let uid = unsafe { libc::geteuid() };
+    let runtime_dir = PathBuf::from(format!("/run/user/{uid}"));
+    match std::fs::metadata(&runtime_dir) {
+        Ok(meta) if meta.is_dir() => Ok(default_control_socket_path(uid)),
+        Ok(_) => Err(DefaultEndpointError::RuntimeDirNotDir(runtime_dir)),
+        Err(_) => Err(DefaultEndpointError::RuntimeDirMissing(runtime_dir)),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lifecycle lock
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Path of the lifecycle lock file guarding a socket endpoint:
+/// the socket path with a `.lock` suffix appended.
+fn lifecycle_lock_path(socket_path: &Path) -> PathBuf {
+    let mut os = socket_path.as_os_str().to_owned();
+    os.push(".lock");
+    PathBuf::from(os)
+}
+
+/// A non-blocking advisory lock (`flock(LOCK_EX | LOCK_NB)`) guarding a
+/// single control socket endpoint for the lifetime of the server.
+///
+/// The kernel releases the lock automatically when the process exits, so a
+/// crashed instance never wedges the endpoint. The lock file itself is
+/// intentionally left in place on clean shutdown to avoid a delete/reopen
+/// race between a departing and an arriving instance.
+struct LifecycleLock {
+    // Held for RAII: dropping closes the fd and releases the flock.
+    _file: std::fs::File,
+}
+
+/// Acquire the lifecycle lock for `socket_path` without blocking.
+///
+/// Returns an error if another instance already holds the lock (the
+/// endpoint is live) or the lock file cannot be created.
+fn acquire_lifecycle_lock(socket_path: &Path) -> Result<LifecycleLock, Box<dyn std::error::Error>> {
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::io::AsRawFd;
+
+    let lock_path = lifecycle_lock_path(socket_path);
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(&lock_path)
+        .map_err(|e| {
+            format!(
+                "failed to open lifecycle lock '{}': {e}",
+                lock_path.display()
+            )
+        })?;
+
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        let e = std::io::Error::last_os_error();
+        if e.raw_os_error() == Some(libc::EWOULDBLOCK) {
+            return Err(format!(
+                "another skillfs instance already owns the control socket endpoint '{}'",
+                socket_path.display()
+            )
+            .into());
+        }
+        return Err(format!(
+            "failed to acquire lifecycle lock '{}': {e}",
+            lock_path.display()
+        )
+        .into());
+    }
+
+    Ok(LifecycleLock { _file: file })
+}
+
+/// Read the `(dev, ino)` identity of the object at `path` without
+/// following symlinks. Returns `None` if it does not exist or is not a
+/// socket.
+fn socket_identity(path: &Path) -> Option<FileId> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    if !meta.file_type().is_socket() {
+        return None;
+    }
+    Some(FileId {
+        dev: meta.dev(),
+        ino: meta.ino(),
+    })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1004,36 +1544,53 @@ pub struct ControlSocketHandle {
     socket_path: PathBuf,
     shutdown: Arc<AtomicBool>,
     thread: Option<std::thread::JoinHandle<()>>,
+    /// `(dev, ino)` of the socket this instance bound. On shutdown the
+    /// path is unlinked only if it still resolves to this identity, so a
+    /// path replaced by another object after bind is never deleted.
+    bound_identity: Option<FileId>,
+    /// Held for the server's lifetime; released on shutdown/drop.
+    _lifecycle_lock: LifecycleLock,
 }
 
 impl ControlSocketHandle {
     pub fn shutdown(mut self) {
-        self.shutdown.store(true, Ordering::SeqCst);
-
-        // Connect to the socket to unblock the accept() call.
-        let _ = UnixStream::connect(&self.socket_path);
-
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
-
-        // Clean up socket file.
-        let _ = std::fs::remove_file(&self.socket_path);
+        self.stop_and_cleanup();
     }
 
     pub fn socket_path(&self) -> &Path {
         &self.socket_path
     }
+
+    /// Stop the accept loop, join the thread, and remove the socket file
+    /// only if it still resolves to the identity this instance bound.
+    fn stop_and_cleanup(&mut self) {
+        // Signal the non-blocking accept loop to exit. It polls the flag,
+        // so shutdown is bounded and does not depend on connecting to the
+        // socket path (which may have been replaced).
+        self.shutdown.store(true, Ordering::SeqCst);
+
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+
+        // Only remove the socket if it is still the exact object we bound.
+        // If the path was replaced by another socket or object, leave it.
+        match (self.bound_identity, socket_identity(&self.socket_path)) {
+            (Some(bound), Some(current)) if bound == current => {
+                let _ = std::fs::remove_file(&self.socket_path);
+            }
+            _ => {}
+        }
+    }
 }
 
 impl Drop for ControlSocketHandle {
     fn drop(&mut self) {
-        self.shutdown.store(true, Ordering::SeqCst);
-        let _ = UnixStream::connect(&self.socket_path);
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
+        // `shutdown()` consumes self and would have taken the thread; if
+        // the handle is dropped without an explicit shutdown, clean up.
+        if self.thread.is_some() {
+            self.stop_and_cleanup();
         }
-        let _ = std::fs::remove_file(&self.socket_path);
     }
 }
 
@@ -1056,10 +1613,18 @@ impl ControlSocketServer {
     pub fn start(self) -> Result<ControlSocketHandle, Box<dyn std::error::Error>> {
         // Secure socket parent directory to 0o700 before bind to
         // eliminate the bind-to-chmod permission window. Runs before
-        // preflight so that create_dir_all satisfies the parent
-        // existence check.
+        // the lifecycle lock so that create_dir_all provides the parent
+        // the lock file lives in.
         secure_socket_parent(&self.config.socket_path)?;
 
+        // Acquire the non-blocking lifecycle lock before touching the
+        // socket path. A second instance targeting the same endpoint
+        // fails here instead of unlinking a live socket.
+        let lifecycle_lock = acquire_lifecycle_lock(&self.config.socket_path)?;
+
+        // Reclaim only a confirmed-stale, owned socket (checked while the
+        // lock is held). Fails closed on non-sockets, wrong owner, or a
+        // live listener.
         preflight_socket_path(&self.config.socket_path)?;
 
         let listener = UnixListener::bind(&self.config.socket_path)?;
@@ -1071,6 +1636,10 @@ impl ControlSocketServer {
             let perms = std::fs::Permissions::from_mode(0o600);
             std::fs::set_permissions(&self.config.socket_path, perms)?;
         }
+
+        // Record the bound socket identity so shutdown only removes the
+        // exact object we created, never a replacement at the same path.
+        let bound_identity = socket_identity(&self.config.socket_path);
 
         let shutdown = self.shutdown.clone();
         let config = self.config.clone();
@@ -1095,9 +1664,15 @@ impl ControlSocketServer {
             socket_path,
             shutdown,
             thread: Some(thread),
+            bound_identity,
+            _lifecycle_lock: lifecycle_lock,
         })
     }
 }
+
+/// Poll interval for the non-blocking accept loop. Bounds shutdown
+/// latency without a per-request thread or a self-pipe.
+const ACCEPT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
 fn run_server_loop(
     listener: &UnixListener,
@@ -1105,31 +1680,34 @@ fn run_server_loop(
     ctx: Option<&ControlSocketContext>,
     shutdown: &AtomicBool,
 ) {
+    // Non-blocking accept + shutdown-flag poll. This makes shutdown
+    // reliable and bounded even if the socket path is later replaced by
+    // another object (connecting to the path to unblock a blocking
+    // accept would not work in that case). Connections are still handled
+    // one at a time on this single thread — no thread-per-request.
     listener
-        .set_nonblocking(false)
-        .unwrap_or_else(|e| warn!("failed to set listener blocking: {e}"));
+        .set_nonblocking(true)
+        .unwrap_or_else(|e| warn!("failed to set listener non-blocking: {e}"));
 
-    for stream_result in listener.incoming() {
-        if shutdown.load(Ordering::SeqCst) {
-            break;
-        }
-
-        let stream = match stream_result {
-            Ok(s) => s,
+    while !shutdown.load(Ordering::SeqCst) {
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                if shutdown.load(Ordering::SeqCst) {
+                    break;
+                }
+                handle_connection(stream, config, ctx);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(ACCEPT_POLL_INTERVAL);
+            }
             Err(e) => {
                 if shutdown.load(Ordering::SeqCst) {
                     break;
                 }
                 warn!("control socket accept error: {e}");
-                continue;
+                std::thread::sleep(ACCEPT_POLL_INTERVAL);
             }
-        };
-
-        if shutdown.load(Ordering::SeqCst) {
-            break;
         }
-
-        handle_connection(stream, config, ctx);
     }
 
     debug!("control socket server loop exited");
@@ -1147,6 +1725,9 @@ fn handle_connection(
     config: &ControlSocketConfig,
     ctx: Option<&ControlSocketContext>,
 ) {
+    // The listener is non-blocking; ensure the accepted stream is blocking
+    // so the read timeout governs the per-connection hold time.
+    let _ = stream.set_nonblocking(false);
     let _ = stream.set_read_timeout(Some(CONNECTION_READ_TIMEOUT));
 
     let peer_identity = match identify_peer(&stream) {
@@ -1240,6 +1821,94 @@ fn send_response(stream: &UnixStream, resp: &ControlResponse) -> std::io::Result
 mod tests {
     use super::*;
 
+    // ── Liveness retry state machine (deterministic, injected probes) ────
+    //
+    // The real `connect(2)` teardown almost always yields ECONNREFUSED on the
+    // first attempt, so the live-socket integration test cannot reliably
+    // reach the Ambiguous retry branch. These drive `resolve_socket_liveness`
+    // with scripted single-probe outcomes to pin every branch.
+
+    fn eagain() -> std::io::Error {
+        std::io::Error::from_raw_os_error(libc::EAGAIN)
+    }
+
+    /// Build a probe closure that returns the given outcomes in order, then
+    /// repeats the final outcome for any further attempts.
+    fn scripted(outcomes: Vec<ProbeOnce>) -> impl FnMut() -> ProbeOnce {
+        let mut i = 0usize;
+        move || {
+            // Reconstruct each outcome fresh (io::Error is not Clone).
+            let idx = i.min(outcomes.len().saturating_sub(1));
+            i += 1;
+            match &outcomes[idx] {
+                ProbeOnce::Connected => ProbeOnce::Connected,
+                ProbeOnce::Refused => ProbeOnce::Refused,
+                ProbeOnce::Ambiguous(e) => ProbeOnce::Ambiguous(std::io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            }
+        }
+    }
+
+    #[test]
+    fn liveness_ambiguous_then_refused_is_stale() {
+        // EAGAIN/EINPROGRESS that later settles to ECONNREFUSED → Stale.
+        let probe = scripted(vec![
+            ProbeOnce::Ambiguous(eagain()),
+            ProbeOnce::Ambiguous(std::io::Error::from_raw_os_error(libc::EINPROGRESS)),
+            ProbeOnce::Refused,
+        ]);
+        let r = resolve_socket_liveness(40, probe, || {});
+        assert!(matches!(r, SocketLiveness::Stale));
+    }
+
+    #[test]
+    fn liveness_persistent_ambiguous_backlog_is_live() {
+        // Persistent EAGAIN (backlog-full live listener) → Live, never unlink.
+        let probe = || ProbeOnce::Ambiguous(eagain());
+        let r = resolve_socket_liveness(5, probe, || {});
+        assert!(matches!(r, SocketLiveness::Live));
+    }
+
+    #[test]
+    fn liveness_persistent_other_error_is_inconclusive() {
+        // Persistent non-backlog error (e.g. EACCES) → fail closed.
+        let probe = || ProbeOnce::Ambiguous(std::io::Error::from_raw_os_error(libc::EACCES));
+        let r = resolve_socket_liveness(5, probe, || {});
+        match r {
+            SocketLiveness::Inconclusive(e) => {
+                assert_eq!(e.raw_os_error(), Some(libc::EACCES));
+            }
+            _ => panic!("expected Inconclusive"),
+        }
+    }
+
+    #[test]
+    fn liveness_connected_is_immediately_live() {
+        // A definitive connect on the first attempt → Live, no retries.
+        let mut attempts = 0u32;
+        let probe = || {
+            attempts += 1;
+            ProbeOnce::Connected
+        };
+        let r = resolve_socket_liveness(40, probe, || panic!("must not wait after Connected"));
+        assert!(matches!(r, SocketLiveness::Live));
+        assert_eq!(attempts, 1, "Connected must return on the first attempt");
+    }
+
+    #[test]
+    fn liveness_refused_is_immediately_stale() {
+        // A definitive refusal on the first attempt → Stale, no retries.
+        let mut attempts = 0u32;
+        let probe = || {
+            attempts += 1;
+            ProbeOnce::Refused
+        };
+        let r = resolve_socket_liveness(40, probe, || panic!("must not wait after Refused"));
+        assert!(matches!(r, SocketLiveness::Stale));
+        assert_eq!(attempts, 1, "Refused must return on the first attempt");
+    }
+
     // ── Protocol parse / serialize ───────────────────────────────────────
 
     #[test]
@@ -1331,7 +2000,9 @@ mod tests {
 
     fn test_ctx(source_root: &Path) -> ControlSocketContext {
         ControlSocketContext {
+            canonical_root: source_root.to_path_buf(),
             source_root: source_root.to_path_buf(),
+            layout: SkillLayout::Flat,
             resolver: Some(Arc::new(ActiveSkillResolver::new(source_root))),
             protocol_event_writer: None,
         }
@@ -1525,7 +2196,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir(dir.path().join("alpha")).unwrap();
         let ctx = ControlSocketContext {
+            canonical_root: dir.path().to_path_buf(),
             source_root: dir.path().to_path_buf(),
+            layout: SkillLayout::Flat,
             resolver: None,
             protocol_event_writer: None,
         };
@@ -1556,7 +2229,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir(dir.path().join("alpha")).unwrap();
         let ctx = ControlSocketContext {
+            canonical_root: dir.path().to_path_buf(),
             source_root: dir.path().to_path_buf(),
+            layout: SkillLayout::Flat,
             resolver: None,
             protocol_event_writer: None,
         };
@@ -1667,7 +2342,9 @@ mod tests {
 
         let resolver = Arc::new(ActiveSkillResolver::new(dir.path()));
         let ctx = ControlSocketContext {
+            canonical_root: dir.path().to_path_buf(),
             source_root: dir.path().to_path_buf(),
+            layout: SkillLayout::Flat,
             resolver: Some(resolver.clone()),
             protocol_event_writer: None,
         };
@@ -1699,7 +2376,9 @@ mod tests {
 
         let resolver = Arc::new(ActiveSkillResolver::new(dir.path()));
         let ctx = ControlSocketContext {
+            canonical_root: dir.path().to_path_buf(),
             source_root: dir.path().to_path_buf(),
+            layout: SkillLayout::Flat,
             resolver: Some(resolver.clone()),
             protocol_event_writer: None,
         };
@@ -1885,6 +2564,213 @@ mod tests {
         let path = dir.path().join("new.sock");
         let result = preflight_socket_path(&path);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn preflight_symlink_not_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, "x").unwrap();
+        let link = dir.path().join("link.sock");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let result = preflight_socket_path(&link);
+        assert!(matches!(
+            result,
+            Err(SocketPreflightError::ExistingPathNotSocket(_))
+        ));
+        // The symlink must not have been deleted.
+        assert!(
+            std::fs::symlink_metadata(&link).is_ok(),
+            "symlink must not be deleted"
+        );
+    }
+
+    // ── Socket-object classification ─────────────────────────────────────
+
+    #[test]
+    fn classify_socket_object_non_socket_never_deleted() {
+        assert_eq!(
+            classify_socket_object(false, 1000, 1000),
+            SocketObjectClass::NotSocket
+        );
+    }
+
+    #[test]
+    fn classify_socket_object_wrong_owner_never_deleted() {
+        // A socket owned by a different uid must never be reclaimed.
+        assert_eq!(
+            classify_socket_object(true, 999, 1000),
+            SocketObjectClass::WrongOwner(999)
+        );
+    }
+
+    #[test]
+    fn classify_socket_object_owned_socket_is_reclaim_candidate() {
+        assert_eq!(
+            classify_socket_object(true, 1000, 1000),
+            SocketObjectClass::OwnedSocket
+        );
+    }
+
+    // ── Default endpoint + priority ──────────────────────────────────────
+
+    #[test]
+    fn default_endpoint_path_is_under_run_user_never_tmp() {
+        let p = default_control_socket_path(1000);
+        assert_eq!(p, PathBuf::from("/run/user/1000/skillfs/control.sock"));
+        let s = p.to_string_lossy();
+        assert!(
+            !s.contains("/tmp"),
+            "default endpoint must not use /tmp: {s}"
+        );
+        assert!(
+            !s.contains("/var/tmp"),
+            "default endpoint must not use /var/tmp: {s}"
+        );
+    }
+
+    #[test]
+    fn resolve_default_endpoint_is_run_user_or_actionable_error() {
+        let uid = unsafe { libc::geteuid() };
+        match resolve_default_control_socket_endpoint() {
+            Ok(p) => {
+                // When /run/user/<uid> exists, the resolved path is the
+                // per-user endpoint and never a public temp directory.
+                assert_eq!(p, default_control_socket_path(uid));
+                let s = p.to_string_lossy();
+                assert!(!s.contains("/tmp") && !s.contains("/var/tmp"));
+            }
+            Err(e) => {
+                // When it is unavailable, the error is clear and actionable.
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("--control-socket"),
+                    "error must be actionable: {msg}"
+                );
+                assert!(
+                    msg.contains(&format!("/run/user/{uid}")),
+                    "error must name the runtime dir: {msg}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn endpoint_priority_cli_over_config_over_default() {
+        // CLI value wins over config (the `or_else` merge in cmd_mount is
+        // applied first, then classified here).
+        let cli = Some(PathBuf::from("/cli.sock"));
+        let config = Some(PathBuf::from("/config.sock"));
+        let merged = cli.clone().or(config.clone());
+        assert_eq!(
+            classify_control_socket_endpoint(merged.as_deref(), true),
+            EndpointResolution::Explicit(PathBuf::from("/cli.sock"))
+        );
+
+        // Config value wins over the default when there is no CLI value.
+        let merged2: Option<PathBuf> = None.or(config);
+        assert_eq!(
+            classify_control_socket_endpoint(merged2.as_deref(), true),
+            EndpointResolution::Explicit(PathBuf::from("/config.sock"))
+        );
+
+        // Trusted peer, no explicit path → default endpoint.
+        assert_eq!(
+            classify_control_socket_endpoint(None, true),
+            EndpointResolution::UseDefault
+        );
+    }
+
+    #[test]
+    fn endpoint_explicit_path_without_trusted_peer_is_error() {
+        assert_eq!(
+            classify_control_socket_endpoint(Some(Path::new("/x.sock")), false),
+            EndpointResolution::MissingTrustedPeer(PathBuf::from("/x.sock"))
+        );
+    }
+
+    #[test]
+    fn endpoint_neither_disables_control_plane() {
+        assert_eq!(
+            classify_control_socket_endpoint(None, false),
+            EndpointResolution::Disabled
+        );
+    }
+
+    // ── skill.resolveLiveSource dispatch plumbing ────────────────────────
+    //
+    // The resolver behavior suite (managed/not-managed/errors, layout
+    // boundaries, identity, no-side-effects) lives in `super::resolver`'s
+    // unit tests against the pure `resolve_live_source`. These tests cover
+    // only the control-socket dispatch layer: context threading and
+    // envelope validation.
+
+    fn resolver_ctx(canonical_root: &Path, live_root: &Path) -> ControlSocketContext {
+        ControlSocketContext {
+            canonical_root: canonical_root.to_path_buf(),
+            source_root: live_root.to_path_buf(),
+            layout: SkillLayout::Flat,
+            // The read-only resolver must work without an active resolver.
+            resolver: None,
+            protocol_event_writer: None,
+        }
+    }
+
+    fn seed_skill(root: &Path, rel: &str) {
+        let dir = root.join(rel);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: x\ndescription: y\n---\nbody\n",
+        )
+        .unwrap();
+    }
+
+    fn resolve_req(canonical_skill_dir: &str) -> serde_json::Value {
+        serde_json::json!({
+            "schemaVersion": "1",
+            "method": "skill.resolveLiveSource",
+            "canonicalSkillDir": canonical_skill_dir,
+        })
+    }
+
+    #[test]
+    fn resolve_missing_canonical_field_is_invalid_request() {
+        let root = tempfile::tempdir().unwrap();
+        let ctx = resolver_ctx(root.path(), root.path());
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "skill.resolveLiveSource",
+        });
+        let resp = dispatch_resolve_live_source(&raw, Some(&ctx));
+        assert!(!resp.ok);
+        assert_eq!(resp.error.unwrap().code, "invalid_request");
+    }
+
+    #[test]
+    fn resolve_without_context_is_not_configured() {
+        let raw = resolve_req("/x/y");
+        let resp = dispatch_resolve_live_source(&raw, None);
+        assert!(!resp.ok);
+        assert_eq!(resp.error.unwrap().code, "not_configured");
+    }
+
+    #[test]
+    fn resolve_dispatches_via_dispatch_request() {
+        // The method is reachable through the top-level dispatcher and
+        // threads the context roots + layout into the resolver.
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "my-skill");
+        let ctx = resolver_ctx(root.path(), root.path());
+        let raw = resolve_req(root.path().join("my-skill").to_str().unwrap());
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "skill.resolveLiveSource".to_string(),
+        };
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+        assert!(resp.ok);
+        assert_eq!(resp.result.unwrap()["managed"], true);
     }
 
     // ── Peer verification ────────────────────────────────────────────────
@@ -2636,7 +3522,9 @@ mod tests {
             let writer =
                 Arc::new(super::super::super::protocol_events::InMemoryProtocolEventWriter::new());
             let ctx = ControlSocketContext {
+                canonical_root: source_root.to_path_buf(),
                 source_root: source_root.to_path_buf(),
+                layout: SkillLayout::Flat,
                 resolver: Some(resolver),
                 protocol_event_writer: Some(writer),
             };
@@ -2719,7 +3607,9 @@ mod tests {
 
             let socket_path = dir.path().join("test.sock");
             let ctx = ControlSocketContext {
+                canonical_root: source.path().to_path_buf(),
                 source_root: source.path().to_path_buf(),
+                layout: SkillLayout::Flat,
                 resolver: None,
                 protocol_event_writer: None,
             };
@@ -2963,7 +3853,9 @@ mod tests {
 
             let socket_path = dir.path().join("test.sock");
             let ctx = ControlSocketContext {
+                canonical_root: source.path().to_path_buf(),
                 source_root: source.path().to_path_buf(),
+                layout: SkillLayout::Flat,
                 resolver: None,
                 protocol_event_writer: None,
             };
@@ -3084,6 +3976,391 @@ mod tests {
                 libc::lremovexattr(c_path.as_ptr(), c_name.as_ptr());
             }
             true
+        }
+
+        // ── skill.resolveLiveSource over the socket ──────────────────
+
+        fn seed_skill_dir(root: &Path, rel: &str) {
+            let dir = root.join(rel);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), "---\nname: x\ndescription: y\n---\n").unwrap();
+        }
+
+        #[test]
+        fn server_resolve_live_source_managed() {
+            // start_server_with_context uses the default (Flat) layout, so
+            // seed a flat skill. Nested/Hermes boundary behavior is covered
+            // by the resolver module's own unit tests.
+            let dir = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            seed_skill_dir(source.path(), "my-skill");
+            let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
+
+            let canonical = source.path().join("my-skill");
+            let req = serde_json::json!({
+                "schemaVersion": "1",
+                "method": "skill.resolveLiveSource",
+                "canonicalSkillDir": canonical.to_string_lossy(),
+            });
+            let resp_str = connect_and_send(&socket_path, &req.to_string());
+            let resp: ControlResponse = serde_json::from_str(&resp_str).unwrap();
+            assert!(resp.ok, "expected ok, got {resp:?}");
+            let r = resp.result.unwrap();
+            assert_eq!(r["managed"], true);
+            assert_eq!(r["skillId"], "my-skill");
+            assert_eq!(r["transport"], "shared_path");
+
+            handle.shutdown();
+        }
+
+        #[test]
+        fn server_resolve_live_source_not_managed() {
+            let dir = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            let other = tempfile::tempdir().unwrap();
+            let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
+
+            let req = serde_json::json!({
+                "schemaVersion": "1",
+                "method": "skill.resolveLiveSource",
+                "canonicalSkillDir": other.path().join("x").to_string_lossy(),
+            });
+            let resp_str = connect_and_send(&socket_path, &req.to_string());
+            let resp: ControlResponse = serde_json::from_str(&resp_str).unwrap();
+            assert!(resp.ok);
+            let r = resp.result.unwrap();
+            assert_eq!(r["managed"], false);
+            assert_eq!(r["reason"], "not_managed");
+
+            handle.shutdown();
+        }
+
+        #[test]
+        fn server_resolve_live_source_relative_path_error() {
+            let dir = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
+
+            let req = serde_json::json!({
+                "schemaVersion": "1",
+                "method": "skill.resolveLiveSource",
+                "canonicalSkillDir": "relative/path",
+            });
+            let resp_str = connect_and_send(&socket_path, &req.to_string());
+            let resp: ControlResponse = serde_json::from_str(&resp_str).unwrap();
+            assert!(!resp.ok);
+            assert_eq!(resp.error.unwrap().code, "invalid_canonical_path");
+
+            handle.shutdown();
+        }
+
+        #[test]
+        fn server_resolve_live_source_untrusted_peer_rejected() {
+            let dir = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            seed_skill_dir(source.path(), "my-skill");
+
+            let socket_path = dir.path().join("test.sock");
+            let ctx = ControlSocketContext {
+                canonical_root: source.path().to_path_buf(),
+                source_root: source.path().to_path_buf(),
+                layout: SkillLayout::Flat,
+                resolver: None,
+                protocol_event_writer: None,
+            };
+            let config = ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: TrustedPeerConfig {
+                    exe_path: PathBuf::from("/nonexistent/binary"),
+                    exe_file_id: FileId { dev: 0, ino: 0 },
+                    uid: None,
+                    gid: None,
+                },
+            };
+            let handle = ControlSocketServer::new(config)
+                .with_context(ctx)
+                .start()
+                .unwrap();
+
+            let req = serde_json::json!({
+                "schemaVersion": "1",
+                "method": "skill.resolveLiveSource",
+                "canonicalSkillDir": source.path().join("my-skill").to_string_lossy(),
+            });
+            let mut stream = UnixStream::connect(&socket_path).unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            let _ = writeln!(stream, "{req}");
+            let _ = stream.flush();
+            let mut reader = BufReader::new(&stream);
+            let mut response = String::new();
+            reader.read_line(&mut response).unwrap();
+            let resp: ControlResponse = serde_json::from_str(&response).unwrap();
+            assert!(!resp.ok);
+            assert_eq!(resp.error.unwrap().code, "permission_denied");
+
+            handle.shutdown();
+        }
+
+        #[test]
+        fn burst_mixed_queries_independent_and_deadlock_free() {
+            let dir = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            seed_skill_dir(source.path(), "my-skill");
+            let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
+
+            let managed_path = source.path().join("my-skill");
+            let outside = tempfile::tempdir().unwrap();
+            let not_managed_path = outside.path().join("x");
+
+            let mut managed_ok = 0;
+            let mut not_managed_ok = 0;
+            let mut invalid_ok = 0;
+
+            const ITERATIONS: usize = 120;
+            for i in 0..ITERATIONS {
+                let (req, expect): (serde_json::Value, &str) = match i % 3 {
+                    0 => (
+                        serde_json::json!({
+                            "schemaVersion": "1",
+                            "method": "skill.resolveLiveSource",
+                            "canonicalSkillDir": managed_path.to_string_lossy(),
+                        }),
+                        "managed",
+                    ),
+                    1 => (
+                        serde_json::json!({
+                            "schemaVersion": "1",
+                            "method": "skill.resolveLiveSource",
+                            "canonicalSkillDir": not_managed_path.to_string_lossy(),
+                        }),
+                        "not_managed",
+                    ),
+                    _ => (
+                        // Malformed: relative canonicalSkillDir.
+                        serde_json::json!({
+                            "schemaVersion": "1",
+                            "method": "skill.resolveLiveSource",
+                            "canonicalSkillDir": "relative/path",
+                        }),
+                        "invalid",
+                    ),
+                };
+
+                let resp_str = connect_and_send(&socket_path, &req.to_string());
+                // Each response is a single, complete, independent JSON line.
+                let resp: ControlResponse = serde_json::from_str(&resp_str)
+                    .unwrap_or_else(|e| panic!("iteration {i}: bad response '{resp_str}': {e}"));
+
+                match expect {
+                    "managed" => {
+                        assert!(resp.ok, "iteration {i}: {resp:?}");
+                        let r = resp.result.unwrap();
+                        assert_eq!(r["managed"], true);
+                        assert_eq!(r["skillId"], "my-skill");
+                        managed_ok += 1;
+                    }
+                    "not_managed" => {
+                        assert!(resp.ok);
+                        assert_eq!(resp.result.unwrap()["managed"], false);
+                        not_managed_ok += 1;
+                    }
+                    _ => {
+                        assert!(!resp.ok);
+                        assert_eq!(resp.error.unwrap().code, "invalid_canonical_path");
+                        invalid_ok += 1;
+                    }
+                }
+            }
+
+            assert_eq!(managed_ok + not_managed_ok + invalid_ok, ITERATIONS);
+            assert!(managed_ok >= 40 && not_managed_ok >= 40 && invalid_ok >= 40);
+
+            handle.shutdown();
+        }
+
+        // ── Socket lifecycle ─────────────────────────────────────────
+
+        #[test]
+        fn second_instance_fails_while_socket_active() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            let handle1 = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start()
+            .unwrap();
+
+            // A second instance must fail (lifecycle lock held) and must
+            // NOT unlink the active socket.
+            let result2 = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start();
+            assert!(result2.is_err(), "second instance must fail to start");
+            assert!(socket_path.exists(), "active socket must not be removed");
+
+            // The first instance is still serving.
+            let resp_str =
+                connect_and_send(&socket_path, r#"{"schemaVersion":"1","method":"ping"}"#);
+            assert!(resp_str.contains("\"ok\":true"));
+
+            handle1.shutdown();
+        }
+
+        #[test]
+        fn lifecycle_lock_does_not_block_unbounded() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            let handle1 = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start()
+            .unwrap();
+
+            let start = std::time::Instant::now();
+            let result2 = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start();
+            let elapsed = start.elapsed();
+            assert!(result2.is_err());
+            assert!(
+                elapsed < std::time::Duration::from_secs(1),
+                "non-blocking lock must fail fast, took {elapsed:?}"
+            );
+
+            handle1.shutdown();
+        }
+
+        #[test]
+        fn stale_socket_is_recovered() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            // Leave a stale socket file behind (std does not unlink on drop)
+            // and recover it immediately — no pre-settling. This exercises
+            // the real "listener just closed, restart now" path, where the
+            // bounded-retry preflight probe must let the endpoint settle to
+            // ECONNREFUSED and reclaim it rather than misreading a teardown
+            // transient as a live listener.
+            {
+                let _l = UnixListener::bind(&socket_path).unwrap();
+            }
+            assert!(socket_path.exists());
+
+            let handle = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start()
+            .expect("stale socket must be recoverable");
+
+            let resp_str =
+                connect_and_send(&socket_path, r#"{"schemaVersion":"1","method":"ping"}"#);
+            assert!(resp_str.contains("\"ok\":true"));
+
+            handle.shutdown();
+        }
+
+        #[test]
+        fn start_refuses_symlink_at_socket_path() {
+            let dir = tempfile::tempdir().unwrap();
+            let target = dir.path().join("target");
+            std::fs::write(&target, "x").unwrap();
+            let socket_path = dir.path().join("test.sock");
+            std::os::unix::fs::symlink(&target, &socket_path).unwrap();
+
+            let result = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start();
+            assert!(result.is_err(), "symlink at socket path must fail closed");
+            assert!(
+                std::fs::symlink_metadata(&socket_path)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink(),
+                "symlink must not be deleted"
+            );
+        }
+
+        #[test]
+        fn start_refuses_regular_file_at_socket_path() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            std::fs::write(&socket_path, "not a socket").unwrap();
+
+            let result = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start();
+            assert!(result.is_err(), "regular file at socket path must fail");
+            assert!(socket_path.exists(), "regular file must not be deleted");
+            assert_eq!(
+                std::fs::read_to_string(&socket_path).unwrap(),
+                "not a socket"
+            );
+        }
+
+        #[test]
+        fn shutdown_does_not_delete_replaced_path() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            let handle = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start()
+            .unwrap();
+
+            // Replace the socket with a different object after bind.
+            std::fs::remove_file(&socket_path).unwrap();
+            std::fs::write(&socket_path, "replacement").unwrap();
+
+            handle.shutdown();
+
+            // The replacement object must survive: shutdown only removes the
+            // exact socket identity this instance bound.
+            assert!(
+                socket_path.exists(),
+                "replacement object must not be deleted"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&socket_path).unwrap(),
+                "replacement"
+            );
+        }
+
+        #[test]
+        fn socket_and_parent_permissions() {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = tempfile::tempdir().unwrap();
+            let parent = dir.path().join("sock-parent");
+            let socket_path = parent.join("test.sock");
+            let handle = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start()
+            .unwrap();
+
+            let parent_mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+            assert_eq!(parent_mode, 0o700, "parent must be 0700");
+            let sock_mode = std::fs::metadata(&socket_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(sock_mode, 0o600, "socket must be 0600");
+
+            handle.shutdown();
         }
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/security/install.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/install.rs
@@ -1526,7 +1526,7 @@ mod tests {
         let events = client.events();
         let mutation_events: Vec<_> = events
             .iter()
-            .filter(|e| e.skill_name == "demo-weather" && e.event_kind == "write")
+            .filter(|e| e.skill_id == "demo-weather" && e.event_kind == "write")
             .collect();
         assert_eq!(
             mutation_events.len(),
@@ -1583,7 +1583,7 @@ mod tests {
         let events = client.events();
         let matching: Vec<_> = events
             .iter()
-            .filter(|e| e.skill_name == "demo-weather")
+            .filter(|e| e.skill_id == "demo-weather")
             .collect();
         assert!(
             matching.is_empty(),

--- a/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
@@ -15,7 +15,8 @@
 //! [`super::ActiveSkillResolver`] mapping. The existing trusted view stays
 //! in place until the daemon writes a new `activation.json` / xattr.
 //!
-//! Wire format follows `SKILL_LEDGER_SKILLFS_ACTIVATION_CN.md` §变更通知接口.
+//! Wire format follows §4 of `SKILL_LEDGER_SKILLFS_INTEGRATION_zh.md`
+//! (SkillFS Notify v2 contract).
 
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read as IoRead, Write as IoWrite};

--- a/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
@@ -38,8 +38,10 @@ use super::path::is_skill_meta_path;
 use super::protocol_events::{NoopProtocolEventWriter, ProtocolEvent, ProtocolEventWriter};
 use super::refresh::MutationKind;
 
+/// Daemon method used for SkillFS change notifications.
 pub const NOTIFY_METHOD: &str = "skill_ledger.skillfs_notify_change";
-pub const NOTIFY_SCHEMA_VERSION: u64 = 1;
+/// Notify request and response schema version accepted by SkillFS.
+pub const NOTIFY_SCHEMA_VERSION: u64 = 2;
 pub const DEFAULT_NOTIFY_TIMEOUT_MS: u64 = 5000;
 pub const DEFAULT_NOTIFY_DEBOUNCE_MS: u64 = 300;
 /// Maximum number of relative paths per notification. Exceeding this sends
@@ -118,18 +120,24 @@ pub struct NotifyChangeEvent {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// Versioned notify parameters sent inside the daemon request envelope.
 pub struct NotifyParams {
+    /// Protocol version; only v2 is supported.
     pub schema_version: u64,
-    pub skill_dir: String,
-    pub skill_name: String,
+    /// User-visible absolute Skill directory addressed by the ledger.
+    pub canonical_skill_dir: String,
+    /// Complete Skill id relative to the canonical root.
+    pub skill_id: String,
+    /// Last mutation kind observed in the debounce window.
     pub event_kind: String,
+    /// Sorted changed paths relative to the canonical Skill directory.
     pub paths: Vec<String>,
 }
 
 impl NotifyChangeEvent {
     pub fn new(
-        skill_dir: impl Into<String>,
-        skill_name: impl Into<String>,
+        canonical_skill_dir: impl Into<String>,
+        skill_id: impl Into<String>,
         event_kind: NotifyEventKind,
         paths: Vec<String>,
         timeout_ms: u64,
@@ -139,8 +147,8 @@ impl NotifyChangeEvent {
             method: NOTIFY_METHOD,
             params: NotifyParams {
                 schema_version: NOTIFY_SCHEMA_VERSION,
-                skill_dir: skill_dir.into(),
-                skill_name: skill_name.into(),
+                canonical_skill_dir: canonical_skill_dir.into(),
+                skill_id: skill_id.into(),
                 event_kind: event_kind.as_str().to_string(),
                 paths,
             },
@@ -265,9 +273,21 @@ fn validate_response(body: &str) -> Result<(), NotifyError> {
         });
     }
 
-    let accepted = parsed
+    let data = parsed
         .get("data")
-        .and_then(|d| d.get("accepted"))
+        .and_then(|value| value.as_object())
+        .ok_or_else(|| NotifyError::InvalidResponse {
+            body: body.trim().to_string(),
+        })?;
+    let schema_version = data.get("schemaVersion").and_then(|value| value.as_u64());
+    if schema_version != Some(NOTIFY_SCHEMA_VERSION) {
+        return Err(NotifyError::InvalidResponse {
+            body: body.trim().to_string(),
+        });
+    }
+
+    let accepted = data
+        .get("accepted")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     if !accepted {
@@ -296,11 +316,18 @@ pub struct InMemoryNotifyClient {
 }
 
 #[derive(Debug, Clone)]
+/// Notify v2 values recorded by [`InMemoryNotifyClient`].
 pub struct CapturedNotify {
-    pub skill_name: String,
+    /// Captured protocol schema version.
+    pub schema_version: u64,
+    /// Captured complete Skill id.
+    pub skill_id: String,
+    /// Captured mutation kind.
     pub event_kind: String,
+    /// Captured relative paths.
     pub paths: Vec<String>,
-    pub skill_dir: String,
+    /// Captured user-visible canonical Skill directory.
+    pub canonical_skill_dir: String,
 }
 
 impl InMemoryNotifyClient {
@@ -324,10 +351,11 @@ impl InMemoryNotifyClient {
 impl NotifyClient for InMemoryNotifyClient {
     fn send(&self, event: &NotifyChangeEvent) -> Result<(), NotifyError> {
         self.events.lock().push(CapturedNotify {
-            skill_name: event.params.skill_name.clone(),
+            schema_version: event.params.schema_version,
+            skill_id: event.params.skill_id.clone(),
             event_kind: event.params.event_kind.clone(),
             paths: event.params.paths.clone(),
-            skill_dir: event.params.skill_dir.clone(),
+            canonical_skill_dir: event.params.canonical_skill_dir.clone(),
         });
         Ok(())
     }
@@ -380,7 +408,7 @@ struct NotifyInner {
     /// A5: watcher registrar for auto-tracking skills observed through
     /// notify. Set post-construction via `set_watcher_registrar`.
     watcher_registrar: Mutex<Option<Arc<dyn WatcherRegistrar>>>,
-    source_root: PathBuf,
+    canonical_root: PathBuf,
     debounce: Duration,
     timeout_ms: u64,
     pending: Mutex<HashMap<String, NotifyPendingState>>,
@@ -390,7 +418,7 @@ struct NotifyInner {
 
 #[derive(Debug, Clone)]
 struct NotifyPendingState {
-    skill_name: String,
+    skill_id: String,
     event_kind: NotifyEventKind,
     paths: HashSet<String>,
     fire_at: Instant,
@@ -405,13 +433,13 @@ enum NotifyCommand {
 impl NotifyController {
     pub fn new(
         client: Arc<dyn NotifyClient>,
-        source_root: impl Into<PathBuf>,
+        canonical_root: impl Into<PathBuf>,
         debounce: Duration,
         timeout_ms: u64,
     ) -> Arc<Self> {
         Self::new_with_protocol_writer(
             client,
-            source_root,
+            canonical_root,
             debounce,
             timeout_ms,
             Arc::new(NoopProtocolEventWriter),
@@ -420,14 +448,14 @@ impl NotifyController {
 
     pub fn new_with_protocol_writer(
         client: Arc<dyn NotifyClient>,
-        source_root: impl Into<PathBuf>,
+        canonical_root: impl Into<PathBuf>,
         debounce: Duration,
         timeout_ms: u64,
         protocol_event_writer: Arc<dyn ProtocolEventWriter>,
     ) -> Arc<Self> {
         Self::new_full(
             client,
-            source_root,
+            canonical_root,
             debounce,
             timeout_ms,
             protocol_event_writer,
@@ -437,7 +465,7 @@ impl NotifyController {
 
     pub fn new_with_reload(
         client: Arc<dyn NotifyClient>,
-        source_root: impl Into<PathBuf>,
+        canonical_root: impl Into<PathBuf>,
         debounce: Duration,
         timeout_ms: u64,
         protocol_event_writer: Arc<dyn ProtocolEventWriter>,
@@ -445,7 +473,7 @@ impl NotifyController {
     ) -> Arc<Self> {
         Self::new_full(
             client,
-            source_root,
+            canonical_root,
             debounce,
             timeout_ms,
             protocol_event_writer,
@@ -455,7 +483,7 @@ impl NotifyController {
 
     fn new_full(
         client: Arc<dyn NotifyClient>,
-        source_root: impl Into<PathBuf>,
+        canonical_root: impl Into<PathBuf>,
         debounce: Duration,
         timeout_ms: u64,
         protocol_event_writer: Arc<dyn ProtocolEventWriter>,
@@ -467,7 +495,7 @@ impl NotifyController {
             protocol_event_writer,
             reload_controller,
             watcher_registrar: Mutex::new(None),
-            source_root: source_root.into(),
+            canonical_root: canonical_root.into(),
             debounce,
             timeout_ms,
             pending: Mutex::new(HashMap::new()),
@@ -515,11 +543,11 @@ impl NotifyController {
     /// `false` when filtered (skill-discover, `.skill-meta/**`, lifecycle).
     pub fn observe(
         &self,
-        skill_name: &str,
+        skill_id: &str,
         relative_path: Option<&Path>,
         kind: MutationKind,
     ) -> bool {
-        if !is_notify_eligible(skill_name) {
+        if !is_notify_eligible(skill_id) {
             return false;
         }
         if let Some(rel) = relative_path {
@@ -533,15 +561,14 @@ impl NotifyController {
         let fire_at = now + self.inner.debounce;
         {
             let mut pending = self.inner.pending.lock();
-            let entry =
-                pending
-                    .entry(skill_name.to_string())
-                    .or_insert_with(|| NotifyPendingState {
-                        skill_name: skill_name.to_string(),
-                        event_kind,
-                        paths: HashSet::new(),
-                        fire_at,
-                    });
+            let entry = pending
+                .entry(skill_id.to_string())
+                .or_insert_with(|| NotifyPendingState {
+                    skill_id: skill_id.to_string(),
+                    event_kind,
+                    paths: HashSet::new(),
+                    fire_at,
+                });
             entry.fire_at = fire_at;
             entry.event_kind = event_kind;
             if let Some(rel) = relative_path {
@@ -559,11 +586,11 @@ impl NotifyController {
     /// Convenience wrapper matching `RefreshController::observe_mutation`.
     pub fn observe_mutation(
         &self,
-        skill_name: &str,
+        skill_id: &str,
         relative_path: Option<&Path>,
         kind: MutationKind,
     ) -> bool {
-        self.observe(skill_name, relative_path, kind)
+        self.observe(skill_id, relative_path, kind)
     }
 
     /// Drain and send all pending notifications synchronously. Test helper.
@@ -590,22 +617,26 @@ impl NotifyController {
     /// path.
     ///
     /// Returns the number of reconcile events emitted.
-    pub fn emit_startup_reconcile(&self, skill_names: &[String]) -> usize {
+    pub fn emit_startup_reconcile(&self, skill_ids: &[String]) -> usize {
         let mut count = 0;
-        for name in skill_names {
-            if !is_notify_eligible(name) {
+        for skill_id in skill_ids {
+            if !is_notify_eligible(skill_id) {
                 continue;
             }
-            let skill_dir = self.inner.source_root.join(name);
-            let skill_dir_str = skill_dir.to_string_lossy().to_string();
+            let canonical_skill_dir = self.inner.canonical_root.join(skill_id);
+            let canonical_skill_dir = canonical_skill_dir.to_string_lossy().to_string();
 
-            let protocol_event =
-                ProtocolEvent::new(&skill_dir_str, name.as_str(), "reconcile", Vec::new());
+            let protocol_event = ProtocolEvent::new(
+                &canonical_skill_dir,
+                skill_id.as_str(),
+                "reconcile",
+                Vec::new(),
+            );
             self.inner.protocol_event_writer.emit(&protocol_event);
 
             let event = NotifyChangeEvent::new(
-                &skill_dir_str,
-                name.as_str(),
+                &canonical_skill_dir,
+                skill_id.as_str(),
                 NotifyEventKind::Reconcile,
                 Vec::new(),
                 self.inner.timeout_ms,
@@ -613,13 +644,13 @@ impl NotifyController {
 
             if let Err(e) = self.inner.client.send(&event) {
                 warn!(
-                    skill = %name,
+                    skill = %skill_id,
                     error = %e,
                     "reconcile: failed to send reconcile notification"
                 );
             } else {
                 debug!(
-                    skill = %name,
+                    skill = %skill_id,
                     "reconcile: startup reconcile notification sent"
                 );
             }
@@ -663,10 +694,10 @@ impl NotifyController {
     /// worker. Bypasses the debounce window (fire_at = now) but does NOT
     /// block the calling thread on socket send or activation reload poll.
     /// The worker picks it up on its next iteration.
-    pub fn enqueue_immediate(&self, skill_name: &str, kind: MutationKind, paths: Vec<String>) {
+    pub fn enqueue_immediate(&self, skill_id: &str, kind: MutationKind, paths: Vec<String>) {
         let event_kind = NotifyEventKind::from_mutation_kind(kind);
         let state = NotifyPendingState {
-            skill_name: skill_name.to_string(),
+            skill_id: skill_id.to_string(),
             event_kind,
             paths: paths.into_iter().collect(),
             fire_at: Instant::now(),
@@ -674,7 +705,7 @@ impl NotifyController {
         self.inner
             .pending
             .lock()
-            .insert(skill_name.to_string(), state);
+            .insert(skill_id.to_string(), state);
         let _ = self.inner.sender.send(NotifyCommand::Wakeup);
         self.inner.notify.notify_one();
     }
@@ -717,8 +748,8 @@ impl NotifyInner {
     }
 
     fn send_one(&self, state: NotifyPendingState) {
-        let skill_dir = self.source_root.join(&state.skill_name);
-        let skill_dir_str = skill_dir.to_string_lossy().to_string();
+        let canonical_skill_dir = self.canonical_root.join(&state.skill_id);
+        let canonical_skill_dir = canonical_skill_dir.to_string_lossy().to_string();
 
         // A3: snapshot activation freshness BEFORE sending the notify so
         // the poll baseline predates the daemon's activation write.
@@ -726,7 +757,7 @@ impl NotifyInner {
         let pre_notify_freshness = self
             .reload_controller
             .as_ref()
-            .map(|r| r.snapshot_freshness(&state.skill_name));
+            .map(|r| r.snapshot_freshness(&state.skill_id));
 
         let paths: Vec<String> = if state.paths.len() > MAX_NOTIFY_PATHS {
             Vec::new()
@@ -738,16 +769,16 @@ impl NotifyInner {
 
         // Write protocol event log regardless of notify outcome.
         let protocol_event = ProtocolEvent::new(
-            &skill_dir_str,
-            &state.skill_name,
+            &canonical_skill_dir,
+            &state.skill_id,
             state.event_kind.as_str(),
             paths.clone(),
         );
         self.protocol_event_writer.emit(&protocol_event);
 
         let event = NotifyChangeEvent::new(
-            skill_dir_str.clone(),
-            state.skill_name.clone(),
+            canonical_skill_dir.clone(),
+            state.skill_id.clone(),
             state.event_kind,
             paths,
             self.timeout_ms,
@@ -755,17 +786,17 @@ impl NotifyInner {
 
         if let Err(e) = self.client.send(&event) {
             warn!(
-                skill = %state.skill_name,
+                skill = %state.skill_id,
                 error = %e,
                 "notify: failed to send change notification; \
                  current activation mapping unchanged"
             );
             // A5: daemon unreachable — register for watcher convergence
             // so a later daemon repair can still be observed.
-            self.register_with_watcher(&state.skill_name);
+            self.register_with_watcher(&state.skill_id);
         } else {
             debug!(
-                skill = %state.skill_name,
+                skill = %state.skill_id,
                 event_kind = state.event_kind.as_str(),
                 "notify: change notification accepted"
             );
@@ -776,12 +807,12 @@ impl NotifyInner {
             let baseline = pre_notify_freshness
                 .expect("reload_controller presence implies freshness was captured");
             debug!(
-                skill = %state.skill_name,
+                skill = %state.skill_id,
                 "notify: starting activation reload poll"
             );
-            let outcome = reload.poll_reload_skill(&state.skill_name, baseline);
+            let outcome = reload.poll_reload_skill(&state.skill_id, baseline);
             debug!(
-                skill = %state.skill_name,
+                skill = %state.skill_id,
                 outcome = ?outcome,
                 "notify: activation reload poll completed"
             );
@@ -790,13 +821,13 @@ impl NotifyInner {
             // so late activation writes are still caught by the
             // background convergence loop.
             if matches!(outcome, super::activation_reload::ReloadOutcome::Timeout) {
-                self.register_with_watcher(&state.skill_name);
+                self.register_with_watcher(&state.skill_id);
             }
 
             // A4: emit reload outcome as a protocol event.
             let reload_event = ProtocolEvent::with_reload_outcome(
-                &skill_dir_str,
-                &state.skill_name,
+                &canonical_skill_dir,
+                &state.skill_id,
                 outcome.as_protocol_label(),
             );
             self.protocol_event_writer.emit(&reload_event);
@@ -880,8 +911,8 @@ mod tests {
             method: NOTIFY_METHOD,
             params: NotifyParams {
                 schema_version: NOTIFY_SCHEMA_VERSION,
-                skill_dir: "/srv/skills/tianqi-weather".to_string(),
-                skill_name: "tianqi-weather".to_string(),
+                canonical_skill_dir: "/srv/skills/category/tianqi-weather".to_string(),
+                skill_id: "category/tianqi-weather".to_string(),
                 event_kind: "write".to_string(),
                 paths: vec!["SKILL.md".to_string()],
             },
@@ -890,13 +921,33 @@ mod tests {
         };
 
         let json = serde_json::to_value(&event).unwrap();
+        let envelope = json.as_object().unwrap();
+        assert_eq!(envelope.len(), 5);
         assert_eq!(json["id"], "skillfs-42");
         assert_eq!(json["method"], "skill_ledger.skillfs_notify_change");
-        assert_eq!(json["params"]["schemaVersion"], 1);
-        assert_eq!(json["params"]["skillDir"], "/srv/skills/tianqi-weather");
-        assert_eq!(json["params"]["skillName"], "tianqi-weather");
+        let params = json["params"].as_object().unwrap();
+        assert_eq!(params.len(), 5);
+        assert_eq!(json["params"]["schemaVersion"], 2);
+        assert_eq!(
+            json["params"]["canonicalSkillDir"],
+            "/srv/skills/category/tianqi-weather"
+        );
+        assert_eq!(json["params"]["skillId"], "category/tianqi-weather");
         assert_eq!(json["params"]["eventKind"], "write");
         assert_eq!(json["params"]["paths"], serde_json::json!(["SKILL.md"]));
+        for forbidden in [
+            "skillDir",
+            "skillName",
+            "mountId",
+            "generation",
+            "resolverSocket",
+            "sourceId",
+        ] {
+            assert!(
+                !params.contains_key(forbidden),
+                "unexpected field: {forbidden}"
+            );
+        }
         assert_eq!(json["trace_context"], serde_json::json!({}));
         assert_eq!(json["timeout_ms"], 5000);
     }
@@ -972,15 +1023,34 @@ mod tests {
         client.send(&event).unwrap();
         assert_eq!(client.len(), 1);
         let events = client.events();
-        assert_eq!(events[0].skill_name, "alpha");
+        assert_eq!(events[0].schema_version, 2);
+        assert_eq!(events[0].skill_id, "alpha");
         assert_eq!(events[0].event_kind, "write");
         assert_eq!(events[0].paths, vec!["SKILL.md"]);
     }
 
     #[test]
     fn validate_response_accepts_ok_accepted() {
-        let body = r#"{"ok":true,"data":{"schemaVersion":1,"accepted":true}}"#;
+        let body = r#"{"ok":true,"data":{"schemaVersion":2,"accepted":true}}"#;
         assert!(validate_response(body).is_ok());
+    }
+
+    #[test]
+    fn validate_response_rejects_v1_schema() {
+        let body = r#"{"ok":true,"data":{"schemaVersion":1,"accepted":true}}"#;
+        assert!(matches!(
+            validate_response(body),
+            Err(NotifyError::InvalidResponse { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_response_rejects_missing_schema() {
+        let body = r#"{"ok":true,"data":{"accepted":true}}"#;
+        assert!(matches!(
+            validate_response(body),
+            Err(NotifyError::InvalidResponse { .. })
+        ));
     }
 
     #[test]
@@ -994,7 +1064,7 @@ mod tests {
 
     #[test]
     fn validate_response_rejects_accepted_false() {
-        let body = r#"{"ok":true,"data":{"accepted":false}}"#;
+        let body = r#"{"ok":true,"data":{"schemaVersion":2,"accepted":false}}"#;
         assert!(matches!(
             validate_response(body),
             Err(NotifyError::Rejected { .. })
@@ -1015,7 +1085,7 @@ mod tests {
         let body = r#"{"ok":true}"#;
         assert!(matches!(
             validate_response(body),
-            Err(NotifyError::Rejected { .. })
+            Err(NotifyError::InvalidResponse { .. })
         ));
     }
 
@@ -1087,7 +1157,7 @@ mod tests {
         assert_eq!(processed, 1, "five observations must collapse to one");
         let events = client.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].skill_name, "alpha");
+        assert_eq!(events[0].skill_id, "alpha");
         ctrl.shutdown();
     }
 
@@ -1111,9 +1181,7 @@ mod tests {
         assert_eq!(processed, 1);
         let events = client.events();
         assert_eq!(events.len(), 1);
-        let mut paths = events[0].paths.clone();
-        paths.sort();
-        assert_eq!(paths, vec!["SKILL.md", "scripts/run.sh"]);
+        assert_eq!(events[0].paths, vec!["SKILL.md", "scripts/run.sh"]);
         ctrl.shutdown();
     }
 
@@ -1155,7 +1223,7 @@ mod tests {
     }
 
     #[test]
-    fn controller_source_root_appears_in_skill_dir() {
+    fn controller_canonical_root_appears_in_flat_skill_dir() {
         let client = Arc::new(InMemoryNotifyClient::new());
         let ctrl = NotifyController::new(
             client.clone(),
@@ -1166,7 +1234,36 @@ mod tests {
         ctrl.observe("weather", Some(Path::new("SKILL.md")), MutationKind::Write);
         ctrl.flush_for_testing();
         let events = client.events();
-        assert_eq!(events[0].skill_dir, "/home/user/skills/weather");
+        assert_eq!(events[0].schema_version, 2);
+        assert_eq!(events[0].skill_id, "weather");
+        assert_eq!(events[0].canonical_skill_dir, "/home/user/skills/weather");
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn controller_preserves_hermes_full_skill_id() {
+        let client = Arc::new(InMemoryNotifyClient::new());
+        let ctrl = NotifyController::new(
+            client.clone(),
+            "/home/user/skills",
+            Duration::from_millis(50),
+            5000,
+        );
+        ctrl.observe(
+            "category/weather",
+            Some(Path::new("scripts/run.sh")),
+            MutationKind::Write,
+        );
+        ctrl.flush_for_testing();
+
+        let events = client.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].skill_id, "category/weather");
+        assert_eq!(
+            events[0].canonical_skill_dir,
+            "/home/user/skills/category/weather"
+        );
+        assert_eq!(events[0].paths, vec!["scripts/run.sh"]);
         ctrl.shutdown();
     }
 
@@ -1205,7 +1302,7 @@ mod tests {
             assert_eq!(ctrl.flush_for_testing(), 1);
             let events = client.events();
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].skill_name, "alpha");
+            assert_eq!(events[0].skill_id, "alpha");
             // Drop the Arc — Drop sends Shutdown, the worker returns,
             // the private runtime thread exits cleanly.
             drop(ctrl);
@@ -1543,7 +1640,7 @@ mod tests {
         // Verify notify still works with default noop writer.
         let events = client.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].skill_name, "alpha");
+        assert_eq!(events[0].skill_id, "alpha");
         ctrl.shutdown();
     }
 
@@ -1577,10 +1674,12 @@ mod tests {
         let notify_events = client.events();
         assert_eq!(notify_events.len(), 2);
         let mut notify_names: Vec<String> =
-            notify_events.iter().map(|e| e.skill_name.clone()).collect();
+            notify_events.iter().map(|e| e.skill_id.clone()).collect();
         notify_names.sort();
         assert_eq!(notify_names, vec!["alpha", "beta"]);
         for e in &notify_events {
+            assert_eq!(e.schema_version, 2);
+            assert_eq!(e.canonical_skill_dir, format!("/srv/skills/{}", e.skill_id));
             assert_eq!(e.event_kind, "reconcile");
             assert!(e.paths.is_empty());
         }
@@ -1624,9 +1723,7 @@ mod tests {
         let notify_events = client.events();
         assert_eq!(notify_events.len(), 2);
         assert!(
-            notify_events
-                .iter()
-                .all(|e| e.skill_name != "skill-discover"),
+            notify_events.iter().all(|e| e.skill_id != "skill-discover"),
             "skill-discover must not appear in notify events"
         );
 
@@ -1657,7 +1754,7 @@ mod tests {
         assert_eq!(count, 1, "lifecycle roots must be filtered");
         let notify_events = client.events();
         assert_eq!(notify_events.len(), 1);
-        assert_eq!(notify_events[0].skill_name, "alpha");
+        assert_eq!(notify_events[0].skill_id, "alpha");
 
         ctrl.shutdown();
     }
@@ -1717,7 +1814,10 @@ mod tests {
         ctrl.emit_startup_reconcile(&["weather".to_string()]);
 
         let notify_events = client.events();
-        assert_eq!(notify_events[0].skill_dir, "/home/user/skills/weather");
+        assert_eq!(
+            notify_events[0].canonical_skill_dir,
+            "/home/user/skills/weather"
+        );
 
         let proto_events = writer.events();
         assert_eq!(proto_events[0].skill_dir, "/home/user/skills/weather");
@@ -1758,7 +1858,7 @@ mod tests {
             use std::io::Write;
             let mut writer = std::io::BufWriter::new(&stream);
             writer
-                .write_all(br#"{"ok":true,"data":{"schemaVersion":1,"accepted":true}}"#)
+                .write_all(br#"{"ok":true,"data":{"schemaVersion":2,"accepted":true}}"#)
                 .unwrap();
             writer.write_all(b"\n").unwrap();
             writer.flush().unwrap();

--- a/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
@@ -409,6 +409,7 @@ struct NotifyInner {
     /// notify. Set post-construction via `set_watcher_registrar`.
     watcher_registrar: Mutex<Option<Arc<dyn WatcherRegistrar>>>,
     canonical_root: PathBuf,
+    protocol_event_root: PathBuf,
     debounce: Duration,
     timeout_ms: u64,
     pending: Mutex<HashMap<String, NotifyPendingState>>,
@@ -437,8 +438,10 @@ impl NotifyController {
         debounce: Duration,
         timeout_ms: u64,
     ) -> Arc<Self> {
+        let canonical_root = canonical_root.into();
         Self::new_with_protocol_writer(
             client,
+            canonical_root.clone(),
             canonical_root,
             debounce,
             timeout_ms,
@@ -449,6 +452,7 @@ impl NotifyController {
     pub fn new_with_protocol_writer(
         client: Arc<dyn NotifyClient>,
         canonical_root: impl Into<PathBuf>,
+        protocol_event_root: impl Into<PathBuf>,
         debounce: Duration,
         timeout_ms: u64,
         protocol_event_writer: Arc<dyn ProtocolEventWriter>,
@@ -456,6 +460,7 @@ impl NotifyController {
         Self::new_full(
             client,
             canonical_root,
+            protocol_event_root,
             debounce,
             timeout_ms,
             protocol_event_writer,
@@ -466,6 +471,7 @@ impl NotifyController {
     pub fn new_with_reload(
         client: Arc<dyn NotifyClient>,
         canonical_root: impl Into<PathBuf>,
+        protocol_event_root: impl Into<PathBuf>,
         debounce: Duration,
         timeout_ms: u64,
         protocol_event_writer: Arc<dyn ProtocolEventWriter>,
@@ -474,6 +480,7 @@ impl NotifyController {
         Self::new_full(
             client,
             canonical_root,
+            protocol_event_root,
             debounce,
             timeout_ms,
             protocol_event_writer,
@@ -484,6 +491,7 @@ impl NotifyController {
     fn new_full(
         client: Arc<dyn NotifyClient>,
         canonical_root: impl Into<PathBuf>,
+        protocol_event_root: impl Into<PathBuf>,
         debounce: Duration,
         timeout_ms: u64,
         protocol_event_writer: Arc<dyn ProtocolEventWriter>,
@@ -496,6 +504,7 @@ impl NotifyController {
             reload_controller,
             watcher_registrar: Mutex::new(None),
             canonical_root: canonical_root.into(),
+            protocol_event_root: protocol_event_root.into(),
             debounce,
             timeout_ms,
             pending: Mutex::new(HashMap::new()),
@@ -625,9 +634,11 @@ impl NotifyController {
             }
             let canonical_skill_dir = self.inner.canonical_root.join(skill_id);
             let canonical_skill_dir = canonical_skill_dir.to_string_lossy().to_string();
+            let protocol_skill_dir = self.inner.protocol_event_root.join(skill_id);
+            let protocol_skill_dir = protocol_skill_dir.to_string_lossy().to_string();
 
             let protocol_event = ProtocolEvent::new(
-                &canonical_skill_dir,
+                &protocol_skill_dir,
                 skill_id.as_str(),
                 "reconcile",
                 Vec::new(),
@@ -750,6 +761,8 @@ impl NotifyInner {
     fn send_one(&self, state: NotifyPendingState) {
         let canonical_skill_dir = self.canonical_root.join(&state.skill_id);
         let canonical_skill_dir = canonical_skill_dir.to_string_lossy().to_string();
+        let protocol_skill_dir = self.protocol_event_root.join(&state.skill_id);
+        let protocol_skill_dir = protocol_skill_dir.to_string_lossy().to_string();
 
         // A3: snapshot activation freshness BEFORE sending the notify so
         // the poll baseline predates the daemon's activation write.
@@ -769,7 +782,7 @@ impl NotifyInner {
 
         // Write protocol event log regardless of notify outcome.
         let protocol_event = ProtocolEvent::new(
-            &canonical_skill_dir,
+            &protocol_skill_dir,
             &state.skill_id,
             state.event_kind.as_str(),
             paths.clone(),
@@ -826,7 +839,7 @@ impl NotifyInner {
 
             // A4: emit reload outcome as a protocol event.
             let reload_event = ProtocolEvent::with_reload_outcome(
-                &canonical_skill_dir,
+                &protocol_skill_dir,
                 &state.skill_id,
                 outcome.as_protocol_label(),
             );
@@ -1328,6 +1341,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client.clone(),
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1352,6 +1366,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1372,6 +1387,7 @@ mod tests {
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
+            "/srv/skills",
             "/srv/skills",
             Duration::from_millis(50),
             5000,
@@ -1395,6 +1411,7 @@ mod tests {
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
+            "/srv/skills",
             "/srv/skills",
             Duration::from_millis(50),
             5000,
@@ -1423,6 +1440,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1450,6 +1468,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1468,6 +1487,7 @@ mod tests {
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
+            "/srv/skills",
             "/srv/skills",
             Duration::from_millis(50),
             5000,
@@ -1494,6 +1514,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1519,6 +1540,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1541,6 +1563,7 @@ mod tests {
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
+            "/srv/skills",
             "/srv/skills",
             Duration::from_millis(50),
             5000,
@@ -1589,6 +1612,7 @@ mod tests {
         let client = Arc::new(InMemoryNotifyClient::new());
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
+            "/srv/skills",
             "/srv/skills",
             Duration::from_millis(50),
             5000,
@@ -1660,6 +1684,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client.clone(),
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1707,6 +1732,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client.clone(),
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1737,6 +1763,7 @@ mod tests {
         let ctrl = NotifyController::new_with_protocol_writer(
             client.clone(),
             "/srv/skills",
+            "/srv/skills",
             Duration::from_millis(50),
             5000,
             writer.clone(),
@@ -1765,6 +1792,7 @@ mod tests {
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let ctrl = NotifyController::new_with_protocol_writer(
             client,
+            "/srv/skills",
             "/srv/skills",
             Duration::from_millis(50),
             5000,
@@ -1805,6 +1833,7 @@ mod tests {
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let ctrl = NotifyController::new_with_protocol_writer(
             client.clone(),
+            "/home/user/skills",
             "/home/user/skills",
             Duration::from_millis(50),
             5000,
@@ -1943,6 +1972,7 @@ mod tests {
         let writer = Arc::new(InMemoryProtocolEventWriter::new());
         let ctrl = NotifyController::new_with_reload(
             client.clone(),
+            dir.path().to_path_buf(),
             dir.path().to_path_buf(),
             Duration::from_millis(50),
             5000,

--- a/src/skillfs/crates/skillfs-fuse/src/security/protocol_events.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/protocol_events.rs
@@ -4,7 +4,8 @@
 //! troubleshooting. Independent from the existing audit JSONL
 //! ([`super::audit`]) and security event stream ([`super::event_stream`]).
 //!
-//! Schema follows `SKILL_LEDGER_SKILLFS_ACTIVATION_CN.md` §SkillFS 事件日志需求:
+//! The Ledger boundary follows §6 of `SKILL_LEDGER_SKILLFS_INTEGRATION_zh.md`;
+//! N3 remains a SkillFS-local diagnostic protocol, not a Ledger identity source:
 //!
 //! ```json
 //! {

--- a/src/skillfs/crates/skillfs-fuse/src/security/resolver.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/resolver.rs
@@ -180,6 +180,18 @@ fn validate_canonical_syntax(raw: &str) -> Result<(), ResolveError> {
             format!("canonicalSkillDir '{raw}' is not an absolute path"),
         ));
     }
+    if raw.contains("//") {
+        return Err(ResolveError::new(
+            "invalid_canonical_path",
+            format!("canonicalSkillDir '{raw}' contains a repeated path separator"),
+        ));
+    }
+    if raw.len() > 1 && raw.ends_with('/') {
+        return Err(ResolveError::new(
+            "invalid_canonical_path",
+            format!("canonicalSkillDir '{raw}' contains a trailing path separator"),
+        ));
+    }
     for seg in raw.split('/') {
         if seg == "." || seg == ".." {
             return Err(ResolveError::new(
@@ -688,6 +700,20 @@ mod tests {
         let err =
             resolve_live_source(root.path(), root.path(), SkillLayout::Flat, &bad).unwrap_err();
         assert_eq!(err.code, "invalid_canonical_path");
+    }
+
+    #[test]
+    fn non_normalized_wire_path_is_error() {
+        let root = tempfile::tempdir().unwrap();
+        for raw in [
+            format!("{}//my-skill", root.path().display()),
+            format!("//{}/my-skill", root.path().display()),
+            format!("{}/my-skill/", root.path().display()),
+        ] {
+            let err =
+                resolve_live_source(root.path(), root.path(), SkillLayout::Flat, &raw).unwrap_err();
+            assert_eq!(err.code, "invalid_canonical_path", "{raw}");
+        }
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/security/resolver.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/resolver.rs
@@ -1,0 +1,778 @@
+//! Read-only live-source resolver for the control socket.
+//!
+//! Maps a caller-supplied canonical Skill directory to its physical
+//! live/backing source. This module owns path/layout parsing and response
+//! construction; the control socket owns authentication, JSON dispatch,
+//! and socket lifecycle.
+//!
+//! [`resolve_live_source`] is O(path depth): it opens the live Skill
+//! directory one component at a time with `O_NOFOLLOW` and never scans the
+//! whole Skill root. It has no side effects — no scan, manifest build,
+//! policy decision, or activation write. It enforces the same Flat / Hermes
+//! Skill boundaries as the FUSE layer, so it never reports a phantom Skill
+//! at the wrong directory depth.
+
+use std::ffi::{CStr, CString};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path};
+
+use crate::path::SkillLayout;
+
+use super::trusted_writer::FileId;
+
+/// Reserved top-level skill name for the synthesized discovery view; it has
+/// no physical backing directory.
+const SKILL_DISCOVER_NAME: &str = "skill-discover";
+
+/// A structured resolver error. The `code` reuses the control-protocol
+/// error-code vocabulary; the control socket maps it 1:1 onto an error
+/// response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolveError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ResolveError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// RAII guard that closes a raw fd on drop.
+struct FdGuard(libc::c_int);
+
+impl Drop for FdGuard {
+    fn drop(&mut self) {
+        if self.0 >= 0 {
+            unsafe { libc::close(self.0) };
+        }
+    }
+}
+
+/// Resolve a canonical Skill directory to its live/backing source.
+///
+/// Returns the JSON `result` object on success — either `managed = true`
+/// with the full mapping and the live directory's `(device, inode)`
+/// identity, or `managed = false` when the valid path is outside the
+/// managed root — or a structured [`ResolveError`].
+///
+/// * `canonical_root` — the user-visible root incoming paths are contained
+///   against and the relative skill id is derived from.
+/// * `live_root` — the physical backing root the live Skill directory is
+///   opened under (must be an absolute path).
+/// * `layout` — the mount's Skill layout, used to enforce Skill boundaries.
+/// * `canonical_skill_dir` — the caller-supplied canonical path.
+pub fn resolve_live_source(
+    canonical_root: &Path,
+    live_root: &Path,
+    layout: SkillLayout,
+    canonical_skill_dir: &str,
+) -> Result<serde_json::Value, ResolveError> {
+    // 1. Raw-string lexical validation, BEFORE constructing a `Path` or
+    //    doing containment. `Path::components()` normalizes embedded `.`
+    //    segments and a NUL byte would only surface at CString time, so an
+    //    illegal request must be rejected here rather than silently
+    //    becoming a `managed = false` fallback.
+    validate_canonical_syntax(canonical_skill_dir)?;
+
+    let requested = Path::new(canonical_skill_dir);
+
+    // 2. Lexical containment against the canonical root. The user path is
+    //    never canonicalized; containment is purely component-wise so the
+    //    query never crosses the canonical / FUSE / live boundary. A valid
+    //    path outside the root is a normal `managed = false`.
+    let relative = match requested.strip_prefix(canonical_root) {
+        Ok(rel) => rel,
+        Err(_) => {
+            return Ok(serde_json::json!({
+                "managed": false,
+                "canonicalSkillDir": canonical_skill_dir,
+                "reason": "not_managed",
+            }));
+        }
+    };
+
+    // 3. Derive the relative skill-id components. Every remaining component
+    //    is `Normal` (the syntax check rejected `.`/`..`).
+    let mut components: Vec<&str> = Vec::new();
+    for comp in relative.components() {
+        match comp {
+            Component::Normal(name) => match name.to_str() {
+                Some(s) => components.push(s),
+                None => {
+                    return Err(ResolveError::new(
+                        "invalid_canonical_path",
+                        "canonicalSkillDir contains a non-UTF-8 path component",
+                    ));
+                }
+            },
+            _ => {
+                return Err(ResolveError::new(
+                    "invalid_canonical_path",
+                    "canonicalSkillDir contains an unexpected relative component",
+                ));
+            }
+        }
+    }
+    if components.is_empty() {
+        return Err(ResolveError::new(
+            "invalid_skill_layout",
+            "canonicalSkillDir is the canonical root, not a Skill directory",
+        ));
+    }
+
+    // 4. Reject management / reserved directories. Skill directories and
+    //    Hermes categories are never dot-prefixed, so any dot-prefixed
+    //    component (`.skill-meta`, `.hub`, `.staging`, `.openclaw-*`, …) is
+    //    a managed/reserved location. The synthesized `skill-discover` view
+    //    has no physical backing.
+    for name in &components {
+        if name.starts_with('.') {
+            return Err(ResolveError::new(
+                "invalid_canonical_path",
+                format!("canonicalSkillDir component '{name}' is a managed/reserved directory"),
+            ));
+        }
+    }
+    if components[0] == SKILL_DISCOVER_NAME {
+        return Err(ResolveError::new(
+            "invalid_canonical_path",
+            "canonicalSkillDir refers to the synthesized skill-discover view",
+        ));
+    }
+
+    // 5. Enforce the layout boundary and safely resolve the live directory.
+    let (_leaf, identity) = resolve_leaf(live_root, layout, &components)?;
+
+    let relative_skill_dir = components.join("/");
+    let live_skill_dir = live_root.join(&relative_skill_dir);
+
+    Ok(serde_json::json!({
+        "managed": true,
+        "canonicalSkillDir": canonical_skill_dir,
+        "skillId": relative_skill_dir,
+        "relativeSkillDir": relative_skill_dir,
+        "liveSkillDir": live_skill_dir.to_string_lossy(),
+        "identity": {
+            "device": identity.dev,
+            "inode": identity.ino,
+        },
+        "transport": "shared_path",
+    }))
+}
+
+/// Reject illegal canonical paths on the raw string, before any `Path`
+/// construction or containment check.
+fn validate_canonical_syntax(raw: &str) -> Result<(), ResolveError> {
+    if raw.as_bytes().contains(&0) {
+        return Err(ResolveError::new(
+            "invalid_canonical_path",
+            "canonicalSkillDir contains a NUL byte",
+        ));
+    }
+    if !raw.starts_with('/') {
+        return Err(ResolveError::new(
+            "invalid_canonical_path",
+            format!("canonicalSkillDir '{raw}' is not an absolute path"),
+        ));
+    }
+    for seg in raw.split('/') {
+        if seg == "." || seg == ".." {
+            return Err(ResolveError::new(
+                "invalid_canonical_path",
+                format!("canonicalSkillDir '{raw}' contains a '{seg}' segment"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Enforce the layout Skill boundary and resolve the leaf directory,
+/// descending one component at a time with `O_NOFOLLOW`.
+///
+/// Boundaries mirror the FUSE layer and the Hermes id enumeration:
+///
+/// * Flat — a Skill is exactly one directory level (`<root>/<skill>`); a
+///   deeper path is a subdirectory, not a Skill.
+/// * Hermes — a Skill is a top-level directory (`<root>/<skill>`) or a
+///   `<root>/<category>/<skill>` leaf whose category is not itself a
+///   top-level skill (has no own `SKILL.md`); anything deeper, or a
+///   subdirectory of a top-level skill, is not a Skill.
+fn resolve_leaf(
+    live_root: &Path,
+    layout: SkillLayout,
+    components: &[&str],
+) -> Result<(FdGuard, FileId), ResolveError> {
+    match layout {
+        SkillLayout::Flat => {
+            if components.len() != 1 {
+                return Err(ResolveError::new(
+                    "invalid_skill_layout",
+                    "flat layout Skills occupy a single directory level",
+                ));
+            }
+        }
+        SkillLayout::Hermes => {
+            if components.len() > 2 {
+                return Err(ResolveError::new(
+                    "invalid_skill_layout",
+                    "hermes layout Skills occupy at most two directory levels",
+                ));
+            }
+        }
+    }
+
+    // The live root is trusted; open it without O_NOFOLLOW.
+    let mut current = open_live_root(live_root)?;
+
+    for (idx, name) in components.iter().enumerate() {
+        let dir = openat_dir_nofollow(&current, name)?;
+
+        // Hermes two-level path: the first component must be a category,
+        // i.e. must NOT be a top-level skill. If it carries its own
+        // SKILL.md the deeper path is a subdirectory of a top-level skill,
+        // not a nested Skill. `?` fails closed on an inconclusive stat so a
+        // permission error never masquerades as "no SKILL.md → category".
+        if layout == SkillLayout::Hermes
+            && components.len() == 2
+            && idx == 0
+            && dir_has_skill_md(&dir)?
+        {
+            return Err(ResolveError::new(
+                "invalid_skill_layout",
+                format!(
+                    "'{name}' is a top-level skill, not a category; '{}' is a \
+                     subdirectory, not a nested Skill",
+                    components[1]
+                ),
+            ));
+        }
+
+        current = dir;
+    }
+
+    verify_skill_md(&current)?;
+    let identity = fstat_identity(&current)?;
+    Ok((current, identity))
+}
+
+/// Open the (trusted) live root directory.
+fn open_live_root(live_root: &Path) -> Result<FdGuard, ResolveError> {
+    let c_root = CString::new(live_root.as_os_str().as_bytes())
+        .map_err(|_| ResolveError::new("live_source_unavailable", "live root path contains NUL"))?;
+    let fd = unsafe {
+        libc::open(
+            c_root.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        let e = std::io::Error::last_os_error();
+        return Err(ResolveError::new(
+            "live_source_unavailable",
+            format!("failed to open live root: {e}"),
+        ));
+    }
+    Ok(FdGuard(fd))
+}
+
+/// Open a child directory under `parent` with `O_NOFOLLOW | O_DIRECTORY`,
+/// classifying failures into structured errors.
+fn openat_dir_nofollow(parent: &FdGuard, name: &str) -> Result<FdGuard, ResolveError> {
+    let c_name = CString::new(name.as_bytes()).map_err(|_| {
+        ResolveError::new(
+            "invalid_canonical_path",
+            "skill path component contains NUL",
+        )
+    })?;
+    let fd = unsafe {
+        libc::openat(
+            parent.0,
+            c_name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        let e = std::io::Error::last_os_error();
+        let errno = e.raw_os_error().unwrap_or(0);
+        if errno == libc::ELOOP {
+            return Err(ResolveError::new(
+                "invalid_canonical_path",
+                format!("skill path component '{name}' is a symlink; refusing to follow"),
+            ));
+        }
+        if errno == libc::ENOENT {
+            return Err(ResolveError::new(
+                "skill_not_found",
+                format!("skill path component '{name}' does not exist under the managed root"),
+            ));
+        }
+        if errno == libc::ENOTDIR {
+            if entry_is_symlink(parent, &c_name) {
+                return Err(ResolveError::new(
+                    "invalid_canonical_path",
+                    format!("skill path component '{name}' is a symlink; refusing to follow"),
+                ));
+            }
+            return Err(ResolveError::new(
+                "invalid_skill_layout",
+                format!("skill path component '{name}' is not a directory"),
+            ));
+        }
+        return Err(ResolveError::new(
+            "live_source_unavailable",
+            format!("failed to open skill path component '{name}': {e}"),
+        ));
+    }
+    Ok(FdGuard(fd))
+}
+
+/// Return `true` when the entry named `c_name` under `dir` is a symlink,
+/// probed with `AT_SYMLINK_NOFOLLOW`.
+fn entry_is_symlink(dir: &FdGuard, c_name: &CStr) -> bool {
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::fstatat(dir.0, c_name.as_ptr(), &mut st, libc::AT_SYMLINK_NOFOLLOW) };
+    rc == 0 && (st.st_mode & libc::S_IFMT) == libc::S_IFLNK
+}
+
+/// Classify the `SKILL.md` marker in `dir` using the same "no-follow
+/// regular file" rule as [`skillfs_core::store::has_regular_skill_md`], so
+/// the resolver never disagrees with store discovery, the FUSE layer, or
+/// Hermes activation enumeration about what a Skill is:
+///
+/// * `Ok(true)` — a regular-file `SKILL.md` is present (a valid marker),
+///   even when it is unreadable (mode `000`).
+/// * `Ok(false)` — no valid marker: the entry is absent (`ENOENT`/`ENOTDIR`)
+///   **or** exists but is not a regular file (a symlink — never followed —,
+///   directory, FIFO, …). A non-regular `SKILL.md` is treated as absent, so
+///   a symlinked top-level marker makes the directory a category (its real
+///   nested Skills still resolve) exactly as store discovery treats it.
+/// * `Err(live_source_unavailable)` — the entry cannot be classified (e.g.
+///   an I/O or permission error while stat-ing). Only a genuinely
+///   inconclusive result fails closed.
+///
+/// Existence and type are decided with `fstatat(AT_SYMLINK_NOFOLLOW)` on the
+/// already-opened directory fd rather than a path-based `symlink_metadata`,
+/// which keeps the resolver's symlink-escape-safe fd descent while yielding
+/// the identical marker classification.
+fn dir_has_skill_md(dir: &FdGuard) -> Result<bool, ResolveError> {
+    let c_name = CString::new("SKILL.md")
+        .map_err(|_| ResolveError::new("live_source_unavailable", "SKILL.md name contains NUL"))?;
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::fstatat(dir.0, c_name.as_ptr(), &mut st, libc::AT_SYMLINK_NOFOLLOW) };
+    if rc == 0 {
+        // Present: a valid marker only when it is a regular file. A symlink
+        // (never followed), directory, or other object is not a marker and
+        // is treated as absent — matching store/FUSE discovery.
+        return Ok((st.st_mode & libc::S_IFMT) == libc::S_IFREG);
+    }
+    let e = std::io::Error::last_os_error();
+    match e.raw_os_error() {
+        // Definitively absent.
+        Some(libc::ENOENT) | Some(libc::ENOTDIR) => Ok(false),
+        // Anything else (EACCES, EIO, …) is inconclusive — fail closed
+        // rather than assume the marker is absent.
+        _ => Err(ResolveError::new(
+            "live_source_unavailable",
+            format!("cannot determine SKILL.md presence: {e}"),
+        )),
+    }
+}
+
+/// Verify that `dir` contains a regular-file `SKILL.md`, failing closed on
+/// an inconclusive stat.
+fn verify_skill_md(dir: &FdGuard) -> Result<(), ResolveError> {
+    if dir_has_skill_md(dir)? {
+        Ok(())
+    } else {
+        Err(ResolveError::new(
+            "invalid_skill_layout",
+            "skill directory is missing a regular SKILL.md",
+        ))
+    }
+}
+
+/// Read the `(dev, ino)` identity of an open directory fd via `fstat`.
+fn fstat_identity(dir: &FdGuard) -> Result<FileId, ResolveError> {
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::fstat(dir.0, &mut st) };
+    if rc != 0 {
+        let e = std::io::Error::last_os_error();
+        return Err(ResolveError::new(
+            "live_source_unavailable",
+            format!("failed to stat live skill directory: {e}"),
+        ));
+    }
+    Ok(FileId {
+        dev: st.st_dev,
+        ino: st.st_ino,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn seed_skill(root: &Path, rel: &str) {
+        let dir = root.join(rel);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: x\ndescription: y\n---\nbody\n",
+        )
+        .unwrap();
+    }
+
+    fn dir_identity(path: &Path) -> (u64, u64) {
+        use std::os::unix::fs::MetadataExt;
+        let m = std::fs::metadata(path).unwrap();
+        (m.dev(), m.ino())
+    }
+
+    fn resolve(
+        root: &Path,
+        layout: SkillLayout,
+        canonical: &Path,
+    ) -> Result<serde_json::Value, ResolveError> {
+        resolve_live_source(root, root, layout, canonical.to_str().unwrap())
+    }
+
+    // ── managed = true ───────────────────────────────────────────────────
+
+    #[test]
+    fn flat_skill_managed_true_with_identity() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "my-skill");
+        let canonical = root.path().join("my-skill");
+        let r = resolve(root.path(), SkillLayout::Flat, &canonical).unwrap();
+        assert_eq!(r["managed"], true);
+        assert_eq!(r["skillId"], "my-skill");
+        assert_eq!(r["relativeSkillDir"], "my-skill");
+        assert_eq!(r["transport"], "shared_path");
+        assert_eq!(r["liveSkillDir"], canonical.to_string_lossy().as_ref());
+        let (dev, ino) = dir_identity(&canonical);
+        assert_eq!(r["identity"]["device"], dev);
+        assert_eq!(r["identity"]["inode"], ino);
+    }
+
+    #[test]
+    fn hermes_nested_skill_managed_true() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "apple/apple-notes");
+        let canonical = root.path().join("apple/apple-notes");
+        let r = resolve(root.path(), SkillLayout::Hermes, &canonical).unwrap();
+        assert_eq!(r["managed"], true);
+        assert_eq!(r["skillId"], "apple/apple-notes");
+        assert_eq!(r["relativeSkillDir"], "apple/apple-notes");
+    }
+
+    #[test]
+    fn hermes_mixed_top_level_and_nested() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "weather");
+        seed_skill(root.path(), "apple/apple-notes");
+
+        let top = resolve(
+            root.path(),
+            SkillLayout::Hermes,
+            &root.path().join("weather"),
+        )
+        .unwrap();
+        assert_eq!(top["skillId"], "weather");
+
+        let nested = resolve(
+            root.path(),
+            SkillLayout::Hermes,
+            &root.path().join("apple/apple-notes"),
+        )
+        .unwrap();
+        assert_eq!(nested["skillId"], "apple/apple-notes");
+
+        // The category itself has no SKILL.md → invalid layout.
+        let cat =
+            resolve(root.path(), SkillLayout::Hermes, &root.path().join("apple")).unwrap_err();
+        assert_eq!(cat.code, "invalid_skill_layout");
+    }
+
+    #[test]
+    fn identity_comes_from_live_root_not_canonical() {
+        let canonical_root = tempfile::tempdir().unwrap();
+        let live_root = tempfile::tempdir().unwrap();
+        seed_skill(canonical_root.path(), "my-skill");
+        seed_skill(live_root.path(), "my-skill");
+
+        let r = resolve_live_source(
+            canonical_root.path(),
+            live_root.path(),
+            SkillLayout::Flat,
+            canonical_root.path().join("my-skill").to_str().unwrap(),
+        )
+        .unwrap();
+        let (live_dev, live_ino) = dir_identity(&live_root.path().join("my-skill"));
+        let (canon_dev, canon_ino) = dir_identity(&canonical_root.path().join("my-skill"));
+        assert_eq!(r["identity"]["device"], live_dev);
+        assert_eq!(r["identity"]["inode"], live_ino);
+        assert_ne!((canon_dev, canon_ino), (live_dev, live_ino));
+    }
+
+    // ── layout boundaries (regression: no phantom skills) ────────────────
+
+    #[test]
+    fn flat_rejects_subdirectory_even_with_skill_md() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "skill");
+        seed_skill(root.path(), "skill/subdir");
+        // Flat: a subdirectory is never a Skill, even with its own SKILL.md.
+        let err = resolve(
+            root.path(),
+            SkillLayout::Flat,
+            &root.path().join("skill/subdir"),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, "invalid_skill_layout");
+        // The top-level skill still resolves.
+        let ok = resolve(root.path(), SkillLayout::Flat, &root.path().join("skill")).unwrap();
+        assert_eq!(ok["skillId"], "skill");
+    }
+
+    #[test]
+    fn hermes_rejects_subdir_of_top_level_skill() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "top");
+        seed_skill(root.path(), "top/sub");
+        // `top` is a top-level skill (has SKILL.md), so `top/sub` is a
+        // subdirectory, not a nested Skill.
+        let err = resolve(
+            root.path(),
+            SkillLayout::Hermes,
+            &root.path().join("top/sub"),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, "invalid_skill_layout");
+    }
+
+    #[test]
+    fn hermes_rejects_third_level() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "a/b/c");
+        let err =
+            resolve(root.path(), SkillLayout::Hermes, &root.path().join("a/b/c")).unwrap_err();
+        assert_eq!(err.code, "invalid_skill_layout");
+    }
+
+    #[test]
+    fn hermes_unreadable_top_level_skill_md_is_not_a_phantom_category() {
+        // Regression: `top` is a top-level skill whose SKILL.md is mode 000.
+        // The category check must still see the SKILL.md (via fstatat) and
+        // reject `top/child` as a subdirectory, not a nested Skill — a
+        // permission error must never be swallowed as "no SKILL.md".
+        use std::os::unix::fs::PermissionsExt;
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "top");
+        seed_skill(root.path(), "top/child");
+        let top_md = root.path().join("top/SKILL.md");
+        std::fs::set_permissions(&top_md, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let err = resolve(
+            root.path(),
+            SkillLayout::Hermes,
+            &root.path().join("top/child"),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.code, "invalid_skill_layout",
+            "unreadable top-level SKILL.md must still block a phantom nested skill"
+        );
+
+        // Restore perms so the tempdir can be cleaned up.
+        std::fs::set_permissions(&top_md, std::fs::Permissions::from_mode(0o644)).unwrap();
+    }
+
+    #[test]
+    fn hermes_symlinked_top_level_skill_md_makes_it_a_category() {
+        // `top` has a SKILL.md that is a *symlink*, not a regular file. Under
+        // the shared no-follow regular-file rule this is not a valid marker,
+        // so `top` is a category — exactly as store discovery treats it —
+        // and its real nested skill `top/child` resolves (it is NOT a
+        // phantom). Querying `top` itself is invalid: no regular marker.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("top")).unwrap();
+        let real_md = root.path().join("real-skill.md");
+        std::fs::write(&real_md, "---\nname: x\ndescription: y\n---\n").unwrap();
+        std::os::unix::fs::symlink(&real_md, root.path().join("top/SKILL.md")).unwrap();
+        seed_skill(root.path(), "top/child");
+
+        let ok = resolve(
+            root.path(),
+            SkillLayout::Hermes,
+            &root.path().join("top/child"),
+        )
+        .unwrap();
+        assert_eq!(ok["managed"], true);
+        assert_eq!(ok["skillId"], "top/child");
+
+        let err = resolve(root.path(), SkillLayout::Hermes, &root.path().join("top")).unwrap_err();
+        assert_eq!(
+            err.code, "invalid_skill_layout",
+            "a directory whose only SKILL.md is a symlink has no valid marker"
+        );
+    }
+
+    #[test]
+    fn leaf_skill_md_symlink_is_error_and_not_followed() {
+        // A leaf SKILL.md that is a symlink is not a valid marker (no-follow
+        // regular-file rule), so the leaf has no marker and resolution fails
+        // with invalid_skill_layout — the symlink is never followed.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("skill")).unwrap();
+        let real_md = root.path().join("real.md");
+        std::fs::write(&real_md, "---\nname: x\ndescription: y\n---\n").unwrap();
+        std::os::unix::fs::symlink(&real_md, root.path().join("skill/SKILL.md")).unwrap();
+
+        let err = resolve(root.path(), SkillLayout::Flat, &root.path().join("skill")).unwrap_err();
+        assert_eq!(err.code, "invalid_skill_layout");
+        assert!(err.message.contains("regular SKILL.md"));
+    }
+
+    #[test]
+    fn skill_md_directory_is_error() {
+        // A SKILL.md that is a directory (or any non-regular object) is not
+        // a valid marker.
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("skill/SKILL.md")).unwrap();
+        let err = resolve(root.path(), SkillLayout::Flat, &root.path().join("skill")).unwrap_err();
+        assert_eq!(err.code, "invalid_skill_layout");
+    }
+
+    // ── managed = false ──────────────────────────────────────────────────
+
+    #[test]
+    fn outside_managed_root_is_not_managed() {
+        let root = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let r = resolve(root.path(), SkillLayout::Flat, &other.path().join("x")).unwrap();
+        assert_eq!(r["managed"], false);
+        assert_eq!(r["reason"], "not_managed");
+    }
+
+    // ── structured errors ────────────────────────────────────────────────
+
+    #[test]
+    fn relative_path_is_error() {
+        let root = tempfile::tempdir().unwrap();
+        let err = resolve_live_source(root.path(), root.path(), SkillLayout::Flat, "relative/path")
+            .unwrap_err();
+        assert_eq!(err.code, "invalid_canonical_path");
+    }
+
+    #[test]
+    fn parent_dir_segment_is_error() {
+        let root = tempfile::tempdir().unwrap();
+        let bad = format!("{}/../escape", root.path().display());
+        let err =
+            resolve_live_source(root.path(), root.path(), SkillLayout::Flat, &bad).unwrap_err();
+        assert_eq!(err.code, "invalid_canonical_path");
+    }
+
+    #[test]
+    fn embedded_current_dir_segment_is_error() {
+        // Regression: Path::components() would normalize `/root/./skill`, so
+        // the raw-string check must reject the `.` segment.
+        let root = tempfile::tempdir().unwrap();
+        let bad = format!("{}/./my-skill", root.path().display());
+        let err =
+            resolve_live_source(root.path(), root.path(), SkillLayout::Flat, &bad).unwrap_err();
+        assert_eq!(err.code, "invalid_canonical_path");
+    }
+
+    #[test]
+    fn nul_byte_is_error_not_not_managed() {
+        // A NUL-containing string outside the root must be a structured
+        // error, never a `managed = false` fallback.
+        let root = tempfile::tempdir().unwrap();
+        let err = resolve_live_source(root.path(), root.path(), SkillLayout::Flat, "/outside/\0/x")
+            .unwrap_err();
+        assert_eq!(err.code, "invalid_canonical_path");
+        assert!(err.message.contains("NUL"));
+    }
+
+    #[test]
+    fn symlink_escape_is_error() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        seed_skill(outside.path(), "target");
+        std::os::unix::fs::symlink(outside.path().join("target"), root.path().join("linkskill"))
+            .unwrap();
+        let err = resolve(
+            root.path(),
+            SkillLayout::Flat,
+            &root.path().join("linkskill"),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, "invalid_canonical_path");
+    }
+
+    #[test]
+    fn missing_skill_inside_root_is_error() {
+        let root = tempfile::tempdir().unwrap();
+        let err = resolve(root.path(), SkillLayout::Flat, &root.path().join("ghost")).unwrap_err();
+        assert_eq!(err.code, "skill_not_found");
+    }
+
+    #[test]
+    fn missing_skill_md_is_error() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("nomd")).unwrap();
+        let err = resolve(root.path(), SkillLayout::Flat, &root.path().join("nomd")).unwrap_err();
+        assert_eq!(err.code, "invalid_skill_layout");
+    }
+
+    #[test]
+    fn reserved_directories_are_error() {
+        let root = tempfile::tempdir().unwrap();
+        for reserved in [".skill-meta", ".staging", ".certified", ".hub"] {
+            let err =
+                resolve(root.path(), SkillLayout::Flat, &root.path().join(reserved)).unwrap_err();
+            assert_eq!(err.code, "invalid_canonical_path", "{reserved}");
+        }
+    }
+
+    #[test]
+    fn skill_discover_is_reserved() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "skill-discover");
+        let err = resolve(
+            root.path(),
+            SkillLayout::Flat,
+            &root.path().join("skill-discover"),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, "invalid_canonical_path");
+    }
+
+    #[test]
+    fn canonical_root_itself_is_error() {
+        let root = tempfile::tempdir().unwrap();
+        let err = resolve(root.path(), SkillLayout::Flat, root.path()).unwrap_err();
+        assert_eq!(err.code, "invalid_skill_layout");
+    }
+
+    #[test]
+    fn resolve_has_no_side_effects() {
+        let root = tempfile::tempdir().unwrap();
+        seed_skill(root.path(), "my-skill");
+        let canonical = root.path().join("my-skill");
+        resolve(root.path(), SkillLayout::Flat, &canonical).unwrap();
+        assert!(!canonical.join(".skill-meta").exists());
+        let entries: Vec<String> = std::fs::read_dir(&canonical)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(entries, vec![PathBuf::from("SKILL.md").to_string_lossy()]);
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
@@ -16,6 +16,9 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(dead_code)]
 
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -49,6 +52,18 @@ impl ActivationMount {
         S: FnOnce(&Path),
         R: FnOnce(&Path) -> Option<Arc<ActiveSkillResolver>>,
     {
+        Self::new_with_layout(seed, resolver_builder, None)
+    }
+
+    fn new_with_layout<S, R>(
+        seed: S,
+        resolver_builder: R,
+        skill_layout: Option<skillfs_fuse::SkillLayout>,
+    ) -> Self
+    where
+        S: FnOnce(&Path),
+        R: FnOnce(&Path) -> Option<Arc<ActiveSkillResolver>>,
+    {
         let source = tempfile::tempdir().expect("source tempdir");
         seed(source.path());
         let resolver = resolver_builder(source.path());
@@ -66,6 +81,7 @@ impl ActivationMount {
             false,
             MountConfig {
                 active_resolver: resolver,
+                skill_layout,
                 ..MountConfig::default()
             },
         )
@@ -129,6 +145,25 @@ fn write_snapshot(source: &Path, skill: &str, version: &str, skill_md: &str) -> 
     std::fs::create_dir_all(&dir).expect("create snapshot dir");
     std::fs::write(dir.join("SKILL.md"), skill_md).expect("write snapshot SKILL.md");
     dir
+}
+
+fn set_mode(path: &Path, mode: u32) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .expect("set fixture permissions");
+}
+
+fn access_errno(path: &Path, mask: i32) -> Option<i32> {
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains no NUL");
+    let result = unsafe { libc::access(c_path.as_ptr(), mask) };
+    if result == 0 {
+        None
+    } else {
+        Some(
+            std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or(libc::EIO),
+        )
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -217,6 +252,125 @@ fn valid_snapshot_activation_reads_snapshot_skill_md() {
 
     assert!(mount.skill_dir("demo-weather").exists());
     assert!(mount.skill_md("demo-weather").exists());
+}
+
+#[test]
+fn snapshot_access_uses_visible_flat_permissions() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let mount = ActivationMount::new(
+        |src| {
+            create_skill_dir(src, "access-check");
+            let live = src.join("access-check");
+            std::fs::write(live.join("tool.sh"), "UNTRUSTED-LIVE\n").unwrap();
+            std::fs::write(live.join("payload.txt"), "UNTRUSTED-LIVE\n").unwrap();
+            set_mode(&live.join("SKILL.md"), 0o700);
+            set_mode(&live.join("tool.sh"), 0o700);
+            set_mode(&live.join("payload.txt"), 0o200);
+
+            let snapshot = write_snapshot(
+                src,
+                "access-check",
+                "v000001.snapshot",
+                "---\nname: access-check\ndescription: snapshot\n---\n",
+            );
+            std::fs::write(snapshot.join("tool.sh"), "TRUSTED-SNAPSHOT\n").unwrap();
+            std::fs::write(snapshot.join("payload.txt"), "TRUSTED-SNAPSHOT\n").unwrap();
+            std::fs::write(snapshot.join("snapshot-only.txt"), "SNAPSHOT-ONLY\n").unwrap();
+            set_mode(&snapshot.join("SKILL.md"), 0o600);
+            set_mode(&snapshot.join("tool.sh"), 0o600);
+            set_mode(&snapshot.join("payload.txt"), 0o400);
+            set_mode(&snapshot.join("snapshot-only.txt"), 0o400);
+            write_activation(
+                src,
+                "access-check",
+                r#"{"schemaVersion": 1, "target": ".skill-meta/versions/v000001.snapshot"}"#,
+            );
+        },
+        |src_root| {
+            let resolver = ActiveSkillResolver::new(src_root);
+            bootstrap_activation(src_root, &["access-check".to_string()], &resolver);
+            Some(Arc::new(resolver))
+        },
+    );
+
+    let skill = mount.skill_dir("access-check");
+    let skill_md = skill.join("SKILL.md");
+    let tool = skill.join("tool.sh");
+    let payload = skill.join("payload.txt");
+    let snapshot_only = skill.join("snapshot-only.txt");
+
+    assert_eq!(
+        std::fs::metadata(&tool).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+    assert_eq!(
+        std::fs::read_to_string(&payload).unwrap(),
+        "TRUSTED-SNAPSHOT\n"
+    );
+    assert_eq!(access_errno(&skill_md, libc::X_OK), Some(libc::EACCES));
+    assert_eq!(access_errno(&tool, libc::X_OK), Some(libc::EACCES));
+    assert_eq!(access_errno(&payload, libc::R_OK), None);
+    assert_eq!(access_errno(&payload, libc::W_OK), None);
+    assert_eq!(access_errno(&payload, libc::R_OK | libc::W_OK), None);
+    assert_eq!(access_errno(&snapshot_only, libc::F_OK), None);
+}
+
+#[test]
+fn snapshot_access_uses_visible_hermes_permissions() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let mount = ActivationMount::new_with_layout(
+        |src| {
+            let live = src.join("category/nested");
+            std::fs::create_dir_all(&live).unwrap();
+            std::fs::write(
+                live.join("SKILL.md"),
+                "---\nname: nested\ndescription: live\n---\n",
+            )
+            .unwrap();
+            std::fs::write(live.join("tool.sh"), "UNTRUSTED-LIVE\n").unwrap();
+            set_mode(&live.join("tool.sh"), 0o700);
+
+            let snapshot = write_snapshot(
+                src,
+                "category/nested",
+                "v000001.snapshot",
+                "---\nname: nested\ndescription: snapshot\n---\n",
+            );
+            std::fs::write(snapshot.join("tool.sh"), "TRUSTED-SNAPSHOT\n").unwrap();
+            set_mode(&snapshot.join("tool.sh"), 0o600);
+            write_activation(
+                src,
+                "category/nested",
+                r#"{"schemaVersion": 1, "target": ".skill-meta/versions/v000001.snapshot"}"#,
+            );
+        },
+        |src_root| {
+            let resolver = ActiveSkillResolver::new(src_root);
+            let ids = enumerate_hermes_skill_ids(src_root);
+            bootstrap_activation(src_root, &ids, &resolver);
+            Some(Arc::new(resolver))
+        },
+        Some(skillfs_fuse::SkillLayout::Hermes),
+    );
+
+    let tool = mount.skill_dir("category/nested").join("tool.sh");
+    assert_eq!(
+        std::fs::read_to_string(&tool).unwrap(),
+        "TRUSTED-SNAPSHOT\n"
+    );
+    assert_eq!(
+        std::fs::metadata(&tool).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+    assert_eq!(access_errno(&tool, libc::X_OK), Some(libc::EACCES));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
@@ -166,6 +166,13 @@ fn access_errno(path: &Path, mask: i32) -> Option<i32> {
     }
 }
 
+fn assert_errno<T>(result: std::io::Result<T>, expected: i32) {
+    match result {
+        Ok(_) => panic!("operation unexpectedly succeeded"),
+        Err(error) => assert_eq!(error.raw_os_error(), Some(expected)),
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests: target=null -> hidden
 // ─────────────────────────────────────────────────────────────────────────────
@@ -614,6 +621,107 @@ fn hermes_symlinked_top_marker_is_category_nested_child_visible() {
         content.contains("SNAPSHOT BODY"),
         "activated nested skill must serve its snapshot via id top/child, got {content:?}"
     );
+}
+
+#[test]
+fn hermes_symlinked_boundaries_are_hidden_and_cannot_escape() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let top_target = outside.path().join("top-target");
+    let nested_target = outside.path().join("nested-target");
+    std::fs::create_dir_all(&top_target).unwrap();
+    std::fs::create_dir_all(&nested_target).unwrap();
+    std::fs::write(
+        top_target.join("SKILL.md"),
+        "---\nname: escaped-top\ndescription: outside\n---\n",
+    )
+    .unwrap();
+    std::fs::write(top_target.join("secret.txt"), "TOP-SECRET\n").unwrap();
+    std::fs::write(
+        nested_target.join("SKILL.md"),
+        "---\nname: escaped-nested\ndescription: outside\n---\n",
+    )
+    .unwrap();
+    std::fs::write(nested_target.join("secret.txt"), "NESTED-SECRET\n").unwrap();
+
+    let mount = ActivationMount::new_with_layout(
+        |src| {
+            create_skill_dir(src, "top-skill");
+            std::fs::create_dir_all(src.join("safe/real")).unwrap();
+            std::fs::write(
+                src.join("safe/real/SKILL.md"),
+                "---\nname: real\ndescription: safe\n---\n",
+            )
+            .unwrap();
+            std::os::unix::fs::symlink(&top_target, src.join("evil-top")).unwrap();
+            std::os::unix::fs::symlink(&nested_target, src.join("safe/evil-nested")).unwrap();
+        },
+        |_| None,
+        Some(skillfs_fuse::SkillLayout::Hermes),
+    );
+
+    let skills = mount.skills_dir();
+    let root_listing = sorted_dir(&skills);
+    assert!(root_listing.contains(&"top-skill".to_string()));
+    assert!(root_listing.contains(&"safe".to_string()));
+    assert!(!root_listing.contains(&"evil-top".to_string()));
+
+    let category_listing = sorted_dir(&skills.join("safe"));
+    assert!(category_listing.contains(&"real".to_string()));
+    assert!(!category_listing.contains(&"evil-nested".to_string()));
+
+    let escaped_top = skills.join("evil-top");
+    let escaped_nested = skills.join("safe/evil-nested");
+    assert_errno(std::fs::symlink_metadata(&escaped_top), libc::ENOENT);
+    assert_errno(std::fs::symlink_metadata(&escaped_nested), libc::ENOENT);
+    assert_errno(
+        std::fs::read_to_string(escaped_top.join("secret.txt")),
+        libc::ENOENT,
+    );
+    assert_errno(
+        std::fs::read_to_string(escaped_nested.join("secret.txt")),
+        libc::ENOENT,
+    );
+    assert_errno(
+        std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(escaped_top.join("secret.txt")),
+        libc::ENOENT,
+    );
+    assert_errno(
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(escaped_nested.join("created.txt")),
+        libc::ENOENT,
+    );
+    assert_errno(
+        std::fs::remove_file(escaped_nested.join("secret.txt")),
+        libc::ENOENT,
+    );
+    assert_errno(
+        std::fs::rename(
+            escaped_top.join("secret.txt"),
+            skills.join("safe/moved.txt"),
+        ),
+        libc::ENOENT,
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(top_target.join("secret.txt")).unwrap(),
+        "TOP-SECRET\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(nested_target.join("secret.txt")).unwrap(),
+        "NESTED-SECRET\n"
+    );
+    assert!(!nested_target.join("created.txt").exists());
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
@@ -23,7 +23,8 @@ use std::time::Duration;
 use parking_lot::RwLock;
 use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
 use skillfs_fuse::security::{
-    ACTIVATION_XATTR, ActiveSkillResolver, ActiveTarget, bootstrap_activation, load_activation,
+    ACTIVATION_XATTR, ActiveSkillResolver, ActiveTarget, bootstrap_activation,
+    enumerate_hermes_skill_ids, load_activation,
 };
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
@@ -340,6 +341,184 @@ fn activation_mode_off_preserves_original_behavior() {
 
     let md = std::fs::read_to_string(mount.skill_md("alpha")).expect("read SKILL.md");
     assert!(!md.is_empty(), "SKILL.md should be readable");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hermes: a symlinked top-level SKILL.md is a category, not a top-level skill.
+//
+// Regression (marker-consistency across all layers): a directory whose only
+// SKILL.md is a symlink is not a Skill. `top` must be a category, and its real
+// nested child `top/child` (regular SKILL.md) must be classified with the
+// nested id "top/child" by enumeration/resolver AND stay reachable through
+// readdir with activation keyed on that id. Previously `hermes_is_top_level_skill`
+// followed the symlink, reclassified `top` as a flat skill "top" that had no
+// activation key, and fail-closed-hid the entire directory.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn hermes_symlinked_top_marker_is_category_nested_child_visible() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let source = tempfile::tempdir().expect("source tempdir");
+    let src = source.path();
+    std::fs::create_dir_all(src.join("top/child")).unwrap();
+    // `top`'s only SKILL.md is a symlink → not a valid marker.
+    let real = src.join("real-marker.md");
+    std::fs::write(&real, "---\nname: r\ndescription: d\n---\n").unwrap();
+    std::os::unix::fs::symlink(&real, src.join("top/SKILL.md")).unwrap();
+    // Nested child has a real regular SKILL.md, activated to a snapshot.
+    std::fs::write(
+        src.join("top/child/SKILL.md"),
+        "---\nname: child\ndescription: live\n---\nlive body\n",
+    )
+    .unwrap();
+    write_snapshot(
+        src,
+        "top/child",
+        "v000001.snapshot",
+        "---\nname: child\ndescription: snapshot\n---\nSNAPSHOT BODY\n",
+    );
+    write_activation(
+        src,
+        "top/child",
+        r#"{"schemaVersion": 1, "target": ".skill-meta/versions/v000001.snapshot"}"#,
+    );
+
+    // Every layer must agree on the id: enumeration yields "top/child",
+    // never "top".
+    let ids = enumerate_hermes_skill_ids(src);
+    assert!(
+        ids.contains(&"top/child".to_string()),
+        "enumeration must yield nested id top/child, got {ids:?}"
+    );
+    assert!(
+        !ids.iter().any(|i| i == "top"),
+        "symlink-marker top must NOT be a top-level skill id, got {ids:?}"
+    );
+
+    let resolver = ActiveSkillResolver::new(src);
+    bootstrap_activation(src, &ids, &resolver);
+
+    let mut store = SkillStore::new();
+    store.load_from_directory(src, &ParseConfig::default());
+    let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+
+    // Normal mode: mountpoint is separate from the source, so the resolver
+    // and readdir gating read the physical source directly (no over-mount
+    // recursion). Hermes exposes nested skills at /skills/<category>/<skill>.
+    let mountpoint = tempfile::tempdir().expect("mount tempdir");
+    let handle = mount_background_configured(
+        mountpoint.path(),
+        src,
+        shared,
+        MountOptions::default(),
+        false,
+        MountConfig {
+            skill_layout: Some(skillfs_fuse::SkillLayout::Hermes),
+            active_resolver: Some(Arc::new(resolver)),
+            ..MountConfig::default()
+        },
+    )
+    .expect("mount_background_configured");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let skills_root = mountpoint.path().join("skills");
+    // Capture first, then always unmount so the failure path never leaks the
+    // mount.
+    let root = sorted_dir(&skills_root);
+    let top_listing = std::fs::read_dir(skills_root.join("top")).map(|it| {
+        let mut v: Vec<String> = it
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        v.sort();
+        v
+    });
+    let child_md = std::fs::read_to_string(skills_root.join("top/child/SKILL.md"));
+
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(150));
+    let _ = std::process::Command::new("fusermount3")
+        .args(["-u", &mountpoint.path().to_string_lossy()])
+        .output();
+
+    assert!(
+        root.contains(&"top".to_string()),
+        "category `top` must be listed under /skills (not hidden), got {root:?}"
+    );
+    let top_listing = top_listing.expect("read_dir /skills/top");
+    assert!(
+        top_listing.contains(&"child".to_string()),
+        "activated nested skill `child` must be visible under category `top` via id \
+         top/child (not fail-closed-hidden as a phantom top-level skill), got {top_listing:?}"
+    );
+    let content = child_md.expect("/skills/top/child/SKILL.md must be readable");
+    assert!(
+        content.contains("SNAPSHOT BODY"),
+        "activated nested skill must serve its snapshot via id top/child, got {content:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flat: a symlinked Skill directory is not a managed Skill.
+//
+// Regression (cross-layer symlink consistency): `<root>/linked-skill ->
+// <outside>/real-skill`. The resolver descends with openat(O_NOFOLLOW) and
+// rejects the symlinked component, so store discovery must reject it too —
+// otherwise SkillFS would list/activate/read a Skill the resolver refuses to
+// resolve, and the ledger could misread that as "not managed" and direct-
+// fallback. The store-driven /skills view must not expose it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn flat_symlinked_skill_dir_not_exposed_as_managed_skill() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let real = outside.path().join("outside-skill");
+    std::fs::create_dir(&real).unwrap();
+    std::fs::write(
+        real.join("SKILL.md"),
+        "---\nname: outside\ndescription: d\n---\nbody\n",
+    )
+    .unwrap();
+    let real_for_seed = real.clone();
+
+    let mount = ActivationMount::new(
+        move |src| {
+            create_skill_dir(src, "genuine");
+            std::os::unix::fs::symlink(&real_for_seed, src.join("linked-skill")).unwrap();
+        },
+        // No resolver: exercises the pure store-driven /skills view.
+        |_src| None,
+    );
+
+    let listing = sorted_dir(&mount.skills_dir());
+    assert!(
+        listing.contains(&"genuine".to_string()),
+        "the real skill must be listed, got {listing:?}"
+    );
+    assert!(
+        !listing.contains(&"linked-skill".to_string()),
+        "a symlinked Skill directory must not be exposed under /skills (matches the \
+         resolver's O_NOFOLLOW rejection), got {listing:?}"
+    );
+    // Lookup / read of the symlinked skill must fail — it is not a managed
+    // Skill, consistent with the resolver refusing to resolve it.
+    let err = std::fs::metadata(mount.skill_md("linked-skill")).unwrap_err();
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ENOENT),
+        "symlinked Skill must not be resolvable as a managed skill"
+    );
+    // `outside` (the symlink target) outlives `mount`: locals drop in reverse
+    // declaration order, so `mount` is torn down before `outside` here.
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/skillfs/crates/skillfs-fuse/tests/activation_watcher_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/activation_watcher_tests.rs
@@ -290,6 +290,7 @@ fn startup_reconcile_then_daemon_writes_refreshes() {
     let notify_ctrl = NotifyController::new_with_reload(
         notify_client.clone(),
         dir.path().to_path_buf(),
+        dir.path().to_path_buf(),
         Duration::from_millis(50),
         5000,
         writer.clone(),
@@ -526,6 +527,7 @@ fn new_skill_notify_poll_timeout_then_late_activation_converges() {
     let notify_ctrl = NotifyController::new_with_reload(
         notify_client,
         dir.path().to_path_buf(),
+        dir.path().to_path_buf(),
         Duration::from_millis(50),
         5000,
         writer.clone(),
@@ -601,6 +603,7 @@ fn notify_send_failure_auto_registers_for_convergence() {
     let failing_client = Arc::new(FailingNotifyClient);
     let notify_ctrl = NotifyController::new_with_protocol_writer(
         failing_client,
+        dir.path().to_path_buf(),
         dir.path().to_path_buf(),
         Duration::from_millis(50),
         5000,

--- a/src/skillfs/crates/skillfs-fuse/tests/backing_root_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/backing_root_tests.rs
@@ -77,11 +77,10 @@ fn notify_v2_uses_canonical_root_with_backing_root() {
     let client = Arc::new(InMemoryNotifyClient::new());
     let writer = Arc::new(InMemoryProtocolEventWriter::new());
 
-    // The CLI passes the canonical root to notify while activation
-    // bootstrap/reload receive the distinct live root.
     let ctrl = NotifyController::new_with_protocol_writer(
         client.clone(),
         canonical_root.path().to_path_buf(),
+        live_root.path().to_path_buf(),
         Duration::from_millis(50),
         5000,
         writer.clone(),
@@ -122,7 +121,52 @@ fn notify_v2_uses_canonical_root_with_backing_root() {
         canonical_skill_dir,
         live_root.path().display()
     );
-    assert_eq!(writer.events()[0].skill_dir, *canonical_skill_dir);
+
+    let protocol_events = writer.events();
+    assert_eq!(protocol_events[0].schema_version, 1);
+    assert_eq!(protocol_events[0].skill_name, "alpha");
+    assert_eq!(
+        protocol_events[0].skill_dir,
+        live_root.path().join("alpha").to_string_lossy().to_string()
+    );
+    assert!(
+        !protocol_events[0]
+            .skill_dir
+            .starts_with(canonical_root.path().to_string_lossy().as_ref()),
+        "protocol event skillDir '{}' must not use canonical root '{}'",
+        protocol_events[0].skill_dir,
+        canonical_root.path().display()
+    );
+
+    let count = ctrl.emit_startup_reconcile(&["alpha".to_string()]);
+    assert_eq!(count, 1);
+
+    let notify_events = client.events();
+    let reconcile_notify = notify_events
+        .iter()
+        .find(|event| event.event_kind == "reconcile")
+        .expect("startup reconcile notify event");
+    assert_eq!(reconcile_notify.schema_version, 2);
+    assert_eq!(reconcile_notify.skill_id, "alpha");
+    assert_eq!(
+        reconcile_notify.canonical_skill_dir,
+        canonical_root
+            .path()
+            .join("alpha")
+            .to_string_lossy()
+            .to_string()
+    );
+
+    let protocol_events = writer.events();
+    let reconcile_protocol = protocol_events
+        .iter()
+        .find(|event| event.event_kind == "reconcile")
+        .expect("startup reconcile protocol event");
+    assert_eq!(reconcile_protocol.schema_version, 1);
+    assert_eq!(
+        reconcile_protocol.skill_dir,
+        live_root.path().join("alpha").to_string_lossy().to_string()
+    );
 }
 
 #[test]

--- a/src/skillfs/crates/skillfs-fuse/tests/backing_root_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/backing_root_tests.rs
@@ -1,7 +1,7 @@
 //! A6/B1: Ledger Backing Root integration tests.
 //!
-//! Verifies that daemon-facing operations use the backing root path:
-//! - Notify `skillDir` uses the daemon root, not the FUSE source path.
+//! Verifies canonical/live root separation with a backing root:
+//! - Notify v2 uses canonical paths, never the live backing root.
 //! - Activation bootstrap reads from the daemon root.
 //! - Activation reload reads from the daemon root.
 //! - In-place hidden skill is invisible through FUSE but the source
@@ -68,22 +68,20 @@ const SNAPSHOT_ACTIVATION: &str =
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn notify_skilldir_uses_daemon_root() {
-    // When a backing root is configured, the NotifyController should
-    // construct skillDir from the daemon root, not the FUSE source path.
-    let source = tempfile::tempdir().unwrap();
-    let daemon_root = tempfile::tempdir().unwrap();
-    make_skill(source.path(), "alpha");
-    make_skill(daemon_root.path(), "alpha"); // daemon root mirrors source
+fn notify_v2_uses_canonical_root_with_backing_root() {
+    let canonical_root = tempfile::tempdir().unwrap();
+    let live_root = tempfile::tempdir().unwrap();
+    make_skill(canonical_root.path(), "alpha");
+    make_skill(live_root.path(), "alpha");
 
     let client = Arc::new(InMemoryNotifyClient::new());
     let writer = Arc::new(InMemoryProtocolEventWriter::new());
 
-    // Simulate what the CLI does: pass daemon_root as the source_root
-    // to NotifyController.
+    // The CLI passes the canonical root to notify while activation
+    // bootstrap/reload receive the distinct live root.
     let ctrl = NotifyController::new_with_protocol_writer(
         client.clone(),
-        daemon_root.path().to_path_buf(),
+        canonical_root.path().to_path_buf(),
         Duration::from_millis(50),
         5000,
         writer.clone(),
@@ -107,19 +105,24 @@ fn notify_skilldir_uses_daemon_root() {
 
     let events = client.events();
     assert!(!events.is_empty(), "expected at least one notify event");
-    let skill_dir = &events[0].skill_dir;
-    assert!(
-        skill_dir.starts_with(daemon_root.path().to_string_lossy().as_ref()),
-        "skillDir '{}' should start with daemon root '{}'",
-        skill_dir,
-        daemon_root.path().display()
+    let canonical_skill_dir = &events[0].canonical_skill_dir;
+    assert_eq!(events[0].schema_version, 2);
+    assert_eq!(events[0].skill_id, "alpha");
+    assert_eq!(
+        canonical_skill_dir,
+        &canonical_root
+            .path()
+            .join("alpha")
+            .to_string_lossy()
+            .to_string()
     );
     assert!(
-        !skill_dir.starts_with(source.path().to_string_lossy().as_ref()),
-        "skillDir '{}' must NOT start with source path '{}'",
-        skill_dir,
-        source.path().display()
+        !canonical_skill_dir.starts_with(live_root.path().to_string_lossy().as_ref()),
+        "canonicalSkillDir '{}' must not expose live root '{}'",
+        canonical_skill_dir,
+        live_root.path().display()
     );
+    assert_eq!(writer.events()[0].skill_dir, *canonical_skill_dir);
 }
 
 #[test]
@@ -725,7 +728,7 @@ backing_root = "{}"
 }
 
 #[test]
-fn normal_mount_notify_uses_source_as_skilldir() {
+fn normal_mount_notify_uses_source_as_canonical_skill_dir() {
     let source = tempfile::tempdir().unwrap();
     make_skill(source.path(), "alpha");
 
@@ -744,8 +747,8 @@ fn normal_mount_notify_uses_source_as_skilldir() {
     assert_eq!(events.len(), 1);
     let expected_dir = source.path().join("alpha").to_string_lossy().to_string();
     assert_eq!(
-        events[0].skill_dir, expected_dir,
-        "normal mount (no backing root) must use source dir as skillDir"
+        events[0].canonical_skill_dir, expected_dir,
+        "normal mount must use source dir as canonicalSkillDir"
     );
     ctrl.shutdown();
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/hermes_layout_tests.rs
@@ -604,13 +604,13 @@ fn hermes_nested_write_triggers_notify() {
 
     let event = &events[0];
     assert_eq!(
-        event.skill_name, "apple/apple-notes",
-        "skillName must be category/skill"
+        event.skill_id, "apple/apple-notes",
+        "skillId must be category/skill"
     );
     assert!(
-        event.skill_dir.ends_with("/apple/apple-notes"),
-        "skillDir must end with /apple/apple-notes, got: {}",
-        event.skill_dir
+        event.canonical_skill_dir.ends_with("/apple/apple-notes"),
+        "canonicalSkillDir must end with /apple/apple-notes, got: {}",
+        event.canonical_skill_dir
     );
     assert!(
         event.paths.contains(&"SKILL.md".to_string()),
@@ -682,13 +682,15 @@ fn hermes_nested_file_rename_triggers_notify() {
     let events = notify_client.events();
     let rename_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "apple/apple-notes" && e.event_kind == "rename")
+        .filter(|e| e.skill_id == "apple/apple-notes" && e.event_kind == "rename")
         .collect();
-    assert!(
-        !rename_events.is_empty(),
-        "nested file rename must trigger notify for apple/apple-notes, got: {:?}",
-        events
+    assert_eq!(
+        rename_events.len(),
+        1,
+        "nested file rename must trigger one notify for apple/apple-notes: {events:?}"
     );
+    assert_eq!(rename_events[0].schema_version, 2);
+    assert_eq!(rename_events[0].paths, vec!["new.txt", "old.txt"]);
 }
 
 // -----------------------------------------------------------------------

--- a/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/install_staging_tests.rs
@@ -294,7 +294,7 @@ fn staging_writes_never_trigger_notify_even_after_long_wait() {
     let events = fixture.notify_client.events();
     let staging_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .collect();
     assert!(
         staging_events.is_empty(),
@@ -409,7 +409,7 @@ fn fuse_e2e_staging_mkdir_write_rename_flow() {
     let events_before_rename = fixture.notify_client.events();
     let staging_events: Vec<_> = events_before_rename
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .collect();
     assert!(
         staging_events.is_empty(),
@@ -429,7 +429,7 @@ fn fuse_e2e_staging_mkdir_write_rename_flow() {
     let all_events = fixture.notify_client.events();
     let rename_events: Vec<_> = all_events
         .iter()
-        .filter(|e| e.skill_name == "newskill" && e.event_kind == "rename")
+        .filter(|e| e.skill_id == "newskill" && e.event_kind == "rename")
         .collect();
     assert_eq!(
         rename_events.len(),
@@ -437,9 +437,12 @@ fn fuse_e2e_staging_mkdir_write_rename_flow() {
         "expected exactly one rename notify for newskill, got all events: {:?}",
         all_events
     );
+    assert_eq!(rename_events[0].schema_version, 2);
+    assert_eq!(rename_events[0].skill_id, "newskill");
+    assert!(rename_events[0].canonical_skill_dir.ends_with("/newskill"));
     let staging_name_events: Vec<_> = all_events
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .collect();
     assert!(
         staging_name_events.is_empty(),
@@ -569,7 +572,7 @@ impl QuietTimeoutMountFixture {
                 .events()
                 .iter()
                 .filter(|e| {
-                    e.skill_name == skill_name
+                    e.skill_id == skill_name
                         && e.event_kind != "install-complete"
                         && e.paths.is_empty()
                 })
@@ -626,7 +629,7 @@ fn quiet_timeout_staging_writes_never_trigger_notify() {
     let events = fixture.notify_client.events();
     let staging_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .collect();
     assert!(
         staging_events.is_empty(),
@@ -652,7 +655,7 @@ fn quiet_timeout_direct_final_skill_triggers_mutation_notify() {
     let mutation_events: Vec<_> = events
         .iter()
         .filter(|e| {
-            e.skill_name == "direct-install"
+            e.skill_id == "direct-install"
                 && e.event_kind != "install-complete"
                 && e.paths.is_empty()
         })
@@ -662,6 +665,12 @@ fn quiet_timeout_direct_final_skill_triggers_mutation_notify() {
         1,
         "expected one quiet-timeout mutation notify for final skill, got: {:?}",
         events
+    );
+    assert_eq!(mutation_events[0].schema_version, 2);
+    assert!(
+        mutation_events[0]
+            .canonical_skill_dir
+            .ends_with("/direct-install")
     );
     assert!(
         events.iter().all(|e| e.event_kind != "install-complete"),
@@ -689,9 +698,7 @@ fn quiet_timeout_direct_writes_collapse_to_one() {
     let quiet_events: Vec<_> = events
         .iter()
         .filter(|e| {
-            e.skill_name == "multi-write"
-                && e.event_kind != "install-complete"
-                && e.paths.is_empty()
+            e.skill_id == "multi-write" && e.event_kind != "install-complete" && e.paths.is_empty()
         })
         .collect();
     assert_eq!(
@@ -724,7 +731,7 @@ fn no_quiet_timeout_direct_writes_do_not_fire_quiet_mutation() {
     // (with non-empty paths). No empty-paths quiet-timeout event should appear.
     let quiet_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "alpha" && e.paths.is_empty())
+        .filter(|e| e.skill_id == "alpha" && e.paths.is_empty())
         .collect();
     assert!(
         quiet_events.is_empty(),
@@ -753,7 +760,7 @@ fn quiet_timeout_rename_still_immediate_no_staging_events() {
             .notify_client
             .events()
             .iter()
-            .filter(|e| e.skill_name == "renamed-skill" && e.event_kind == "rename")
+            .filter(|e| e.skill_id == "renamed-skill" && e.event_kind == "rename")
             .count();
         if count >= 1 {
             break;
@@ -770,7 +777,7 @@ fn quiet_timeout_rename_still_immediate_no_staging_events() {
     let events = fixture.notify_client.events();
     let staging_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .collect();
     assert!(
         staging_events.is_empty(),
@@ -806,7 +813,7 @@ fn quiet_timeout_skill_meta_writes_do_not_trigger() {
     let quiet_events: Vec<_> = events
         .iter()
         .filter(|e| {
-            e.skill_name == "meta-test" && e.event_kind != "install-complete" && e.paths.is_empty()
+            e.skill_id == "meta-test" && e.event_kind != "install-complete" && e.paths.is_empty()
         })
         .collect();
     assert_eq!(quiet_events.len(), 1);
@@ -1160,7 +1167,7 @@ fn resolver_staging_intermediate_writes_do_not_notify() {
         .notify_client
         .events()
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .cloned()
         .collect();
     assert!(
@@ -1196,7 +1203,7 @@ fn resolver_staging_rename_triggers_rename_mutation() {
             .notify_client
             .events()
             .iter()
-            .filter(|e| e.skill_name == "eta" && e.event_kind == "rename")
+            .filter(|e| e.skill_id == "eta" && e.event_kind == "rename")
             .count();
         if count >= 1 {
             break;
@@ -1213,7 +1220,7 @@ fn resolver_staging_rename_triggers_rename_mutation() {
     let all_events = fixture.notify_client.events();
     let staging_events: Vec<_> = all_events
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .collect();
     assert!(
         staging_events.is_empty(),
@@ -1371,7 +1378,7 @@ fn pending_mkdir_does_not_notify() {
     let events = fixture.notify_client.events();
     let new_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "new-skill")
+        .filter(|e| e.skill_id == "new-skill")
         .collect();
     assert!(
         new_events.is_empty(),
@@ -1465,7 +1472,7 @@ fn pending_skill_md_missing_no_notify() {
     let events = fixture.notify_client.events();
     let incomplete_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "incomplete")
+        .filter(|e| e.skill_id == "incomplete")
         .collect();
     assert!(
         incomplete_events.is_empty(),
@@ -1494,7 +1501,7 @@ fn pending_skill_md_unparseable_no_notify() {
     let events = fixture.notify_client.events();
     let bad_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "bad-parse")
+        .filter(|e| e.skill_id == "bad-parse")
         .collect();
     assert!(
         bad_events.is_empty(),
@@ -1527,13 +1534,19 @@ fn pending_complete_skill_notifies_after_timeout() {
     let events = fixture.notify_client.events();
     let complete_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "complete-skill")
+        .filter(|e| e.skill_id == "complete-skill")
         .collect();
     assert_eq!(
         complete_events.len(),
         1,
         "complete skill must trigger exactly one notify: {:?}",
         events
+    );
+    assert_eq!(complete_events[0].schema_version, 2);
+    assert!(
+        complete_events[0]
+            .canonical_skill_dir
+            .ends_with("/complete-skill")
     );
     assert!(
         events.iter().all(|e| e.event_kind != "install-complete"),
@@ -1568,7 +1581,7 @@ fn pending_multiple_writes_collapse() {
     let events = fixture.notify_client.events();
     let mw_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "multi-write-pending")
+        .filter(|e| e.skill_id == "multi-write-pending")
         .collect();
     assert_eq!(
         mw_events.len(),
@@ -1603,7 +1616,7 @@ fn pending_activation_clears_pending_and_shows_skill() {
     // Verify notify happened
     let events = fixture.notify_client.events();
     assert!(
-        events.iter().any(|e| e.skill_name == "activated-new"),
+        events.iter().any(|e| e.skill_id == "activated-new"),
         "pending complete must have fired notify"
     );
 
@@ -1702,7 +1715,7 @@ fn pending_activated_skill_uses_normal_notify() {
             .notify_client
             .events()
             .iter()
-            .filter(|e| e.skill_name == "existing")
+            .filter(|e| e.skill_id == "existing")
             .count();
         if count >= 1 {
             break;
@@ -1719,10 +1732,7 @@ fn pending_activated_skill_uses_normal_notify() {
     // The notify for "existing" should come from normal notify path
     // (with paths populated), not from pending install
     let events = fixture.notify_client.events();
-    let existing_events: Vec<_> = events
-        .iter()
-        .filter(|e| e.skill_name == "existing")
-        .collect();
+    let existing_events: Vec<_> = events.iter().filter(|e| e.skill_id == "existing").collect();
     assert!(
         !existing_events.is_empty(),
         "activated skill must use normal notify"
@@ -1809,7 +1819,7 @@ fn pending_staging_inbox_not_affected() {
     let staging_events: Vec<_> = notify_client
         .events()
         .iter()
-        .filter(|e| e.skill_name.starts_with(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.starts_with(".openclaw-install-stage-"))
         .cloned()
         .collect();
     assert!(
@@ -2446,7 +2456,7 @@ fn post_publish_grace_direct_pending_complete_triggers_session() {
     // Verify notify fired
     let events = notify_client.events();
     assert!(
-        events.iter().any(|e| e.skill_name == "direct-grace"),
+        events.iter().any(|e| e.skill_id == "direct-grace"),
         "pending complete must have fired notify: {:?}",
         events
     );
@@ -2911,7 +2921,7 @@ fn hermes_staging_writes_no_notify() {
         .notify_client
         .events()
         .iter()
-        .filter(|e| e.skill_name.contains(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.contains(".openclaw-install-stage-"))
         .cloned()
         .collect();
     assert!(
@@ -2945,7 +2955,7 @@ fn hermes_staging_rename_triggers_notify() {
     let events = fix.notify_client.events();
     let rename_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "apple/beta" && e.event_kind == "rename")
+        .filter(|e| e.skill_id == "apple/beta" && e.event_kind == "rename")
         .collect();
     assert_eq!(
         rename_events.len(),
@@ -2954,14 +2964,16 @@ fn hermes_staging_rename_triggers_notify() {
         events
     );
     assert!(
-        rename_events[0].skill_dir.ends_with("/apple/beta"),
+        rename_events[0]
+            .canonical_skill_dir
+            .ends_with("/apple/beta"),
         "skillDir must end with /apple/beta, got: {}",
-        rename_events[0].skill_dir
+        rename_events[0].canonical_skill_dir
     );
 
     let staging_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name.contains(".openclaw-install-stage-"))
+        .filter(|e| e.skill_id.contains(".openclaw-install-stage-"))
         .collect();
     assert!(
         staging_events.is_empty(),
@@ -3140,7 +3152,7 @@ fn hermes_pending_complete_notifies() {
     let events = fix.notify_client.events();
     let new_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "apple/new-skill")
+        .filter(|e| e.skill_id == "apple/new-skill")
         .collect();
     assert_eq!(
         new_events.len(),
@@ -3169,7 +3181,7 @@ fn hermes_pending_incomplete_no_notify() {
     let events = fix.notify_client.events();
     let inc_events: Vec<_> = events
         .iter()
-        .filter(|e| e.skill_name == "apple/incomplete")
+        .filter(|e| e.skill_id == "apple/incomplete")
         .collect();
     assert!(
         inc_events.is_empty(),

--- a/src/skillfs/crates/skillfs-fuse/tests/notify_client_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/notify_client_tests.rs
@@ -49,8 +49,8 @@ fn spawn_fake_daemon(
 
 fn make_event() -> NotifyChangeEvent {
     NotifyChangeEvent::new(
-        "/srv/skills/weather",
-        "weather",
+        "/srv/skills/category/weather",
+        "category/weather",
         NotifyEventKind::Write,
         vec!["SKILL.md".to_string()],
         5000,
@@ -62,16 +62,34 @@ fn notify_client_accepted() {
     let (sock_path, daemon) = spawn_fake_daemon(|req_json| {
         let parsed: serde_json::Value = serde_json::from_str(req_json).unwrap();
         assert_eq!(parsed["method"], "skill_ledger.skillfs_notify_change");
-        assert_eq!(parsed["params"]["schemaVersion"], 1);
-        assert_eq!(parsed["params"]["skillDir"], "/srv/skills/weather");
-        assert_eq!(parsed["params"]["skillName"], "weather");
+        let params = parsed["params"].as_object().unwrap();
+        assert_eq!(params.len(), 5);
+        assert_eq!(parsed["params"]["schemaVersion"], 2);
+        assert_eq!(
+            parsed["params"]["canonicalSkillDir"],
+            "/srv/skills/category/weather"
+        );
+        assert_eq!(parsed["params"]["skillId"], "category/weather");
         assert_eq!(parsed["params"]["eventKind"], "write");
         assert_eq!(parsed["params"]["paths"], serde_json::json!(["SKILL.md"]));
+        for forbidden in [
+            "skillDir",
+            "skillName",
+            "mountId",
+            "generation",
+            "resolverSocket",
+            "sourceId",
+        ] {
+            assert!(
+                !params.contains_key(forbidden),
+                "unexpected field: {forbidden}"
+            );
+        }
         assert!(!parsed["id"].as_str().unwrap().is_empty());
         assert_eq!(parsed["trace_context"], serde_json::json!({}));
         assert_eq!(parsed["timeout_ms"], 5000);
 
-        r#"{"id":"resp-1","ok":true,"data":{"schemaVersion":1,"accepted":true},"stdout":"","stderr":"","exit_code":0}"#.to_string()
+        r#"{"id":"resp-1","ok":true,"data":{"schemaVersion":2,"accepted":true},"stdout":"","stderr":"","exit_code":0}"#.to_string()
     });
 
     let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_secs(5));
@@ -163,7 +181,7 @@ fn notify_client_timeout() {
 #[test]
 fn notify_client_accepted_false_is_rejected() {
     let (sock_path, daemon) = spawn_fake_daemon(|_| {
-        r#"{"ok":true,"data":{"schemaVersion":1,"accepted":false}}"#.to_string()
+        r#"{"ok":true,"data":{"schemaVersion":2,"accepted":false}}"#.to_string()
     });
 
     let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_secs(5));
@@ -171,6 +189,23 @@ fn notify_client_accepted_false_is_rejected() {
     assert!(
         matches!(result, Err(NotifyError::Rejected { .. })),
         "accepted=false must be Rejected, got {result:?}"
+    );
+
+    daemon.join().unwrap();
+    let _ = std::fs::remove_dir_all(sock_path.parent().unwrap());
+}
+
+#[test]
+fn notify_client_v1_response_is_rejected() {
+    let (sock_path, daemon) = spawn_fake_daemon(|_| {
+        r#"{"ok":true,"data":{"schemaVersion":1,"accepted":true}}"#.to_string()
+    });
+
+    let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_secs(5));
+    let result = client.send(&make_event());
+    assert!(
+        matches!(result, Err(NotifyError::InvalidResponse { .. })),
+        "v1 response must be rejected, got {result:?}"
     );
 
     daemon.join().unwrap();

--- a/src/skillfs/crates/skillfs-fuse/tests/notify_fuse_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/notify_fuse_tests.rs
@@ -514,6 +514,7 @@ impl ReloadMountFixture {
         let notify_ctrl = NotifyController::new_with_reload(
             client,
             source.path().to_path_buf(),
+            source.path().to_path_buf(),
             Duration::from_millis(50),
             5000,
             Arc::new(skillfs_fuse::security::NoopProtocolEventWriter),
@@ -685,6 +686,7 @@ fn startup_reconcile_spawn_produces_events() {
     let writer = Arc::new(InMemoryProtocolEventWriter::new());
     let ctrl = NotifyController::new_with_protocol_writer(
         client.clone(),
+        source.path().to_path_buf(),
         source.path().to_path_buf(),
         Duration::from_millis(50),
         5000,

--- a/src/skillfs/crates/skillfs-fuse/tests/notify_fuse_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/notify_fuse_tests.rs
@@ -20,7 +20,8 @@ use parking_lot::RwLock;
 use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
 use skillfs_fuse::security::{
     ActivationReloadController, ActiveSkillResolver, ActiveTarget, FailingNotifyClient,
-    InMemoryNotifyClient, InMemoryProtocolEventWriter, NoopNotifyClient, NotifyController,
+    InMemoryNotifyClient, InMemoryProtocolEventWriter, NoopNotifyClient, NotifyChangeEvent,
+    NotifyClient, NotifyController, NotifyError, UnixSocketNotifyClient,
 };
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
@@ -241,7 +242,7 @@ fn write_triggers_one_notify() {
 
     let events = client.events();
     assert_eq!(events.len(), 1, "one write should produce one notify");
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
     assert!(events[0].paths.contains(&"SKILL.md".to_string()));
 }
 
@@ -330,6 +331,42 @@ fn notify_failure_does_not_affect_read_view() {
     );
 }
 
+#[derive(Debug, Default)]
+struct RejectingNotifyClient;
+
+impl NotifyClient for RejectingNotifyClient {
+    fn send(&self, _event: &NotifyChangeEvent) -> Result<(), NotifyError> {
+        Err(NotifyError::Rejected {
+            body: r#"{"ok":true,"data":{"schemaVersion":2,"accepted":false}}"#.to_string(),
+        })
+    }
+}
+
+#[test]
+fn notify_rejection_does_not_affect_read_view() {
+    skip_if_no_fuse!();
+
+    let fixture = NotifyActivatedMountFixture::new(
+        Arc::new(RejectingNotifyClient),
+        |src| {
+            create_skill(src, "alpha");
+        },
+        &["alpha"],
+    );
+
+    let skill_md = fixture.skill_path("alpha").join("SKILL.md");
+    std::fs::write(&skill_md, "---\nname: alpha\ndescription: rejected\n---\n").unwrap();
+    std::thread::sleep(Duration::from_millis(500));
+    fixture.notify_controller.flush_for_testing();
+
+    let contents = std::fs::read_to_string(&skill_md).unwrap();
+    assert!(contents.contains("alpha"));
+    assert!(matches!(
+        fixture.resolver.get("alpha"),
+        Some(ActiveTarget::Current { .. })
+    ));
+}
+
 #[test]
 fn create_file_triggers_notify() {
     skip_if_no_fuse!();
@@ -346,7 +383,86 @@ fn create_file_triggers_notify() {
 
     let events = client.events();
     assert!(!events.is_empty(), "file creation must trigger notify");
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
+}
+
+#[test]
+fn same_skill_rename_reports_old_and_new_relative_paths() {
+    skip_if_no_fuse!();
+
+    let client = Arc::new(InMemoryNotifyClient::new());
+    let fixture = NotifyMountFixture::new(client.clone(), |src| {
+        create_skill(src, "alpha");
+        std::fs::write(src.join("alpha/old.txt"), "rename me").unwrap();
+    });
+
+    let skill_dir = fixture.skill_path("alpha");
+    std::fs::rename(skill_dir.join("old.txt"), skill_dir.join("new.txt")).unwrap();
+    fixture.wait_for_notify(1, &client);
+
+    let events = client.events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].schema_version, 2);
+    assert_eq!(events[0].skill_id, "alpha");
+    assert_eq!(events[0].event_kind, "rename");
+    assert_eq!(events[0].paths, vec!["new.txt", "old.txt"]);
+}
+
+#[test]
+fn fuse_mutation_reaches_fake_daemon_as_notify_v2() {
+    skip_if_no_fuse!();
+
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+
+    let socket_dir = tempfile::tempdir().unwrap();
+    let socket_path = socket_dir.path().join("sec-core.sock");
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    let (request_tx, request_rx) = std::sync::mpsc::sync_channel(1);
+    let daemon = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(&stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        request_tx.send(line).unwrap();
+
+        let mut writer = std::io::BufWriter::new(&stream);
+        writer
+            .write_all(br#"{"ok":true,"data":{"schemaVersion":2,"accepted":true}}"#)
+            .unwrap();
+        writer.write_all(b"\n").unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = Arc::new(UnixSocketNotifyClient::new(
+        &socket_path,
+        Duration::from_secs(5),
+    ));
+    let fixture = NotifyMountFixture::new(client, |src| {
+        create_skill(src, "alpha");
+    });
+    let expected_canonical_dir = fixture.source.path().join("alpha");
+
+    std::fs::write(fixture.skill_path("alpha").join("config.json"), "{}").unwrap();
+
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("fake daemon must receive FUSE mutation notify");
+    let request: serde_json::Value = serde_json::from_str(request.trim()).unwrap();
+    assert_eq!(request["method"], "skill_ledger.skillfs_notify_change");
+    assert_eq!(request["params"]["schemaVersion"], 2);
+    assert_eq!(
+        request["params"]["canonicalSkillDir"],
+        expected_canonical_dir.to_string_lossy().as_ref()
+    );
+    assert_eq!(request["params"]["skillId"], "alpha");
+    assert!(
+        request["params"]["paths"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("config.json"))
+    );
+    daemon.join().unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -623,6 +739,7 @@ fn startup_reconcile_spawn_produces_events() {
     let notify_events = client.events();
     assert_eq!(notify_events.len(), 2);
     for e in &notify_events {
+        assert_eq!(e.schema_version, 2);
         assert_eq!(e.event_kind, "reconcile");
     }
 
@@ -950,7 +1067,7 @@ fn inbox_install_complete_triggers_notify_controller() {
         !events.is_empty(),
         "inbox .install-complete sentinel must trigger notify_controller"
     );
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
     assert_ne!(
         events[0].event_kind, "install-complete",
         "protocol events must use real mutation kinds, not install-complete"
@@ -987,7 +1104,7 @@ fn open_trunc_skill_md_triggers_notify() {
         !events.is_empty(),
         "O_TRUNC on SKILL.md must trigger notify"
     );
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
 }
 
 /// P2b regression: `open(O_RDONLY|O_TRUNC)` on a passthrough file must
@@ -1022,7 +1139,7 @@ fn open_rdonly_trunc_passthrough_triggers_notify() {
         !events.is_empty(),
         "O_RDONLY|O_TRUNC on passthrough file must trigger notify"
     );
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
 }
 
 /// P2b+ regression: `open(O_WRONLY|O_TRUNC)` on a passthrough file must
@@ -1057,7 +1174,7 @@ fn open_wronly_trunc_passthrough_triggers_notify() {
         !events.is_empty(),
         "O_WRONLY|O_TRUNC on passthrough file must trigger notify"
     );
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
 }
 
 /// P2c regression: successful `symlink` creation must trigger notify.
@@ -1080,7 +1197,7 @@ fn symlink_creation_triggers_notify() {
 
     let events = client.events();
     assert!(!events.is_empty(), "symlink creation must trigger notify");
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
 }
 
 /// P2d regression: successful `link` (hardlink) must trigger notify.
@@ -1104,7 +1221,7 @@ fn hardlink_creation_triggers_notify() {
 
     let events = client.events();
     assert!(!events.is_empty(), "hardlink creation must trigger notify");
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
 }
 
 /// P2e regression: successful FIFO (`mknod`) must trigger notify.
@@ -1139,5 +1256,5 @@ fn fifo_creation_triggers_notify() {
         !events.is_empty(),
         "FIFO (mknod) creation must trigger notify"
     );
-    assert_eq!(events[0].skill_name, "alpha");
+    assert_eq!(events[0].skill_id, "alpha");
 }

--- a/src/skillfs/docs/design/control-socket-resolver.md
+++ b/src/skillfs/docs/design/control-socket-resolver.md
@@ -126,6 +126,7 @@ The following are structured errors, never disguised as `managed=false`:
 | --- | --- |
 | protocol / request format error | `invalid_request` |
 | non-absolute path | `invalid_canonical_path` |
+| repeated or trailing path separator | `invalid_canonical_path` |
 | illegal `..` (or `.`) segment | `invalid_canonical_path` |
 | symlink / path escape | `invalid_canonical_path` |
 | management / reserved directory | `invalid_canonical_path` |
@@ -142,19 +143,21 @@ system is not redesigned.
 The resolver context stores the two roots explicitly rather than relying
 on a single ambiguous `source_root`:
 
-- **canonical root** — the user-visible Skill root the ledger addresses
-  (`source_canon` in the CLI). Incoming `canonicalSkillDir` paths are
-  checked for lexical containment against it, and the relative skill id is
-  derived from it.
+- **canonical root** — the absolute, lexically normalized user-visible
+  Skill identity the ledger addresses (`canonical_identity_root` in the
+  CLI). It does not follow a source-root symlink. Incoming
+  `canonicalSkillDir` paths are checked for lexical containment against it,
+  and the relative skill id is derived from it.
 - **live root** — the backing/daemon-facing root whose physical content
   stays accessible after the FUSE over-mount (`daemon_root` in the CLI:
-  the ledger backing root when configured, otherwise the source). The
-  live Skill directory is opened under this root, and its `(dev, ino)` is
-  reported.
+  the ledger backing root when configured, otherwise the realpath-resolved
+  physical source). The live Skill directory is opened under this root,
+  and its `(dev, ino)` is reported.
 
-In the common single-source in-place mount the two resolve to the same
-tree (or a bind-mount alias of it), but they are kept separate so a query
-never crosses the canonical / FUSE / live boundary implicitly.
+The roots can use different path strings even without a backing root when
+the configured source is a symlink. They still identify the same tree, but
+are kept separate so a query never crosses the canonical / FUSE / live
+boundary implicitly.
 
 The control plane is a **daemon-facing operation**: in an in-place mount
 the source path is a FUSE over-mount, so resolving against it would return
@@ -172,10 +175,11 @@ Resolution is O(path depth) and never scans the whole Skill root:
 
 1. **Raw-string lexical syntax** — validate the raw request string before
    constructing a `Path` or doing containment: reject a NUL byte, a
-   non-absolute path, and any `.`/`..` segment. This runs on the raw bytes
-   because `Path::components()` would silently normalize an embedded `.`
-   (e.g. `/root/./skill`) and a NUL would only surface later — an illegal
-   request must never fall through to `managed=false`.
+   non-absolute path, repeated separators, a trailing separator, and any
+   `.`/`..` segment. This runs on the raw bytes because
+   `Path::components()` would silently normalize aliases such as
+   `/root//skill`, `/root/skill/`, and `/root/./skill`; an illegal request
+   must never fall through to `managed=false`.
 2. **Lexical containment** — the user path is *not* canonicalized;
    containment against the canonical root is purely component-wise. A
    valid path outside the root becomes `managed=false`.

--- a/src/skillfs/docs/design/control-socket-resolver.md
+++ b/src/skillfs/docs/design/control-socket-resolver.md
@@ -285,9 +285,9 @@ it.
 
 Deferred to S2 and not implemented here:
 
-- notify v2 (the future notify payload is agreed to carry only
-  `canonicalSkillDir`, the full `skillId`, `eventKind`, and relative
-  paths); the existing notify protocol is unchanged in S1.
+- notify v2 (implemented separately in
+  [SkillFS Notify v2](notify-v2.md)); the existing notify protocol is
+  unchanged in S1.
 - `register` / `unregister`, `mountId`, `generation`, `sourceId`,
   `resolverSocket`, and `integrationProtocolVersion`.
 - deletion-state semantics (tombstone / `exists`); S1 does not add these

--- a/src/skillfs/docs/design/control-socket-resolver.md
+++ b/src/skillfs/docs/design/control-socket-resolver.md
@@ -1,0 +1,298 @@
+# SkillFS Control Socket Resolver (S1)
+
+Design record for the stable default control socket endpoint and the
+read-only `skill.resolveLiveSource` query. This is SkillFS package **S1**.
+It does not implement notify v2, `register`, `mountId`, `generation`,
+`sourceId`, multi-source runtime aggregation, or deletion-state semantics
+— those are deferred to S2 (see [Out of scope](#out-of-scope)).
+
+## Goals
+
+`skill-ledger` needs a stable, authenticated way to ask a running SkillFS
+instance: "for this canonical Skill directory, where is the physical
+live/backing source, and is it yours to manage?" S1 provides:
+
+1. A stable default control socket endpoint per UID / security domain, so
+   the ledger does not need to be told a socket path out of band.
+2. A read-only `skill.resolveLiveSource` query answering the mapping above
+   with a strict three-state contract.
+
+Everything reuses the existing control socket, its `schemaVersion "1"`
+envelope, and its `SO_PEERCRED` + trusted-executable-identity +
+process-starttime authentication. No second authentication mechanism and
+no new protocol version are introduced.
+
+## Endpoint
+
+Each UID / security domain has one resolver endpoint:
+
+```
+/run/user/<uid>/skillfs/control.sock
+```
+
+The effective endpoint is resolved by priority:
+
+1. CLI `--control-socket <PATH>`
+2. `[control_socket].path` in the config file
+3. the default per-user endpoint above
+
+The default path never falls back to `/tmp` or `/var/tmp`. If
+`/run/user/<uid>` does not exist or is not a directory, startup fails with
+a clear, actionable error instructing the operator to pass
+`--control-socket` explicitly; SkillFS never invents `/run/user/<uid>`.
+
+The control plane stays **opt-in and authenticated**:
+
+| trusted peer configured | socket path configured | result |
+| --- | --- | --- |
+| yes | no | use the default endpoint |
+| no | yes | configuration error |
+| no | no | control plane stays off |
+| yes | yes | use the explicit path |
+
+Authentication is unchanged: `SO_PEERCRED` credentials, the peer's
+`/proc/<pid>/exe` `(dev, ino)` pinned against the configured trusted
+executable, and `/proc/<pid>/stat` starttime bracketing for PID-reuse
+defense.
+
+A single SkillFS instance may in the future manage multiple canonical
+roots behind this same endpoint, selecting the live source by
+`canonicalSkillDir`. S1 implements only the current single-source case and
+does not pre-build multi-source runtime aggregation.
+
+## `skill.resolveLiveSource`
+
+Request (business parameter is only `canonicalSkillDir`):
+
+```json
+{
+  "schemaVersion": "1",
+  "method": "skill.resolveLiveSource",
+  "canonicalSkillDir": "/absolute/canonical/skill/path"
+}
+```
+
+### managed = true
+
+The path is inside this instance's canonical root and resolves to a valid
+live Skill directory.
+
+```json
+{
+  "schemaVersion": "1",
+  "ok": true,
+  "result": {
+    "managed": true,
+    "canonicalSkillDir": "/canonical/path/apple/apple-notes",
+    "skillId": "apple/apple-notes",
+    "relativeSkillDir": "apple/apple-notes",
+    "liveSkillDir": "/physical/live/path/apple/apple-notes",
+    "identity": { "device": 42, "inode": 1001 },
+    "transport": "shared_path"
+  }
+}
+```
+
+- The physical live/backing source is returned — never a FUSE current,
+  fallback, or hidden view.
+- `identity` comes from the actual opened live Skill directory.
+- The query is read-only: it triggers no scan, manifest build, policy
+  decision, or activation write.
+
+### managed = false
+
+Used only when the request is well-formed, `canonicalSkillDir` is a valid
+absolute path, and the path lies outside this instance's managed root.
+This is a normal success; `skill-ledger` may fall back to managing that
+directory directly.
+
+```json
+{
+  "schemaVersion": "1",
+  "ok": true,
+  "result": {
+    "managed": false,
+    "canonicalSkillDir": "/some/other/path",
+    "reason": "not_managed"
+  }
+}
+```
+
+### structured error
+
+The following are structured errors, never disguised as `managed=false`:
+
+| condition | error code |
+| --- | --- |
+| protocol / request format error | `invalid_request` |
+| non-absolute path | `invalid_canonical_path` |
+| illegal `..` (or `.`) segment | `invalid_canonical_path` |
+| symlink / path escape | `invalid_canonical_path` |
+| management / reserved directory | `invalid_canonical_path` |
+| Skill directory does not exist under the managed root | `skill_not_found` |
+| invalid Skill layout / missing `SKILL.md` | `invalid_skill_layout` |
+| live source cannot be safely accessed / identity unverifiable | `live_source_unavailable` |
+| peer authentication failure | `permission_denied` |
+
+The error codes reuse the existing control-protocol style. The error
+system is not redesigned.
+
+## Canonical root vs live root
+
+The resolver context stores the two roots explicitly rather than relying
+on a single ambiguous `source_root`:
+
+- **canonical root** — the user-visible Skill root the ledger addresses
+  (`source_canon` in the CLI). Incoming `canonicalSkillDir` paths are
+  checked for lexical containment against it, and the relative skill id is
+  derived from it.
+- **live root** — the backing/daemon-facing root whose physical content
+  stays accessible after the FUSE over-mount (`daemon_root` in the CLI:
+  the ledger backing root when configured, otherwise the source). The
+  live Skill directory is opened under this root, and its `(dev, ino)` is
+  reported.
+
+In the common single-source in-place mount the two resolve to the same
+tree (or a bind-mount alias of it), but they are kept separate so a query
+never crosses the canonical / FUSE / live boundary implicitly.
+
+The control plane is a **daemon-facing operation**: in an in-place mount
+the source path is a FUSE over-mount, so resolving against it would return
+the current/fallback/hidden view instead of the physical live source.
+SkillFS therefore requires `--ledger-backing-root` whenever an in-place
+`--security --activation-mode file` mount enables the control plane (as it
+already does for notify/activation), and startup fails closed otherwise.
+The live root is always an absolute path (the backing root, or the
+canonicalized source), so `liveSkillDir` is usable regardless of the CWD
+the mount was launched from.
+
+## Path resolution and escape safety
+
+Resolution is O(path depth) and never scans the whole Skill root:
+
+1. **Raw-string lexical syntax** — validate the raw request string before
+   constructing a `Path` or doing containment: reject a NUL byte, a
+   non-absolute path, and any `.`/`..` segment. This runs on the raw bytes
+   because `Path::components()` would silently normalize an embedded `.`
+   (e.g. `/root/./skill`) and a NUL would only surface later — an illegal
+   request must never fall through to `managed=false`.
+2. **Lexical containment** — the user path is *not* canonicalized;
+   containment against the canonical root is purely component-wise. A
+   valid path outside the root becomes `managed=false`.
+3. **Reserved directories** — reject any dot-prefixed component
+   (`.skill-meta`, `.hub`, lifecycle roots, staging dirs, …) and the
+   synthesized `skill-discover` view.
+4. **Layout boundary** — enforce the same Skill boundary as the FUSE layer
+   and the Hermes id enumeration, so a subdirectory is never reported as a
+   phantom Skill. Flat: a Skill is exactly one directory level. Hermes: a
+   Skill is a top-level directory, or a `<category>/<skill>` leaf whose
+   category is not itself a top-level skill (has no own `SKILL.md`);
+   anything deeper, or a subdirectory of a top-level skill, is rejected
+   with `invalid_skill_layout`.
+5. **Safe descent** — open the live Skill directory one component at a
+   time from the live-root directory fd, each with `O_NOFOLLOW |
+   O_DIRECTORY`, so a symlink at any level fails closed (escape →
+   `invalid_canonical_path`) rather than following outside the managed
+   root. `(dev, ino)` is read via `fstat` on the final opened fd.
+6. **Leaf layout check** — a Skill directory must contain a `SKILL.md` that
+   is a **no-follow regular file**. Presence and type are classified with
+   `fstatat(AT_SYMLINK_NOFOLLOW)` on the already-opened directory fd (never
+   `openat`, so an unreadable mode-`000` marker is still correctly seen as
+   present). A `SKILL.md` that is a symlink (never followed), directory, or
+   any other non-regular object is **not a valid marker and is treated as
+   absent** — a queried leaf without a regular marker returns
+   `invalid_skill_layout`, and a symlinked *top-level* marker means the
+   directory is a category whose real nested Skills still resolve. Only a
+   genuinely inconclusive `stat` (e.g. an I/O error) fails closed as
+   `live_source_unavailable`. This is the same predicate — a shared
+   `has_regular_skill_md` — that store discovery, the FUSE readdir/read
+   gating, and Hermes activation enumeration apply, so no layer disagrees
+   about what a Skill is (see [Skill layout](#skill-layout-and-skill-id)).
+
+The backing path is never produced by naively joining unvalidated user
+input; each component is validated and opened without following symlinks.
+
+## Skill layout and skill id
+
+The full skill id is derived from the canonical relative path, never from
+the basename:
+
+- **Flat**: `<root>/my-skill/SKILL.md` → `my-skill`
+- **Hermes nested**: `<root>/apple/apple-notes/SKILL.md` → `apple/apple-notes`
+
+Top-level and Hermes nested skills may coexist under one root. Querying a
+category directory that has no `SKILL.md` of its own (e.g. `apple`) returns
+`invalid_skill_layout`. The resolver enforces the layout depth boundary
+(see [Path resolution](#path-resolution-and-escape-safety) step 4), so a
+subdirectory of a Skill — `my-skill/subdir` under Flat, `top/sub` under a
+Hermes top-level skill, or any third-level path — is never reported as a
+phantom Skill, keeping the resolver's identities consistent with the FUSE
+layer and the notify id enumeration.
+
+Whether a directory "has a `SKILL.md`" — used for the top-level-vs-category
+decision and the leaf check — is the single shared `has_regular_skill_md`
+predicate: a **no-follow regular file**. A `SKILL.md` that is a symlink or
+other non-regular object is not a marker, so such a top-level directory is a
+category (its real nested Skills resolve) and such a leaf is
+`invalid_skill_layout`. Store discovery, FUSE readdir/read gating, and Hermes
+activation enumeration all use the same predicate, so a directory is a Skill
+in every layer or in none — the resolver cannot report a Skill the store
+never loaded, or reject one it did.
+
+### Relationship to activation writes
+
+The read-only resolver is layout-agnostic and supports nested ids. The
+existing activation *write* methods (`meta.writeActivation`,
+`meta.setActivationXattr`) still validate a single skill-name component and
+reject nested ids with a clear invalid-skill-name error — they are not
+widened, and a nested write is never truncated to a basename and applied
+to the wrong target. Enabling the resolver under Hermes layout only lifts
+the blanket startup gate that previously refused to start the control
+socket in Hermes mode; it does not extend the write protocol.
+
+## Socket lifecycle hardening
+
+Single-instance, fail-closed lifecycle:
+
+- The socket parent directory must be a directory owned by the current
+  uid with mode `0700`; the socket file is `0600`.
+- A non-blocking `flock` lifecycle lock on `<socket>.lock` guards the
+  endpoint. A second instance targeting a live endpoint fails fast (it
+  never blocks unbounded and never unlinks the active socket).
+- A pre-existing object is only reclaimed when it is confirmed stale: a
+  socket the current uid owns whose non-blocking `connect` probe returns a
+  definitive `ECONNREFUSED`. A successful connect (live listener), a
+  backlog-full result, or any inconclusive error (`EACCES`, `EINTR`,
+  resource exhaustion, …) fails closed rather than unlinking. Symlinks,
+  regular files, directories, and sockets owned by another uid are never
+  deleted.
+- The bound socket's `(dev, ino)` is recorded. On shutdown the path is
+  unlinked only if it still resolves to that exact identity, so an object
+  that later replaced the path is never deleted.
+- The accept loop is non-blocking and polls the shutdown flag, so shutdown
+  is bounded even when the path has been replaced.
+
+## Query load
+
+`skill-ledger` issues high-frequency, saturating resolve queries over
+candidate directories. S1 keeps the existing one-request-per-connection
+model handled on a single accept thread — no thread-per-request, no
+speculative global cache, and no artificial millisecond SLA. Each query is
+O(path depth). Bounded concurrency is deferred until measurements justify
+it.
+
+## Out of scope
+
+Deferred to S2 and not implemented here:
+
+- notify v2 (the future notify payload is agreed to carry only
+  `canonicalSkillDir`, the full `skillId`, `eventKind`, and relative
+  paths); the existing notify protocol is unchanged in S1.
+- `register` / `unregister`, `mountId`, `generation`, `sourceId`,
+  `resolverSocket`, and `integrationProtocolVersion`.
+- deletion-state semantics (tombstone / `exists`); S1 does not add these
+  unsettled fields and does not interpret a deleted path as `not_managed`.
+- multi-source runtime aggregation.
+- `dir-fd` / `SCM_RIGHTS` transports (`transport` is always
+  `shared_path`).
+- any change to `agent-sec-core`.

--- a/src/skillfs/docs/design/notify-v2.md
+++ b/src/skillfs/docs/design/notify-v2.md
@@ -80,8 +80,9 @@ the current activation mapping stays in place.
 
 Notify and activation use two explicit roots:
 
-- **Canonical root** (`source_canon` in the CLI) is the user-visible root that
-  callers and the ledger address. Notify derives
+- **Canonical root** (`canonical_identity_root` in the CLI) is the absolute,
+  lexically normalized user-visible identity that callers and the ledger
+  address. It does not follow a source-root symlink. Notify derives
   `canonicalSkillDir = canonical_root.join(skillId)`.
 - **Live root** (`daemon_root` in the CLI) is the physical source that remains
   reachable after an in-place FUSE over-mount. It is the configured backing
@@ -122,6 +123,11 @@ The sec-core consumer switches directly to v2 and must:
    scan/resolve pass; and
 5. return `schemaVersion=2` with `accepted=true` only after accepting the
    event.
+
+An in-place notify v2 mount starts only when the authenticated S1 resolver
+control plane is enabled. The canonical path becomes the FUSE over-mount after
+startup, so a daemon without the resolver could otherwise mistake that view for
+the physical live source.
 
 ## Deferred Work
 

--- a/src/skillfs/docs/design/notify-v2.md
+++ b/src/skillfs/docs/design/notify-v2.md
@@ -124,10 +124,12 @@ The sec-core consumer switches directly to v2 and must:
 5. return `schemaVersion=2` with `accepted=true` only after accepting the
    event.
 
-An in-place notify v2 mount starts only when the authenticated S1 resolver
-control plane is enabled. The canonical path becomes the FUSE over-mount after
-startup, so a daemon without the resolver could otherwise mistake that view for
-the physical live source.
+An in-place notify v2 mount, or any notify mount with an explicit backing root,
+starts only when the authenticated S1 resolver control plane is enabled. The
+canonical path becomes the FUSE over-mount in-place, while an out-of-place
+backing root intentionally replaces the canonical host path as the
+daemon-facing source. Without the resolver, the daemon cannot identify the
+physical live source in either case.
 
 ## Deferred Work
 

--- a/src/skillfs/docs/design/notify-v2.md
+++ b/src/skillfs/docs/design/notify-v2.md
@@ -40,6 +40,22 @@ or `sourceId`.
 There is no v1 fallback or runtime version negotiation. SkillFS and the daemon
 must switch directly to v2.
 
+## Relationship to N3 Event Logs
+
+S2 upgrades only the socket notify request. The N3 activation protocol event
+log is a separate JSONL protocol, not a notify v1 fallback, a dual-send path,
+or a runtime negotiation mechanism.
+
+N3 remains schema v1 and keeps its existing fields: `schemaVersion`, `time`,
+`skillDir`, `skillName`, `eventKind`, `paths`, and optional `reloadOutcome`.
+When an in-place mount uses a backing root, N3 `skillDir` continues to use the
+daemon/live backing root so event-log consumers can read the live source
+without traversing the FUSE over-mount.
+
+The two protocols may share a controller implementation, but they must not
+share an ambiguous root. Socket notify v2 derives `canonicalSkillDir` from the
+canonical root; N3 event logs derive `skillDir` from the protocol-event root.
+
 ## Response
 
 SkillFS accepts a response only when the daemon envelope has `ok=true` and its

--- a/src/skillfs/docs/design/notify-v2.md
+++ b/src/skillfs/docs/design/notify-v2.md
@@ -1,0 +1,116 @@
+# SkillFS Notify v2 (S2)
+
+Design record for the one-step switch of
+`skill_ledger.skillfs_notify_change` from notify v1 to v2. S2 keeps the
+existing daemon method and transport, but replaces the Skill identity with a
+canonical path plus a complete Skill id.
+
+## Scope
+
+Notify v2 covers the request model, response validation, canonical/live root
+separation, and all existing notification producers. It does not add runtime
+negotiation, v1 compatibility, dual delivery, registration, multi-root
+aggregation, or deletion-state semantics.
+
+## Request
+
+SkillFS sends one NDJSON daemon request per debounced Skill change:
+
+```json
+{
+  "id": "skillfs-42",
+  "method": "skill_ledger.skillfs_notify_change",
+  "params": {
+    "schemaVersion": 2,
+    "canonicalSkillDir": "/canonical/skills/category/skill",
+    "skillId": "category/skill",
+    "eventKind": "write",
+    "paths": ["SKILL.md", "scripts/run.sh"]
+  },
+  "trace_context": {},
+  "timeout_ms": 5000
+}
+```
+
+`schemaVersion` is the protocol version. The business payload has exactly four
+fields: `canonicalSkillDir`, `skillId`, `eventKind`, and `paths`. Notify v2
+never sends `skillDir`, `skillName`, `mountId`, `generation`, `resolverSocket`,
+or `sourceId`.
+
+There is no v1 fallback or runtime version negotiation. SkillFS and the daemon
+must switch directly to v2.
+
+## Response
+
+SkillFS accepts a response only when the daemon envelope has `ok=true` and its
+data contains both values below:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "schemaVersion": 2,
+    "accepted": true
+  }
+}
+```
+
+A missing or different schema version is an invalid response. `ok=false` or
+`accepted=false` is a rejection. Connection, timeout, invalid-response, and
+rejection failures are diagnostic only: FUSE I/O succeeds independently and
+the current activation mapping stays in place.
+
+## Canonical Root and Live Root
+
+Notify and activation use two explicit roots:
+
+- **Canonical root** (`source_canon` in the CLI) is the user-visible root that
+  callers and the ledger address. Notify derives
+  `canonicalSkillDir = canonical_root.join(skillId)`.
+- **Live root** (`daemon_root` in the CLI) is the physical source that remains
+  reachable after an in-place FUSE over-mount. It is the configured backing
+  root when present and otherwise the source root. Activation bootstrap,
+  activation reload, and pending-install completeness checks continue to use
+  this root.
+
+The live/backing path, including any deployment-private or `PrivateTmp`
+detail, never appears in the notify v2 payload. The daemon uses
+`canonicalSkillDir` with the S1 `skill.resolveLiveSource` resolver when it needs
+the live directory.
+
+## Skill Identity and Paths
+
+`skillId` is always the complete id relative to the canonical root:
+
+- flat layout: `weather`;
+- Hermes layout: `category/weather`.
+
+`paths` are relative to `canonicalSkillDir`. SkillFS sorts and deduplicates
+them. A rename within one Skill includes both the old and new relative paths.
+When more than `MAX_NOTIFY_PATHS` unique paths accumulate, SkillFS sends an
+empty array to request a whole-Skill rescan.
+
+The same construction applies to ordinary FUSE mutations, startup reconcile,
+quiet-timeout delivery, pending-install completion, staging publish/rename,
+and Hermes nested Skill mutations. Startup reconcile and root-level publish
+events may intentionally use an empty `paths` array.
+
+## Daemon Integration
+
+The sec-core consumer switches directly to v2 and must:
+
+1. require notify `schemaVersion=2` and the four business fields;
+2. preserve the complete `skillId`;
+3. interpret every path relative to `canonicalSkillDir`;
+4. resolve the live source through the S1 resolver before each saturating
+   scan/resolve pass; and
+5. return `schemaVersion=2` with `accepted=true` only after accepting the
+   event.
+
+## Deferred Work
+
+S2 does not add `register`, `unregister`, `mountId`, `generation`, `sourceId`,
+`resolverSocket`, tombstones, or multi-directory runtime aggregation. A future
+SkillFS instance may route several canonical roots internally by longest
+prefix match; the external notify and resolver protocols already carry the
+canonical path needed for that routing and do not need another version.

--- a/src/skillfs/docs/security/runtime-activation-implementation-plan.md
+++ b/src/skillfs/docs/security/runtime-activation-implementation-plan.md
@@ -187,13 +187,19 @@ Scope:
 
 - Add a Unix socket client for `skill_ledger.skillfs_notify_change`.
 - Send one NDJSON request frame per debounced skill change.
-- Include `schemaVersion`, `skillDir`, `skillName`, `eventKind`, and relative
-  `paths`.
+- Socket notify v2 includes `schemaVersion=2`, `canonicalSkillDir`, the full
+  `skillId`, `eventKind`, and relative `paths`.
+- Derive `canonicalSkillDir` from the canonical source root. When the daemon
+  needs the live source, it resolves that canonical path through the S1
+  resolver instead of receiving a backing-root path in the notify payload.
 - Treat successful send as event acceptance, not as security approval.
 - On failure, write diagnostics and keep serving the existing trusted mapping.
-- Add a separate JSONL writer for the protocol event schema.
-- Fields: `schemaVersion`, `time`, `skillDir`, `skillName`, `eventKind`,
-  `paths`.
+- Add a separate JSONL writer for the N3 activation protocol event schema.
+- Protocol event log v1 fields remain `schemaVersion`, `time`, `skillDir`,
+  `skillName`, `eventKind`, `paths`, and optional `reloadOutcome`.
+- In in-place/backing-root mode, protocol event `skillDir` uses the
+  daemon/live backing root so existing event-log consumers can read the live
+  source without traversing the FUSE over-mount.
 - Keep it separate from the existing audit stream and security event stream.
 - Do not rely on this log as the only source of truth; daemon reconcile must
   re-read current disk state.
@@ -337,8 +343,9 @@ external daemon
   -> writes .skill-meta/activation.json and activation xattr
 
 SkillFS
-  -> sends notify skillDir under the ledger backing root
-  -> bootstraps/reloads activation from the same backing root
+  -> sends socket notify v2 canonicalSkillDir under the canonical source root
+  -> writes N3 protocol event skillDir under the ledger backing root
+  -> bootstraps/reloads activation from the ledger backing root
   -> exposes hidden/current/fallback through the FUSE view
 ```
 
@@ -356,9 +363,11 @@ Scope:
 - For non-in-place mounts, allow the same concept to be used as a normalized
   daemon working path. It may point at the source directly or at a private
   alias, but SkillFS should present one consistent path shape to the daemon.
-- Use the backing root for notify `skillDir`, activation bootstrap,
-  activation reload, startup reconcile, activation watching, and any future
-  source-side daemon-facing event payloads.
+- Use the canonical source root for socket notify v2 `canonicalSkillDir`.
+- Use the backing root for N3 protocol event `skillDir`, activation
+  bootstrap, activation reload, startup reconcile event-log entries,
+  activation watching, and any future source-side daemon-facing event
+  payloads.
 - Keep the agent-visible FUSE path unchanged. Agents should not need to know
   whether a backing root exists.
 - Validate that the backing root is outside the agent-visible mount path and
@@ -389,8 +398,11 @@ Acceptance criteria:
   the daemon through the backing root.
 - A fallback skill serves the trusted snapshot through the FUSE path while
   the daemon still scans the live current source through the backing root.
-- Notify payloads use the backing-root `skillDir`; the daemon does not need
-  to infer in-place vs non-in-place mount mode.
+- Socket notify v2 payloads use canonical `canonicalSkillDir` plus the full
+  `skillId`; the daemon resolves live source paths through the S1 resolver and
+  does not infer in-place vs non-in-place mount mode from notify fields.
+- N3 protocol event log payloads keep schema v1 and use backing-root
+  `skillDir` so existing event-log consumers can read the live source.
 - Activation bootstrap, reload, reconcile, and activation watching all use
   the same backing root.
 - Backing-root setup fails closed when ownership, parent permissions, path
@@ -494,10 +506,10 @@ Direct final-skill pending install is implemented in I3 below.
 
 **Backing root requirement:** In in-place/security mode with activation or
 notify enabled, the daemon-facing backing root must exist and be accessible
-at startup. All daemon-facing operations (notify `skillDir`, activation
-bootstrap, activation reload, startup reconcile, activation watcher) use
-the backing root path. The agent-visible FUSE mount path must never appear
-in notify payloads.
+at startup. Activation bootstrap, activation reload, activation watcher, and
+N3 protocol event-log `skillDir` use the backing root path. Socket notify v2
+uses canonical `canonicalSkillDir` and the full `skillId`; it does not send the
+backing root or the agent-visible FUSE over-mount path.
 
 Out of scope for I2:
 

--- a/src/skillfs/docs/skillfs-filesystem-capability-record.md
+++ b/src/skillfs/docs/skillfs-filesystem-capability-record.md
@@ -174,7 +174,10 @@ In in-place security mounts, the agent-visible path is intentionally the FUSE
 view. That path is not a safe source of truth for the external daemon because
 hidden skills may be invisible and fallback skills may resolve to a snapshot.
 The ledger backing root creates a private source-side work path for daemon
-scan, activation, reconcile, and notify payloads. It complements the
+scan, activation, reload, and N3 protocol event-log v1 `skillDir` values.
+Socket notify v2 keeps `canonicalSkillDir` under the canonical source root;
+the daemon resolves that identity to the live backing path through the control
+socket when it needs source access. The backing root complements the
 trusted-writer gate: trusted-writer controls selected `.skill-meta/**`
 mutations through the FUSE entry point, while the backing root is protected by
 OS ownership, private parent permissions, identity checks, and mount setup.
@@ -234,8 +237,12 @@ Note: "install-complete" is not a protocol-level event kind. It is an
 internal/historical flush concept only. The formal notify protocol uses
 ordinary filesystem mutation events (rename, write, create, etc.). In
 in-place/security mode, the daemon-facing backing root must be configured
-and accessible; notify payloads always use the backing root path, never the
-FUSE mount path.
+and accessible. Socket notify v2 identifies the skill with
+`canonicalSkillDir` under the canonical source root and the full `skillId`;
+the daemon resolves that identity before accessing live source. The separate
+N3 protocol event log remains schema v1 and writes `skillDir` under the live
+backing root. Activation bootstrap, reload, and watching also use that live
+root rather than the agent-visible FUSE view.
 
 Missing activation remains hidden by default; the notification triggers
 security processing and does not approve exposure. Configuration is via the


### PR DESCRIPTION
## Description

Adds a read-only SkillFS resolver that maps a canonical Skill directory to its
current live source directory for Skill Ledger. SkillFS remains responsible for
FUSE mounts and backing-root details, while Skill Ledger can keep canonical
paths as stable managed identities and resolve the physical path only before
performing I/O.

This change also updates Skill change notifications to identify Skills by their
canonical directory and complete flat or Hermes Skill ID. Path validation,
layout boundaries, socket authentication, backing-root behavior, and mount
lifecycle are covered by regression and FUSE integration tests.

## Related Issue

closes #1233
closes #1638
closes #1640

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## What Was Implemented

- Added `skill.resolveLiveSource` to the authenticated SkillFS control socket.
- Resolves a canonical Skill directory to the live source directory managed by
  SkillFS.
- Added a default resolver endpoint at
  `/run/user/<uid>/skillfs/control.sock`.
- Kept backing-root and FUSE mount details internal to SkillFS.
- Updated Skill notifications to carry:
  - canonical Skill directory;
  - complete flat or Hermes Skill ID;
  - filesystem event kind;
  - relative changed paths.
- Added strict canonical path and Skill layout validation.
- Rejects symlinked Skill directories and non-regular `SKILL.md` markers
  consistently across discovery, FUSE classification, activation, and resolve.
- Added fail-closed socket ownership, peer authentication, stale endpoint, and
  startup validation.
- Preserved the existing activation event-log behavior for current consumers.
- Added documentation for the resolver contract, default endpoint, notification
  fields, fallback semantics, and backing-root behavior.

- Makes Agent-visible access checks use the activated snapshot for existence,
  read, and execute permissions while preserving live-source write checks.
- Hides symlinked Hermes category and Skill boundaries from FUSE and rejects
  descendant read and mutation attempts before physical path resolution.

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `skillfs`: `cargo fmt --all --check`,
      `cargo clippy --workspace --all-targets -- -D warnings`, and
      `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/skillfs`:

```bash
cargo +1.86.0 fmt --all -- --check
cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
cargo +1.86.0 test --workspace
cargo +1.86.0 doc --workspace --no-deps
scripts/test.sh
```

Focused coverage includes:

- canonical directory to live source resolution;
- managed and unmanaged directory responses;
- flat and Hermes Skill layout boundaries;
- in-place mounts with a backing root;
- canonical notification identity;
- activation event-log path compatibility;
- authenticated default resolver endpoint;
- stale socket recovery and endpoint ownership;
- symlinked directories and invalid `SKILL.md` markers;
- startup reconcile and runtime activation reload.

- snapshot-visible `access()` permissions for flat and Hermes activations;
- fail-closed Hermes boundary symlinks across lookup, read, and mutation paths.

All required checks passed. The FUSE smoke suite exercised ordinary mounts,
managed mount recovery, failure circuit breaking, and stop cleanup without
skipping. No residual SkillFS mounts or processes remained after testing.

## Additional Notes

Skill Ledger should use the canonical Skill directory as its stable identity and
call the resolver before scanning or writing live Skill state. Direct filesystem
management should only be used when SkillFS explicitly reports that the
directory is not managed; authentication, invalid-path, and other structured
errors remain fail-closed.

The privileged bind-mount integration test requires root/CAP_SYS_ADMIN and is
ignored in an unprivileged run. The real non-privileged FUSE smoke suite passed.
`cargo doc` reports existing intra-doc link warnings unrelated to this change.