### PR TITLE
fix(cosh-ng): [shell] resolve prompt ghost ESC

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
@@ -27,7 +27,6 @@ pub enum PromptGhostRoute {
     AgentSelection {
         candidates: Vec<PromptGhostCandidate>,
         active: usize,
-        pending_escape: Vec<u8>,
     },
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -91,37 +91,6 @@ pub(super) fn relay_prompt_ghost_input(
     route: &PromptGhostRoute,
     relay: &mut InputRelayContext<'_>,
 ) -> io::Result<bool> {
-    if let PromptGhostRoute::AgentSelection {
-        candidates,
-        active,
-        pending_escape,
-    } = route
-    {
-        if !pending_escape.is_empty() {
-            let mut combined = pending_escape.clone();
-            combined.extend_from_slice(bytes);
-            let resumed = PromptGhostRoute::AgentSelection {
-                candidates: candidates.clone(),
-                active: *active,
-                pending_escape: Vec::new(),
-            };
-            return relay_prompt_ghost_input(&combined, ghost_text, &resumed, relay);
-        }
-        if b"\x1b[Z".starts_with(bytes) && bytes.len() < 3 {
-            let paused = PromptGhostRoute::AgentSelection {
-                candidates: candidates.clone(),
-                active: *active,
-                pending_escape: bytes.to_vec(),
-            };
-            if let Ok(mut mode) = relay.input_mode.lock() {
-                *mode = RawInputMode::PromptGhost {
-                    text: ghost_text.to_string(),
-                    route: paused,
-                };
-            }
-            return Ok(true);
-        }
-    }
     if bytes.starts_with(b"\x1b[Z") {
         if let PromptGhostRoute::AgentSelection {
             candidates, active, ..
@@ -133,7 +102,6 @@ pub(super) fn relay_prompt_ghost_input(
                 let next_route = PromptGhostRoute::AgentSelection {
                     candidates: candidates.clone(),
                     active: next,
-                    pending_escape: Vec::new(),
                 };
                 if let Ok(mut mode) = relay.input_mode.lock() {
                     *mode = RawInputMode::PromptGhost {
@@ -241,6 +209,13 @@ pub(super) fn relay_prompt_ghost_input(
         }
         return Ok(true);
     }
+    dismiss_prompt_ghost_input(bytes, relay)
+}
+
+pub(super) fn dismiss_prompt_ghost_input(
+    bytes: &[u8],
+    relay: &mut InputRelayContext<'_>,
+) -> io::Result<bool> {
     if let Ok(mut mode) = relay.input_mode.lock() {
         *mode = RawInputMode::Passthrough;
     }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -1,7 +1,11 @@
 use std::fs::{self, OpenOptions};
+use std::io::{self, Read};
 use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
-use super::super::PromptGhostCandidate;
+use super::super::spawn::{finish_input_relay, relay_input_bytes, RawInputRelayState};
+use super::super::{PromptGhostCandidate, RawRelayAction};
 use super::*;
 
 fn output_file(label: &str) -> (std::path::PathBuf, File) {
@@ -17,6 +21,600 @@ fn output_file(label: &str) -> (std::path::PathBuf, File) {
         .open(&path)
         .expect("test output file");
     (path, file)
+}
+
+fn selection_input_mode() -> Arc<Mutex<RawInputMode>> {
+    let candidates = vec![
+        PromptGhostCandidate {
+            text: "inspect memory".to_string(),
+            suggestion_id: "health-1".to_string(),
+        },
+        PromptGhostCandidate {
+            text: "continue deployment".to_string(),
+            suggestion_id: "personal-1".to_string(),
+        },
+    ];
+    Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: candidates[0].text.clone(),
+        route: PromptGhostRoute::AgentSelection {
+            candidates,
+            active: 0,
+        },
+    }))
+}
+
+fn expect_prompt_ghost_dismissal(receiver: &mpsc::Receiver<RawInputEvent>) {
+    for _ in 0..2 {
+        if receiver
+            .recv_timeout(Duration::from_millis(250))
+            .expect("prompt ghost dismissal event")
+            == RawInputEvent::PromptGhostDismissed
+        {
+            return;
+        }
+    }
+    panic!("missing prompt ghost dismissal event");
+}
+
+struct ChannelReader {
+    receiver: mpsc::Receiver<Vec<u8>>,
+    pending: Vec<u8>,
+}
+
+impl Read for ChannelReader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        while self.pending.is_empty() {
+            match self.receiver.recv() {
+                Ok(bytes) => self.pending = bytes,
+                Err(_) => return Ok(0),
+            }
+        }
+        let count = buffer.len().min(self.pending.len());
+        buffer[..count].copy_from_slice(&self.pending[..count]);
+        self.pending.drain(..count);
+        Ok(count)
+    }
+}
+
+struct SelectionRelay {
+    path: std::path::PathBuf,
+    master: File,
+    input_tx: Option<mpsc::Sender<Vec<u8>>>,
+    event_rx: mpsc::Receiver<RawInputEvent>,
+    input_mode: Arc<Mutex<RawInputMode>>,
+    relay: thread::JoinHandle<io::Result<()>>,
+}
+
+impl SelectionRelay {
+    fn start(label: &str) -> Self {
+        let (path, master) = output_file(label);
+        let (input_tx, input_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let input_mode = selection_input_mode();
+        let relay = super::super::spawn_raw_input_relay(
+            ChannelReader {
+                receiver: input_rx,
+                pending: Vec::new(),
+            },
+            master.try_clone().expect("clone output file"),
+            event_tx,
+            InputClassifier::default(),
+            input_mode.clone(),
+        );
+        Self {
+            path,
+            master,
+            input_tx: Some(input_tx),
+            event_rx,
+            input_mode,
+            relay,
+        }
+    }
+
+    fn send(&self, bytes: &[u8]) {
+        self.input_tx
+            .as_ref()
+            .expect("input sender")
+            .send(bytes.to_vec())
+            .expect("send input");
+    }
+
+    fn finish(mut self) -> (Vec<RawInputEvent>, Vec<u8>, RawInputMode) {
+        self.input_tx.take();
+        self.relay
+            .join()
+            .expect("relay thread")
+            .expect("relay result");
+        self.master.sync_all().expect("sync test output");
+        let output = fs::read(&self.path).expect("read test output");
+        fs::remove_file(&self.path).ok();
+        let mode = self.input_mode.lock().expect("input mode").clone();
+        (self.event_rx.try_iter().collect(), output, mode)
+    }
+}
+
+#[test]
+fn selection_bare_escape_times_out_without_waiting_for_another_key() {
+    let (path, master) = output_file("selection-bare-escape");
+    let (input_tx, input_rx) = mpsc::channel();
+    let (event_tx, event_rx) = mpsc::channel();
+    let candidates = vec![PromptGhostCandidate {
+        text: "inspect memory".to_string(),
+        suggestion_id: "health-1".to_string(),
+    }];
+    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: candidates[0].text.clone(),
+        route: PromptGhostRoute::AgentSelection {
+            candidates,
+            active: 0,
+        },
+    }));
+    let relay = super::super::spawn_raw_input_relay(
+        ChannelReader {
+            receiver: input_rx,
+            pending: Vec::new(),
+        },
+        master.try_clone().expect("clone output file"),
+        event_tx,
+        InputClassifier::default(),
+        input_mode.clone(),
+    );
+
+    input_tx.send(b"\x1b".to_vec()).expect("send escape");
+    expect_prompt_ghost_dismissal(&event_rx);
+    assert!(matches!(
+        *input_mode.lock().expect("input mode"),
+        RawInputMode::Passthrough
+    ));
+
+    drop(input_tx);
+    relay.join().expect("relay thread").expect("relay result");
+    master.sync_all().expect("sync test output");
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bexit\n");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_action_wait_flushes_escape_at_the_deadline() {
+    let (path, master) = output_file("selection-action-wait");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: "inspect memory".to_string(),
+        route: PromptGhostRoute::AgentSelection {
+            candidates: vec![PromptGhostCandidate {
+                text: "inspect memory".to_string(),
+                suggestion_id: "health-1".to_string(),
+            }],
+            active: 0,
+        },
+    }));
+    let relay = super::super::spawn_raw_action_relay(
+        vec![
+            RawRelayAction::write(b"\x1b"),
+            RawRelayAction::wait(Duration::from_millis(500)),
+        ],
+        master.try_clone().expect("clone output file"),
+        0,
+        tx,
+        InputClassifier::default(),
+        input_mode.clone(),
+    );
+
+    expect_prompt_ghost_dismissal(&rx);
+    assert!(!relay.is_finished());
+    assert!(matches!(
+        *input_mode.lock().expect("input mode"),
+        RawInputMode::Passthrough
+    ));
+
+    relay.join().expect("relay thread").expect("relay result");
+    master.sync_all().expect("sync test output");
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bexit\n");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_shift_tab_cycles_when_arriving_in_one_chunk() {
+    let relay = SelectionRelay::start("selection-shift-tab");
+    relay.send(b"\x1b[Z");
+
+    let (events, output, mode) = relay.finish();
+
+    assert_eq!(output, b"exit\n");
+    assert!(events.contains(&RawInputEvent::PromptGhostCycle {
+        text: "continue deployment".to_string(),
+    }));
+    assert!(matches!(
+        mode,
+        RawInputMode::PromptGhost { text, .. } if text == "continue deployment"
+    ));
+}
+
+#[test]
+fn selection_shift_tab_cycles_when_arriving_in_three_chunks_within_window() {
+    let (path, mut master) = output_file("selection-split-shift-tab");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = selection_input_mode();
+    let classifier = InputClassifier::default();
+    let mut state = RawInputRelayState::default();
+    let received_at = Instant::now();
+
+    for (bytes, offset) in [
+        (b"\x1b".as_slice(), 0),
+        (b"[".as_slice(), 1),
+        (b"Z".as_slice(), 2),
+    ] {
+        relay_input_bytes(
+            bytes,
+            received_at + Duration::from_millis(offset),
+            &mut master,
+            &tx,
+            &classifier,
+            &input_mode,
+            &mut state,
+        )
+        .expect("relay split shift-tab");
+    }
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, RawInputEvent::PromptGhostCycle { .. }))
+            .count(),
+        1
+    );
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_shift_tab_received_before_deadline_survives_a_delayed_relay() {
+    let (path, mut master) = output_file("selection-delayed-shift-tab");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = selection_input_mode();
+    let classifier = InputClassifier::default();
+    let mut state = RawInputRelayState::default();
+
+    relay_input_bytes(
+        b"\x1b",
+        Instant::now()
+            .checked_sub(Duration::from_millis(100))
+            .expect("recent timestamp"),
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("buffer escape");
+    let received_at = Instant::now()
+        .checked_sub(Duration::from_millis(90))
+        .expect("recent timestamp");
+    relay_input_bytes(
+        b"[Z",
+        received_at,
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("cycle delayed shift-tab");
+
+    assert!(rx.try_iter().any(|event| matches!(
+        event,
+        RawInputEvent::PromptGhostCycle { text } if text == "continue deployment"
+    )));
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_escape_with_nonmatching_follow_up_dismisses_and_forwards_all_bytes() {
+    let relay = SelectionRelay::start("selection-escape-nonmatching");
+    relay.send(b"\x1b");
+    relay.send(b"x");
+
+    let (events, output, mode) = relay.finish();
+
+    assert_eq!(output, b"\x1bxexit\n");
+    assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, RawInputEvent::PromptGhostCycle { .. })));
+    assert!(matches!(mode, RawInputMode::Passthrough));
+}
+
+#[test]
+fn selection_partial_csi_times_out_and_forwards_all_bytes() {
+    let relay = SelectionRelay::start("selection-partial-csi");
+    relay.send(b"\x1b[");
+    expect_prompt_ghost_dismissal(&relay.event_rx);
+
+    let (_, output, mode) = relay.finish();
+    assert_eq!(output, b"\x1b[exit\n");
+    assert!(matches!(mode, RawInputMode::Passthrough));
+}
+
+#[test]
+fn selection_pending_escape_at_eof_dismisses_and_forwards_escape() {
+    let relay = SelectionRelay::start("selection-escape-eof");
+    relay.send(b"\x1b");
+
+    let (events, output, mode) = relay.finish();
+
+    assert_eq!(output, b"\x1bexit\n");
+    assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
+    assert!(matches!(mode, RawInputMode::Passthrough));
+}
+
+#[test]
+fn selection_pending_escape_at_eof_after_route_change_is_not_dropped() {
+    let (path, mut master) = output_file("selection-escape-route-eof");
+    let (tx, rx) = mpsc::channel();
+    let old_route = PromptGhostRoute::AgentSelection {
+        candidates: vec![PromptGhostCandidate {
+            text: "old selection".to_string(),
+            suggestion_id: "old-1".to_string(),
+        }],
+        active: 0,
+    };
+    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: "old selection".to_string(),
+        route: old_route,
+    }));
+    let classifier = InputClassifier::default();
+    let mut state = RawInputRelayState::default();
+    relay_input_bytes(
+        b"\x1b",
+        Instant::now(),
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("buffer escape");
+    *input_mode.lock().expect("input mode") = RawInputMode::PromptGhost {
+        text: "new selection".to_string(),
+        route: PromptGhostRoute::AgentSelection {
+            candidates: vec![PromptGhostCandidate {
+                text: "new selection".to_string(),
+                suggestion_id: "new-1".to_string(),
+            }],
+            active: 0,
+        },
+    };
+    finish_input_relay(&mut master, &tx, &classifier, &input_mode, &mut state)
+        .expect("finish relay");
+
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bexit\n");
+    assert!(rx
+        .try_iter()
+        .any(|event| event == RawInputEvent::PromptGhostDismissed));
+    assert!(matches!(
+        *input_mode.lock().expect("input mode"),
+        RawInputMode::Passthrough
+    ));
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_route_change_before_deadline_dismisses_then_forwards_shift_tab() {
+    let (path, mut master) = output_file("selection-route-change-shift-tab");
+    let (tx, rx) = mpsc::channel();
+    let old_route = PromptGhostRoute::AgentSelection {
+        candidates: vec![PromptGhostCandidate {
+            text: "old selection".to_string(),
+            suggestion_id: "old-1".to_string(),
+        }],
+        active: 0,
+    };
+    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: "old selection".to_string(),
+        route: old_route,
+    }));
+    let classifier = InputClassifier::default();
+    let mut state = RawInputRelayState::default();
+    let received_at = Instant::now();
+
+    relay_input_bytes(
+        b"\x1b",
+        received_at,
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("buffer escape");
+    *input_mode.lock().expect("input mode") = RawInputMode::PromptGhost {
+        text: "new selection".to_string(),
+        route: PromptGhostRoute::AgentSelection {
+            candidates: vec![
+                PromptGhostCandidate {
+                    text: "new selection".to_string(),
+                    suggestion_id: "new-1".to_string(),
+                },
+                PromptGhostCandidate {
+                    text: "another selection".to_string(),
+                    suggestion_id: "new-2".to_string(),
+                },
+            ],
+            active: 0,
+        },
+    };
+
+    relay_input_bytes(
+        b"[Z",
+        received_at + Duration::from_millis(1),
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("handle shift-tab after route change");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1b[Z");
+    assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, RawInputEvent::PromptGhostCycle { .. })));
+    assert!(matches!(
+        *input_mode.lock().expect("input mode"),
+        RawInputMode::Passthrough
+    ));
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_expired_escape_dismisses_instead_of_rebuffering_for_a_new_route() {
+    let (path, mut master) = output_file("selection-expired-route-change");
+    let (tx, rx) = mpsc::channel();
+    let old_route = PromptGhostRoute::AgentSelection {
+        candidates: vec![PromptGhostCandidate {
+            text: "old selection".to_string(),
+            suggestion_id: "old-1".to_string(),
+        }],
+        active: 0,
+    };
+    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
+        text: "old selection".to_string(),
+        route: old_route,
+    }));
+    let classifier = InputClassifier::default();
+    let mut state = RawInputRelayState::default();
+    let received_at = Instant::now()
+        .checked_sub(Duration::from_millis(100))
+        .expect("recent timestamp");
+    relay_input_bytes(
+        b"\x1b",
+        received_at,
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("buffer escape");
+    *input_mode.lock().expect("input mode") = RawInputMode::PromptGhost {
+        text: "new selection".to_string(),
+        route: PromptGhostRoute::AgentSelection {
+            candidates: vec![PromptGhostCandidate {
+                text: "new selection".to_string(),
+                suggestion_id: "new-1".to_string(),
+            }],
+            active: 0,
+        },
+    };
+    relay_input_bytes(
+        b"",
+        received_at + Duration::from_millis(51),
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("flush expired escape");
+
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1b");
+    assert!(rx
+        .try_iter()
+        .any(|event| event == RawInputEvent::PromptGhostDismissed));
+    assert!(matches!(
+        *input_mode.lock().expect("input mode"),
+        RawInputMode::Passthrough
+    ));
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_timeout_and_follow_up_byte_do_not_duplicate_or_reorder_input() {
+    let (path, mut master) = output_file("selection-timeout-follow-up");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = selection_input_mode();
+    let classifier = InputClassifier::default();
+    let mut state = RawInputRelayState::default();
+    let received_at = Instant::now()
+        .checked_sub(Duration::from_millis(100))
+        .expect("recent timestamp");
+
+    relay_input_bytes(
+        b"\x1b",
+        received_at,
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("buffer escape");
+    relay_input_bytes(
+        b"x",
+        received_at + Duration::from_millis(51),
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("flush escape and relay follow-up");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bx");
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| **event == RawInputEvent::PromptGhostDismissed)
+            .count(),
+        1
+    );
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn selection_pending_escape_is_forwarded_when_the_input_mode_changes() {
+    let (path, mut master) = output_file("selection-mode-change");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = selection_input_mode();
+    let classifier = InputClassifier::default();
+    let mut state = RawInputRelayState::default();
+    let received_at = Instant::now();
+
+    relay_input_bytes(
+        b"\x1b",
+        received_at,
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("buffer escape");
+    *input_mode.lock().expect("input mode") = RawInputMode::RawPassthrough;
+    relay_input_bytes(
+        b"x",
+        received_at + Duration::from_millis(1),
+        &mut master,
+        &tx,
+        &classifier,
+        &input_mode,
+        &mut state,
+    )
+    .expect("relay pending escape after mode change");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    let mode = input_mode.lock().expect("input mode").clone();
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bx");
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, RawInputEvent::PromptGhostCycle { .. })));
+    assert!(matches!(mode, RawInputMode::RawPassthrough));
+    fs::remove_file(path).ok();
 }
 
 #[test]
@@ -151,77 +749,19 @@ fn agent_prompt_tab_stays_local_until_enter_and_keeps_suggestion_id() {
 
 #[test]
 fn selection_shift_tab_cycles_and_tab_inserts_the_active_prompt() {
-    let (path, mut master) = output_file("selection-cycle-tab");
-    let (tx, rx) = mpsc::channel();
-    let candidates = vec![
-        PromptGhostCandidate {
-            text: "inspect memory".to_string(),
-            suggestion_id: "health-1".to_string(),
-        },
-        PromptGhostCandidate {
-            text: "continue deployment".to_string(),
-            suggestion_id: "personal-1".to_string(),
-        },
-    ];
-    let route = PromptGhostRoute::AgentSelection {
-        candidates: candidates.clone(),
-        active: 0,
-        pending_escape: Vec::new(),
-    };
-    let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
-        text: candidates[0].text.clone(),
-        route: route.clone(),
-    }));
-    let mut line_buffer = CandidateLineBuffer::default();
-    let mut native_line_state = NativeLineState::default();
-    let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::default();
-    let mut relay = InputRelayContext {
-        master: &mut master,
-        input_classifier: &classifier,
-        input_events: &tx,
-        input_mode: &input_mode,
-        line_buffer: &mut line_buffer,
-        native_line_state: &mut native_line_state,
-        exit_tracker: &mut exit_tracker,
-    };
+    let relay = SelectionRelay::start("selection-cycle-tab");
+    relay.send(b"\x1b[Z");
+    relay.send(b"\t");
 
-    relay_prompt_ghost_input(b"\x1b", &candidates[0].text, &route, &mut relay)
-        .expect("buffer shift-tab escape");
-    let paused = match input_mode.lock().unwrap().clone() {
-        RawInputMode::PromptGhost { route, .. } => route,
-        mode => panic!("expected prompt ghost, got {mode:?}"),
-    };
-    relay_prompt_ghost_input(b"[", &candidates[0].text, &paused, &mut relay)
-        .expect("buffer shift-tab bracket");
-    let paused = match input_mode.lock().unwrap().clone() {
-        RawInputMode::PromptGhost { route, .. } => route,
-        mode => panic!("expected prompt ghost, got {mode:?}"),
-    };
-    relay_prompt_ghost_input(b"Z", &candidates[0].text, &paused, &mut relay)
-        .expect("cycle split selection");
-    let cycled_route = PromptGhostRoute::AgentSelection {
-        candidates,
-        active: 1,
-        pending_escape: Vec::new(),
-    };
-    relay_prompt_ghost_input(b"\t", "continue deployment", &cycled_route, &mut relay)
-        .expect("insert active selection");
-
-    assert_eq!(line_buffer.visible_line_bytes(), b"continue deployment");
-    assert_eq!(
-        line_buffer.forced_agent_suggestion_id.as_deref(),
-        Some("personal-1")
-    );
-    let events = rx.try_iter().collect::<Vec<_>>();
+    let (events, output, mode) = relay.finish();
     assert!(events.contains(&RawInputEvent::PromptGhostCycle {
         text: "continue deployment".to_string(),
     }));
     assert!(events.contains(&RawInputEvent::PromptGhostAccepted {
         suggestion_id: Some("personal-1".to_string()),
     }));
-    assert_eq!(fs::read(&path).unwrap(), b"");
-    fs::remove_file(path).ok();
+    assert_eq!(output, b"exit\n");
+    assert!(matches!(mode, RawInputMode::Passthrough));
 }
 
 #[test]
@@ -234,7 +774,6 @@ fn selection_enter_submits_the_active_prompt_without_shell_execution() {
             suggestion_id: "health-disk".to_string(),
         }],
         active: 0,
-        pending_escape: Vec::new(),
     };
     let input_mode = Arc::new(Mutex::new(RawInputMode::PromptGhost {
         text: "inspect disk pressure".to_string(),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -1,9 +1,10 @@
 use std::fs::File;
 use std::io::{self, Read};
 use std::os::fd::AsRawFd;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use nix::libc;
 
@@ -15,13 +16,53 @@ use super::event_parser::{CandidateLineBuffer, NativeLineState};
 use super::mode::{current_raw_input_mode, RawInputMode};
 use super::pty::{set_pty_winsize, signal_process_group, write_all_pty};
 use super::relay::{
-    relay_delayed_input, relay_passthrough_input, relay_prompt_ghost_input, send_held_input_events,
-    send_raw_input_events, ExplicitExitTracker, InputRelayContext,
+    dismiss_prompt_ghost_input, relay_delayed_input, relay_passthrough_input,
+    relay_prompt_ghost_input, send_held_input_events, send_raw_input_events, ExplicitExitTracker,
+    InputRelayContext,
 };
-use super::{RawInputEvent, RawRelayAction};
+use super::{PromptGhostRoute, RawInputEvent, RawRelayAction};
+
+const PROMPT_GHOST_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
+// Retain a complete split Shift+Tab sequence while the relay handles ESC.
+const INPUT_READ_AHEAD_CAPACITY: usize = 3;
+
+struct PendingPromptGhostEscape {
+    bytes: Vec<u8>,
+    text: String,
+    route: PromptGhostRoute,
+    deadline: Instant,
+}
+
+impl PendingPromptGhostEscape {
+    fn matches_mode(&self, mode: &RawInputMode) -> bool {
+        matches!(
+            mode,
+            RawInputMode::PromptGhost { text, route }
+                if text == &self.text && route == &self.route
+        )
+    }
+}
+
+#[derive(Default)]
+pub(super) struct RawInputRelayState {
+    card_state: CardInputState,
+    line_buffer: CandidateLineBuffer,
+    native_line_state: NativeLineState,
+    exit_tracker: ExplicitExitTracker,
+    pending_prompt_ghost_escape: Option<PendingPromptGhostEscape>,
+}
+
+enum InputRead {
+    Bytes {
+        bytes: Vec<u8>,
+        received_at: Instant,
+    },
+    Eof,
+    Error(io::Error),
+}
 
 pub(crate) fn spawn_raw_input_relay<R>(
-    mut input: R,
+    input: R,
     mut master: File,
     input_events: Sender<RawInputEvent>,
     input_classifier: InputClassifier,
@@ -31,97 +72,338 @@ where
     R: Read + Send + 'static,
 {
     thread::spawn(move || {
-        let mut buffer = [0_u8; 8192];
-        let mut card_state = CardInputState::default();
-        let mut line_buffer = CandidateLineBuffer::default();
-        let mut native_line_state = NativeLineState::default();
-        let mut exit_tracker = ExplicitExitTracker::default();
+        let (read_tx, read_rx) = mpsc::sync_channel(INPUT_READ_AHEAD_CAPACITY);
+        // The relay must wake without a later keystroke to resolve a bare ESC.
+        thread::spawn(move || read_input_chunks(input, read_tx));
+
+        let mut state = RawInputRelayState::default();
         loop {
-            match input.read(&mut buffer) {
-                Ok(0) => {
-                    if !exit_tracker.saw_explicit_exit() {
-                        write_all_pty(&mut master, b"exit\n")?;
-                    }
+            let input = match receive_input(&read_rx, &state) {
+                Ok(input) => input,
+                Err(RecvTimeoutError::Timeout) => {
+                    flush_pending_prompt_ghost_escape(
+                        false,
+                        Instant::now(),
+                        &mut master,
+                        &input_events,
+                        &input_classifier,
+                        &input_mode,
+                        &mut state,
+                    )?;
+                    continue;
+                }
+                Err(RecvTimeoutError::Disconnected) => InputRead::Eof,
+            };
+            match input {
+                InputRead::Bytes { bytes, received_at } => relay_input_bytes(
+                    &bytes,
+                    received_at,
+                    &mut master,
+                    &input_events,
+                    &input_classifier,
+                    &input_mode,
+                    &mut state,
+                )?,
+                InputRead::Eof => {
+                    finish_input_relay(
+                        &mut master,
+                        &input_events,
+                        &input_classifier,
+                        &input_mode,
+                        &mut state,
+                    )?;
                     return Ok(());
                 }
-                Ok(n) => match current_raw_input_mode(&input_mode) {
-                    RawInputMode::Capture(capture) => {
-                        if consume_captured_input(
-                            &mut card_state,
-                            &capture,
-                            &buffer[..n],
-                            &input_events,
-                            &input_mode,
-                        ) {
-                            line_buffer.clear();
-                            native_line_state.clear();
-                        }
-                    }
-                    RawInputMode::Hold => {
-                        card_state.reset();
-                        send_held_input_events(&buffer[..n], &input_events);
-                    }
-                    RawInputMode::Delay => {
-                        card_state.reset();
-                        let mut relay = InputRelayContext {
-                            master: &mut master,
-                            input_classifier: &input_classifier,
-                            input_events: &input_events,
-                            input_mode: &input_mode,
-                            line_buffer: &mut line_buffer,
-                            native_line_state: &mut native_line_state,
-                            exit_tracker: &mut exit_tracker,
-                        };
-                        relay_delayed_input(&buffer[..n], &mut relay)?;
-                    }
-                    RawInputMode::Passthrough => {
-                        card_state.reset();
-                        let mut relay = InputRelayContext {
-                            master: &mut master,
-                            input_classifier: &input_classifier,
-                            input_events: &input_events,
-                            input_mode: &input_mode,
-                            line_buffer: &mut line_buffer,
-                            native_line_state: &mut native_line_state,
-                            exit_tracker: &mut exit_tracker,
-                        };
-                        if relay_passthrough_input(&buffer[..n], &mut relay)? {
-                            continue;
-                        }
-                    }
-                    RawInputMode::PromptGhost {
-                        text: ghost_text,
-                        route,
-                    } => {
-                        card_state.reset();
-                        let mut relay = InputRelayContext {
-                            master: &mut master,
-                            input_classifier: &input_classifier,
-                            input_events: &input_events,
-                            input_mode: &input_mode,
-                            line_buffer: &mut line_buffer,
-                            native_line_state: &mut native_line_state,
-                            exit_tracker: &mut exit_tracker,
-                        };
-                        if relay_prompt_ghost_input(&buffer[..n], &ghost_text, &route, &mut relay)?
-                        {
-                            continue;
-                        }
-                    }
-                    RawInputMode::RawPassthrough => {
-                        card_state.reset();
-                        line_buffer.clear();
-                        send_raw_input_events(&buffer[..n], &input_events);
-                        native_line_state.observe_shell_bytes(&buffer[..n]);
-                        exit_tracker.observe_shell_bytes(&buffer[..n]);
-                        write_all_pty(&mut master, &buffer[..n])?;
-                    }
-                },
-                Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
-                Err(err) => return Err(err),
+                InputRead::Error(error) => return Err(error),
             }
         }
     })
+}
+
+fn read_input_chunks<R>(mut input: R, sender: SyncSender<InputRead>)
+where
+    R: Read,
+{
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let input = match input.read(&mut buffer) {
+            Ok(0) => InputRead::Eof,
+            Ok(count) => InputRead::Bytes {
+                bytes: buffer[..count].to_vec(),
+                received_at: Instant::now(),
+            },
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => InputRead::Error(error),
+        };
+        let done = !matches!(input, InputRead::Bytes { .. });
+        if sender.send(input).is_err() || done {
+            return;
+        }
+    }
+}
+
+fn receive_input(
+    receiver: &Receiver<InputRead>,
+    state: &RawInputRelayState,
+) -> Result<InputRead, RecvTimeoutError> {
+    match state.pending_prompt_ghost_escape.as_ref() {
+        Some(pending) => {
+            receiver.recv_timeout(pending.deadline.saturating_duration_since(Instant::now()))
+        }
+        None => receiver.recv().map_err(|_| RecvTimeoutError::Disconnected),
+    }
+}
+
+pub(super) fn relay_input_bytes(
+    bytes: &[u8],
+    received_at: Instant,
+    master: &mut File,
+    input_events: &Sender<RawInputEvent>,
+    input_classifier: &InputClassifier,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> io::Result<()> {
+    if state
+        .pending_prompt_ghost_escape
+        .as_ref()
+        .is_some_and(|pending| received_at > pending.deadline)
+    {
+        flush_pending_prompt_ghost_escape(
+            false,
+            received_at,
+            master,
+            input_events,
+            input_classifier,
+            input_mode,
+            state,
+        )?;
+    }
+
+    let mode = current_raw_input_mode(input_mode);
+    let mut pending_deadline = None;
+    let mut combined = Vec::new();
+    let bytes = if let Some(pending) = state.pending_prompt_ghost_escape.take() {
+        if !pending.matches_mode(&mode) {
+            // The pending prefix belongs to the previous ghost. Route it before
+            // processing the new bytes so they cannot become its Shift+Tab suffix.
+            relay_input_for_mode(
+                &pending.bytes,
+                mode,
+                master,
+                input_events,
+                input_classifier,
+                input_mode,
+                state,
+            )?;
+            return relay_input_bytes(
+                bytes,
+                received_at,
+                master,
+                input_events,
+                input_classifier,
+                input_mode,
+                state,
+            );
+        }
+        pending_deadline = Some(pending.deadline);
+        combined.extend_from_slice(&pending.bytes);
+        combined.extend_from_slice(bytes);
+        &combined
+    } else {
+        bytes
+    };
+
+    if let RawInputMode::PromptGhost {
+        text,
+        route: route @ PromptGhostRoute::AgentSelection { .. },
+    } = &mode
+    {
+        if b"\x1b[Z".starts_with(bytes) && bytes.len() < 3 {
+            state.pending_prompt_ghost_escape = Some(PendingPromptGhostEscape {
+                bytes: bytes.to_vec(),
+                text: text.clone(),
+                route: route.clone(),
+                deadline: pending_deadline.unwrap_or(received_at + PROMPT_GHOST_ESCAPE_TIMEOUT),
+            });
+            return Ok(());
+        }
+    }
+
+    relay_input_for_mode(
+        bytes,
+        mode,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )
+}
+
+fn relay_input_for_mode(
+    bytes: &[u8],
+    mode: RawInputMode,
+    master: &mut File,
+    input_events: &Sender<RawInputEvent>,
+    input_classifier: &InputClassifier,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> io::Result<()> {
+    match mode {
+        RawInputMode::Capture(capture) => {
+            if consume_captured_input(
+                &mut state.card_state,
+                &capture,
+                bytes,
+                input_events,
+                input_mode,
+            ) {
+                state.line_buffer.clear();
+                state.native_line_state.clear();
+            }
+        }
+        RawInputMode::Hold => {
+            state.card_state.reset();
+            send_held_input_events(bytes, input_events);
+        }
+        RawInputMode::Delay => {
+            state.card_state.reset();
+            let mut relay =
+                input_relay_context(master, input_classifier, input_events, input_mode, state);
+            relay_delayed_input(bytes, &mut relay)?;
+        }
+        RawInputMode::Passthrough => {
+            state.card_state.reset();
+            let mut relay =
+                input_relay_context(master, input_classifier, input_events, input_mode, state);
+            let _ = relay_passthrough_input(bytes, &mut relay)?;
+        }
+        RawInputMode::PromptGhost { text, route } => {
+            state.card_state.reset();
+            let mut relay =
+                input_relay_context(master, input_classifier, input_events, input_mode, state);
+            let _ = relay_prompt_ghost_input(bytes, &text, &route, &mut relay)?;
+        }
+        RawInputMode::RawPassthrough => {
+            state.card_state.reset();
+            state.line_buffer.clear();
+            send_raw_input_events(bytes, input_events);
+            state.native_line_state.observe_shell_bytes(bytes);
+            state.exit_tracker.observe_shell_bytes(bytes);
+            write_all_pty(master, bytes)?;
+        }
+    }
+    Ok(())
+}
+
+fn input_relay_context<'a>(
+    master: &'a mut File,
+    input_classifier: &'a InputClassifier,
+    input_events: &'a Sender<RawInputEvent>,
+    input_mode: &'a Arc<Mutex<RawInputMode>>,
+    state: &'a mut RawInputRelayState,
+) -> InputRelayContext<'a> {
+    InputRelayContext {
+        master,
+        input_classifier,
+        input_events,
+        input_mode,
+        line_buffer: &mut state.line_buffer,
+        native_line_state: &mut state.native_line_state,
+        exit_tracker: &mut state.exit_tracker,
+    }
+}
+
+fn flush_pending_prompt_ghost_escape(
+    force: bool,
+    now: Instant,
+    master: &mut File,
+    input_events: &Sender<RawInputEvent>,
+    input_classifier: &InputClassifier,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> io::Result<()> {
+    let should_flush = state
+        .pending_prompt_ghost_escape
+        .as_ref()
+        .is_some_and(|pending| force || now >= pending.deadline);
+    if !should_flush {
+        return Ok(());
+    }
+    let Some(pending) = state.pending_prompt_ghost_escape.take() else {
+        return Ok(());
+    };
+    let mode = current_raw_input_mode(input_mode);
+    if pending.matches_mode(&mode) {
+        let mut relay =
+            input_relay_context(master, input_classifier, input_events, input_mode, state);
+        let _ = dismiss_prompt_ghost_input(&pending.bytes, &mut relay)?;
+        return Ok(());
+    }
+    relay_input_for_mode(
+        &pending.bytes,
+        mode,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )
+}
+
+pub(super) fn finish_input_relay(
+    master: &mut File,
+    input_events: &Sender<RawInputEvent>,
+    input_classifier: &InputClassifier,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> io::Result<()> {
+    flush_pending_prompt_ghost_escape(
+        true,
+        Instant::now(),
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )?;
+    if !state.exit_tracker.saw_explicit_exit() {
+        write_all_pty(master, b"exit\n")?;
+    }
+    Ok(())
+}
+
+fn wait_for_raw_action(
+    duration: Duration,
+    master: &mut File,
+    input_events: &Sender<RawInputEvent>,
+    input_classifier: &InputClassifier,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> io::Result<()> {
+    let action_end = Instant::now() + duration;
+    while let Some(deadline) = state
+        .pending_prompt_ghost_escape
+        .as_ref()
+        .map(|pending| pending.deadline)
+    {
+        if deadline > action_end {
+            break;
+        }
+        thread::sleep(deadline.saturating_duration_since(Instant::now()));
+        // Scripted input must resolve ESC at the same boundary as live input.
+        flush_pending_prompt_ghost_escape(
+            false,
+            Instant::now(),
+            master,
+            input_events,
+            input_classifier,
+            input_mode,
+            state,
+        )?;
+    }
+    thread::sleep(action_end.saturating_duration_since(Instant::now()));
+    Ok(())
 }
 
 pub(crate) fn spawn_raw_action_relay(
@@ -133,97 +415,47 @@ pub(crate) fn spawn_raw_action_relay(
     input_mode: Arc<Mutex<RawInputMode>>,
 ) -> JoinHandle<io::Result<()>> {
     thread::spawn(move || {
-        (|| {
-            let mut card_state = CardInputState::default();
-            let mut line_buffer = CandidateLineBuffer::default();
-            let mut native_line_state = NativeLineState::default();
-            let mut exit_tracker = ExplicitExitTracker::default();
-            for action in actions {
-                match action {
-                    RawRelayAction::Write(bytes) => match current_raw_input_mode(&input_mode) {
-                        RawInputMode::Capture(capture) => {
-                            if consume_captured_input(
-                                &mut card_state,
-                                &capture,
-                                &bytes,
-                                &input_events,
-                                &input_mode,
-                            ) {
-                                line_buffer.clear();
-                                native_line_state.clear();
-                            }
-                        }
-                        RawInputMode::Hold => {
-                            card_state.reset();
-                            send_held_input_events(&bytes, &input_events);
-                        }
-                        RawInputMode::Delay => {
-                            card_state.reset();
-                            let mut relay = InputRelayContext {
-                                master: &mut master,
-                                input_classifier: &input_classifier,
-                                input_events: &input_events,
-                                input_mode: &input_mode,
-                                line_buffer: &mut line_buffer,
-                                native_line_state: &mut native_line_state,
-                                exit_tracker: &mut exit_tracker,
-                            };
-                            relay_delayed_input(&bytes, &mut relay)?;
-                        }
-                        RawInputMode::Passthrough => {
-                            card_state.reset();
-                            let mut relay = InputRelayContext {
-                                master: &mut master,
-                                input_classifier: &input_classifier,
-                                input_events: &input_events,
-                                input_mode: &input_mode,
-                                line_buffer: &mut line_buffer,
-                                native_line_state: &mut native_line_state,
-                                exit_tracker: &mut exit_tracker,
-                            };
-                            if relay_passthrough_input(&bytes, &mut relay)? {
-                                continue;
-                            }
-                        }
-                        RawInputMode::PromptGhost {
-                            text: ghost_text,
-                            route,
-                        } => {
-                            card_state.reset();
-                            let mut relay = InputRelayContext {
-                                master: &mut master,
-                                input_classifier: &input_classifier,
-                                input_events: &input_events,
-                                input_mode: &input_mode,
-                                line_buffer: &mut line_buffer,
-                                native_line_state: &mut native_line_state,
-                                exit_tracker: &mut exit_tracker,
-                            };
-                            if relay_prompt_ghost_input(&bytes, &ghost_text, &route, &mut relay)? {
-                                continue;
-                            }
-                        }
-                        RawInputMode::RawPassthrough => {
-                            card_state.reset();
-                            line_buffer.clear();
-                            send_raw_input_events(&bytes, &input_events);
-                            native_line_state.observe_shell_bytes(&bytes);
-                            exit_tracker.observe_shell_bytes(&bytes);
-                            write_all_pty(&mut master, &bytes)?;
-                        }
-                    },
-                    RawRelayAction::Resize(winsize) => {
-                        set_pty_winsize(master.as_raw_fd(), winsize)?;
-                        signal_process_group(child_pid, libc::SIGWINCH)?;
-                    }
-                    RawRelayAction::Wait(duration) => thread::sleep(duration),
+        let mut state = RawInputRelayState::default();
+        for action in actions {
+            flush_pending_prompt_ghost_escape(
+                false,
+                Instant::now(),
+                &mut master,
+                &input_events,
+                &input_classifier,
+                &input_mode,
+                &mut state,
+            )?;
+            match action {
+                RawRelayAction::Write(bytes) => relay_input_bytes(
+                    &bytes,
+                    Instant::now(),
+                    &mut master,
+                    &input_events,
+                    &input_classifier,
+                    &input_mode,
+                    &mut state,
+                )?,
+                RawRelayAction::Resize(winsize) => {
+                    set_pty_winsize(master.as_raw_fd(), winsize)?;
+                    signal_process_group(child_pid, libc::SIGWINCH)?;
                 }
+                RawRelayAction::Wait(duration) => wait_for_raw_action(
+                    duration,
+                    &mut master,
+                    &input_events,
+                    &input_classifier,
+                    &input_mode,
+                    &mut state,
+                )?,
             }
-
-            if !exit_tracker.saw_explicit_exit() {
-                write_all_pty(&mut master, b"exit\n")?;
-            }
-            Ok(())
-        })()
+        }
+        finish_input_relay(
+            &mut master,
+            &input_events,
+            &input_classifier,
+            &input_mode,
+            &mut state,
+        )
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_state.rs
@@ -127,7 +127,6 @@ impl InlineState {
             self.pending_input_ghost_route = PromptGhostRoute::AgentSelection {
                 candidates: remaining,
                 active,
-                pending_escape: Vec::new(),
             };
         } else if had_personal_candidates
             && (selection_route

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
@@ -297,7 +297,6 @@ fn prepare_startup_suggestions(state: &mut InlineState, cwd: &str) -> Vec<Planne
         state.pending_input_ghost_route = PromptGhostRoute::AgentSelection {
             candidates,
             active: 0,
-            pending_escape: Vec::new(),
         };
         state.pending_input_ghost_binding = state
             .pending_prompt_suggestion_bindings

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state_tests.rs
@@ -63,7 +63,6 @@ fn clearing_personal_candidates_rebuilds_health_first_selection() {
             },
         ],
         active: 0,
-        pending_escape: Vec::new(),
     };
 
     assert!(state.clear_personal_prompt_ghost());
@@ -76,7 +75,6 @@ fn clearing_personal_candidates_rebuilds_health_first_selection() {
                 suggestion_id: "health-1".to_string(),
             }],
             active: 0,
-            pending_escape: Vec::new(),
         }
     );
     assert!(!state


### PR DESCRIPTION
## Description

Fixes prompt-ghost handling when AgentSelection receives a bare ESC. The raw input relay now
uses bounded, deadline-aware buffering so split Shift+Tab remains recognized while expired,
non-matching, EOF, route-change, and scripted-input cases dismiss and forward bytes exactly once.

## Related Issue

closes #1654

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (skillfs)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Additional Notes

The reader-to-relay channel is bounded and sized for a complete three-byte Shift+Tab sequence.
