### PR TITLE
fix(sec-core): reject stale CLI wheels

### DIFF
--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -111,6 +111,16 @@ test: test-python test-rust test-openclaw-plugin ## Run all tests
 # Build output directory — all artifacts are collected here after build.
 # Override from outside: make build-all BUILD_DIR=/path/to/output
 BUILD_DIR ?= target
+CLI_WHEEL_BUILD_DIR ?= agent-sec-cli/target/wheels
+CLI_WHEEL_PATTERN := agent_sec_cli-*.whl
+
+define require_single_cli_wheel
+set -- "$(1)"/$(CLI_WHEEL_PATTERN); \
+if [ "$$#" -ne 1 ] || [ ! -f "$$1" ]; then \
+	echo "ERROR: expected exactly one agent-sec-cli wheel in $(1)" >&2; \
+	exit 1; \
+fi;
+endef
 
 .PHONY: build-sandbox
 build-sandbox: ## Build linux-sandbox binary
@@ -120,10 +130,13 @@ build-sandbox: ## Build linux-sandbox binary
 
 .PHONY: build-cli
 build-cli: ## Build agent-sec-cli wheel with maturin (Rust + Python)
+	rm -f $(CLI_WHEEL_BUILD_DIR)/$(CLI_WHEEL_PATTERN)
+	install -d -m 0755 $(BUILD_DIR)/wheels
+	rm -f $(BUILD_DIR)/wheels/$(CLI_WHEEL_PATTERN)
 	cd agent-sec-cli && uv sync --only-group dev --no-install-project && \
 		uv run --no-sync maturin build --release -i python3.11 --manylinux off
-	install -d -m 0755 $(BUILD_DIR)/wheels
-	cp -p agent-sec-cli/target/wheels/*.whl $(BUILD_DIR)/wheels/
+	@$(call require_single_cli_wheel,$(CLI_WHEEL_BUILD_DIR)) \
+		cp -p "$$1" $(BUILD_DIR)/wheels/
 
 .PHONY: setup
 setup: ## Install all dependencies (including dev), create .venv
@@ -272,7 +285,8 @@ install: install-all ## Install all components (alias for install-all)
 
 .PHONY: install-cli
 install-cli: ## Install agent-sec-cli wheel (for dev/debug)
-	pip3 install $(BUILD_DIR)/wheels/agent_sec_cli-*.whl
+	@$(call require_single_cli_wheel,$(BUILD_DIR)/wheels) \
+		pip3 install "$$1"
 
 .PHONY: install-cli-site
 install-cli-site: ## RPM: Copy staged site-packages to private dir + wrappers
@@ -300,8 +314,8 @@ endif
 	@echo "Installing dependencies from uv.lock ..."
 	cd agent-sec-cli && UV_PROJECT_ENVIRONMENT=$(VENV_DIR) uv sync --frozen --no-dev --no-install-project
 	@echo "Installing agent-sec-cli wheel ..."
-	uv pip install --python $(VENV_DIR)/bin/python --no-deps \
-		$(BUILD_DIR)/wheels/agent_sec_cli-*.whl
+	@$(call require_single_cli_wheel,$(BUILD_DIR)/wheels) \
+		uv pip install --python $(VENV_DIR)/bin/python --no-deps "$$1"
 	@echo "Creating symlink ..."
 	install -d -m 0755 $(BINDIR)
 	ln -sf $(VENV_DIR)/bin/agent-sec-cli $(BINDIR)/agent-sec-cli

--- a/src/agent-sec-core/tests/unit-test/test_makefile_wheels.py
+++ b/src/agent-sec-core/tests/unit-test/test_makefile_wheels.py
@@ -1,0 +1,129 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+COMPONENT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def create_sandbox(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
+    sandbox = tmp_path / "agent-sec-core"
+    fake_bin = sandbox / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    (sandbox / "agent-sec-cli").mkdir()
+    shutil.copy2(COMPONENT_ROOT / "Makefile", sandbox / "Makefile")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    return sandbox, fake_bin, env
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def run_make(
+    sandbox: Path,
+    env: dict[str, str],
+    target: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["make", target, "BUILD_DIR=build"],
+        cwd=sandbox,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def install_fake_pip(fake_bin: Path, env: dict[str, str], marker: Path) -> None:
+    env["PIP_MARKER"] = str(marker)
+    write_executable(
+        fake_bin / "pip3",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "%s\\n" "$@" > "$PIP_MARKER"\n',
+    )
+
+
+def test_build_cli_replaces_stale_source_and_staged_wheels(tmp_path: Path) -> None:
+    sandbox, fake_bin, env = create_sandbox(tmp_path)
+    source_wheels = sandbox / "agent-sec-cli/target/wheels"
+    staged_wheels = sandbox / "build/wheels"
+    source_wheels.mkdir(parents=True)
+    staged_wheels.mkdir(parents=True)
+
+    stale_name = "agent_sec_cli-0.7.1-cp311-cp311-linux_aarch64.whl"
+    current_name = "agent_sec_cli-0.8.0-cp311-cp311-linux_aarch64.whl"
+    (source_wheels / stale_name).touch()
+    (staged_wheels / stale_name).touch()
+
+    write_executable(
+        fake_bin / "uv",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [[ ${1:-} == run ]]; then\n"
+        "    mkdir -p target/wheels\n"
+        f"    touch target/wheels/{current_name}\n"
+        "fi\n",
+    )
+
+    result = run_make(sandbox, env, "build-cli")
+
+    assert result.returncode == 0, result.stderr
+    assert [path.name for path in source_wheels.glob("agent_sec_cli-*.whl")] == [
+        current_name
+    ]
+    assert [path.name for path in staged_wheels.glob("agent_sec_cli-*.whl")] == [
+        current_name
+    ]
+
+
+def test_install_cli_passes_the_only_project_wheel_to_pip(tmp_path: Path) -> None:
+    sandbox, fake_bin, env = create_sandbox(tmp_path)
+    staged_wheels = sandbox / "build/wheels"
+    marker = sandbox / "pip-args"
+    staged_wheels.mkdir(parents=True)
+    wheel = staged_wheels / "agent_sec_cli-0.8.0-cp311-cp311-linux_aarch64.whl"
+    wheel.touch()
+    (staged_wheels / "dependency-1.0.0-py3-none-any.whl").touch()
+    install_fake_pip(fake_bin, env, marker)
+
+    result = run_make(sandbox, env, "install-cli")
+
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text(encoding="utf-8").splitlines() == [
+        "install",
+        str(wheel.relative_to(sandbox)),
+    ]
+
+
+def test_install_cli_rejects_missing_project_wheel(tmp_path: Path) -> None:
+    sandbox, fake_bin, env = create_sandbox(tmp_path)
+    marker = sandbox / "pip-called"
+    (sandbox / "build/wheels").mkdir(parents=True)
+    install_fake_pip(fake_bin, env, marker)
+
+    result = run_make(sandbox, env, "install-cli")
+
+    assert result.returncode != 0
+    assert "expected exactly one agent-sec-cli wheel" in result.stderr
+    assert not marker.exists()
+
+
+def test_install_cli_rejects_conflicting_project_wheels(tmp_path: Path) -> None:
+    sandbox, fake_bin, env = create_sandbox(tmp_path)
+    staged_wheels = sandbox / "build/wheels"
+    marker = sandbox / "pip-called"
+    staged_wheels.mkdir(parents=True)
+    (staged_wheels / "agent_sec_cli-0.7.1-cp311-cp311-linux_aarch64.whl").touch()
+    (staged_wheels / "agent_sec_cli-0.8.0-cp311-cp311-linux_aarch64.whl").touch()
+    install_fake_pip(fake_bin, env, marker)
+
+    result = run_make(sandbox, env, "install-cli")
+
+    assert result.returncode != 0
+    assert "expected exactly one agent-sec-cli wheel" in result.stderr
+    assert not marker.exists()


### PR DESCRIPTION
## Description

Prevent stale `agent-sec-cli` wheels from leaking across versioned source builds. The Makefile now clears old project wheels before invoking maturin, clears stale staged project wheels, and uses a reusable in-Makefile shell guard that requires exactly one wheel before copying or installing it. Keeping the guard inside the Makefile avoids adding another file dependency to source and RPM packaging.

## Related Issue

closes #1650

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [x] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `sec-core` (Python): Ruff/Black checks and targeted pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make -n build-cli BUILD_DIR=/tmp/sec-core-build`
- `make -n install-cli BUILD_DIR=/tmp/sec-core-build`
- `make -n install-cli-venv BUILD_DIR=/tmp/sec-core-build INSTALL_PROFILE=user ...`
- `uv run --project agent-sec-cli ruff check --config agent-sec-cli/pyproject.toml tests/unit-test/test_makefile_wheels.py`
- `uv run --project agent-sec-cli black --check tests/unit-test/test_makefile_wheels.py`
- `uv run --project agent-sec-cli pytest tests/unit-test/test_makefile_wheels.py -v` — 4 passed
- Real aarch64 maturin build with stale `0.7.1` wheels pre-seeded in both source and staging directories
- Real `install-cli-venv` installation into an isolated temporary venv; installed only `agent-sec-cli 0.8.0`

## Additional Notes

The regression tests execute the real Makefile with isolated fake tool binaries. They cover stale source/staging cleanup, successful single-wheel installation, and short-circuiting before `pip3` when the project wheel is missing or conflicting.