### PR TITLE
fix(cosh-ng): [cli] align audit contracts

### DIFF
--- a/src/cosh-ng/crates/cosh-cli/src/cmd/audit.rs
+++ b/src/cosh-ng/crates/cosh-cli/src/cmd/audit.rs
@@ -207,62 +207,8 @@ fn run_check(args: CheckArgs, distro: &Distro, start: Instant) -> i32 {
         }
         BuiltAction::ParseDeny { error, raw } => {
             let (loaded, load_warning) = LoadedPolicy::load();
-
-            // If parse failed due to shell metacharacters, try evaluating each segment
-            if matches!(
-                error,
-                ParseError::ContainsShellMeta(_) | ParseError::ContainsControlByte
-            ) {
-                let segments = split_compound_command(&raw);
-
-                // Evaluate each segment and look for a real Deny decision
-                for segment in segments {
-                    if let Ok(mut action) = parse_action_string(&segment) {
-                        let decision = audit::evaluate(&action, &loaded);
-                        if decision.outcome == Outcome::Deny && decision.matched_rule.is_some() {
-                            // Preserve original compound command in audit log
-                            action.raw = Some(raw.clone());
-                            match audit::record_decision(action, &decision, LogSource::Cli) {
-                                Ok(()) => {
-                                    return print_success(
-                                        decision,
-                                        meta_with_optional_warning(
-                                            distro,
-                                            start,
-                                            load_warning.as_deref(),
-                                        ),
-                                    )
-                                }
-                                Err(mut e) => {
-                                    if let Ok(v) = serde_json::to_value(&decision) {
-                                        e = e.with_details(json!({ "decision": v }));
-                                    }
-                                    return print_failure(
-                                        e,
-                                        build_meta("audit", distro, start, false),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Fall back to synthetic Deny
-            let decision = Decision {
-                outcome: Outcome::Deny,
-                reason: format!("parse failed: {}", error),
-                matched_rule: None,
-                policy_version: loaded.policy_version.clone(),
-            };
-            let synthetic = Action {
-                subsystem: ActionSubsystem::Other("unparsed".to_string()),
-                operation: "<unparsed>".to_string(),
-                target: None,
-                args: vec![],
-                raw: Some(raw),
-            };
-            match audit::record_decision(synthetic, &decision, LogSource::Cli) {
+            let (action, decision) = parse_failure_denial(raw, error, &loaded);
+            match audit::record_decision(action, &decision, LogSource::Cli) {
                 Ok(()) => print_success(
                     decision,
                     meta_with_optional_warning(distro, start, load_warning.as_deref()),
@@ -341,11 +287,7 @@ fn filter_log_entries(
         entries.retain(|e| e.timestamp >= cutoff);
     }
     if let Some(limit) = args.limit {
-        if entries.len() > limit {
-            // Keep most recent.
-            let drop = entries.len() - limit;
-            entries.drain(..drop);
-        }
+        entries = entries.into_iter().rev().take(limit).collect();
     }
     Ok(entries)
 }
@@ -497,70 +439,14 @@ fn run_policy_validate(path: PathBuf, distro: &Distro, start: Instant) -> i32 {
 fn run_policy_explain(action_str: String, distro: &Distro, start: Instant) -> i32 {
     let action = match parse_action_string(&action_str) {
         Ok(a) => a,
-        Err(e) => match e {
-            ParseError::Empty => {
-                return print_failure(
-                    CoshError::new(
-                        ErrorCode::AuditActionMalformed,
-                        "empty action string",
-                        "audit",
-                    ),
-                    build_meta("audit", distro, start, false),
-                );
-            }
-            other => {
-                let (loaded, load_warning) = LoadedPolicy::load();
-
-                // Same as run_check: if parse failed due to shell metacharacters,
-                // try evaluating each segment to find a real Deny decision.
-                if matches!(
-                    other,
-                    ParseError::ContainsShellMeta(_) | ParseError::ContainsControlByte
-                ) {
-                    let segments = split_compound_command(&action_str);
-
-                    for segment in segments {
-                        if let Ok(mut action) = parse_action_string(&segment) {
-                            let decision = audit::evaluate(&action, &loaded);
-                            if decision.outcome == Outcome::Deny && decision.matched_rule.is_some()
-                            {
-                                action.raw = Some(action_str.clone());
-                                return print_success(
-                                    PolicyExplainResult { action, decision },
-                                    meta_with_optional_warning(
-                                        distro,
-                                        start,
-                                        load_warning.as_deref(),
-                                    ),
-                                );
-                            }
-                        }
-                    }
-                }
-
-                // Fall back to synthetic Deny
-                let decision = Decision {
-                    outcome: Outcome::Deny,
-                    reason: format!("parse failed: {}", other),
-                    matched_rule: None,
-                    policy_version: loaded.policy_version.clone(),
-                };
-                let synth = Action {
-                    subsystem: ActionSubsystem::Other("unparsed".to_string()),
-                    operation: "<unparsed>".to_string(),
-                    target: None,
-                    args: vec![],
-                    raw: Some(action_str),
-                };
-                return print_success(
-                    PolicyExplainResult {
-                        action: synth,
-                        decision,
-                    },
-                    meta_with_optional_warning(distro, start, load_warning.as_deref()),
-                );
-            }
-        },
+        Err(error) => {
+            let (loaded, load_warning) = LoadedPolicy::load();
+            let (action, decision) = parse_failure_denial(action_str, error, &loaded);
+            return print_success(
+                PolicyExplainResult { action, decision },
+                meta_with_optional_warning(distro, start, load_warning.as_deref()),
+            );
+        }
     };
     let (loaded, load_warning) = LoadedPolicy::load();
     let decision = audit::evaluate(&action, &loaded);
@@ -574,6 +460,42 @@ fn run_policy_explain(action_str: String, distro: &Distro, start: Instant) -> i3
 // Shared helpers
 // ===========================================================================
 
+fn parse_failure_denial(
+    raw: String,
+    error: ParseError,
+    loaded: &LoadedPolicy,
+) -> (Action, Decision) {
+    if matches!(
+        error,
+        ParseError::ContainsShellMeta(_) | ParseError::ContainsControlByte
+    ) {
+        for segment in split_compound_command(&raw) {
+            if let Ok(mut action) = parse_action_string(&segment) {
+                let decision = audit::evaluate(&action, loaded);
+                if decision.outcome == Outcome::Deny && decision.matched_rule.is_some() {
+                    action.raw = Some(raw);
+                    return (action, decision);
+                }
+            }
+        }
+    }
+
+    let action = Action {
+        subsystem: ActionSubsystem::Other("unparsed".to_string()),
+        operation: "<unparsed>".to_string(),
+        target: None,
+        args: vec![],
+        raw: Some(raw),
+    };
+    let decision = Decision {
+        outcome: Outcome::Deny,
+        reason: format!("parse failed: {error}"),
+        matched_rule: None,
+        policy_version: loaded.policy_version.clone(),
+    };
+    (action, decision)
+}
+
 fn meta_with_optional_warning(
     distro: &Distro,
     start: Instant,
@@ -582,5 +504,28 @@ fn meta_with_optional_warning(
     match warning {
         Some(w) => build_meta_with_warning("audit", distro, start, false, w),
         None => build_meta("audit", distro, start, false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_tokens_parse_failure_uses_synthetic_denial() {
+        let loaded = audit::builtin::balanced();
+        let raw = " \t".to_string();
+        let (action, decision) = parse_failure_denial(raw.clone(), ParseError::NoTokens, &loaded);
+
+        assert_eq!(
+            action.subsystem,
+            ActionSubsystem::Other("unparsed".to_string())
+        );
+        assert_eq!(action.operation, "<unparsed>");
+        assert_eq!(action.raw, Some(raw));
+        assert_eq!(decision.outcome, Outcome::Deny);
+        assert_eq!(decision.reason, "parse failed: no tokens after split");
+        assert_eq!(decision.matched_rule, None);
+        assert_eq!(decision.policy_version, loaded.policy_version);
     }
 }

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -7,7 +7,7 @@
 //! - Error handling when daemon is unavailable
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
 /// Get the path to the compiled cosh-cli binary.
 fn cosh_bin() -> Command {
@@ -22,15 +22,110 @@ fn systemctl_query_available() -> bool {
         .unwrap_or(false)
 }
 
-/// Spawn `cosh-cli` with audit env vars pinned to a sandbox: log redirected to
-/// `audit_log` and any external `COSH_AUDIT_POLICY` cleared so the built-in
-/// `balanced` preset is used. Use this for any test that exercises the
-/// audit subsystem so it doesn't pollute the user's real audit log.
+/// Spawn `cosh-cli` with audit state pinned to a sandbox: redirect the log,
+/// isolate user policy discovery, and clear any explicit policy override.
+/// Use this for audit tests so they neither read nor write the user's state.
 fn cosh_bin_with_audit_sandbox(audit_log: &Path) -> Command {
     let mut cmd = cosh_bin();
     cmd.env("COSH_AUDIT_LOG", audit_log);
+    if let Some(sandbox_home) = audit_log.parent() {
+        cmd.env("HOME", sandbox_home);
+    }
     cmd.env_remove("COSH_AUDIT_POLICY");
     cmd
+}
+
+fn assert_json_object_keys(value: &serde_json::Value, expected: &[&str]) {
+    let mut actual: Vec<&str> = value
+        .as_object()
+        .expect("expected JSON object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    actual.sort_unstable();
+    let mut expected = expected.to_vec();
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
+}
+
+fn assert_audit_success(output: &Output) -> serde_json::Value {
+    assert_eq!(output.status.code(), Some(0));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_json_object_keys(&json, &["ok", "data", "meta"]);
+    assert_eq!(json["ok"], true);
+    assert!(json["data"].is_object());
+
+    let meta = &json["meta"];
+    assert_json_object_keys(meta, &["subsystem", "duration_ms", "distro", "dry_run"]);
+    assert_eq!(meta["subsystem"], "audit");
+    assert!(meta["duration_ms"].is_u64());
+    assert!(meta["distro"].is_string());
+    assert_eq!(meta["dry_run"], false);
+    json
+}
+
+fn assert_audit_failure(output: &Output) -> serde_json::Value {
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_json_object_keys(&json, &["ok", "error", "meta"]);
+    assert_eq!(json["ok"], false);
+    assert_json_object_keys(
+        &json["error"],
+        &[
+            "code",
+            "message",
+            "recoverable",
+            "hint",
+            "subsystem",
+            "details",
+        ],
+    );
+
+    let meta = &json["meta"];
+    assert_json_object_keys(meta, &["subsystem", "duration_ms", "distro", "dry_run"]);
+    assert_eq!(meta["subsystem"], "audit");
+    assert!(meta["duration_ms"].is_u64());
+    assert!(meta["distro"].is_string());
+    assert_eq!(meta["dry_run"], false);
+    json
+}
+
+fn record_audit_marker(audit_log: &Path, session: &str, marker: &str) {
+    let raw = format!("echo {marker}");
+    let output = cosh_bin_with_audit_sandbox(audit_log)
+        .env("COSH_SESSION_ID", session)
+        .args(["audit", "check", "--action", &raw])
+        .output()
+        .unwrap();
+    let json = assert_audit_success(&output);
+    assert_json_object_keys(
+        &json["data"],
+        &["outcome", "reason", "matched_rule", "policy_version"],
+    );
+}
+
+fn assert_audit_log_raws(audit_log: &Path, args: &[&str], expected: &[&str]) {
+    let output = cosh_bin_with_audit_sandbox(audit_log)
+        .args(["audit", "log"])
+        .args(args)
+        .output()
+        .unwrap();
+    let json = assert_audit_success(&output);
+    assert_json_object_keys(&json["data"], &["entries", "total"]);
+    assert_eq!(json["data"]["total"], expected.len());
+    let raws: Vec<&str> = json["data"]["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["action"]["raw"].as_str().unwrap())
+        .collect();
+    assert_eq!(raws, expected);
+}
+
+fn audit_log_line_count(audit_log: &Path) -> usize {
+    std::fs::read_to_string(audit_log)
+        .map(|contents| contents.lines().count())
+        .unwrap_or(0)
 }
 
 // --- Help / Version ---
@@ -191,17 +286,27 @@ fn test_audit_check_pkg_search_is_allow() {
 
 #[test]
 fn test_audit_check_missing_required_flags_is_403() {
-    // Neither --action-string nor --subsystem given → AuditActionMalformed.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("audit.log");
-    let output = cosh_bin_with_audit_sandbox(&log)
-        .args(["audit", "check"])
-        .output()
-        .unwrap();
-    assert_eq!(output.status.code(), Some(1));
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["ok"], false);
-    assert_eq!(json["error"]["code"], "AuditActionMalformed");
+    let cases: &[&[&str]] = &[
+        &["audit", "check"],
+        &["audit", "check", "--operation", "search"],
+        &["audit", "check", "--subsystem", "pkg"],
+    ];
+
+    for args in cases {
+        let output = cosh_bin_with_audit_sandbox(&log)
+            .args(*args)
+            .output()
+            .unwrap();
+        let json = assert_audit_failure(&output);
+        assert_eq!(json["error"]["code"], "AuditActionMalformed");
+        assert_eq!(json["error"]["recoverable"], false);
+        assert_eq!(json["error"]["subsystem"], "audit");
+        assert!(json["error"]["message"].is_string());
+        assert!(json["error"]["hint"].is_string());
+        assert!(json["error"]["details"].is_null());
+    }
 }
 
 // --- audit log: envelope ---
@@ -245,6 +350,44 @@ fn test_audit_log_starts_empty_and_grows_with_check() {
     let entries = json["data"]["entries"].as_array().unwrap();
     assert_eq!(entries[0]["action"]["operation"], "search");
     assert_eq!(entries[0]["decision"]["outcome"], "Allow");
+}
+
+#[test]
+fn test_audit_log_limit_is_newest_first_for_all_sizes() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("audit.log");
+    record_audit_marker(&log, "selected", "alpha");
+    record_audit_marker(&log, "excluded", "beta");
+    record_audit_marker(&log, "selected", "gamma");
+
+    assert_audit_log_raws(&log, &[], &["echo alpha", "echo beta", "echo gamma"]);
+    assert_audit_log_raws(&log, &["--limit", "2"], &["echo gamma", "echo beta"]);
+    assert_audit_log_raws(&log, &["--limit", "0"], &[]);
+    assert_audit_log_raws(
+        &log,
+        &["--limit", "3"],
+        &["echo gamma", "echo beta", "echo alpha"],
+    );
+    assert_audit_log_raws(
+        &log,
+        &["--limit", "4"],
+        &["echo gamma", "echo beta", "echo alpha"],
+    );
+}
+
+#[test]
+fn test_audit_log_applies_filters_before_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("audit.log");
+    record_audit_marker(&log, "selected", "alpha");
+    record_audit_marker(&log, "excluded", "beta");
+    record_audit_marker(&log, "selected", "gamma");
+
+    assert_audit_log_raws(
+        &log,
+        &["--session", "selected", "--limit", "2"],
+        &["echo gamma", "echo alpha"],
+    );
 }
 
 // --- audit policy ---
@@ -361,6 +504,60 @@ fn test_audit_policy_explain_returns_match_decision() {
         json["data"]["decision"]["matched_rule"],
         "shell-deny-git-mutating"
     );
+}
+
+#[test]
+fn test_audit_policy_explain_matches_check_for_parse_errors_without_logging() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("audit.log");
+    let cases = [
+        ("", "parse failed: empty action string"),
+        (
+            "echo alpha; echo beta",
+            "parse failed: contains shell metacharacter ';'",
+        ),
+        (
+            "echo alpha\necho beta",
+            "parse failed: contains control byte (\\n or \\r)",
+        ),
+    ];
+
+    for (action, expected_reason) in cases {
+        let before_check = audit_log_line_count(&log);
+        let check_output = cosh_bin_with_audit_sandbox(&log)
+            .args(["audit", "check", "--action", action])
+            .output()
+            .unwrap();
+        let check = assert_audit_success(&check_output);
+        let check_decision = &check["data"];
+        assert_json_object_keys(check_decision, &["outcome", "reason", "policy_version"]);
+        assert_eq!(check_decision["outcome"], "Deny");
+        assert_eq!(check_decision["reason"], expected_reason);
+        assert!(check_decision.get("matched_rule").is_none());
+        assert!(check_decision["policy_version"]
+            .as_str()
+            .unwrap()
+            .starts_with("builtin-balanced@"));
+        assert_eq!(audit_log_line_count(&log), before_check + 1);
+
+        let before_explain = audit_log_line_count(&log);
+        let explain_output = cosh_bin_with_audit_sandbox(&log)
+            .args(["audit", "policy", "explain", action])
+            .output()
+            .unwrap();
+        let explain = assert_audit_success(&explain_output);
+        assert_json_object_keys(&explain["data"], &["action", "decision"]);
+        assert_eq!(explain["data"]["decision"], *check_decision);
+        assert_eq!(
+            explain["data"]["action"],
+            serde_json::json!({
+                "subsystem": "unparsed",
+                "operation": "<unparsed>",
+                "raw": action,
+            })
+        );
+        assert_eq!(audit_log_line_count(&log), before_explain);
+    }
 }
 
 // --- 17+ bypass regressions migrated from cosh-core::is_safe_command ---


### PR DESCRIPTION
## Description

Fix two audit CLI contract mismatches. Limited log queries now apply all
filters before returning the newest entries in newest-first order, including
when the limit is zero or at least the total entry count. Policy explain now
uses the same synthetic denial as audit check for every action parse failure,
while preserving check logging and explain preview-only behavior.

## Related Issue

closes #1623
closes #1624

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --manifest-path src/cosh-ng/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src/cosh-ng/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path src/cosh-ng/Cargo.toml --workspace`
- `cargo build --manifest-path src/cosh-ng/Cargo.toml --workspace --release`

The full workspace test run passed, including 57 cosh-cli integration tests,
335 raw CLI tests (1 ignored), and 43 shell-host tests (1 ignored).

## Additional Notes

No documentation, audit policy, dependency, or lock-file changes are included.
