### PR TITLE
feat(anolisa): make OpenClaw enable host-aware

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -39,8 +39,8 @@ use anolisa_core::adapter::AdapterError;
 use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus};
 use anolisa_core::adapter::driver::{AdapterStatusReport, DriverPlan};
 use anolisa_core::adapter::manager::{
-    AdapterManager, AdapterSourceStatus, DisableOutcome, EnableOutcome, ScanEntry, ScanReport,
-    StatusReport,
+    AdapterManager, AdapterSourceStatus, DisableOutcome, EnableOptions, EnableOutcome, ScanEntry,
+    ScanReport, StatusReport,
 };
 
 use crate::commands::common;
@@ -67,6 +67,19 @@ pub enum AdapterCommands {
         /// Target framework (e.g. `openclaw`). Omit when the component
         /// ships adapters for exactly one framework.
         framework: Option<String>,
+        /// Explicit safety bypass: authorize an unsafe plugin install.
+        ///
+        /// This is an explicit security-bypass authorization. When set,
+        /// ANOLISA is permitted to pass the OpenClaw framework's own
+        /// unsafe-install flag if the installed OpenClaw advertises it as
+        /// effective. Releases where that flag is a deprecated no-op are
+        /// rejected and require operator-owned `security.installPolicy`
+        /// configuration instead.
+        /// Only valid for an OpenClaw plugin adapter; using it with any
+        /// other framework or a skill-only adapter is rejected. Off by
+        /// default; a normal install never bypasses OpenClaw's checks.
+        #[arg(long)]
+        allow_unsafe_plugin_install: bool,
     },
     /// Disable a previously enabled adapter.
     Disable {
@@ -173,7 +186,13 @@ pub fn handle(args: AdapterArgs, ctx: &CliContext) -> Result<(), CliError> {
         AdapterCommands::Enable {
             component,
             framework,
-        } => handle_enable(ctx, &component, framework.as_deref()),
+            allow_unsafe_plugin_install,
+        } => handle_enable(
+            ctx,
+            &component,
+            framework.as_deref(),
+            allow_unsafe_plugin_install,
+        ),
         AdapterCommands::Disable {
             component,
             framework,
@@ -287,13 +306,21 @@ fn handle_enable(
     ctx: &CliContext,
     component: &str,
     framework: Option<&str>,
+    allow_unsafe_plugin_install: bool,
 ) -> Result<(), CliError> {
     const COMMAND: &str = "adapter enable";
     let installed = common::load_installed_state(ctx, COMMAND).unwrap_or_default();
     let component = common::lookup_component_name(component, &installed, ctx, COMMAND);
     let manager = build_manager(ctx);
     let outcome = manager
-        .enable(&component, framework, ctx.dry_run)
+        .enable_with_options(
+            &component,
+            framework,
+            ctx.dry_run,
+            EnableOptions {
+                allow_unsafe_plugin_install,
+            },
+        )
         .map_err(|e| map_err(COMMAND, e))?;
 
     match outcome {
@@ -501,7 +528,9 @@ fn map_err(command: &str, err: AdapterError) -> CliError {
         | AdapterError::ResourceRootNotFound { .. }
         | AdapterError::ContractResourceRootNotFound { .. }
         | AdapterError::FrameworkNotDetected { .. }
+        | AdapterError::FrameworkVersionMismatch { .. }
         | AdapterError::BundleInvalid { .. }
+        | AdapterError::UnsafeInstallNotApplicable { .. }
         | AdapterError::ClaimValidation(_) => CliError::InvalidArgument {
             command: command.to_string(),
             reason: err.to_string(),
@@ -554,9 +583,14 @@ mod tests {
             AdapterCommands::Enable {
                 component,
                 framework,
+                allow_unsafe_plugin_install,
             } => {
                 assert_eq!(component, "tokenless");
                 assert!(framework.is_none());
+                assert!(
+                    !allow_unsafe_plugin_install,
+                    "unsafe install must default to false"
+                );
             }
             _ => panic!("expected enable"),
         }
@@ -568,6 +602,46 @@ mod tests {
             }
             _ => panic!("expected enable"),
         }
+    }
+
+    #[test]
+    fn enable_parses_allow_unsafe_plugin_install_flag() {
+        let cli = TestCli::try_parse_from([
+            "x",
+            "enable",
+            "tokenless",
+            "openclaw",
+            "--allow-unsafe-plugin-install",
+        ])
+        .expect("parse");
+        match cli.command {
+            AdapterCommands::Enable {
+                component,
+                framework,
+                allow_unsafe_plugin_install,
+            } => {
+                assert_eq!(component, "tokenless");
+                assert_eq!(framework.as_deref(), Some("openclaw"));
+                assert!(
+                    allow_unsafe_plugin_install,
+                    "flag must be captured when passed"
+                );
+            }
+            _ => panic!("expected enable"),
+        }
+    }
+
+    #[test]
+    fn unsafe_install_not_applicable_maps_to_invalid_argument() {
+        let err = map_err(
+            "adapter enable",
+            AdapterError::UnsafeInstallNotApplicable {
+                component: "agent-sec".to_string(),
+                framework: "hermes".to_string(),
+                adapter_type: None,
+            },
+        );
+        assert!(matches!(err, CliError::InvalidArgument { .. }));
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -235,6 +235,38 @@ pub enum AdapterError {
         /// Parse failure detail.
         reason: String,
     },
+
+    /// An unsafe-plugin-install authorization was passed for a target that
+    /// does not support it — a framework other than OpenClaw, or a
+    /// `skill_bundle` adapter that installs no plugin. Failing loudly keeps
+    /// the explicit safety-bypass from silently doing nothing.
+    #[error(
+        "--allow-unsafe-plugin-install does not apply to {component}/{framework}{}; it is only valid for an OpenClaw plugin adapter",
+        .adapter_type.as_deref().map(|t| format!(" (adapter_type '{t}')")).unwrap_or_default()
+    )]
+    UnsafeInstallNotApplicable {
+        /// Component the caller asked to enable.
+        component: String,
+        /// Framework the adapter targets.
+        framework: String,
+        /// The declared `adapter_type`, when the manifest set one.
+        adapter_type: Option<String>,
+    },
+
+    /// The framework is installed but its detected version does not satisfy
+    /// the adapter's declared version requirement. Enable stops before any
+    /// framework or filesystem mutation and before persisting a receipt.
+    #[error(
+        "framework '{framework}' version {detected} does not satisfy adapter requirement '{required}'"
+    )]
+    FrameworkVersionMismatch {
+        /// Framework whose version was checked.
+        framework: String,
+        /// Version detected on the host.
+        detected: String,
+        /// The adapter's declared requirement.
+        required: String,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -301,6 +301,28 @@ impl ClaimResource {
     }
 }
 
+/// Confirmation state for a framework configuration mutation.
+///
+/// `Pending` is durable write-ahead intent: the command has not yet produced
+/// a confirmed success, so the host may or may not contain the requested
+/// value. Existing receipts omit this field and therefore deserialize as
+/// `Applied`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigApplyState {
+    /// The framework command completed successfully.
+    #[default]
+    Applied,
+    /// The mutation is about to run or its outcome is uncertain.
+    Pending,
+}
+
+impl ConfigApplyState {
+    fn is_applied(&self) -> bool {
+        *self == Self::Applied
+    }
+}
+
 /// The closed set of resource kinds a receipt may declare.
 ///
 /// Additional kinds (`Tree`, `JsonKeys`) are introduced when their first
@@ -354,14 +376,16 @@ pub enum ClaimResourceKind {
         /// Marketplace name ANOLISA registered.
         marketplace: String,
     },
-    /// A framework configuration key/value pair that ANOLISA applied.
-    /// The key path is framework-specific; the value is the TOML
-    /// representation of what was set.
+    /// A framework configuration key ANOLISA attempted to apply.
     FrameworkConfig {
         /// Framework that owns the config (e.g. `openclaw`).
         framework: String,
         /// Config key path.
         key: String,
+        /// Whether the framework confirmed the mutation. Applied is omitted
+        /// on the wire to preserve compatibility with existing receipts.
+        #[serde(default, skip_serializing_if = "ConfigApplyState::is_applied")]
+        state: ConfigApplyState,
     },
 }
 
@@ -1040,11 +1064,48 @@ mod tests {
             kind: ClaimResourceKind::FrameworkConfig {
                 framework: "openclaw".to_string(),
                 key: "plugins.entries.sec.enabled".to_string(),
+                state: ConfigApplyState::Applied,
             },
         };
         resource
             .validate(&layout, &allowed)
             .expect("config resource should pass");
+    }
+
+    #[test]
+    fn framework_config_state_is_backward_compatible_and_round_trips_pending() {
+        let applied = ClaimResource {
+            id: "config_applied".to_string(),
+            purpose: "openclaw_config".to_string(),
+            kind: ClaimResourceKind::FrameworkConfig {
+                framework: "openclaw".to_string(),
+                key: "applied.key".to_string(),
+                state: ConfigApplyState::Applied,
+            },
+        };
+        let applied_json = serde_json::to_string(&applied).expect("serialize applied");
+        assert!(
+            !applied_json.contains("\"state\""),
+            "default applied state must keep the existing wire shape"
+        );
+        let parsed: ClaimResource =
+            serde_json::from_str(&applied_json).expect("parse implicit applied");
+        assert_eq!(parsed, applied);
+
+        let pending = ClaimResource {
+            id: "config_pending".to_string(),
+            purpose: "openclaw_config".to_string(),
+            kind: ClaimResourceKind::FrameworkConfig {
+                framework: "openclaw".to_string(),
+                key: "pending.key".to_string(),
+                state: ConfigApplyState::Pending,
+            },
+        };
+        let pending_json = serde_json::to_string(&pending).expect("serialize pending");
+        assert!(pending_json.contains("\"state\":\"pending\""));
+        let parsed: ClaimResource =
+            serde_json::from_str(&pending_json).expect("parse explicit pending");
+        assert_eq!(parsed, pending);
     }
 
     #[test]
@@ -1089,6 +1150,7 @@ mod tests {
                     kind: ClaimResourceKind::FrameworkConfig {
                         framework: "openclaw".to_string(),
                         key: "plugins.entries.sec-core.enabled".to_string(),
+                        state: ConfigApplyState::Applied,
                     },
                 },
             ],

--- a/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
@@ -41,7 +41,7 @@ use super::claim::{
 use super::driver::{
     AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
-    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+    FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
 use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
 
@@ -200,7 +200,7 @@ impl FrameworkDriver for ClaudeCodeDriver {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError> {
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let plugin = plugin_name(bundle, ctx);
         let marketplace = marketplace_name(&ctx.component);
         validate_plugin_id(&plugin)?;
@@ -225,26 +225,35 @@ impl FrameworkDriver for ClaudeCodeDriver {
             },
         ];
 
-        Ok(AdapterClaim {
-            claim_schema: CLAIM_SCHEMA_VERSION,
-            component: ctx.component.clone(),
-            framework: self.name().to_string(),
-            plugin_id: Some(plugin),
-            adapter_type: ctx.adapter_type.clone(),
-            enabled_at: now_iso8601(),
-            resource_root: bundle.resource_root.clone(),
-            bundle_digest: bundle.digest.clone(),
-            driver_schema: DRIVER_SCHEMA_VERSION,
-            status: ClaimStatus::Enabled,
-            resources,
-            driver_payload: DriverPayload::ClaudeCode(ClaudeCodeClaim {
-                marketplace_resource: RES_MARKETPLACE.to_string(),
-                plugin_resource: RES_PLUGIN.to_string(),
-            }),
-        })
+        Ok((
+            AdapterClaim {
+                claim_schema: CLAIM_SCHEMA_VERSION,
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                plugin_id: Some(plugin),
+                adapter_type: ctx.adapter_type.clone(),
+                enabled_at: now_iso8601(),
+                resource_root: bundle.resource_root.clone(),
+                bundle_digest: bundle.digest.clone(),
+                driver_schema: DRIVER_SCHEMA_VERSION,
+                status: ClaimStatus::Enabled,
+                resources,
+                driver_payload: DriverPayload::ClaudeCode(ClaudeCodeClaim {
+                    marketplace_resource: RES_MARKETPLACE.to_string(),
+                    plugin_resource: RES_PLUGIN.to_string(),
+                }),
+            },
+            PreparedEnable::None,
+        ))
     }
 
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        _prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        _progress: &mut dyn super::driver::EnableProgress,
+    ) -> Result<(), AdapterError> {
         let plugin = claim_plugin(claim).ok_or_else(|| AdapterError::BundleInvalid {
             root: claim.resource_root.clone(),
             reason: "claude-code receipt has no plugin resource".to_string(),
@@ -780,6 +789,8 @@ mod tests {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: true,
             ops: &ops,
         };
@@ -851,6 +862,8 @@ mod tests {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: true,
             ops: &ops,
         };

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -30,7 +30,7 @@ use super::claim::{
 use super::driver::{
     AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
-    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+    FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
 use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
 
@@ -167,7 +167,7 @@ impl FrameworkDriver for CodexDriver {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError> {
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let layout = MarketplaceLayout::resolve(bundle, ctx)?;
         validate_plugin_id(&layout.plugin)?;
         validate_marketplace_name(&layout.marketplace)?;
@@ -206,28 +206,37 @@ impl FrameworkDriver for CodexDriver {
             },
         ];
 
-        Ok(AdapterClaim {
-            claim_schema: CLAIM_SCHEMA_VERSION,
-            component: ctx.component.clone(),
-            framework: self.name().to_string(),
-            plugin_id: Some(layout.plugin.clone()),
-            adapter_type: ctx.adapter_type.clone(),
-            enabled_at: now_iso8601(),
-            resource_root: bundle.resource_root.clone(),
-            bundle_digest: bundle.digest.clone(),
-            driver_schema: DRIVER_SCHEMA_VERSION,
-            status: ClaimStatus::Enabled,
-            resources,
-            driver_payload: DriverPayload::Codex(CodexClaim {
-                marketplace_dir_resource: RES_MARKETPLACE_DIR.to_string(),
-                symlink_resource: RES_SYMLINK.to_string(),
-                marketplace_resource: RES_MARKETPLACE.to_string(),
-                plugin_resource: RES_PLUGIN.to_string(),
-            }),
-        })
+        Ok((
+            AdapterClaim {
+                claim_schema: CLAIM_SCHEMA_VERSION,
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                plugin_id: Some(layout.plugin.clone()),
+                adapter_type: ctx.adapter_type.clone(),
+                enabled_at: now_iso8601(),
+                resource_root: bundle.resource_root.clone(),
+                bundle_digest: bundle.digest.clone(),
+                driver_schema: DRIVER_SCHEMA_VERSION,
+                status: ClaimStatus::Enabled,
+                resources,
+                driver_payload: DriverPayload::Codex(CodexClaim {
+                    marketplace_dir_resource: RES_MARKETPLACE_DIR.to_string(),
+                    symlink_resource: RES_SYMLINK.to_string(),
+                    marketplace_resource: RES_MARKETPLACE.to_string(),
+                    plugin_resource: RES_PLUGIN.to_string(),
+                }),
+            },
+            PreparedEnable::None,
+        ))
     }
 
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        _prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        _progress: &mut dyn super::driver::EnableProgress,
+    ) -> Result<(), AdapterError> {
         let layout = MarketplaceLayout::from_claim(claim)?;
 
         // 1. Write the marketplace manifest and the plugin symlink.

--- a/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
@@ -28,7 +28,7 @@ use super::claim::{
 use super::driver::{
     AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
-    FrameworkDriver, HostEnv, find_binary_in_path,
+    FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
 use super::util::{bool_status, digest_tree, now_iso8601};
 
@@ -160,32 +160,41 @@ impl FrameworkDriver for CoshDriver {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError> {
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let dst = extension_dir(bundle, ctx)?;
         let resources = vec![ClaimResource {
             id: RES_EXTENSION_DIR.to_string(),
             purpose: "cosh_extension_dir".to_string(),
             kind: ClaimResourceKind::ExternalPath { path: dst },
         }];
-        Ok(AdapterClaim {
-            claim_schema: CLAIM_SCHEMA_VERSION,
-            component: ctx.component.clone(),
-            framework: self.name().to_string(),
-            plugin_id: bundle.plugin_id.clone(),
-            adapter_type: ctx.adapter_type.clone(),
-            enabled_at: now_iso8601(),
-            resource_root: bundle.resource_root.clone(),
-            bundle_digest: bundle.digest.clone(),
-            driver_schema: DRIVER_SCHEMA_VERSION,
-            status: ClaimStatus::Enabled,
-            resources,
-            driver_payload: DriverPayload::Cosh(CoshClaim {
-                extension_dir_resource: RES_EXTENSION_DIR.to_string(),
-            }),
-        })
+        Ok((
+            AdapterClaim {
+                claim_schema: CLAIM_SCHEMA_VERSION,
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                plugin_id: bundle.plugin_id.clone(),
+                adapter_type: ctx.adapter_type.clone(),
+                enabled_at: now_iso8601(),
+                resource_root: bundle.resource_root.clone(),
+                bundle_digest: bundle.digest.clone(),
+                driver_schema: DRIVER_SCHEMA_VERSION,
+                status: ClaimStatus::Enabled,
+                resources,
+                driver_payload: DriverPayload::Cosh(CoshClaim {
+                    extension_dir_resource: RES_EXTENSION_DIR.to_string(),
+                }),
+            },
+            PreparedEnable::None,
+        ))
     }
 
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        _prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        _progress: &mut dyn super::driver::EnableProgress,
+    ) -> Result<(), AdapterError> {
         let dst = claim_extension_dir(claim).ok_or_else(|| AdapterError::BundleInvalid {
             root: claim.resource_root.clone(),
             reason: "cosh receipt has no extension directory resource".to_string(),
@@ -600,6 +609,8 @@ mod tests {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: false,
             ops,
         }
@@ -627,8 +638,10 @@ mod tests {
         let bundle = driver.read_bundle(&ctx).expect("read bundle");
         assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
 
-        let claim = driver.prepare_enable(&bundle, &ctx).expect("claim");
-        driver.apply_enable(&claim, &ctx).expect("apply");
+        let (mut claim, prepared) = driver.prepare_enable(&bundle, &ctx).expect("claim");
+        driver
+            .apply_enable(&mut claim, &prepared, &ctx, &mut ())
+            .expect("apply");
 
         let ext_dir = cosh.join("extensions").join("tokenless");
         assert!(ext_dir.join(COSH_MANIFEST).is_file(), "manifest copied");
@@ -673,9 +686,9 @@ mod tests {
         let driver = CoshDriver::new();
 
         let bundle = driver.read_bundle(&ctx).expect("read bundle");
-        let claim = driver.prepare_enable(&bundle, &ctx).expect("claim");
+        let (mut claim, prepared) = driver.prepare_enable(&bundle, &ctx).expect("claim");
         let err = driver
-            .apply_enable(&claim, &ctx)
+            .apply_enable(&mut claim, &prepared, &ctx, &mut ())
             .expect_err("must refuse to clobber non-ANOLISA extension");
         assert!(
             matches!(err, AdapterError::InvalidAdapterInput { .. }),

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -77,6 +77,19 @@ pub struct DriverCtx<'a> {
     /// should use this to locate the framework-native manifest inside
     /// the resource root instead of hardcoding a filename.
     pub declared_bundle_entry: Option<String>,
+    /// Adapter-level framework version requirement resolved from the
+    /// component manifest. The Manager derives it with
+    /// `[adapters.compat].framework_version` taking precedence over the
+    /// legacy `framework_version_req` compat entry; `None` means the adapter
+    /// declares no minimum. A driver that can probe the framework version
+    /// gates enable on this before any mutation.
+    pub framework_version_req: Option<String>,
+    /// Whether the caller explicitly authorized an unsafe plugin install
+    /// (`--allow-unsafe-plugin-install`). Typed data, never a free-form map:
+    /// only the OpenClaw plugin path consults it, and only to add the
+    /// framework's own unsafe-install flag when the host also exposes it.
+    /// Defaults to `false` for every non-enable operation.
+    pub allow_unsafe_plugin_install: bool,
     /// True when the caller passed `--dry-run`; drivers must not mutate
     /// framework state in this mode (the Manager also guards this).
     pub dry_run: bool,
@@ -119,6 +132,59 @@ pub struct DriverPlan {
     /// run. Display-only — never parsed back into an argv.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub register_command: Option<String>,
+}
+
+/// Driver-private state produced by [`FrameworkDriver::prepare_enable`] and
+/// handed to [`FrameworkDriver::apply_enable`] within the same locked enable.
+///
+/// It carries the host capabilities a driver resolved by read-only probing
+/// *before* the first mutation, so apply can act on them without re-probing —
+/// keeping every probe to once per enable while still completing all probing
+/// up front. It is deliberately **not** part of the receipt: the persisted
+/// [`AdapterClaim`] stays pure typed resource data, and this transient value
+/// never outlives the enable call. Most drivers need no such state and return
+/// [`PreparedEnable::None`].
+#[derive(Debug, Clone, Default)]
+pub enum PreparedEnable {
+    /// The driver needs no prepared host state for apply.
+    #[default]
+    None,
+    /// OpenClaw install/verify capabilities resolved before the first
+    /// mutation. `apply_enable` uses these to decide the unsafe-retry hint and
+    /// the runtime-inspect form without a second probe.
+    OpenClaw {
+        /// The host's `plugins install --help` exposes the unsafe flag.
+        supports_unsafe_install: bool,
+        /// The host's `plugins inspect --help` exposes `--json`.
+        supports_inspect_json: bool,
+        /// The host's `plugins inspect --help` exposes `--runtime`.
+        supports_inspect_runtime: bool,
+        /// Original manifest indices of config entries selected by the
+        /// detected host version. Apply uses this transient intent to avoid
+        /// claiming an entry until its `config set` command succeeds.
+        selected_config_indices: Vec<usize>,
+    },
+}
+
+/// Manager-owned persistence channel for resources applied incrementally.
+///
+/// Drivers use it for write-ahead intent and confirmed-success transitions.
+/// The Manager validates and saves the updated receipt while the enable lock
+/// is still held, keeping cleanup state accurate across partial failure.
+pub trait EnableProgress {
+    /// Validate and persist the current enable receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns claim-validation or installed-state persistence failures.
+    fn persist_claim(&mut self, claim: &AdapterClaim) -> Result<(), AdapterError>;
+}
+
+#[cfg(test)]
+impl EnableProgress for () {
+    fn persist_claim(&mut self, _claim: &AdapterClaim) -> Result<(), AdapterError> {
+        Ok(())
+    }
 }
 
 /// Outcome of [`FrameworkDriver::disable`].
@@ -413,11 +479,16 @@ pub trait FrameworkDriver: Send + Sync {
     ) -> Result<DriverPlan, AdapterError>;
 
     /// Build the pure-data receipt for a future enable operation without
-    /// mutating framework state.
+    /// mutating framework state, together with any driver-private
+    /// [`PreparedEnable`] state (host capabilities resolved by read-only
+    /// probing) that [`Self::apply_enable`] should reuse instead of
+    /// re-probing.
     ///
     /// The Manager validates and persists this claim before
     /// [`Self::apply_enable`] runs, so a later framework-side failure stays
-    /// visible to status/disable.
+    /// visible to status/disable. The returned [`PreparedEnable`] is **not**
+    /// persisted — it flows in-memory to `apply_enable` within the same locked
+    /// enable, keeping the receipt pure typed resource data.
     ///
     /// # Errors
     ///
@@ -427,16 +498,43 @@ pub trait FrameworkDriver: Send + Sync {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError>;
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError>;
+
+    /// Carry still-relevant facts from a validated prior receipt into the
+    /// newly prepared receipt before it replaces prior state.
+    ///
+    /// Most drivers fully supersede their prior receipt and need no merge.
+    /// Drivers whose mutations are not reversed by re-enable can override
+    /// this hook so an early re-enable failure does not erase cleanup facts.
+    ///
+    /// # Errors
+    ///
+    /// Returns a driver-specific receipt consistency error.
+    fn preserve_reenable_facts(
+        &self,
+        _prior: &AdapterClaim,
+        _next: &mut AdapterClaim,
+    ) -> Result<(), AdapterError> {
+        Ok(())
+    }
 
     /// Idempotently apply an already-persisted enable receipt to framework
-    /// state.
+    /// state, reusing the [`PreparedEnable`] state produced by
+    /// [`Self::prepare_enable`] so no read-only host probe runs twice in one
+    /// enable. When a driver applies resources incrementally, it journals
+    /// intent and confirmation transitions through `progress`.
     ///
     /// # Errors
     ///
     /// [`AdapterError::FrameworkCli`] or [`AdapterError::BundleInvalid`] on
     /// failure.
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError>;
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        progress: &mut dyn EnableProgress,
+    ) -> Result<(), AdapterError>;
 
     /// Read-only status check against a receipt. Must not mutate state.
     ///

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -28,7 +28,7 @@ use super::claim::{
 use super::driver::{
     AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
-    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+    FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
 
 /// Default timeout for a Hermes CLI invocation.
@@ -175,7 +175,7 @@ impl FrameworkDriver for HermesDriver {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError> {
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let home = require_home(ctx)?;
         let mut resources = vec![ClaimResource {
             id: RES_HOME.to_string(),
@@ -210,31 +210,40 @@ impl FrameworkDriver for HermesDriver {
             skill_resource_ids.push(res_id);
         }
 
-        Ok(AdapterClaim {
-            claim_schema: CLAIM_SCHEMA_VERSION,
-            component: ctx.component.clone(),
-            framework: self.name().to_string(),
-            plugin_id,
-            adapter_type: ctx.adapter_type.clone(),
-            enabled_at: now_iso8601(),
-            resource_root: bundle.resource_root.clone(),
-            bundle_digest: bundle.digest.clone(),
-            driver_schema: DRIVER_SCHEMA_VERSION,
-            status: ClaimStatus::Enabled,
-            resources,
-            driver_payload: DriverPayload::Hermes(HermesClaim {
-                home_resource: RES_HOME.to_string(),
-                plugin_resource: if ctx.is_skill_bundle() {
-                    String::new()
-                } else {
-                    RES_PLUGIN.to_string()
-                },
-                skill_resources: skill_resource_ids,
-            }),
-        })
+        Ok((
+            AdapterClaim {
+                claim_schema: CLAIM_SCHEMA_VERSION,
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                plugin_id,
+                adapter_type: ctx.adapter_type.clone(),
+                enabled_at: now_iso8601(),
+                resource_root: bundle.resource_root.clone(),
+                bundle_digest: bundle.digest.clone(),
+                driver_schema: DRIVER_SCHEMA_VERSION,
+                status: ClaimStatus::Enabled,
+                resources,
+                driver_payload: DriverPayload::Hermes(HermesClaim {
+                    home_resource: RES_HOME.to_string(),
+                    plugin_resource: if ctx.is_skill_bundle() {
+                        String::new()
+                    } else {
+                        RES_PLUGIN.to_string()
+                    },
+                    skill_resources: skill_resource_ids,
+                }),
+            },
+            PreparedEnable::None,
+        ))
     }
 
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        _prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        _progress: &mut dyn super::driver::EnableProgress,
+    ) -> Result<(), AdapterError> {
         let home = require_home(ctx)?;
 
         if !ctx.is_skill_bundle() {
@@ -992,6 +1001,8 @@ mod tests {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: true,
             ops: &ops,
         };
@@ -1043,6 +1054,8 @@ mod tests {
             }],
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: true,
             ops: &ops,
         };
@@ -1063,7 +1076,7 @@ mod tests {
             "undeclared skill must not appear in plan"
         );
 
-        let claim = driver
+        let (claim, _prepared) = driver
             .prepare_enable(&bundle, &ctx)
             .expect("prepare_enable");
         let skill_resources: Vec<&str> = claim
@@ -1108,6 +1121,8 @@ mod tests {
             }],
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: true,
             ops: &ops,
         };
@@ -1122,7 +1137,7 @@ mod tests {
                 .all(|action| !action.contains("enable hermes plugin")),
         );
 
-        let claim = driver.prepare_enable(&bundle, &ctx).expect("claim");
+        let (claim, _prepared) = driver.prepare_enable(&bundle, &ctx).expect("claim");
         assert!(claim.plugin_id.is_none());
         assert_eq!(claim.adapter_type.as_deref(), Some("skill_bundle"));
         let plugin_paths = claim

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -37,7 +37,8 @@ use super::AdapterError;
 use super::claim::{AdapterClaim, ClaimStatus};
 use super::driver::{
     AdapterCondition, AdapterConditionKind, AdapterOps, AdapterStatusReport, AdapterSummary,
-    CliOutput, ConditionStatus, DisableReport, DriverCtx, DriverPlan, FrameworkCommand, HostEnv,
+    CliOutput, ConditionStatus, DisableReport, DriverCtx, DriverPlan, EnableProgress,
+    FrameworkCommand, HostEnv,
 };
 use super::registry::DriverRegistry;
 use crate::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
@@ -59,6 +60,22 @@ pub enum EnableOutcome {
     Planned(DriverPlan),
     /// Enable ran; the persisted receipt.
     Enabled(Box<AdapterClaim>),
+}
+
+/// Typed knobs for [`AdapterManager::enable_with_options`].
+///
+/// A distinct struct (rather than extra positional parameters) keeps the
+/// default-safe [`AdapterManager::enable`] wrapper stable for its many
+/// callers while letting a new authorization be threaded to the driver as
+/// typed data — never an environment variable or free-form map.
+#[derive(Debug, Clone, Default)]
+pub struct EnableOptions {
+    /// The caller explicitly authorized an unsafe plugin install
+    /// (`--allow-unsafe-plugin-install`). Only honored for the OpenClaw
+    /// plugin adapter; rejected for any other framework or a `skill_bundle`
+    /// adapter. Even when set, the driver adds the framework's unsafe flag
+    /// only if the host's install help exposes it.
+    pub allow_unsafe_plugin_install: bool,
 }
 
 /// Outcome of [`AdapterManager::disable`].
@@ -461,6 +478,25 @@ impl AdapterManager {
         framework: Option<&str>,
         dry_run: bool,
     ) -> Result<EnableOutcome, AdapterError> {
+        self.enable_with_options(component, framework, dry_run, EnableOptions::default())
+    }
+
+    /// Enable with explicit typed [`EnableOptions`]. [`Self::enable`] is the
+    /// default-safe wrapper over this; callers that need to pass an explicit
+    /// safety-bypass authorization use this form.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::enable`], plus [`AdapterError::UnsafeInstallNotApplicable`]
+    /// when an unsafe-install authorization is passed for a framework or
+    /// adapter type that does not support it.
+    pub fn enable_with_options(
+        &self,
+        component: &str,
+        framework: Option<&str>,
+        dry_run: bool,
+        options: EnableOptions,
+    ) -> Result<EnableOutcome, AdapterError> {
         let _lock = InstallLock::acquire(&self.layout.lock_file)?;
         let mut state = InstalledState::load(&self.state_path)?;
 
@@ -485,9 +521,24 @@ impl AdapterManager {
         // so the wrong driver code path can never run.
         validate_adapter_type_for_framework(component, &framework, adapter_type.as_deref())?;
 
+        // An unsafe-install authorization is only meaningful for the OpenClaw
+        // plugin adapter. Reject it for any other framework, and for a
+        // skill_bundle adapter (which never installs a plugin), before doing
+        // any work — the authorization must never silently no-op.
+        if options.allow_unsafe_plugin_install
+            && (framework != "openclaw" || adapter_type.as_deref() == Some("skill_bundle"))
+        {
+            return Err(AdapterError::UnsafeInstallNotApplicable {
+                component: component.to_string(),
+                framework: framework.clone(),
+                adapter_type: adapter_type.clone(),
+            });
+        }
+
         let declared_plugin_id = declared_plugin_id(&manifest, &framework);
         let skill_specs = declared_skills(&manifest, &framework);
         let config = declared_config(&manifest, &framework);
+        let framework_version_req = declared_framework_version_req(&manifest, &framework);
         let bundle_entry = declared_bundle_entry(&manifest, &framework);
         if adapter_type.as_deref() == Some("skill_bundle") && !config.is_empty() {
             return Err(AdapterError::InvalidAdapterInput {
@@ -573,6 +624,8 @@ impl AdapterManager {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run,
             ops: &probe_ops,
         };
@@ -610,6 +663,8 @@ impl AdapterManager {
             declared_skills: skills,
             declared_config: config,
             declared_bundle_entry: bundle_entry,
+            framework_version_req,
+            allow_unsafe_plugin_install: options.allow_unsafe_plugin_install,
             dry_run,
             ops: &ops,
         };
@@ -632,21 +687,41 @@ impl AdapterManager {
             });
         }
 
-        let claim = driver.prepare_enable(&bundle, &ctx)?;
+        let (mut claim, prepared) = driver.prepare_enable(&bundle, &ctx)?;
+        let claim_allowed_roots = driver.allowed_external_roots(&ctx);
+        if let Some(prior) = state.find_adapter_claim(component, &framework).cloned() {
+            // A forged prior receipt must not gain authority merely because a
+            // driver preserves facts from it during re-enable.
+            prior.validate_with_owned_roots(
+                &self.layout,
+                &claim_allowed_roots,
+                &self.all_datadir_roots,
+            )?;
+            driver.preserve_reenable_facts(&prior, &mut claim)?;
+        }
         // Defense in depth: the driver must not emit a claim that points
         // outside its own declared roots. Reject before persisting.
         claim.validate_with_owned_roots(
             &self.layout,
-            &driver.allowed_external_roots(&ctx),
+            &claim_allowed_roots,
             &self.all_datadir_roots,
         )?;
 
         state.upsert_adapter_claim(claim.clone());
         state.save(&self.state_path)?;
-        if let Err(err) = driver.apply_enable(&claim, &ctx) {
-            let mut failed_claim = claim.clone();
-            failed_claim.status = ClaimStatus::CleanupFailed;
-            state.upsert_adapter_claim(failed_claim);
+        let apply_result = {
+            let mut progress = ManagerEnableProgress {
+                state: &mut state,
+                state_path: &self.state_path,
+                layout: &self.layout,
+                allowed_external_roots: &claim_allowed_roots,
+                extra_owned_roots: &self.all_datadir_roots,
+            };
+            driver.apply_enable(&mut claim, &prepared, &ctx, &mut progress)
+        };
+        if let Err(err) = apply_result {
+            claim.status = ClaimStatus::CleanupFailed;
+            state.upsert_adapter_claim(claim.clone());
             if let Err(save_err) = state.save(&self.state_path) {
                 self.log_operation(
                     &label,
@@ -788,6 +863,8 @@ impl AdapterManager {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run,
             ops: &probe_ops,
         };
@@ -815,6 +892,8 @@ impl AdapterManager {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run,
             ops: &ops,
         };
@@ -938,6 +1017,8 @@ impl AdapterManager {
                 declared_skills: Vec::new(),
                 declared_config: Vec::new(),
                 declared_bundle_entry: None,
+                framework_version_req: None,
+                allow_unsafe_plugin_install: false,
                 dry_run: false,
                 ops: &probe_ops,
             };
@@ -965,6 +1046,8 @@ impl AdapterManager {
                 declared_skills: Vec::new(),
                 declared_config: Vec::new(),
                 declared_bundle_entry: None,
+                framework_version_req: None,
+                allow_unsafe_plugin_install: false,
                 dry_run: false,
                 ops: &ops,
             };
@@ -1577,6 +1660,30 @@ struct ManagerOps {
     /// under. Populated from the driver's `allowed_external_roots` plus
     /// the resource root.
     allowed_roots: Vec<PathBuf>,
+}
+
+/// Persists incremental receipt facts while the Manager holds the enable
+/// lock. Drivers never receive the state path or write installed state
+/// directly.
+struct ManagerEnableProgress<'a> {
+    state: &'a mut InstalledState,
+    state_path: &'a Path,
+    layout: &'a FsLayout,
+    allowed_external_roots: &'a [PathBuf],
+    extra_owned_roots: &'a [PathBuf],
+}
+
+impl EnableProgress for ManagerEnableProgress<'_> {
+    fn persist_claim(&mut self, claim: &AdapterClaim) -> Result<(), AdapterError> {
+        claim.validate_with_owned_roots(
+            self.layout,
+            self.allowed_external_roots,
+            self.extra_owned_roots,
+        )?;
+        self.state.upsert_adapter_claim(claim.clone());
+        self.state.save(self.state_path)?;
+        Ok(())
+    }
 }
 
 impl ManagerOps {
@@ -2491,6 +2598,32 @@ fn declared_config(
     adapter.config.clone()
 }
 
+/// Resolve the adapter-level framework version requirement for a framework.
+///
+/// `[adapters.compat].framework_version` is the primary source; the legacy
+/// top-level `framework_version_req` is the compatibility entry used only
+/// when `compat.framework_version` is absent. This precedence lets newer
+/// manifests express the requirement in the structured `compat` table while
+/// older manifests keep working unchanged.
+fn declared_framework_version_req(manifest: &ComponentManifest, framework: &str) -> Option<String> {
+    let adapter = manifest
+        .adapters
+        .iter()
+        .find(|a| a.framework.as_deref().map(str::trim) == Some(framework))?;
+    // Precedence only — no validity check here. `[adapters.compat]
+    // .framework_version` is primary: when the field is *present* (even if
+    // empty), the legacy `framework_version_req` is not consulted, so a
+    // migrated manifest cannot accidentally fall back to a stale value. The
+    // raw value (including a present-but-empty one) is passed through to the
+    // driver, which alone decides validity — this keeps the framework-agnostic
+    // Manager from imposing OpenClaw's version rules on other frameworks
+    // (Hermes/Codex/Qoder/Cosh ignore the field entirely).
+    if let Some(raw) = adapter.compat.framework_version.as_deref() {
+        return Some(raw.to_string());
+    }
+    adapter.framework_version_req.as_deref().map(str::to_string)
+}
+
 /// Extract the bundle entry-point from the manifest, checking the
 /// framework-specific section first then falling back to the generic
 /// `[adapters.bundle].entry`.
@@ -2728,6 +2861,83 @@ fn prioritize_datadir_root(roots: &[PathBuf], preferred: Option<&Path>) -> Vec<P
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The framework-agnostic Manager resolves the requirement by precedence
+    /// only and never validates it — a present-but-empty value is passed
+    /// through verbatim (the owning driver decides validity), and it never
+    /// errors for any framework. This keeps the strict OpenClaw emptiness
+    /// rule from leaking onto Hermes/Codex/Qoder/Cosh (Issue non-goal).
+    #[test]
+    fn declared_framework_version_req_is_precedence_only() {
+        let compat_wins = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "c"
+            version = "1.0.0"
+            [[adapters]]
+            framework = "openclaw"
+            framework_version_req = ">=legacy"
+            [adapters.compat]
+            framework_version = ">=2026.4.14"
+        "#,
+        )
+        .expect("parse");
+        assert_eq!(
+            declared_framework_version_req(&compat_wins, "openclaw").as_deref(),
+            Some(">=2026.4.14"),
+            "compat is primary; legacy is not consulted when compat is present"
+        );
+
+        // A present-but-empty compat value is returned as-is (not collapsed to
+        // None, not an error) — the driver validates it.
+        let empty_compat = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "c"
+            version = "1.0.0"
+            [[adapters]]
+            framework = "hermes"
+            [adapters.compat]
+            framework_version = ""
+        "#,
+        )
+        .expect("parse");
+        assert_eq!(
+            declared_framework_version_req(&empty_compat, "hermes").as_deref(),
+            Some(""),
+            "a non-OpenClaw framework's empty requirement passes through unchanged, never erroring"
+        );
+
+        // Legacy field is the fallback only when compat is absent.
+        let legacy_only = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "c"
+            version = "1.0.0"
+            [[adapters]]
+            framework = "openclaw"
+            framework_version_req = ">=1.2"
+        "#,
+        )
+        .expect("parse");
+        assert_eq!(
+            declared_framework_version_req(&legacy_only, "openclaw").as_deref(),
+            Some(">=1.2")
+        );
+
+        // No field at all → None.
+        let none = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "c"
+            version = "1.0.0"
+            [[adapters]]
+            framework = "openclaw"
+        "#,
+        )
+        .expect("parse");
+        assert_eq!(declared_framework_version_req(&none, "openclaw"), None);
+    }
 
     #[test]
     fn prepend_path_puts_dirs_in_front() {
@@ -5513,6 +5723,7 @@ dest = "{datadir}/skills"
                 kind: ClaimResourceKind::FrameworkConfig {
                     framework: "openclaw".to_string(),
                     key: "plugins.entries.test-comp.enabled".to_string(),
+                    state: crate::adapter::claim::ConfigApplyState::Applied,
                 },
             }],
             Vec::new(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -13,7 +13,23 @@
 //! `OPENCLAW_HOME`, set `OPENCLAW_STATE_DIR` to the resolved home, and
 //! prepend the standard bin dirs to `PATH`. `OPENCLAW_BIN` overrides the
 //! executable (used by tests to point at a fake CLI).
+//!
+//! Before the first framework mutation — during `prepare_enable` (and, for
+//! `--dry-run`, `plan_enable`) — `enable` builds a read-only
+//! `OpenClawHostProfile` from all three probes (`openclaw --version`,
+//! `plugins install --help`, `plugins inspect --help`). From it the driver
+//! gates on the adapter's declared framework version, chooses
+//! version-conditioned config, decides the install argv (`--force`, and
+//! `--dangerously-force-unsafe-install` only when both authorized and
+//! advertised as effective by the host), and records the inspect capabilities.
+//! The install/verify capabilities flow to `apply_enable` as typed
+//! [`PreparedEnable`] state, so
+//! apply performs no probe of its own — each probe runs exactly once per
+//! enable, all before the first mutation. The host version or argv is never
+//! written into the receipt — the receipt stays pure typed data.
 
+use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -22,13 +38,15 @@ use sha2::{Digest, Sha256};
 use super::AdapterError;
 use super::claim::{
     AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
-    DRIVER_SCHEMA_VERSION, DriverPayload, OpenClawClaim, validate_plugin_id,
+    ConfigApplyState, DRIVER_SCHEMA_VERSION, DriverPayload, OpenClawClaim, validate_plugin_id,
 };
 use super::driver::{
     AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
-    ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
-    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+    ClaimResourceRef, CliOutput, ConditionStatus, DetectResult, DisableReport, DriverCtx,
+    DriverPlan, EnableProgress, FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable,
+    find_binary_in_path,
 };
+use crate::manifest::AdapterConfigSetSpec;
 
 /// Default timeout for an OpenClaw CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
@@ -140,11 +158,20 @@ impl FrameworkDriver for OpenClawDriver {
         let home = require_home(ctx)?;
         let mut actions = Vec::new();
         let mut register_command = None;
-        if !ctx.is_skill_bundle() {
+        // Plugin adapters resolve a read-only host profile so the dry-run
+        // plan shows the exact install command (including whether the
+        // authorized unsafe flag is used) and only the config the host
+        // version actually selects — the same decisions a real enable makes.
+        let mut selected_config: Vec<(usize, &AdapterConfigSetSpec)> = Vec::new();
+        if ctx.is_skill_bundle() {
+            // The adapter-level version gate still applies to skill bundles.
+            self.gate_skill_bundle_version(ctx)?;
+        } else {
             let plugin_id = require_plugin_id(bundle)?;
             validate_plugin_id(&plugin_id)?;
-            let cmd = build_install_cmd(&bundle.resource_root, &home, ctx.user_home.as_deref());
-            register_command = Some(display_command(&cmd));
+            let preflight = self.plugin_preflight(&bundle.resource_root, ctx)?;
+            selected_config = preflight.selected_config;
+            register_command = Some(display_command(&preflight.install_cmd));
             actions.push(format!(
                 "register openclaw plugin '{plugin_id}' from {}",
                 bundle.resource_root.display()
@@ -164,14 +191,12 @@ impl FrameworkDriver for OpenClawDriver {
                 skill.name,
             ));
         }
-        if !ctx.is_skill_bundle() {
-            for (i, cfg) in ctx.declared_config.iter().enumerate() {
-                actions.push(format!(
-                    "set openclaw config [{i}] {} = {}",
-                    cfg.key,
-                    config_value_display(&cfg.value)
-                ));
-            }
+        for &(i, cfg) in &selected_config {
+            actions.push(format!(
+                "set openclaw config [{i}] {} = {}",
+                cfg.key,
+                config_value_display(&cfg.value)
+            ));
         }
 
         Ok(DriverPlan {
@@ -186,18 +211,50 @@ impl FrameworkDriver for OpenClawDriver {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError> {
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let home = require_home(ctx)?;
-        let mut resources = vec![ClaimResource {
-            id: RES_STATE_DIR.to_string(),
-            purpose: "openclaw_state_dir".to_string(),
-            kind: ClaimResourceKind::ExternalPath { path: home.clone() },
-        }];
+
+        // Resolve the plugin id and, for plugin adapters, run all read-only
+        // probing and gating BEFORE building any resource — so a version
+        // mismatch, a missing `--force`/`--json`, or an unsupported authorized
+        // unsafe flag fails here, before the Manager persists the receipt. The
+        // config the host version selects is computed once and carried as
+        // transient intent; apply journals each entry as Pending before its
+        // write and confirms it only after success. The install/verify
+        // capabilities are carried forward to `apply_enable` as typed
+        // `PreparedEnable` so apply never re-probes.
         let plugin_id = if ctx.is_skill_bundle() {
             None
         } else {
             let plugin_id = require_plugin_id(bundle)?;
             validate_plugin_id(&plugin_id)?;
+            Some(plugin_id)
+        };
+        let prepared = if ctx.is_skill_bundle() {
+            // Skill bundles run no plugin install, but the adapter-level
+            // version gate still applies before the receipt is persisted.
+            self.gate_skill_bundle_version(ctx)?;
+            PreparedEnable::None
+        } else {
+            let preflight = self.plugin_preflight(&bundle.resource_root, ctx)?;
+            PreparedEnable::OpenClaw {
+                supports_unsafe_install: preflight.supports_unsafe_install,
+                supports_inspect_json: preflight.supports_inspect_json,
+                supports_inspect_runtime: preflight.supports_inspect_runtime,
+                selected_config_indices: preflight
+                    .selected_config
+                    .iter()
+                    .map(|(index, _)| *index)
+                    .collect(),
+            }
+        };
+
+        let mut resources = vec![ClaimResource {
+            id: RES_STATE_DIR.to_string(),
+            purpose: "openclaw_state_dir".to_string(),
+            kind: ClaimResourceKind::ExternalPath { path: home.clone() },
+        }];
+        if let Some(plugin_id) = &plugin_id {
             resources.push(ClaimResource {
                 id: RES_PLUGIN.to_string(),
                 purpose: "openclaw_plugin".to_string(),
@@ -206,8 +263,7 @@ impl FrameworkDriver for OpenClawDriver {
                     plugin_id: plugin_id.clone(),
                 },
             });
-            Some(plugin_id)
-        };
+        }
 
         let mut skill_resources = Vec::new();
         for skill in &ctx.declared_skills {
@@ -222,23 +278,7 @@ impl FrameworkDriver for OpenClawDriver {
             skill_resources.push(res_id);
         }
 
-        let mut config_resources = Vec::new();
-        if !ctx.is_skill_bundle() {
-            for (i, cfg) in ctx.declared_config.iter().enumerate() {
-                let res_id = format!("openclaw_config_{i}");
-                resources.push(ClaimResource {
-                    id: res_id.clone(),
-                    purpose: "openclaw_config".to_string(),
-                    kind: ClaimResourceKind::FrameworkConfig {
-                        framework: self.name().to_string(),
-                        key: cfg.key.clone(),
-                    },
-                });
-                config_resources.push(res_id);
-            }
-        }
-
-        Ok(AdapterClaim {
+        let claim = AdapterClaim {
             claim_schema: CLAIM_SCHEMA_VERSION,
             component: ctx.component.clone(),
             framework: self.name().to_string(),
@@ -258,31 +298,136 @@ impl FrameworkDriver for OpenClawDriver {
                     RES_PLUGIN.to_string()
                 },
                 skill_resources,
-                config_resources,
+                // Pending/applied config resources are journaled during apply;
+                // this list references confirmed entries only.
+                config_resources: Vec::new(),
             }),
-        })
+        };
+        Ok((claim, prepared))
     }
 
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
-        let home = require_home(ctx)?;
+    fn preserve_reenable_facts(
+        &self,
+        prior: &AdapterClaim,
+        next: &mut AdapterClaim,
+    ) -> Result<(), AdapterError> {
+        preserve_openclaw_config_facts(prior, next)
+    }
 
-        if !ctx.is_skill_bundle() {
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        progress: &mut dyn EnableProgress,
+    ) -> Result<(), AdapterError> {
+        let home = require_home(ctx)?;
+        let user_home = ctx.user_home.as_deref();
+
+        // The install/verify capabilities (unsafe support, inspect `--runtime`)
+        // and all gating were resolved and validated by `prepare_enable`, which
+        // probed the host once and handed the results forward as `prepared`.
+        // `apply_enable` therefore does NOT probe at all: the install argv is
+        // rebuilt from the typed `ctx` (required `--force`, plus the unsafe
+        // flag iff the caller authorized it), config selection comes from
+        // prepared state, and runtime verification uses the prepared
+        // `--runtime` capability. Each probe (`--version`, install `--help`,
+        // inspect `--help`) thus runs exactly once per enable, all in prepare,
+        // and no two probe generations are ever mixed.
+        //
+        // Defense in depth: `PreparedEnable` and this trait are public, so a
+        // caller could hand a mismatched value. Validate the (adapter kind,
+        // prepared variant) pairing and re-check the capabilities BEFORE the
+        // first mutation, failing closed on any mismatch rather than silently
+        // degrading (which could skip the `--json` precondition, verify without
+        // `--runtime`, or add the unsafe flag on an unverified host).
+        let (host_supports_unsafe, verify_with_runtime, selected_config_indices) = if ctx
+            .is_skill_bundle()
+        {
+            if !matches!(prepared, PreparedEnable::None) {
+                return Err(prepared_state_mismatch(
+                    "skill_bundle adapters carry no prepared host capabilities",
+                ));
+            }
+            // Skill bundles run no plugin install and no runtime verification;
+            // these values are unused for them.
+            (false, false, Vec::new())
+        } else {
+            match prepared {
+                PreparedEnable::OpenClaw {
+                    supports_unsafe_install,
+                    supports_inspect_json,
+                    supports_inspect_runtime,
+                    selected_config_indices,
+                } => {
+                    if !supports_inspect_json {
+                        return Err(AdapterError::FrameworkCli {
+                            program: openclaw_bin(),
+                            reason: "`openclaw plugins inspect --help` does not expose --json; \
+                                     cannot verify plugin runtime status"
+                                .to_string(),
+                        });
+                    }
+                    if ctx.allow_unsafe_plugin_install && !supports_unsafe_install {
+                        return Err(AdapterError::FrameworkCli {
+                            program: openclaw_bin(),
+                            reason: "unsafe plugin install was explicitly authorized but this \
+                                     openclaw does not expose --dangerously-force-unsafe-install"
+                                .to_string(),
+                        });
+                    }
+                    validate_prepared_config_indices(selected_config_indices, ctx)?;
+                    (
+                        *supports_unsafe_install,
+                        *supports_inspect_runtime,
+                        selected_config_indices.clone(),
+                    )
+                }
+                PreparedEnable::None => {
+                    return Err(prepared_state_mismatch(
+                        "openclaw plugin enable requires prepared host capabilities",
+                    ));
+                }
+            }
+        };
+        validate_config_claim_state(claim)?;
+        validate_pending_config_selection(claim, &selected_config_indices, ctx)?;
+
+        let plugin = if ctx.is_skill_bundle() {
+            None
+        } else {
             let plugin_id = claim_plugin_id(claim).ok_or_else(|| AdapterError::BundleInvalid {
                 root: claim.resource_root.clone(),
                 reason: "openclaw receipt has no plugin id".to_string(),
             })?;
             validate_plugin_id(&plugin_id)?;
-
-            let cmd = build_install_cmd(&claim.resource_root, &home, ctx.user_home.as_deref());
+            let cmd = base_cmd(
+                install_argv(&claim.resource_root, ctx.allow_unsafe_plugin_install),
+                &home,
+                user_home,
+            );
             let program = cmd.program.clone();
             let output = ctx.ops.run_framework_cli(cmd)?;
             if !output.success() {
-                return Err(AdapterError::FrameworkCli {
-                    program,
-                    reason: cli_failure_reason("plugins install", &output),
-                });
+                let mut reason = full_failure_reason("plugins install", &output);
+                // Point the operator at the explicit, auditable retry only when
+                // it could actually help: the host exposes the unsafe flag, the
+                // user did not already authorize it, and the failure looks like
+                // a plugin-safety rejection. Never retry automatically.
+                if host_supports_unsafe
+                    && !ctx.allow_unsafe_plugin_install
+                    && install_output_looks_like_safety_rejection(&output)
+                {
+                    reason.push_str(
+                        "; this looks like an OpenClaw plugin-safety rejection — review the \
+                         reported findings and, only if you accept them, re-run enable with \
+                         --allow-unsafe-plugin-install",
+                    );
+                }
+                return Err(AdapterError::FrameworkCli { program, reason });
             }
-        }
+            Some(plugin_id)
+        };
 
         for skill in &ctx.declared_skills {
             let src = skill
@@ -293,19 +438,36 @@ impl FrameworkDriver for OpenClawDriver {
             ctx.ops.copy_tree(&src, &dst)?;
         }
 
-        if !ctx.is_skill_bundle() {
-            for cfg in &ctx.declared_config {
-                let cmd =
-                    build_config_set_cmd(&cfg.key, &cfg.value, &home, ctx.user_home.as_deref());
+        if let Some(plugin_id) = &plugin {
+            // Apply only the entries selected during prepare. A selected
+            // entry becomes a durable Pending resource before the command,
+            // then transitions to Applied after success. Matching resources
+            // from re-enable are reused rather than duplicated.
+            for i in selected_config_indices {
+                let cfg = &ctx.declared_config[i];
+                let resource_id = ensure_config_intent(claim, i, cfg)?;
+                // Write-ahead persistence closes the mutation-without-receipt
+                // window. On timeout/non-zero exit the entry remains Pending,
+                // accurately expressing that host state is uncertain.
+                progress.persist_claim(claim)?;
+                let cmd = build_config_set_cmd(&cfg.key, &cfg.value, &home, user_home);
                 let program = cmd.program.clone();
                 let output = ctx.ops.run_framework_cli(cmd)?;
                 if !output.success() {
                     return Err(AdapterError::FrameworkCli {
                         program,
-                        reason: cli_failure_reason("config set", &output),
+                        reason: full_failure_reason("config set", &output),
                     });
                 }
+                confirm_config_applied(claim, &resource_id, cfg)?;
+                progress.persist_claim(claim)?;
             }
+
+            // Post-install runtime verification: the plugin must report
+            // loaded. A non-loaded status surfaces the framework diagnostics
+            // and, via the Manager's receipt-first model, leaves a
+            // cleanup_failed receipt for later disable.
+            self.verify_runtime(plugin_id, &home, user_home, ctx, verify_with_runtime)?;
         }
 
         Ok(())
@@ -452,10 +614,27 @@ impl FrameworkDriver for OpenClawDriver {
 
         // 3. Config entries are NOT reversed on disable (framework-wide
         //    config should persist).
-        let config_count = claim_config_count(claim);
-        if config_count > 0 {
+        let (applied_config_count, pending_config_count) = claim_config_counts(claim);
+        if applied_config_count > 0 {
+            let noun = if applied_config_count == 1 {
+                "entry"
+            } else {
+                "entries"
+            };
             messages.push(format!(
-                "{config_count} openclaw config entries left in place (not reversed on disable)"
+                "{applied_config_count} confirmed openclaw config {noun} left in place \
+                 (not reversed on disable)"
+            ));
+        }
+        if pending_config_count > 0 {
+            let noun = if pending_config_count == 1 {
+                "entry"
+            } else {
+                "entries"
+            };
+            messages.push(format!(
+                "{pending_config_count} openclaw config {noun} with an uncertain apply outcome \
+                 left in place (not reversed on disable)"
             ));
         }
 
@@ -567,6 +746,1231 @@ impl OpenClawDriver {
 }
 
 // ---------------------------------------------------------------------------
+// Host profile (read-only probing) and enable gating
+// ---------------------------------------------------------------------------
+
+/// Read-only pre-install facts about the installed OpenClaw CLI, gathered by
+/// [`OpenClawDriver::host_profile`] from all three probes (`openclaw
+/// --version`, `plugins install --help`, `plugins inspect --help`) before the
+/// first mutation. Private typed data — never persisted into a receipt.
+#[derive(Debug, Clone)]
+struct OpenClawHostProfile {
+    /// Parsed `openclaw --version`, when the output was recognizable.
+    version: Option<OpenClawVersion>,
+    /// Trimmed raw `--version` output, for diagnostics.
+    version_display: String,
+    /// `openclaw plugins install --help` exposes `--force`.
+    supports_install_force: bool,
+    /// `openclaw plugins install --help` exposes
+    /// `--dangerously-force-unsafe-install`, including whether the advertised
+    /// option is still effective or has become a deprecated no-op.
+    unsafe_install_support: UnsafeInstallSupport,
+    /// `openclaw plugins inspect --help` exposes `--json`.
+    supports_inspect_json: bool,
+    /// `openclaw plugins inspect --help` exposes `--runtime`.
+    supports_inspect_runtime: bool,
+}
+
+/// Effective semantics of OpenClaw's unsafe-install compatibility option.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnsafeInstallSupport {
+    Unsupported,
+    Effective,
+    DeprecatedNoOp,
+}
+
+impl UnsafeInstallSupport {
+    fn is_effective(self) -> bool {
+        self == Self::Effective
+    }
+}
+
+/// A plugin adapter's resolved read-only preflight, derived before the first
+/// framework mutation and consumed by `prepare_enable`/`plan_enable`: the
+/// selected config, the single install command, and the install/verify
+/// capabilities to hand forward as [`PreparedEnable`].
+struct PluginPreflight<'a> {
+    /// The host's `plugins install --help` exposes the unsafe flag.
+    supports_unsafe_install: bool,
+    /// The host's `plugins inspect --help` exposes `--json`.
+    supports_inspect_json: bool,
+    /// The host's `plugins inspect --help` exposes `--runtime`.
+    supports_inspect_runtime: bool,
+    /// Selected config entries as `(original manifest index, spec)`. The
+    /// index anchors the receipt's `openclaw_config_<i>` resource id so
+    /// `apply_enable` can execute exactly the selected entries even when two
+    /// entries share a config key.
+    selected_config: Vec<(usize, &'a AdapterConfigSetSpec)>,
+    install_cmd: FrameworkCommand,
+}
+
+impl OpenClawDriver {
+    /// Run one read-only probe command, failing closed on timeout **or a
+    /// non-zero exit**, and return its combined stdout/stderr on success. A
+    /// failed probe must never be mistaken for a capability answer (e.g. an
+    /// error message mentioning `--force`), so the exit status is checked
+    /// before the output is interpreted; the diagnostics are carried in the
+    /// error.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when the probe cannot spawn, times out,
+    /// or exits non-zero.
+    fn run_read_probe(
+        &self,
+        ctx: &DriverCtx,
+        cmd: FrameworkCommand,
+        label: &str,
+    ) -> Result<String, AdapterError> {
+        let out = ctx.ops.run_framework_cli(cmd)?;
+        if out.timed_out || !out.success() {
+            return Err(AdapterError::FrameworkCli {
+                program: openclaw_bin(),
+                reason: full_failure_reason(label, &out),
+            });
+        }
+        Ok(combine_output(&out))
+    }
+
+    /// Probe `openclaw --version` read-only, failing closed on timeout or a
+    /// non-zero exit. The version may still be unparseable (`None`); callers
+    /// that require it enforce that separately.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when the probe cannot spawn, times out,
+    /// or exits non-zero.
+    fn probe_version(
+        &self,
+        ctx: &DriverCtx,
+    ) -> Result<(Option<OpenClawVersion>, String), AdapterError> {
+        let home = require_home(ctx)?;
+        let text = self.run_read_probe(
+            ctx,
+            build_version_cmd(&home, ctx.user_home.as_deref()),
+            "openclaw --version",
+        )?;
+        let version = parse_openclaw_version_output(&text);
+        // Keep the full trimmed output (bounded by the Manager's capture cap)
+        // so a diagnostic that precedes the version line does not hide the
+        // real, unparseable version text in the error.
+        Ok((version, text.trim().to_string()))
+    }
+
+    /// Probe the host CLI read-only for every pre-install fact: version,
+    /// `plugins install --help`, and `plugins inspect --help`. All probing
+    /// happens here — before the first mutation — and the inspect
+    /// capabilities are carried forward to `apply_enable` as
+    /// [`PreparedEnable`] so apply never re-probes. Fails closed when a probe
+    /// times out or exits non-zero.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when a probe command cannot be spawned,
+    /// times out, or exits non-zero.
+    fn host_profile(&self, ctx: &DriverCtx) -> Result<OpenClawHostProfile, AdapterError> {
+        let home = require_home(ctx)?;
+        let user_home = ctx.user_home.as_deref();
+
+        let (version, version_display) = self.probe_version(ctx)?;
+
+        let install_help = self.run_read_probe(
+            ctx,
+            build_install_help_cmd(&home, user_home),
+            "openclaw plugins install --help",
+        )?;
+        let supports_install_force = help_lists_flag(&install_help, "--force");
+        let unsafe_install_support = unsafe_install_support(&install_help);
+
+        let inspect_help = self.run_read_probe(
+            ctx,
+            build_inspect_help_cmd(&home, user_home),
+            "openclaw plugins inspect --help",
+        )?;
+        let supports_inspect_json = help_lists_flag(&inspect_help, "--json");
+        let supports_inspect_runtime = help_lists_flag(&inspect_help, "--runtime");
+
+        Ok(OpenClawHostProfile {
+            version,
+            version_display,
+            supports_install_force,
+            unsafe_install_support,
+            supports_inspect_json,
+            supports_inspect_runtime,
+        })
+    }
+
+    /// Enforce the adapter-level framework version requirement against a
+    /// probed version. A `None` requirement is a no-op. When set, the host
+    /// version must be known and satisfy the constraint. Applies to every
+    /// OpenClaw adapter (plugin and skill_bundle alike).
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when the version cannot be determined;
+    /// [`AdapterError::InvalidAdapterInput`] when the requirement is malformed
+    /// (a manifest bug); [`AdapterError::FrameworkVersionMismatch`] when the
+    /// detected version does not satisfy the requirement.
+    fn enforce_version_gate(
+        &self,
+        ctx: &DriverCtx,
+        version: Option<&OpenClawVersion>,
+        version_display: &str,
+    ) -> Result<(), AdapterError> {
+        // A missing field (`None`) means "no requirement". OpenClaw owns the
+        // validity check for its own adapters (the framework-agnostic Manager
+        // does not gate other frameworks on this), so a present-but-empty
+        // requirement is a declaration error here, not a silent no-op.
+        let Some(raw) = ctx.framework_version_req.as_deref() else {
+            return Ok(());
+        };
+        let req = raw.trim();
+        if req.is_empty() {
+            return Err(AdapterError::InvalidAdapterInput {
+                component: ctx.component.clone(),
+                framework: ctx.framework.clone(),
+                reason: "adapter framework_version requirement is present but empty".to_string(),
+            });
+        }
+        let version = version.ok_or_else(|| AdapterError::FrameworkCli {
+            program: openclaw_bin(),
+            reason: format!(
+                "cannot determine openclaw version (from `openclaw --version`: {version_display:?}) to check adapter requirement '{req}'"
+            ),
+        })?;
+        match openclaw_version_req_satisfied(req, version) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(AdapterError::FrameworkVersionMismatch {
+                framework: self.name().to_string(),
+                detected: version.to_string(),
+                required: req.to_string(),
+            }),
+            Err(reason) => Err(AdapterError::InvalidAdapterInput {
+                component: ctx.component.clone(),
+                framework: ctx.framework.clone(),
+                reason: format!("invalid adapter framework_version requirement: {reason}"),
+            }),
+        }
+    }
+
+    /// Probe the version and enforce the adapter-level requirement for a
+    /// skill_bundle adapter. Only probes when a requirement is declared, so a
+    /// requirement-free skill bundle keeps its previous no-CLI behavior.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::enforce_version_gate`].
+    fn gate_skill_bundle_version(&self, ctx: &DriverCtx) -> Result<(), AdapterError> {
+        // Only probe when a requirement is declared, so a requirement-free
+        // skill bundle keeps its previous no-CLI behavior. `enforce_version_gate`
+        // still validates a present-but-empty requirement.
+        if ctx.framework_version_req.is_none() {
+            return Ok(());
+        }
+        let (version, display) = self.probe_version(ctx)?;
+        self.enforce_version_gate(ctx, version.as_ref(), &display)
+    }
+
+    /// Resolve the full plugin preflight before any mutation: profile (all
+    /// three probes), version precondition, `--json` inspect precondition,
+    /// version gate, install command, and selected config. Fails closed — the
+    /// version must be parseable, the host must expose machine-readable
+    /// (`--json`) inspect output for verification, and the `--force` /
+    /// unsafe-flag capabilities must hold (see [`build_install_cmd`]).
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] / [`AdapterError::FrameworkVersionMismatch`]
+    /// / [`AdapterError::InvalidAdapterInput`] for any failed probe,
+    /// precondition, gate, or malformed condition.
+    fn plugin_preflight<'a>(
+        &self,
+        resource_root: &Path,
+        ctx: &'a DriverCtx,
+    ) -> Result<PluginPreflight<'a>, AdapterError> {
+        let home = require_home(ctx)?;
+        let profile = self.host_profile(ctx)?;
+        // Fail closed before the first write: the version must be known even
+        // when the manifest declares no version condition, so an unreadable
+        // `--version` never silently proceeds to an install.
+        if profile.version.is_none() {
+            return Err(AdapterError::FrameworkCli {
+                program: openclaw_bin(),
+                reason: format!(
+                    "cannot determine openclaw version from `openclaw --version` (output: {:?})",
+                    profile.version_display
+                ),
+            });
+        }
+        // Runtime verification relies on machine-readable inspect output, so a
+        // host without `--json` is rejected before install, not after.
+        if !profile.supports_inspect_json {
+            return Err(AdapterError::FrameworkCli {
+                program: openclaw_bin(),
+                reason: "`openclaw plugins inspect --help` does not expose --json; \
+                         cannot verify plugin runtime status"
+                    .to_string(),
+            });
+        }
+        self.enforce_version_gate(ctx, profile.version.as_ref(), &profile.version_display)?;
+        let install_cmd = build_install_cmd(
+            resource_root,
+            &home,
+            ctx.user_home.as_deref(),
+            &profile,
+            ctx.allow_unsafe_plugin_install,
+        )?;
+        let selected_config = self.select_config(ctx, &profile)?;
+        Ok(PluginPreflight {
+            supports_unsafe_install: profile.unsafe_install_support.is_effective(),
+            supports_inspect_json: profile.supports_inspect_json,
+            supports_inspect_runtime: profile.supports_inspect_runtime,
+            selected_config,
+            install_cmd,
+        })
+    }
+
+    /// Select the declared config entries whose optional `framework_version`
+    /// condition the host version satisfies, paired with their original
+    /// manifest index. A missing condition (`None`) always selects; a
+    /// condition the host does not satisfy is skipped (left out of the
+    /// receipt). A present-but-empty or malformed condition is a manifest bug.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::InvalidAdapterInput`] when a condition is present but
+    /// empty or malformed; [`AdapterError::FrameworkCli`] when a valid
+    /// condition cannot be evaluated because the host version is unknown.
+    fn select_config<'a>(
+        &self,
+        ctx: &'a DriverCtx,
+        profile: &OpenClawHostProfile,
+    ) -> Result<Vec<(usize, &'a AdapterConfigSetSpec)>, AdapterError> {
+        let mut selected = Vec::new();
+        for (i, cfg) in ctx.declared_config.iter().enumerate() {
+            // A missing field means "always apply"; an explicit empty value is
+            // a declaration error, not an implicit unconditional apply.
+            let Some(raw) = cfg.framework_version.as_deref() else {
+                selected.push((i, cfg));
+                continue;
+            };
+            let req = raw.trim();
+            if req.is_empty() {
+                return Err(AdapterError::InvalidAdapterInput {
+                    component: ctx.component.clone(),
+                    framework: ctx.framework.clone(),
+                    reason: format!(
+                        "config '{}' declares an empty framework_version condition",
+                        cfg.key
+                    ),
+                });
+            }
+            let version = profile.version.as_ref().ok_or_else(|| AdapterError::FrameworkCli {
+                program: openclaw_bin(),
+                reason: format!(
+                    "cannot evaluate config version condition '{req}' for key '{}': openclaw version unknown",
+                    cfg.key
+                ),
+            })?;
+            match openclaw_version_req_satisfied(req, version) {
+                Ok(true) => selected.push((i, cfg)),
+                Ok(false) => {}
+                Err(reason) => {
+                    return Err(AdapterError::InvalidAdapterInput {
+                        component: ctx.component.clone(),
+                        framework: ctx.framework.clone(),
+                        reason: format!(
+                            "config '{}' has an invalid framework_version condition: {reason}",
+                            cfg.key
+                        ),
+                    });
+                }
+            }
+        }
+        Ok(selected)
+    }
+
+    /// Verify the plugin reports `loaded` after install/skill/config apply.
+    ///
+    /// Uses `plugins inspect <id> --runtime --json` when `with_runtime` (the
+    /// host's `--runtime` support, resolved during prepare and passed via
+    /// [`PreparedEnable`]), else `plugins inspect <id> --json`. No inspect-help
+    /// probe runs here — it already ran during prepare. The JSON is parsed in
+    /// Rust (legacy diagnostic lines before it are tolerated) and
+    /// `.plugin.status` must equal `"loaded"`.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] carrying the OpenClaw diagnostics when
+    /// the command fails, the JSON is missing/invalid, or the status is not
+    /// `loaded`.
+    fn verify_runtime(
+        &self,
+        plugin_id: &str,
+        home: &Path,
+        user_home: Option<&Path>,
+        ctx: &DriverCtx,
+        with_runtime: bool,
+    ) -> Result<(), AdapterError> {
+        let cmd = build_inspect_cmd(plugin_id, home, user_home, with_runtime);
+        let output = ctx.ops.run_framework_cli(cmd)?;
+        if !output.success() {
+            return Err(AdapterError::FrameworkCli {
+                program: openclaw_bin(),
+                reason: format!(
+                    "runtime verification of plugin '{plugin_id}' failed: {}",
+                    inspect_diagnostics(&output)
+                ),
+            });
+        }
+        let value =
+            extract_trailing_json(&output.stdout).ok_or_else(|| AdapterError::FrameworkCli {
+                program: openclaw_bin(),
+                reason: format!(
+                    "could not parse `plugins inspect` JSON for plugin '{plugin_id}'; diagnostics: {}",
+                    inspect_diagnostics(&output)
+                ),
+            })?;
+        let status = value
+            .get("plugin")
+            .and_then(|p| p.get("status"))
+            .and_then(|s| s.as_str());
+        match status {
+            Some("loaded") => Ok(()),
+            other => Err(AdapterError::FrameworkCli {
+                program: openclaw_bin(),
+                reason: format!(
+                    "plugin '{plugin_id}' runtime status is {} (expected \"loaded\"); diagnostics: {}",
+                    other
+                        .map(|s| format!("\"{s}\""))
+                        .unwrap_or_else(|| "absent".to_string()),
+                    inspect_diagnostics(&output)
+                ),
+            }),
+        }
+    }
+}
+
+/// Merge a command's stdout and stderr into one searchable string. Help and
+/// version output land on either stream across CLI implementations.
+fn combine_output(output: &CliOutput) -> String {
+    let mut s = output.stdout.clone();
+    if !output.stderr.is_empty() {
+        if !s.is_empty() {
+            s.push('\n');
+        }
+        s.push_str(&output.stderr);
+    }
+    s
+}
+
+/// Compose a compact diagnostics string from an inspect command's output,
+/// preserving the framework's own messages for the operator.
+fn inspect_diagnostics(output: &CliOutput) -> String {
+    let mut parts = Vec::new();
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        parts.push(stdout.to_string());
+    }
+    let stderr = output.stderr.trim();
+    if !stderr.is_empty() {
+        parts.push(format!("stderr: {stderr}"));
+    }
+    if output.timed_out {
+        parts.push("timed out".to_string());
+    }
+    if parts.is_empty() {
+        "<no output>".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+/// Parse a JSON object from `stdout`, tolerating legacy diagnostic lines
+/// printed before it. Tries the whole trimmed output first, then each `{`
+/// boundary in turn — OpenClaw prints the JSON last, so the first prefix
+/// that parses cleanly is the intended value.
+fn extract_trailing_json(stdout: &str) -> Option<serde_json::Value> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return Some(value);
+    }
+    for (idx, _) in stdout.char_indices().filter(|&(_, c)| c == '{') {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout[idx..].trim()) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+/// Validate prepared config indices before the first mutation.
+fn validate_prepared_config_indices(
+    indices: &[usize],
+    ctx: &DriverCtx,
+) -> Result<(), AdapterError> {
+    let mut previous = None;
+    for &index in indices {
+        if index >= ctx.declared_config.len() {
+            return Err(prepared_state_mismatch(&format!(
+                "config index {index} is outside the declared config"
+            )));
+        }
+        if previous.is_some_and(|value| value >= index) {
+            return Err(prepared_state_mismatch(
+                "selected config indices must be unique and in manifest order",
+            ));
+        }
+        previous = Some(index);
+    }
+    Ok(())
+}
+
+/// Validate the OpenClaw payload's applied-resource references and the
+/// write-ahead state of every config resource.
+fn validate_config_claim_state(claim: &AdapterClaim) -> Result<(), AdapterError> {
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        return Err(invalid_config_claim(
+            claim,
+            "receipt payload is not OpenClaw",
+        ));
+    };
+
+    let mut applied_ids = HashSet::new();
+    for resource_id in &payload.config_resources {
+        if !applied_ids.insert(resource_id.as_str()) {
+            return Err(invalid_config_claim(
+                claim,
+                &format!("applied config resource '{resource_id}' is referenced more than once"),
+            ));
+        }
+    }
+
+    let mut resource_ids = HashSet::new();
+    let mut config_keys = HashSet::new();
+    let mut has_pending = false;
+    for resource in &claim.resources {
+        if !resource_ids.insert(resource.id.as_str()) {
+            return Err(invalid_config_claim(
+                claim,
+                &format!("resource id '{}' is duplicated", resource.id),
+            ));
+        }
+        let ClaimResourceKind::FrameworkConfig { key, state, .. } = &resource.kind else {
+            continue;
+        };
+        if !config_keys.insert(key.as_str()) {
+            return Err(invalid_config_claim(
+                claim,
+                &format!("config key '{key}' has more than one receipt resource"),
+            ));
+        }
+        let referenced_as_applied = applied_ids.contains(resource.id.as_str());
+        match (*state, referenced_as_applied) {
+            (ConfigApplyState::Applied, true) | (ConfigApplyState::Pending, false) => {}
+            (ConfigApplyState::Applied, false) => {
+                return Err(invalid_config_claim(
+                    claim,
+                    &format!(
+                        "applied config resource '{}' is missing from the OpenClaw payload",
+                        resource.id
+                    ),
+                ));
+            }
+            (ConfigApplyState::Pending, true) => {
+                return Err(invalid_config_claim(
+                    claim,
+                    &format!(
+                        "pending config resource '{}' is listed as applied",
+                        resource.id
+                    ),
+                ));
+            }
+        }
+        has_pending |= *state == ConfigApplyState::Pending;
+    }
+
+    for resource_id in applied_ids {
+        match claim.resource(resource_id).map(|resource| &resource.kind) {
+            Some(ClaimResourceKind::FrameworkConfig {
+                state: ConfigApplyState::Applied,
+                ..
+            }) => {}
+            Some(_) => {
+                return Err(invalid_config_claim(
+                    claim,
+                    &format!(
+                        "applied config resource '{resource_id}' does not reference confirmed config"
+                    ),
+                ));
+            }
+            None => {
+                return Err(invalid_config_claim(
+                    claim,
+                    &format!("applied config resource '{resource_id}' does not exist"),
+                ));
+            }
+        }
+    }
+    if has_pending && claim.status != ClaimStatus::CleanupFailed {
+        return Err(invalid_config_claim(
+            claim,
+            "pending config resources require cleanup_failed receipt status",
+        ));
+    }
+    Ok(())
+}
+
+/// Ensure every uncertain prior config can be replayed by this enable.
+///
+/// A removed or version-incompatible key cannot be confirmed or superseded.
+/// Reject it before another framework mutation so enable never reports success
+/// while retaining an indefinitely pending receipt.
+fn validate_pending_config_selection(
+    claim: &AdapterClaim,
+    selected_indices: &[usize],
+    ctx: &DriverCtx,
+) -> Result<(), AdapterError> {
+    let selected_keys: HashSet<&str> = selected_indices
+        .iter()
+        .map(|&index| ctx.declared_config[index].key.as_str())
+        .collect();
+    let unmatched_keys: Vec<&str> = claim
+        .resources
+        .iter()
+        .filter_map(|resource| match &resource.kind {
+            ClaimResourceKind::FrameworkConfig {
+                key,
+                state: ConfigApplyState::Pending,
+                ..
+            } if !selected_keys.contains(key.as_str()) => Some(key.as_str()),
+            _ => None,
+        })
+        .collect();
+    if unmatched_keys.is_empty() {
+        return Ok(());
+    }
+
+    Err(AdapterError::InvalidAdapterInput {
+        component: claim.component.clone(),
+        framework: claim.framework.clone(),
+        reason: format!(
+            "pending OpenClaw config key(s) [{}] are not selected by the current manifest and \
+             host version; restore matching config entries and re-run enable to reconcile them, \
+             or disable the adapter to acknowledge they are left in place",
+            unmatched_keys.join(", ")
+        ),
+    })
+}
+
+/// Carry confirmed and uncertain config facts into a replacement receipt so a
+/// re-enable failure cannot erase host state that the new attempt did not
+/// supersede.
+fn preserve_openclaw_config_facts(
+    prior: &AdapterClaim,
+    next: &mut AdapterClaim,
+) -> Result<(), AdapterError> {
+    validate_config_claim_state(prior)?;
+    validate_config_claim_state(next)?;
+
+    let prior_resources: Vec<ClaimResource> = prior
+        .resources
+        .iter()
+        .filter(|resource| matches!(resource.kind, ClaimResourceKind::FrameworkConfig { .. }))
+        .cloned()
+        .collect();
+    for resource in prior_resources {
+        match next.resource(&resource.id) {
+            Some(existing) if existing == &resource => {}
+            Some(_) => {
+                return Err(invalid_config_claim(
+                    next,
+                    &format!(
+                        "prior config resource id '{}' collides with the replacement receipt",
+                        resource.id
+                    ),
+                ));
+            }
+            None => next.resources.push(resource),
+        }
+    }
+
+    let DriverPayload::OpenClaw(prior_payload) = &prior.driver_payload else {
+        return Err(invalid_config_claim(
+            prior,
+            "receipt payload is not OpenClaw",
+        ));
+    };
+    let DriverPayload::OpenClaw(next_payload) = &mut next.driver_payload else {
+        return Err(invalid_config_claim(
+            next,
+            "receipt payload is not OpenClaw",
+        ));
+    };
+    for resource_id in &prior_payload.config_resources {
+        if !next_payload.config_resources.contains(resource_id) {
+            next_payload.config_resources.push(resource_id.clone());
+        }
+    }
+    if next.resources.iter().any(|resource| {
+        matches!(
+            resource.kind,
+            ClaimResourceKind::FrameworkConfig {
+                state: ConfigApplyState::Pending,
+                ..
+            }
+        )
+    }) {
+        next.status = ClaimStatus::CleanupFailed;
+    }
+    validate_config_claim_state(next)
+}
+
+/// Ensure one selected config key has a durable typed intent resource.
+///
+/// Existing matching applied or pending resources are reused, which keeps
+/// repeated apply idempotent. When a manifest index collides with a preserved
+/// resource for another key, a deterministic numeric suffix avoids erasing the
+/// prior fact.
+fn ensure_config_intent(
+    claim: &mut AdapterClaim,
+    index: usize,
+    config: &AdapterConfigSetSpec,
+) -> Result<String, AdapterError> {
+    validate_config_claim_state(claim)?;
+
+    let existing_id = claim.resources.iter().find_map(|resource| {
+        matches!(
+            &resource.kind,
+            ClaimResourceKind::FrameworkConfig { framework, key, .. }
+                if framework == &claim.framework && key == &config.key
+        )
+        .then(|| resource.id.clone())
+    });
+
+    let resource_id = match existing_id {
+        Some(resource_id) => resource_id,
+        None => {
+            let base_id = format!("openclaw_config_{index}");
+            let resource_id = if claim.resource(&base_id).is_none() {
+                base_id
+            } else {
+                let mut suffix = 1usize;
+                loop {
+                    let candidate = format!("{base_id}_{suffix}");
+                    if claim.resource(&candidate).is_none() {
+                        break candidate;
+                    }
+                    suffix += 1;
+                }
+            };
+            let framework = claim.framework.clone();
+            claim.resources.push(ClaimResource {
+                id: resource_id.clone(),
+                purpose: "openclaw_config".to_string(),
+                kind: ClaimResourceKind::FrameworkConfig {
+                    framework,
+                    key: config.key.clone(),
+                    state: ConfigApplyState::Pending,
+                },
+            });
+            resource_id
+        }
+    };
+
+    let Some(resource) = claim
+        .resources
+        .iter_mut()
+        .find(|resource| resource.id == resource_id)
+    else {
+        return Err(invalid_config_claim(
+            claim,
+            &format!("config resource '{resource_id}' disappeared before apply"),
+        ));
+    };
+    match &mut resource.kind {
+        ClaimResourceKind::FrameworkConfig { state, .. } => {
+            *state = ConfigApplyState::Pending;
+        }
+        _ => {
+            return Err(invalid_config_claim(
+                claim,
+                &format!("config resource '{resource_id}' is not framework config"),
+            ));
+        }
+    }
+    let DriverPayload::OpenClaw(payload) = &mut claim.driver_payload else {
+        return Err(invalid_config_claim(
+            claim,
+            "receipt payload is not OpenClaw",
+        ));
+    };
+    payload
+        .config_resources
+        .retain(|existing| existing != &resource_id);
+    claim.status = ClaimStatus::CleanupFailed;
+    validate_config_claim_state(claim)?;
+    Ok(resource_id)
+}
+
+/// Promote a matching pending resource to a confirmed applied fact.
+fn confirm_config_applied(
+    claim: &mut AdapterClaim,
+    resource_id: &str,
+    config: &AdapterConfigSetSpec,
+) -> Result<(), AdapterError> {
+    let framework = claim.framework.clone();
+    let Some(resource_index) = claim
+        .resources
+        .iter()
+        .position(|resource| resource.id == resource_id)
+    else {
+        return Err(invalid_config_claim(
+            claim,
+            &format!("config resource '{resource_id}' disappeared during apply"),
+        ));
+    };
+    let resource = &mut claim.resources[resource_index];
+    match &mut resource.kind {
+        ClaimResourceKind::FrameworkConfig {
+            framework: resource_framework,
+            key,
+            state,
+        } if resource_framework == &framework && key == &config.key => {
+            *state = ConfigApplyState::Applied;
+        }
+        _ => {
+            return Err(invalid_config_claim(
+                claim,
+                &format!(
+                    "config resource '{resource_id}' does not match '{}'",
+                    config.key
+                ),
+            ));
+        }
+    }
+
+    let DriverPayload::OpenClaw(payload) = &mut claim.driver_payload else {
+        return Err(invalid_config_claim(
+            claim,
+            "receipt payload is not OpenClaw",
+        ));
+    };
+    if !payload
+        .config_resources
+        .iter()
+        .any(|existing| existing == resource_id)
+    {
+        payload.config_resources.push(resource_id.to_string());
+    }
+    claim.status = if claim.resources.iter().any(|resource| {
+        matches!(
+            resource.kind,
+            ClaimResourceKind::FrameworkConfig {
+                state: ConfigApplyState::Pending,
+                ..
+            }
+        )
+    }) {
+        ClaimStatus::CleanupFailed
+    } else {
+        ClaimStatus::Enabled
+    };
+    validate_config_claim_state(claim)?;
+    Ok(())
+}
+
+fn invalid_config_claim(claim: &AdapterClaim, reason: &str) -> AdapterError {
+    AdapterError::BundleInvalid {
+        root: claim.resource_root.clone(),
+        reason: format!("invalid OpenClaw config receipt: {reason}"),
+    }
+}
+
+/// Whether an install command's output looks like an OpenClaw plugin-safety
+/// rejection (as opposed to a generic failure). Used only to decide whether
+/// to surface the explicit-retry hint — never to auto-retry.
+fn install_output_looks_like_safety_rejection(output: &CliOutput) -> bool {
+    let haystack = format!("{}\n{}", output.stdout, output.stderr).to_lowercase();
+    ["unsafe", "safety", "dangerous"]
+        .iter()
+        .any(|marker| haystack.contains(marker))
+}
+
+// ---------------------------------------------------------------------------
+// OpenClaw version parsing and comparison
+// ---------------------------------------------------------------------------
+
+/// A parsed OpenClaw version.
+///
+/// OpenClaw ships calendar-style versions (`2026.4.14`) that may carry a
+/// purely-numeric *correction* suffix (`2026.5.3-1`, a rebuild of the same
+/// release), an alphabetic prerelease (`2026.4.14-beta.1`, `-rc.2`), and/or
+/// `+build` metadata (ignored for ordering).
+///
+/// The deliberate departure from plain semver: a numeric-only suffix is a
+/// correction that sorts **above** the base version, not a prerelease that
+/// sorts below. Comparing with a stock semver `Version` would wrongly rank
+/// `2026.5.3-1 < 2026.5.3`, so this type implements its own ordering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OpenClawVersion {
+    core: [u64; 3],
+    suffix: VersionSuffix,
+}
+
+/// The suffix of an [`OpenClawVersion`], ranked prerelease < release <
+/// correction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum VersionSuffix {
+    /// Alphabetic prerelease identifiers (`beta.1`); sorts below the release.
+    Prerelease(Vec<PreId>),
+    /// No suffix.
+    Release,
+    /// Numeric-only correction identifiers (`1`, `2.1`); sorts above release.
+    Correction(Vec<u64>),
+}
+
+/// One prerelease identifier, numeric or textual, compared semver-style.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PreId {
+    /// Purely-numeric identifier, compared by value.
+    Num(u64),
+    /// Textual identifier, compared lexically.
+    Text(String),
+}
+
+impl OpenClawVersion {
+    /// Parse an OpenClaw version string. Returns `None` for any malformed
+    /// input — a non-numeric or >3-component core, an empty or invalid
+    /// `-suffix`, or empty/invalid `+build` metadata — so a bad constraint
+    /// like `>=2026.4.14-` is rejected rather than silently treated as
+    /// `>=2026.4.14`. Build metadata is validated for well-formedness, then
+    /// discarded (it does not affect identity or ordering).
+    fn parse(input: &str) -> Option<OpenClawVersion> {
+        let s = input.trim();
+        if s.is_empty() {
+            return None;
+        }
+        // Separate optional `+build`; validate then drop it. An empty or
+        // invalid build metadata segment is a malformed version.
+        let s = match s.split_once('+') {
+            Some((before, build)) => {
+                if !is_valid_dot_identifiers(build) {
+                    return None;
+                }
+                before
+            }
+            None => s,
+        };
+        // Separate optional `-suffix`. A trailing `-` with no suffix is
+        // malformed, not a plain release.
+        let (core_str, pre_str) = match s.split_once('-') {
+            Some((core, pre)) => (core, Some(pre)),
+            None => (s, None),
+        };
+
+        let mut core = [0u64; 3];
+        let mut count = 0usize;
+        for (i, part) in core_str.split('.').enumerate() {
+            if i >= 3 {
+                return None;
+            }
+            core[i] = part.parse().ok()?;
+            count = i + 1;
+        }
+        if count == 0 {
+            return None;
+        }
+
+        let suffix = match pre_str {
+            None => VersionSuffix::Release,
+            Some(pre) => {
+                // Every identifier must be non-empty and drawn from the
+                // semver alphabet (`[0-9A-Za-z-]`); an empty `-` or an illegal
+                // character is rejected rather than accepted as text.
+                if !is_valid_dot_identifiers(pre) {
+                    return None;
+                }
+                let ids: Vec<&str> = pre.split('.').collect();
+                let all_numeric = ids.iter().all(|id| id.bytes().all(|b| b.is_ascii_digit()));
+                if all_numeric {
+                    let nums = ids
+                        .iter()
+                        .map(|id| id.parse::<u64>().ok())
+                        .collect::<Option<Vec<_>>>()?;
+                    VersionSuffix::Correction(nums)
+                } else {
+                    let parsed = ids
+                        .iter()
+                        .map(|id| {
+                            if id.bytes().all(|b| b.is_ascii_digit()) {
+                                id.parse::<u64>().ok().map(PreId::Num)
+                            } else {
+                                Some(PreId::Text((*id).to_string()))
+                            }
+                        })
+                        .collect::<Option<Vec<_>>>()?;
+                    VersionSuffix::Prerelease(parsed)
+                }
+            }
+        };
+        Some(OpenClawVersion { core, suffix })
+    }
+}
+
+/// Whether `s` is one or more dot-separated identifiers, each non-empty and
+/// composed only of ASCII alphanumerics and `-` (the semver
+/// prerelease/build alphabet). Rejects empty input and empty identifiers
+/// (leading/trailing/double dots).
+fn is_valid_dot_identifiers(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    s.split('.')
+        .all(|id| !id.is_empty() && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-'))
+}
+
+impl std::fmt::Display for OpenClawVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.core[0], self.core[1], self.core[2])?;
+        match &self.suffix {
+            VersionSuffix::Release => Ok(()),
+            VersionSuffix::Correction(nums) => {
+                let joined = nums
+                    .iter()
+                    .map(u64::to_string)
+                    .collect::<Vec<_>>()
+                    .join(".");
+                write!(f, "-{joined}")
+            }
+            VersionSuffix::Prerelease(ids) => {
+                let joined = ids
+                    .iter()
+                    .map(|id| match id {
+                        PreId::Num(n) => n.to_string(),
+                        PreId::Text(t) => t.clone(),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(".");
+                write!(f, "-{joined}")
+            }
+        }
+    }
+}
+
+impl Ord for OpenClawVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.core
+            .cmp(&other.core)
+            .then_with(|| self.suffix.cmp(&other.suffix))
+    }
+}
+
+impl PartialOrd for OpenClawVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl VersionSuffix {
+    /// Ordering rank: prerelease (0) < release (1) < correction (2).
+    fn rank(&self) -> u8 {
+        match self {
+            VersionSuffix::Prerelease(_) => 0,
+            VersionSuffix::Release => 1,
+            VersionSuffix::Correction(_) => 2,
+        }
+    }
+}
+
+impl Ord for VersionSuffix {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (VersionSuffix::Prerelease(a), VersionSuffix::Prerelease(b)) => cmp_pre_ids(a, b),
+            (VersionSuffix::Correction(a), VersionSuffix::Correction(b)) => a.cmp(b),
+            _ => self.rank().cmp(&other.rank()),
+        }
+    }
+}
+
+impl PartialOrd for VersionSuffix {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Compare prerelease identifier lists semver-style: numeric identifiers
+/// compare by value, numeric sorts below textual, textual compares lexically,
+/// and a shorter list sorts below a longer one when the shared prefix is
+/// equal.
+fn cmp_pre_ids(a: &[PreId], b: &[PreId]) -> Ordering {
+    for (x, y) in a.iter().zip(b.iter()) {
+        let ord = match (x, y) {
+            (PreId::Num(m), PreId::Num(n)) => m.cmp(n),
+            (PreId::Text(m), PreId::Text(n)) => m.cmp(n),
+            (PreId::Num(_), PreId::Text(_)) => Ordering::Less,
+            (PreId::Text(_), PreId::Num(_)) => Ordering::Greater,
+        };
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    a.len().cmp(&b.len())
+}
+
+/// Comparison operators supported in an OpenClaw version requirement.
+#[derive(Debug, Clone, Copy)]
+enum ReqOp {
+    /// `>=`
+    Gte,
+    /// `>`
+    Gt,
+    /// `<=`
+    Lte,
+    /// `<`
+    Lt,
+    /// `=` / `==`
+    Eq,
+}
+
+/// Split a single requirement clause into its operator and version text. A
+/// bare version (no operator) is treated as a minimum (`>=`), matching how
+/// these fields express a lowest supported framework version.
+fn split_req_clause(clause: &str) -> (ReqOp, &str) {
+    const OPS: [(&str, ReqOp); 6] = [
+        (">=", ReqOp::Gte),
+        ("<=", ReqOp::Lte),
+        ("==", ReqOp::Eq),
+        (">", ReqOp::Gt),
+        ("<", ReqOp::Lt),
+        ("=", ReqOp::Eq),
+    ];
+    for (prefix, op) in OPS {
+        if let Some(rest) = clause.strip_prefix(prefix) {
+            return (op, rest.trim());
+        }
+    }
+    (ReqOp::Gte, clause)
+}
+
+/// Evaluate a comma-separated requirement (`>=2026.4.14, <2027.0.0`) against
+/// a version. All clauses must hold.
+///
+/// # Errors
+///
+/// Returns `Err(reason)` when the requirement is empty, contains an empty
+/// clause (a leading/trailing/double comma), or a clause's version cannot be
+/// parsed — all manifest bugs, distinct from a non-match.
+fn openclaw_version_req_satisfied(req: &str, version: &OpenClawVersion) -> Result<bool, String> {
+    if req.trim().is_empty() {
+        return Err(format!("empty version requirement '{req}'"));
+    }
+    let mut clauses = Vec::new();
+    for clause in req.split(',') {
+        let clause = clause.trim();
+        // An empty clause (from `>=X,,<Y` or a trailing/leading comma) is a
+        // malformed requirement, not something to silently skip.
+        if clause.is_empty() {
+            return Err(format!("empty clause in version requirement '{req}'"));
+        }
+        let (op, ver_str) = split_req_clause(clause);
+        let required = OpenClawVersion::parse(ver_str)
+            .ok_or_else(|| format!("unparseable version '{ver_str}' in requirement '{req}'"))?;
+        clauses.push((op, required));
+    }
+
+    Ok(clauses.into_iter().all(|(op, required)| {
+        let ord = version.cmp(&required);
+        match op {
+            ReqOp::Gte => ord != Ordering::Less,
+            ReqOp::Gt => ord == Ordering::Greater,
+            ReqOp::Lte => ord != Ordering::Greater,
+            ReqOp::Lt => ord == Ordering::Less,
+            ReqOp::Eq => ord == Ordering::Equal,
+        }
+    }))
+}
+
+/// Extract an [`OpenClawVersion`] from `openclaw --version` output.
+///
+/// Only an unambiguous version line is accepted: either a bare calendar-shaped
+/// version or a version following an explicit `OpenClaw`, `OpenClaw version`,
+/// or `OpenClaw CLI version` label. Calendar-shaped tokens embedded in warning
+/// or diagnostic lines are ignored. Zero or multiple candidates return `None`
+/// so callers fail closed instead of guessing which number belongs to the CLI.
+fn parse_openclaw_version_output(output: &str) -> Option<OpenClawVersion> {
+    let candidates: Vec<OpenClawVersion> = output
+        .lines()
+        .filter_map(parse_openclaw_version_line)
+        .collect();
+    if candidates.len() == 1 {
+        candidates.into_iter().next()
+    } else {
+        None
+    }
+}
+
+fn parse_openclaw_version_line(line: &str) -> Option<OpenClawVersion> {
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    let (version_token, trailing) = match tokens.as_slice() {
+        [version] => (*version, &[][..]),
+        [label, cli, keyword, version, trailing @ ..]
+            if is_openclaw_label(label)
+                && cli.eq_ignore_ascii_case("cli")
+                && keyword.eq_ignore_ascii_case("version") =>
+        {
+            (*version, trailing)
+        }
+        [label, keyword, version, trailing @ ..]
+            if is_openclaw_label(label) && keyword.eq_ignore_ascii_case("version") =>
+        {
+            (*version, trailing)
+        }
+        [label, version, trailing @ ..] if is_openclaw_label(label) => (*version, trailing),
+        _ => return None,
+    };
+    if !trailing_version_annotation_is_known(trailing) {
+        return None;
+    }
+    let version_token = version_token
+        .strip_prefix('v')
+        .or_else(|| version_token.strip_prefix('V'))
+        .unwrap_or(version_token);
+    is_calendar_shaped_token(version_token)
+        .then(|| OpenClawVersion::parse(version_token))
+        .flatten()
+}
+
+fn is_openclaw_label(token: &str) -> bool {
+    token.trim_end_matches(':').eq_ignore_ascii_case("openclaw")
+}
+
+fn trailing_version_annotation_is_known(tokens: &[&str]) -> bool {
+    tokens.is_empty()
+        || (tokens.first().is_some_and(|token| token.starts_with('('))
+            && tokens.last().is_some_and(|token| token.ends_with(')')))
+}
+
+/// Whether `token` has an OpenClaw calendar-shaped core: exactly three
+/// dot-separated numeric components with a 4-digit leading year, ignoring any
+/// `-`/`+` suffix. `2026.4.14` and `2026.5.3-1` pass; `22.14.0` and `2026.4`
+/// (a short version, valid only in a *requirement*) do not.
+fn is_calendar_shaped_token(token: &str) -> bool {
+    let core = token.split(['-', '+']).next().unwrap_or(token);
+    let parts: Vec<&str> = core.split('.').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    let year_ok = parts[0].len() == 4 && parts[0].bytes().all(|b| b.is_ascii_digit());
+    year_ok
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+}
+
+// ---------------------------------------------------------------------------
 // Pure helpers (no spawning) — unit-testable
 // ---------------------------------------------------------------------------
 
@@ -621,24 +2025,162 @@ fn base_cmd(args: Vec<String>, home: &Path, user_home: Option<&Path>) -> Framewo
     }
 }
 
-/// Build `openclaw plugins install <resource_root> --force
-/// --dangerously-force-unsafe-install`.
+/// Build the single `openclaw plugins install <resource_root> --force
+/// [--dangerously-force-unsafe-install]` command for the current host.
+///
+/// `--force` is a required capability of the driver contract; if the host's
+/// install help does not expose it, this fails before any mutation. The
+/// unsafe flag is appended only when the caller both authorized it
+/// (`allow_unsafe`) and the host's help describes it as effective. An
+/// authorized request fails when the option is absent or advertised as a
+/// deprecated no-op, and a normal install never carries it.
+///
+/// # Errors
+///
+/// [`AdapterError::FrameworkCli`] when `--force` is unsupported, or when an
+/// authorized unsafe install is requested but the host does not expose an
+/// effective unsafe flag.
 fn build_install_cmd(
     resource_root: &Path,
     home: &Path,
     user_home: Option<&Path>,
-) -> FrameworkCommand {
+    profile: &OpenClawHostProfile,
+    allow_unsafe: bool,
+) -> Result<FrameworkCommand, AdapterError> {
+    if !profile.supports_install_force {
+        return Err(AdapterError::FrameworkCli {
+            program: openclaw_bin(),
+            reason: "`openclaw plugins install --help` does not expose the required \
+                     --force flag; cannot install non-interactively"
+                .to_string(),
+        });
+    }
+    if allow_unsafe {
+        match profile.unsafe_install_support {
+            UnsafeInstallSupport::Effective => {}
+            UnsafeInstallSupport::Unsupported => {
+                return Err(AdapterError::FrameworkCli {
+                    program: openclaw_bin(),
+                    reason: "unsafe plugin install was explicitly authorized but this openclaw \
+                             does not expose --dangerously-force-unsafe-install"
+                        .to_string(),
+                });
+            }
+            UnsafeInstallSupport::DeprecatedNoOp => {
+                return Err(AdapterError::FrameworkCli {
+                    program: openclaw_bin(),
+                    reason: "unsafe plugin install was explicitly authorized, but this openclaw \
+                             advertises --dangerously-force-unsafe-install as a deprecated no-op; \
+                             configure the operator-owned security.installPolicy instead"
+                        .to_string(),
+                });
+            }
+        }
+    }
+    Ok(base_cmd(
+        install_argv(resource_root, allow_unsafe),
+        home,
+        user_home,
+    ))
+}
+
+/// Build the `plugins install <root> --force [--dangerously-force-unsafe-install]`
+/// argv. `--force` is always present (a required capability); the unsafe flag
+/// is appended iff `allow_unsafe`. Capability support is the caller's concern
+/// ([`build_install_cmd`] verifies it during preflight); `apply_enable` builds
+/// this directly from the authorized decision without re-probing.
+fn install_argv(resource_root: &Path, allow_unsafe: bool) -> Vec<String> {
+    let mut args = vec![
+        "plugins".to_string(),
+        "install".to_string(),
+        resource_root.to_string_lossy().into_owned(),
+        "--force".to_string(),
+    ];
+    if allow_unsafe {
+        args.push("--dangerously-force-unsafe-install".to_string());
+    }
+    args
+}
+
+/// Whether `help` lists `flag` as a standalone option token — not merely as a
+/// prefix of a longer flag. A flag token continues through any character that
+/// can appear inside an option name (ASCII alphanumeric, `-`, `_`, `.`), so a
+/// near-miss like `--force-color`, `--json-file`, `--json_file`, or
+/// `--runtime.mode` stays a single token and never matches `--force`/`--json`/
+/// `--runtime`, while genuine boundaries (`--json`, `--json=<path>`,
+/// `--json,`) do.
+fn help_lists_flag(help: &str, flag: &str) -> bool {
+    help.split(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')))
+        .any(|token| token == flag)
+}
+
+/// Classify the unsafe option by its advertised help semantics. Current
+/// OpenClaw releases retain the token as a deprecated no-op, so token presence
+/// alone must not authorize an ineffective bypass or produce invalid retry
+/// advice.
+fn unsafe_install_support(help: &str) -> UnsafeInstallSupport {
+    const FLAG: &str = "--dangerously-force-unsafe-install";
+    let Some(option_line) = help.lines().find(|line| help_lists_flag(line, FLAG)) else {
+        return UnsafeInstallSupport::Unsupported;
+    };
+    let description = option_line.to_ascii_lowercase();
+    if description.contains("no-op") || description.contains("no op") {
+        UnsafeInstallSupport::DeprecatedNoOp
+    } else {
+        UnsafeInstallSupport::Effective
+    }
+}
+
+/// Build the read-only `openclaw --version` probe.
+fn build_version_cmd(home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
+    base_cmd(vec!["--version".to_string()], home, user_home)
+}
+
+/// Build the read-only `openclaw plugins install --help` probe.
+fn build_install_help_cmd(home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
     base_cmd(
         vec![
             "plugins".to_string(),
             "install".to_string(),
-            resource_root.to_string_lossy().into_owned(),
-            "--force".to_string(),
-            "--dangerously-force-unsafe-install".to_string(),
+            "--help".to_string(),
         ],
         home,
         user_home,
     )
+}
+
+/// Build the read-only `openclaw plugins inspect --help` probe.
+fn build_inspect_help_cmd(home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
+    base_cmd(
+        vec![
+            "plugins".to_string(),
+            "inspect".to_string(),
+            "--help".to_string(),
+        ],
+        home,
+        user_home,
+    )
+}
+
+/// Build `openclaw plugins inspect <plugin_id> [--runtime] --json` for
+/// post-install runtime verification. `--runtime` is included only when the
+/// host's inspect help exposes it.
+fn build_inspect_cmd(
+    plugin_id: &str,
+    home: &Path,
+    user_home: Option<&Path>,
+    with_runtime: bool,
+) -> FrameworkCommand {
+    let mut args = vec![
+        "plugins".to_string(),
+        "inspect".to_string(),
+        plugin_id.to_string(),
+    ];
+    if with_runtime {
+        args.push("--runtime".to_string());
+    }
+    args.push("--json".to_string());
+    base_cmd(args, home, user_home)
 }
 
 /// Build `openclaw plugins uninstall <plugin_id> --force`.
@@ -935,6 +2477,16 @@ fn require_home(ctx: &DriverCtx) -> Result<PathBuf, AdapterError> {
     })
 }
 
+/// Fail-closed error for a `PreparedEnable` that does not match the adapter
+/// being applied. Signals a driver-contract misuse (a caller handed the wrong
+/// prepared state); raised before any mutation.
+fn prepared_state_mismatch(reason: &str) -> AdapterError {
+    AdapterError::FrameworkCli {
+        program: openclaw_bin(),
+        reason: format!("prepared enable state does not match the adapter: {reason}"),
+    }
+}
+
 /// Compose a failure reason string from a non-success [`CliOutput`].
 fn cli_failure_reason(verb: &str, output: &super::driver::CliOutput) -> String {
     if output.timed_out {
@@ -949,6 +2501,36 @@ fn cli_failure_reason(verb: &str, output: &super::driver::CliOutput) -> String {
     if !stderr.is_empty() {
         reason.push_str(": ");
         reason.push_str(stderr);
+    }
+    reason
+}
+
+/// Compose a failure reason keeping the exit/timeout status **and both**
+/// stdout and stderr.
+///
+/// Used on every enable-path command failure (probes, install, config set):
+/// OpenClaw may report plugin-safety findings on stdout, and a timeout must
+/// not drop stderr — the plain [`cli_failure_reason`] omits both. Both streams
+/// are already bounded by the Manager's capture cap.
+fn full_failure_reason(verb: &str, output: &super::driver::CliOutput) -> String {
+    let mut reason = if output.timed_out {
+        format!("'{verb}' timed out")
+    } else {
+        let code = output
+            .status
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "killed".to_string());
+        format!("'{verb}' exited with {code}")
+    };
+    let stderr = output.stderr.trim();
+    if !stderr.is_empty() {
+        reason.push_str("; stderr: ");
+        reason.push_str(stderr);
+    }
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        reason.push_str("; stdout: ");
+        reason.push_str(stdout);
     }
     reason
 }
@@ -1075,12 +2657,24 @@ fn claim_skill_resources(claim: &AdapterClaim) -> Vec<String> {
         .collect()
 }
 
-/// Count config resources in a claim's OpenClaw payload.
-fn claim_config_count(claim: &AdapterClaim) -> usize {
-    match &claim.driver_payload {
-        DriverPayload::OpenClaw(oc) => oc.config_resources.len(),
-        _ => 0,
-    }
+/// Count confirmed and uncertain OpenClaw config facts.
+fn claim_config_counts(claim: &AdapterClaim) -> (usize, usize) {
+    claim
+        .resources
+        .iter()
+        .fold((0, 0), |(applied, pending), resource| {
+            match &resource.kind {
+                ClaimResourceKind::FrameworkConfig {
+                    state: ConfigApplyState::Applied,
+                    ..
+                } => (applied + 1, pending),
+                ClaimResourceKind::FrameworkConfig {
+                    state: ConfigApplyState::Pending,
+                    ..
+                } => (applied, pending + 1),
+                _ => (applied, pending),
+            }
+        })
 }
 
 /// ISO 8601 UTC timestamp, second precision.
@@ -1270,14 +2864,35 @@ mod tests {
         assert!(list_contains_plugin(table, "enclaw-plugin"));
     }
 
+    /// Build a host profile with the given install capabilities; version
+    /// parsed from `"2026.4.14"` and inspect `--json`/`--runtime` supported by
+    /// default (the fields `build_install_cmd` does not read).
+    fn profile(force: bool, unsafe_install: bool) -> OpenClawHostProfile {
+        OpenClawHostProfile {
+            version: OpenClawVersion::parse("2026.4.14"),
+            version_display: "2026.4.14".to_string(),
+            supports_install_force: force,
+            unsafe_install_support: if unsafe_install {
+                UnsafeInstallSupport::Effective
+            } else {
+                UnsafeInstallSupport::Unsupported
+            },
+            supports_inspect_json: true,
+            supports_inspect_runtime: true,
+        }
+    }
+
     #[test]
-    fn install_cmd_mirrors_script_contract() {
+    fn install_cmd_default_uses_force_only_no_unsafe() {
         let _env = OpenClawBinEnvGuard::unset();
         let cmd = build_install_cmd(
             Path::new("/data/adapters/tokenless/openclaw"),
             Path::new("/home/u/.openclaw"),
             Some(Path::new("/home/u")),
-        );
+            &profile(true, true),
+            false,
+        )
+        .expect("force-capable host builds an install command");
         assert_eq!(cmd.program, "openclaw");
         assert_eq!(
             cmd.args,
@@ -1286,8 +2901,8 @@ mod tests {
                 "install",
                 "/data/adapters/tokenless/openclaw",
                 "--force",
-                "--dangerously-force-unsafe-install",
-            ]
+            ],
+            "a normal install must never carry the unsafe flag"
         );
         assert!(cmd.env_remove.contains(&"OPENCLAW_HOME".to_string()));
         assert_eq!(
@@ -1298,6 +2913,336 @@ mod tests {
             )]
         );
         assert_eq!(cmd.path_prepend[0], PathBuf::from("/home/u/.local/bin"));
+    }
+
+    #[test]
+    fn install_cmd_missing_force_capability_fails() {
+        let _env = OpenClawBinEnvGuard::unset();
+        let err = build_install_cmd(
+            Path::new("/data/adapters/tokenless/openclaw"),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+            &profile(false, true),
+            false,
+        )
+        .expect_err("no --force must fail before mutation");
+        assert!(matches!(err, AdapterError::FrameworkCli { .. }));
+    }
+
+    #[test]
+    fn install_cmd_authorized_unsafe_supported_appends_flag() {
+        let _env = OpenClawBinEnvGuard::unset();
+        let cmd = build_install_cmd(
+            Path::new("/data/adapters/tokenless/openclaw"),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+            &profile(true, true),
+            true,
+        )
+        .expect("authorized + supported unsafe install builds a command");
+        assert_eq!(
+            cmd.args,
+            vec![
+                "plugins",
+                "install",
+                "/data/adapters/tokenless/openclaw",
+                "--force",
+                "--dangerously-force-unsafe-install",
+            ],
+            "a single install argv carries the unsafe flag exactly once"
+        );
+    }
+
+    #[test]
+    fn install_cmd_authorized_unsafe_unsupported_fails() {
+        let _env = OpenClawBinEnvGuard::unset();
+        let err = build_install_cmd(
+            Path::new("/data/adapters/tokenless/openclaw"),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+            &profile(true, false),
+            true,
+        )
+        .expect_err("authorized but unsupported unsafe must fail before mutation");
+        assert!(matches!(err, AdapterError::FrameworkCli { .. }));
+    }
+
+    #[test]
+    fn install_cmd_authorized_unsafe_deprecated_noop_fails() {
+        let _env = OpenClawBinEnvGuard::unset();
+        let mut host = profile(true, false);
+        host.unsafe_install_support = UnsafeInstallSupport::DeprecatedNoOp;
+        let err = build_install_cmd(
+            Path::new("/data/adapters/tokenless/openclaw"),
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+            &host,
+            true,
+        )
+        .expect_err("a deprecated no-op must not be treated as an unsafe bypass");
+        match err {
+            AdapterError::FrameworkCli { reason, .. } => {
+                assert!(reason.contains("deprecated no-op"), "{reason}");
+                assert!(reason.contains("security.installPolicy"), "{reason}");
+            }
+            other => panic!("expected FrameworkCli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inspect_cmd_uses_runtime_when_supported() {
+        let _env = OpenClawBinEnvGuard::unset();
+        let with_runtime = build_inspect_cmd(
+            "agent-sec",
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+            true,
+        );
+        assert_eq!(
+            with_runtime.args,
+            vec!["plugins", "inspect", "agent-sec", "--runtime", "--json"]
+        );
+        let without_runtime = build_inspect_cmd(
+            "agent-sec",
+            Path::new("/home/u/.openclaw"),
+            Some(Path::new("/home/u")),
+            false,
+        );
+        assert_eq!(
+            without_runtime.args,
+            vec!["plugins", "inspect", "agent-sec", "--json"]
+        );
+    }
+
+    // -- version parsing / comparison ------------------------------------
+
+    #[test]
+    fn version_parses_core_and_variants() {
+        let base = OpenClawVersion::parse("2026.4.14").expect("core");
+        assert_eq!(base.core, [2026, 4, 14]);
+        assert_eq!(base.suffix, VersionSuffix::Release);
+
+        // Build metadata is ignored for identity.
+        let build = OpenClawVersion::parse("2026.4.14+build.5").expect("build meta");
+        assert_eq!(build, base);
+
+        // Alphabetic prerelease.
+        let beta = OpenClawVersion::parse("2026.4.14-beta.1").expect("beta");
+        assert!(matches!(beta.suffix, VersionSuffix::Prerelease(_)));
+
+        // Numeric correction.
+        let corr = OpenClawVersion::parse("2026.5.3-1").expect("correction");
+        assert_eq!(corr.suffix, VersionSuffix::Correction(vec![1]));
+
+        // Two-component core pads the patch to zero.
+        let short = OpenClawVersion::parse("2026.4").expect("short");
+        assert_eq!(short.core, [2026, 4, 0]);
+
+        // Non-numeric core is rejected.
+        assert!(OpenClawVersion::parse("not.a.version").is_none());
+        assert!(OpenClawVersion::parse("").is_none());
+    }
+
+    #[test]
+    fn version_rejects_malformed_suffixes() {
+        // An empty `-suffix` must not be treated as a plain release.
+        assert!(OpenClawVersion::parse("2026.4.14-").is_none());
+        // Empty build metadata must be rejected, not silently dropped.
+        assert!(OpenClawVersion::parse("2026.4.14+").is_none());
+        // Empty prerelease/build identifiers (double/leading/trailing dots).
+        assert!(OpenClawVersion::parse("2026.4.14-beta..1").is_none());
+        assert!(OpenClawVersion::parse("2026.4.14-.1").is_none());
+        assert!(OpenClawVersion::parse("2026.4.14+build.").is_none());
+        // Illegal characters in a prerelease identifier are rejected, not
+        // accepted as free text.
+        assert!(OpenClawVersion::parse("2026.4.14-beta_1").is_none());
+        assert!(OpenClawVersion::parse("2026.4.14-beta!1").is_none());
+        // Well-formed suffixes still parse (incl. hyphen inside identifiers
+        // and validated-then-dropped build metadata).
+        assert!(OpenClawVersion::parse("2026.4.14-rc-1").is_some());
+        assert_eq!(
+            OpenClawVersion::parse("2026.4.14-beta.1+build.5"),
+            OpenClawVersion::parse("2026.4.14-beta.1")
+        );
+    }
+
+    #[test]
+    fn version_ordering_ranks_correction_above_and_prerelease_below() {
+        let base = OpenClawVersion::parse("2026.5.3").unwrap();
+        let corr = OpenClawVersion::parse("2026.5.3-1").unwrap();
+        let beta = OpenClawVersion::parse("2026.5.3-beta.1").unwrap();
+        let rc = OpenClawVersion::parse("2026.5.3-rc.2").unwrap();
+
+        // The key departure from stock semver: numeric correction > base.
+        assert!(corr > base, "numeric correction must sort above the base");
+        assert!(
+            beta < base,
+            "alphabetic prerelease must sort below the base"
+        );
+        assert!(beta < rc, "beta precedes rc");
+        assert!(rc < base, "prerelease precedes the release");
+
+        // Core precedence still dominates the suffix.
+        let newer = OpenClawVersion::parse("2026.5.4").unwrap();
+        assert!(newer > corr);
+        assert!(newer > base);
+
+        // A larger correction number sorts above a smaller one.
+        let corr2 = OpenClawVersion::parse("2026.5.3-2").unwrap();
+        assert!(corr2 > corr);
+    }
+
+    #[test]
+    fn version_req_satisfaction_covers_operators_and_correction() {
+        let v = OpenClawVersion::parse("2026.4.24").unwrap();
+        assert_eq!(openclaw_version_req_satisfied(">=2026.4.14", &v), Ok(true));
+        assert_eq!(openclaw_version_req_satisfied(">=2026.4.24", &v), Ok(true));
+        assert_eq!(openclaw_version_req_satisfied(">=2026.5.0", &v), Ok(false));
+        assert_eq!(openclaw_version_req_satisfied(">2026.4.24", &v), Ok(false));
+        assert_eq!(openclaw_version_req_satisfied("<2026.5.0", &v), Ok(true));
+        assert_eq!(
+            openclaw_version_req_satisfied(">=2026.4.14, <2026.5.0", &v),
+            Ok(true)
+        );
+        // Bare version behaves as a minimum.
+        assert_eq!(openclaw_version_req_satisfied("2026.4.14", &v), Ok(true));
+
+        // A numeric-correction host satisfies a `>=` on the base release.
+        let corr = OpenClawVersion::parse("2026.5.3-1").unwrap();
+        assert_eq!(
+            openclaw_version_req_satisfied(">=2026.5.3", &corr),
+            Ok(true)
+        );
+
+        // Malformed requirement is an error, not a silent false.
+        assert!(openclaw_version_req_satisfied(">=not.a.version", &v).is_err());
+        assert!(
+            openclaw_version_req_satisfied(">=2027.0.0, >=not.a.version", &v).is_err(),
+            "every clause must be validated before a non-match is returned"
+        );
+        assert!(openclaw_version_req_satisfied("", &v).is_err());
+        // A malformed suffix in the constraint is an error, not a match.
+        assert!(openclaw_version_req_satisfied(">=2026.4.14-", &v).is_err());
+        // Empty clauses (double/leading/trailing comma) are errors.
+        assert!(openclaw_version_req_satisfied(">=2026.4.14,,<2027.0.0", &v).is_err());
+        assert!(openclaw_version_req_satisfied(">=2026.4.14,", &v).is_err());
+        assert!(openclaw_version_req_satisfied(",>=2026.4.14", &v).is_err());
+    }
+
+    #[test]
+    fn version_output_parsing_extracts_token() {
+        assert_eq!(
+            parse_openclaw_version_output("openclaw 2026.4.14"),
+            OpenClawVersion::parse("2026.4.14")
+        );
+        assert_eq!(
+            parse_openclaw_version_output("OpenClaw CLI version v2026.4.14 (abcdef)"),
+            OpenClawVersion::parse("2026.4.14")
+        );
+        assert_eq!(
+            parse_openclaw_version_output("2026.5.3-1\n"),
+            OpenClawVersion::parse("2026.5.3-1")
+        );
+        assert!(parse_openclaw_version_output("no version here").is_none());
+    }
+
+    #[test]
+    fn version_output_only_accepts_calendar_shape() {
+        // An unrelated dependency/runtime version must not be mistaken for
+        // OpenClaw's own version, and a non-calendar token is ignored.
+        assert!(
+            parse_openclaw_version_output(
+                "warning: node 22.14.0 is unsupported\nopenclaw nightly-build"
+            )
+            .is_none(),
+            "22.14.0 is not calendar-shaped and nightly-build is not a version"
+        );
+        // A leading warning number does not derail extraction of the real one.
+        assert_eq!(
+            parse_openclaw_version_output("note: 3 plugins loaded\nopenclaw 2026.4.14"),
+            OpenClawVersion::parse("2026.4.14")
+        );
+        assert_eq!(
+            parse_openclaw_version_output(
+                "warning: certificate expires on 2099.1.1\nopenclaw 2026.4.14"
+            ),
+            OpenClawVersion::parse("2026.4.14"),
+            "a calendar-shaped warning token must not outrank the explicit version line"
+        );
+        assert!(
+            parse_openclaw_version_output("warning: retry after 2099.1.1").is_none(),
+            "a diagnostic date is not an OpenClaw version"
+        );
+        assert!(
+            parse_openclaw_version_output("openclaw 2026.4.14\n2026.5.0").is_none(),
+            "multiple plausible version lines are ambiguous"
+        );
+        // A two-component version is not accepted as a host version.
+        assert!(parse_openclaw_version_output("openclaw 2026.4").is_none());
+    }
+
+    #[test]
+    fn help_lists_flag_requires_whole_token() {
+        assert!(help_lists_flag("  --force    overwrite", "--force"));
+        assert!(help_lists_flag("--json=<path>  machine readable", "--json"));
+        assert!(help_lists_flag("use --json, or --yaml", "--json"));
+        assert!(help_lists_flag(
+            "  --dangerously-force-unsafe-install  bypass",
+            "--dangerously-force-unsafe-install"
+        ));
+        // Similar-prefixed flags must not be mistaken for the target flag.
+        assert!(!help_lists_flag("--force-color   colorize", "--force"));
+        assert!(!help_lists_flag("--json-file <p>  write json", "--json"));
+        assert!(!help_lists_flag(
+            "--runtime-only   skip static",
+            "--runtime"
+        ));
+    }
+
+    #[test]
+    fn unsafe_install_help_distinguishes_effective_from_noop() {
+        assert_eq!(
+            unsafe_install_support(
+                "  --dangerously-force-unsafe-install  bypass plugin safety checks"
+            ),
+            UnsafeInstallSupport::Effective
+        );
+        assert_eq!(
+            unsafe_install_support(
+                "  --dangerously-force-unsafe-install  Deprecated no-op; security.installPolicy may still block"
+            ),
+            UnsafeInstallSupport::DeprecatedNoOp
+        );
+        assert_eq!(
+            unsafe_install_support("  --force  overwrite an existing plugin"),
+            UnsafeInstallSupport::Unsupported
+        );
+    }
+
+    #[test]
+    fn extract_trailing_json_tolerates_leading_diagnostics() {
+        let clean = r#"{"plugin":{"status":"loaded"}}"#;
+        assert_eq!(
+            extract_trailing_json(clean).and_then(|v| v
+                .get("plugin")?
+                .get("status")?
+                .as_str()
+                .map(str::to_string)),
+            Some("loaded".to_string())
+        );
+
+        let with_diag = "warning: legacy diagnostic line\nreading registry...\n{\"plugin\":{\"status\":\"loaded\"}}\n";
+        let value = extract_trailing_json(with_diag).expect("json after diagnostics");
+        assert_eq!(
+            value
+                .get("plugin")
+                .and_then(|p| p.get("status"))
+                .and_then(|s| s.as_str()),
+            Some("loaded")
+        );
+
+        assert!(extract_trailing_json("not json at all").is_none());
+        assert!(extract_trailing_json("").is_none());
     }
 
     #[test]
@@ -1429,7 +3374,7 @@ mod tests {
         );
     }
 
-    // -- claim_skill_resources / claim_config_count ---------------------
+    // -- claim_skill_resources / claim_config_counts --------------------
 
     #[test]
     fn claim_skill_resources_extracts_names() {
@@ -1443,8 +3388,27 @@ mod tests {
             resource_root: PathBuf::from("/tmp"),
             bundle_digest: None,
             driver_schema: DRIVER_SCHEMA_VERSION,
-            status: ClaimStatus::Enabled,
-            resources: Vec::new(),
+            status: ClaimStatus::CleanupFailed,
+            resources: vec![
+                ClaimResource {
+                    id: "openclaw_config_0".to_string(),
+                    purpose: "openclaw_config".to_string(),
+                    kind: ClaimResourceKind::FrameworkConfig {
+                        framework: "openclaw".to_string(),
+                        key: "applied.key".to_string(),
+                        state: ConfigApplyState::Applied,
+                    },
+                },
+                ClaimResource {
+                    id: "openclaw_config_1".to_string(),
+                    purpose: "openclaw_config".to_string(),
+                    kind: ClaimResourceKind::FrameworkConfig {
+                        framework: "openclaw".to_string(),
+                        key: "pending.key".to_string(),
+                        state: ConfigApplyState::Pending,
+                    },
+                },
+            ],
             driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
                 state_dir_resource: "s".to_string(),
                 plugin_resource: "p".to_string(),
@@ -1457,7 +3421,7 @@ mod tests {
         };
         let skills = claim_skill_resources(&claim);
         assert_eq!(skills, vec!["sec-audit", "cred-scan"]);
-        assert_eq!(claim_config_count(&claim), 1);
+        assert_eq!(claim_config_counts(&claim), (1, 1));
     }
 
     #[test]
@@ -1507,6 +3471,8 @@ mod tests {
             }],
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: true,
             ops: &ops,
         };
@@ -1522,7 +3488,7 @@ mod tests {
                 .all(|action| !action.contains("register openclaw plugin")),
         );
 
-        let claim = driver.prepare_enable(&bundle, &ctx).expect("claim");
+        let (claim, _prepared) = driver.prepare_enable(&bundle, &ctx).expect("claim");
         assert!(claim.plugin_id.is_none());
         assert_eq!(claim.adapter_type.as_deref(), Some("skill_bundle"));
         assert!(
@@ -1548,5 +3514,150 @@ mod tests {
             condition.kind == AdapterConditionKind::VerificationSupported
                 && condition.status == ConditionStatus::True
         }));
+    }
+
+    /// A mismatched (or under-capable) `PreparedEnable` must fail closed in
+    /// `apply_enable` **before** any framework CLI runs. The ops handle panics
+    /// on `run_framework_cli`, so any test reaching this line proves no
+    /// mutation was attempted.
+    #[test]
+    fn apply_enable_rejects_mismatched_prepared_state() {
+        use crate::adapter::driver::{AdapterOps, CliOutput};
+
+        struct PanicOps;
+        impl AdapterOps for PanicOps {
+            fn run_framework_cli(&self, _: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+                panic!("apply must fail closed before running any framework CLI");
+            }
+            fn copy_tree(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                panic!("no tree copy before validation");
+            }
+            fn copy_file(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn remove_tree(&self, _: &Path) -> Result<bool, AdapterError> {
+                unimplemented!()
+            }
+            fn write_file(&self, _: &Path, _: &[u8]) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
+                unimplemented!()
+            }
+            fn read_file(&self, _: &Path) -> Result<Option<Vec<u8>>, AdapterError> {
+                unimplemented!()
+            }
+        }
+
+        let layout = anolisa_platform::fs_layout::FsLayout::user(PathBuf::from("/tmp/test-home"));
+        let ops = PanicOps;
+        let mk_ctx = |adapter_type: Option<&str>, allow_unsafe: bool| DriverCtx {
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            layout: &layout,
+            resource_root: PathBuf::from("/tmp/test-home/resource"),
+            user_home: Some(PathBuf::from("/tmp/test-home")),
+            declared_plugin_id: None,
+            adapter_type: adapter_type.map(str::to_string),
+            declared_skills: Vec::new(),
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: allow_unsafe,
+            dry_run: false,
+            ops: &ops,
+        };
+        let mut plugin_claim = AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            plugin_id: Some("tokenless".to_string()),
+            adapter_type: None,
+            enabled_at: "2026-01-01T00:00:00Z".to_string(),
+            resource_root: PathBuf::from("/tmp/test-home/resource"),
+            bundle_digest: None,
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            resources: vec![ClaimResource {
+                id: RES_PLUGIN.to_string(),
+                purpose: "openclaw_plugin".to_string(),
+                kind: ClaimResourceKind::FrameworkPlugin {
+                    framework: "openclaw".to_string(),
+                    plugin_id: "tokenless".to_string(),
+                },
+            }],
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: RES_STATE_DIR.to_string(),
+                plugin_resource: RES_PLUGIN.to_string(),
+                skill_resources: Vec::new(),
+                config_resources: Vec::new(),
+            }),
+        };
+        let mut skill_claim = plugin_claim.clone();
+        skill_claim.adapter_type = Some("skill_bundle".to_string());
+        skill_claim.plugin_id = None;
+
+        let driver = OpenClawDriver::new();
+        let _env = OpenClawBinEnvGuard::unset();
+
+        // Plugin adapter but no prepared capabilities → reject.
+        assert!(matches!(
+            driver.apply_enable(
+                &mut plugin_claim,
+                &PreparedEnable::None,
+                &mk_ctx(None, false),
+                &mut (),
+            ),
+            Err(AdapterError::FrameworkCli { .. })
+        ));
+
+        // Skill bundle but plugin capabilities supplied → reject.
+        assert!(matches!(
+            driver.apply_enable(
+                &mut skill_claim,
+                &PreparedEnable::OpenClaw {
+                    supports_unsafe_install: true,
+                    supports_inspect_json: true,
+                    supports_inspect_runtime: true,
+                    selected_config_indices: Vec::new(),
+                },
+                &mk_ctx(Some("skill_bundle"), false),
+                &mut (),
+            ),
+            Err(AdapterError::FrameworkCli { .. })
+        ));
+
+        // Plugin adapter but the host cannot produce JSON inspect → reject.
+        assert!(matches!(
+            driver.apply_enable(
+                &mut plugin_claim,
+                &PreparedEnable::OpenClaw {
+                    supports_unsafe_install: true,
+                    supports_inspect_json: false,
+                    supports_inspect_runtime: false,
+                    selected_config_indices: Vec::new(),
+                },
+                &mk_ctx(None, false),
+                &mut (),
+            ),
+            Err(AdapterError::FrameworkCli { .. })
+        ));
+
+        // Unsafe authorized but the prepared state says the host lacks the
+        // flag → reject (never add the dangerous flag on an unverified host).
+        assert!(matches!(
+            driver.apply_enable(
+                &mut plugin_claim,
+                &PreparedEnable::OpenClaw {
+                    supports_unsafe_install: false,
+                    supports_inspect_json: true,
+                    supports_inspect_runtime: false,
+                    selected_config_indices: Vec::new(),
+                },
+                &mk_ctx(None, true),
+                &mut (),
+            ),
+            Err(AdapterError::FrameworkCli { .. })
+        ));
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
@@ -53,7 +53,7 @@ use super::claim::{
 use super::driver::{
     AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
-    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+    FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
 use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
 
@@ -221,7 +221,7 @@ impl FrameworkDriver for QoderDriver {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError> {
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let plugin = plugin_name(bundle, ctx);
         validate_plugin_id(&plugin)?;
         let settings =
@@ -250,28 +250,37 @@ impl FrameworkDriver for QoderDriver {
             },
         ];
 
-        Ok(AdapterClaim {
-            claim_schema: CLAIM_SCHEMA_VERSION,
-            component: ctx.component.clone(),
-            framework: self.name().to_string(),
-            plugin_id: Some(plugin),
-            adapter_type: ctx.adapter_type.clone(),
-            enabled_at: now_iso8601(),
-            resource_root: bundle.resource_root.clone(),
-            bundle_digest: bundle.digest.clone(),
-            driver_schema: DRIVER_SCHEMA_VERSION,
-            status: ClaimStatus::Enabled,
-            resources,
-            driver_payload: DriverPayload::Qoder(QoderClaim {
-                plugin_resource: RES_PLUGIN.to_string(),
-                settings_resource: RES_SETTINGS.to_string(),
-                managed_hooks,
-                managed_hook_specs,
-            }),
-        })
+        Ok((
+            AdapterClaim {
+                claim_schema: CLAIM_SCHEMA_VERSION,
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                plugin_id: Some(plugin),
+                adapter_type: ctx.adapter_type.clone(),
+                enabled_at: now_iso8601(),
+                resource_root: bundle.resource_root.clone(),
+                bundle_digest: bundle.digest.clone(),
+                driver_schema: DRIVER_SCHEMA_VERSION,
+                status: ClaimStatus::Enabled,
+                resources,
+                driver_payload: DriverPayload::Qoder(QoderClaim {
+                    plugin_resource: RES_PLUGIN.to_string(),
+                    settings_resource: RES_SETTINGS.to_string(),
+                    managed_hooks,
+                    managed_hook_specs,
+                }),
+            },
+            PreparedEnable::None,
+        ))
     }
 
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        _prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        _progress: &mut dyn super::driver::EnableProgress,
+    ) -> Result<(), AdapterError> {
         // Resolve plugin + settings strictly from the receipt's payload
         // references (Manager-validated), failing closed on a malformed
         // receipt rather than falling back to ctx-derived defaults.
@@ -965,6 +974,8 @@ mod tests {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: true,
             ops: &ops,
         };

--- a/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
@@ -37,7 +37,7 @@ use super::claim::{
 use super::driver::{
     AdapterBundle, AdapterCondition, AdapterConditionKind, AdapterStatusReport, AdapterSummary,
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
-    FrameworkCommand, FrameworkDriver, HostEnv, find_binary_in_path,
+    FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
 use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
 
@@ -179,7 +179,7 @@ impl FrameworkDriver for QwenCodeDriver {
         &self,
         bundle: &AdapterBundle,
         ctx: &DriverCtx,
-    ) -> Result<AdapterClaim, AdapterError> {
+    ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let plugin = bundle_plugin(bundle)?;
         let home =
             qwen_home(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
@@ -205,7 +205,7 @@ impl FrameworkDriver for QwenCodeDriver {
             },
         ];
 
-        Ok(AdapterClaim {
+        let claim = AdapterClaim {
             claim_schema: CLAIM_SCHEMA_VERSION,
             component: ctx.component.clone(),
             framework: self.name().to_string(),
@@ -221,10 +221,17 @@ impl FrameworkDriver for QwenCodeDriver {
                 extension_dir_resource: RES_EXTENSION_DIR.to_string(),
                 plugin_resource: RES_PLUGIN.to_string(),
             }),
-        })
+        };
+        Ok((claim, PreparedEnable::None))
     }
 
-    fn apply_enable(&self, claim: &AdapterClaim, ctx: &DriverCtx) -> Result<(), AdapterError> {
+    fn apply_enable(
+        &self,
+        claim: &mut AdapterClaim,
+        _prepared: &PreparedEnable,
+        ctx: &DriverCtx,
+        _progress: &mut dyn super::driver::EnableProgress,
+    ) -> Result<(), AdapterError> {
         let layout = QwenLayout::from_claim(claim)?;
         ensure_current_home(&layout, ctx)?;
         ensure_supported_version(&layout.home, ctx)?;
@@ -1473,6 +1480,8 @@ mod tests {
             declared_skills: Vec::new(),
             declared_config: Vec::new(),
             declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
             dry_run: false,
             ops,
         }
@@ -1483,7 +1492,9 @@ mod tests {
         ctx: &DriverCtx,
     ) -> Result<AdapterClaim, AdapterError> {
         let bundle = driver.read_bundle(ctx)?;
-        driver.prepare_enable(&bundle, ctx)
+        driver
+            .prepare_enable(&bundle, ctx)
+            .map(|(claim, _prepared)| claim)
     }
 
     fn seed_owned_link(home: &Path, source: &Path) {
@@ -1513,9 +1524,11 @@ mod tests {
         let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
         let ctx = ctx(&resource, &user_home, &ops, &layout);
         let driver = QwenCodeDriver::new();
-        let claim = prepare_claim(&driver, &ctx).expect("claim");
+        let mut claim = prepare_claim(&driver, &ctx).expect("claim");
 
-        driver.apply_enable(&claim, &ctx).expect("enable");
+        driver
+            .apply_enable(&mut claim, &PreparedEnable::None, &ctx, &mut ())
+            .expect("enable");
         assert_eq!(
             ops.commands(),
             vec![
@@ -1560,9 +1573,11 @@ mod tests {
         let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
         let ctx = ctx(&resource, &user_home, &ops, &layout);
         let driver = QwenCodeDriver::new();
-        let claim = prepare_claim(&driver, &ctx).expect("claim");
+        let mut claim = prepare_claim(&driver, &ctx).expect("claim");
 
-        driver.apply_enable(&claim, &ctx).expect("re-enable");
+        driver
+            .apply_enable(&mut claim, &PreparedEnable::None, &ctx, &mut ())
+            .expect("re-enable");
         assert_eq!(
             ops.commands(),
             vec![
@@ -1593,10 +1608,10 @@ mod tests {
         let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
         let ctx = ctx(&resource, &user_home, &ops, &layout);
         let driver = QwenCodeDriver::new();
-        let claim = prepare_claim(&driver, &ctx).expect("claim");
+        let mut claim = prepare_claim(&driver, &ctx).expect("claim");
 
         let error = driver
-            .apply_enable(&claim, &ctx)
+            .apply_enable(&mut claim, &PreparedEnable::None, &ctx, &mut ())
             .expect_err("missing postcondition must fail");
         assert!(matches!(error, AdapterError::FrameworkCli { .. }));
         assert_eq!(
@@ -1620,10 +1635,10 @@ mod tests {
         let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
         let ctx = ctx(&resource, &user_home, &ops, &layout);
         let driver = QwenCodeDriver::new();
-        let claim = prepare_claim(&driver, &ctx).expect("claim");
+        let mut claim = prepare_claim(&driver, &ctx).expect("claim");
 
         let error = driver
-            .apply_enable(&claim, &ctx)
+            .apply_enable(&mut claim, &PreparedEnable::None, &ctx, &mut ())
             .expect_err("foreign extension must be preserved");
         assert!(matches!(error, AdapterError::InvalidAdapterInput { .. }));
         assert_eq!(ops.commands(), vec![vec!["--version".to_string()]]);
@@ -1646,10 +1661,10 @@ mod tests {
         let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
         let ctx = ctx(&resource, &user_home, &ops, &layout);
         let driver = QwenCodeDriver::new();
-        let claim = prepare_claim(&driver, &ctx).expect("claim");
+        let mut claim = prepare_claim(&driver, &ctx).expect("claim");
 
         let error = driver
-            .apply_enable(&claim, &ctx)
+            .apply_enable(&mut claim, &PreparedEnable::None, &ctx, &mut ())
             .expect_err("malformed shared state must fail closed");
         assert!(matches!(error, AdapterError::FrameworkCli { .. }));
         assert_eq!(ops.commands(), vec![vec!["--version".to_string()]]);
@@ -1820,10 +1835,10 @@ mod tests {
         let layout = anolisa_platform::fs_layout::FsLayout::user(user_home.clone());
         let ctx = ctx(&resource, &user_home, &ops, &layout);
         let driver = QwenCodeDriver::new();
-        let claim = prepare_claim(&driver, &ctx).expect("claim");
+        let mut claim = prepare_claim(&driver, &ctx).expect("claim");
 
         let error = driver
-            .apply_enable(&claim, &ctx)
+            .apply_enable(&mut claim, &PreparedEnable::None, &ctx, &mut ())
             .expect_err("old Qwen must fail");
         assert!(matches!(error, AdapterError::FrameworkCli { .. }));
         assert_eq!(ops.commands(), vec![vec!["--version".to_string()]]);
@@ -1968,7 +1983,7 @@ mod tests {
         }
 
         let error = driver
-            .apply_enable(&claim, &ctx)
+            .apply_enable(&mut claim, &PreparedEnable::None, &ctx, &mut ())
             .expect_err("malformed payload must fail");
         assert!(matches!(error, AdapterError::BundleInvalid { .. }));
         assert!(ops.commands().is_empty());

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -686,6 +686,15 @@ pub struct AdapterConfigSetSpec {
     pub key: String,
     /// Value to set.
     pub value: toml::Value,
+    /// Optional semver-style constraint on the target framework version,
+    /// e.g. `">=2026.4.24"`. When present, the driver applies this config
+    /// entry only if the detected framework version satisfies the
+    /// constraint; otherwise the entry is skipped and left out of the
+    /// receipt. Absent means "always apply", preserving backward
+    /// compatibility with older manifests. Skipped on serialize when absent
+    /// so those manifests round-trip byte-stable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub framework_version: Option<String>,
 }
 
 /// One skill entry in an `[[adapters]]` or framework-specific section.
@@ -2796,6 +2805,72 @@ mod tests {
         assert_eq!(
             m.adapters[0].framework_version_req,
             m2.adapters[0].framework_version_req
+        );
+    }
+
+    #[test]
+    fn adapter_config_framework_version_parses_and_round_trips() {
+        // The issue's suggested component shape: a per-config framework
+        // version condition alongside the adapter-level compat requirement.
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.1.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            plugin_id = "agent-sec"
+
+            [adapters.compat]
+            framework_version = ">=2026.4.14"
+
+            [[adapters.openclaw.config]]
+            key = "plugins.entries.agent-sec.hooks.allowConversationAccess"
+            value = true
+            framework_version = ">=2026.4.24"
+
+            [[adapters.openclaw.config]]
+            key = "plugins.entries.agent-sec.enabled"
+            value = true
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let a = &m.adapters[0];
+        assert_eq!(a.compat.framework_version.as_deref(), Some(">=2026.4.14"));
+        let oc = a.openclaw.as_ref().expect("openclaw section");
+        assert_eq!(oc.config.len(), 2);
+        assert_eq!(
+            oc.config[0].framework_version.as_deref(),
+            Some(">=2026.4.24")
+        );
+        // A config entry with no condition means "always apply".
+        assert!(oc.config[1].framework_version.is_none());
+
+        // The condition must survive a serialize→parse round-trip, and an
+        // absent condition must not be emitted (old manifests stay stable).
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        let m2 = ComponentManifest::from_toml_str(&serialized).expect("re-parse");
+        assert_eq!(m.adapters, m2.adapters);
+    }
+
+    #[test]
+    fn adapter_config_without_framework_version_skips_serializing_field() {
+        let toml_text = r#"
+            [component]
+            name = "skiptest"
+            version = "1.0.0"
+
+            [[adapters]]
+            framework = "openclaw"
+
+            [[adapters.config]]
+            key = "some.key"
+            value = "hello"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        assert!(
+            !serialized.contains("framework_version"),
+            "absent per-config framework_version must be skipped: {serialized}"
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -19,9 +19,11 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
 use anolisa_core::adapter::AdapterError;
-use anolisa_core::adapter::claim::{ClaimResourceKind, ClaimStatus};
+use anolisa_core::adapter::claim::{
+    ClaimResourceKind, ClaimStatus, ConfigApplyState, DriverPayload,
+};
 use anolisa_core::adapter::driver::{AdapterSummary, ConditionStatus};
-use anolisa_core::adapter::manager::{AdapterManager, EnableOutcome};
+use anolisa_core::adapter::manager::{AdapterManager, EnableOptions, EnableOutcome};
 use anolisa_core::state::InstalledState;
 use anolisa_platform::fs_layout::FsLayout;
 
@@ -59,24 +61,127 @@ impl World {
     fn load_state(&self) -> InstalledState {
         InstalledState::load(&self.layout.state_dir.join("installed.toml")).expect("load state")
     }
+
+    /// Path the fake CLI appends each invocation's argv to (test-only).
+    fn argv_log(&self) -> PathBuf {
+        self.openclaw_home
+            .parent()
+            .expect("prefix")
+            .join("argv.log")
+    }
+
+    /// Whether the openclaw registry marker for the component exists.
+    fn registry_marker_exists(&self) -> bool {
+        self.openclaw_home.join("registry").join(COMPONENT).exists()
+    }
+
+    fn config_marker_exists(&self, key: &str) -> bool {
+        self.openclaw_home.join("config").join(key).exists()
+    }
+
+    fn has_claim(&self) -> bool {
+        self.load_state()
+            .find_adapter_claim(COMPONENT, FRAMEWORK)
+            .is_some()
+    }
 }
+
+/// Lines the fake CLI recorded, in invocation order (empty when unset/absent).
+fn argv_lines(path: &Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .map(|s| s.lines().map(str::to_string).collect())
+        .unwrap_or_default()
+}
+
+/// The real `plugins install` invocation (excluding the `--help` probe).
+fn install_argv(lines: &[String]) -> Option<&String> {
+    lines
+        .iter()
+        .find(|l| l.starts_with("plugins install ") && !l.contains("--help"))
+}
+
+/// The real `plugins inspect` invocation (excluding the `--help` probe).
+fn inspect_argv(lines: &[String]) -> Option<&String> {
+    lines
+        .iter()
+        .find(|l| l.starts_with("plugins inspect ") && !l.contains("--help"))
+}
+
+/// Overwrite the component's installed manifest with a custom `[[adapters]]`
+/// block, keeping the component recorded as installed. `adapters_block` is a
+/// substituted string, so `{datadir}`/`{component}` placeholders inside it
+/// reach the manifest verbatim.
+fn write_openclaw_manifest(layout: &FsLayout, adapters_block: &str) {
+    let manifest_path = layout
+        .state_dir
+        .join("component-manifests")
+        .join(COMPONENT)
+        .join("component.toml");
+    std::fs::create_dir_all(manifest_path.parent().unwrap()).expect("manifest dir");
+    let toml = format!(
+        r#"[component]
+name = "{COMPONENT}"
+version = "0.1.0"
+
+[component.layout]
+modes = ["system"]
+
+{adapters_block}
+"#
+    );
+    std::fs::write(&manifest_path, toml).expect("seed component manifest");
+}
+
+/// A plain OpenClaw plugin adapter block with an optional adapter-level
+/// framework version requirement.
+fn plugin_adapter_block(compat_req: Option<&str>) -> String {
+    let compat = compat_req
+        .map(|r| format!("\n[adapters.compat]\nframework_version = \"{r}\"\n"))
+        .unwrap_or_default();
+    format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+{compat}"#
+    )
+}
+
+/// Every environment variable this test binary's fake OpenClaw contract
+/// owns. The guard saves and restores exactly these so no test leaks state
+/// into another. `FAKE_OC_*` are the capability knobs the fake CLI reads.
+const OWNED_ENV: &[&str] = &[
+    "OPENCLAW_BIN",
+    "OPENCLAW_HOME",
+    "FAKE_OPENCLAW_FAIL",
+    "FAKE_OC_VERSION",
+    "FAKE_OC_INSTALL_FORCE",
+    "FAKE_OC_INSTALL_UNSAFE",
+    "FAKE_OC_INSTALL_UNSAFE_NOOP",
+    "FAKE_OC_INSPECT_JSON",
+    "FAKE_OC_INSPECT_RUNTIME",
+    "FAKE_OC_RUNTIME_STATUS",
+    "FAKE_OC_INSPECT_DIAG",
+    "FAKE_OC_ARGV_LOG",
+    "FAKE_OC_PROBE_FAIL",
+    "FAKE_OC_VERSION_PREAMBLE",
+    "FAKE_OC_CONFIG_FAIL_KEY",
+    "FAKE_OC_CONFIG_FAIL_AFTER_KEY",
+];
 
 struct OpenClawEnvGuard {
     _lock: MutexGuard<'static, ()>,
-    saved_bin: Option<OsString>,
-    saved_home: Option<OsString>,
-    saved_fail: Option<OsString>,
+    saved: Vec<(&'static str, Option<OsString>)>,
 }
 
 impl OpenClawEnvGuard {
     fn acquire() -> Self {
         let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let guard = Self {
-            _lock: lock,
-            saved_bin: std::env::var_os("OPENCLAW_BIN"),
-            saved_home: std::env::var_os("OPENCLAW_HOME"),
-            saved_fail: std::env::var_os("FAKE_OPENCLAW_FAIL"),
-        };
+        let saved = OWNED_ENV
+            .iter()
+            .map(|&k| (k, std::env::var_os(k)))
+            .collect();
+        let guard = Self { _lock: lock, saved };
         guard.clear();
         guard
     }
@@ -85,9 +190,9 @@ impl OpenClawEnvGuard {
         // SAFETY: this guard holds ENV_LOCK, so tests in this binary cannot
         // observe a half-mutated OpenClaw env contract.
         unsafe {
-            std::env::remove_var("OPENCLAW_BIN");
-            std::env::remove_var("OPENCLAW_HOME");
-            std::env::remove_var("FAKE_OPENCLAW_FAIL");
+            for &key in OWNED_ENV {
+                std::env::remove_var(key);
+            }
         }
     }
 
@@ -110,13 +215,25 @@ impl OpenClawEnvGuard {
             std::env::set_var("OPENCLAW_BIN", value);
         }
     }
+
+    /// Set one of the owned fake-CLI knobs (or `OsStr`-valued path).
+    fn set(&self, key: &str, value: impl AsRef<std::ffi::OsStr>) {
+        assert!(
+            OWNED_ENV.contains(&key),
+            "env key {key} must be guard-owned"
+        );
+        // SAFETY: this guard holds ENV_LOCK.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
 }
 
 impl Drop for OpenClawEnvGuard {
     fn drop(&mut self) {
-        restore_env("OPENCLAW_BIN", self.saved_bin.as_ref());
-        restore_env("OPENCLAW_HOME", self.saved_home.as_ref());
-        restore_env("FAKE_OPENCLAW_FAIL", self.saved_fail.as_ref());
+        for (key, value) in &self.saved {
+            restore_env(key, value.as_ref());
+        }
     }
 }
 
@@ -173,37 +290,112 @@ fn stage() -> World {
 
 /// Write a fake `openclaw` CLI honoring the driver's argv/env contract.
 ///
+/// Read-only probes, defaulting to a modern, force-capable, JSON-capable host:
+/// - `--version` prints `openclaw $FAKE_OC_VERSION` (default `2026.4.14`) and
+///   creates NO registry/config/state.
+/// - `plugins install --help` lists `--force` unless `FAKE_OC_INSTALL_FORCE=0`
+///   and `--dangerously-force-unsafe-install` when `FAKE_OC_INSTALL_UNSAFE=1`;
+///   `FAKE_OC_INSTALL_UNSAFE_NOOP=1` marks that option as a deprecated no-op.
+/// - `plugins inspect --help` lists `--json` unless `FAKE_OC_INSPECT_JSON=0`
+///   and `--runtime` when `FAKE_OC_INSPECT_RUNTIME=1`.
+///
+/// Mutations / runtime state:
 /// - `plugins install <root> ...` reads `<root>/openclaw.plugin.json` and
 ///   touches a marker in `$OPENCLAW_STATE_DIR/registry/<id>`.
-/// - `plugins uninstall <id> ...` removes that marker.
-/// - `plugins list` prints the registry markers, one id per line.
-/// - `FAKE_OPENCLAW_FAIL=install|install_after_register|uninstall`
-///   forces that verb to exit non-zero.
+/// - `plugins inspect <id> [--runtime] --json` prints an optional legacy
+///   diagnostic line (when `FAKE_OC_INSPECT_DIAG` is set) followed by the JSON
+///   `{"plugin":{"id":..,"status":"$FAKE_OC_RUNTIME_STATUS"}}` (default
+///   `loaded`).
+/// - `plugins uninstall <id> ...` removes the marker; `plugins list` prints
+///   markers; `config set` echoes.
+/// - `FAKE_OPENCLAW_FAIL=install|install_after_register|uninstall` forces that
+///   verb to exit non-zero; `FAKE_OC_CONFIG_FAIL_KEY` fails `config set`
+///   before mutation, while `FAKE_OC_CONFIG_FAIL_AFTER_KEY` fails after
+///   writing a marker for one exact key.
+///
+/// When `FAKE_OC_ARGV_LOG` names a file, every invocation appends its full
+/// argv (one line) — test instrumentation, not OpenClaw state.
 fn write_fake_openclaw(dir: &Path) -> PathBuf {
     let script = r#"#!/bin/sh
+if [ -n "${FAKE_OC_ARGV_LOG:-}" ]; then printf '%s\n' "$*" >> "$FAKE_OC_ARGV_LOG"; fi
+
+ver="${FAKE_OC_VERSION:-2026.4.14}"
+if [ "$1" = "--version" ]; then
+  [ -n "${FAKE_OC_VERSION_PREAMBLE:-}" ] && echo "$FAKE_OC_VERSION_PREAMBLE"
+  echo "openclaw $ver"
+  [ "${FAKE_OC_PROBE_FAIL:-}" = "version" ] && exit 3
+  exit 0
+fi
+
 sub="$1"; action="$2"; arg3="$3"
-reg="$OPENCLAW_STATE_DIR/registry"
-mkdir -p "$reg" 2>/dev/null
+
 if [ "$sub" = "config" ] && [ "$action" = "set" ]; then
+  if [ -n "${FAKE_OC_CONFIG_FAIL_KEY:-}" ] && [ "$arg3" = "$FAKE_OC_CONFIG_FAIL_KEY" ]; then
+    echo "boom-config-$arg3" >&2
+    exit 13
+  fi
+  config_dir="$OPENCLAW_STATE_DIR/config"; mkdir -p "$config_dir" 2>/dev/null
+  printf '%s' "$4" > "$config_dir/$arg3"
+  if [ -n "${FAKE_OC_CONFIG_FAIL_AFTER_KEY:-}" ] && [ "$arg3" = "$FAKE_OC_CONFIG_FAIL_AFTER_KEY" ]; then
+    echo "boom-after-config-$arg3" >&2
+    exit 14
+  fi
   echo "config set $arg3 $4"
   exit 0
 fi
 if [ "$sub" != "plugins" ]; then echo "unknown subcommand: $sub" >&2; exit 2; fi
+
 case "$action" in
   install)
+    if [ "$arg3" = "--help" ]; then
+      echo "Usage: openclaw plugins install <path> [options]"
+      [ "${FAKE_OC_INSTALL_FORCE:-1}" = "1" ] && echo "  --force                             overwrite an existing plugin"
+      if [ "${FAKE_OC_INSTALL_UNSAFE:-0}" = "1" ]; then
+        if [ "${FAKE_OC_INSTALL_UNSAFE_NOOP:-0}" = "1" ]; then
+          echo "  --dangerously-force-unsafe-install  Deprecated no-op; security.installPolicy may still block"
+        else
+          echo "  --dangerously-force-unsafe-install  bypass plugin safety checks"
+        fi
+      fi
+      [ "${FAKE_OC_PROBE_FAIL:-}" = "install_help" ] && exit 4
+      exit 0
+    fi
+    reg="$OPENCLAW_STATE_DIR/registry"; mkdir -p "$reg" 2>/dev/null
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "install" ]; then echo "boom-install" >&2; exit 7; fi
+    if [ "${FAKE_OPENCLAW_FAIL:-}" = "install_unsafe_policy" ]; then
+      echo "refusing install: plugin failed safety checks (pass --dangerously-force-unsafe-install to override)" >&2
+      exit 11
+    fi
+    if [ "${FAKE_OPENCLAW_FAIL:-}" = "install_unsafe_policy_stdout" ]; then
+      echo "SECURITY FINDING: plugin failed safety review; pass --dangerously-force-unsafe-install to override"
+      exit 12
+    fi
     id=$(sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$arg3/openclaw.plugin.json" | head -n 1)
     if [ -z "$id" ]; then echo "missing plugin id" >&2; exit 9; fi
     : > "$reg/$id"
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "install_after_register" ]; then echo "boom-after-register" >&2; exit 10; fi
     echo "installed $id"
     ;;
+  inspect)
+    if [ "$arg3" = "--help" ]; then
+      echo "Usage: openclaw plugins inspect <id> [options]"
+      [ "${FAKE_OC_INSPECT_JSON:-1}" = "1" ] && echo "  --json      machine-readable output"
+      [ "${FAKE_OC_INSPECT_RUNTIME:-0}" = "1" ] && echo "  --runtime   include live runtime status"
+      [ "${FAKE_OC_PROBE_FAIL:-}" = "inspect_help" ] && exit 5
+      exit 0
+    fi
+    status="${FAKE_OC_RUNTIME_STATUS:-loaded}"
+    [ -n "${FAKE_OC_INSPECT_DIAG:-}" ] && echo "legacy: reading plugin registry for $arg3 ..."
+    echo "{\"plugin\":{\"id\":\"$arg3\",\"status\":\"$status\"}}"
+    ;;
   uninstall)
+    reg="$OPENCLAW_STATE_DIR/registry"; mkdir -p "$reg" 2>/dev/null
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "uninstall" ]; then echo "boom-uninstall" >&2; exit 8; fi
     rm -f "$reg/$arg3"
     echo "uninstalled $arg3"
     ;;
   list)
+    reg="$OPENCLAW_STATE_DIR/registry"
     ls "$reg" 2>/dev/null || true
     ;;
   *)
@@ -847,5 +1039,1543 @@ fn dry_run_disable_no_receipt_is_noop() {
             .any(|m| m.contains("no receipt")),
         "must report no receipt: {:?}",
         outcome.report.messages
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1534: version gating, install policy, and runtime verification
+// ---------------------------------------------------------------------------
+
+/// 1. Host below the adapter minimum: no plugin install and no receipt.
+#[test]
+fn host_below_adapter_minimum_blocks_enable() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &plugin_adapter_block(Some(">=2026.5.0")));
+    world.apply_env(&guard, None); // FAKE_OC_VERSION defaults to 2026.4.14
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("host below minimum must block enable");
+    assert!(
+        matches!(err, AdapterError::FrameworkVersionMismatch { .. }),
+        "got {err:?}"
+    );
+    assert!(
+        !world.registry_marker_exists(),
+        "no plugin install before the version gate"
+    );
+    assert!(
+        !world.has_claim(),
+        "no receipt persisted on version mismatch"
+    );
+}
+
+/// 2. Host version cannot be parsed: fail before any mutation.
+#[test]
+fn unparseable_host_version_blocks_enable() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &plugin_adapter_block(Some(">=2026.4.14")));
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_VERSION", "unreleased-nightly");
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("unparseable version must block enable");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// 3. Install help does not expose `--force`: fail before mutation and before
+///    the receipt is persisted.
+#[test]
+fn missing_install_force_blocks_before_mutation() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSTALL_FORCE", "0");
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("missing --force must block enable");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(
+        !world.has_claim(),
+        "the force-capability gate runs before the receipt is persisted"
+    );
+}
+
+/// 4. Unsafe flag supported but not authorized: the install argv omits it.
+#[test]
+fn unsafe_supported_without_authorization_omits_flag() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let lines = argv_lines(&world.argv_log());
+    let install = install_argv(&lines).expect("install argv recorded");
+    assert!(
+        install.contains("--force"),
+        "install must pass --force: {install}"
+    );
+    assert!(
+        !install.contains("--dangerously-force-unsafe-install"),
+        "unsafe flag must be absent without authorization: {install}"
+    );
+}
+
+/// 5. Unsafe flag supported and explicitly authorized: the single install
+///    argv carries it exactly once.
+#[test]
+fn authorized_unsafe_supported_includes_flag_once() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable_with_options(
+            COMPONENT,
+            Some(FRAMEWORK),
+            false,
+            EnableOptions {
+                allow_unsafe_plugin_install: true,
+            },
+        )
+        .expect("authorized unsafe enable");
+    let lines = argv_lines(&world.argv_log());
+    let install = install_argv(&lines).expect("install argv recorded");
+    assert_eq!(
+        install
+            .matches("--dangerously-force-unsafe-install")
+            .count(),
+        1,
+        "unsafe flag must appear exactly once in the single install argv: {install}"
+    );
+    // No second install invocation.
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|l| l.starts_with("plugins install ") && !l.contains("--help"))
+            .count(),
+        1,
+        "exactly one real install must run"
+    );
+}
+
+/// 6. Unsafe authorized but the host does not expose the flag: fail before
+///    mutation, no receipt.
+#[test]
+fn authorized_unsafe_unsupported_blocks() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None); // FAKE_OC_INSTALL_UNSAFE defaults to 0
+    let manager = world.manager();
+
+    let err = manager
+        .enable_with_options(
+            COMPONENT,
+            Some(FRAMEWORK),
+            false,
+            EnableOptions {
+                allow_unsafe_plugin_install: true,
+            },
+        )
+        .expect_err("authorized-but-unsupported unsafe must block");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// An advertised unsafe option that is a deprecated no-op is not an effective
+/// capability. Explicit authorization fails before mutation and points the
+/// operator at OpenClaw's policy configuration instead.
+#[test]
+fn authorized_unsafe_deprecated_noop_blocks() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1");
+    guard.set("FAKE_OC_INSTALL_UNSAFE_NOOP", "1");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    let err = manager
+        .enable_with_options(
+            COMPONENT,
+            Some(FRAMEWORK),
+            false,
+            EnableOptions {
+                allow_unsafe_plugin_install: true,
+            },
+        )
+        .expect_err("a deprecated no-op cannot satisfy unsafe authorization");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(reason.contains("deprecated no-op"), "{reason}");
+            assert!(reason.contains("security.installPolicy"), "{reason}");
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+    assert!(
+        install_argv(&argv_lines(&world.argv_log())).is_none(),
+        "preflight must block before a real install"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// 7. Config entry whose version condition is unmet: not set, and left out
+///    of the receipt.
+#[test]
+fn config_version_mismatch_skips_config_and_claim() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "plugins.entries.tokenless.hooks.allowConversationAccess"
+value = true
+framework_version = ">=2026.5.0"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None); // host 2026.4.14 < 2026.5.0
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let lines = argv_lines(&world.argv_log());
+    assert!(
+        !lines.iter().any(|l| l.starts_with("config set")),
+        "a config entry with an unmet version condition must not be applied: {lines:?}"
+    );
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("claim");
+    assert!(
+        !claim
+            .resources
+            .iter()
+            .any(|r| matches!(r.kind, ClaimResourceKind::FrameworkConfig { .. })),
+        "skipped config must not appear in the receipt"
+    );
+}
+
+/// 8. Config entry whose version condition is met: set, and recorded in the
+///    receipt.
+#[test]
+fn config_version_match_applies_and_records() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let key = "plugins.entries.tokenless.hooks.allowConversationAccess";
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "{key}"
+value = true
+framework_version = ">=2026.4.0"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None); // host 2026.4.14 satisfies >=2026.4.0
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let lines = argv_lines(&world.argv_log());
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.starts_with("config set") && l.contains(key)),
+        "a config entry with a met version condition must be applied: {lines:?}"
+    );
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("claim");
+    assert!(
+        claim.resources.iter().any(|r| matches!(
+            &r.kind,
+            ClaimResourceKind::FrameworkConfig { key: k, .. } if k == key
+        )),
+        "applied config must be recorded in the receipt"
+    );
+}
+
+/// A failed re-enable must not discard config facts from the last successful
+/// enable because those keys remain present on the host.
+#[test]
+fn reenable_install_failure_preserves_applied_config_facts() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "preserved.key"
+value = true
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("initial enable");
+    world.apply_env(&guard, Some("install"));
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("re-enable install must fail");
+
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("cleanup receipt");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+    assert!(
+        claim.resources.iter().any(|resource| matches!(
+            &resource.kind,
+            ClaimResourceKind::FrameworkConfig {
+                key,
+                state: ConfigApplyState::Applied,
+                ..
+            } if key == "preserved.key"
+        )),
+        "the successful enable's config fact must survive failed re-enable"
+    );
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        panic!("expected OpenClaw payload");
+    };
+    assert_eq!(payload.config_resources.len(), 1);
+}
+
+/// Successful re-enable reuses the matching applied fact without duplicating
+/// either the resource or its payload reference.
+#[test]
+fn successful_reenable_keeps_config_receipt_idempotent() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "idempotent.key"
+value = true
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("initial enable");
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("re-enable");
+
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("enabled receipt");
+    let config_resources: Vec<_> = claim
+        .resources
+        .iter()
+        .filter(|resource| matches!(resource.kind, ClaimResourceKind::FrameworkConfig { .. }))
+        .collect();
+    assert_eq!(config_resources.len(), 1);
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        panic!("expected OpenClaw payload");
+    };
+    assert_eq!(payload.config_resources.len(), 1);
+    assert_eq!(payload.config_resources[0], config_resources[0].id);
+}
+
+/// A command that mutates and then exits non-zero must leave a typed pending
+/// fact rather than falsely claiming success or omitting uncertain host state.
+#[test]
+fn first_config_failure_after_mutation_records_pending_intent() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "first.key"
+value = true
+
+[[adapters.openclaw.config]]
+key = "second.key"
+value = true
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_CONFIG_FAIL_AFTER_KEY", "first.key");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+
+    world
+        .manager()
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("the first config write must fail enable");
+
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("cleanup receipt");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+    assert!(
+        world.config_marker_exists("first.key"),
+        "fake host must reproduce mutation before failure"
+    );
+    let config_resources: Vec<_> = claim
+        .resources
+        .iter()
+        .filter(|resource| matches!(resource.kind, ClaimResourceKind::FrameworkConfig { .. }))
+        .collect();
+    assert_eq!(config_resources.len(), 1);
+    assert!(matches!(
+        &config_resources[0].kind,
+        ClaimResourceKind::FrameworkConfig {
+            key,
+            state: ConfigApplyState::Pending,
+            ..
+        } if key == "first.key"
+    ));
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        panic!("expected OpenClaw payload");
+    };
+    assert!(payload.config_resources.is_empty());
+
+    let config_sets: Vec<String> = argv_lines(&world.argv_log())
+        .into_iter()
+        .filter(|line| line.starts_with("config set "))
+        .collect();
+    assert_eq!(config_sets.len(), 1);
+    assert!(config_sets[0].contains("first.key"));
+    assert!(!config_sets[0].contains("second.key"));
+
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_CONFIG_FAIL_AFTER_KEY", "");
+    world
+        .manager()
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("re-enable must replay and confirm the pending entry");
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("recovered receipt");
+    assert_eq!(claim.status, ClaimStatus::Enabled);
+    let config_resources: Vec<_> = claim
+        .resources
+        .iter()
+        .filter(|resource| matches!(resource.kind, ClaimResourceKind::FrameworkConfig { .. }))
+        .collect();
+    assert_eq!(config_resources.len(), 2);
+    assert!(config_resources.iter().all(|resource| matches!(
+        &resource.kind,
+        ClaimResourceKind::FrameworkConfig {
+            state: ConfigApplyState::Applied,
+            ..
+        }
+    )));
+    assert_eq!(
+        config_resources
+            .iter()
+            .filter(|resource| matches!(
+                &resource.kind,
+                ClaimResourceKind::FrameworkConfig { key, .. } if key == "first.key"
+            ))
+            .count(),
+        1,
+        "the recovered pending key must not be duplicated"
+    );
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        panic!("expected OpenClaw payload");
+    };
+    assert_eq!(payload.config_resources.len(), 2);
+}
+
+/// A pending config that the replacement manifest no longer selects cannot be
+/// reconciled, so re-enable must fail before another framework mutation.
+#[test]
+fn reenable_rejects_pending_config_removed_from_manifest() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "removed.key"
+value = true
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_CONFIG_FAIL_AFTER_KEY", "removed.key");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+
+    world
+        .manager()
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("the first config write must fail enable");
+    write_openclaw_manifest(&world.layout, &plugin_adapter_block(None));
+    guard.set("FAKE_OC_CONFIG_FAIL_AFTER_KEY", "");
+
+    let err = world
+        .manager()
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("an unselected pending config must block re-enable");
+    let message = err.to_string();
+    assert!(message.contains("removed.key"), "got {message}");
+    assert!(message.contains("disable"), "got {message}");
+
+    let lines = argv_lines(&world.argv_log());
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|line| line.starts_with("plugins install ") && !line.contains("--help"))
+            .count(),
+        1,
+        "the blocked re-enable must fail before another plugin install"
+    );
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|line| line.starts_with("config set removed.key "))
+            .count(),
+        1,
+        "the removed pending key cannot be replayed"
+    );
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("pending receipt must remain visible");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+    assert!(claim.resources.iter().any(|resource| matches!(
+        &resource.kind,
+        ClaimResourceKind::FrameworkConfig {
+            key,
+            state: ConfigApplyState::Pending,
+            ..
+        } if key == "removed.key"
+    )));
+}
+
+/// Explicit disable reports uncertain config that may remain on the host
+/// before removing the receipt.
+#[test]
+fn disable_reports_pending_config_left_in_place() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "uncertain.key"
+value = true
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_CONFIG_FAIL_AFTER_KEY", "uncertain.key");
+
+    world
+        .manager()
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("the config write must leave pending state");
+    guard.set("FAKE_OC_CONFIG_FAIL_AFTER_KEY", "");
+    let outcome = world
+        .manager()
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("explicit disable");
+
+    assert!(outcome.claim_removed);
+    assert!(outcome.report.cleanup_complete);
+    assert!(
+        outcome.report.messages.iter().any(|message| {
+            message.contains("1 openclaw config entry")
+                && message.contains("uncertain")
+                && message.contains("left in place")
+        }),
+        "disable must disclose uncertain config before discarding the receipt: {:?}",
+        outcome.report.messages
+    );
+    assert!(!world.has_claim());
+}
+
+/// A mid-sequence failure keeps the successful prefix confirmed, the failed
+/// entry pending, and later unattempted entries absent.
+#[test]
+fn mid_sequence_config_failure_records_applied_prefix() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "first.key"
+value = true
+
+[[adapters.openclaw.config]]
+key = "second.key"
+value = true
+
+[[adapters.openclaw.config]]
+key = "third.key"
+value = true
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_CONFIG_FAIL_KEY", "second.key");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+
+    world
+        .manager()
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("the second config write must fail enable");
+
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("cleanup receipt");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+    let config_resources: Vec<_> = claim
+        .resources
+        .iter()
+        .filter(|resource| matches!(resource.kind, ClaimResourceKind::FrameworkConfig { .. }))
+        .collect();
+    assert_eq!(config_resources.len(), 2);
+    assert_eq!(config_resources[0].id, "openclaw_config_0");
+    assert!(matches!(
+        &config_resources[0].kind,
+        ClaimResourceKind::FrameworkConfig {
+            key,
+            state: ConfigApplyState::Applied,
+            ..
+        } if key == "first.key"
+    ));
+    assert_eq!(config_resources[1].id, "openclaw_config_1");
+    assert!(matches!(
+        &config_resources[1].kind,
+        ClaimResourceKind::FrameworkConfig {
+            key,
+            state: ConfigApplyState::Pending,
+            ..
+        } if key == "second.key"
+    ));
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        panic!("expected OpenClaw payload");
+    };
+    assert_eq!(payload.config_resources, ["openclaw_config_0"]);
+
+    let config_sets: Vec<String> = argv_lines(&world.argv_log())
+        .into_iter()
+        .filter(|line| line.starts_with("config set "))
+        .collect();
+    assert_eq!(config_sets.len(), 2);
+    assert!(config_sets[0].contains("first.key"));
+    assert!(config_sets[1].contains("second.key"));
+    assert!(!config_sets.iter().any(|line| line.contains("third.key")));
+}
+
+/// 9. Inspect help exposes `--runtime`: runtime verification uses it.
+#[test]
+fn runtime_verification_uses_runtime_flag_when_supported() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSPECT_RUNTIME", "1");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let lines = argv_lines(&world.argv_log());
+    let inspect = inspect_argv(&lines).expect("inspect argv recorded");
+    assert!(
+        inspect.contains("--runtime") && inspect.contains("--json"),
+        "runtime-capable host must inspect with --runtime --json: {inspect}"
+    );
+}
+
+/// 10. Inspect help lacks `--runtime`: verification falls back to `--json`.
+#[test]
+fn runtime_verification_falls_back_to_json_only() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None); // FAKE_OC_INSPECT_RUNTIME defaults to 0
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let lines = argv_lines(&world.argv_log());
+    let inspect = inspect_argv(&lines).expect("inspect argv recorded");
+    assert!(
+        inspect.contains("--json"),
+        "must inspect with --json: {inspect}"
+    );
+    assert!(
+        !inspect.contains("--runtime"),
+        "must not pass --runtime when unsupported: {inspect}"
+    );
+}
+
+/// 11. Legacy diagnostics before the JSON must still parse.
+#[test]
+fn runtime_verification_tolerates_leading_diagnostics() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSPECT_DIAG", "1");
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable succeeds despite legacy diagnostics before the JSON");
+    assert!(world.has_claim());
+}
+
+/// 12. Runtime status is not `loaded`: enable fails with diagnostics and the
+///     receipt is kept for cleanup retry.
+#[test]
+fn runtime_status_error_fails_and_keeps_cleanup_receipt() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_RUNTIME_STATUS", "error");
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("non-loaded runtime status must fail enable");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(
+                reason.contains("error") && reason.contains("loaded"),
+                "diagnostics must surface the observed and expected status: {reason}"
+            );
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+    assert!(
+        world.registry_marker_exists(),
+        "install ran before the failed runtime verification"
+    );
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("receipt kept for cleanup retry");
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+}
+
+/// 13. Dry-run: probes are allowed but nothing is mutated, and the plan shows
+///     the single install command.
+#[test]
+fn dry_run_probes_but_does_not_mutate() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("dry-run enable");
+    match outcome {
+        EnableOutcome::Planned(plan) => {
+            let cmd = plan
+                .register_command
+                .expect("plan shows the install command");
+            assert!(cmd.contains("--force"), "plan must show --force: {cmd}");
+            assert!(
+                !cmd.contains("--dangerously-force-unsafe-install"),
+                "unauthorized dry-run plan must not show the unsafe flag: {cmd}"
+            );
+        }
+        EnableOutcome::Enabled(_) => panic!("dry-run must not enable"),
+    }
+    // Read-only probes may have run, but nothing was installed or persisted.
+    let lines = argv_lines(&world.argv_log());
+    assert!(
+        install_argv(&lines).is_none(),
+        "dry-run must not run a real install: {lines:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// 15. An unsafe authorization for a skill-only adapter is rejected before
+///     any work.
+#[test]
+fn unsafe_authorization_rejected_for_skill_bundle() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+adapter_type = "skill_bundle"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let err = manager
+        .enable_with_options(
+            COMPONENT,
+            Some(FRAMEWORK),
+            false,
+            EnableOptions {
+                allow_unsafe_plugin_install: true,
+            },
+        )
+        .expect_err("unsafe authorization must be rejected for skill_bundle");
+    assert!(
+        matches!(err, AdapterError::UnsafeInstallNotApplicable { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.has_claim());
+}
+
+/// 1 (extended). A skill_bundle also honors the adapter-level version gate:
+/// an incompatible host blocks enable with no receipt.
+#[test]
+fn skill_bundle_honors_adapter_version_gate() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+adapter_type = "skill_bundle"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[adapters.compat]
+framework_version = ">=2026.5.0"
+
+[adapters.openclaw]
+skills = ["sec-audit"]
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None); // host 2026.4.14 < 2026.5.0
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("skill_bundle below the adapter minimum must be blocked");
+    assert!(
+        matches!(err, AdapterError::FrameworkVersionMismatch { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.has_claim());
+}
+
+/// P1 fail-closed: an unparseable `--version` blocks a plugin enable even
+/// when the manifest declares no version condition.
+#[test]
+fn unparseable_version_blocks_even_without_condition() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage(); // default manifest declares no compat requirement
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_VERSION", "nightly-build");
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("an unreadable version must fail closed before install");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// P1 fail-closed: a host whose inspect help exposes no `--json` is rejected
+/// before the first mutation (the full profile, including inspect help, is
+/// probed during prepare), so no plugin is installed and no receipt is left.
+#[test]
+fn missing_inspect_json_blocks_before_mutation() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSPECT_JSON", "0");
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("no --json inspect support must fail closed before install");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(
+                reason.contains("--json"),
+                "must explain the missing --json capability: {reason}"
+            );
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+    assert!(
+        !world.registry_marker_exists(),
+        "install must not run when runtime verification cannot be performed"
+    );
+    assert!(!world.has_claim());
+}
+
+/// P1 fail-closed: every read-only probe — `--version`, install `--help`, and
+/// inspect `--help` — is performed before the first mutation, so a non-zero
+/// exit from any of them blocks enable with no install and no receipt, even
+/// when the output would otherwise look like a capability answer.
+#[test]
+fn nonzero_probe_exit_blocks_enable_before_mutation() {
+    for (stage_label, note) in [
+        ("version", "a non-zero `--version` with parseable output"),
+        (
+            "install_help",
+            "a non-zero install --help still mentioning --force",
+        ),
+        (
+            "inspect_help",
+            "a non-zero inspect --help still mentioning --json",
+        ),
+    ] {
+        let guard = OpenClawEnvGuard::acquire();
+        let world = stage();
+        world.apply_env(&guard, None);
+        guard.set("FAKE_OC_PROBE_FAIL", stage_label);
+        let manager = world.manager();
+
+        let err = manager
+            .enable(COMPONENT, Some(FRAMEWORK), false)
+            .expect_err(note);
+        assert!(
+            matches!(err, AdapterError::FrameworkCli { .. }),
+            "{note}: got {err:?}"
+        );
+        assert!(!world.registry_marker_exists(), "{note}: no install");
+        assert!(!world.has_claim(), "{note}: no receipt");
+    }
+}
+
+/// Each probe runs exactly once in a real enable: all three (`--version`,
+/// install `--help`, inspect `--help`) happen in prepare, and apply re-probes
+/// nothing (it reuses the prepared capabilities).
+#[test]
+fn each_probe_runs_exactly_once_per_enable() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let lines = argv_lines(&world.argv_log());
+    let count = |pred: &dyn Fn(&&String) -> bool| lines.iter().filter(|l| pred(l)).count();
+    assert_eq!(
+        count(&|l| l.as_str() == "--version"),
+        1,
+        "one --version probe: {lines:?}"
+    );
+    assert_eq!(
+        count(&|l| l.as_str() == "plugins install --help"),
+        1,
+        "one install --help probe: {lines:?}"
+    );
+    assert_eq!(
+        count(&|l| l.as_str() == "plugins inspect --help"),
+        1,
+        "one inspect --help probe: {lines:?}"
+    );
+}
+
+/// P2 (negative): when the host does NOT expose the unsafe flag, a plain
+/// safety-rejected install must not dangle the `--allow-unsafe-plugin-install`
+/// hint (retrying would just fail in prepare), and there is no auto-retry.
+#[test]
+fn safety_rejection_without_unsafe_support_omits_hint() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, Some("install_unsafe_policy"));
+    // FAKE_OC_INSTALL_UNSAFE defaults to 0 → host does not expose the flag.
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("safety-rejected install must fail");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(
+                !reason.contains("--allow-unsafe-plugin-install"),
+                "must not suggest an unsafe retry the host cannot honor: {reason}"
+            );
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+    let lines = argv_lines(&world.argv_log());
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|l| l.starts_with("plugins install ") && !l.contains("--help"))
+            .count(),
+        1,
+        "must not auto-retry the install: {lines:?}"
+    );
+}
+
+/// An advertised deprecated no-op is equivalent to no effective unsafe
+/// capability for retry guidance.
+#[test]
+fn safety_rejection_with_deprecated_noop_omits_hint() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, Some("install_unsafe_policy"));
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1");
+    guard.set("FAKE_OC_INSTALL_UNSAFE_NOOP", "1");
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("safety-rejected install must fail");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(
+                !reason.contains("--allow-unsafe-plugin-install"),
+                "must not suggest retrying with a no-op option: {reason}"
+            );
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+}
+
+/// P2: plugin-safety findings printed to stdout are surfaced in the failure,
+/// alongside the explicit-retry hint.
+#[test]
+fn safety_rejection_on_stdout_is_surfaced() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, Some("install_unsafe_policy_stdout"));
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1"); // host supports the unsafe flag
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("stdout safety rejection must fail");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(
+                reason.contains("SECURITY FINDING"),
+                "stdout findings must be surfaced to the operator: {reason}"
+            );
+            assert!(
+                reason.contains("--allow-unsafe-plugin-install"),
+                "must hint the explicit retry: {reason}"
+            );
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+}
+
+/// P1: two config entries sharing a key but gated on different versions —
+/// only the entry whose condition the host satisfies is applied and recorded.
+#[test]
+fn same_key_config_applies_only_selected_version() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "shared.key"
+value = "future"
+framework_version = ">=2026.5.0"
+
+[[adapters.openclaw.config]]
+key = "shared.key"
+value = "current"
+framework_version = ">=2026.4.0"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None); // host 2026.4.14: only the ">=2026.4.0" entry matches
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable");
+    let lines = argv_lines(&world.argv_log());
+    let config_sets: Vec<&String> = lines
+        .iter()
+        .filter(|l| l.starts_with("config set "))
+        .collect();
+    assert_eq!(
+        config_sets.len(),
+        1,
+        "only the version-selected same-key entry must be applied: {config_sets:?}"
+    );
+    assert!(
+        config_sets[0].contains("current") && !config_sets[0].contains("future"),
+        "the applied value must be the selected version's, not the skipped one: {config_sets:?}"
+    );
+    // The receipt records exactly one config resource.
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("claim");
+    assert_eq!(
+        claim
+            .resources
+            .iter()
+            .filter(|r| matches!(r.kind, ClaimResourceKind::FrameworkConfig { .. }))
+            .count(),
+        1,
+        "only the selected config entry must appear in the receipt"
+    );
+}
+
+/// P2: when a normal install is rejected by OpenClaw's plugin-safety policy
+/// and the host exposes the unsafe flag, the error points the operator at the
+/// explicit `--allow-unsafe-plugin-install` retry — without auto-retrying.
+#[test]
+fn safety_rejection_surfaces_explicit_retry_hint() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, Some("install_unsafe_policy"));
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1"); // host supports the unsafe flag
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("safety-rejected install must fail");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(
+                reason.contains("--allow-unsafe-plugin-install"),
+                "must hint the explicit retry authorization: {reason}"
+            );
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+    // No automatic unsafe retry: only the one failed (safe) install ran.
+    let lines = argv_lines(&world.argv_log());
+    let installs: Vec<&String> = lines
+        .iter()
+        .filter(|l| l.starts_with("plugins install ") && !l.contains("--help"))
+        .collect();
+    assert_eq!(
+        installs.len(),
+        1,
+        "must not auto-retry the install: {installs:?}"
+    );
+    assert!(
+        !installs[0].contains("--dangerously-force-unsafe-install"),
+        "the failed attempt must have been the safe one: {installs:?}"
+    );
+}
+
+/// P1: an explicitly empty adapter-level version requirement is a manifest
+/// error, not a silent "no requirement" — it must not fall through to enable.
+#[test]
+fn empty_compat_framework_version_is_invalid() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[adapters.compat]
+framework_version = ""
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("an empty compat.framework_version must be rejected");
+    assert!(
+        matches!(err, AdapterError::InvalidAdapterInput { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// P1: an explicitly empty per-config version condition is a manifest error;
+/// no config is applied and no receipt is written.
+#[test]
+fn empty_config_framework_version_is_invalid() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "some.key"
+value = true
+framework_version = ""
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("an empty config framework_version must be rejected");
+    assert!(
+        matches!(err, AdapterError::InvalidAdapterInput { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// P1: a malformed version constraint is a typed input error (not a generic
+/// framework-CLI error), and enable stops before any mutation.
+#[test]
+fn malformed_config_constraint_is_invalid_input() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "some.key"
+value = true
+framework_version = ">=not.a.version"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("a malformed constraint must be rejected");
+    assert!(
+        matches!(err, AdapterError::InvalidAdapterInput { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// Every config condition clause is validated before the condition is
+/// evaluated. A malformed later clause cannot hide behind an earlier
+/// non-match and silently skip the config.
+#[test]
+fn malformed_later_config_clause_is_invalid_input() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[[adapters.openclaw.config]]
+key = "some.key"
+value = true
+framework_version = ">=2027.0.0, >=not.a.version"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None); // host fails the first clause
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("a malformed later clause must still be rejected");
+    assert!(
+        matches!(err, AdapterError::InvalidAdapterInput { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// P1: a malformed adapter-level constraint (an empty `-` suffix here) is a
+/// typed input error and stops enable before any mutation — it must not be
+/// silently treated as the well-formed `>=2026.4.14`.
+#[test]
+fn malformed_compat_constraint_is_invalid_input() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &plugin_adapter_block(Some(">=2026.4.14-")));
+    world.apply_env(&guard, None); // host 2026.4.14 would satisfy >=2026.4.14
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("a malformed compat constraint must be rejected");
+    assert!(
+        matches!(err, AdapterError::InvalidAdapterInput { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// P1: a `--version` output carrying only an unrelated (non-calendar) number
+/// is treated as unknown; with a declared requirement, enable fails closed.
+#[test]
+fn unrelated_numeric_version_is_not_accepted() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &plugin_adapter_block(Some(">=2026.4.0")));
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_VERSION", "22.14.0"); // not calendar-shaped
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("a non-calendar version must not satisfy the gate");
+    assert!(
+        matches!(err, AdapterError::FrameworkCli { .. }),
+        "got {err:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// A calendar-shaped token in a warning must not be selected ahead of the
+/// explicit OpenClaw version line.
+#[test]
+fn version_warning_date_does_not_override_openclaw_version() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &plugin_adapter_block(Some("<2027.0.0")));
+    world.apply_env(&guard, None);
+    guard.set(
+        "FAKE_OC_VERSION_PREAMBLE",
+        "warning: certificate expires on 2099.1.1",
+    );
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("the explicit 2026.4.14 version satisfies the gate");
+    assert!(world.registry_marker_exists());
+    assert!(world.has_claim());
+}
+
+/// P2: when `--version` output is multi-line and unparseable, the failure
+/// preserves the full trimmed output (not just the first line), so the real
+/// version text is actionable even behind a leading warning line.
+#[test]
+fn unparseable_version_error_keeps_full_output() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    write_openclaw_manifest(&world.layout, &plugin_adapter_block(Some(">=2026.4.0")));
+    world.apply_env(&guard, None);
+    guard.set(
+        "FAKE_OC_VERSION_PREAMBLE",
+        "warning: config migration pending",
+    );
+    guard.set("FAKE_OC_VERSION", "nightly-build"); // unparseable, on the 2nd line
+    let manager = world.manager();
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("unparseable version must block");
+    match err {
+        AdapterError::FrameworkCli { reason, .. } => {
+            assert!(
+                reason.contains("nightly-build"),
+                "the real (unparseable) version line must survive, not just the warning: {reason}"
+            );
+        }
+        other => panic!("expected FrameworkCli, got {other:?}"),
+    }
+    assert!(!world.has_claim());
+}
+
+/// P2 acceptance: an authorized-unsafe dry-run shows the unsafe flag in the
+/// planned install command and mutates nothing.
+#[test]
+fn authorized_unsafe_dry_run_shows_flag_without_mutation() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1");
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable_with_options(
+            COMPONENT,
+            Some(FRAMEWORK),
+            true,
+            EnableOptions {
+                allow_unsafe_plugin_install: true,
+            },
+        )
+        .expect("dry-run enable");
+    match outcome {
+        EnableOutcome::Planned(plan) => {
+            let cmd = plan
+                .register_command
+                .expect("plan shows the install command");
+            assert!(
+                cmd.contains("--dangerously-force-unsafe-install"),
+                "authorized dry-run plan must show the unsafe flag: {cmd}"
+            );
+        }
+        EnableOutcome::Enabled(_) => panic!("dry-run must not enable"),
+    }
+    let lines = argv_lines(&world.argv_log());
+    assert!(
+        install_argv(&lines).is_none(),
+        "dry-run must not run a real install: {lines:?}"
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+/// P2 acceptance: an authorized real enable records the exact install command,
+/// including the unsafe flag, in the live central operation log.
+#[test]
+fn central_log_records_authorized_unsafe_install_argv() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("FAKE_OC_INSTALL_UNSAFE", "1");
+    let manager = world.manager();
+
+    manager
+        .enable_with_options(
+            COMPONENT,
+            Some(FRAMEWORK),
+            false,
+            EnableOptions {
+                allow_unsafe_plugin_install: true,
+            },
+        )
+        .expect("authorized unsafe enable");
+    let log = std::fs::read_to_string(&world.layout.central_log).expect("central log");
+    assert!(
+        log.contains("plugins install")
+            && log.contains("--force")
+            && log.contains("--dangerously-force-unsafe-install"),
+        "central log must record the exact install argv incl. the unsafe flag: {log}"
+    );
+}
+
+/// 15. An unsafe authorization for a non-OpenClaw framework is rejected.
+#[test]
+fn unsafe_authorization_rejected_for_non_openclaw_framework() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "hermes"
+source = "adapters/{COMPONENT}/hermes"
+dest = "{{datadir}}/adapters/{{component}}/hermes/"
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    let err = manager
+        .enable_with_options(
+            COMPONENT,
+            Some("hermes"),
+            false,
+            EnableOptions {
+                allow_unsafe_plugin_install: true,
+            },
+        )
+        .expect_err("unsafe authorization must be rejected for a non-OpenClaw framework");
+    assert!(
+        matches!(err, AdapterError::UnsafeInstallNotApplicable { .. }),
+        "got {err:?}"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "hermes")
+            .is_none(),
+        "no receipt for a rejected unsafe authorization"
     );
 }


### PR DESCRIPTION
## Description

This PR makes OpenClaw adapter enable compatibility-aware by resolving a
typed, read-only host profile before any framework or adapter mutation. It
enforces component-declared version requirements, selects version-compatible
config, separates unsafe capability from explicit operator authorization, and
verifies that the plugin reaches the `loaded` runtime state after one install
attempt. A transient `PreparedEnable` value carries probed capabilities from
prepare to apply, keeping each probe to one execution without introducing
version-specific command arrays or an executable manifest DSL. Existing
non-OpenClaw drivers retain their previous behavior.

## Related Issue

closes #1534

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa`:

```bash
cargo fmt --all -- --check
cargo check --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --locked --workspace
cargo doc --workspace --no-deps
git diff --check
```

Focused coverage includes:

- OpenClaw version parsing, ordering, malformed constraints, and corrections.
- Host version and install/inspect capability probing before mutation.
- Missing, timed-out, and non-zero probe failures.
- Adapter-level version gating for plugins and skill bundles.
- Version-conditioned config selection and claim accuracy.
- Default-safe, explicitly authorized, and unsupported unsafe-install paths.
- Dry-run and central-log disclosure of unsafe authorization.
- Single-install behavior with no automatic unsafe retry.
- Runtime verification with `--runtime --json` and JSON-only fallback.
- Legacy diagnostics before inspect JSON and non-loaded runtime failures.
- Prepared-state mismatch rejection before any mutation.
- Existing enable, disable, status, skill-bundle, and dry-run behavior.

## Additional Notes

- No sec-core deployment script or component contract was changed.
- No component-owned executable behavior or generic installation DSL was added.
- OpenClaw gateway restart remains intentionally outside the driver contract.
- Changelog updates remain in the release version-bump PR.

### Ship Note

- Changed: OpenClaw adapter enable now probes host compatibility, applies only
  compatible config, requires explicit unsafe-install authorization, and
  verifies that installed plugins reach `loaded`.
- Known limitations: None beyond the explicit non-goals in Issue #1534.
- Not covered: Live OpenClaw E2E validation of shipping help text, security
  rejection wording, and inspect JSON variants.
- Verification: `cargo fmt --all -- --check`, `cargo check --locked`,
  `cargo clippy --workspace --all-targets --locked -- -D warnings`,
  `cargo test --locked --workspace`, and
  `cargo doc --workspace --no-deps`.
