### PR TITLE
fix(cosh-ng): [shell] preserve signal exits

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 use std::io::{IsTerminal, Write};
+use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 use std::time::Duration;
 
 use crate::diagnostics::health::{
@@ -284,7 +285,7 @@ pub(crate) fn passthrough_non_interactive(args: &[String]) -> Option<i32> {
         let status = Command::new(command)
             .args(&args[3..])
             .status()
-            .map(|s| s.code().unwrap_or(1))
+            .map(passthrough_exit_code)
             .unwrap_or_else(|err| {
                 let command = crate::evidence::redact_sensitive_text(command).0;
                 let err = crate::evidence::redact_sensitive_text(&err.to_string()).0;
@@ -300,7 +301,7 @@ pub(crate) fn passthrough_non_interactive(args: &[String]) -> Option<i32> {
         let status = Command::new(&shell)
             .args(&pass_args)
             .status()
-            .map(|s| s.code().unwrap_or(1))
+            .map(passthrough_exit_code)
             .unwrap_or_else(|err| {
                 eprintln!("cosh-shell: exec {shell} failed: {err}");
                 126
@@ -315,7 +316,7 @@ pub(crate) fn passthrough_non_interactive(args: &[String]) -> Option<i32> {
             .args(&pass_args)
             .stdin(Stdio::inherit())
             .status()
-            .map(|s| s.code().unwrap_or(1))
+            .map(passthrough_exit_code)
             .unwrap_or_else(|err| {
                 eprintln!("cosh-shell: exec {shell} failed: {err}");
                 126
@@ -324,6 +325,13 @@ pub(crate) fn passthrough_non_interactive(args: &[String]) -> Option<i32> {
     }
 
     None
+}
+
+fn passthrough_exit_code(status: ExitStatus) -> i32 {
+    status
+        .code()
+        .or_else(|| status.signal().map(|signal| 128 + signal))
+        .unwrap_or(1)
 }
 
 pub(crate) fn passthrough_raw_non_interactive(args: &[String]) -> Option<i32> {

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
@@ -47,6 +47,54 @@ fn raw_cli_double_dash_passthrough_preserves_exit_status() {
 }
 
 #[test]
+fn raw_cli_double_dash_passthrough_preserves_signal_exit_status() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+
+    for (signal, expected) in [("INT", 130), ("TERM", 143), ("KILL", 137)] {
+        let command = format!("kill -{signal} $$");
+        let output = raw_cli_command(binary)
+            .args(["--", "sh", "-c", command.as_str()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("run direct command terminated by signal");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.code(),
+            Some(expected),
+            "signal={signal}\nstdout={stdout}\nstderr={stderr}"
+        );
+    }
+}
+
+#[test]
+fn raw_cli_double_dash_passthrough_preserves_start_failure_status() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .args(["--", "/definitely/not/a/cosh-shell-command"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run missing direct command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(126),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains("exec /definitely/not/a/cosh-shell-command failed"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[test]
 fn raw_cli_double_dash_passthrough_does_not_capture_child_help_arg() {
     let binary = env!("CARGO_BIN_EXE_cosh-shell");
     let output = raw_cli_command(binary)
@@ -117,6 +165,30 @@ fn raw_cli_dash_c_passthrough_preserves_exit_status() {
         !stdout.contains("Thinking..."),
         "stdout={stdout}\nstderr={stderr}"
     );
+}
+
+#[test]
+fn raw_cli_dash_c_passthrough_preserves_signal_exit_status() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+
+    for (signal, expected) in [("INT", 130), ("TERM", 143), ("KILL", 137)] {
+        let command = format!("kill -{signal} $$");
+        let output = raw_cli_command(binary)
+            .args(["-c", command.as_str()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("run dash-c command terminated by signal");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.code(),
+            Some(expected),
+            "signal={signal}\nstdout={stdout}\nstderr={stderr}"
+        );
+    }
 }
 
 #[test]
@@ -236,6 +308,34 @@ fn raw_cli_stdin_passthrough_preserves_exit_status() {
         !stdout.contains("Thinking..."),
         "stdout={stdout}\nstderr={stderr}"
     );
+}
+
+#[test]
+fn raw_cli_stdin_passthrough_preserves_signal_exit_status() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+
+    for (signal, expected) in [("INT", 130), ("TERM", 143), ("KILL", 137)] {
+        let mut child = raw_cli_command(binary)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn stdin passthrough");
+
+        {
+            let mut stdin = child.stdin.take().expect("child stdin");
+            writeln!(stdin, "kill -{signal} $$").expect("write stdin command terminated by signal");
+        }
+
+        let output = child.wait_with_output().expect("wait stdin passthrough");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.code(),
+            Some(expected),
+            "signal={signal}\nstdout={stdout}\nstderr={stderr}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Description

Preserve Unix signal termination status in all non-interactive cosh-shell
passthrough paths. Previously, `ExitStatus::code()` returned `None` for a
signal-terminated child and every signal was collapsed to exit code 1.

The shared conversion now returns normal exit codes unchanged, maps Unix
signals to `128 + signal`, and keeps 1 only as the unclassified fallback.
This lets CI runners and process supervisors distinguish signal termination
from an ordinary command failure.

## Related Issue

closes #1622

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test --package cosh-shell --test raw_cli passthrough::`
  - 21 passed
- `cargo test --package cosh-shell --lib`
  - 820 passed
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The raw CLI tests cover `--`, `-c`, and stdin passthrough for SIGINT,
SIGTERM, and SIGKILL. They also preserve ordinary nonzero exits and verify
that command startup failures return 126.

## Additional Notes

The existing cosh-shell layout audit still reports registered repository
debt for large production files and source-heavy tests. This change does not
add a new violation group.
