### PR TITLE
fix(tokenless): replace Claude Code tool output instead of appending compressed context

### DIFF
--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix Claude Code PostToolUse hook to *replace* the model-visible tool result via `hookSpecificOutput.updatedToolOutput` (Claude Code >= 2.1.121) instead of appending the compressed payload through the additive `additionalContext`, which duplicated the original output — `additionalContext` now carries only additive env-attribution diagnostics, empty schema fields (e.g. Bash `stderr`/`interrupted`/`isImage`) are restored on the replacement, older or undetectable Claude Code versions fail open by disabling compression, and non-beneficial compressions now pass through unchanged for every agent; adds `tests/test-posttooluse-replacement.sh` covering replacement semantics (closes #1645)
+
 ## 0.7.1
 
 - fix RPM tarball to exclude generated `.anolisa/component.toml`, ensuring rpmbuild always regenerates the adapter contract from the authoritative `.toml.in` template — previously stale checked-in copies shipped outdated contracts missing claude-code, codex, and cosh adapter declarations (closes #1470)

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -18,6 +18,17 @@ Pipeline: Env Attribution → Layered分流 → Compression → TOON Encoding
 
 Hook point: **PostToolUse**
 
+Output contract per agent:
+  - claude-code (>= 2.1.121): the compressed payload *replaces* the
+    model-visible tool result via ``hookSpecificOutput.updatedToolOutput``.
+    ``additionalContext`` is additive in Claude Code (appended alongside
+    the original tool result), so it only carries genuinely additive
+    diagnostics (environment attribution). Older Claude Code versions fail
+    open: compression is disabled instead of injecting a duplicate payload
+    (issue #1645).
+  - other agents: the compressed payload is injected via
+    ``additionalContext`` per each runtime's hook contract.
+
 The agent ID is read from the TOKENLESS_AGENT_ID environment variable
 (set by the install action script).  Fallback paths follow the ANOLISA
 FHS spec: /usr/bin/tokenless.
@@ -38,8 +49,10 @@ from hook_utils import (
     classify_env_error,
     get_thresholds,
     is_skill_file,
+    parse_version,
     resolve_binary,
     resolve_tool_call_id,
+    secure_write_text,
     skip,
     try_parse_json,
     unwrap_string_json,
@@ -50,6 +63,19 @@ from hook_utils import (
 
 _AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
 _MIN_RESPONSE_CHARS = 200
+
+# Claude Code added hookSpecificOutput.updatedToolOutput (normal-path tool
+# output replacement for all tools) in v2.1.121. Older versions only support
+# the additive additionalContext, which would duplicate the payload.
+_CLAUDE_AGENT_ID = "claude-code"
+_CLAUDE_MIN_REPLACE_VERSION = (2, 1, 121)
+
+# Cache for `claude --version`, keyed on binary path+mtime+size so upgrades
+# invalidate it. Hooks run as a fresh process per tool call and spawning the
+# node CLI every time would add noticeable latency.
+_CLAUDE_VERSION_CACHE = os.path.join(
+    os.path.expanduser("~"), ".tokenless", ".claude-version"
+)
 
 
 # -- helpers -------------------------------------------------------------------
@@ -64,6 +90,99 @@ def _build_additional_context(
         parts.append(env_attribution)
     parts.append(content)
     return "\n".join(parts)
+
+
+def _emit(output: dict) -> None:
+    print(json.dumps(output, ensure_ascii=False))
+
+
+def _emit_attribution_or_skip(env_attribution: str) -> None:
+    """Pass the original result through, keeping only additive diagnostics.
+
+    Emits an attribution-only additionalContext when present (it is genuinely
+    additive and safe on every agent), otherwise a plain skip. Never returns.
+    """
+    if env_attribution:
+        _emit({
+            "suppressOutput": True,
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": env_attribution,
+            },
+        })
+        sys.exit(0)
+    skip()
+
+
+def _cached_claude_version(claude_bin: str) -> tuple | None:
+    """Return the Claude Code version tuple, caching `claude --version`."""
+    try:
+        st = os.stat(claude_bin)
+        cache_key = f"{claude_bin}:{int(st.st_mtime)}:{st.st_size}"
+    except OSError:
+        cache_key = claude_bin
+
+    try:
+        with open(_CLAUDE_VERSION_CACHE) as f:
+            key, _, ver_str = f.read().strip().partition("\n")
+        if key == cache_key:
+            return parse_version(ver_str)
+    except OSError:
+        pass
+
+    try:
+        proc = subprocess.run(
+            [claude_bin, "--version"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception as e:
+        warn(f"claude --version failed: {e}")
+        return None
+    if proc.returncode != 0:
+        return None
+    ver = parse_version(proc.stdout)
+    if ver:
+        try:
+            # Same hardened write as other ~/.tokenless state files (0o600,
+            # symlink-safe) so the cache stays private on shared HOMEs.
+            secure_write_text(
+                _CLAUDE_VERSION_CACHE, f"{cache_key}\n{proc.stdout.strip()}"
+            )
+        except OSError:
+            pass
+    return ver
+
+
+def _claude_supports_replacement() -> bool:
+    """Whether the running Claude Code supports updatedToolOutput (>= 2.1.121).
+
+    Returns False when the version cannot be determined; the caller then
+    fails open by disabling compression, so unknown versions never receive a
+    duplicate compressed payload through additionalContext.
+    """
+    claude_bin = resolve_binary("claude")
+    if not claude_bin:
+        return False
+    ver = _cached_claude_version(claude_bin)
+    return ver is not None and ver >= _CLAUDE_MIN_REPLACE_VERSION
+
+
+def _restore_dropped_schema_fields(original: dict, compressed: dict) -> dict:
+    """Restore top-level keys dropped by compression when originally empty.
+
+    compress-response drops nulls, empty values ("" / {} / []) and configured
+    debug fields. Built-in Claude Code tools expect a stable output schema
+    (e.g. Bash: stdout/stderr/interrupted/isImage), so cheap empty fields are
+    restored for updatedToolOutput; intentionally dropped non-empty debug
+    payloads stay dropped.
+    """
+    restored = dict(compressed)
+    for key, value in original.items():
+        if key in restored:
+            continue
+        if value is None or value == "" or value == {} or value == []:
+            restored[key] = value
+    return restored
 
 
 # -- main --------------------------------------------------------------------
@@ -138,33 +257,13 @@ def main() -> None:
 
     # 10. Content retrieval — skip entirely (preserve integrity)
     if tool_name in SKIP_TOOLS:
-        if env_attribution:
-            output = {
-                "suppressOutput": True,
-                "hookSpecificOutput": {
-                    "hookEventName": "PostToolUse",
-                    "additionalContext": env_attribution,
-                },
-            }
-            print(json.dumps(output, ensure_ascii=False))
-            return
-        skip()
+        _emit_attribution_or_skip(env_attribution)
 
     # 11. All other tools — skip small responses, but still inject
     # env attribution for error cases (small size doesn't mean the
     # error classification is unimportant to the agent).
     if len(tool_response) < _MIN_RESPONSE_CHARS:
-        if env_attribution:
-            output = {
-                "suppressOutput": True,
-                "hookSpecificOutput": {
-                    "hookEventName": "PostToolUse",
-                    "additionalContext": env_attribution,
-                },
-            }
-            print(json.dumps(output, ensure_ascii=False))
-            return
-        skip()
+        _emit_attribution_or_skip(env_attribution)
 
     # 12. Step 1: Response compression with 3-layer thresholds
     #   Layer 1 (content retrieval): already skipped above
@@ -232,20 +331,77 @@ def main() -> None:
     # Determine final output
     final_output = toon_output if toon_output else compressed
 
-    # 14. Build response
+    # Nothing shrank — pass the original through untouched instead of
+    # emitting a same-size duplicate of the response (applies to all agents).
+    if not used_resp_compression and not toon_output:
+        _emit_attribution_or_skip(env_attribution)
+
+    # 14. Build response.
+    #
+    # Claude Code: additionalContext is *additive* — the model would see both
+    # the original tool result and the compressed copy, inflating the context
+    # instead of shrinking it (issue #1645). Replace the tool result via
+    # updatedToolOutput (>= 2.1.121) and keep additionalContext for additive
+    # diagnostics only. Unsupported versions fail open via pass-through.
+    if _AGENT_ID == _CLAUDE_AGENT_ID:
+        if not _claude_supports_replacement():
+            warn(
+                "Claude Code < 2.1.121 (or version unknown): "
+                "updatedToolOutput unsupported, response compression disabled."
+            )
+            _emit_attribution_or_skip(env_attribution)
+
+        if isinstance(tool_response_raw, (dict, list)):
+            # Structured original: the replacement must preserve the built-in
+            # tool output schema, so TOON (a text encoding) is not applicable
+            # and only a genuine compress-response win qualifies.
+            if not used_resp_compression:
+                _emit_attribution_or_skip(env_attribution)
+            compressed_parsed = try_parse_json(compressed)
+            if isinstance(tool_response_raw, dict) and isinstance(
+                compressed_parsed, dict
+            ):
+                updated_output = _restore_dropped_schema_fields(
+                    tool_response_raw, compressed_parsed
+                )
+            elif compressed_parsed is not None:
+                updated_output = compressed_parsed
+            else:
+                _emit_attribution_or_skip(env_attribution)
+            # Restoring empty schema fields can cancel out a marginal win;
+            # only replace when the result is strictly smaller than the
+            # original serialized response.
+            if len(json.dumps(updated_output, separators=(",", ":"))) >= len(
+                tool_response
+            ):
+                _emit_attribution_or_skip(env_attribution)
+        else:
+            # String original (JSON-in-string): replace with the smallest
+            # text form (TOON when it won, compressed JSON otherwise).
+            updated_output = final_output
+
+        hook_output = {
+            "hookEventName": "PostToolUse",
+            "updatedToolOutput": updated_output,
+        }
+        if env_attribution:
+            hook_output["additionalContext"] = env_attribution
+        _emit({"suppressOutput": True, "hookSpecificOutput": hook_output})
+        return
+
+    # Other agents: inject via additionalContext per their hook contracts.
     context = _build_additional_context(
         final_output,
         env_attribution=env_attribution,
     )
 
-    output = {
+    _emit({
         "suppressOutput": True,
         "hookSpecificOutput": {
             "hookEventName": "PostToolUse",
             "additionalContext": context,
         },
-    }
-    print(json.dumps(output, ensure_ascii=False))
+    })
 
 
 if __name__ == "__main__":

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -352,19 +352,28 @@ def resolve_tool_call_id(agent_id: str, input_data: dict) -> str:
     return input_data.get("tool_use_id") or input_data.get("toolCallId", "")
 
 
-def write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
-    """Write context file for rtk rewrite session tracking."""
-    os.makedirs(_CONTEXT_DIR, mode=0o700, exist_ok=True)
-    if os.path.islink(_CONTEXT_FILE):
-        os.unlink(_CONTEXT_FILE)
+def secure_write_text(path: str, content: str) -> None:
+    """Write a private hook state file (0o600, symlink-safe).
+
+    Shared hardening for state files under ~/.tokenless: the parent directory
+    is created 0o700, symlinks are refused (unlink + O_NOFOLLOW) and the file
+    stays owner-readable only, so hook state never leaks through a shared or
+    mounted HOME.
+    """
+    os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+    if os.path.islink(path):
+        os.unlink(path)
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
-    fd = os.open(_CONTEXT_FILE, flags, 0o600)
+    fd = os.open(path, flags, 0o600)
     with os.fdopen(fd, "w") as f:
-        f.write(f"{agent_id}\n")
-        f.write(f"{session_id}\n")
-        f.write(f"{tool_use_id}\n")
+        f.write(content)
+
+
+def write_context(agent_id: str, session_id: str, tool_use_id: str) -> None:
+    """Write context file for rtk rewrite session tracking."""
+    secure_write_text(_CONTEXT_FILE, f"{agent_id}\n{session_id}\n{tool_use_id}\n")
 
 
 def forward_stderr(proc: subprocess.CompletedProcess) -> None:

--- a/src/tokenless/docs/response-compression.md
+++ b/src/tokenless/docs/response-compression.md
@@ -117,9 +117,13 @@ Step 2：tokenless compress-toon（无损 TOON 编码）
 
 使用共享的 `compress_response_hook.py`（与 copilot-shell 共用），通过 `hooks.json` 中的 `${QODER_TOKENLESS_HOOKS}` 变量引用共享 hook 路径。
 
+注意：对所有非 Claude Code 的 agent（路径 2/4 等共享该 hook 的运行时），`additionalContext` 中的载荷在 TOON 编码更小时是 **TOON 文本**而非 JSON。TOON 是面向 LLM 直接阅读的紧凑文本格式，集成方无需解码；仅在离线调试需要还原 JSON 时可用 `toon -d` 转换。
+
 ### 路径 5：Claude Code 插件（`PostToolUse` hook）
 
 通过 `run-hook.sh` 调度器定位共享 hook 脚本，调用 `compress_response_hook.py`。Claude Code 复制插件到版本化缓存目录，因此 `run-hook.sh` 通过 FHS 路径查找共享 hook。
+
+与其他 agent 不同，Claude Code 的 `additionalContext` 是**追加式**的（模型会同时看到原始工具结果和注入内容），因此压缩结果通过 `hookSpecificOutput.updatedToolOutput`（Claude Code >= 2.1.121）**替换**模型可见的工具结果，`additionalContext` 仅保留真正追加式的诊断信息（环境错误归因）。替换时会回填被压缩剥离的空 schema 字段（如 Bash 的 `stderr`/`interrupted`/`isImage`），保持内置工具输出结构不变；结构化响应不做 TOON 编码（TOON 为文本格式，会破坏 schema）。旧版本 Claude Code（< 2.1.121）或版本无法探测时 fail-open：直接透传原始结果，不注入重复内容。版本探测结果缓存于 `~/.tokenless/.claude-version`（0600 权限、拒绝符号链接，与其他 hook 状态文件一致），缓存键为 claude 二进制的路径+mtime+大小，升级 Claude Code 后自动失效重探，避免每次 PostToolUse 都启动 node CLI。
 
 ### 路径 6：Codex 插件（`PostToolUse` hook）
 

--- a/src/tokenless/tests/test-posttooluse-replacement.sh
+++ b/src/tokenless/tests/test-posttooluse-replacement.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# PostToolUse replacement semantics test (issue #1645)
+#
+# Verifies compress_response_hook.py output contracts per agent:
+#   - claude-code >= 2.1.121: compressed payload replaces the tool result
+#     via hookSpecificOutput.updatedToolOutput (present exactly once, original
+#     sentinel absent, built-in tool schema preserved)
+#   - claude-code with undetectable/old version: fail open (pass-through,
+#     no duplicate injection)
+#   - non-beneficial compression: pass-through for every agent
+#   - other agents: additionalContext contract unchanged
+#
+# Uses stub `tokenless` / `claude` binaries so no real installation is needed.
+# JSON handling uses python3 only (already required by the hook itself), so
+# the test carries no extra dependency such as jq.
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; ((PASS++)); ((TOTAL++)); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; ((FAIL++)); ((TOTAL++)); }
+info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+section() { echo -e "\n${YELLOW}========== $1 ==========${NC}\n"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_DIR="$SCRIPT_DIR/../adapters/tokenless/common/hooks"
+HOOK="$HOOK_DIR/compress_response_hook.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo -e "${RED}ERROR: python3 not found (required by the hook itself)${NC}"; exit 1
+fi
+[ -f "$HOOK" ] || { echo -e "${RED}ERROR: hook not found: $HOOK${NC}"; exit 1; }
+
+WORKDIR=$(mktemp -d /tmp/tokenless_replace_test_XXXXXX)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# -- JSON helpers (python3-based, no jq dependency) -----------------------------
+
+jget() {
+    # $1 = JSON document; $2 = dot-separated key path. Prints empty when the
+    # path is missing; dict/list values are re-serialized as compact JSON.
+    python3 -c '
+import json, sys
+try:
+    obj = json.loads(sys.argv[1])
+except Exception:
+    print(); sys.exit(0)
+for key in sys.argv[2].split("."):
+    if isinstance(obj, dict) and key in obj:
+        obj = obj[key]
+    else:
+        print(); sys.exit(0)
+if isinstance(obj, (dict, list)):
+    print(json.dumps(obj, ensure_ascii=False))
+elif isinstance(obj, bool):
+    print("true" if obj else "false")
+else:
+    print(obj)
+' "$1" "$2"
+}
+
+build_bash_input() {
+    # $1 = tool_use_id; $2 = stdout; $3 = stderr; $4 = exit_code ("" to omit)
+    python3 -c '
+import json, sys
+resp = {"stdout": sys.argv[2], "stderr": sys.argv[3],
+        "interrupted": False, "isImage": False}
+if sys.argv[4]:
+    resp["exit_code"] = int(sys.argv[4])
+print(json.dumps({"tool_name": "Bash", "session_id": "sess-1",
+                  "tool_use_id": sys.argv[1], "tool_response": resp}))
+' "$1" "$2" "$3" "$4"
+}
+
+# -- stub binaries -------------------------------------------------------------
+
+make_stub_tokenless() {
+    # $1 = dir; $2 = mode (compress|passthrough)
+    local dir="$1" mode="$2"
+    if [ "$mode" = "compress" ]; then
+        cat > "$dir/tokenless" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  compress-response)
+    python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+def shrink(v):
+    return v[:100] if isinstance(v, str) else v
+if isinstance(data, dict):
+    out = {k: shrink(v) for k, v in data.items() if v not in (None, "", {}, [])}
+else:
+    out = data
+print(json.dumps(out, separators=(",", ":")))
+'
+    ;;
+  compress-toon) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+    else
+        # passthrough: compression yields no savings
+        cat > "$dir/tokenless" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  compress-response) cat ;;
+  compress-toon) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+    fi
+    chmod +x "$dir/tokenless"
+}
+
+make_stub_claude() {
+    # $1 = dir; $2 = version string or "broken"
+    local dir="$1" ver="$2"
+    if [ "$ver" = "broken" ]; then
+        printf '#!/usr/bin/env bash\nexit 1\n' > "$dir/claude"
+    else
+        printf '#!/usr/bin/env bash\necho "%s (Claude Code)"\n' "$ver" > "$dir/claude"
+    fi
+    chmod +x "$dir/claude"
+}
+
+run_hook() {
+    # $1 = agent id; $2 = stub dir; $3 = input JSON
+    local agent="$1" stubdir="$2" input="$3" home
+    home=$(mktemp -d "$WORKDIR/home_XXXXXX")
+    echo "$input" | HOME="$home" PATH="$stubdir:$PATH" \
+        TOKENLESS_AGENT_ID="$agent" python3 "$HOOK" 2>/dev/null
+}
+
+# Sentinel long enough (>200 chars) to enter the compression pipeline and be
+# visibly truncated by the stub (100-char cap).
+SENTINEL="TOKENLESS_SENTINEL_$(head -c8 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+LONG_OUT="${SENTINEL}_$(printf 'x%.0s' $(seq 1 400))"
+
+BASH_INPUT=$(build_bash_input "toolu_1" "$LONG_OUT" "" "")
+
+# ===== 1. claude-code >= 2.1.121: replacement via updatedToolOutput =====
+section "Test 1: claude-code replacement semantics"
+
+STUB1="$WORKDIR/stub1"; mkdir -p "$STUB1"
+make_stub_tokenless "$STUB1" compress
+make_stub_claude "$STUB1" "2.1.210"
+
+out=$(run_hook claude-code "$STUB1" "$BASH_INPUT")
+
+info "1.1: updatedToolOutput present with compressed stdout"
+updated_stdout=$(jget "$out" "hookSpecificOutput.updatedToolOutput.stdout")
+case "$updated_stdout" in
+    "$SENTINEL"*) pass "updatedToolOutput.stdout carries compressed content" ;;
+    *) fail "updatedToolOutput.stdout missing or wrong: $out" ;;
+esac
+
+info "1.2: original (uncompressed) sentinel payload absent"
+if echo "$out" | grep -qF "$LONG_OUT"; then
+    fail "full original payload leaked into hook output"
+else
+    pass "original full payload absent from hook output"
+fi
+
+info "1.3: compressed payload present exactly once"
+count=$(echo "$out" | grep -oF "$SENTINEL" | wc -l)
+[ "$count" -eq 1 ] && pass "sentinel appears exactly once" \
+    || fail "sentinel appears $count times (expected 1)"
+
+info "1.4: compressed payload not duplicated into additionalContext"
+extra=$(jget "$out" "hookSpecificOutput.additionalContext")
+if echo "$extra" | grep -qF "$SENTINEL"; then
+    fail "compressed payload duplicated in additionalContext"
+else
+    pass "additionalContext free of compressed payload"
+fi
+
+info "1.5: built-in Bash output schema preserved"
+schema_ok=$(python3 -c '
+import json, sys
+try:
+    uto = json.loads(sys.argv[1])["hookSpecificOutput"]["updatedToolOutput"]
+except Exception:
+    print("false"); sys.exit(0)
+keys = {"stdout", "stderr", "interrupted", "isImage"}
+print("true" if isinstance(uto, dict) and keys <= set(uto) else "false")
+' "$out")
+[ "$schema_ok" = "true" ] && pass "stdout/stderr/interrupted/isImage all present" \
+    || fail "schema fields missing: $out"
+
+# ===== 2. Version gating: fail open =====
+section "Test 2: version gating (fail open)"
+
+info "2.1: old Claude Code (2.1.100) → pass-through, no injection"
+STUB2="$WORKDIR/stub2"; mkdir -p "$STUB2"
+make_stub_tokenless "$STUB2" compress
+make_stub_claude "$STUB2" "2.1.100"
+out=$(run_hook claude-code "$STUB2" "$BASH_INPUT")
+trimmed=$(echo "$out" | tr -d '[:space:]')
+[ "$trimmed" = "{}" ] && pass "old version passes through with {}" \
+    || fail "expected {}, got: $out"
+
+info "2.2: undetectable claude version → pass-through"
+STUB3="$WORKDIR/stub3"; mkdir -p "$STUB3"
+make_stub_tokenless "$STUB3" compress
+make_stub_claude "$STUB3" broken
+out=$(run_hook claude-code "$STUB3" "$BASH_INPUT")
+trimmed=$(echo "$out" | tr -d '[:space:]')
+[ "$trimmed" = "{}" ] && pass "unknown version passes through with {}" \
+    || fail "expected {}, got: $out"
+
+# ===== 3. Non-beneficial compression: pass-through for all agents =====
+section "Test 3: non-beneficial compression"
+
+STUB4="$WORKDIR/stub4"; mkdir -p "$STUB4"
+make_stub_tokenless "$STUB4" passthrough
+make_stub_claude "$STUB4" "2.1.210"
+
+info "3.1: claude-code — no savings → no additive duplication"
+out=$(run_hook claude-code "$STUB4" "$BASH_INPUT")
+trimmed=$(echo "$out" | tr -d '[:space:]')
+[ "$trimmed" = "{}" ] && pass "claude-code passes through with {}" \
+    || fail "expected {}, got: $out"
+
+info "3.2: qoder-cli — no savings → no additive duplication"
+out=$(run_hook qoder-cli "$STUB4" "$BASH_INPUT")
+trimmed=$(echo "$out" | tr -d '[:space:]')
+[ "$trimmed" = "{}" ] && pass "qoder-cli passes through with {}" \
+    || fail "expected {}, got: $out"
+
+# ===== 4. Other agents keep the additionalContext contract =====
+section "Test 4: non-claude agents unchanged"
+
+info "4.1: qoder-cli — compressed payload via additionalContext"
+out=$(run_hook qoder-cli "$STUB1" "$BASH_INPUT")
+extra=$(jget "$out" "hookSpecificOutput.additionalContext")
+updated=$(jget "$out" "hookSpecificOutput.updatedToolOutput")
+if echo "$extra" | grep -qF "$SENTINEL" && [ -z "$updated" ]; then
+    pass "qoder-cli keeps additionalContext, no updatedToolOutput"
+else
+    fail "qoder-cli contract changed: $out"
+fi
+
+# ===== 5. Env attribution stays additive-only on the replacement path =====
+section "Test 5: env attribution with replacement"
+
+ERR_OUT="bash: frobnicate: command not found. $(printf 'e%.0s' $(seq 1 300)) ${SENTINEL}"
+ERR_INPUT=$(build_bash_input "toolu_2" "" "$ERR_OUT" 127)
+
+out=$(run_hook claude-code "$STUB1" "$ERR_INPUT")
+
+info "5.1: updatedToolOutput present for error response"
+updated=$(jget "$out" "hookSpecificOutput.updatedToolOutput")
+[ -n "$updated" ] && pass "replacement emitted for error response" \
+    || fail "no updatedToolOutput: $out"
+
+info "5.2: additionalContext carries only the env attribution"
+extra=$(jget "$out" "hookSpecificOutput.additionalContext")
+if echo "$extra" | grep -qF "[tokenless:env]" && ! echo "$extra" | grep -qF "$SENTINEL"; then
+    pass "additionalContext is attribution-only"
+else
+    fail "additionalContext wrong: $extra"
+fi
+
+# ===== 6. Version cache file is written with hardened permissions =====
+section "Test 6: version cache hardening"
+
+info "6.1: cache file mode is 0600 under a 0700 ~/.tokenless"
+home=$(mktemp -d "$WORKDIR/home_perm_XXXXXX")
+echo "$BASH_INPUT" | HOME="$home" PATH="$STUB1:$PATH" \
+    TOKENLESS_AGENT_ID=claude-code python3 "$HOOK" >/dev/null 2>&1
+cache="$home/.tokenless/.claude-version"
+if [ -f "$cache" ]; then
+    dir_mode=$(stat -c '%a' "$home/.tokenless")
+    file_mode=$(stat -c '%a' "$cache")
+    [ "$file_mode" = "600" ] && [ "$dir_mode" = "700" ] \
+        && pass "cache dir=700 file=600" \
+        || fail "unexpected modes: dir=$dir_mode file=$file_mode"
+else
+    fail "version cache not written: $cache"
+fi
+
+# ===== summary =====
+echo ""
+echo "============================================"
+echo "  Summary: ${PASS}/${TOTAL} passed"
+echo "============================================"
+[ "$FAIL" -gt 0 ] && exit 1
+echo -e "\n${GREEN}All tests passed!${NC}"


### PR DESCRIPTION
## Summary

The Tokenless Claude Code adapter returned compressed PostToolUse data through `hookSpecificOutput.additionalContext` with `suppressOutput: true`. In Claude Code, `additionalContext` is **additive** — the model receives both the original tool result and the compressed copy, inflating the context instead of shrinking it.

Ref: #1645

## Changes

- **Replacement instead of appending** (`compress_response_hook.py`): for `claude-code`, the compressed payload now *replaces* the model-visible tool result via `hookSpecificOutput.updatedToolOutput` (Claude Code >= 2.1.121). `additionalContext` only carries genuinely additive diagnostics (env attribution).
- **Schema preservation**: empty top-level fields stripped by `compress-response` (e.g. Bash `stderr:""` / `interrupted` / `isImage`) are restored on the replacement so built-in tool output schemas stay intact; structured responses skip TOON (text encoding would break the schema).
- **Version gating, fail open**: Claude Code version is detected via `claude --version` (cached in `~/.tokenless/.claude-version`, keyed on binary path+mtime+size). Older or undetectable versions disable compression entirely — no duplicate payload is ever injected.
- **No-net-win pass-through (all agents)**: when compression (after schema restoration) is not strictly smaller than the original, the hook passes through instead of emitting a same-size duplicate — this also fixes the byte-identical duplication case from the issue report.
- Other agents (`qoder-cli` / `qwencode` / `copilot-shell`) keep their existing `additionalContext` contract.
- Docs (`response-compression.md` path 5) and CHANGELOG updated.

## Testing

- New stub-based integration test `tests/test-posttooluse-replacement.sh` (no real installation required): 12/12 assertions covering replacement-exactly-once, original-sentinel-absent, schema fields present, version-gate fail-open, no-net-win pass-through, non-claude contract unchanged, attribution-only `additionalContext`.
- End-to-end verified with local Claude Code 2.1.211 + tokenless 0.7.1:
  - 86.8KB Bash stdout → hook emitted `updatedToolOutput` (66.8KB); transcript shows the model-visible result derived from the replaced content (persisted as 64KB, not the original 84.8KB), zero `hook_additional_context` events, original full output absent.
  - 3.2KB response with no net win → hook emitted `{}` (pass-through) — previously this injected a byte-identical duplicate.
  - 107KB output already persisted by Claude Code (`<persisted-output>`) → hook correctly skips.

## Acceptance criteria from the issue

- [x] Original sentinel text absent from the model-visible tool result after successful compression
- [x] Compressed replacement present exactly once
- [x] Small or non-beneficial transformations pass through without additive duplication
- [x] Built-in tool output schemas preserved
- [x] Unsupported Claude Code versions fail open without injecting duplicate content
- [x] Automated PostToolUse integration test verifies replacement semantics and prompt-visible size
