### PR TITLE
fix(cosh-ng): [shell] parse session commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/slash/session.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/session.rs
@@ -1,8 +1,10 @@
+mod command;
 mod panel;
 mod state;
 #[cfg(test)]
 mod tests;
 
+use self::command::{parse_session_command, SessionCommand};
 use self::panel::{
     close_session_panel, core_adapter, partition_protected, redraw_session_panel,
     render_current_session_panel, render_not_ready, render_session_error, render_unavailable,
@@ -27,42 +29,24 @@ pub(crate) fn render_session_command<W: Write>(
     state: &mut InlineState,
     output: &mut W,
 ) -> std::io::Result<bool> {
-    let mut parts = arguments.split_whitespace();
-    match parts.next() {
-        None => open_session_manager(blocks, adapter, state, output),
-        Some("status") if parts.next().is_none() => {
+    match parse_session_command(arguments) {
+        SessionCommand::OpenPicker => open_session_manager(blocks, adapter, state, output),
+        SessionCommand::Status => {
             render_session_status(blocks, adapter, state, output)?;
             Ok(true)
         }
-        Some("list") if parts.next().is_none() => {
+        SessionCommand::List => {
             render_session_list(blocks, adapter, state, output)?;
             Ok(true)
         }
-        Some("resume") => {
-            let Some(session_id) = parts.next() else {
-                return open_session_manager(blocks, adapter, state, output);
-            };
-            if parts.next().is_some() {
-                render_usage(state, output)?;
-                return Ok(true);
-            }
+        SessionCommand::Resume(session_id) => {
             select_session(session_id, blocks, adapter, state, output)?;
             Ok(true)
         }
-        Some("clear") => {
-            let requested = parts.map(ToOwned::to_owned).collect::<Vec<_>>();
-            if requested.is_empty() {
-                render_usage(state, output)?;
-                return Ok(true);
-            }
+        SessionCommand::Clear(requested) => {
             begin_explicit_clear(requested, blocks, adapter, state, output)
         }
-        // `/resume ID` is parsed through the same command family.
-        Some(session_id) if parts.next().is_none() => {
-            select_session(session_id, blocks, adapter, state, output)?;
-            Ok(true)
-        }
-        Some(_) => {
+        SessionCommand::Usage => {
             render_usage(state, output)?;
             Ok(true)
         }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/session/command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/session/command.rs
@@ -1,0 +1,84 @@
+//! Deterministic grammar for session slash-command arguments.
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum SessionCommand<'a> {
+    OpenPicker,
+    Status,
+    List,
+    Resume(&'a str),
+    Clear(Vec<String>),
+    Usage,
+}
+
+pub(super) fn parse_session_command(arguments: &str) -> SessionCommand<'_> {
+    let tokens = arguments.split_whitespace().collect::<Vec<_>>();
+    match tokens.as_slice() {
+        [] | ["resume"] => SessionCommand::OpenPicker,
+        ["status"] => SessionCommand::Status,
+        ["list"] => SessionCommand::List,
+        ["resume", session_id] => SessionCommand::Resume(session_id),
+        ["clear", "--all"] => SessionCommand::Clear(vec!["--all".to_string()]),
+        ["clear", session_ids @ ..]
+            if !session_ids.is_empty() && !session_ids.contains(&"--all") =>
+        {
+            SessionCommand::Clear(
+                session_ids
+                    .iter()
+                    .map(|session_id| (*session_id).to_string())
+                    .collect(),
+            )
+        }
+        [session_id] if is_bare_session_id(session_id) => SessionCommand::Resume(session_id),
+        _ => SessionCommand::Usage,
+    }
+}
+
+fn is_bare_session_id(value: &str) -> bool {
+    !value.starts_with('-') && !matches!(value, "status" | "list" | "resume" | "clear")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_session_command, SessionCommand};
+
+    const SESSION_ID: &str = "00000000-0000-4000-8000-000000000000";
+
+    #[test]
+    fn parses_session_command_grammar_without_fallthrough() {
+        let cases = [
+            ("", SessionCommand::OpenPicker),
+            ("status", SessionCommand::Status),
+            ("list", SessionCommand::List),
+            ("resume", SessionCommand::OpenPicker),
+            (
+                "resume 00000000-0000-4000-8000-000000000000",
+                SessionCommand::Resume(SESSION_ID),
+            ),
+            (
+                "clear 00000000-0000-4000-8000-000000000000 second-id",
+                SessionCommand::Clear(vec![SESSION_ID.to_string(), "second-id".to_string()]),
+            ),
+            (
+                "clear --all",
+                SessionCommand::Clear(vec!["--all".to_string()]),
+            ),
+            (SESSION_ID, SessionCommand::Resume(SESSION_ID)),
+            ("status extra", SessionCommand::Usage),
+            ("list extra", SessionCommand::Usage),
+            ("--all", SessionCommand::Usage),
+            ("clear", SessionCommand::Usage),
+            ("resume status extra", SessionCommand::Usage),
+            ("clear --all extra", SessionCommand::Usage),
+            ("clear first --all", SessionCommand::Usage),
+            ("-reserved", SessionCommand::Usage),
+        ];
+
+        for (arguments, expected) in cases {
+            assert_eq!(
+                parse_session_command(arguments),
+                expected,
+                "unexpected parse for {arguments:?}"
+            );
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/slash/session/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/session/tests.rs
@@ -2,6 +2,58 @@ use super::*;
 use crate::agent::run::{ActiveAgentRun, AgentRunOrigin};
 use crate::evidence::stream::CoshRequestStreamFilter;
 
+const SESSION_ID: &str = "00000000-0000-4000-8000-000000000000";
+const SESSION_USAGE: &str = "Usage: /session [status|list|resume <id>|clear <id>...|clear --all]";
+const SESSION_UNAVAILABLE: &str = "Session recovery requires the cosh-core backend.";
+
+#[test]
+fn malformed_session_commands_render_usage_instead_of_selecting() {
+    for arguments in [
+        "status extra",
+        "list extra",
+        "--all",
+        "resume 00000000-0000-4000-8000-000000000000 extra",
+        "clear",
+        "-reserved",
+    ] {
+        let rendered = render_session_arguments(arguments);
+        assert!(
+            rendered.contains(SESSION_USAGE),
+            "{arguments:?} did not render usage: {rendered}"
+        );
+        assert!(
+            !rendered.contains(SESSION_UNAVAILABLE),
+            "{arguments:?} entered session recovery: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn valid_resume_and_clear_all_keep_session_recovery_routes() {
+    for arguments in [SESSION_ID, "resume 00000000-0000-4000-8000-000000000000"] {
+        let rendered = render_session_arguments(arguments);
+        assert!(
+            rendered.contains(SESSION_UNAVAILABLE),
+            "{arguments:?} did not enter session recovery: {rendered}"
+        );
+        assert!(
+            !rendered.contains(SESSION_USAGE),
+            "{arguments:?} unexpectedly rendered usage: {rendered}"
+        );
+    }
+
+    let rendered = render_session_arguments("clear --all");
+    assert!(rendered.contains(SESSION_UNAVAILABLE), "{rendered}");
+    assert!(!rendered.contains(SESSION_USAGE), "{rendered}");
+}
+
+#[test]
+fn resume_without_id_keeps_picker_contract() {
+    let rendered = render_session_arguments("resume");
+    assert!(rendered.contains(SESSION_UNAVAILABLE), "{rendered}");
+    assert!(!rendered.contains(SESSION_USAGE), "{rendered}");
+}
+
 #[test]
 fn direct_resume_refuses_to_select_while_agent_run_is_active() {
     let adapter = AdapterInstance::CoshCore(CoshCoreAdapter {
@@ -33,6 +85,19 @@ fn direct_resume_refuses_to_select_while_agent_run_is_active() {
         },
         SessionRecoveryState::None
     );
+}
+
+fn render_session_arguments(arguments: &str) -> String {
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState {
+        language: Language::EnUs,
+        ..InlineState::default()
+    };
+    let mut output = Vec::new();
+
+    render_session_command(arguments, &[], &adapter, &mut state, &mut output)
+        .expect("render session command");
+    String::from_utf8(output).expect("UTF-8 session panel")
 }
 
 fn test_active_run() -> ActiveAgentRun {


### PR DESCRIPTION
## Description

Fix `/session status extra` and `/session list extra` incorrectly routing
to session recovery. Session arguments are now parsed into typed commands
by matching complete token slices, avoiding iterator side effects in match
guards. Invalid forms render usage while existing picker, resume, and clear
behavior remains unchanged.

## Related Issue

closes #1621

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove the fix is effective
- [x] For `cosh-ng`: Clippy and formatting checks pass
- [x] Lock files are up to date (unchanged)

## Testing

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --lib` — 820 passed
- `cargo test --package cosh-shell --test logic` — 7 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- `check-layout.sh` — no new violation groups compared with `origin/main`

## Additional Notes

No PTY test was added because the change is isolated to pure argument parsing
and render routing, both directly covered by unit tests.