### PR TITLE
fix(cosh-ng): [core] emit tool selection errors

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -30,29 +30,6 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
         }
     };
 
-    let stdin = BufReader::new(tokio::io::stdin());
-    let mut lines = stdin.lines();
-
-    // --- Auth check: if no API key, request auth from Shell ---
-    let mut buffered_lines: Vec<String> = Vec::new();
-    let provider = if crate::needs_auth(&config) {
-        match request_auth(&mut config, &mut lines, &mut writer, &mut buffered_lines).await {
-            Some(p) => p,
-            None => {
-                // Auth failed/cancelled, use mock provider
-                Box::new(crate::provider::mock::MockProvider::text_only(
-                    "Authentication required. Please configure API key via environment variable or config.toml.",
-                )) as Box<dyn crate::provider::ContentGenerator>
-            }
-        }
-    } else {
-        crate::create_provider(&config)
-    };
-
-    let resolved = config.resolve_provider();
-    let extra_params = resolved.extra_params.clone();
-    session.finalize_model(&resolved.model, args.model.is_some());
-
     // --- Extension Manager setup ---
     let project_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     let mut ext_manager = ExtensionManager::new(project_root.clone());
@@ -79,8 +56,44 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
     }
     crate::tool::mcp::register_configured_tools(&mut tools, &config.mcp.servers).await;
     if let Some(selection) = args.tools.as_deref() {
-        tools.retain_selected_tools(selection)?;
+        if let Err(error) = tools.retain_selected_tools(selection) {
+            let message = OutputMessage::result_error_with_code(
+                session.record.session_id.as_str(),
+                &error,
+                Some("InvalidToolSelection"),
+            );
+            if let Ok(json) = serde_json::to_string(&message) {
+                let _ = writeln!(writer, "{json}");
+                let _ = writer.flush();
+            }
+            eprintln!("[cosh-core] {error}");
+            return Ok(2);
+        }
     }
+
+    let stdin = BufReader::new(tokio::io::stdin());
+    let mut lines = stdin.lines();
+
+    // --- Auth check: if no API key, request auth from Shell ---
+    let mut buffered_lines: Vec<String> = Vec::new();
+    let provider = if crate::needs_auth(&config) {
+        match request_auth(&mut config, &mut lines, &mut writer, &mut buffered_lines).await {
+            Some(p) => p,
+            None => {
+                // Auth failed/cancelled, use mock provider
+                Box::new(crate::provider::mock::MockProvider::text_only(
+                    "Authentication required. Please configure API key via environment variable or config.toml.",
+                )) as Box<dyn crate::provider::ContentGenerator>
+            }
+        }
+    } else {
+        crate::create_provider(&config)
+    };
+
+    let resolved = config.resolve_provider();
+    let extra_params = resolved.extra_params.clone();
+    session.finalize_model(&resolved.model, args.model.is_some());
+
     let mut engine = CoshCore::new(config, provider, tools);
     engine.extra_params = extra_params;
     engine.session_id = session.record.session_id.to_string();

--- a/src/cosh-ng/crates/cosh-core/tests/cli_tools.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/cli_tools.rs
@@ -1,4 +1,9 @@
-use std::process::{Command, Stdio};
+use std::fs;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
 
 fn run_with_tools(selection: &str) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_cosh-core"))
@@ -8,13 +13,80 @@ fn run_with_tools(selection: &str) -> std::process::Output {
         .expect("run cosh-core")
 }
 
-#[test]
-fn unknown_tools_exit_nonzero() {
-    let output = run_with_tools("missing_tool");
+fn wait_for_output(mut child: Child, timeout: Duration) -> std::process::Output {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if child.try_wait().expect("poll cosh-core").is_some() {
+            return child.wait_with_output().expect("collect cosh-core output");
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let output = child.wait_with_output().expect("collect timed out output");
+            panic!(
+                "cosh-core did not exit before auth timeout\nstdout={}\nstderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
 
-    assert!(!output.status.success(), "status={:?}", output.status);
+fn run_invalid_tools_without_credentials(selection: &str) -> std::process::Output {
+    let home = tempfile::tempdir().expect("temp home");
+    let child = Command::new(env!("CARGO_BIN_EXE_cosh-core"))
+        .args(["--headless", "--bare", "--tools", selection])
+        .env("HOME", home.path())
+        .env("COSH_AI_PROVIDER", "cli-tools-no-auth")
+        .env_remove("OPENAI_BASE_URL")
+        .env_remove("DASHSCOPE_API_KEY")
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ALIBABA_CLOUD_ACCESS_KEY_ID")
+        .env_remove("ALIBABA_CLOUD_ACCESS_KEY_SECRET")
+        .env_remove("ALIBABA_CLOUD_SECURITY_TOKEN")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cosh-core");
+
+    wait_for_output(child, Duration::from_secs(5))
+}
+
+#[test]
+fn unknown_tools_fail_before_authentication() {
+    let output = run_invalid_tools_without_credentials("shell,unknown_tool");
+
+    assert_eq!(output.status.code(), Some(2), "status={:?}", output.status);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let messages = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("valid JSONL output"))
+        .collect::<Vec<_>>();
+    assert!(!messages.is_empty(), "stdout must contain JSONL output");
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("unknown tools: missing_tool"),
+        messages
+            .iter()
+            .all(|message| message["type"] != "control_request"),
+        "tool selection must fail before authentication: {stdout}"
+    );
+
+    let error = messages
+        .iter()
+        .find(|message| {
+            message["type"] == "result"
+                && message["subtype"] == "error"
+                && message["is_error"] == true
+        })
+        .expect("tool selection error result");
+    assert_eq!(error["errors"][0], "unknown tools: unknown_tool");
+    assert_eq!(error["error_code"], "InvalidToolSelection");
+    assert!(error["session_id"].is_string());
+
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown tools: unknown_tool"),
         "stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
@@ -28,6 +100,74 @@ fn empty_tools_remain_valid() {
         output.status.success(),
         "status={:?}\nstderr={}",
         output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn configured_mcp_tool_selection_remains_valid() {
+    let home = tempfile::tempdir().expect("temp home");
+    let config_dir = home.path().join(".copilot-shell");
+    fs::create_dir_all(&config_dir).expect("create config directory");
+
+    let server = home.path().join("fake-mcp.sh");
+    fs::write(
+        &server,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}}}}\n' "$id"
+      ;;
+    *'"method":"tools/list"'*)
+      id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"echo","inputSchema":{"type":"object"}}]}}\n' "$id"
+      ;;
+  esac
+done
+"#,
+    )
+    .expect("write fake MCP server");
+
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            r#"[ai]
+active_provider = "mock"
+
+[ai.providers.mock]
+type = "mock"
+
+[mcp.servers.fake]
+command = "sh"
+args = ["{}"]
+startup_timeout_ms = 1000
+"#,
+            server.display()
+        ),
+    )
+    .expect("write cosh-core config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cosh-core"))
+        .args(["--headless", "--bare", "--tools", "mcp__fake__echo"])
+        .env("HOME", home.path())
+        .env("COSH_STATES_DIR", home.path().join("states"))
+        .env_remove("COSH_AI_PROVIDER")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run cosh-core with configured MCP tool");
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("unknown tools"),
+        "stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
 }


### PR DESCRIPTION
## Description

Validate headless `--tools` selections before the authentication handshake and emit a structured `InvalidToolSelection` result for unknown tool names. This preserves exit status 2 and the existing stderr diagnostic while giving JSONL consumers a terminal protocol error. The regression test isolates credentials and keeps stdin open to prove invalid selections cannot be hidden behind the authentication timeout.

## Related Issue

closes #1652

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --package cosh-core --test cli_tools`
- `cargo test --package cosh-core --test jsonl_protocol`

The no-credential regression keeps stdin open and verifies that the process exits with status 2 without emitting an `auth_required` control request.

## Additional Notes

No protocol schema or dependency changes are included.
