### PR TITLE
fix(anolisa): sync rpm component manifests

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
@@ -6,6 +6,9 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use anolisa_core::adapter::contract::{
+    ContractProvenance, ContractSourceKind, read_snapshot_provenance,
+};
 use anolisa_core::central_log::CentralLog;
 use anolisa_core::{ServiceManager, ServiceRunOutcome, deactivate_services};
 use anolisa_platform::fs_layout::FsLayout;
@@ -86,23 +89,78 @@ enum DatadirContractLookup {
     },
 }
 
+#[derive(Clone, Copy)]
+enum ContractSourcePolicy {
+    InstallOrAdopt,
+    RpmReconciliation,
+}
+
 /// Read-only result for comparing an RPM-owned contract with its state snapshot.
 pub(crate) struct ContractDriftInspection {
-    /// Whether the state snapshot is absent, unreadable, or byte-different.
+    /// Whether the snapshot and provenance differ from the package contract.
     pub(crate) drifted: bool,
     /// Non-fatal lookup or path-resolution failures.
     pub(crate) warnings: Vec<String>,
 }
 
-fn datadir_contract_roots(layout: &FsLayout) -> Vec<PathBuf> {
-    let mut roots: Vec<PathBuf> = Vec::new();
-    if let Some(packaged) = crate::packaged::packaged_datadir_root(layout) {
-        roots.push(packaged);
+/// Result of refreshing a package-owned contract snapshot and its provenance.
+pub(crate) struct ContractRefreshOutcome {
+    /// Whether publication succeeded, was unnecessary, or failed.
+    state: ContractRefreshState,
+    /// Diagnostics for lookup or publication failures.
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum ContractRefreshState {
+    Refreshed,
+    NotApplicable,
+    Failed,
+}
+
+impl ContractRefreshOutcome {
+    /// Describe why a required refresh did not complete.
+    pub(crate) fn failure_detail(&self) -> Option<String> {
+        match self.state {
+            ContractRefreshState::Refreshed => None,
+            ContractRefreshState::NotApplicable => {
+                Some("the package-owned component contract was unavailable during refresh".into())
+            }
+            ContractRefreshState::Failed => Some(self.warning_detail()),
+        }
     }
-    if let Some(package_datadir) = layout.package_datadir()
-        && !roots.iter().any(|root| root == &package_datadir)
-    {
+
+    /// Describe a genuine lookup or publication failure.
+    pub(crate) fn error_detail(&self) -> Option<String> {
+        matches!(self.state, ContractRefreshState::Failed).then(|| self.warning_detail())
+    }
+
+    fn warning_detail(&self) -> String {
+        if self.warnings.is_empty() {
+            "the package-owned component contract could not be refreshed".to_string()
+        } else {
+            self.warnings.join("; ")
+        }
+    }
+}
+
+fn datadir_contract_roots(layout: &FsLayout, policy: ContractSourcePolicy) -> Vec<PathBuf> {
+    if matches!(policy, ContractSourcePolicy::RpmReconciliation) {
+        return vec![
+            layout
+                .package_datadir()
+                .unwrap_or_else(|| layout.datadir.clone()),
+        ];
+    }
+
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Some(package_datadir) = layout.package_datadir() {
         roots.push(package_datadir);
+    }
+    if let Some(packaged) = crate::packaged::packaged_datadir_root(layout)
+        && !roots.iter().any(|root| root == &packaged)
+    {
+        roots.push(packaged);
     }
     if !roots.iter().any(|root| root == &layout.datadir) {
         roots.push(layout.datadir.clone());
@@ -110,9 +168,13 @@ fn datadir_contract_roots(layout: &FsLayout) -> Vec<PathBuf> {
     roots
 }
 
-fn lookup_datadir_contract(layout: &FsLayout, component: &str) -> DatadirContractLookup {
+fn lookup_datadir_contract(
+    layout: &FsLayout,
+    component: &str,
+    policy: ContractSourcePolicy,
+) -> DatadirContractLookup {
     let mut searched: Vec<PathBuf> = Vec::new();
-    for datadir_root in datadir_contract_roots(layout) {
+    for datadir_root in datadir_contract_roots(layout, policy) {
         let source_path = FsLayout::component_contract_path(&datadir_root, component);
         match std::fs::read_to_string(&source_path) {
             Ok(content) => {
@@ -146,27 +208,28 @@ pub(crate) fn inspect_datadir_contract_drift(
     component: &str,
     command: &str,
 ) -> ContractDriftInspection {
-    let contract = match lookup_datadir_contract(layout, component) {
-        DatadirContractLookup::Found(contract) => contract,
-        DatadirContractLookup::Missing(_) => {
-            return ContractDriftInspection {
-                drifted: false,
-                warnings: Vec::new(),
-            };
-        }
-        DatadirContractLookup::Unreadable {
-            source_path,
-            source,
-        } => {
-            return ContractDriftInspection {
-                drifted: false,
-                warnings: vec![format!(
-                    "could not read datadir component contract at {}: {source}",
-                    source_path.display()
-                )],
-            };
-        }
-    };
+    let contract =
+        match lookup_datadir_contract(layout, component, ContractSourcePolicy::RpmReconciliation) {
+            DatadirContractLookup::Found(contract) => contract,
+            DatadirContractLookup::Missing(_) => {
+                return ContractDriftInspection {
+                    drifted: false,
+                    warnings: Vec::new(),
+                };
+            }
+            DatadirContractLookup::Unreadable {
+                source_path,
+                source,
+            } => {
+                return ContractDriftInspection {
+                    drifted: false,
+                    warnings: vec![format!(
+                        "could not read datadir component contract at {}: {source}",
+                        source_path.display()
+                    )],
+                };
+            }
+        };
     let destination = match common::installed_component_manifest_path(layout, component, command) {
         Ok(path) => path,
         Err(err) => {
@@ -179,9 +242,16 @@ pub(crate) fn inspect_datadir_contract_drift(
         }
     };
 
+    let expected_provenance = ContractProvenance {
+        schema_version: 1,
+        source_kind: ContractSourceKind::Datadir,
+        source_path: contract.source_path,
+        datadir_root: contract.datadir_root,
+    };
     match std::fs::read_to_string(&destination) {
         Ok(snapshot) => ContractDriftInspection {
-            drifted: snapshot != contract.content,
+            drifted: snapshot != contract.content
+                || !snapshot_provenance_matches(&destination, &expected_provenance),
             warnings: Vec::new(),
         },
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => ContractDriftInspection {
@@ -198,16 +268,23 @@ pub(crate) fn inspect_datadir_contract_drift(
     }
 }
 
+fn snapshot_provenance_matches(snapshot_path: &Path, expected: &ContractProvenance) -> bool {
+    read_snapshot_provenance(snapshot_path).is_some_and(|actual| {
+        actual.schema_version == expected.schema_version
+            && actual.source_kind == expected.source_kind
+            && actual.source_path == expected.source_path
+            && actual.datadir_root == expected.datadir_root
+    })
+}
+
 /// Best-effort snapshot of the datadir component contract for RPM paths.
 ///
 /// After an RPM adopt or delegated install the package-owned contract lives
 /// at `{datadir}/components/<component>/component.toml`. Real RPMs install
 /// to `%{_datadir}` (`/usr/share/anolisa/`), which may differ from the CLI
-/// install prefix (`/usr/local/share/anolisa/`). To handle both, this
-/// function probes the packaged datadir root first (exe-sibling /
-/// `ANOLISA_DATA_DIR` / `layout.datadir`), then falls back to
-/// `layout.datadir` if the packaged root differs. The first existing
-/// contract wins.
+/// install prefix (`/usr/local/share/anolisa/`). Install and adopt probe the
+/// FHS package datadir first, then packaged and layout datadirs for explicitly
+/// relocated or locally supplied contracts.
 ///
 /// The contract is copied verbatim (no TOML parsing) to the state snapshot
 /// at `{state_dir}/component-manifests/<component>/component.toml` so that
@@ -221,19 +298,33 @@ pub(crate) fn snapshot_datadir_contract(
     component: &str,
     command: &str,
 ) -> Vec<String> {
-    snapshot_datadir_contract_with_missing_policy(layout, component, command, true)
+    snapshot_datadir_contract_with_missing_policy(
+        layout,
+        component,
+        command,
+        true,
+        ContractSourcePolicy::InstallOrAdopt,
+    )
+    .warnings
 }
 
 /// Refresh an existing state snapshot when the RPM publishes a contract.
 ///
-/// Unlike first-time install/adopt, an RPM without a contract is not a new
-/// warning during upgrade or repair because there is no snapshot to refresh.
+/// Reconciliation only trusts the FHS package datadir. Unlike first-time
+/// install/adopt, an RPM without a contract is not a new warning during upgrade
+/// or repair because there is no authoritative snapshot to refresh.
 pub(crate) fn refresh_datadir_contract_snapshot(
     layout: &FsLayout,
     component: &str,
     command: &str,
-) -> Vec<String> {
-    snapshot_datadir_contract_with_missing_policy(layout, component, command, false)
+) -> ContractRefreshOutcome {
+    snapshot_datadir_contract_with_missing_policy(
+        layout,
+        component,
+        command,
+        false,
+        ContractSourcePolicy::RpmReconciliation,
+    )
 }
 
 fn snapshot_datadir_contract_with_missing_policy(
@@ -241,9 +332,10 @@ fn snapshot_datadir_contract_with_missing_policy(
     component: &str,
     command: &str,
     warn_if_missing: bool,
-) -> Vec<String> {
+    policy: ContractSourcePolicy,
+) -> ContractRefreshOutcome {
     let mut warnings: Vec<String> = Vec::new();
-    let contract = match lookup_datadir_contract(layout, component) {
+    let contract = match lookup_datadir_contract(layout, component, policy) {
         DatadirContractLookup::Found(contract) => contract,
         DatadirContractLookup::Missing(searched) => {
             if warn_if_missing {
@@ -256,7 +348,10 @@ fn snapshot_datadir_contract_with_missing_policy(
                     paths.join(" or ")
                 ));
             }
-            return warnings;
+            return ContractRefreshOutcome {
+                state: ContractRefreshState::NotApplicable,
+                warnings,
+            };
         }
         DatadirContractLookup::Unreadable {
             source_path,
@@ -266,7 +361,10 @@ fn snapshot_datadir_contract_with_missing_policy(
                 "could not read datadir component contract at {}: {source}",
                 source_path.display()
             ));
-            return warnings;
+            return ContractRefreshOutcome {
+                state: ContractRefreshState::Failed,
+                warnings,
+            };
         }
     };
 
@@ -276,41 +374,95 @@ fn snapshot_datadir_contract_with_missing_policy(
             warnings.push(format!(
                 "could not resolve snapshot path for component '{component}': {err}"
             ));
-            return warnings;
+            return ContractRefreshOutcome {
+                state: ContractRefreshState::Failed,
+                warnings,
+            };
         }
     };
 
-    if let Err(err) = write_atomic_text(&dest, &contract.content) {
-        let msg = format!(
-            "failed to snapshot component contract to {}: {err}",
-            dest.display()
-        );
-        eprintln!("warning: {msg}");
-        warnings.push(msg);
-        return warnings;
-    }
-
-    // Best-effort provenance sidecar so adapter operations can resolve
-    // {datadir} without content-matching against scoped datadir roots.
-    use anolisa_core::adapter::contract::{
-        ContractProvenance, ContractSourceKind, write_snapshot_provenance,
-    };
     let provenance = ContractProvenance {
         schema_version: 1,
         source_kind: ContractSourceKind::Datadir,
         source_path: contract.source_path,
         datadir_root: contract.datadir_root,
     };
-    if let Err(err) = write_snapshot_provenance(&dest, &provenance) {
-        let msg = format!("failed to write contract provenance for component '{component}': {err}");
+    if let Err(msg) = publish_contract_pair(&dest, &contract.content, &provenance) {
         eprintln!("warning: {msg}");
         warnings.push(msg);
+        return ContractRefreshOutcome {
+            state: ContractRefreshState::Failed,
+            warnings,
+        };
     }
 
-    warnings
+    ContractRefreshOutcome {
+        state: ContractRefreshState::Refreshed,
+        warnings,
+    }
+}
+
+fn publish_contract_pair(
+    snapshot_path: &Path,
+    snapshot_content: &str,
+    provenance: &ContractProvenance,
+) -> Result<(), String> {
+    let previous_snapshot = match std::fs::read(snapshot_path) {
+        Ok(content) => Some(content),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            return Err(format!(
+                "failed to preserve existing component contract at {}: {err}",
+                snapshot_path.display()
+            ));
+        }
+    };
+    let provenance_content = toml::to_string_pretty(provenance).map_err(|err| {
+        format!(
+            "failed to serialize contract provenance for {}: {err}",
+            snapshot_path.display()
+        )
+    })?;
+
+    write_atomic_text(snapshot_path, snapshot_content).map_err(|err| {
+        format!(
+            "failed to snapshot component contract to {}: {err}",
+            snapshot_path.display()
+        )
+    })?;
+
+    let provenance_path = FsLayout::provenance_path_for_snapshot(snapshot_path);
+    if let Err(err) = write_atomic_text(&provenance_path, &provenance_content) {
+        let rollback = restore_snapshot(snapshot_path, previous_snapshot.as_deref());
+        let rollback_detail = match rollback {
+            Ok(()) => "the previous snapshot was restored".to_string(),
+            Err(rollback_err) => format!("snapshot rollback also failed: {rollback_err}"),
+        };
+        return Err(format!(
+            "failed to publish contract provenance at {}: {err}; {rollback_detail}",
+            provenance_path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+fn restore_snapshot(path: &Path, previous: Option<&[u8]>) -> std::io::Result<()> {
+    match previous {
+        Some(content) => write_atomic(path, content),
+        None => match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        },
+    }
 }
 
 pub(crate) fn write_atomic_text(path: &Path, content: &str) -> std::io::Result<()> {
+    write_atomic(path, content.as_bytes())
+}
+
+fn write_atomic(path: &Path, content: &[u8]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -330,7 +482,7 @@ pub(crate) fn write_atomic_text(path: &Path, content: &str) -> std::io::Result<(
         options.mode(0o644);
     }
     let mut file = options.open(&tmp)?;
-    file.write_all(content.as_bytes())?;
+    file.write_all(content)?;
     drop(file);
     if let Err(err) = std::fs::rename(&tmp, path) {
         let _ = std::fs::remove_file(&tmp);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
@@ -71,6 +71,133 @@ pub(crate) fn write_installed_component_manifest(
     Ok(path)
 }
 
+struct DatadirContract {
+    content: String,
+    source_path: PathBuf,
+    datadir_root: PathBuf,
+}
+
+enum DatadirContractLookup {
+    Found(DatadirContract),
+    Missing(Vec<PathBuf>),
+    Unreadable {
+        source_path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+/// Read-only result for comparing an RPM-owned contract with its state snapshot.
+pub(crate) struct ContractDriftInspection {
+    /// Whether the state snapshot is absent, unreadable, or byte-different.
+    pub(crate) drifted: bool,
+    /// Non-fatal lookup or path-resolution failures.
+    pub(crate) warnings: Vec<String>,
+}
+
+fn datadir_contract_roots(layout: &FsLayout) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Some(packaged) = crate::packaged::packaged_datadir_root(layout) {
+        roots.push(packaged);
+    }
+    if let Some(package_datadir) = layout.package_datadir()
+        && !roots.iter().any(|root| root == &package_datadir)
+    {
+        roots.push(package_datadir);
+    }
+    if !roots.iter().any(|root| root == &layout.datadir) {
+        roots.push(layout.datadir.clone());
+    }
+    roots
+}
+
+fn lookup_datadir_contract(layout: &FsLayout, component: &str) -> DatadirContractLookup {
+    let mut searched: Vec<PathBuf> = Vec::new();
+    for datadir_root in datadir_contract_roots(layout) {
+        let source_path = FsLayout::component_contract_path(&datadir_root, component);
+        match std::fs::read_to_string(&source_path) {
+            Ok(content) => {
+                return DatadirContractLookup::Found(DatadirContract {
+                    content,
+                    source_path,
+                    datadir_root,
+                });
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                searched.push(source_path);
+            }
+            Err(source) => {
+                return DatadirContractLookup::Unreadable {
+                    source_path,
+                    source,
+                };
+            }
+        }
+    }
+    DatadirContractLookup::Missing(searched)
+}
+
+/// Compare the package-owned component contract with its state snapshot.
+///
+/// A missing package contract is not drift because there is no authoritative
+/// content to copy. An unreadable snapshot is drift so a real reconciliation
+/// can attempt to replace it and surface any write failure.
+pub(crate) fn inspect_datadir_contract_drift(
+    layout: &FsLayout,
+    component: &str,
+    command: &str,
+) -> ContractDriftInspection {
+    let contract = match lookup_datadir_contract(layout, component) {
+        DatadirContractLookup::Found(contract) => contract,
+        DatadirContractLookup::Missing(_) => {
+            return ContractDriftInspection {
+                drifted: false,
+                warnings: Vec::new(),
+            };
+        }
+        DatadirContractLookup::Unreadable {
+            source_path,
+            source,
+        } => {
+            return ContractDriftInspection {
+                drifted: false,
+                warnings: vec![format!(
+                    "could not read datadir component contract at {}: {source}",
+                    source_path.display()
+                )],
+            };
+        }
+    };
+    let destination = match common::installed_component_manifest_path(layout, component, command) {
+        Ok(path) => path,
+        Err(err) => {
+            return ContractDriftInspection {
+                drifted: false,
+                warnings: vec![format!(
+                    "could not resolve snapshot path for component '{component}': {err}"
+                )],
+            };
+        }
+    };
+
+    match std::fs::read_to_string(&destination) {
+        Ok(snapshot) => ContractDriftInspection {
+            drifted: snapshot != contract.content,
+            warnings: Vec::new(),
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => ContractDriftInspection {
+            drifted: true,
+            warnings: Vec::new(),
+        },
+        Err(err) => ContractDriftInspection {
+            drifted: true,
+            warnings: vec![format!(
+                "could not read installed component manifest at {}: {err}",
+                destination.display()
+            )],
+        },
+    }
+}
+
 /// Best-effort snapshot of the datadir component contract for RPM paths.
 ///
 /// After an RPM adopt or delegated install the package-owned contract lives
@@ -94,60 +221,53 @@ pub(crate) fn snapshot_datadir_contract(
     component: &str,
     command: &str,
 ) -> Vec<String> {
+    snapshot_datadir_contract_with_missing_policy(layout, component, command, true)
+}
+
+/// Refresh an existing state snapshot when the RPM publishes a contract.
+///
+/// Unlike first-time install/adopt, an RPM without a contract is not a new
+/// warning during upgrade or repair because there is no snapshot to refresh.
+pub(crate) fn refresh_datadir_contract_snapshot(
+    layout: &FsLayout,
+    component: &str,
+    command: &str,
+) -> Vec<String> {
+    snapshot_datadir_contract_with_missing_policy(layout, component, command, false)
+}
+
+fn snapshot_datadir_contract_with_missing_policy(
+    layout: &FsLayout,
+    component: &str,
+    command: &str,
+    warn_if_missing: bool,
+) -> Vec<String> {
     let mut warnings: Vec<String> = Vec::new();
-
-    // Build the set of datadir roots to search, deduped, in priority
-    // order. packaged_datadir_root covers env override → exe-sibling →
-    // layout.datadir, while package_datadir covers the FHS RPM/DEB root
-    // (`/usr/share/anolisa`, rebased under prefix). Always include
-    // layout.datadir as the final fallback so the path appears in the
-    // "not found" warning.
-    let mut roots: Vec<PathBuf> = Vec::new();
-    if let Some(packaged) = crate::packaged::packaged_datadir_root(layout) {
-        roots.push(packaged);
-    }
-    if let Some(package_datadir) = layout.package_datadir()
-        && !roots.iter().any(|r| r == &package_datadir)
-    {
-        roots.push(package_datadir);
-    }
-    if !roots.iter().any(|r| r == &layout.datadir) {
-        roots.push(layout.datadir.clone());
-    }
-
-    let mut content: Option<String> = None;
-    let mut found_source: Option<PathBuf> = None;
-    let mut found_root: Option<PathBuf> = None;
-    let mut searched: Vec<PathBuf> = Vec::new();
-    for root in &roots {
-        let source = FsLayout::component_contract_path(root, component);
-        match std::fs::read_to_string(&source) {
-            Ok(c) => {
-                content = Some(c);
-                found_source = Some(source);
-                found_root = Some(root.clone());
-                break;
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                searched.push(source);
-            }
-            Err(err) => {
+    let contract = match lookup_datadir_contract(layout, component) {
+        DatadirContractLookup::Found(contract) => contract,
+        DatadirContractLookup::Missing(searched) => {
+            if warn_if_missing {
+                let paths: Vec<String> = searched
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect();
                 warnings.push(format!(
-                    "could not read datadir component contract at {}: {err}",
-                    source.display()
+                    "component '{component}' does not publish an ANOLISA component contract at {}",
+                    paths.join(" or ")
                 ));
-                return warnings;
             }
+            return warnings;
         }
-    }
-
-    let Some(content) = content else {
-        let paths: Vec<String> = searched.iter().map(|p| p.display().to_string()).collect();
-        warnings.push(format!(
-            "component '{component}' does not publish an ANOLISA component contract at {}",
-            paths.join(" or ")
-        ));
-        return warnings;
+        DatadirContractLookup::Unreadable {
+            source_path,
+            source,
+        } => {
+            warnings.push(format!(
+                "could not read datadir component contract at {}: {source}",
+                source_path.display()
+            ));
+            return warnings;
+        }
     };
 
     let dest = match common::installed_component_manifest_path(layout, component, command) {
@@ -160,7 +280,7 @@ pub(crate) fn snapshot_datadir_contract(
         }
     };
 
-    if let Err(err) = write_atomic_text(&dest, &content) {
+    if let Err(err) = write_atomic_text(&dest, &contract.content) {
         let msg = format!(
             "failed to snapshot component contract to {}: {err}",
             dest.display()
@@ -172,22 +292,19 @@ pub(crate) fn snapshot_datadir_contract(
 
     // Best-effort provenance sidecar so adapter operations can resolve
     // {datadir} without content-matching against scoped datadir roots.
-    if let (Some(source_path), Some(datadir_root)) = (found_source, found_root) {
-        use anolisa_core::adapter::contract::{
-            ContractProvenance, ContractSourceKind, write_snapshot_provenance,
-        };
-        let provenance = ContractProvenance {
-            schema_version: 1,
-            source_kind: ContractSourceKind::Datadir,
-            source_path,
-            datadir_root,
-        };
-        if let Err(err) = write_snapshot_provenance(&dest, &provenance) {
-            let msg =
-                format!("failed to write contract provenance for component '{component}': {err}");
-            eprintln!("warning: {msg}");
-            warnings.push(msg);
-        }
+    use anolisa_core::adapter::contract::{
+        ContractProvenance, ContractSourceKind, write_snapshot_provenance,
+    };
+    let provenance = ContractProvenance {
+        schema_version: 1,
+        source_kind: ContractSourceKind::Datadir,
+        source_path: contract.source_path,
+        datadir_root: contract.datadir_root,
+    };
+    if let Err(err) = write_snapshot_provenance(&dest, &provenance) {
+        let msg = format!("failed to write contract provenance for component '{component}': {err}");
+        eprintln!("warning: {msg}");
+        warnings.push(msg);
     }
 
     warnings

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -25,7 +25,8 @@ use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::{
-    refresh_datadir_contract_snapshot, rpm_package_candidates_with_index, snapshot_datadir_contract,
+    inspect_datadir_contract_drift, refresh_datadir_contract_snapshot,
+    rpm_package_candidates_with_index, snapshot_datadir_contract,
 };
 use crate::commands::tier1::rpm_install::{self, PendingRpmInstall};
 use crate::context::CliContext;
@@ -45,7 +46,7 @@ pub struct RepairArgs {
 
 /// Wire shape for a `repair <component>` result (`--json`) and its dry-run
 /// preview.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct RepairPayload {
     component: String,
     package: String,
@@ -63,6 +64,9 @@ struct RepairPayload {
     refreshed: bool,
     /// Whether the rpmdb EVR differed from what ANOLISA had recorded.
     changed: bool,
+    /// Manifest-only reconciliation planned or completed alongside state repair.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_reconciliation: Option<&'static str>,
     dry_run: bool,
     /// `None` on dry-run (nothing recorded).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,7 +83,9 @@ struct RepairPayload {
 /// write fails.
 pub fn handle(args: RepairArgs, ctx: &CliContext) -> Result<(), CliError> {
     let query = RpmPackageQuery::system();
-    repair_with_query(&args.component, ctx, &query)
+    let payload = repair_with_query(&args.component, ctx, &query)?;
+    render_repair(ctx, &payload);
+    Ok(())
 }
 
 /// Core of [`handle`] with the package query injected so tests drive the
@@ -89,7 +95,7 @@ fn repair_with_query(
     target: &str,
     ctx: &CliContext,
     query: &dyn PackageQuery,
-) -> Result<(), CliError> {
+) -> Result<RepairPayload, CliError> {
     let command = format!("repair {target}");
     common::require_system_mode(
         ctx,
@@ -186,6 +192,10 @@ fn repair_with_query(
             None
         }
     };
+    let manifest = inspect_datadir_contract_drift(&layout, &component, &command);
+    let manifest_drifted = manifest.drifted;
+    let manifest_reconciliation = manifest_drifted.then_some("component manifest drift");
+    warnings.extend(manifest.warnings);
 
     if ctx.dry_run {
         let payload = RepairPayload {
@@ -198,15 +208,15 @@ fn repair_with_query(
             to_version: to_evr,
             refreshed: false,
             changed,
+            manifest_reconciliation,
             dry_run: true,
             operation_id: None,
             warnings,
         };
-        render_repair(ctx, &payload);
-        return Ok(());
+        return Ok(payload);
     }
 
-    let operation_id = persist_repair(
+    let persisted = persist_repair(
         ctx,
         &component,
         &package,
@@ -215,6 +225,7 @@ fn repair_with_query(
         &to_evr,
         source_repo.as_deref(),
         &command,
+        manifest_drifted,
         &mut warnings,
     )?;
 
@@ -228,12 +239,14 @@ fn repair_with_query(
         to_version: to_evr,
         refreshed: true,
         changed,
+        manifest_reconciliation: persisted
+            .manifest_reconciled
+            .then_some("component manifest drift"),
         dry_run: false,
-        operation_id: Some(operation_id),
+        operation_id: Some(persisted.operation_id),
         warnings,
     };
-    render_repair(ctx, &payload);
-    Ok(())
+    Ok(payload)
 }
 
 fn repair_pending_rpm(
@@ -243,7 +256,7 @@ fn repair_pending_rpm(
     pending: PendingRpmInstall,
     query: &dyn PackageQuery,
     command: &str,
-) -> Result<(), CliError> {
+) -> Result<RepairPayload, CliError> {
     // Preview must reject the same ownership conflicts as execution; otherwise
     // dry-run could promise a recovery that the locked path will refuse.
     reject_pending_state_owner(preview_state, &pending, command)?;
@@ -268,12 +281,12 @@ fn repair_pending_rpm(
             to_version: info.version.to_string(),
             refreshed: false,
             changed: true,
+            manifest_reconciliation: None,
             dry_run: true,
             operation_id: None,
             warnings,
         };
-        render_repair(ctx, &payload);
-        return Ok(());
+        return Ok(payload);
     }
 
     let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
@@ -406,12 +419,12 @@ fn repair_pending_rpm(
         to_version: info.version.to_string(),
         refreshed: true,
         changed: true,
+        manifest_reconciliation: None,
         dry_run: false,
         operation_id: Some(operation_id),
         warnings,
     };
-    render_repair(ctx, &payload);
-    Ok(())
+    Ok(payload)
 }
 
 fn pending_claim_changed_error(pending: &PendingRpmInstall, command: &str) -> CliError {
@@ -604,9 +617,15 @@ fn resolve_repair_package(
         })
 }
 
+#[derive(Debug)]
+struct PersistRepairOutcome {
+    operation_id: String,
+    manifest_reconciled: bool,
+}
+
 /// Persist the reconciled RPM metadata under the install lock, then append an
 /// audit record. Ownership and `install_backend` are left untouched — repair
-/// never switches backend. Returns the operation id.
+/// never switches backend.
 #[allow(clippy::too_many_arguments)]
 fn persist_repair(
     ctx: &CliContext,
@@ -617,8 +636,42 @@ fn persist_repair(
     to_evr: &str,
     source_repo: Option<&str>,
     command: &str,
+    manifest_drifted: bool,
     warnings: &mut Vec<String>,
-) -> Result<String, CliError> {
+) -> Result<PersistRepairOutcome, CliError> {
+    let mut save_state = |state: &InstalledState, path: &std::path::Path| state.save(path);
+    persist_repair_with_state_saver(
+        ctx,
+        component,
+        package,
+        ownership,
+        info,
+        to_evr,
+        source_repo,
+        command,
+        manifest_drifted,
+        warnings,
+        &mut save_state,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_repair_with_state_saver(
+    ctx: &CliContext,
+    component: &str,
+    package: &str,
+    ownership: Ownership,
+    info: &PackageInfo,
+    to_evr: &str,
+    source_repo: Option<&str>,
+    command: &str,
+    manifest_drifted: bool,
+    warnings: &mut Vec<String>,
+    save_state: &mut dyn FnMut(
+        &InstalledState,
+        &std::path::Path,
+    ) -> Result<(), anolisa_core::state::StateError>,
+) -> Result<PersistRepairOutcome, CliError> {
     let layout = common::resolve_layout(ctx);
     let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
         command: command.to_string(),
@@ -702,40 +755,77 @@ fn persist_repair(
     state.operations.push(OperationRecord {
         id: operation_id.clone(),
         command: command.to_string(),
-        status: "ok".to_string(),
+        status: if manifest_drifted {
+            "partial".to_string()
+        } else {
+            "ok".to_string()
+        },
         started_at: now.clone(),
         finished_at: Some(now.clone()),
     });
 
     let state_path = layout.state_dir.join("installed.toml");
-    state.save(&state_path).map_err(|err| CliError::Runtime {
+    save_state(&state, &state_path).map_err(|err| CliError::Runtime {
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
 
-    warnings.extend(refresh_datadir_contract_snapshot(
-        &layout, component, command,
-    ));
+    let mut completion_failure = if manifest_drifted {
+        let refresh = refresh_datadir_contract_snapshot(&layout, component, command);
+        let failure = refresh
+            .failure_detail()
+            .map(|detail| format!("component manifest reconciliation did not complete: {detail}"));
+        warnings.extend(refresh.warnings);
+        failure
+    } else {
+        None
+    };
+
+    if manifest_drifted && completion_failure.is_none() {
+        if let Some(operation) = state.operations.last_mut() {
+            operation.status = "ok".to_string();
+        }
+        if let Err(err) = save_state(&state, &state_path) {
+            completion_failure = Some(format!(
+                "component manifest reconciliation completed, but the repair operation could not be finalized as ok: {err}"
+            ));
+        }
+    }
 
     // Audit log is best-effort: the repair already persisted, so a log failure
     // downgrades to a warning instead of unwinding.
     let log = CentralLog::open(layout.central_log.clone());
+    let (severity, status, message) = if completion_failure.is_some() {
+        (
+            Severity::Warn,
+            LogStatus::Partial,
+            format!(
+                "refreshed ANOLISA state for component {component} to {to_evr}, but component manifest reconciliation did not complete"
+            ),
+        )
+    } else {
+        (
+            Severity::Info,
+            LogStatus::Ok,
+            format!(
+                "refreshed ANOLISA state for component {component} to {to_evr} from rpmdb package {package} ({ownership_label})",
+                ownership_label = ownership.label(),
+            ),
+        )
+    };
     let record = LogRecord {
         kind: LogKind::Operation,
         operation_id: Some(operation_id.clone()),
         command: command.to_string(),
         source: "anolisa-cli".to_string(),
         component: Some(component.to_string()),
-        severity: Severity::Info,
-        message: format!(
-            "refreshed ANOLISA state for component {component} to {to_evr} from rpmdb package {package} ({ownership_label})",
-            ownership_label = ownership.label(),
-        ),
+        severity,
+        message,
         actor: "cli".to_string(),
         install_mode: Some(ctx.install_mode.as_str().to_string()),
         started_at: now.clone(),
         finished_at: Some(now),
-        status: Some(LogStatus::Ok),
+        status: Some(status),
         objects: vec![component.to_string()],
         backup_ids: Vec::new(),
         warnings: warnings.to_vec(),
@@ -745,7 +835,19 @@ fn persist_repair(
         eprintln!("warning: failed to write central log: {err}");
     }
 
-    Ok(operation_id)
+    if let Some(reason) = completion_failure {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "state repair was saved with partial status, but {reason}; run `anolisa repair {component}` again after restoring write access"
+            ),
+        });
+    }
+
+    Ok(PersistRepairOutcome {
+        operation_id,
+        manifest_reconciled: manifest_drifted,
+    })
 }
 
 /// Human/JSON renderer for a repair result.
@@ -799,6 +901,14 @@ fn render_repair(ctx: &CliContext, payload: &RepairPayload) {
             payload.to_version,
         );
     }
+    if let Some(reason) = payload.manifest_reconciliation {
+        let label = if payload.dry_run {
+            "would reconcile:"
+        } else {
+            "reconciled:"
+        };
+        println!("{} {reason}", color.label(label));
+    }
     // Remind the operator that an observed row is a pre-existing system RPM.
     if payload.ownership == "rpm-observed" {
         println!(
@@ -847,8 +957,10 @@ mod tests {
 
     use std::{cell::Cell, fs, path::PathBuf};
 
+    use anolisa_core::adapter::contract::ContractProvenance;
+    use anolisa_core::central_log::LogFilter;
     use anolisa_core::state::{
-        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
+        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, StateError,
     };
     use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus};
     use anolisa_platform::fs_layout::FsLayout;
@@ -1139,7 +1251,8 @@ mod tests {
             ),
         );
         let layout = common::resolve_layout(&c);
-        let source = FsLayout::component_contract_path(&layout.datadir, component);
+        let package_datadir = layout.package_datadir().expect("package datadir");
+        let source = FsLayout::component_contract_path(&package_datadir, component);
         fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
         fs::write(&source, "framework = \"new\"\n").expect("write source contract");
         let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
@@ -1155,6 +1268,343 @@ mod tests {
         assert_eq!(
             fs::read_to_string(snapshot).expect("read refreshed snapshot"),
             "framework = \"new\"\n"
+        );
+    }
+
+    #[test]
+    fn repair_reports_partial_when_manifest_refresh_fails() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let component = "manifest-write-failure";
+        let package = "manifest-write-failure-rpm";
+        let evr = "2.0.0-1.al8";
+        seed(
+            &c,
+            rpm_object(
+                component,
+                package,
+                evr,
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let layout = common::resolve_layout(&c);
+        let package_datadir = layout.package_datadir().expect("package datadir");
+        let source = FsLayout::component_contract_path(&package_datadir, component);
+        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+        fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+        let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+        fs::create_dir_all(&snapshot).expect("create blocking snapshot directory");
+        let marker = snapshot.join("keep");
+        fs::write(&marker, "unchanged").expect("write snapshot marker");
+        let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
+        let rpm = FakeQuery::new(
+            package,
+            Some(pkg_info(package, "2.0.0", Some("1.al8"), "x86_64")),
+        );
+
+        let err = repair_with_query(component, &c, &rpm).expect_err("manifest refresh must fail");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        let CliError::Runtime { reason, .. } = err else {
+            panic!("expected runtime error");
+        };
+        assert!(reason.contains("state repair was saved"));
+        assert!(reason.contains("manifest reconciliation did not complete"));
+        assert_eq!(
+            fs::read_to_string(marker).expect("read unchanged marker"),
+            "unchanged"
+        );
+        assert!(
+            !provenance_path.exists(),
+            "failed refresh must not create provenance"
+        );
+        let state = load_state(&c);
+        assert_eq!(
+            state
+                .operations
+                .last()
+                .map(|operation| operation.status.as_str()),
+            Some("partial")
+        );
+    }
+
+    #[test]
+    fn repair_restores_snapshot_when_provenance_refresh_fails() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let component = "provenance-write-failure";
+        let package = "provenance-write-failure-rpm";
+        let evr = "2.0.0-1.al8";
+        seed(
+            &c,
+            rpm_object(
+                component,
+                package,
+                evr,
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let layout = common::resolve_layout(&c);
+        let package_datadir = layout.package_datadir().expect("package datadir");
+        let source = FsLayout::component_contract_path(&package_datadir, component);
+        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+        fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+        let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+        fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+        fs::write(&snapshot, "framework = \"old\"\n").expect("write old snapshot");
+        let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
+        fs::create_dir(&provenance_path).expect("create blocking provenance directory");
+        let marker = provenance_path.join("keep");
+        fs::write(&marker, "unchanged").expect("write provenance marker");
+        let rpm = FakeQuery::new(
+            package,
+            Some(pkg_info(package, "2.0.0", Some("1.al8"), "x86_64")),
+        );
+
+        let err = repair_with_query(component, &c, &rpm).expect_err("provenance refresh must fail");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert_eq!(
+            fs::read_to_string(&snapshot).expect("read restored snapshot"),
+            "framework = \"old\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(marker).expect("read unchanged provenance marker"),
+            "unchanged"
+        );
+        let state = load_state(&c);
+        assert_eq!(
+            state
+                .operations
+                .last()
+                .map(|operation| operation.status.as_str()),
+            Some("partial")
+        );
+    }
+
+    #[test]
+    fn repair_keeps_durable_partial_when_final_status_save_fails() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let component = "repair-final-save-failure";
+        let package = "repair-final-save-failure-rpm";
+        let evr = "2.0.0-1.al8";
+        seed(
+            &c,
+            rpm_object(
+                component,
+                package,
+                evr,
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let layout = common::resolve_layout(&c);
+        let package_datadir = layout.package_datadir().expect("package datadir");
+        let source = FsLayout::component_contract_path(&package_datadir, component);
+        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+        fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+        let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+        fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+        fs::write(&snapshot, "framework = \"old\"\n").expect("write old snapshot");
+        let save_calls = Cell::new(0);
+        let mut save_state = |state: &InstalledState, path: &std::path::Path| {
+            let call = save_calls.get() + 1;
+            save_calls.set(call);
+            if call == 2 {
+                return Err(StateError::Io {
+                    path: path.to_path_buf(),
+                    source: std::io::Error::other("injected second-save failure"),
+                });
+            }
+            state.save(path)
+        };
+        let mut warnings = Vec::new();
+        let command = format!("repair {component}");
+        let info = pkg_info(package, "2.0.0", Some("1.al8"), "x86_64");
+
+        let err = persist_repair_with_state_saver(
+            &c,
+            component,
+            package,
+            Ownership::RpmManaged,
+            &info,
+            evr,
+            None,
+            &command,
+            true,
+            &mut warnings,
+            &mut save_state,
+        )
+        .expect_err("final status save must fail");
+
+        assert_eq!(save_calls.get(), 2);
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert!(err.reason().contains("could not be finalized as ok"));
+        let state = load_state(&c);
+        assert_eq!(
+            state
+                .operations
+                .last()
+                .map(|operation| operation.status.as_str()),
+            Some("partial")
+        );
+        let records = CentralLog::open(layout.central_log)
+            .query(&LogFilter::default())
+            .expect("query central log");
+        assert_eq!(
+            records.last().and_then(|record| record.status.as_ref()),
+            Some(&LogStatus::Partial)
+        );
+    }
+
+    #[test]
+    fn repair_dry_run_previews_manifest_reconciliation_without_writes() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        let component = "manifest-preview-test";
+        let package = "manifest-preview-test-rpm";
+        let evr = "2.0.0-1.al8";
+        seed(
+            &c,
+            rpm_object(
+                component,
+                package,
+                evr,
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let layout = common::resolve_layout(&c);
+        let package_datadir = layout.package_datadir().expect("package datadir");
+        let source = FsLayout::component_contract_path(&package_datadir, component);
+        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+        fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+        let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+        fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+        fs::write(&snapshot, "framework = \"old\"\n").expect("write stale snapshot");
+        let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
+        fs::write(&provenance_path, "unchanged = true\n").expect("write provenance");
+        let rpm = FakeQuery::new(
+            package,
+            Some(pkg_info(package, "2.0.0", Some("1.al8"), "x86_64")),
+        );
+
+        let payload =
+            repair_with_query(component, &c, &rpm).expect("preview manifest reconciliation");
+
+        assert!(!payload.changed, "equal EVR must remain unchanged");
+        assert!(!payload.refreshed, "dry-run must not report a state write");
+        assert_eq!(
+            payload.manifest_reconciliation,
+            Some("component manifest drift")
+        );
+        let json = serde_json::to_value(&payload).expect("serialize repair preview");
+        assert_eq!(json["manifest_reconciliation"], "component manifest drift");
+        assert_eq!(
+            fs::read_to_string(&snapshot).expect("read unchanged snapshot"),
+            "framework = \"old\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(provenance_path).expect("read unchanged provenance"),
+            "unchanged = true\n"
+        );
+    }
+
+    #[test]
+    fn repair_prefers_rpm_manifest_over_local_stale_copy() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let component = "manifest-source-test";
+        let package = "manifest-source-test-rpm";
+        let evr = "2.0.0-1.al8";
+        seed(
+            &c,
+            rpm_object(
+                component,
+                package,
+                evr,
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let layout = common::resolve_layout(&c);
+        let local_source = FsLayout::component_contract_path(&layout.datadir, component);
+        fs::create_dir_all(local_source.parent().expect("local source parent"))
+            .expect("mkdir local source");
+        fs::write(&local_source, "framework = \"local-old\"\n").expect("write local contract");
+        let package_datadir = layout.package_datadir().expect("package datadir");
+        let rpm_source = FsLayout::component_contract_path(&package_datadir, component);
+        fs::create_dir_all(rpm_source.parent().expect("rpm source parent"))
+            .expect("mkdir rpm source");
+        fs::write(&rpm_source, "framework = \"rpm-new\"\n").expect("write rpm contract");
+        let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+        fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+        fs::write(&snapshot, "framework = \"old\"\n").expect("write stale snapshot");
+        let rpm = FakeQuery::new(
+            package,
+            Some(pkg_info(package, "2.0.0", Some("1.al8"), "x86_64")),
+        );
+
+        repair_with_query(component, &c, &rpm).expect("repair manifest source");
+
+        assert_eq!(
+            fs::read_to_string(&snapshot).expect("read refreshed snapshot"),
+            "framework = \"rpm-new\"\n"
+        );
+        let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
+        let provenance: ContractProvenance =
+            toml::from_str(&fs::read_to_string(provenance_path).expect("read snapshot provenance"))
+                .expect("parse snapshot provenance");
+        assert_eq!(provenance.datadir_root, package_datadir);
+        assert_eq!(provenance.source_path, rpm_source);
+    }
+
+    #[test]
+    fn repair_ignores_local_manifest_when_rpm_contract_is_missing() {
+        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let component = "manifest-missing-test";
+        let package = "manifest-missing-test-rpm";
+        let evr = "2.0.0-1.al8";
+        seed(
+            &c,
+            rpm_object(
+                component,
+                package,
+                evr,
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let layout = common::resolve_layout(&c);
+        let local_source = FsLayout::component_contract_path(&layout.datadir, component);
+        fs::create_dir_all(local_source.parent().expect("local source parent"))
+            .expect("mkdir local source");
+        fs::write(&local_source, "framework = \"local-stale\"\n").expect("write local contract");
+        let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+        fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+        fs::write(&snapshot, "framework = \"installed\"\n").expect("write snapshot");
+        let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
+        fs::write(&provenance_path, "unchanged = true\n").expect("write provenance");
+        let rpm = FakeQuery::new(
+            package,
+            Some(pkg_info(package, "2.0.0", Some("1.al8"), "x86_64")),
+        );
+
+        repair_with_query(component, &c, &rpm).expect("repair without rpm contract");
+
+        assert_eq!(
+            fs::read_to_string(&snapshot).expect("read unchanged snapshot"),
+            "framework = \"installed\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(provenance_path).expect("read unchanged provenance"),
+            "unchanged = true\n"
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -25,7 +25,7 @@ use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::{
-    rpm_package_candidates_with_index, snapshot_datadir_contract,
+    refresh_datadir_contract_snapshot, rpm_package_candidates_with_index, snapshot_datadir_contract,
 };
 use crate::commands::tier1::rpm_install::{self, PendingRpmInstall};
 use crate::context::CliContext;
@@ -215,7 +215,7 @@ fn repair_with_query(
         &to_evr,
         source_repo.as_deref(),
         &command,
-        &warnings,
+        &mut warnings,
     )?;
 
     let payload = RepairPayload {
@@ -617,7 +617,7 @@ fn persist_repair(
     to_evr: &str,
     source_repo: Option<&str>,
     command: &str,
-    warnings: &[String],
+    warnings: &mut Vec<String>,
 ) -> Result<String, CliError> {
     let layout = common::resolve_layout(ctx);
     let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
@@ -712,6 +712,10 @@ fn persist_repair(
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
+
+    warnings.extend(refresh_datadir_contract_snapshot(
+        &layout, component, command,
+    ));
 
     // Audit log is best-effort: the repair already persisted, so a log failure
     // downgrades to a warning instead of unwinding.
@@ -847,6 +851,7 @@ mod tests {
         InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
     };
     use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus};
+    use anolisa_platform::fs_layout::FsLayout;
     use anolisa_platform::pkg_query::PackageVersion;
 
     /// Configurable in-memory [`PackageQuery`] for the repair tests. Repair runs
@@ -1114,6 +1119,43 @@ mod tests {
         assert_eq!(meta.evr.as_deref(), Some("2.3.0-1.al8"));
         assert_eq!(meta.source_repo.as_deref(), Some("alinux-updates"));
         assert_ne!(obj.last_operation_id.as_deref(), Some("op-prior"));
+    }
+
+    #[test]
+    fn repair_refreshes_stale_component_manifest() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let component = "manifest-sync-test";
+        let package = "manifest-sync-test-rpm";
+        let evr = "2.0.0-1.al8";
+        seed(
+            &c,
+            rpm_object(
+                component,
+                package,
+                evr,
+                Ownership::RpmManaged,
+                ObjectStatus::Installed,
+            ),
+        );
+        let layout = common::resolve_layout(&c);
+        let source = FsLayout::component_contract_path(&layout.datadir, component);
+        fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+        fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+        let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+        fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+        fs::write(&snapshot, "framework = \"old\"\n").expect("write stale snapshot");
+        let rpm = FakeQuery::new(
+            package,
+            Some(pkg_info(package, "2.0.0", Some("1.al8"), "x86_64")),
+        );
+
+        repair_with_query(component, &c, &rpm).expect("repair manifest drift");
+
+        assert_eq!(
+            fs::read_to_string(snapshot).expect("read refreshed snapshot"),
+            "framework = \"new\"\n"
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -52,6 +52,9 @@ use super::update::check::{
 use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
+use crate::commands::tier1::install::{
+    inspect_datadir_contract_drift, refresh_datadir_contract_snapshot,
+};
 use crate::commands::tier1::rpm_install;
 use crate::context::{CliContext, InstallMode};
 use crate::progress::{self, Activity, ProgressReporter};
@@ -706,7 +709,7 @@ fn run_upgrade_with_deps(
         // Dry-run reads state/rpmdb without taking the install lock, applying a
         // transaction, or constructing an operation to persist.
         let state = common::load_installed_state(ctx, command)?;
-        return Ok(render_plan_preview(plan, &state, query));
+        return Ok(render_plan_preview(plan, layout, &state, query, command));
     }
 
     // Real execution needs root for the dnf transactions. Check up front so the
@@ -1041,11 +1044,13 @@ fn installed_origin_or_warn(
 /// Inspect existing RPM-backed component rows against rpmdb without mutating
 /// state. Callers decide whether to preview or apply the returned changes.
 fn inspect_rpm_reconciliations(
+    layout: &FsLayout,
     state: &InstalledState,
     query: &dyn PackageQuery,
     excluded: &HashSet<String>,
     legacy_reconciliations: &[PlannedLegacyReconciliation],
     warnings: &mut Vec<String>,
+    command: &str,
 ) -> ReconciliationInspection {
     let mut inspection = ReconciliationInspection::default();
 
@@ -1112,7 +1117,9 @@ fn inspect_rpm_reconciliations(
                 && metadata.evr.as_deref() == Some(to.as_str())
                 && metadata.arch.as_deref() == Some(refreshed.arch.as_str())
         });
-        let drifted = object.version != to || !metadata_current;
+        let manifest = inspect_datadir_contract_drift(layout, &object.name, command);
+        warnings.extend(manifest.warnings);
+        let drifted = object.version != to || !metadata_current || manifest.drifted;
         if !drifted {
             continue;
         }
@@ -1166,8 +1173,10 @@ fn txn_error_reason(err: PackageTransactionError) -> String {
 /// reconciliation detection.
 fn render_plan_preview(
     plan: &UpgradePlan,
+    layout: &FsLayout,
     state: &InstalledState,
     query: &dyn PackageQuery,
+    command: &str,
 ) -> UpgradeResult {
     let mut updated: Vec<UpdatedItem> = Vec::new();
     if let Some(cli) = &plan.cli {
@@ -1221,11 +1230,13 @@ fn render_plan_preview(
         .collect();
     let mut warnings = Vec::new();
     let inspection = inspect_rpm_reconciliations(
+        layout,
         state,
         query,
         &excluded,
         &plan.legacy_reconciliations,
         &mut warnings,
+        command,
     );
     let reconciled = inspection
         .pending
@@ -1488,8 +1499,15 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         .chain(outcome.installed.iter().map(|item| item.name.clone()))
         .chain(outcome.recorded.iter().map(|item| item.name.clone()))
         .collect();
-    let inspection =
-        inspect_rpm_reconciliations(state, query, &excluded, legacy_reconciliations, warnings);
+    let inspection = inspect_rpm_reconciliations(
+        layout,
+        state,
+        query,
+        &excluded,
+        legacy_reconciliations,
+        warnings,
+        command,
+    );
     // Apply errors do not exclude a component from the sweep: a transient
     // post-transaction query may recover here and still reconcile state. If
     // the retry fails again, keep the original item error instead of counting
@@ -1587,6 +1605,22 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
+
+    // Refresh package-owned component contracts only after state persisted.
+    // This heals stale snapshots left by external yum/dnf upgrades without
+    // exposing a new contract when the corresponding state write failed.
+    for component in outcome
+        .updated
+        .iter()
+        .map(|item| item.name.as_str())
+        .chain(outcome.installed.iter().map(|item| item.name.as_str()))
+        .chain(outcome.reconciled.iter().map(|item| item.name.as_str()))
+        .chain(outcome.recorded.iter().map(|item| item.name.as_str()))
+    {
+        warnings.extend(refresh_datadir_contract_snapshot(
+            layout, component, command,
+        ));
+    }
 
     // Audit log is best-effort: state already persisted, so a log failure
     // downgrades to a stderr warning rather than unwinding.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -1577,34 +1577,41 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
     // Count the whole command's outcome, not just component state: the CLI
     // update (not an ANOLISA object) and the transaction-phase errors are folded
     // in so the durable record shows the true `ok` / `partial` / `failed`.
-    let total_success = cli_updated.is_some() as usize
+    let initial_total_success = cli_updated.is_some() as usize
         + outcome.updated.len()
         + outcome.installed.len()
         + outcome.reconciled.len()
         + outcome.recorded.len();
-    let total_errors = prior_errors.len() + outcome.errors.len();
+    let initial_total_errors = prior_errors.len() + outcome.errors.len();
 
-    if total_success == 0 && total_errors == 0 {
+    if initial_total_success == 0 && initial_total_errors == 0 {
         // No transaction actually happened (e.g. only skips/noops reached here);
         // nothing to audit and nothing to persist.
         return Ok(outcome);
     }
 
-    let status = apply_status(total_success, total_errors);
-    let (log_status, severity) = match status {
-        STATUS_OK => (LogStatus::Ok, Severity::Info),
-        STATUS_PARTIAL => (LogStatus::Partial, Severity::Warn),
-        _ => (LogStatus::Failed, Severity::Error),
-    };
+    let required_manifest_refreshes = outcome
+        .reconciled
+        .iter()
+        .filter(|item| reconciliation_requires_manifest_refresh(item))
+        .count();
+    let transaction_manifest_refreshes =
+        outcome.updated.len() + outcome.installed.len() + outcome.recorded.len();
+    let provisional_status = apply_status(
+        initial_total_success - required_manifest_refreshes,
+        initial_total_errors + required_manifest_refreshes + transaction_manifest_refreshes,
+    );
 
     // Always append the operation record and save when real work or an item
     // error occurred, even if no component object changed (for example a
-    // CLI-only upgrade or failed rpmdb query). The record keeps the attempt
-    // auditable via `anolisa logs`.
+    // CLI-only upgrade or failed rpmdb query). Required manifest refreshes are
+    // pessimistically counted as errors until their artifact writes succeed or
+    // prove unnecessary, so a failed final status save cannot leave a durable
+    // false `ok`.
     state.operations.push(OperationRecord {
         id: audit.operation_id.clone(),
         command: command.to_string(),
-        status: status.to_string(),
+        status: provisional_status.to_string(),
         started_at: audit.started_at.clone(),
         finished_at: Some(now_iso8601()),
     });
@@ -1618,18 +1625,89 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
     // Refresh package-owned component contracts only after state persisted.
     // This heals stale snapshots left by external yum/dnf upgrades without
     // exposing a new contract when the corresponding state write failed.
-    for component in outcome
+    for (component, package) in outcome
         .updated
         .iter()
-        .map(|item| item.name.as_str())
-        .chain(outcome.installed.iter().map(|item| item.name.as_str()))
-        .chain(outcome.reconciled.iter().map(|item| item.name.as_str()))
-        .chain(outcome.recorded.iter().map(|item| item.name.as_str()))
+        .map(|item| (item.name.as_str(), item.package.as_str()))
+        .chain(
+            outcome
+                .installed
+                .iter()
+                .map(|item| (item.name.as_str(), item.package.as_str())),
+        )
+        .chain(
+            outcome
+                .recorded
+                .iter()
+                .map(|item| (item.name.as_str(), item.package.as_str())),
+        )
     {
-        warnings.extend(refresh_datadir_contract_snapshot(
-            layout, component, command,
-        ));
+        let refresh = refresh_datadir_contract_snapshot(layout, component, command);
+        let failure_detail = refresh.error_detail();
+        warnings.extend(refresh.warnings);
+        if let Some(detail) = failure_detail {
+            outcome.errors.push(ErrorResult {
+                name: component.to_string(),
+                reason: format!(
+                    "component manifest refresh after transaction for package '{package}' did not complete: {detail}"
+                ),
+            });
+        }
     }
+
+    let mut reconciled = Vec::with_capacity(outcome.reconciled.len());
+    for item in std::mem::take(&mut outcome.reconciled) {
+        if !reconciliation_requires_manifest_refresh(&item) {
+            reconciled.push(item);
+            continue;
+        }
+        let refresh = refresh_datadir_contract_snapshot(layout, &item.name, command);
+        let failure_detail = refresh.failure_detail();
+        warnings.extend(refresh.warnings);
+        if let Some(detail) = failure_detail {
+            outcome.errors.push(ErrorResult {
+                name: item.name,
+                reason: format!(
+                    "component manifest reconciliation for package '{}' did not complete: {detail}",
+                    item.package
+                ),
+            });
+            continue;
+        }
+        reconciled.push(item);
+    }
+    outcome.reconciled = reconciled;
+
+    let total_success = cli_updated.is_some() as usize
+        + outcome.updated.len()
+        + outcome.installed.len()
+        + outcome.reconciled.len()
+        + outcome.recorded.len();
+    let total_errors = prior_errors.len() + outcome.errors.len();
+    let final_status = apply_status(total_success, total_errors);
+    let mut persisted_status = final_status;
+    let mut final_status_save_failure = None;
+    if final_status != provisional_status {
+        if let Some(operation) = state.operations.last_mut() {
+            operation.status = final_status.to_string();
+        }
+        if let Err(err) = state.save(&state_path) {
+            if let Some(operation) = state.operations.last_mut() {
+                operation.status = provisional_status.to_string();
+            }
+            persisted_status = provisional_status;
+            let detail =
+                format!("could not finalize the upgrade operation as '{final_status}': {err}");
+            warnings.push(detail.clone());
+            final_status_save_failure = Some(detail);
+        }
+    }
+
+    let (log_status, severity) = match persisted_status {
+        STATUS_OK => (LogStatus::Ok, Severity::Info),
+        STATUS_PARTIAL => (LogStatus::Partial, Severity::Warn),
+        _ => (LogStatus::Failed, Severity::Error),
+    };
 
     // Audit log is best-effort: state already persisted, so a log failure
     // downgrades to a stderr warning rather than unwinding.
@@ -1673,7 +1751,23 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         });
     }
 
+    if let Some(detail) = final_status_save_failure {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "upgrade changes were saved with conservative status '{provisional_status}', but {detail}"
+            ),
+        });
+    }
+
     Ok(outcome)
+}
+
+fn reconciliation_requires_manifest_refresh(item: &ReconciledItem) -> bool {
+    matches!(
+        item.reason,
+        "component manifest drift" | "RPM state and component manifest drift"
+    )
 }
 
 /// The current ANOLISA-state slot for a to-be-installed default, classified

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -489,6 +489,8 @@ struct ReconciledItem {
     package: String,
     from: String,
     to: String,
+    /// Drift that caused this no-transaction reconciliation.
+    reason: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -553,6 +555,7 @@ struct PendingReconciliation {
     refreshed: PackageInfo,
     source_repo: Option<String>,
     allow_metadata_backfill: bool,
+    reason: &'static str,
 }
 
 #[derive(Default)]
@@ -1118,11 +1121,15 @@ fn inspect_rpm_reconciliations(
                 && metadata.arch.as_deref() == Some(refreshed.arch.as_str())
         });
         let manifest = inspect_datadir_contract_drift(layout, &object.name, command);
+        let manifest_drifted = manifest.drifted;
         warnings.extend(manifest.warnings);
-        let drifted = object.version != to || !metadata_current || manifest.drifted;
-        if !drifted {
-            continue;
-        }
+        let rpm_state_drifted = object.version != to || !metadata_current;
+        let reason = match (rpm_state_drifted, manifest_drifted) {
+            (true, true) => "RPM state and component manifest drift",
+            (true, false) => "RPM state drift",
+            (false, true) => "component manifest drift",
+            (false, false) => continue,
+        };
         let source_repo = installed_origin_or_warn(query, &package, warnings);
         inspection.pending.push(PendingReconciliation {
             name: object.name.clone(),
@@ -1131,6 +1138,7 @@ fn inspect_rpm_reconciliations(
             refreshed,
             source_repo,
             allow_metadata_backfill,
+            reason,
         });
     }
 
@@ -1143,6 +1151,7 @@ fn reconciliation_result(pending: &PendingReconciliation) -> ReconciledItem {
         package: pending.package.clone(),
         from: pending.from.clone(),
         to: pending.refreshed.version.to_string(),
+        reason: pending.reason,
     }
 }
 
@@ -1888,7 +1897,7 @@ fn render_result(ctx: &CliContext, result: &UpgradeResult) {
             item.name,
             item.from,
             item.to,
-            color.muted(format!("({})", item.package)),
+            color.muted(format!("({}; {})", item.package, item.reason)),
         );
     }
     for item in &result.recorded {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -1427,6 +1427,9 @@ fn empty_plan_reconciles_stale_component_manifest() {
     .expect("preview manifest drift");
 
     assert_eq!(preview.reconciled.len(), 1);
+    assert_eq!(preview.reconciled[0].reason, "component manifest drift");
+    let json = serde_json::to_value(&preview).expect("serialize preview");
+    assert_eq!(json["reconciled"][0]["reason"], "component manifest drift");
     assert_eq!(
         std::fs::read_to_string(&snapshot).expect("read unchanged snapshot"),
         "framework = \"old\"\n",
@@ -2181,6 +2184,7 @@ fn upgrade_dry_run_reports_reconcile_without_writes() {
     assert_eq!(result.reconciled[0].to, "2.7.0-1.alnx4");
     let json = serde_json::to_value(&result).expect("serialize result");
     assert_eq!(json["reconciled"][0]["package"], "copilot-shell");
+    assert_eq!(json["reconciled"][0]["reason"], "RPM state drift");
     assert!(host.txn_calls().is_empty());
     assert_eq!(std::fs::read(&state_path).expect("state bytes"), before);
     assert!(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -1386,6 +1386,80 @@ fn empty_plan_reconciles_all_drifted_rpm_components() {
 }
 
 #[test]
+fn empty_plan_reconciles_stale_component_manifest() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let component = "manifest-sync-test";
+    let package = "manifest-sync-test-rpm";
+    let evr = "2.0.0-1.alnx4";
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            component,
+            package,
+            evr,
+            Ownership::RpmManaged,
+        )],
+    );
+
+    let source = FsLayout::component_contract_path(&layout.datadir, component);
+    std::fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+    std::fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+    let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+    std::fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+    std::fs::write(&snapshot, "framework = \"old\"\n").expect("write stale snapshot");
+
+    let host = FakeHost::default().with_installed(package, info(package, "2.0.0", Some("1.alnx4")));
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let preview = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        false,
+        true,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("preview manifest drift");
+
+    assert_eq!(preview.reconciled.len(), 1);
+    assert_eq!(
+        std::fs::read_to_string(&snapshot).expect("read unchanged snapshot"),
+        "framework = \"old\"\n",
+        "dry-run must not refresh the snapshot"
+    );
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("reconcile manifest drift");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.reconciled.len(), 1);
+    assert_eq!(result.reconciled[0].name, component);
+    assert!(
+        host.txn_calls().is_empty(),
+        "manifest sync must not call dnf"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&snapshot).expect("read refreshed snapshot"),
+        "framework = \"new\"\n"
+    );
+}
+
+#[test]
 fn empty_plan_reconciles_legacy_rpm_component_and_backfills_metadata() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let ctx = system_ctx(tmp.path().to_path_buf());

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -9,6 +9,10 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+use anolisa_core::adapter::contract::{
+    ContractProvenance, ContractSourceKind, read_snapshot_provenance, write_snapshot_provenance,
+};
+use anolisa_core::central_log::LogFilter;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
 
 use anolisa_core::state::{InstalledObject, InstalledState, RpmMetadata, SubscriptionScope};
@@ -1386,7 +1390,7 @@ fn empty_plan_reconciles_all_drifted_rpm_components() {
 }
 
 #[test]
-fn empty_plan_reconciles_stale_component_manifest() {
+fn empty_plan_reconciles_missing_manifest_provenance() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let ctx = system_ctx(tmp.path().to_path_buf());
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
@@ -1403,12 +1407,14 @@ fn empty_plan_reconciles_stale_component_manifest() {
         )],
     );
 
-    let source = FsLayout::component_contract_path(&layout.datadir, component);
+    let package_datadir = layout.package_datadir().expect("package datadir");
+    let source = FsLayout::component_contract_path(&package_datadir, component);
     std::fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
-    std::fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+    std::fs::write(&source, "framework = \"same\"\n").expect("write source contract");
     let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
     std::fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
-    std::fs::write(&snapshot, "framework = \"old\"\n").expect("write stale snapshot");
+    std::fs::write(&snapshot, "framework = \"same\"\n").expect("write matching snapshot");
+    let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
 
     let host = FakeHost::default().with_installed(package, info(package, "2.0.0", Some("1.alnx4")));
     let plan = build_plan(None, &cli_noop(), &[]);
@@ -1432,8 +1438,12 @@ fn empty_plan_reconciles_stale_component_manifest() {
     assert_eq!(json["reconciled"][0]["reason"], "component manifest drift");
     assert_eq!(
         std::fs::read_to_string(&snapshot).expect("read unchanged snapshot"),
-        "framework = \"old\"\n",
+        "framework = \"same\"\n",
         "dry-run must not refresh the snapshot"
+    );
+    assert!(
+        !provenance_path.exists(),
+        "dry-run must not create provenance"
     );
 
     let result = run_upgrade_with_deps(
@@ -1458,8 +1468,347 @@ fn empty_plan_reconciles_stale_component_manifest() {
     );
     assert_eq!(
         std::fs::read_to_string(&snapshot).expect("read refreshed snapshot"),
-        "framework = \"new\"\n"
+        "framework = \"same\"\n"
     );
+    let provenance = read_snapshot_provenance(&snapshot).expect("read refreshed provenance");
+    assert_eq!(provenance.source_kind, ContractSourceKind::Datadir);
+    assert_eq!(provenance.source_path, source);
+    assert_eq!(provenance.datadir_root, package_datadir);
+}
+
+#[test]
+fn empty_plan_reconciles_stale_manifest_provenance() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let component = "manifest-stale-provenance";
+    let package = "manifest-stale-provenance-rpm";
+    let evr = "2.0.0-1.alnx4";
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            component,
+            package,
+            evr,
+            Ownership::RpmManaged,
+        )],
+    );
+
+    let package_datadir = layout.package_datadir().expect("package datadir");
+    let source = FsLayout::component_contract_path(&package_datadir, component);
+    std::fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+    std::fs::write(&source, "framework = \"same\"\n").expect("write source contract");
+    let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+    std::fs::create_dir_all(snapshot.parent().expect("snapshot parent")).expect("mkdir snapshot");
+    std::fs::write(&snapshot, "framework = \"same\"\n").expect("write matching snapshot");
+    let stale_root = layout.datadir.clone();
+    write_snapshot_provenance(
+        &snapshot,
+        &ContractProvenance {
+            schema_version: 1,
+            source_kind: ContractSourceKind::Datadir,
+            source_path: FsLayout::component_contract_path(&stale_root, component),
+            datadir_root: stale_root,
+        },
+    )
+    .expect("write stale provenance");
+
+    let host = FakeHost::default().with_installed(package, info(package, "2.0.0", Some("1.alnx4")));
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let preview = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        false,
+        true,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("preview provenance drift");
+
+    assert_eq!(preview.reconciled.len(), 1);
+    assert_eq!(preview.reconciled[0].reason, "component manifest drift");
+    let stale = read_snapshot_provenance(&snapshot).expect("read stale provenance");
+    assert_ne!(stale.datadir_root, package_datadir);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("reconcile provenance drift");
+
+    assert_eq!(result.status, STATUS_OK);
+    assert_eq!(result.reconciled.len(), 1);
+    assert!(
+        host.txn_calls().is_empty(),
+        "provenance sync must not call dnf"
+    );
+    let provenance = read_snapshot_provenance(&snapshot).expect("read refreshed provenance");
+    assert_eq!(provenance.source_path, source);
+    assert_eq!(provenance.datadir_root, package_datadir);
+}
+
+#[derive(Clone, Copy)]
+enum BlockedManifestArtifact {
+    Snapshot,
+    Provenance,
+}
+
+fn assert_manifest_refresh_failure(blocked: BlockedManifestArtifact) {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let component = "manifest-refresh-failure";
+    let package = "manifest-refresh-failure-rpm";
+    let evr = "2.0.0-1.alnx4";
+    let mut objects = vec![rpm_component(
+        component,
+        package,
+        evr,
+        Ownership::RpmManaged,
+    )];
+    if matches!(blocked, BlockedManifestArtifact::Provenance) {
+        objects.push(rpm_component(
+            "state-drift-success",
+            "state-drift-success-rpm",
+            "1.0.0-1.alnx4",
+            Ownership::RpmManaged,
+        ));
+    }
+    seed_state(&layout, objects);
+
+    let package_datadir = layout.package_datadir().expect("package datadir");
+    let source = FsLayout::component_contract_path(&package_datadir, component);
+    std::fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+    std::fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+    let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+    let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
+    let marker = match blocked {
+        BlockedManifestArtifact::Snapshot => {
+            std::fs::create_dir_all(&snapshot).expect("create blocking snapshot directory");
+            snapshot.join("keep")
+        }
+        BlockedManifestArtifact::Provenance => {
+            std::fs::create_dir_all(snapshot.parent().expect("snapshot parent"))
+                .expect("mkdir snapshot");
+            std::fs::write(&snapshot, "framework = \"old\"\n").expect("write old snapshot");
+            std::fs::create_dir(&provenance_path).expect("create blocking provenance directory");
+            provenance_path.join("keep")
+        }
+    };
+    std::fs::write(&marker, "unchanged").expect("write artifact marker");
+
+    let mut host =
+        FakeHost::default().with_installed(package, info(package, "2.0.0", Some("1.alnx4")));
+    if matches!(blocked, BlockedManifestArtifact::Provenance) {
+        host.installed.insert(
+            "state-drift-success-rpm".to_string(),
+            info("state-drift-success-rpm", "2.0.0", Some("1.alnx4")),
+        );
+    }
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("render failed manifest reconciliation");
+
+    let (expected_status, expected_log_status, expected_reconciled) = match blocked {
+        BlockedManifestArtifact::Snapshot => (STATUS_FAILED, LogStatus::Failed, 0),
+        BlockedManifestArtifact::Provenance => (STATUS_PARTIAL, LogStatus::Partial, 1),
+    };
+    assert_eq!(result.status, expected_status);
+    assert_eq!(result.reconciled.len(), expected_reconciled);
+    assert!(
+        result.reconciled.iter().all(|item| item.name != component),
+        "failed manifest item must not remain reconciled"
+    );
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].name, component);
+    assert!(result.errors[0].reason.contains("manifest reconciliation"));
+    assert!(
+        host.txn_calls().is_empty(),
+        "failed manifest sync must not call dnf"
+    );
+    let json = serde_json::to_value(&result).expect("serialize failed result");
+    assert_eq!(json["status"], expected_status);
+    assert_eq!(
+        std::fs::read_to_string(&marker).expect("read unchanged marker"),
+        "unchanged"
+    );
+    if matches!(blocked, BlockedManifestArtifact::Provenance) {
+        assert_eq!(
+            std::fs::read_to_string(&snapshot).expect("read restored snapshot"),
+            "framework = \"old\"\n"
+        );
+    }
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(
+        state
+            .operations
+            .last()
+            .map(|operation| operation.status.as_str()),
+        Some(expected_status)
+    );
+    let records = CentralLog::open(layout.central_log)
+        .query(&LogFilter::default())
+        .expect("query central log");
+    assert_eq!(
+        records.last().and_then(|record| record.status.as_ref()),
+        Some(&expected_log_status)
+    );
+}
+
+#[test]
+fn empty_plan_reports_snapshot_refresh_failure() {
+    assert_manifest_refresh_failure(BlockedManifestArtifact::Snapshot);
+}
+
+#[test]
+fn empty_plan_reports_provenance_refresh_failure() {
+    assert_manifest_refresh_failure(BlockedManifestArtifact::Provenance);
+}
+
+fn assert_updated_manifest_refresh_failure(blocked: BlockedManifestArtifact) {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let component = "manifest-update-failure";
+    let package = "manifest-update-failure-rpm";
+    let from = "1.0.0-1.alnx4";
+    let to = "2.0.0-1.alnx4";
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            component,
+            package,
+            from,
+            Ownership::RpmManaged,
+        )],
+    );
+
+    let package_datadir = layout.package_datadir().expect("package datadir");
+    let source = FsLayout::component_contract_path(&package_datadir, component);
+    std::fs::create_dir_all(source.parent().expect("source parent")).expect("mkdir source");
+    std::fs::write(&source, "framework = \"new\"\n").expect("write source contract");
+    let snapshot = FsLayout::component_manifest_snapshot_path(&layout.state_dir, component);
+    let provenance_path = FsLayout::provenance_path_for_snapshot(&snapshot);
+    let marker = match blocked {
+        BlockedManifestArtifact::Snapshot => {
+            std::fs::create_dir_all(&snapshot).expect("create blocking snapshot directory");
+            snapshot.join("keep")
+        }
+        BlockedManifestArtifact::Provenance => {
+            std::fs::create_dir_all(snapshot.parent().expect("snapshot parent"))
+                .expect("mkdir snapshot");
+            std::fs::write(&snapshot, "framework = \"old\"\n").expect("write old snapshot");
+            std::fs::create_dir(&provenance_path).expect("create blocking provenance directory");
+            provenance_path.join("keep")
+        }
+    };
+    std::fs::write(&marker, "unchanged").expect("write artifact marker");
+
+    let host = FakeHost::default().with_installed(package, info(package, "2.0.0", Some("1.alnx4")));
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            component,
+            Some(package),
+            Some("rpm-managed"),
+            Some(from),
+            Some(to),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let result = run_upgrade_with_deps(
+        &ctx,
+        &layout,
+        &plan,
+        &host,
+        &host,
+        true,
+        false,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("render failed post-transaction manifest refresh");
+
+    assert_eq!(result.status, STATUS_PARTIAL);
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].name, component);
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].name, component);
+    assert!(result.errors[0].reason.contains("manifest refresh"));
+    assert_eq!(host.txn_calls(), vec![format!("update:{package}")]);
+    let json = serde_json::to_value(&result).expect("serialize failed result");
+    assert_eq!(json["status"], STATUS_PARTIAL);
+    assert_eq!(json["updated"][0]["name"], component);
+    assert_eq!(json["errors"][0]["name"], component);
+    assert_eq!(
+        std::fs::read_to_string(&marker).expect("read unchanged marker"),
+        "unchanged"
+    );
+    if matches!(blocked, BlockedManifestArtifact::Provenance) {
+        assert_eq!(
+            std::fs::read_to_string(&snapshot).expect("read restored snapshot"),
+            "framework = \"old\"\n"
+        );
+    }
+
+    let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
+    assert_eq!(
+        state
+            .find_object(ObjectKind::Component, component)
+            .expect("updated component")
+            .version,
+        to
+    );
+    assert_eq!(
+        state
+            .operations
+            .last()
+            .map(|operation| operation.status.as_str()),
+        Some(STATUS_PARTIAL)
+    );
+    let records = CentralLog::open(layout.central_log)
+        .query(&LogFilter::default())
+        .expect("query central log");
+    assert_eq!(
+        records.last().and_then(|record| record.status.as_ref()),
+        Some(&LogStatus::Partial)
+    );
+}
+
+#[test]
+fn updated_transaction_reports_snapshot_refresh_failure() {
+    assert_updated_manifest_refresh_failure(BlockedManifestArtifact::Snapshot);
+}
+
+#[test]
+fn updated_transaction_reports_provenance_refresh_failure() {
+    assert_updated_manifest_refresh_failure(BlockedManifestArtifact::Provenance);
 }
 
 #[test]
@@ -1687,6 +2036,10 @@ fn planned_update_is_not_reported_as_reconciled() {
 
     let state = InstalledState::load(&layout.state_dir.join("installed.toml")).expect("state");
     assert_eq!(state.operations.len(), 1, "one operation and one save path");
+    assert_eq!(
+        state.operations[0].status, STATUS_OK,
+        "a component without a contract remains a successful update"
+    );
     let operation_id = &state.operations[0].id;
     for name in ["cosh", "sec-core"] {
         assert_eq!(


### PR DESCRIPTION
## Description

This fixes the incomplete manifest synchronization found while regressing
#1470. ANOLISA now treats drift between an RPM-owned component contract and its
state snapshot as an upgrade reconciliation, even when RPM version metadata is
already current.

Dry-run reports the reconciliation without writing files. Real upgrade and
repair flows refresh snapshots only after installed state has been durably
saved, while missing package contracts remain silent during refresh.

## Related Issue

closes #1560

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa` on macOS arm64:

- `cargo test -p anolisa-cli stale_component_manifest --locked` (2 passed)
- `cargo test -p anolisa-cli upgrade --locked` (44 passed)
- `cargo test -p anolisa-cli repair --locked` (27 passed)
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `cargo doc --workspace --no-deps`

The focused tests cover same-version manifest-only reconciliation, dry-run
behavior without file writes, snapshot refresh after upgrade and repair, and
the absence of an unnecessary DNF transaction.

## Additional Notes

No documentation or dependency lock file changes are required.

### Ship Note

- Changed: `anolisa upgrade` and `anolisa repair` now refresh stale RPM
  component manifest snapshots.
- Known limitations: None known.
- Not covered: A live RPM upgrade smoke test on Alibaba Cloud Linux.
