### PR TITLE
fix(cosh-ng): [shell] reject quoted slash args

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -41,6 +41,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashUnknownBody => "Unknown slash command: {command}",
         MessageId::SlashUnknownSuggestionBody => "Did you mean {command}?",
         MessageId::SlashUnknownFooter => "Use /help to see available commands.",
+        MessageId::SlashQuotedArgumentsUnsupported => {
+            "Quoted arguments are not supported. Use /mode approval trust confirm instead."
+        }
         MessageId::SlashInfoAuditTitle => "Audit",
         MessageId::SlashInfoAuditApprovalsBody => {
             "Approval decisions are available with Details actions."

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -41,6 +41,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashUnknownBody => "Unknown slash command: {command}",
         MessageId::SlashUnknownSuggestionBody => "Did you mean {command}?",
         MessageId::SlashUnknownFooter => "Use /help to see available commands.",
+        MessageId::SlashInvalidArgumentsTitle => "Invalid slash arguments",
         MessageId::SlashQuotedArgumentsUnsupported => {
             "Quoted arguments are not supported. Use /mode approval trust confirm instead."
         }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -78,4 +78,5 @@ collect_message_ids!([
     help_registry_ids,
     session_compaction_ids,
     compaction_queue_ids,
+    slash_parse_error_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -36,6 +36,7 @@ macro_rules! help_core_ids {
             SlashUnknownBody,
             SlashUnknownSuggestionBody,
             SlashUnknownFooter,
+            SlashQuotedArgumentsUnsupported,
             SlashInfoAuditTitle,
             SlashInfoAuditApprovalsBody,
             SlashInfoAuditActivityBody,

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -36,7 +36,6 @@ macro_rules! help_core_ids {
             SlashUnknownBody,
             SlashUnknownSuggestionBody,
             SlashUnknownFooter,
-            SlashQuotedArgumentsUnsupported,
             SlashInfoAuditTitle,
             SlashInfoAuditApprovalsBody,
             SlashInfoAuditActivityBody,
@@ -80,6 +79,17 @@ macro_rules! help_registry_ids {
             SlashHooksAgentUnavailable,
             SlashExtensionsEmptyBody,
             SlashSkillsEmptyBody,
+        );
+    };
+}
+
+macro_rules! slash_parse_error_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            SlashInvalidArgumentsTitle,
+            SlashQuotedArgumentsUnsupported,
         );
     };
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -109,6 +109,9 @@ mod tests {
         for (ordinal, id) in MessageId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, ordinal);
         }
+        assert_eq!(MessageId::AgentControlQueueFullBody as usize, 750);
+        assert_eq!(MessageId::SlashInvalidArgumentsTitle as usize, 751);
+        assert_eq!(MessageId::SlashQuotedArgumentsUnsupported as usize, 752);
     }
 
     #[test]
@@ -155,11 +158,19 @@ mod tests {
     fn quoted_argument_error_is_localized() {
         let en = I18n::new(Language::EnUs);
         assert_eq!(
+            en.t(MessageId::SlashInvalidArgumentsTitle),
+            "Invalid slash arguments"
+        );
+        assert_eq!(
             en.t(MessageId::SlashQuotedArgumentsUnsupported),
             "Quoted arguments are not supported. Use /mode approval trust confirm instead."
         );
 
         let zh = I18n::new(Language::ZhCn);
+        assert_eq!(
+            zh.t(MessageId::SlashInvalidArgumentsTitle),
+            "Slash 参数错误"
+        );
         assert_eq!(
             zh.t(MessageId::SlashQuotedArgumentsUnsupported),
             "不支持带引号的参数。本例请改用 /mode approval trust confirm。"

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -150,4 +150,19 @@ mod tests {
             "已自动批准"
         );
     }
+
+    #[test]
+    fn quoted_argument_error_is_localized() {
+        let en = I18n::new(Language::EnUs);
+        assert_eq!(
+            en.t(MessageId::SlashQuotedArgumentsUnsupported),
+            "Quoted arguments are not supported. Use /mode approval trust confirm instead."
+        );
+
+        let zh = I18n::new(Language::ZhCn);
+        assert_eq!(
+            zh.t(MessageId::SlashQuotedArgumentsUnsupported),
+            "不支持带引号的参数。本例请改用 /mode approval trust confirm。"
+        );
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -37,6 +37,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashUnknownBody => "未知 slash 命令: {command}",
         MessageId::SlashUnknownSuggestionBody => "你是不是想用 {command}？",
         MessageId::SlashUnknownFooter => "使用 /help 查看可用命令。",
+        MessageId::SlashInvalidArgumentsTitle => "Slash 参数错误",
         MessageId::SlashQuotedArgumentsUnsupported => {
             "不支持带引号的参数。本例请改用 /mode approval trust confirm。"
         }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -37,6 +37,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::SlashUnknownBody => "未知 slash 命令: {command}",
         MessageId::SlashUnknownSuggestionBody => "你是不是想用 {command}？",
         MessageId::SlashUnknownFooter => "使用 /help 查看可用命令。",
+        MessageId::SlashQuotedArgumentsUnsupported => {
+            "不支持带引号的参数。本例请改用 /mode approval trust confirm。"
+        }
         MessageId::SlashInfoAuditTitle => "审计",
         MessageId::SlashInfoAuditApprovalsBody => "审批决策可通过 Details 操作查看。",
         MessageId::SlashInfoAuditActivityBody => "活动 output ref 可通过 Details 操作查看。",

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -1,6 +1,26 @@
 use crate::runtime::prelude::*;
 use crate::slash::panel::render_notice_panel;
-use crate::slash::parser::{slash_command_hints, RemovedCommand, SlashInfoCommand};
+use crate::slash::parser::{
+    slash_command_hints, RemovedCommand, SlashInfoCommand, SlashParseError,
+};
+
+pub(super) fn render_slash_parse_error<W: Write>(
+    error: SlashParseError,
+    state: &InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let i18n = state.i18n();
+    match error {
+        SlashParseError::QuotedArgumentsUnsupported => render_notice_panel(
+            output,
+            i18n.t(MessageId::SlashUnknownTitle),
+            vec![i18n
+                .t(MessageId::SlashQuotedArgumentsUnsupported)
+                .to_string()],
+            None,
+        ),
+    }
+}
 
 pub(super) fn render_removed_command<W: Write>(
     command: RemovedCommand<'_>,

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -13,7 +13,7 @@ pub(super) fn render_slash_parse_error<W: Write>(
     match error {
         SlashParseError::QuotedArgumentsUnsupported => render_notice_panel(
             output,
-            i18n.t(MessageId::SlashUnknownTitle),
+            i18n.t(MessageId::SlashInvalidArgumentsTitle),
             vec![i18n
                 .t(MessageId::SlashQuotedArgumentsUnsupported)
                 .to_string()],

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -126,6 +126,7 @@ fn parser_owned_command(token: &str) -> bool {
             | "/audit"
             | "/config"
             | "/debug"
+            | "/health"
             | "/extensions"
             | "/skills"
             | "/session"
@@ -204,6 +205,7 @@ mod tests {
             "/mode approval \"trust confirm\"",
             "/mode approval 'trust confirm'",
             "/config language \"en US\"",
+            "/health \"quick\"",
             "/recommendations \"on\"",
         ] {
             assert!(

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -31,11 +31,23 @@ pub(super) enum SlashCommand<'a> {
     Recommendations(Option<&'a str>, Option<&'a str>, Option<&'a str>),
 }
 
+/// Explains why a parser-owned slash command could not be decoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SlashParseError {
+    /// Single- and double-quoted arguments are intentionally unsupported.
+    QuotedArgumentsUnsupported,
+}
+
 impl<'a> SlashCommand<'a> {
-    pub(super) fn parse(input: &'a str) -> Option<Self> {
+    pub(super) fn parse(input: &'a str) -> Result<Option<Self>, SlashParseError> {
         let mut parts = input.split_whitespace();
-        let token = parts.next()?;
-        match token {
+        let Some(token) = parts.next() else {
+            return Ok(None);
+        };
+        if parser_owned_command(token) && input.contains(['\'', '"']) {
+            return Err(SlashParseError::QuotedArgumentsUnsupported);
+        }
+        Ok(match token {
             "/help" => Some(Self::Help),
             "/auth" => Some(Self::Auth),
             "/hooks" => {
@@ -95,8 +107,32 @@ impl<'a> SlashCommand<'a> {
                 }
             }
             _ => None,
-        }
+        })
     }
+}
+
+fn parser_owned_command(token: &str) -> bool {
+    matches!(
+        token,
+        "/help"
+            | "/auth"
+            | "/hooks"
+            | "/mode"
+            | "/approval-mode"
+            | "/allow"
+            | "/approve"
+            | "/deny"
+            | "/answer"
+            | "/audit"
+            | "/config"
+            | "/debug"
+            | "/extensions"
+            | "/skills"
+            | "/session"
+            | "/resume"
+            | "/recommendations"
+            | "/"
+    )
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -119,13 +155,13 @@ pub(super) fn slash_command_hints(prefix: &str) -> Vec<&'static SlashCommandSpec
 
 #[cfg(test)]
 mod tests {
-    use super::{RemovedCommand, SlashCommand, SlashCommandSpec};
+    use super::{RemovedCommand, SlashCommand, SlashCommandSpec, SlashParseError};
 
     #[test]
     fn removed_decision_commands_parse_as_removed_not_unknown() {
         for command in ["/allow 1", "/approve 1", "/deny 1"] {
             match SlashCommand::parse(command) {
-                Some(SlashCommand::Removed(RemovedCommand::ApprovalDecision(token))) => {
+                Ok(Some(SlashCommand::Removed(RemovedCommand::ApprovalDecision(token)))) => {
                     assert_eq!(token, command.split_whitespace().next().unwrap());
                 }
                 _ => panic!("{command} did not parse as removed approval decision"),
@@ -133,7 +169,7 @@ mod tests {
         }
 
         match SlashCommand::parse("/answer yes") {
-            Some(SlashCommand::Removed(RemovedCommand::QuestionAnswer)) => {}
+            Ok(Some(SlashCommand::Removed(RemovedCommand::QuestionAnswer))) => {}
             _ => panic!("/answer did not parse as removed question answer"),
         }
     }
@@ -141,11 +177,11 @@ mod tests {
     #[test]
     fn session_commands_and_resume_alias_share_parser_path() {
         match SlashCommand::parse("/session resume abc") {
-            Some(SlashCommand::Session(arguments)) => assert_eq!(arguments, "resume abc"),
+            Ok(Some(SlashCommand::Session(arguments))) => assert_eq!(arguments, "resume abc"),
             _ => panic!("/session did not parse as a session command"),
         }
         match SlashCommand::parse("/resume abc") {
-            Some(SlashCommand::Session(arguments)) => assert_eq!(arguments, "abc"),
+            Ok(Some(SlashCommand::Session(arguments))) => assert_eq!(arguments, "abc"),
             _ => panic!("/resume did not parse as a session command"),
         }
     }
@@ -153,13 +189,47 @@ mod tests {
     #[test]
     fn recommendations_preserves_subcommand_and_rejectable_extra_arguments() {
         match SlashCommand::parse("/recommendations on unexpected extra") {
-            Some(SlashCommand::Recommendations(sub, arg, extra)) => {
+            Ok(Some(SlashCommand::Recommendations(sub, arg, extra))) => {
                 assert_eq!(sub, Some("on"));
                 assert_eq!(arg, Some("unexpected"));
                 assert_eq!(extra, Some("extra"));
             }
             _ => panic!("recommendations command did not parse"),
         }
+    }
+
+    #[test]
+    fn quoted_arguments_are_rejected_for_parser_owned_commands() {
+        for command in [
+            "/mode approval \"trust confirm\"",
+            "/mode approval 'trust confirm'",
+            "/config language \"en US\"",
+            "/recommendations \"on\"",
+        ] {
+            assert!(
+                matches!(
+                    SlashCommand::parse(command),
+                    Err(SlashParseError::QuotedArgumentsUnsupported)
+                ),
+                "{command}"
+            );
+        }
+    }
+
+    #[test]
+    fn unquoted_arguments_keep_the_existing_token_contract() {
+        match SlashCommand::parse("/mode approval trust confirm") {
+            Ok(Some(SlashCommand::Mode(Some("approval"), Some("trust"), Some("confirm")))) => {}
+            _ => panic!("unquoted trust confirmation did not parse"),
+        }
+    }
+
+    #[test]
+    fn shell_commands_with_quotes_are_not_slash_parse_errors() {
+        assert!(matches!(
+            SlashCommand::parse("printf '\"hello world\"\\n'"),
+            Ok(None)
+        ));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
@@ -2,6 +2,7 @@ use crate::runtime::mode::render_mode_card_actions;
 use crate::runtime::prelude::*;
 use crate::slash::commands::render_slash_command;
 use crate::slash::config::render_config_card_actions;
+use crate::slash::notices::render_slash_parse_error;
 use crate::slash::parser::{slash_input, SlashCommand};
 use crate::slash::prompt::{clear_shell_prompt_line, write_shell_prompt};
 use crate::slash::session::{render_session_card_actions, render_session_launch};
@@ -24,8 +25,10 @@ pub(crate) fn render_slash_actions<W: Write>(
         let Some(input) = slash_input(event) else {
             continue;
         };
-        let Some(command) = SlashCommand::parse(input) else {
-            continue;
+        let parsed = match SlashCommand::parse(input) {
+            Ok(Some(command)) => Ok(command),
+            Ok(None) => continue,
+            Err(error) => Err(error),
         };
 
         let key = stable_event_key("slash", event_index, event);
@@ -34,15 +37,21 @@ pub(crate) fn render_slash_actions<W: Write>(
         }
 
         clear_shell_prompt_line(output)?;
-        let restore_prompt = render_slash_command(
-            command,
-            event,
-            blocks,
-            adapter,
-            state,
-            event.cwd.as_deref(),
-            output,
-        )?;
+        let restore_prompt = match parsed {
+            Ok(command) => render_slash_command(
+                command,
+                event,
+                blocks,
+                adapter,
+                state,
+                event.cwd.as_deref(),
+                output,
+            )?,
+            Err(error) => {
+                render_slash_parse_error(error, state, output)?;
+                true
+            }
+        };
         if restore_prompt {
             write_shell_prompt(state, output)?;
         }

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
@@ -121,14 +121,15 @@ fn raw_cli_mode_rejects_quoted_arguments_without_changing_mode() {
         "/mode approval \"trust confirm\"\n\
          /mode approval 'trust confirm'\n\
          /config language \"en US\"\n\
-         printf '\"hello world\"\\n'\n\
+         /health \"quick\"\n\
+         printf 'quoted-shell-output:%s\\n' '\"hello world\"'\n\
          /help\n\
          exit\n",
     );
 
     assert_eq!(
         count_occurrences(&output, "Quoted arguments are not supported."),
-        3,
+        4,
         "{output}"
     );
     assert!(
@@ -139,7 +140,10 @@ fn raw_cli_mode_rejects_quoted_arguments_without_changing_mode() {
     assert!(!output.contains("Invalid language"), "{output}");
     assert!(!output.contains("Mode set to trust."), "{output}");
     assert!(output.contains("Mode: auto. Strategy: smart."), "{output}");
-    assert!(output.contains("\r\n\"hello world\"\r\n"), "{output}");
+    assert!(
+        output.contains("quoted-shell-output:\"hello world\""),
+        "{output}"
+    );
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
@@ -115,6 +115,52 @@ fn raw_cli_pasted_trust_confirm_sets_trust_mode() {
 }
 
 #[test]
+fn raw_cli_mode_rejects_quoted_arguments_without_changing_mode() {
+    let output = run_raw_cli_with_input(
+        "fake",
+        "/mode approval \"trust confirm\"\n\
+         /mode approval 'trust confirm'\n\
+         /config language \"en US\"\n\
+         printf '\"hello world\"\\n'\n\
+         /help\n\
+         exit\n",
+    );
+
+    assert_eq!(
+        count_occurrences(&output, "Quoted arguments are not supported."),
+        3,
+        "{output}"
+    );
+    assert!(
+        output.contains("Use /mode approval trust confirm instead."),
+        "{output}"
+    );
+    assert!(!output.contains("Unknown approval mode"), "{output}");
+    assert!(!output.contains("Invalid language"), "{output}");
+    assert!(!output.contains("Mode set to trust."), "{output}");
+    assert!(output.contains("Mode: auto. Strategy: smart."), "{output}");
+    assert!(output.contains("\r\n\"hello world\"\r\n"), "{output}");
+}
+
+#[test]
+fn raw_cli_mode_quoted_argument_error_uses_zh_language_env() {
+    let output = run_raw_cli_with_env(
+        "fake",
+        "/mode approval 'trust confirm'\n/help\nexit\n",
+        &[("COSH_SHELL_LANG", "zh-CN")],
+    );
+
+    assert!(output.contains("不支持带引号的参数。"), "{output}");
+    assert!(
+        output.contains("本例请改用 /mode approval trust confirm。"),
+        "{output}"
+    );
+    assert!(!output.contains("未知审批模式"), "{output}");
+    assert!(!output.contains("模式已设置为 trust。"), "{output}");
+    assert!(output.contains("模式: auto. 策略: smart."), "{output}");
+}
+
+#[test]
 fn raw_cli_help_and_mode_use_zh_language_env() {
     let output = run_raw_cli_with_env(
         "fake",


### PR DESCRIPTION
## Description

The slash parser now distinguishes non-slash, valid slash, and malformed slash
input through a typed result. Parser-owned commands reject single- and
double-quoted arguments before reaching their handlers, preventing quoted trust
confirmation from being silently reshaped into incorrect tokens.

The rejection guidance is localized through the shared `MessageId` catalog.
Existing fixed-width command arity and ordinary shell quoting remain unchanged.

## Related Issue

closes #1626

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] For `cosh-ng`: clippy and formatting checks pass
- [x] Lock files are up to date

## Testing

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --lib` — 821 passed
- `cargo test --package cosh-shell --bin cosh-shell slash::parser::tests` — 6 passed
- `cargo test --package cosh-shell --test raw_cli mode -- --nocapture` — 37 passed
- `cargo test --package cosh-shell --test logic` — 7 passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

## Additional Notes

`check-layout.sh` continues to report the existing large-file and
source-heavy-test violation groups. Centralizing the new catalog key brings
`message_id.rs` and `message_id_all.rs` to the 700-line threshold.