### PR TITLE
fix(anolisa): skip raw health probes for rpm

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -645,12 +645,13 @@ fn record_from_object(
     // catalog is loaded — fresh checkouts without a packaged catalog still
     // get integrity-only behavior.
     //
-    // rpm-observed objects are exempt: ANOLISA owns none of their files and
-    // does not lay out the raw artifact tree, so the manifest health checks
-    // (which assume that layout) would spuriously escalate an adopted row to
-    // degraded/failed (§8, review P2). The status stays `adopted`.
+    // RpmManaged and RpmObserved objects both use the file layout selected by
+    // RPM macros rather than ANOLISA's raw-backend layout. Manifest health
+    // probes assume the raw layout, so applying them to either RPM ownership
+    // can spuriously escalate a valid package. RPM status remains adjudicated
+    // by the rpmdb drift probe after this projection.
     let manifest_status = match catalog {
-        Some(cat) if !obj.is_rpm_observed() => {
+        Some(cat) if !obj.effective_ownership().is_rpm() => {
             let (manifest_entries, escalated) =
                 manifest_health_probe(layout, cat, install_mode, obj, &integrity_status);
             health.extend(manifest_entries);
@@ -2973,6 +2974,88 @@ mod tests {
         assert_eq!(obs[0].rpm_package.as_deref(), Some("copilot-shell"));
         assert_eq!(obs[0].rpm_evr.as_deref(), Some("2.3.0-1.al8"));
         assert_eq!(obs[0].rpm_source_repo.as_deref(), Some("@System"));
+    }
+
+    #[test]
+    fn rpm_managed_row_skips_raw_layout_health_probe() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let layout = test_layout(dir.path());
+        let state_path = layout.state_dir.join("installed.toml");
+        let manifest = r#"
+            [component]
+            name = "cosh"
+            version = "2.3.0-1.al8"
+
+            [[health_checks]]
+            name = "launcher"
+            kind = "command"
+            command = "{bindir}/cosh --version"
+        "#;
+        let (catalog, _guard) = catalog_with_component("cosh", manifest);
+        let catalogs = ScopedCatalogs::from_entries(vec![(state_path.clone(), catalog)]);
+        let query = FakeQuery {
+            installed: vec![(
+                "copilot-shell".to_string(),
+                pkg_info("copilot-shell", "2.3.0", "1.al8"),
+            )],
+            origins: Vec::new(),
+        };
+        let project = |object: InstalledObject| {
+            let mut state = InstalledState::default();
+            state.upsert_object(object);
+            let root = ScopedStateRoot {
+                scope: StateScope::System,
+                layout: layout.clone(),
+                state_path: state_path.clone(),
+                writable: true,
+                state,
+            };
+            let view = StateView {
+                writable: root.clone(),
+                visible_roots: vec![root],
+                warnings: Vec::new(),
+            };
+            select_components_from_view(&view, &catalogs, Some("cosh"), None, Some(&query))
+        };
+
+        let mut rpm_managed = component_object("cosh", "2.3.0-1.al8", ObjectStatus::Installed);
+        rpm_managed.install_backend = Some("rpm".to_string());
+        rpm_managed.ownership = Some(Ownership::RpmManaged);
+        rpm_managed.rpm_metadata = Some(rpm_meta("copilot-shell", "2.3.0-1.al8"));
+        let rpm_records = project(rpm_managed);
+        let rpm = &rpm_records[0];
+
+        assert_eq!(rpm.status, "installed");
+        assert!(
+            !rpm.health
+                .iter()
+                .any(|entry| entry.name == "cosh:command:launcher"),
+            "RPM rows must not run raw-layout manifest commands",
+        );
+        assert!(
+            !rpm.health
+                .iter()
+                .any(|entry| entry.status == "command_error"),
+            "RPM rows must not report raw-layout command failures",
+        );
+        assert!(
+            !rpm.health.iter().any(|entry| entry.name == "rpm:drift"),
+            "matching rpmdb EVR must remain installed without drift",
+        );
+
+        let mut raw_managed = component_object("cosh", "2.3.0-1.al8", ObjectStatus::Installed);
+        raw_managed.install_backend = Some("raw".to_string());
+        raw_managed.ownership = Some(Ownership::RawManaged);
+        let raw_records = project(raw_managed);
+        let raw = &raw_records[0];
+
+        assert_eq!(raw.status, "failed");
+        let launcher = raw
+            .health
+            .iter()
+            .find(|entry| entry.name == "cosh:command:launcher")
+            .expect("raw-managed launcher health entry");
+        assert_eq!(launcher.status, "command_error");
     }
 
     /// Configurable [`PackageQuery`] for the observed-probe tests.


### PR DESCRIPTION
## Description

Skip raw-layout manifest health probes for both RPM-managed and RPM-observed
components in `anolisa status`. RPM packages use distribution-defined file
layouts, so checking them against ANOLISA's raw `/usr/local` layout can
incorrectly mark valid installations as failed. RPM-backed status continues
to be determined by the existing rpmdb drift probe, while raw-managed
components retain manifest health validation.

## Related Issue

closes #1498

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa`:

```shell
cargo fmt --all -- --check
cargo test -p anolisa-cli rpm_managed_row_skips_raw_layout_health_probe --locked
cargo test -p anolisa-cli rpm_observed_row_skips_manifest_health_escalation --locked
cargo test -p anolisa-cli probe_rpm_drift --locked
cargo clippy -p anolisa-cli --all-targets --locked -- -D warnings
cargo test -p anolisa-cli --locked
```

Results:

- RPM-managed regression test: 1 passed
- RPM-observed regression test: 1 passed
- RPM drift tests: 5 passed
- Clippy: passed with no warnings
- Full `anolisa-cli` suite: 592 passed

Covered edge cases:

- RPM-managed components skip raw `{bindir}` command probes and remain
  `installed` when rpmdb EVR matches.
- Raw-managed components still fail when the required `{bindir}` launcher is
  missing.
- Missing packages, EVR drift, and unavailable RPM query tooling retain their
  existing behavior.

## Additional Notes

No documentation or lockfile changes are required because this corrects an
internal status-projection rule without changing the CLI interface. The fix is
implemented in ANOLISA status ownership handling and requires no RPM package
layout changes.

### Ship Note

- Changed: RPM-installed components no longer fail status checks because their
  binaries use distribution paths instead of ANOLISA's raw layout.
- Known limitations: RPM health remains limited to the existing rpmdb
  package-presence and EVR drift checks.
- Not covered: End-to-end validation on a live RPM-based host.
- Verification: `cargo test -p anolisa-cli --locked` passed all 592 tests.
