### PR TITLE
fix(cosh-ng): [build] respect cargo config

### DIFF
--- a/src/cosh-ng/.cargo/config.toml
+++ b/src/cosh-ng/.cargo/config.toml
@@ -1,8 +1,2 @@
-[source.crates-io]
-replace-with = 'mirror'
-
-[source.mirror]
-registry = "sparse+https://mirrors.aliyun.com/crates.io-index/"
-
 [net]
 git-fetch-with-cli = true


### PR DESCRIPTION
## Description

Remove cosh-ng's project-level crates.io source replacement while retaining
`git-fetch-with-cli`. Cargo now respects the registry policy selected by the
user or CI environment instead of defining a second alias for the same mirror
URL and failing during configuration merge.

## Related Issue

Part of #1644

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] Existing build validation covers the configuration change
- [ ] Documentation update required
- [x] Lock files are unchanged

## Testing

Run from `src/cosh-ng` while `~/.cargo/config.toml` replaces crates.io
with an Aliyun source named `aliyun`:

```bash
cargo metadata --no-deps --format-version 1
cargo check --workspace
```

Both commands pass. Before this change, Cargo fails before dependency
resolution because the project source named `mirror` and the user source
named `aliyun` resolve to the same registry URL.

## Additional Notes

The build-all integration requested by #1644 is intentionally handled in a
separate PR.