### PR TITLE
fix(cosh-ng): [cli,platform] allow search patterns

### DIFF
--- a/src/cosh-ng/crates/cosh-cli/src/cmd/pkg.rs
+++ b/src/cosh-ng/crates/cosh-cli/src/cmd/pkg.rs
@@ -4,7 +4,7 @@ use clap::Subcommand;
 
 use cosh_platform::detect::Distro;
 use cosh_platform::pkg;
-use cosh_platform::validate::validate_pkg_name;
+use cosh_platform::validate::{validate_pkg_name, validate_pkg_search_query};
 
 use crate::{build_meta, print_failure, print_success};
 
@@ -60,7 +60,7 @@ pub fn run(action: PkgCommands, distro: &Distro, start: Instant) -> i32 {
             }
         }
         PkgCommands::Search { query } => {
-            if let Err(e) = validate_pkg_name(&query) {
+            if let Err(e) = validate_pkg_search_query(&query) {
                 return print_failure(e, build_meta("pkg", distro, start, false));
             }
             match pkg::pkg_search(distro, &query) {

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -965,6 +965,12 @@ fn test_pkg_search_rejects_shell_metachar() {
 
     assert_eq!(json["ok"], false);
     assert_eq!(json["error"]["code"], "InvalidInput");
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("search query")));
+    assert!(json["error"]["hint"]
+        .as_str()
+        .is_some_and(|hint| hint.contains("Search queries")));
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-platform/src/pkg.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/pkg.rs
@@ -81,7 +81,12 @@ pub fn pkg_install(
     }
 }
 
-/// Execute a package search operation.
+/// Execute a package search operation using the selected backend's pattern semantics.
+///
+/// The query is passed as one argument without shell expansion. CLI callers use
+/// [`crate::validate::validate_pkg_search_query`] to enforce a portable pattern
+/// subset; direct callers are responsible for choosing their validation policy.
+/// DNF glob matching and apt-cache regular-expression matching are not equivalent.
 pub fn pkg_search(distro: &Distro, query: &str) -> Result<PkgSearchResult, CoshError> {
     let mgr = distro.pkg_manager();
     let (cmd, args) = match mgr {
@@ -99,6 +104,12 @@ pub fn pkg_search(distro: &Distro, query: &str) -> Result<PkgSearchResult, CoshE
     };
 
     let output = run_command(Command::new(cmd).args(&args), PKG_TIMEOUT, "pkg")?;
+    check_search_status(
+        cmd,
+        output.status.success(),
+        output.status.code(),
+        &output.stderr,
+    )?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut packages = parse_search_output(&stdout, mgr);
@@ -114,6 +125,33 @@ pub fn pkg_search(distro: &Distro, query: &str) -> Result<PkgSearchResult, CoshE
 
     let total = packages.len();
     Ok(PkgSearchResult { packages, total })
+}
+
+fn check_search_status(
+    cmd: &str,
+    success: bool,
+    status_code: Option<i32>,
+    stderr: &[u8],
+) -> Result<(), CoshError> {
+    if success {
+        return Ok(());
+    }
+
+    let status = status_code.map_or_else(
+        || "terminated without an exit code".to_string(),
+        |code| format!("exit code {code}"),
+    );
+    let stderr = String::from_utf8_lossy(stderr);
+    let detail = stderr.trim();
+    let message = if detail.is_empty() {
+        format!("{cmd} failed to process the search query ({status})")
+    } else {
+        format!("{cmd} failed to process the search query ({status}): {detail}")
+    };
+
+    Err(CoshError::new(ErrorCode::PkgBackendError, message, "pkg")
+        .recoverable(true)
+        .with_hint("Review the search query for the selected package manager's pattern syntax"))
 }
 
 /// List installed packages on the detected distro.
@@ -707,6 +745,33 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.code, ErrorCode::UnsupportedDistro);
+    }
+
+    #[test]
+    fn test_pkg_search_backend_failure_is_propagated() {
+        let err = check_search_status(
+            "apt-cache",
+            false,
+            Some(100),
+            b"Regex compilation error - Invalid regular expression",
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::PkgBackendError);
+        assert!(err.recoverable);
+        assert!(err.message.contains("apt-cache"));
+        assert!(err.message.contains("search query"));
+        assert!(err.message.contains("exit code 100"));
+        assert!(err.message.contains("Regex compilation error"));
+        assert!(err
+            .hint
+            .as_deref()
+            .is_some_and(|hint| hint.contains("search query")));
+    }
+
+    #[test]
+    fn test_pkg_search_backend_success_ignores_stderr() {
+        assert!(check_search_status("dnf", true, Some(0), b"warning").is_ok());
     }
 
     // --- pkg_remove with unsupported distro ---

--- a/src/cosh-ng/crates/cosh-platform/src/validate.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/validate.rs
@@ -29,6 +29,48 @@ pub fn validate_pkg_name(name: &str) -> Result<(), CoshError> {
     Ok(())
 }
 
+/// Validate a package search query before forwarding it as a backend argument.
+///
+/// Accepts a portable subset of package-search syntax: package-name characters
+/// plus `*`, `?`, `[`, and `]`. This CLI safety boundary does not expose each
+/// backend's full syntax; apt-cache anchors such as `^...$` and Homebrew
+/// `/regex/` queries are intentionally rejected.
+pub fn validate_pkg_search_query(query: &str) -> Result<(), CoshError> {
+    if query.is_empty() {
+        return Err(CoshError::new(
+            ErrorCode::InvalidInput,
+            "Search query cannot be empty",
+            "pkg",
+        ));
+    }
+    if query.len() > 256 {
+        return Err(CoshError::new(
+            ErrorCode::InvalidInput,
+            "Search query too long (max 256 characters)",
+            "pkg",
+        ));
+    }
+    if query.starts_with('-') {
+        return Err(CoshError::new(
+            ErrorCode::InvalidInput,
+            "Search query cannot start with '-'",
+            "pkg",
+        )
+        .with_hint("Start the search query with a package-name character or a pattern"));
+    }
+    if let Some(c) = query.chars().find(|c| !is_valid_pkg_search_char(*c)) {
+        return Err(CoshError::new(
+            ErrorCode::InvalidInput,
+            format!("Invalid character {c:?} in search query"),
+            "pkg",
+        )
+        .with_hint(
+            "Search queries use the portable pattern subset: a-z A-Z 0-9 . _ + - : * ? [ ]",
+        ));
+    }
+    Ok(())
+}
+
 /// Validate a service name. Allows `[a-zA-Z0-9._@:-]`.
 pub fn validate_svc_name(name: &str) -> Result<(), CoshError> {
     if name.is_empty() {
@@ -58,6 +100,10 @@ pub fn validate_svc_name(name: &str) -> Result<(), CoshError> {
 
 fn is_valid_pkg_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '+' | '-' | ':')
+}
+
+fn is_valid_pkg_search_char(c: char) -> bool {
+    is_valid_pkg_char(c) || matches!(c, '*' | '?' | '[' | ']')
 }
 
 fn is_valid_svc_char(c: char) -> bool {
@@ -94,6 +140,71 @@ mod tests {
         let long_name = "a".repeat(257);
         let err = validate_pkg_name(&long_name).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidInput);
+    }
+
+    #[test]
+    fn test_valid_pkg_search_queries() {
+        assert!(validate_pkg_search_query("nginx*").is_ok());
+        assert!(validate_pkg_search_query("python3-?").is_ok());
+        assert!(validate_pkg_search_query("lib[0-9]*").is_ok());
+    }
+
+    #[test]
+    fn test_invalid_pkg_search_queries() {
+        for query in [
+            "",
+            "pkg\nname",
+            "pkg\rname",
+            "pkg\tname",
+            "pkg;cmd",
+            "pkg|cmd",
+            "pkg&cmd",
+            "pkg$VAR",
+            "pkg`cmd`",
+            "pkg$(cmd)",
+            "pkg>file",
+            "pkg<input",
+            "pkg(cmd)",
+            "pkg{cmd}",
+        ] {
+            assert!(
+                validate_pkg_search_query(query).is_err(),
+                "query should be rejected: {query:?}"
+            );
+        }
+
+        let err = validate_pkg_search_query("pkg|cmd").unwrap_err();
+        assert!(err.message.contains("search query"));
+        assert!(!err.message.contains("package name"));
+        assert!(err
+            .hint
+            .as_deref()
+            .is_some_and(|hint| hint.contains("Search queries")));
+    }
+
+    #[test]
+    fn test_pkg_search_query_rejects_backend_specific_regex_syntax() {
+        for query in ["^nginx$", "/nginx.*/"] {
+            assert!(
+                validate_pkg_search_query(query).is_err(),
+                "backend-specific query should be rejected: {query:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pkg_search_query_too_long() {
+        let long_query = "a".repeat(257);
+        let err = validate_pkg_search_query(&long_query).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidInput);
+        assert!(err.message.contains("Search query"));
+    }
+
+    #[test]
+    fn test_pkg_search_query_rejects_leading_option() {
+        let err = validate_pkg_search_query("-nginx").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidInput);
+        assert!(err.message.contains("Search query"));
     }
 
     #[test]


### PR DESCRIPTION
# fix(cosh-ng): [cli,platform] allow search patterns

## Description

`pkg search` previously reused package-name validation, causing wildcard
queries to be rejected. This change adds query-specific validation for a
portable pattern subset (`*`, `?`, and `[]`) while rejecting unsafe input
and option injection. Queries remain single command arguments, and backend
pattern errors are reported as recoverable failures.

## Related Issue

closes #1625

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] I have updated the documentation accordingly
- [x] For `cosh-ng`: Clippy and formatting checks pass
- [x] Lock files are up to date

## Testing

- `cargo fmt --all -- --check`
- `cargo test --package cosh-platform pkg_search`
- `cargo test --package cosh-platform validate`
- `cargo test --package cosh-cli --test cli_integration pkg_search`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `git diff --check`

Manually verified successful searches for `nginx*` and `python3-?`.
Also verified that an invalid apt-cache regex returns a recoverable
`PkgBackendError` instead of an empty successful result.

## Additional Notes

The CLI intentionally exposes only the portable `*`, `?`, and `[]`
pattern subset. DNF and apt-cache interpret that subset according to their own
glob and regular-expression semantics. Full apt-cache expressions such as
`^nginx$` and Homebrew `/regex/` syntax remain outside the CLI contract.
Queries are passed as one argument without invoking a shell.