### PR TITLE
fix(skillfs): honor telemetry opt-out

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -27,12 +27,12 @@ use skillfs_fuse::security::{
     ProtocolEventWriter, RefreshController, ReloadMode, RuntimeDecisionOutcome, RuntimeMetricsSink,
     RuntimeMetricsWriter, SecurityConfig, SecurityEventWriter, SecurityModeConfig,
     SessionStatsWriter, SkillfsSessionStats, SourceDriftObserver, StagingMatcher,
-    TrustedPeerConfig, TrustedWriterConfig, UnixSocketNotifyClient, bootstrap_activation,
-    resolve_events_path, resolve_protocol_events_path, spawn_drift_watcher,
+    SummaryWriteOutcome, TrustedPeerConfig, TrustedWriterConfig, UnixSocketNotifyClient,
+    bootstrap_activation, resolve_events_path, resolve_protocol_events_path, spawn_drift_watcher,
 };
 use skillfs_fuse::{FuseError as FuseErr, MountConfig, MountOptions, mount_configured};
 use tokio::signal;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 mod help_text;
 mod managed;
@@ -2322,20 +2322,32 @@ async fn cmd_mount(
             return;
         };
         let writer = SessionStatsWriter::default_path();
-        if let Err(e) = writer.write_summary(&summary) {
-            warn!(
-                error = %e,
-                path = %writer.path().display(),
-                "session stats: failed to flush summary (non-fatal)"
-            );
-        } else {
-            info!(
-                path = %writer.path().display(),
-                session_id = %session_id,
-                mount_duration_ms = summary.mount_duration_ms,
-                skill_hit_times = summary.skill_hit_times,
-                "session stats: summary flushed to session metrics log"
-            );
+        match writer.write_summary_with_outcome(&summary) {
+            Ok(SummaryWriteOutcome::Written) => {
+                info!(
+                    path = %writer.path().display(),
+                    session_id = %session_id,
+                    mount_duration_ms = summary.mount_duration_ms,
+                    skill_hit_times = summary.skill_hit_times,
+                    "session stats: summary flushed to session metrics log"
+                );
+            }
+            Ok(SummaryWriteOutcome::SkippedDisabled) => {
+                // Telemetry disabled by sentinel: nothing was written, so do
+                // not claim a flush. Normal state, not an error.
+                debug!(
+                    path = %writer.path().display(),
+                    session_id = %session_id,
+                    "session stats: telemetry disabled, summary not written"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    path = %writer.path().display(),
+                    "session stats: failed to flush summary (non-fatal)"
+                );
+            }
         }
     }
 

--- a/src/skillfs/crates/skillfs-cli/src/sls_ops.rs
+++ b/src/skillfs/crates/skillfs-cli/src/sls_ops.rs
@@ -175,6 +175,10 @@ fn resolve_ops_path(env_val: Option<&str>) -> PathBuf {
 /// Best-effort JSONL ops writer.
 pub struct SlsOpsWriter {
     path: PathBuf,
+    /// Telemetry disable sentinel. Pinned to the production sentinel in
+    /// [`SlsOpsWriter::new`] (no override path exists); tests inject a temp path
+    /// so the gate does not depend on the host's real sentinel.
+    sentinel: PathBuf,
 }
 
 impl Default for SlsOpsWriter {
@@ -190,13 +194,28 @@ impl SlsOpsWriter {
         let env_val = std::env::var(SLS_OPS_PATH_ENV).ok();
         Self {
             path: resolve_ops_path(env_val.as_deref()),
+            sentinel: PathBuf::from(skillfs_fuse::security::TELEMETRY_DISABLED_SENTINEL),
         }
     }
 
-    /// Create a writer targeting an explicit path (for tests).
+    /// Create a writer targeting an explicit path (for tests). The telemetry
+    /// sentinel is pointed at a sibling path the tests never create, isolating
+    /// them from the host's real `/etc/anolisa/.telemetry_disabled`.
     #[cfg(test)]
     fn with_path(path: impl Into<PathBuf>) -> Self {
-        Self { path: path.into() }
+        let path = path.into();
+        let sentinel = path
+            .parent()
+            .map(|p| p.join(".telemetry_disabled"))
+            .unwrap_or_else(|| PathBuf::from(skillfs_fuse::security::TELEMETRY_DISABLED_SENTINEL));
+        Self { path, sentinel }
+    }
+
+    /// Override the telemetry sentinel path (tests only).
+    #[cfg(test)]
+    fn with_sentinel(mut self, sentinel: impl Into<PathBuf>) -> Self {
+        self.sentinel = sentinel.into();
+        self
     }
 
     /// Append one ops record as a JSONL line (open + append + close).
@@ -205,6 +224,12 @@ impl SlsOpsWriter {
     /// file creation. Serialization or write failures are logged via
     /// `tracing::warn` and swallowed; they never change CLI behavior.
     pub fn write(&self, record: &SlsOpsRecord) {
+        // Re-check the disable sentinel on every write (before serialization
+        // and open) so creating/removing it takes effect immediately without
+        // restarting; disabled is a normal state, so skip silently.
+        if !skillfs_fuse::security::telemetry_allowed_at(&self.sentinel) {
+            return;
+        }
         if !self.path.exists() {
             return;
         }
@@ -305,6 +330,25 @@ mod tests {
         let obj: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(obj["component.name"], "skillfs");
         assert_eq!(obj["ops_name"], "list");
+    }
+
+    #[test]
+    fn disabled_sentinel_suppresses_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&path).unwrap();
+
+        // Sentinel present -> the write is suppressed even though the log file
+        // exists.
+        let sentinel = dir.path().join(".telemetry_disabled");
+        std::fs::File::create(&sentinel).unwrap();
+        let writer = SlsOpsWriter::with_path(&path).with_sentinel(&sentinel);
+        writer.write(&SlsOpsRecord::new("list", 3, None));
+
+        assert!(
+            std::fs::read_to_string(&path).unwrap().is_empty(),
+            "disabled telemetry must not append any record"
+        );
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/sls_ops_cli_tests.rs
@@ -12,6 +12,22 @@ fn bin_path() -> &'static str {
     env!("CARGO_BIN_EXE_skillfs")
 }
 
+/// Skip guard for record-expecting tests.
+///
+/// The CLI subprocess checks the real `/etc/anolisa/.telemetry_disabled` at
+/// runtime, and there is deliberately no production override to relocate it.
+/// When telemetry is disabled on the host, the CLI writes zero ops records, so
+/// the "expect one record" assertions below cannot hold — skip rather than
+/// fail. The enabled write path stays covered by the unit tests, which inject a
+/// temp sentinel. Returns `true` (and prints a SKIP line) when disabled.
+fn skip_if_telemetry_disabled() -> bool {
+    if skillfs_fuse::security::telemetry_allowed() {
+        return false;
+    }
+    eprintln!("SKIP: telemetry disabled on host (/etc/anolisa/.telemetry_disabled present)");
+    true
+}
+
 const VALID_SKILL: &str = r#"---
 name: good-skill
 description: A valid skill
@@ -115,6 +131,9 @@ fn run_with_merged_output_closed(args: &[&str], ops_log: &Path) -> std::process:
 
 #[test]
 fn list_appends_ops_record_on_success() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     // /tmp-based temp dir required so the override prefix check accepts it.
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
@@ -139,6 +158,9 @@ fn list_appends_ops_record_on_success() {
 
 #[test]
 fn validate_appends_ops_record_on_success() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -156,6 +178,9 @@ fn validate_appends_ops_record_on_success() {
 
 #[test]
 fn validate_appends_record_before_nonzero_exit() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -179,6 +204,9 @@ fn validate_appends_record_before_nonzero_exit() {
 
 #[test]
 fn classify_dry_run_appends_ops_record_on_success() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -232,6 +260,9 @@ fn missing_ops_log_is_not_created_and_command_succeeds() {
 
 #[test]
 fn list_writes_one_record_when_stdout_reader_closes_early() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -256,6 +287,9 @@ fn list_writes_one_record_when_stdout_reader_closes_early() {
 
 #[test]
 fn classify_dry_run_writes_one_record_when_stdout_reader_closes_early() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -288,6 +322,9 @@ fn classify_dry_run_writes_one_record_when_stdout_reader_closes_early() {
 
 #[test]
 fn validate_writes_one_record_when_stdout_reader_closes_early() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -317,6 +354,9 @@ fn mount_writes_one_record_through_guard_on_fast_failure() {
     // `finish` path emits exactly one "mount" record without a live mount. The
     // broken-pipe Drop path for `mount` is covered separately by
     // `mount_writes_one_record_when_merged_output_closes_early`.
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -365,6 +405,9 @@ fn mount_writes_one_record_through_guard_on_fast_failure() {
 
 #[test]
 fn list_writes_one_record_when_merged_output_closes_early() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -383,6 +426,9 @@ fn list_writes_one_record_when_merged_output_closes_early() {
 
 #[test]
 fn classify_dry_run_writes_one_record_when_merged_output_closes_early() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -410,6 +456,9 @@ fn classify_dry_run_writes_one_record_when_merged_output_closes_early() {
 
 #[test]
 fn validate_writes_one_record_when_merged_output_closes_early() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
     let ops_log = make_ops_log(dir.path());
 
@@ -431,6 +480,9 @@ fn validate_writes_one_record_when_merged_output_closes_early() {
 
 #[test]
 fn mount_writes_one_record_when_merged_output_closes_early() {
+    if skip_if_telemetry_disabled() {
+        return;
+    }
     // The first tracing write gets EPIPE, then tracing's internal error report
     // panics on the closed stderr. This happens before the command body and any
     // FUSE mount attempt; the guard records the panic and the test leaves no

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -113,6 +113,7 @@ pub mod refresh;
 pub mod runtime_metrics;
 pub mod session_stats;
 pub mod session_stats_writer;
+pub mod telemetry_gate;
 pub mod trusted_writer;
 
 pub use activation::{
@@ -203,7 +204,10 @@ pub use runtime_metrics::{
 pub use session_stats::{
     RuntimeDecisionOutcome, SkillfsSessionStats, SkillfsSessionSummary, serialize_session_summary,
 };
-pub use session_stats_writer::{SKILLFS_SESSION_METRICS_LOG_PATH, SessionStatsWriter};
+pub use session_stats_writer::{
+    SKILLFS_SESSION_METRICS_LOG_PATH, SessionStatsWriter, SummaryWriteOutcome,
+};
+pub use telemetry_gate::{TELEMETRY_DISABLED_SENTINEL, telemetry_allowed, telemetry_allowed_at};
 pub use trusted_writer::{
     FileId, LinuxProcCommResolver, ProcessIdentity, ProcessIdentityResolver, TrustedWriterConfig,
     TrustedWriterDecision, default_identity_resolver, evaluate_trusted_writer, read_comm_file,

--- a/src/skillfs/crates/skillfs-fuse/src/security/runtime_metrics.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/runtime_metrics.rs
@@ -30,6 +30,8 @@ use std::time::Instant;
 use serde::Serialize;
 use tracing::warn;
 
+use super::telemetry_gate::{TELEMETRY_DISABLED_SENTINEL, telemetry_allowed_at};
+
 /// Default ops log path (shared with CLI ops and the legacy session summary).
 pub const SKILLFS_RUNTIME_METRICS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/skillfs.jsonl";
 
@@ -99,17 +101,32 @@ impl RuntimeMetricRecord {
 /// Best-effort append-only JSONL writer for runtime metric records.
 pub struct RuntimeMetricsWriter {
     path: PathBuf,
+    /// Telemetry disable sentinel. Pinned to [`TELEMETRY_DISABLED_SENTINEL`] in
+    /// production (no override path exists); tests inject a temp path so the
+    /// gate does not depend on the host's real sentinel.
+    sentinel: PathBuf,
 }
 
 impl RuntimeMetricsWriter {
     /// Create a writer targeting `path`.
     pub fn new(path: impl Into<PathBuf>) -> Self {
-        Self { path: path.into() }
+        Self {
+            path: path.into(),
+            sentinel: PathBuf::from(TELEMETRY_DISABLED_SENTINEL),
+        }
     }
 
     /// Create a writer targeting the default deployment path.
     pub fn default_path() -> Self {
         Self::new(SKILLFS_RUNTIME_METRICS_LOG_PATH)
+    }
+
+    /// Override the telemetry sentinel path (tests only) so writer tests do not
+    /// depend on the host's real `/etc/anolisa/.telemetry_disabled`.
+    #[cfg(test)]
+    fn with_sentinel(mut self, sentinel: impl Into<PathBuf>) -> Self {
+        self.sentinel = sentinel.into();
+        self
     }
 
     /// The target file path.
@@ -120,6 +137,12 @@ impl RuntimeMetricsWriter {
     /// Append one record as a JSONL line. Skips silently when the file is
     /// absent; serialization/write failures are logged and swallowed.
     pub fn write(&self, record: &RuntimeMetricRecord) {
+        // Re-check the disable sentinel on every write (before serialization
+        // and open) so creating/removing it takes effect immediately; disabled
+        // is a normal state, so skip silently.
+        if !telemetry_allowed_at(&self.sentinel) {
+            return;
+        }
         if !self.path.exists() {
             return;
         }
@@ -291,8 +314,14 @@ mod tests {
     use super::*;
 
     fn sink_to(path: &Path) -> RuntimeMetricsSink {
+        // Point the gate at a sentinel beside the log file that tests never
+        // create, isolating them from the host's real sentinel.
+        let sentinel = path
+            .parent()
+            .map(|p| p.join(".telemetry_disabled"))
+            .unwrap_or_else(|| PathBuf::from("/nonexistent/.telemetry_disabled"));
         RuntimeMetricsSink::new(
-            RuntimeMetricsWriter::new(path),
+            RuntimeMetricsWriter::new(path).with_sentinel(sentinel),
             "sess-1".to_string(),
             "agent".to_string(),
         )
@@ -365,6 +394,28 @@ mod tests {
     fn writer_non_fatal_on_bad_path() {
         let sink = sink_to(Path::new("/nonexistent/deep/dir/skillfs.jsonl"));
         sink.record_skill_hit(); // no panic
+    }
+
+    #[test]
+    fn disabled_sentinel_suppresses_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&path).unwrap();
+
+        // Sentinel present -> the writer must not append despite the log file
+        // existing.
+        let sentinel = dir.path().join(".telemetry_disabled");
+        std::fs::File::create(&sentinel).unwrap();
+        let writer = RuntimeMetricsWriter::new(&path).with_sentinel(&sentinel);
+        let sink = RuntimeMetricsSink::new(writer, "sess".to_string(), "agent".to_string());
+
+        sink.emit_mount_start();
+        sink.record_skill_hit();
+
+        assert!(
+            std::fs::read_to_string(&path).unwrap().is_empty(),
+            "disabled telemetry must not append any record"
+        );
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/security/session_stats_writer.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/session_stats_writer.rs
@@ -22,9 +22,25 @@ use std::path::{Path, PathBuf};
 use tracing::warn;
 
 use super::session_stats::{SkillfsSessionSummary, serialize_session_summary};
+use super::telemetry_gate::{TELEMETRY_DISABLED_SENTINEL, telemetry_allowed_at};
 
 /// Default session metrics log path per the default deployment convention.
 pub const SKILLFS_SESSION_METRICS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/skillfs.jsonl";
+
+/// Result of a successful [`SessionStatsWriter::write_summary`] call.
+///
+/// `Ok(())` alone was ambiguous once the telemetry gate could suppress the
+/// write: a caller could not tell an appended line apart from a silent skip and
+/// would log a misleading "flushed" message. This distinguishes the two so the
+/// caller logs success only when a line was actually appended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SummaryWriteOutcome {
+    /// The summary line was appended to the metrics log.
+    Written,
+    /// The telemetry sentinel is present, so nothing was written. This is a
+    /// normal, non-error state and must not affect mount exit status.
+    SkippedDisabled,
+}
 
 /// Best-effort JSONL summary writer.
 ///
@@ -34,17 +50,32 @@ pub const SKILLFS_SESSION_METRICS_LOG_PATH: &str = "/var/log/anolisa/sls/ops/ski
 /// `tracing::warn` and returned as `Err`, but the CLI must not retry or abort.
 pub struct SessionStatsWriter {
     path: PathBuf,
+    /// Telemetry disable sentinel. Pinned to [`TELEMETRY_DISABLED_SENTINEL`] in
+    /// production (no override path exists); tests inject a temp path so the
+    /// gate does not depend on the host's real sentinel.
+    sentinel: PathBuf,
 }
 
 impl SessionStatsWriter {
     /// Create a writer targeting the given path.
     pub fn new(path: impl Into<PathBuf>) -> Self {
-        Self { path: path.into() }
+        Self {
+            path: path.into(),
+            sentinel: PathBuf::from(TELEMETRY_DISABLED_SENTINEL),
+        }
     }
 
     /// Create a writer targeting the default session metrics log.
     pub fn default_path() -> Self {
         Self::new(SKILLFS_SESSION_METRICS_LOG_PATH)
+    }
+
+    /// Override the telemetry sentinel path (tests only) so writer tests do not
+    /// depend on the host's real `/etc/anolisa/.telemetry_disabled`.
+    #[cfg(test)]
+    fn with_sentinel(mut self, sentinel: impl Into<PathBuf>) -> Self {
+        self.sentinel = sentinel.into();
+        self
     }
 
     /// The target file path.
@@ -54,9 +85,38 @@ impl SessionStatsWriter {
 
     /// Write one session summary as a JSONL line (open + append + close).
     ///
-    /// Returns `Ok(())` on success. On failure, logs a warning and returns
-    /// the underlying IO error. Callers should treat failure as non-fatal.
+    /// Returns `Ok(())` when a line was appended **or** when the telemetry
+    /// sentinel suppressed the write — both are non-error outcomes that must
+    /// not affect mount exit status. On IO failure, logs a warning and returns
+    /// the underlying error. Callers must treat failure as non-fatal.
+    ///
+    /// This is the stable, backward-compatible signature. Callers that need to
+    /// distinguish an actual write from a sentinel skip (e.g. to avoid logging
+    /// a spurious "flushed" message) should use
+    /// [`SessionStatsWriter::write_summary_with_outcome`].
     pub fn write_summary(&self, summary: &SkillfsSessionSummary) -> std::io::Result<()> {
+        self.write_summary_with_outcome(summary).map(|_| ())
+    }
+
+    /// Like [`SessionStatsWriter::write_summary`] but reports whether a line was
+    /// actually appended.
+    ///
+    /// Returns [`SummaryWriteOutcome::Written`] when a line was appended and
+    /// [`SummaryWriteOutcome::SkippedDisabled`] when the telemetry sentinel
+    /// suppressed the write. On IO failure, logs a warning and returns the
+    /// underlying error. Callers must treat failure as non-fatal.
+    pub fn write_summary_with_outcome(
+        &self,
+        summary: &SkillfsSessionSummary,
+    ) -> std::io::Result<SummaryWriteOutcome> {
+        // Re-check the disable sentinel on every write (before serialization
+        // and open) so creating/removing it takes effect immediately without a
+        // restart. Disabled is a normal state: skip silently and report the skip
+        // so a suppressed summary neither errors nor logs a spurious success.
+        if !telemetry_allowed_at(&self.sentinel) {
+            return Ok(SummaryWriteOutcome::SkippedDisabled);
+        }
+
         let mut line = serialize_session_summary(summary);
         line.push('\n');
 
@@ -76,7 +136,7 @@ impl SessionStatsWriter {
             );
         }
 
-        result
+        result.map(|()| SummaryWriteOutcome::Written)
     }
 }
 
@@ -89,6 +149,13 @@ mod tests {
     use super::*;
     use crate::security::session_stats::SkillfsSessionStats;
 
+    /// Build a writer whose telemetry sentinel points at a path inside `dir`
+    /// that is never created, isolating writer tests from the host's real
+    /// `/etc/anolisa/.telemetry_disabled`.
+    fn writer_enabled(log_path: impl Into<PathBuf>, dir: &Path) -> SessionStatsWriter {
+        SessionStatsWriter::new(log_path).with_sentinel(dir.join(".telemetry_disabled"))
+    }
+
     #[test]
     fn writes_one_valid_json_line_to_temp_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -96,13 +163,18 @@ mod tests {
 
         std::fs::File::create(&log_path).unwrap();
 
-        let writer = SessionStatsWriter::new(&log_path);
+        let writer = writer_enabled(&log_path, dir.path());
         let stats = SkillfsSessionStats::new();
         stats.set_skill_counts(20, 6);
         stats.record_skill_hit("weather");
         let summary = stats.build_summary("test-write-1", "agent");
 
-        writer.write_summary(&summary).expect("write must succeed");
+        assert_eq!(
+            writer
+                .write_summary_with_outcome(&summary)
+                .expect("write must succeed"),
+            SummaryWriteOutcome::Written
+        );
 
         let content = std::fs::read_to_string(&log_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
@@ -127,7 +199,7 @@ mod tests {
 
         std::fs::File::create(&log_path).unwrap();
 
-        let writer = SessionStatsWriter::new(&log_path);
+        let writer = writer_enabled(&log_path, dir.path());
 
         let stats1 = SkillfsSessionStats::new();
         let summary1 = stats1.build_summary("session-a", "agent");
@@ -154,7 +226,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("missing-skillfs.jsonl");
 
-        let writer = SessionStatsWriter::new(&log_path);
+        let writer = writer_enabled(&log_path, dir.path());
         let stats = SkillfsSessionStats::new();
         let summary = stats.build_summary("missing-file-test", "agent");
         let err = writer
@@ -170,11 +242,35 @@ mod tests {
 
     #[test]
     fn write_failure_on_invalid_path_returns_error() {
-        let writer = SessionStatsWriter::new("/nonexistent/deep/skillfs.jsonl");
+        let dir = tempfile::tempdir().unwrap();
+        let writer = writer_enabled("/nonexistent/deep/skillfs.jsonl", dir.path());
         let stats = SkillfsSessionStats::new();
         let summary = stats.build_summary("fail-test", "agent");
         let result = writer.write_summary(&summary);
         assert!(result.is_err(), "expected write to fail on invalid path");
+    }
+
+    #[test]
+    fn disabled_sentinel_skips_write_and_reports_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("skillfs.jsonl");
+        std::fs::File::create(&log_path).unwrap();
+
+        // Point the gate at a sentinel that exists -> writes are suppressed.
+        let sentinel = dir.path().join(".telemetry_disabled");
+        std::fs::File::create(&sentinel).unwrap();
+        let writer = SessionStatsWriter::new(&log_path).with_sentinel(&sentinel);
+
+        let stats = SkillfsSessionStats::new();
+        let summary = stats.build_summary("disabled-test", "agent");
+        assert_eq!(
+            writer.write_summary_with_outcome(&summary).unwrap(),
+            SummaryWriteOutcome::SkippedDisabled
+        );
+        assert!(
+            std::fs::read_to_string(&log_path).unwrap().is_empty(),
+            "disabled telemetry must not append any line"
+        );
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/security/telemetry_gate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/telemetry_gate.rs
@@ -1,0 +1,126 @@
+//! Dynamic telemetry gate shared by every SkillFS SLS writer.
+//!
+//! When the deployment-owned sentinel file exists, SkillFS must not append new
+//! records to the SLS telemetry log (`/var/log/anolisa/sls/ops/skillfs.jsonl`).
+//! The gate is re-evaluated on every write, so creating or removing the
+//! sentinel takes effect immediately without restarting the process — the
+//! startup-time state is never cached.
+//!
+//! Fail-closed contract: telemetry is allowed **only** when the sentinel path
+//! resolves to `ENOENT` (nothing is there). A regular file, directory, valid
+//! symlink, or dangling symlink each disable telemetry, and any non-`ENOENT`
+//! stat error (e.g. `EACCES`) also disables it. [`std::fs::symlink_metadata`]
+//! is used rather than [`std::path::Path::exists`] so a dangling symlink is
+//! treated as "present" (disable) instead of "absent" (allow).
+
+use std::path::Path;
+
+/// Deployment-owned sentinel; its presence disables SLS telemetry writes.
+pub const TELEMETRY_DISABLED_SENTINEL: &str = "/etc/anolisa/.telemetry_disabled";
+
+/// Returns `true` when SLS telemetry writes are permitted, i.e. the sentinel at
+/// [`TELEMETRY_DISABLED_SENTINEL`] does not exist. Convenience wrapper over
+/// [`telemetry_allowed_at`] pinned to the production sentinel; re-checks the
+/// filesystem on every call — disabled is a normal, silent state, so callers
+/// skip without emitting a warning.
+pub fn telemetry_allowed() -> bool {
+    telemetry_allowed_at(Path::new(TELEMETRY_DISABLED_SENTINEL))
+}
+
+/// Path-injectable form of the gate. Production writers pin the argument to
+/// [`TELEMETRY_DISABLED_SENTINEL`] (via their default sentinel or
+/// [`telemetry_allowed`]) — there is no env var or config that repoints the
+/// production gate. This form is exposed so the writers' unit tests can point
+/// the gate at a controlled temp path instead of depending on the host's real
+/// `/etc/anolisa/.telemetry_disabled`.
+///
+/// Telemetry is allowed only when `symlink_metadata` reports `ENOENT`. Every
+/// other outcome — the path exists in any form (file, dir, valid or dangling
+/// symlink), or the stat fails for any other reason — fails closed.
+pub fn telemetry_allowed_at(path: &Path) -> bool {
+    matches!(
+        std::fs::symlink_metadata(path),
+        Err(error) if error.raw_os_error() == Some(libc::ENOENT)
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convenience_wrapper_pins_production_sentinel() {
+        // Host-independent: whatever the real sentinel state is, the no-arg
+        // wrapper must agree with the pinned-path form.
+        assert_eq!(
+            telemetry_allowed(),
+            telemetry_allowed_at(Path::new(TELEMETRY_DISABLED_SENTINEL))
+        );
+    }
+
+    #[test]
+    fn allows_when_sentinel_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let sentinel = dir.path().join(".telemetry_disabled");
+        assert!(
+            telemetry_allowed_at(&sentinel),
+            "missing sentinel must allow telemetry"
+        );
+    }
+
+    #[test]
+    fn disables_immediately_after_sentinel_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let sentinel = dir.path().join(".telemetry_disabled");
+
+        assert!(telemetry_allowed_at(&sentinel));
+        std::fs::File::create(&sentinel).unwrap();
+        assert!(
+            !telemetry_allowed_at(&sentinel),
+            "creating the sentinel must disable telemetry on the next check"
+        );
+    }
+
+    #[test]
+    fn restores_immediately_after_sentinel_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let sentinel = dir.path().join(".telemetry_disabled");
+
+        std::fs::File::create(&sentinel).unwrap();
+        assert!(!telemetry_allowed_at(&sentinel));
+        std::fs::remove_file(&sentinel).unwrap();
+        assert!(
+            telemetry_allowed_at(&sentinel),
+            "removing the sentinel must restore telemetry on the next check"
+        );
+    }
+
+    #[test]
+    fn directory_sentinel_disables() {
+        let dir = tempfile::tempdir().unwrap();
+        let sentinel = dir.path().join(".telemetry_disabled");
+        std::fs::create_dir(&sentinel).unwrap();
+        assert!(
+            !telemetry_allowed_at(&sentinel),
+            "a directory at the sentinel path must disable telemetry"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_disables() {
+        let dir = tempfile::tempdir().unwrap();
+        let sentinel = dir.path().join(".telemetry_disabled");
+        // Target intentionally does not exist: symlink_metadata stats the link
+        // itself (not the target), so this must fail closed and disable.
+        std::os::unix::fs::symlink(dir.path().join("nonexistent-target"), &sentinel).unwrap();
+        assert!(
+            !telemetry_allowed_at(&sentinel),
+            "a dangling symlink must disable telemetry, unlike Path::exists()"
+        );
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/tests/common/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/common/mod.rs
@@ -72,6 +72,18 @@ pub fn fuse_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Returns `true` when SLS telemetry is enabled on the host, i.e. the real
+/// `/etc/anolisa/.telemetry_disabled` sentinel is absent.
+///
+/// Tests that mount with a `RuntimeMetricsSink` and assert metric records must
+/// skip when this is `false`: the production writer pins the real sentinel (no
+/// override exists), so a disabled host writes zero records and the assertions
+/// cannot hold. The enabled write path stays covered by the writer unit tests,
+/// which inject a temp sentinel.
+pub fn telemetry_enabled() -> bool {
+    skillfs_fuse::security::telemetry_allowed()
+}
+
 /// Skip the current test (early `return`) with a deterministic stderr line
 /// when FUSE is unavailable. Use at the top of every FUSE-dependent test.
 #[macro_export]

--- a/src/skillfs/crates/skillfs-fuse/tests/runtime_metrics_fuse_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/runtime_metrics_fuse_tests.rs
@@ -24,7 +24,7 @@ use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_conf
 #[path = "common/mod.rs"]
 mod common;
 
-use crate::common::{create_skill_dir, fuse_available};
+use crate::common::{create_skill_dir, fuse_available, telemetry_enabled};
 
 /// Normal-mode mount that injects a `RuntimeMetricsSink` (and optionally an
 /// `ActiveSkillResolver`) and points the metrics writer at `metrics_path`.
@@ -188,6 +188,10 @@ fn skill_open_emits_skill_hit_without_resolver_but_no_policy() {
         eprintln!("SKIP: FUSE not available");
         return;
     }
+    if !telemetry_enabled() {
+        eprintln!("SKIP: telemetry disabled on host (/etc/anolisa/.telemetry_disabled present)");
+        return;
+    }
 
     let (_dir, metrics) = make_metrics_file();
     let mount = MetricsMount::new(
@@ -218,6 +222,10 @@ fn skill_open_emits_skill_hit_without_resolver_but_no_policy() {
 fn current_skill_open_emits_policy_allow() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    if !telemetry_enabled() {
+        eprintln!("SKIP: telemetry disabled on host (/etc/anolisa/.telemetry_disabled present)");
         return;
     }
 
@@ -254,6 +262,10 @@ fn current_skill_open_emits_policy_allow() {
 fn snapshot_skill_open_emits_policy_fallback() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    if !telemetry_enabled() {
+        eprintln!("SKIP: telemetry disabled on host (/etc/anolisa/.telemetry_disabled present)");
         return;
     }
 
@@ -295,6 +307,10 @@ fn snapshot_skill_open_emits_policy_fallback() {
 fn hidden_skill_open_emits_policy_denied() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    if !telemetry_enabled() {
+        eprintln!("SKIP: telemetry disabled on host (/etc/anolisa/.telemetry_disabled present)");
         return;
     }
 


### PR DESCRIPTION
## Description

Adds a shared, fail-closed telemetry gate across all three SkillFS SLS
writers. Every append re-checks `/etc/anolisa/.telemetry_disabled` with
`symlink_metadata`, and only `ENOENT` permits a write. The existing telemetry
schema and `SessionStatsWriter::write_summary` API remain compatible, while an
additive outcome API prevents disabled summaries from being reported as
successfully flushed. Tests cover dynamic gate behavior and remain stable when
host telemetry is disabled.

## Related Issue

<!-- TODO: Link the tracking issue before marking this draft ready. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Passed:

- `cargo fmt --all -- --check`
- `cargo build -p skillfs -p skillfs-fuse`
- `cargo doc -p skillfs-fuse --no-deps`
- `cargo test -p skillfs-fuse`
- `cargo test -p skillfs`
- `cargo test -p skillfs --test sls_ops_cli_tests` (13 passed)
- `cargo test -p skillfs-fuse --test runtime_metrics_fuse_tests` (4 passed)
- `scripts/test.sh`

Verified edge cases:

- Missing sentinel permits telemetry.
- File, directory, or dangling-symlink sentinel disables telemetry.
- Creating or removing the sentinel affects the next write without a restart.
- Disabled session summaries do not emit a false flushed-success log.
- No telemetry JSON fields or schemas changed.

## Additional Notes

The sentinel affects only SkillFS SLS writers. Runtime logs, local audit logs,
security event streams, and activation protocol logs remain unchanged.

`cargo clippy --workspace --all-targets -- -D warnings` is blocked by
pre-existing warnings in untouched files. `cargo test --workspace` also hits
four pre-existing `skillfs-core::watcher::MaxFilesWatch` failures caused by the
Lifsea sandbox's inotify watch-limit exhaustion. The changed SkillFS CLI and
FUSE suites pass independently.

Rustdoc completes with pre-existing unresolved-link warnings in unrelated
modules. Integration tests that require telemetry output skip when the host
telemetry gate is closed.
