### PR TITLE
fix(tokenless): sync component contract version

### DIFF
--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -6,7 +6,7 @@
 # Installed to: %{_datadir}/anolisa/components/tokenless/component.toml
 [component]
 name = "tokenless"
-version = "0.7.0"
+version = "0.7.1"
 
 [[adapters]]
 framework = "openclaw"


### PR DESCRIPTION
## Description

Synchronizes the checked-in tokenless component contract with the authoritative `Cargo.toml` version (`0.7.1`).

The contract check regenerates `.anolisa/component.toml` from its template and compares it with the tracked file. The stale `0.7.0` value caused every tokenless CI run to fail before formatting, linting, or tests began.

## Related Issue

no-issue: repair a pre-existing generated contract version drift

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] My code follows the project's code style
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
make -C src/tokenless check-component-contract
git diff --check
```

Both commands pass. The contract generation now reproduces the tracked `0.7.1` version.

## Additional Notes

The version drift was introduced when tokenless was bumped to `0.7.1`; this patch intentionally changes only the generated contract file.
