### PR TITLE
feat(cosh-ng): [shell] gate startup suggestions

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_planner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_planner.rs
@@ -57,22 +57,7 @@ pub(crate) enum OmittedReason {
     Suppressed,
     Duplicate,
     Capacity,
-    RendererUnavailable,
     HealthUnresolved,
-}
-
-impl RenderedStartupSuggestions {
-    pub(crate) fn renderer_unavailable(candidate_count: usize) -> Self {
-        let mut omitted_reasons = BTreeMap::new();
-        if candidate_count > 0 {
-            omitted_reasons.insert(OmittedReason::RendererUnavailable, candidate_count);
-        }
-        Self {
-            omitted_count: candidate_count,
-            omitted_reasons,
-            ..Self::default()
-        }
-    }
 }
 
 pub(crate) fn plan_startup(

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_planner_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_planner_tests.rs
@@ -303,12 +303,6 @@ fn omitted_reasons_distinguish_all_render_decisions() {
     )];
     let capacity = plan_startup(&context(), HealthResolution::Resolved(&health), &personal);
     assert_eq!(capacity.omitted_reasons[&OmittedReason::Capacity], 1);
-
-    let unavailable = RenderedStartupSuggestions::renderer_unavailable(2);
-    assert_eq!(
-        unavailable.omitted_reasons[&OmittedReason::RendererUnavailable],
-        2
-    );
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use crate::diagnostics::health::{record_startup_health_recommendations, HealthScanReport};
+use crate::diagnostics::health::{
+    record_startup_health_recommendations, HealthFindingCategory, HealthScanReport, HealthSeverity,
+};
 use crate::raw_input::{PromptGhostCandidate, PromptGhostRoute};
 use crate::recommendation::personal_context::discover_repo_context;
 use crate::recommendation::personal_crypto::random_hex;
@@ -44,7 +46,7 @@ const STARTUP_HEALTH_ROW_WAIT: Duration = Duration::from_millis(150);
 
 mod recommendations;
 #[cfg(test)]
-pub(super) use recommendations::{
+use recommendations::{
     plan_startup_for_render, record_visible_personal_impressions, visible_personal_candidates,
     write_startup_suggestion_card,
 };
@@ -64,15 +66,42 @@ fn restore_startup_prompt<W: Write>(
     Ok(())
 }
 
-fn startup_prompt_ghost_allowed(_report: &HealthScanReport) -> bool {
-    startup_prompt_selection_supported(
-        std::env::var("COSH_SHELL_ISOLATED").is_ok(),
-        std::env::var("TERM").ok().as_deref(),
-    )
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupSuggestionMode {
+    Hidden,
+    ReadOnly,
+    Interactive,
 }
 
-fn startup_prompt_selection_supported(isolated: bool, term: Option<&str>) -> bool {
+fn startup_suggestion_mode(
+    isolated: bool,
+    term: Option<&str>,
+    report: &HealthScanReport,
+) -> StartupSuggestionMode {
+    if !startup_suggestion_display_supported(isolated, term) {
+        StartupSuggestionMode::Hidden
+    } else if health_report_supports_interactive_suggestions(report) {
+        StartupSuggestionMode::Interactive
+    } else {
+        StartupSuggestionMode::ReadOnly
+    }
+}
+
+fn startup_suggestion_display_supported(isolated: bool, term: Option<&str>) -> bool {
     !isolated && !term.is_some_and(|term| term.eq_ignore_ascii_case("dumb"))
+}
+
+fn health_report_supports_interactive_suggestions(report: &HealthScanReport) -> bool {
+    !report
+        .findings
+        .iter()
+        .any(|finding| finding.category == HealthFindingCategory::CollectionGap)
+        && !report.unavailable.iter().any(|item| {
+            matches!(
+                item.severity,
+                HealthSeverity::Unavailable | HealthSeverity::Degraded
+            )
+        })
 }
 
 fn startup_banner_enabled() -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
@@ -73,10 +73,16 @@ pub(crate) fn render_startup_banner<W: Write>(
         }
         state.startup_health.rendered = true;
     }
-    write_startup_suggestion_card(state, &renderer, &suggestions, output)?;
+    write_startup_suggestion_card(
+        state,
+        &renderer,
+        suggestions.mode,
+        &suggestions.candidates,
+        output,
+    )?;
     output.flush()?;
     if let Some(report) = state.startup_health.report.as_ref() {
-        record_visible_startup_health_recommendations(report, &suggestions);
+        record_visible_startup_health_recommendations(report, &suggestions.candidates);
     }
     record_visible_personal_impressions(state, cwd);
     if recommendation_notice {
@@ -194,7 +200,7 @@ pub(crate) fn render_startup_health_banner<W: Write>(
         .unwrap_or_else(|| ".".to_string());
     let suggestions = prepare_startup_suggestions(state, &cwd);
     let show_health = !health_uses_startup_row(&report);
-    if !show_health && suggestions.is_empty() {
+    if !show_health && suggestions.candidates.is_empty() {
         return Ok(());
     }
     write!(output, "\r\x1b[2K")?;
@@ -204,22 +210,48 @@ pub(crate) fn render_startup_health_banner<W: Write>(
         renderer.write_health_banner(output, HealthBannerModel { report: &facts })?;
         writeln!(output)?;
     }
-    write_startup_suggestion_card(state, &renderer, &suggestions, output)?;
+    write_startup_suggestion_card(
+        state,
+        &renderer,
+        suggestions.mode,
+        &suggestions.candidates,
+        output,
+    )?;
     output.flush()?;
-    record_visible_startup_health_recommendations(&report, &suggestions);
+    record_visible_startup_health_recommendations(&report, &suggestions.candidates);
     record_visible_personal_impressions(state, &cwd);
     restore_startup_prompt(state, output)?;
     output.flush()
 }
 
-fn prepare_startup_suggestions(state: &mut InlineState, cwd: &str) -> Vec<PlannerCandidate> {
+struct PreparedStartupSuggestions {
+    mode: StartupSuggestionMode,
+    candidates: Vec<PlannerCandidate>,
+}
+
+fn prepare_startup_suggestions(state: &mut InlineState, cwd: &str) -> PreparedStartupSuggestions {
     let Some(report) = state.startup_health.report.clone() else {
         state.personalization.startup_suppressed = true;
-        return Vec::new();
+        return PreparedStartupSuggestions {
+            mode: StartupSuggestionMode::Hidden,
+            candidates: Vec::new(),
+        };
     };
-    let renderer_available = startup_prompt_ghost_allowed(&report);
+    let mode = startup_suggestion_mode(
+        std::env::var("COSH_SHELL_ISOLATED").is_ok(),
+        std::env::var("TERM").ok().as_deref(),
+        &report,
+    );
+    if mode == StartupSuggestionMode::Hidden {
+        state.personalization.startup_suppressed = true;
+        return PreparedStartupSuggestions {
+            mode,
+            candidates: Vec::new(),
+        };
+    }
     state.personalization.poll_ready();
-    let personal_enabled = state.analysis_mode != crate::runtime::state::AnalysisMode::Manual
+    let personal_enabled = mode == StartupSuggestionMode::Interactive
+        && state.analysis_mode != crate::runtime::state::AnalysisMode::Manual
         && !state.personalization.ai_disabled;
     let now = now_hour_bucket();
     let (personal, context, profile_generation) = if personal_enabled {
@@ -244,15 +276,22 @@ fn prepare_startup_suggestions(state: &mut InlineState, cwd: &str) -> Vec<Planne
         host_id: context.as_ref().and_then(|value| value.host_id.clone()),
     };
     let planned = plan_startup_for_render(state.i18n(), Some(&report), &planner_context, &personal);
-    if !renderer_available {
-        state.personalization.startup_suppressed = true;
-        let unavailable = crate::recommendation::personal_planner::RenderedStartupSuggestions::renderer_unavailable(
-            planned.visible_candidates.len(),
-        );
-        debug_assert_eq!(unavailable.omitted_count, planned.visible_candidates.len());
-        return Vec::new();
+    let visible_all = match mode {
+        StartupSuggestionMode::ReadOnly => planned
+            .visible_candidates
+            .iter()
+            .filter(|candidate| candidate.source == CandidateSource::Health)
+            .cloned()
+            .collect(),
+        StartupSuggestionMode::Interactive => planned.visible_candidates.clone(),
+        StartupSuggestionMode::Hidden => Vec::new(),
+    };
+    if mode == StartupSuggestionMode::ReadOnly {
+        return PreparedStartupSuggestions {
+            mode,
+            candidates: visible_all,
+        };
     }
-    let visible_all = planned.visible_candidates.clone();
     let visible_personal = visible_personal_candidates(&planned)
         .into_iter()
         .cloned()
@@ -304,7 +343,10 @@ fn prepare_startup_suggestions(state: &mut InlineState, cwd: &str) -> Vec<Planne
             .get(&first_id)
             .cloned();
     }
-    visible_all
+    PreparedStartupSuggestions {
+        mode,
+        candidates: visible_all,
+    }
 }
 
 pub(crate) fn record_visible_personal_impressions(state: &mut InlineState, cwd: &str) {
@@ -368,9 +410,10 @@ fn current_personal_context(
     )
 }
 
-pub(crate) fn write_startup_suggestion_card<W: Write>(
+pub(super) fn write_startup_suggestion_card<W: Write>(
     state: &InlineState,
     renderer: &RatatuiInlineRenderer,
+    mode: StartupSuggestionMode,
     suggestions: &[PlannerCandidate],
     output: &mut W,
 ) -> std::io::Result<()> {
@@ -390,11 +433,18 @@ pub(crate) fn write_startup_suggestion_card<W: Write>(
             format!("{}. [{source}] {}", index + 1, candidate.prompt_text)
         })
         .collect();
-    let footer = match (state.language, suggestions.len() > 1) {
-        (Language::ZhCn, true) => "Shift+Tab 切换 · Tab 填入 · Enter 直接提问",
-        (Language::ZhCn, false) => "Tab 填入 · Enter 直接提问",
-        (_, true) => "Shift+Tab cycle · Tab insert · Enter ask",
-        (_, false) => "Tab insert · Enter ask",
+    let footer = match (mode, state.language, suggestions.len() > 1) {
+        (StartupSuggestionMode::Interactive, Language::ZhCn, true) => {
+            Some("Shift+Tab 切换 · Tab 填入 · Enter 直接提问")
+        }
+        (StartupSuggestionMode::Interactive, Language::ZhCn, false) => {
+            Some("Tab 填入 · Enter 直接提问")
+        }
+        (StartupSuggestionMode::Interactive, _, true) => {
+            Some("Shift+Tab cycle · Tab insert · Enter ask")
+        }
+        (StartupSuggestionMode::Interactive, _, false) => Some("Tab insert · Enter ask"),
+        _ => None,
     };
     renderer.write_notice_panel(
         output,
@@ -405,7 +455,7 @@ pub(crate) fn write_startup_suggestion_card<W: Write>(
                 "Suggested prompts"
             },
             body,
-            footer: Some(footer),
+            footer,
         },
     )?;
     writeln!(output)

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
@@ -3,10 +3,14 @@ use std::collections::BTreeMap;
 use super::{
     extract_bootstrap_path, merge_path_lists, plan_startup_for_render, raw_passthrough_args,
     record_visible_personal_impressions, render_pending_recommendation_notice,
-    startup_prompt_selection_supported, visible_personal_candidates, write_startup_suggestion_card,
+    startup_suggestion_mode, visible_personal_candidates, write_startup_suggestion_card,
+    StartupSuggestionMode,
 };
 use crate::config::Language;
-use crate::diagnostics::health::{HealthMessageId, HealthScanReport, HealthTryItem, HealthTryKind};
+use crate::diagnostics::health::{
+    HealthCollector, HealthFinding, HealthFindingCategory, HealthMessageId, HealthScanReport,
+    HealthSeverity, HealthTryItem, HealthTryKind, HealthUnavailableReason, UnavailableCollector,
+};
 use crate::recommendation::personal_feedback::FrozenPromptBinding;
 use crate::recommendation::personal_model::{
     ActivityPayload, CandidateEvidenceSummary, CandidateSource, ContextAffinity, FeedbackAction,
@@ -306,6 +310,7 @@ fn suggestion_card_labels_health_before_personal_and_explains_all_keys() {
     write_startup_suggestion_card(
         &state,
         &RatatuiInlineRenderer::with_width(120).with_language(Language::ZhCn),
+        StartupSuggestionMode::Interactive,
         &rendered.visible_candidates,
         &mut output,
     )
@@ -326,6 +331,7 @@ fn single_suggestion_hides_cycle_instruction() {
     write_startup_suggestion_card(
         &state,
         &RatatuiInlineRenderer::with_width(120),
+        StartupSuggestionMode::Interactive,
         &[personal("recent-a")],
         &mut output,
     )
@@ -337,17 +343,79 @@ fn single_suggestion_hides_cycle_instruction() {
 }
 
 #[test]
-fn prompt_selection_requires_capable_terminal_but_not_color() {
-    assert!(startup_prompt_selection_supported(
-        false,
-        Some("xterm-256color")
-    ));
-    assert!(startup_prompt_selection_supported(false, None));
-    assert!(!startup_prompt_selection_supported(false, Some("dumb")));
-    assert!(!startup_prompt_selection_supported(
-        true,
-        Some("xterm-256color")
-    ));
+fn startup_suggestion_mode_separates_display_and_interaction_policy() {
+    let healthy = HealthScanReport::new("healthy", 0);
+    let mut warning = HealthScanReport::new("warning", 0);
+    warning.overall_severity = HealthSeverity::Warning;
+    let mut critical = HealthScanReport::new("critical", 0);
+    critical.overall_severity = HealthSeverity::Critical;
+
+    assert_eq!(
+        startup_suggestion_mode(false, Some("xterm-256color"), &healthy),
+        StartupSuggestionMode::Interactive
+    );
+    assert_eq!(
+        startup_suggestion_mode(false, Some("xterm-256color"), &warning),
+        StartupSuggestionMode::Interactive
+    );
+    assert_eq!(
+        startup_suggestion_mode(false, Some("xterm-256color"), &critical),
+        StartupSuggestionMode::Interactive
+    );
+
+    let degraded_gap = collection_gap_report(HealthSeverity::Degraded);
+    let unavailable_gap = collection_gap_report(HealthSeverity::Unavailable);
+    let warning_gap = collection_gap_report(HealthSeverity::Warning);
+    let critical_gap = collection_gap_report(HealthSeverity::Critical);
+    for report in [&degraded_gap, &unavailable_gap, &warning_gap, &critical_gap] {
+        assert_eq!(
+            startup_suggestion_mode(false, Some("xterm-256color"), report),
+            StartupSuggestionMode::ReadOnly
+        );
+    }
+
+    assert_eq!(
+        startup_suggestion_mode(true, Some("xterm-256color"), &healthy),
+        StartupSuggestionMode::Hidden
+    );
+    assert_eq!(
+        startup_suggestion_mode(false, Some("dumb"), &healthy),
+        StartupSuggestionMode::Hidden
+    );
+
+    for (collector, severity) in [
+        (HealthCollector::Memory, HealthSeverity::Degraded),
+        (HealthCollector::KernelSignal, HealthSeverity::Unavailable),
+        (HealthCollector::ConfiguredService, HealthSeverity::Degraded),
+    ] {
+        let mut report = HealthScanReport::new("collector-unavailable", 0);
+        report.unavailable.push(UnavailableCollector {
+            collector,
+            reason: HealthUnavailableReason::Timeout,
+            severity,
+            elapsed_ms: 0,
+        });
+        assert_eq!(
+            startup_suggestion_mode(false, Some("xterm-256color"), &report),
+            StartupSuggestionMode::ReadOnly
+        );
+    }
+}
+
+fn collection_gap_report(overall_severity: HealthSeverity) -> HealthScanReport {
+    let mut report = HealthScanReport::new("collection-gap", 0);
+    report.overall_severity = overall_severity;
+    report.findings.push(HealthFinding {
+        id: "collection-gap".to_string(),
+        severity: HealthSeverity::Degraded,
+        category: HealthFindingCategory::CollectionGap,
+        title_id: HealthMessageId::HealthFindingCoreCollectorUnavailable,
+        detail_id: None,
+        detail_args: BTreeMap::new(),
+        evidence_fact_ids: Vec::new(),
+        suggested_try_ids: Vec::new(),
+    });
+    report
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/startup.rs
@@ -216,6 +216,46 @@ fn raw_cli_startup_health_critical_fixture_uses_compact_oom_copy() {
 }
 
 #[test]
+fn raw_cli_startup_health_degraded_fixture_is_read_only() {
+    let cwd = temp_shell_home("startup-health-degraded-read-only");
+    let suppression_store = cwd.join("health-suppression");
+    let suppression_store = suppression_store.to_string_lossy().into_owned();
+    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("COSH_SHELL_STARTUP_BANNER", "1"),
+            ("COSH_SHELL_HEALTH_SCAN", "fixture:linux-degraded"),
+            (
+                "COSH_SHELL_HEALTH_SUPPRESSION_STORE",
+                suppression_store.as_str(),
+            ),
+            ("COSH_SHELL_LANG", "en-US"),
+            ("TERM", "xterm-256color"),
+            ("COSH_SHELL_ISOLATED", "0"),
+        ],
+        &cwd,
+        vec![
+            (b"\t\n".to_vec(), Duration::from_millis(1400)),
+            (b"exit\n".to_vec(), Duration::from_millis(700)),
+        ],
+    );
+
+    assert!(output.contains("Health check"), "{output}");
+    assert!(output.contains("degraded"), "{output}");
+    assert!(output.contains("Suggested prompts"), "{output}");
+    assert!(output.contains("[Health]"), "{output}");
+    assert!(!output.contains("[Personal]"), "{output}");
+    assert!(!output.contains("Tab insert"), "{output}");
+    assert!(!output.contains("Enter ask"), "{output}");
+    assert!(!output.contains("Shift+Tab cycle"), "{output}");
+    assert!(
+        !output.contains("Received shell prompt request:"),
+        "{output}"
+    );
+}
+
+#[test]
 fn raw_cli_startup_health_healthy_fixture_keeps_only_default_startup_card() {
     let cwd = temp_shell_home("startup-health-healthy-fixture");
     let suppression_store = cwd.join("health-suppression");


### PR DESCRIPTION
## Description

This separates terminal display support from health-report reliability and prompt interaction policy. Degraded or unavailable collection gaps now keep actionable health suggestions visible in read-only mode while suppressing personalized suggestions, prompt ghosts, bindings, and agent-selection routes. Complete reports retain the existing interactive behavior, including NO_COLOR terminals.

## Related Issue

closes #1656

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --lib` — 834 passed
- `cargo test --package cosh-shell --test raw_cli raw_cli_startup_health_degraded_fixture_is_read_only`
- `cargo check --package cosh-shell --all-targets`
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `git diff --check`

The Cargo commands used a command-line-only override for the duplicate local Aliyun source definition; no repository or user configuration was changed.

## Additional Notes

`crates/cosh-shell/scripts/check-layout.sh` still reports two pre-existing repository-wide debt groups in unrelated modules. None of the changed startup or planner files appears in those violations.