### PR TITLE
fix(cosh): terminate hook process tree on timeout and cancellation

### DIFF
--- a/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
+++ b/src/copilot-shell/packages/core/src/core/coreToolScheduler.ts
@@ -871,6 +871,7 @@ export class CoreToolScheduler {
                 reqInfo.args,
                 skillContext,
                 reqInfo.callId,
+                signal,
               );
 
               if (hookOutput) {
@@ -1530,6 +1531,7 @@ export class CoreToolScheduler {
                     undefined,
                     undefined,
                     callId,
+                    signal,
                   );
 
                   if (postToolOutput) {

--- a/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookEventHandler.ts
@@ -87,6 +87,7 @@ export class HookEventHandler {
     toolInput: Record<string, unknown>,
     skillContext?: import('./types.js').SkillToolContext,
     toolUseId?: string,
+    signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     debugLogger.info(
       `[Hook Debug] hookEventHandler.firePreToolUseEvent: tool=${toolName}`,
@@ -99,7 +100,12 @@ export class HookEventHandler {
       ...(toolUseId && { tool_use_id: toolUseId }),
     };
 
-    const result = await this.executeHooks(HookEventName.PreToolUse, input);
+    const result = await this.executeHooks(
+      HookEventName.PreToolUse,
+      input,
+      undefined,
+      signal,
+    );
     debugLogger.info(
       `[Hook Debug] hookEventHandler.firePreToolUseEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
     );
@@ -158,6 +164,7 @@ export class HookEventHandler {
     mcpContext?: McpToolContext,
     originalRequestName?: string,
     toolUseId?: string,
+    signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     debugLogger.info(
       `[Hook Debug] hookEventHandler.firePostToolUseEvent: tool=${toolName}`,
@@ -179,6 +186,7 @@ export class HookEventHandler {
       HookEventName.PostToolUse,
       input,
       context,
+      signal,
     );
     debugLogger.info(
       `[Hook Debug] hookEventHandler.firePostToolUseEvent: completed, outputs=${result.allOutputs.length}, errors=${result.errors.length}`,
@@ -362,11 +370,18 @@ export class HookEventHandler {
   /**
    * Execute hooks for a specific event (direct execution without MessageBus)
    * Used as fallback when MessageBus is not available
+   *
+   * The optional `signal` propagates caller cancellation (e.g. Ctrl+C) so
+   * hook process trees are terminated instead of being orphaned.
+   * Only the tool-use call sites (PreToolUse/PostToolUse) currently supply
+   * a signal; other events accept one but have no cancellation source yet,
+   * so their hooks are still bounded only by the per-hook timeout.
    */
   private async executeHooks(
     eventName: HookEventName,
     input: HookInput,
     context?: HookEventContext,
+    signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     try {
       // Create execution plan
@@ -397,6 +412,7 @@ export class HookEventHandler {
             input,
             onHookStart,
             onHookEnd,
+            signal,
           )
         : await this.hookRunner.executeHooksParallel(
             plan.hookConfigs,
@@ -404,6 +420,7 @@ export class HookEventHandler {
             input,
             onHookStart,
             onHookEnd,
+            signal,
           );
 
       // Aggregate results

--- a/src/copilot-shell/packages/core/src/hooks/hookRunner.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookRunner.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { HookRunner } from './hookRunner.js';
 import { HookEventName, HookType, HooksConfigSource } from './types.js';
 import type { HookConfig, HookInput } from './types.js';
@@ -700,4 +700,190 @@ describe('HookRunner', () => {
       expect(result.output?.decision).toBe('allow');
     });
   });
+
+  // Process-group semantics are POSIX-only; on Windows the runner falls
+  // back to signalling the direct child.
+  describe.skipIf(process.platform === 'win32')(
+    'timeout and cancellation',
+    () => {
+      // Simulates a child (or descendant) that ignores SIGTERM and keeps the
+      // inherited stdio open: no 'close' event ever fires (issue #1582).
+      const createHungProcess = () => ({
+        pid: 12345,
+        exitCode: null as number | null,
+        signalCode: null as NodeJS.Signals | null,
+        killed: false,
+        stdin: { on: vi.fn(), write: vi.fn(), end: vi.fn(), destroy: vi.fn() },
+        stdout: { on: vi.fn(), destroy: vi.fn() },
+        stderr: { on: vi.fn(), destroy: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn().mockReturnValue(true),
+      });
+
+      const hungHookConfig: HookConfig = {
+        type: HookType.Command,
+        name: 'timeout-repro',
+        command: "trap '' TERM; sleep 600",
+        timeout: 1000,
+        source: HooksConfigSource.Project,
+      };
+
+      let killSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        vi.useFakeTimers();
+        killSpy = vi
+          .spyOn(process, 'kill')
+          .mockImplementation(() => true) as ReturnType<typeof vi.spyOn>;
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+      });
+
+      it('should spawn the hook in its own process group', async () => {
+        const proc = createHungProcess();
+        mockSpawn.mockImplementation(() => proc);
+
+        void hookRunner.executeHook(
+          hungHookConfig,
+          HookEventName.PreToolUse,
+          createMockInput(),
+        );
+
+        expect(mockSpawn.mock.calls[0][2]).toMatchObject({ detached: true });
+      });
+
+      it('should SIGKILL the process group even when child.killed is true', async () => {
+        const proc = createHungProcess();
+        mockSpawn.mockImplementation(() => proc);
+
+        const promise = hookRunner.executeHook(
+          hungHookConfig,
+          HookEventName.PreToolUse,
+          createMockInput(),
+        );
+
+        // Timeout elapses: SIGTERM goes to the whole group, not the child
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+
+        // child.killed only means a signal was sent; the process is still
+        // alive (exitCode/signalCode are null), so SIGKILL must follow.
+        proc.killed = true;
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGKILL');
+
+        // Bounded settlement: no 'close' event, yet the promise resolves
+        await vi.advanceTimersByTimeAsync(1000);
+        const result = await promise;
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain('Hook timed out after 1000ms');
+        // Exit state is surfaced for observability; the process never exited
+        expect(result.error?.message).toContain(
+          'exitCode=null, signalCode=null',
+        );
+        expect(proc.stdout.destroy).toHaveBeenCalled();
+        expect(proc.stderr.destroy).toHaveBeenCalled();
+      });
+
+      it('should settle via close and stop escalation when the child exits after SIGTERM', async () => {
+        const proc = createHungProcess();
+        let closeCallback: ((code: number | null) => void) | undefined;
+        proc.on = vi.fn(
+          (event: string, callback: (code: number | null) => void) => {
+            if (event === 'close') {
+              closeCallback = callback;
+            }
+          },
+        );
+        mockSpawn.mockImplementation(() => proc);
+
+        const promise = hookRunner.executeHook(
+          hungHookConfig,
+          HookEventName.PreToolUse,
+          createMockInput(),
+        );
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+
+        // Child exits within the grace period
+        proc.signalCode = 'SIGTERM';
+        closeCallback?.(null);
+
+        const result = await promise;
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain('Hook timed out after 1000ms');
+        // The child honored SIGTERM; the error message records that
+        expect(result.error?.message).toContain('signalCode=SIGTERM');
+
+        // Escalation timers were cleared: no SIGKILL is ever sent
+        await vi.advanceTimersByTimeAsync(60000);
+        expect(killSpy).not.toHaveBeenCalledWith(-12345, 'SIGKILL');
+      });
+
+      it('should terminate the process tree when the abort signal fires', async () => {
+        const proc = createHungProcess();
+        mockSpawn.mockImplementation(() => proc);
+
+        const controller = new AbortController();
+        const promise = hookRunner.executeHook(
+          { ...hungHookConfig, timeout: 60000 },
+          HookEventName.PreToolUse,
+          createMockInput(),
+          controller.signal,
+        );
+
+        controller.abort();
+        expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGKILL');
+
+        await vi.advanceTimersByTimeAsync(1000);
+        const result = await promise;
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain('Hook cancelled');
+      });
+
+      it('should not spawn when the signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        const result = await hookRunner.executeHook(
+          hungHookConfig,
+          HookEventName.PreToolUse,
+          createMockInput(),
+          controller.signal,
+        );
+
+        expect(mockSpawn).not.toHaveBeenCalled();
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toBe('Hook cancelled before start');
+      });
+
+      it('should fall back to killing the direct child when the group is gone', async () => {
+        const proc = createHungProcess();
+        mockSpawn.mockImplementation(() => proc);
+        killSpy.mockImplementation(() => {
+          throw new Error('ESRCH');
+        });
+
+        const promise = hookRunner.executeHook(
+          hungHookConfig,
+          HookEventName.PreToolUse,
+          createMockInput(),
+        );
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+
+        await vi.advanceTimersByTimeAsync(6000);
+        const result = await promise;
+        expect(result.success).toBe(false);
+      });
+    },
+  );
 });

--- a/src/copilot-shell/packages/core/src/hooks/hookRunner.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookRunner.ts
@@ -29,6 +29,18 @@ const debugLogger = createDebugLogger('TRUSTED_HOOKS');
 const DEFAULT_HOOK_TIMEOUT = 60000;
 
 /**
+ * Grace period after SIGTERM before escalating to SIGKILL
+ */
+const SIGTERM_GRACE_PERIOD_MS = 5000;
+
+/**
+ * Bounded settlement window after SIGKILL. Descendants that inherit the
+ * hook's stdio can keep the pipes open and suppress the 'close' event
+ * forever, so the promise must resolve without it after this window.
+ */
+const FORCE_SETTLE_GRACE_PERIOD_MS = 1000;
+
+/**
  * Maximum length for stdout/stderr output (1MB)
  * Prevents memory issues from unbounded output
  */
@@ -46,11 +58,15 @@ const EXIT_CODE_NON_BLOCKING_ERROR = 1;
 export class HookRunner {
   /**
    * Execute a single hook
+   *
+   * An aborted `signal` terminates the hook's entire process tree and
+   * settles the result within a bounded grace period.
    */
   async executeHook(
     hookConfig: HookConfig,
     eventName: HookEventName,
     input: HookInput,
+    signal?: AbortSignal,
   ): Promise<HookExecutionResult> {
     const startTime = Date.now();
 
@@ -60,6 +76,7 @@ export class HookRunner {
         eventName,
         input,
         startTime,
+        signal,
       );
     } catch (error) {
       const duration = Date.now() - startTime;
@@ -86,10 +103,11 @@ export class HookRunner {
     input: HookInput,
     onHookStart?: (config: HookConfig, index: number) => void,
     onHookEnd?: (config: HookConfig, result: HookExecutionResult) => void,
+    signal?: AbortSignal,
   ): Promise<HookExecutionResult[]> {
     const promises = hookConfigs.map(async (config, index) => {
       onHookStart?.(config, index);
-      const result = await this.executeHook(config, eventName, input);
+      const result = await this.executeHook(config, eventName, input, signal);
       onHookEnd?.(config, result);
       return result;
     });
@@ -106,6 +124,7 @@ export class HookRunner {
     input: HookInput,
     onHookStart?: (config: HookConfig, index: number) => void,
     onHookEnd?: (config: HookConfig, result: HookExecutionResult) => void,
+    signal?: AbortSignal,
   ): Promise<HookExecutionResult[]> {
     const results: HookExecutionResult[] = [];
     let currentInput = input;
@@ -113,7 +132,12 @@ export class HookRunner {
     for (let i = 0; i < hookConfigs.length; i++) {
       const config = hookConfigs[i];
       onHookStart?.(config, i);
-      const result = await this.executeHook(config, eventName, currentInput);
+      const result = await this.executeHook(
+        config,
+        eventName,
+        currentInput,
+        signal,
+      );
       onHookEnd?.(config, result);
       results.push(result);
 
@@ -190,8 +214,10 @@ export class HookRunner {
     eventName: HookEventName,
     input: HookInput,
     startTime: number,
+    signal?: AbortSignal,
   ): Promise<HookExecutionResult> {
     const timeout = hookConfig.timeout ?? DEFAULT_HOOK_TIMEOUT;
+    const hookId = hookConfig.name || hookConfig.command || 'unknown';
 
     return new Promise((resolve) => {
       if (!hookConfig.command) {
@@ -212,6 +238,8 @@ export class HookRunner {
       let stdout = '';
       let stderr = '';
       let timedOut = false;
+      let cancelled = false;
+      let settled = false;
 
       const shellConfig = getShellConfiguration();
       const command = this.expandCommand(
@@ -229,6 +257,24 @@ export class HookRunner {
         ...hookConfig.env,
       };
 
+      // If the caller already cancelled, do not spawn at all
+      if (signal?.aborted) {
+        resolve({
+          hookConfig,
+          eventName,
+          success: false,
+          error: new Error('Hook cancelled before start'),
+          duration: Date.now() - startTime,
+        });
+        return;
+      }
+
+      // POSIX: run the hook in its own process group so that timeout and
+      // cancellation can terminate the entire process tree. Otherwise
+      // descendants survive, get reparented to PID 1, and keep the
+      // inherited stdio pipes open (see issue #1582).
+      const useProcessGroup = process.platform !== 'win32';
+
       const child = spawn(
         shellConfig.executable,
         [...shellConfig.argsPrefix, command],
@@ -237,21 +283,124 @@ export class HookRunner {
           cwd: input.cwd,
           stdio: ['pipe', 'pipe', 'pipe'],
           shell: false,
+          detached: useProcessGroup,
         },
       );
+
+      // child.killed only records that a signal was sent; exitCode and
+      // signalCode reflect whether the process actually terminated.
+      const hasExited = (): boolean =>
+        child.exitCode !== null || child.signalCode !== null;
+
+      // Signal the whole process group when available, falling back to the
+      // direct child if the group is already gone.
+      const killProcessTree = (killSignal: NodeJS.Signals): void => {
+        if (child.pid === undefined) {
+          return;
+        }
+        if (useProcessGroup) {
+          try {
+            process.kill(-child.pid, killSignal);
+            return;
+          } catch {
+            // Group no longer exists; fall through to the direct child.
+          }
+        }
+        try {
+          child.kill(killSignal);
+        } catch {
+          // Process already exited.
+        }
+      };
+
+      let sigkillHandle: NodeJS.Timeout | undefined;
+      let settleHandle: NodeJS.Timeout | undefined;
+
+      const onAbort = (): void => {
+        cancelled = true;
+        debugLogger.warn(
+          `Hook '${hookId}' cancelled; terminating process group (pid=${child.pid})`,
+        );
+        terminate();
+      };
+
+      const settle = (result: HookExecutionResult): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutHandle);
+        if (sigkillHandle) {
+          clearTimeout(sigkillHandle);
+        }
+        if (settleHandle) {
+          clearTimeout(settleHandle);
+        }
+        signal?.removeEventListener('abort', onAbort);
+        resolve(result);
+      };
+
+      const terminationError = (): Error => {
+        // Include the child's actual exit state so logs can distinguish a
+        // hook that honored SIGTERM from one that had to be SIGKILLed or
+        // never exited at all.
+        const exitState = `exitCode=${child.exitCode}, signalCode=${child.signalCode}`;
+        return cancelled
+          ? new Error(`Hook cancelled (${exitState})`)
+          : new Error(`Hook timed out after ${timeout}ms (${exitState})`);
+      };
+
+      // Escalation path shared by timeout and cancellation: SIGTERM the
+      // tree, SIGKILL survivors after a grace period, then force-settle so
+      // descendants holding the inherited stdio cannot block the promise.
+      const terminate = (): void => {
+        if (settled || sigkillHandle) {
+          return;
+        }
+        killProcessTree('SIGTERM');
+
+        sigkillHandle = setTimeout(() => {
+          if (!hasExited()) {
+            debugLogger.warn(
+              `Hook '${hookId}' did not exit after SIGTERM; sending SIGKILL to process group (pid=${child.pid})`,
+            );
+          }
+          // Always re-signal the group: even if the direct child exited,
+          // descendants may still be running in the same group.
+          killProcessTree('SIGKILL');
+
+          settleHandle = setTimeout(() => {
+            debugLogger.warn(
+              `Hook '${hookId}' stdio still open after SIGKILL (pid=${child.pid}); force-settling without close event`,
+            );
+            // Release our ends of the pipes so no descendant can keep the
+            // event loop or this promise alive.
+            child.stdin?.destroy();
+            child.stdout?.destroy();
+            child.stderr?.destroy();
+            settle({
+              hookConfig,
+              eventName,
+              success: false,
+              error: terminationError(),
+              stdout,
+              stderr,
+              duration: Date.now() - startTime,
+            });
+          }, FORCE_SETTLE_GRACE_PERIOD_MS);
+        }, SIGTERM_GRACE_PERIOD_MS);
+      };
 
       // Set up timeout
       const timeoutHandle = setTimeout(() => {
         timedOut = true;
-        child.kill('SIGTERM');
-
-        // Force kill after 5 seconds
-        setTimeout(() => {
-          if (!child.killed) {
-            child.kill('SIGKILL');
-          }
-        }, 5000);
+        debugLogger.warn(
+          `Hook '${hookId}' timed out after ${timeout}ms; terminating process group (pid=${child.pid})`,
+        );
+        terminate();
       }, timeout);
+
+      signal?.addEventListener('abort', onAbort, { once: true });
 
       // Send input to stdin
       if (child.stdin) {
@@ -303,23 +452,21 @@ export class HookRunner {
 
       // Handle process exit
       child.on('close', (exitCode) => {
-        clearTimeout(timeoutHandle);
         const duration = Date.now() - startTime;
 
         // Forward hook stderr to terminal for visibility
         if (stderr.trim()) {
-          const hookId = hookConfig.name || hookConfig.command || 'unknown';
           debugLogger.info(
             `[Hook Debug] hookRunner: hook '${hookId}' stderr:\n${stderr.trim()}`,
           );
         }
 
-        if (timedOut) {
-          resolve({
+        if (timedOut || cancelled) {
+          settle({
             hookConfig,
             eventName,
             success: false,
-            error: new Error(`Hook timed out after ${timeout}ms`),
+            error: terminationError(),
             stdout,
             stderr,
             duration,
@@ -361,7 +508,7 @@ export class HookRunner {
           }
         }
 
-        resolve({
+        settle({
           hookConfig,
           eventName,
           success: exitCode === EXIT_CODE_SUCCESS,
@@ -375,10 +522,9 @@ export class HookRunner {
 
       // Handle process errors
       child.on('error', (error) => {
-        clearTimeout(timeoutHandle);
         const duration = Date.now() - startTime;
 
-        resolve({
+        settle({
           hookConfig,
           eventName,
           success: false,

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.test.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.test.ts
@@ -191,6 +191,7 @@ describe('HookSystem', () => {
         { command: 'ls' },
         undefined,
         'tool-call-1',
+        undefined,
       );
     });
   });

--- a/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
+++ b/src/copilot-shell/packages/core/src/hooks/hookSystem.ts
@@ -112,6 +112,7 @@ export class HookSystem {
     toolInput: Record<string, unknown>,
     skillContext?: import('./types.js').SkillToolContext,
     toolUseId?: string,
+    signal?: AbortSignal,
   ): Promise<PreToolUseHookOutput | undefined> {
     debugLogger.info(
       `[Hook Debug] hookSystem.firePreToolUseEvent: entering facade, tool=${toolName}`,
@@ -121,6 +122,7 @@ export class HookSystem {
       toolInput,
       skillContext,
       toolUseId,
+      signal,
     );
     const output = result.finalOutput
       ? (createHookOutput(
@@ -185,6 +187,7 @@ export class HookSystem {
     mcpContext?: McpToolContext,
     originalRequestName?: string,
     toolUseId?: string,
+    signal?: AbortSignal,
   ): Promise<PostToolUseHookOutput | undefined> {
     debugLogger.info(
       `[Hook Debug] hookSystem.firePostToolUseEvent: entering facade, tool=${toolName}`,
@@ -196,6 +199,7 @@ export class HookSystem {
       mcpContext,
       originalRequestName,
       toolUseId,
+      signal,
     );
     const output = result.finalOutput
       ? (createHookOutput(


### PR DESCRIPTION
## Description

Hook timeout previously only sent SIGTERM to the direct child process, so
descendants (e.g. `sudo apt-get` spawned by a hook script) survived, were
reparented to PID 1, and kept the inherited stdout/stderr pipes open. Since
the hook promise resolved only on the `close` event, cosh could spin
indefinitely past the configured timeout. The SIGKILL fallback was also dead
code because it checked `child.killed`, which is already true right after
`kill()` is called regardless of whether the process exited.

This PR runs each hook in its own process group on POSIX (`detached: true`),
signals the entire group on timeout/cancellation, verifies real exit state
via `exitCode`/`signalCode`, and adds a bounded settlement path (SIGTERM ->
5s grace -> SIGKILL -> 1s -> destroy pipes and resolve) so a hook always
returns within `timeout + 6s`. The scheduler's `AbortSignal` is now
propagated through `HookSystem` / `HookEventHandler` into `HookRunner` so
Ctrl+C cancellation terminates the hook process tree as well.

## Related Issue

closes #1582

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/copilot-shell`:

    npx vitest run packages/core/src/hooks/ --root packages/core
    npx vitest run packages/core/src/core/coreToolScheduler.test.ts \
      --root packages/core
    npx tsc --noEmit -p packages/core
    npx eslint packages/core/src/hooks packages/core/src/core/coreToolScheduler.ts

- 148 hook tests pass (6 new cases in `hookRunner.test.ts`): process-group
  spawn, SIGKILL escalation when `child.killed` is true but the process is
  alive, force-settle without a `close` event, escalation stops when the
  child exits within the grace period, abort-signal termination, pre-aborted
  signal skips spawn, and direct-child fallback when the group is gone
- 45 coreToolScheduler tests pass; type check, ESLint, and Prettier clean

## Additional Notes

- Process-group semantics are POSIX-only; on Windows the runner falls back
  to signalling the direct child as before.
- `AbortSignal` is wired for PreToolUse/PostToolUse from the tool scheduler.
  Other hook events accept the optional signal but have no caller-side
  cancellation source yet; related follow-ups tracked in #1497 / #1581.