### PR TITLE
fix(anolisa): isolate cli tests from user state

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -536,27 +536,29 @@ mod tests {
     use super::*;
 
     fn ctx_with_prefix(prefix: PathBuf) -> CliContext {
-        CliContext {
-            install_mode: InstallMode::System,
-            prefix: Some(prefix),
-            json: false,
-            dry_run: false,
-            verbose: false,
-            quiet: false,
-            no_color: false,
-        }
+        crate::test_support::context_for_root(
+            Path::new("/tmp/anolisa-commands-validation"),
+            InstallMode::System,
+            Some(prefix),
+            crate::test_support::TestContextOptions {
+                quiet: false,
+                no_color: false,
+                ..Default::default()
+            },
+        )
     }
 
     fn user_ctx() -> CliContext {
-        CliContext {
-            install_mode: InstallMode::User,
-            prefix: None,
-            json: false,
-            dry_run: false,
-            verbose: false,
-            quiet: false,
-            no_color: false,
-        }
+        crate::test_support::context_for_root(
+            Path::new("/tmp/anolisa-commands-validation"),
+            InstallMode::User,
+            None,
+            crate::test_support::TestContextOptions {
+                quiet: false,
+                no_color: false,
+                ..Default::default()
+            },
+        )
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -29,13 +29,7 @@ const INSTALLED_COMPONENT_MANIFEST_FILE: &str = "component.toml";
 /// Build the layout for the active install mode, honoring `--prefix`
 /// (system-mode) and the current process user's home (user-mode).
 pub fn resolve_layout(ctx: &CliContext) -> FsLayout {
-    match ctx.install_mode {
-        InstallMode::System => FsLayout::system(ctx.prefix.clone()),
-        InstallMode::User => {
-            let home = anolisa_env::EnvService::detect().home;
-            FsLayout::user(home)
-        }
-    }
+    ctx.layout().clone()
 }
 
 /// Build a consistent package-transaction permission error.
@@ -174,10 +168,13 @@ pub(crate) fn load_repo_config(
     command: &str,
     persist_policy: RepoPersistPolicy,
 ) -> Result<RepoConfig, CliError> {
-    let repo_load = RepoConfig::load(layout, ctx.dry_run).map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: err.to_string(),
-    })?;
+    let repo_load =
+        RepoConfig::load(layout, ctx.dry_run, ctx.packaged_data_probe()).map_err(|err| {
+            CliError::Runtime {
+                command: command.to_string(),
+                reason: err.to_string(),
+            }
+        })?;
     enforce_repo_persist_policy(&repo_load.provisioning, persist_policy, command)?;
     render_repo_config_provisioning(ctx, &repo_load.provisioning);
     Ok(repo_load.config)
@@ -467,9 +464,12 @@ pub(crate) fn build_adapter_manager(ctx: &CliContext) -> AdapterManager {
     let (mut manager, layout) = new_adapter_manager(ctx);
 
     match StateView::load(ctx, "adapter", StateVisibility::UserPlusSystem) {
-        Ok(view) => configure_adapter_manager(&mut manager, &view),
+        Ok(view) => configure_adapter_manager(&mut manager, &view, ctx.packaged_data_probe()),
         Err(_) => {
-            manager.set_visible_roots(vec![visible_root_for_adapter(&layout)]);
+            manager.set_visible_roots(vec![visible_root_for_adapter(
+                &layout,
+                ctx.packaged_data_probe(),
+            )]);
         }
     }
 
@@ -483,7 +483,7 @@ pub(crate) fn build_adapter_manager_from_view(
     view: &StateView,
 ) -> AdapterManager {
     let (mut manager, _) = new_adapter_manager(ctx);
-    configure_adapter_manager(&mut manager, view);
+    configure_adapter_manager(&mut manager, view, ctx.packaged_data_probe());
     manager
 }
 
@@ -496,11 +496,15 @@ fn new_adapter_manager(ctx: &CliContext) -> (AdapterManager, FsLayout) {
     )
 }
 
-fn configure_adapter_manager(manager: &mut AdapterManager, view: &StateView) {
+fn configure_adapter_manager(
+    manager: &mut AdapterManager,
+    view: &StateView,
+    packaged_data_probe: &packaged::PackagedDataProbe,
+) {
     let roots = view
         .visible_roots
         .iter()
-        .map(|root| visible_root_for_adapter(&root.layout))
+        .map(|root| visible_root_for_adapter(&root.layout, packaged_data_probe))
         .collect();
     manager.set_visible_roots(roots);
     for warning in &view.warnings {
@@ -508,14 +512,20 @@ fn configure_adapter_manager(manager: &mut AdapterManager, view: &StateView) {
     }
 }
 
-fn visible_root_for_adapter(layout: &FsLayout) -> VisibleRoot {
+fn visible_root_for_adapter(
+    layout: &FsLayout,
+    packaged_data_probe: &packaged::PackagedDataProbe,
+) -> VisibleRoot {
     VisibleRoot {
         state_dir: layout.state_dir.clone(),
-        contract_datadir_roots: adapter_contract_datadir_roots(layout),
+        contract_datadir_roots: adapter_contract_datadir_roots(layout, packaged_data_probe),
     }
 }
 
-fn adapter_contract_datadir_roots(layout: &FsLayout) -> Vec<PathBuf> {
+fn adapter_contract_datadir_roots(
+    layout: &FsLayout,
+    packaged_data_probe: &packaged::PackagedDataProbe,
+) -> Vec<PathBuf> {
     // Two independent datadir-discovery mechanisms are layered here:
     //
     //   packaged_datadir_root()  — runtime probe: env override → exe-sibling
@@ -532,7 +542,7 @@ fn adapter_contract_datadir_roots(layout: &FsLayout) -> Vec<PathBuf> {
     // exe-sibling probe handles relocated installs; the FHS constant handles
     // cross-install-method discovery (raw binary + RPM components).
     let mut roots = vec![layout.datadir.clone()];
-    if let Some(packaged) = packaged::packaged_datadir_root(layout)
+    if let Some(packaged) = packaged::packaged_datadir_root(layout, packaged_data_probe)
         && !roots.contains(&packaged)
     {
         roots.push(packaged);

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
@@ -82,7 +82,7 @@ impl StateView {
 
         if ctx.install_mode == InstallMode::User && visibility == StateVisibility::UserPlusSystem {
             roots.push((
-                FsLayout::system(ctx.prefix.clone()),
+                ctx.visible_system_layout().clone(),
                 RootSpec {
                     scope: StateScope::System,
                     writable: false,
@@ -115,7 +115,7 @@ impl StateView {
         let mut warnings = Vec::new();
 
         if ctx.install_mode == InstallMode::User && visibility == StateVisibility::UserPlusSystem {
-            let system_layout = FsLayout::system(ctx.prefix.clone());
+            let system_layout = ctx.visible_system_layout().clone();
             let system_state_path = system_layout.state_dir.join(INSTALLED_STATE_FILE);
             match load_root_state(command, &system_layout, &system_state_path, false) {
                 Ok(state) => visible_roots.push(ScopedStateRoot {

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view/tests.rs
@@ -2,7 +2,7 @@ use anolisa_core::InstalledState;
 use anolisa_platform::fs_layout::FsLayout;
 use tempfile::tempdir;
 
-use crate::context::{CliContext, InstallMode};
+use crate::context::InstallMode;
 
 use super::*;
 use support::{component, user_layout, write_state};
@@ -172,15 +172,15 @@ fn system_mode_visibility_does_not_load_user_state() {
     let xdg_state = tmp.path().join("xdg-state");
     let user_layout = FsLayout::user_with_overrides(home, None, None, Some(xdg_state), None, None);
     write_state(&user_layout, vec![component("user-only")]);
-    let ctx = CliContext {
-        install_mode: InstallMode::System,
-        prefix: Some(system_prefix),
-        json: true,
-        dry_run: false,
-        verbose: false,
-        quiet: true,
-        no_color: true,
-    };
+    let ctx = crate::test_support::context_for_root(
+        tmp.path(),
+        InstallMode::System,
+        Some(system_prefix),
+        crate::test_support::TestContextOptions {
+            json: true,
+            ..Default::default()
+        },
+    );
 
     let view =
         StateView::load(&ctx, "test", StateVisibility::UserPlusSystem).expect("system state view");

--- a/src/anolisa/crates/anolisa-cli/src/commands/system.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/system.rs
@@ -96,7 +96,7 @@ const ANOLISA_GROUP: &str = "anolisa";
 
 /// Resolve the system-mode FsLayout from context.
 fn resolve_layout(ctx: &CliContext) -> FsLayout {
-    FsLayout::system(ctx.prefix.clone())
+    ctx.visible_system_layout().clone()
 }
 
 fn require_root(command: &str, reason: &str, hint: &str) -> Result<(), CliError> {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -117,14 +117,16 @@ pub(crate) fn adopt_with_query(
     query: &dyn PackageQuery,
 ) -> Result<(), CliError> {
     let command = format!("{COMMAND} {target}");
+    if ctx.install_mode == InstallMode::User {
+        return Err(CliError::InvalidArgument {
+            command,
+            reason: "adopt is available only in system mode".to_string(),
+        });
+    }
     let layout = common::resolve_layout(ctx);
     let state_path = layout.state_dir.join("installed.toml");
     let journal_dir = rpm_install::journal_dir(&layout);
-    let uid = privilege::effective_uid();
-    let scope = match ctx.install_mode {
-        InstallMode::System => InstallationScope::System,
-        InstallMode::User => InstallationScope::User { uid },
-    };
+    let scope = InstallationScope::System;
     let now = now_iso8601();
     let env = anolisa_env::EnvService::detect();
 
@@ -468,7 +470,8 @@ fn execute_adopt_plan(
     // Best-effort: snapshot the datadir component contract so adapter
     // commands can discover declared adapters. Missing or unwritable
     // contracts produce warnings, never failures.
-    for warning in snapshot_datadir_contract(layout, component, command) {
+    for warning in snapshot_datadir_contract(layout, component, command, ctx.packaged_data_probe())
+    {
         eprintln!("warning: {warning}");
     }
 
@@ -717,10 +720,12 @@ mod tests {
         package_provides: Vec<(String, Vec<String>)>,
         /// package → source repo for `installed_origin`.
         origins: Vec<(String, String)>,
+        calls: Cell<usize>,
     }
 
     impl PackageQuery for FakeQuery {
         fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            self.calls.set(self.calls.get() + 1);
             if self.multi_version.iter().any(|p| p == package) {
                 return Err(PackageQueryError::UnexpectedOutput {
                     command: "rpm".to_string(),
@@ -734,9 +739,11 @@ mod tests {
                 .map(|(_, info)| info.clone()))
         }
         fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            self.calls.set(self.calls.get() + 1);
             Ok(Vec::new())
         }
         fn installed_origin(&self, package: &str) -> Result<Option<String>, PackageQueryError> {
+            self.calls.set(self.calls.get() + 1);
             Ok(self
                 .origins
                 .iter()
@@ -747,6 +754,7 @@ mod tests {
             &self,
             capability: &str,
         ) -> Result<Vec<String>, PackageQueryError> {
+            self.calls.set(self.calls.get() + 1);
             Ok(self
                 .provides
                 .iter()
@@ -758,6 +766,7 @@ mod tests {
             &self,
             capability: &str,
         ) -> Result<Vec<String>, PackageQueryError> {
+            self.calls.set(self.calls.get() + 1);
             Ok(self
                 .available_provides
                 .iter()
@@ -769,6 +778,7 @@ mod tests {
             &self,
             package: &str,
         ) -> Result<Vec<String>, PackageQueryError> {
+            self.calls.set(self.calls.get() + 1);
             Ok(self
                 .package_provides
                 .iter()
@@ -851,15 +861,15 @@ mod tests {
     }
 
     fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
-        CliContext {
+        crate::test_support::context_for_root(
+            &prefix,
             install_mode,
-            prefix: Some(prefix),
-            json: false,
-            dry_run,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
+            Some(prefix.clone()),
+            crate::test_support::TestContextOptions {
+                dry_run,
+                ..Default::default()
+            },
+        )
     }
 
     /// A tracked component object with the given provenance, as legacy v4
@@ -1242,13 +1252,20 @@ mod tests {
     fn adopt_refuses_in_user_mode() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::User, false);
-        let err = adopt_with_query("copilot-shell", None, &c, &FakeQuery::default())
+        let query = FakeQuery::default();
+        let err = adopt_with_query("copilot-shell", None, &c, &query)
             .expect_err("user mode must be refused");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(
             err.reason().contains("system"),
             "user-mode refusal mentions system scope: {}",
             err.reason()
+        );
+        assert_eq!(query.calls.get(), 0, "user refusal must not query rpmdb");
+        assert_eq!(
+            std::fs::read_dir(tmp.path()).expect("sandbox root").count(),
+            0,
+            "user refusal must not create filesystem state"
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/bug.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/bug.rs
@@ -527,15 +527,16 @@ mod tests {
     #[test]
     fn missing_central_log_yields_empty_recent_logs() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ctx = CliContext {
-            install_mode: crate::context::InstallMode::System,
-            prefix: Some(tmp.path().to_path_buf()),
-            json: false,
-            dry_run: false,
-            verbose: false,
-            quiet: false,
-            no_color: false,
-        };
+        let ctx = crate::test_support::context_for_root(
+            tmp.path(),
+            crate::context::InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+            crate::test_support::TestContextOptions {
+                quiet: false,
+                no_color: false,
+                ..Default::default()
+            },
+        );
 
         let logs = collect_recent_logs(None, DEFAULT_LIMIT, &ctx).expect("missing log is ok");
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -381,15 +381,15 @@ mod tests {
     use crate::context::InstallMode;
 
     fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
-        CliContext {
+        crate::test_support::context_for_root(
+            &prefix,
             install_mode,
-            prefix: Some(prefix),
-            json: false,
-            dry_run,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
+            Some(prefix.clone()),
+            crate::test_support::TestContextOptions {
+                dry_run,
+                ..Default::default()
+            },
+        )
     }
 
     /// An adopted rpm-observed component object (legacy v4 shape; loading it

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -118,11 +118,9 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
     // Each handle_one call runs in quiet mode so it doesn't print individual
     // JSON envelopes or human-mode messages — only the batch summary at the
     // end goes to stdout.
-    let suppressed_ctx = CliContext {
-        json: false,
-        quiet: true,
-        ..ctx.clone()
-    };
+    let mut suppressed_ctx = ctx.clone();
+    suppressed_ctx.json = false;
+    suppressed_ctx.quiet = true;
 
     // Peek phase: plan every component read-only and classify. Fresh
     // delegated installs merge into one native transaction; everything else
@@ -406,11 +404,9 @@ fn execute_merged_group(
     ctx: &CliContext,
 ) -> Vec<AllSummaryItem> {
     let per_args = per_component_args(&group[0].name, args);
-    let suppressed_ctx = CliContext {
-        json: false,
-        quiet: true,
-        ..ctx.clone()
-    };
+    let mut suppressed_ctx = ctx.clone();
+    suppressed_ctx.json = false;
+    suppressed_ctx.quiet = true;
     let (query, txn) = match host_backends(&group[0].name, &per_args, &suppressed_ctx) {
         Ok(backends) => backends,
         Err(err) => {
@@ -638,9 +634,12 @@ fn execute_merged_group_with_deps(
                             finished_at: Some(now_iso8601()),
                             parent_operation_id: Some(batch_operation_id.clone()),
                         });
-                        for warning in
-                            super::io_util::snapshot_datadir_contract(&layout, &target, COMMAND)
-                        {
+                        for warning in super::io_util::snapshot_datadir_contract(
+                            &layout,
+                            &target,
+                            COMMAND,
+                            ctx.packaged_data_probe(),
+                        ) {
                             eprintln!("warning: {warning}");
                         }
                         items.push(AllSummaryItem {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -963,7 +963,12 @@ fn install_delegated(
     // Best-effort: snapshot the datadir component contract so adapter
     // commands can discover declared adapters. Missing or unwritable
     // contracts produce warnings, never failures.
-    for warning in super::io_util::snapshot_datadir_contract(layout, target, command) {
+    for warning in super::io_util::snapshot_datadir_contract(
+        layout,
+        target,
+        command,
+        ctx.packaged_data_probe(),
+    ) {
         eprintln!("warning: {warning}");
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
@@ -144,7 +144,11 @@ impl ContractRefreshOutcome {
     }
 }
 
-fn datadir_contract_roots(layout: &FsLayout, policy: ContractSourcePolicy) -> Vec<PathBuf> {
+fn datadir_contract_roots(
+    layout: &FsLayout,
+    policy: ContractSourcePolicy,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
+) -> Vec<PathBuf> {
     if matches!(policy, ContractSourcePolicy::RpmReconciliation) {
         return vec![
             layout
@@ -157,7 +161,7 @@ fn datadir_contract_roots(layout: &FsLayout, policy: ContractSourcePolicy) -> Ve
     if let Some(package_datadir) = layout.package_datadir() {
         roots.push(package_datadir);
     }
-    if let Some(packaged) = crate::packaged::packaged_datadir_root(layout)
+    if let Some(packaged) = crate::packaged::packaged_datadir_root(layout, packaged_data_probe)
         && !roots.iter().any(|root| root == &packaged)
     {
         roots.push(packaged);
@@ -172,9 +176,10 @@ fn lookup_datadir_contract(
     layout: &FsLayout,
     component: &str,
     policy: ContractSourcePolicy,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> DatadirContractLookup {
     let mut searched: Vec<PathBuf> = Vec::new();
-    for datadir_root in datadir_contract_roots(layout, policy) {
+    for datadir_root in datadir_contract_roots(layout, policy, packaged_data_probe) {
         let source_path = FsLayout::component_contract_path(&datadir_root, component);
         match std::fs::read_to_string(&source_path) {
             Ok(content) => {
@@ -207,29 +212,34 @@ pub(crate) fn inspect_datadir_contract_drift(
     layout: &FsLayout,
     component: &str,
     command: &str,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> ContractDriftInspection {
-    let contract =
-        match lookup_datadir_contract(layout, component, ContractSourcePolicy::RpmReconciliation) {
-            DatadirContractLookup::Found(contract) => contract,
-            DatadirContractLookup::Missing(_) => {
-                return ContractDriftInspection {
-                    drifted: false,
-                    warnings: Vec::new(),
-                };
-            }
-            DatadirContractLookup::Unreadable {
-                source_path,
-                source,
-            } => {
-                return ContractDriftInspection {
-                    drifted: false,
-                    warnings: vec![format!(
-                        "could not read datadir component contract at {}: {source}",
-                        source_path.display()
-                    )],
-                };
-            }
-        };
+    let contract = match lookup_datadir_contract(
+        layout,
+        component,
+        ContractSourcePolicy::RpmReconciliation,
+        packaged_data_probe,
+    ) {
+        DatadirContractLookup::Found(contract) => contract,
+        DatadirContractLookup::Missing(_) => {
+            return ContractDriftInspection {
+                drifted: false,
+                warnings: Vec::new(),
+            };
+        }
+        DatadirContractLookup::Unreadable {
+            source_path,
+            source,
+        } => {
+            return ContractDriftInspection {
+                drifted: false,
+                warnings: vec![format!(
+                    "could not read datadir component contract at {}: {source}",
+                    source_path.display()
+                )],
+            };
+        }
+    };
     let destination = match common::installed_component_manifest_path(layout, component, command) {
         Ok(path) => path,
         Err(err) => {
@@ -297,6 +307,7 @@ pub(crate) fn snapshot_datadir_contract(
     layout: &FsLayout,
     component: &str,
     command: &str,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> Vec<String> {
     snapshot_datadir_contract_with_missing_policy(
         layout,
@@ -304,6 +315,7 @@ pub(crate) fn snapshot_datadir_contract(
         command,
         true,
         ContractSourcePolicy::InstallOrAdopt,
+        packaged_data_probe,
     )
     .warnings
 }
@@ -317,6 +329,7 @@ pub(crate) fn refresh_datadir_contract_snapshot(
     layout: &FsLayout,
     component: &str,
     command: &str,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> ContractRefreshOutcome {
     snapshot_datadir_contract_with_missing_policy(
         layout,
@@ -324,6 +337,7 @@ pub(crate) fn refresh_datadir_contract_snapshot(
         command,
         false,
         ContractSourcePolicy::RpmReconciliation,
+        packaged_data_probe,
     )
 }
 
@@ -333,9 +347,10 @@ fn snapshot_datadir_contract_with_missing_policy(
     command: &str,
     warn_if_missing: bool,
     policy: ContractSourcePolicy,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> ContractRefreshOutcome {
     let mut warnings: Vec<String> = Vec::new();
-    let contract = match lookup_datadir_contract(layout, component, policy) {
+    let contract = match lookup_datadir_contract(layout, component, policy, packaged_data_probe) {
         DatadirContractLookup::Found(contract) => contract,
         DatadirContractLookup::Missing(searched) => {
             if warn_if_missing {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -26,19 +26,23 @@ use tar::{Builder, Header};
 use tempfile::tempdir;
 
 pub fn ctx_with_prefix(json: bool, prefix: Option<PathBuf>) -> CliContext {
-    CliContext {
-        install_mode: if prefix.is_some() {
-            InstallMode::System
-        } else {
-            InstallMode::User
+    let root = prefix
+        .as_deref()
+        .unwrap_or_else(|| std::path::Path::new("/tmp/anolisa-install-validation"));
+    let install_mode = if prefix.is_some() {
+        InstallMode::System
+    } else {
+        InstallMode::User
+    };
+    crate::test_support::context_for_root(
+        root,
+        install_mode,
+        prefix.clone(),
+        crate::test_support::TestContextOptions {
+            json,
+            ..Default::default()
         },
-        prefix,
-        json,
-        dry_run: false,
-        verbose: false,
-        quiet: true, // suppress stdout during tests
-        no_color: true,
-    }
+    )
 }
 
 pub fn args(component: &str) -> InstallArgs {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/contract.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/contract.rs
@@ -7,7 +7,6 @@ use tempfile::tempdir;
 
 #[test]
 fn adopt_snapshots_datadir_contract() {
-    let _env_guard = crate::packaged::DataDirEnvGuard::clear();
     let (_tmp, ctx) = system_ctx_with_raw_repo(false);
     let layout = common::resolve_layout(&ctx);
     let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
@@ -36,7 +35,6 @@ fn adopt_snapshots_datadir_contract() {
 
 #[test]
 fn adopt_without_datadir_contract_succeeds_with_warning() {
-    let _env_guard = crate::packaged::DataDirEnvGuard::clear();
     let (_tmp, ctx) = system_ctx_with_raw_repo(false);
     let layout = common::resolve_layout(&ctx);
     // Deliberately do NOT seed a datadir contract.
@@ -62,7 +60,6 @@ fn adopt_without_datadir_contract_succeeds_with_warning() {
 
 #[test]
 fn delegated_install_snapshots_datadir_contract() {
-    let _env_guard = crate::packaged::DataDirEnvGuard::clear();
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
     let layout = common::resolve_layout(&ctx);
     let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
@@ -92,7 +89,6 @@ fn delegated_install_snapshots_datadir_contract() {
 
 #[test]
 fn delegated_install_without_datadir_contract_succeeds() {
-    let _env_guard = crate::packaged::DataDirEnvGuard::clear();
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
     let layout = common::resolve_layout(&ctx);
     // No datadir contract seeded.
@@ -130,8 +126,7 @@ fn adopt_snapshots_packaged_datadir_contract() {
     std::fs::write(contract_dir.join("component.toml"), &contract)
         .expect("write packaged contract");
 
-    // Guard sets ANOLISA_DATA_DIR and restores on drop (panic-safe).
-    let _env_guard = crate::packaged::DataDirEnvGuard::set(&packaged);
+    let ctx = ctx.with_packaged_data_root(packaged);
 
     let q = FakeQuery {
         installed: vec![(
@@ -159,7 +154,6 @@ fn adopt_snapshots_packaged_datadir_contract() {
 
 #[test]
 fn adopt_snapshots_fhs_package_datadir_contract() {
-    let _env_guard = crate::packaged::DataDirEnvGuard::clear();
     let tmp = tempdir().expect("tempdir");
     let prefix = tmp.path().join("sys");
     let ctx = ctx_with_prefix(false, Some(prefix));
@@ -202,13 +196,13 @@ fn adopt_snapshots_fhs_package_datadir_contract() {
 
 #[test]
 fn snapshot_datadir_contract_writes_provenance() {
-    let _env_guard = crate::packaged::DataDirEnvGuard::clear();
     let (_tmp, ctx) = system_ctx_with_raw_repo(false);
     let layout = common::resolve_layout(&ctx);
     let contract = component_manifest_toml("sec-core", "1.0.0", &["system"]);
     seed_datadir_contract(&layout, "sec-core", &contract);
 
-    let warnings = snapshot_datadir_contract(&layout, "sec-core", COMMAND);
+    let warnings =
+        snapshot_datadir_contract(&layout, "sec-core", COMMAND, ctx.packaged_data_probe());
     assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
 
     let snapshot = common::installed_component_manifest_path(&layout, "sec-core", COMMAND)

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -229,7 +229,8 @@ fn repair_attempt(
             .map(|r| &r.binding),
         Some(ProviderBinding::Delegated { .. })
     ) && {
-        let inspection = inspect_datadir_contract_drift(&layout, target, &command);
+        let inspection =
+            inspect_datadir_contract_drift(&layout, target, &command, ctx.packaged_data_probe());
         if !ctx.quiet {
             for warning in &inspection.warnings {
                 eprintln!("warning: {warning}");
@@ -588,7 +589,8 @@ fn repair_delegated(
 
     let mut completion_failure = None;
     if manifest_drifted {
-        let refresh = refresh_datadir_contract_snapshot(layout, target, command);
+        let refresh =
+            refresh_datadir_contract_snapshot(layout, target, command, ctx.packaged_data_probe());
         if !ctx.quiet {
             for warning in &refresh.warnings {
                 eprintln!("warning: {warning}");
@@ -1662,6 +1664,7 @@ fn recover_legacy_rpm_install(
                 layout,
                 &pending.component,
                 command,
+                ctx.packaged_data_probe(),
             ));
             render_warnings(&warnings, &Palette::new(ctx.no_color));
             append_repair_log(
@@ -2452,15 +2455,15 @@ mod tests {
     }
 
     fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
-        CliContext {
+        crate::test_support::context_for_root(
+            &prefix,
             install_mode,
-            prefix: Some(prefix),
-            json: false,
-            dry_run,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
+            Some(prefix.clone()),
+            crate::test_support::TestContextOptions {
+                dry_run,
+                ..Default::default()
+            },
+        )
     }
 
     /// Legacy (v4) RPM-backed component object; the store migrates it on
@@ -2722,7 +2725,6 @@ mod tests {
 
     #[test]
     fn healthy_record_with_stale_manifest_snapshot_reconciles_it() {
-        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
         use anolisa_core::adapter::contract::read_snapshot_provenance;
 
         let tmp = tempfile::tempdir().expect("tmpdir");
@@ -2770,7 +2772,6 @@ mod tests {
 
     #[test]
     fn manifest_refresh_failure_keeps_the_operation_partial() {
-        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
         let tmp = tempfile::tempdir().expect("tmpdir");
         let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         let component = "manifest-write-failure";
@@ -2824,7 +2825,6 @@ mod tests {
 
     #[test]
     fn dry_run_previews_manifest_reconciliation_without_writes() {
-        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
         let tmp = tempfile::tempdir().expect("tmpdir");
         let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
         let component = "manifest-dry-run";
@@ -2865,7 +2865,6 @@ mod tests {
 
     #[test]
     fn manifest_drift_is_judged_against_the_package_datadir_only() {
-        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
         use anolisa_core::adapter::contract::{
             ContractProvenance, ContractSourceKind, write_snapshot_provenance,
         };
@@ -2930,7 +2929,6 @@ mod tests {
 
     #[test]
     fn local_manifest_is_ignored_when_the_package_contract_is_missing() {
-        let _env_guard = crate::packaged::DataDirEnvGuard::clear();
         let tmp = tempfile::tempdir().expect("tmpdir");
         let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         let component = "manifest-missing-package-contract";

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -553,15 +553,15 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx_with_prefix(install_mode: InstallMode, prefix: Option<PathBuf>) -> CliContext {
-        CliContext {
+        let root = prefix
+            .as_deref()
+            .unwrap_or_else(|| std::path::Path::new("/tmp/anolisa-restart-validation"));
+        crate::test_support::context_for_root(
+            root,
             install_mode,
-            prefix,
-            json: false,
-            dry_run: false,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
+            prefix.clone(),
+            Default::default(),
+        )
     }
 
     /// Fake `CommandRunner` returning a canned `rpm -ql` listing (or a spawn

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1368,15 +1368,19 @@ mod tests {
         install_mode: InstallMode,
         prefix: Option<PathBuf>,
     ) -> CliContext {
-        CliContext {
+        let root = prefix
+            .as_deref()
+            .expect("stateful uninstall tests require an isolated prefix");
+        crate::test_support::context_for_root(
+            root,
             install_mode,
-            prefix,
-            json,
-            dry_run,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
+            prefix.clone(),
+            crate::test_support::TestContextOptions {
+                json,
+                dry_run,
+                ..Default::default()
+            },
+        )
     }
 
     fn legacy_state_for_layout(layout: &FsLayout) -> InstalledState {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -1209,7 +1209,8 @@ pub(crate) fn complete_delegated_update(
         ));
     }
 
-    let refresh = refresh_datadir_contract_snapshot(layout, target, command);
+    let refresh =
+        refresh_datadir_contract_snapshot(layout, target, command, ctx.packaged_data_probe());
     if !ctx.quiet {
         for warning in &refresh.warnings {
             eprintln!("warning: {warning}");
@@ -1931,15 +1932,15 @@ pub(crate) mod tests {
     }
 
     fn self_ctx(prefix: PathBuf, dry_run: bool) -> CliContext {
-        CliContext {
-            install_mode: crate::context::InstallMode::System,
-            prefix: Some(prefix),
-            json: false,
-            dry_run,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
+        crate::test_support::context_for_root(
+            &prefix,
+            crate::context::InstallMode::System,
+            Some(prefix.clone()),
+            crate::test_support::TestContextOptions {
+                dry_run,
+                ..Default::default()
+            },
+        )
     }
 
     struct FakeSelfUpdateOps {
@@ -2415,15 +2416,15 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
-        CliContext {
+        crate::test_support::context_for_root(
+            &prefix,
             install_mode,
-            prefix: Some(prefix),
-            json: false,
-            dry_run,
-            verbose: false,
-            quiet: true,
-            no_color: true,
-        }
+            Some(prefix.clone()),
+            crate::test_support::TestContextOptions {
+                dry_run,
+                ..Default::default()
+            },
+        )
     }
 
     /// Build a legacy (v4) RPM-backed component object; the store migrates it

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
@@ -120,11 +120,9 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
     }
 
     // Suppress per-component rendering: the batch owns the final output.
-    let suppressed_ctx = CliContext {
-        json: false,
-        quiet: true,
-        ..ctx.clone()
-    };
+    let mut suppressed_ctx = ctx.clone();
+    suppressed_ctx.json = false;
+    suppressed_ctx.quiet = true;
 
     // Peek phase: plan every component read-only and classify. Delegated
     // refreshes (U5) merge into one native transaction; everything else
@@ -371,11 +369,9 @@ fn merged_update_package(planned: &PlannedComponentUpdate) -> Option<String> {
 /// the configured ANOLISA repo, degrade re-plans through the per-item
 /// pipeline.
 fn execute_merged_updates(group: Vec<MergedUpdate>, ctx: &CliContext) -> Vec<UpdateAllItem> {
-    let suppressed_ctx = CliContext {
-        json: false,
-        quiet: true,
-        ..ctx.clone()
-    };
+    let mut suppressed_ctx = ctx.clone();
+    suppressed_ctx.json = false;
+    suppressed_ctx.quiet = true;
     let (query, txn) = match update_backends(&group[0].name, &suppressed_ctx) {
         Ok(backends) => backends,
         Err(err) => {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -318,7 +318,7 @@ pub(crate) fn compute_update_check_report(
     ctx: &CliContext,
     layout: &FsLayout,
 ) -> Result<UpdateCheckReport, CliError> {
-    let repo_config = load_repo_config_read_only(layout)?;
+    let repo_config = load_repo_config_read_only(ctx, layout)?;
     let env = anolisa_env::EnvService::detect();
     let repo = super::rpm_repo_source_for_update(&repo_config, &env, CHECK_COMMAND)?.ok_or_else(
         || CliError::InvalidArgument {
@@ -346,7 +346,8 @@ pub(crate) fn compute_update_check_report(
 
     // An omitted `--target` resolves to the release default profile, so the
     // report always carries a target and can surface missing defaults.
-    let (target_name, target_profile) = load_effective_target_profile(layout, target)?;
+    let (target_name, target_profile) =
+        load_effective_target_profile(layout, target, ctx.packaged_data_probe())?;
 
     // Best-effort component identity index so a profile default already present
     // on the host (but not adopted into ANOLISA state) is checked against rpmdb
@@ -375,8 +376,8 @@ pub(crate) fn compute_update_check_report(
 /// the check needs even on a host that has not provisioned repo config yet. The
 /// no-write behaviour of the dry-run path is covered by
 /// `repo_config::tests::load_dry_run_fetches_without_writing`.
-fn load_repo_config_read_only(layout: &FsLayout) -> Result<RepoConfig, CliError> {
-    RepoConfig::load(layout, true)
+fn load_repo_config_read_only(ctx: &CliContext, layout: &FsLayout) -> Result<RepoConfig, CliError> {
+    RepoConfig::load(layout, true, ctx.packaged_data_probe())
         .map(|loaded| loaded.config)
         .map_err(|err| CliError::Runtime {
             command: CHECK_COMMAND.to_string(),
@@ -1124,9 +1125,13 @@ fn effective_target_name(target: Option<&str>) -> &str {
 fn load_effective_target_profile(
     layout: &FsLayout,
     target: Option<&str>,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> Result<(String, TargetProfile), CliError> {
     let name = effective_target_name(target);
-    Ok((name.to_string(), load_target_profile_by_name(layout, name)?))
+    Ok((
+        name.to_string(),
+        load_target_profile_by_name(layout, name, packaged_data_probe)?,
+    ))
 }
 
 /// Resolve and read a named target profile. The name is validated as a single
@@ -1137,7 +1142,11 @@ fn load_effective_target_profile(
 /// default name — the built-in profile compiled into the binary. A missing
 /// non-default profile is a hard [`CliError::InvalidArgument`] listing the
 /// searched paths.
-fn load_target_profile_by_name(layout: &FsLayout, name: &str) -> Result<TargetProfile, CliError> {
+fn load_target_profile_by_name(
+    layout: &FsLayout,
+    name: &str,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
+) -> Result<TargetProfile, CliError> {
     validate_target_name(name)?;
 
     let mut searched = Vec::new();
@@ -1151,8 +1160,8 @@ fn load_target_profile_by_name(layout: &FsLayout, name: &str) -> Result<TargetPr
     }
     searched.push(etc_path);
 
-    let packaged_root =
-        crate::packaged::packaged_datadir_root(layout).unwrap_or_else(|| layout.datadir.clone());
+    let packaged_root = crate::packaged::packaged_datadir_root(layout, packaged_data_probe)
+        .unwrap_or_else(|| layout.datadir.clone());
     let packaged_path = packaged_root
         .join(PROFILES_SUBDIR)
         .join(format!("{name}.toml"));

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -263,15 +263,12 @@ fn run_with_index_and_backend(
 }
 
 fn system_ctx() -> CliContext {
-    CliContext {
-        install_mode: crate::context::InstallMode::System,
-        prefix: None,
-        json: false,
-        dry_run: false,
-        verbose: false,
-        quiet: true,
-        no_color: true,
-    }
+    crate::test_support::context_for_root(
+        std::path::Path::new("/tmp/anolisa-update-check-validation"),
+        crate::context::InstallMode::System,
+        None,
+        Default::default(),
+    )
 }
 
 // ── CLI parse surface ───────────────────────────────────────────────
@@ -1074,6 +1071,10 @@ fn update_check_cache_usable_requires_matching_target() {
 
 // ── repo config read-only + target profile ──────────────────────────
 
+fn isolated_packaged_data_probe() -> crate::packaged::PackagedDataProbe {
+    crate::packaged::PackagedDataProbe::from_inputs(None, None)
+}
+
 /// `--check` must load repo config without writing it. Here the config already
 /// exists locally, so the read-only load returns it and touches nothing else;
 /// the missing-config no-write guarantee is covered by
@@ -1082,6 +1083,12 @@ fn update_check_cache_usable_requires_matching_target() {
 fn update_check_read_only_load_uses_existing_config_without_writing() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let ctx = crate::test_support::context_for_root(
+        tmp.path(),
+        crate::context::InstallMode::System,
+        Some(tmp.path().to_path_buf()),
+        Default::default(),
+    );
     std::fs::create_dir_all(&layout.etc_dir).expect("mkdir etc");
     let repo_toml = layout.etc_dir.join("repo.toml");
     std::fs::write(
@@ -1090,7 +1097,7 @@ fn update_check_read_only_load_uses_existing_config_without_writing() {
     )
     .expect("write repo.toml");
 
-    let cfg = load_repo_config_read_only(&layout).expect("read-only load");
+    let cfg = load_repo_config_read_only(&ctx, &layout).expect("read-only load");
     assert_eq!(cfg.default_backend, "rpm");
     // No scratch file was left behind by the read-only path.
     assert!(!repo_toml.with_extension("toml.tmp").exists());
@@ -1108,7 +1115,9 @@ fn update_check_target_profile_parses_default_components() {
     )
     .expect("write profile");
 
-    let profile = load_target_profile_by_name(&layout, "image-v1.0").expect("profile loads");
+    let probe = isolated_packaged_data_probe();
+    let profile =
+        load_target_profile_by_name(&layout, "image-v1.0", &probe).expect("profile loads");
     assert_eq!(profile.default_components, vec!["cosh", "sec-core"]);
 }
 
@@ -1116,22 +1125,21 @@ fn update_check_target_profile_parses_default_components() {
 fn update_check_target_profile_rejects_traversal() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-    let err = load_target_profile_by_name(&layout, "../escape").expect_err("must reject traversal");
+    let probe = isolated_packaged_data_probe();
+    let err = load_target_profile_by_name(&layout, "../escape", &probe)
+        .expect_err("must reject traversal");
     assert_eq!(err.code(), "INVALID_ARGUMENT");
 }
 
 // ── default target profile + user-mode gating ───────────────────────
 
 fn user_ctx() -> CliContext {
-    CliContext {
-        install_mode: crate::context::InstallMode::User,
-        prefix: None,
-        json: false,
-        dry_run: false,
-        verbose: false,
-        quiet: true,
-        no_color: true,
-    }
+    crate::test_support::context_for_root(
+        std::path::Path::new("/tmp/anolisa-update-check-validation"),
+        crate::context::InstallMode::User,
+        None,
+        Default::default(),
+    )
 }
 
 /// A non-system install mode is out of scope for the RPM upgrade check and must
@@ -1190,8 +1198,9 @@ fn update_check_builtin_default_profile_parses() {
 fn update_check_omitted_target_uses_builtin_default() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let probe = isolated_packaged_data_probe();
     let (name, profile) =
-        load_effective_target_profile(&layout, None).expect("default target resolves");
+        load_effective_target_profile(&layout, None, &probe).expect("default target resolves");
     assert_eq!(name, DEFAULT_TARGET_PROFILE_NAME);
     assert!(!profile.default_components.is_empty());
 }
@@ -1212,8 +1221,9 @@ fn update_check_omitted_target_uses_disk_default_profile() {
     )
     .expect("write default profile");
 
+    let probe = isolated_packaged_data_probe();
     let (name, profile) =
-        load_effective_target_profile(&layout, None).expect("default target resolves");
+        load_effective_target_profile(&layout, None, &probe).expect("default target resolves");
     assert_eq!(name, DEFAULT_TARGET_PROFILE_NAME);
     assert_eq!(profile.default_components, vec!["disk-only"]);
 }
@@ -1222,10 +1232,10 @@ fn update_check_omitted_target_uses_disk_default_profile() {
 /// the compiled-in default rather than erroring.
 #[test]
 fn update_check_explicit_default_target_falls_back_to_builtin() {
-    let _guard = crate::packaged::DataDirEnvGuard::clear();
     let tmp = tempfile::tempdir().expect("tmpdir");
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-    let profile = load_target_profile_by_name(&layout, DEFAULT_TARGET_PROFILE_NAME)
+    let probe = isolated_packaged_data_probe();
+    let profile = load_target_profile_by_name(&layout, DEFAULT_TARGET_PROFILE_NAME, &probe)
         .expect("explicit default falls back to builtin");
     assert!(!profile.default_components.is_empty());
 }
@@ -1234,10 +1244,10 @@ fn update_check_explicit_default_target_falls_back_to_builtin() {
 /// message names the profile.
 #[test]
 fn update_check_explicit_custom_target_missing_is_invalid_argument() {
-    let _guard = crate::packaged::DataDirEnvGuard::clear();
     let tmp = tempfile::tempdir().expect("tmpdir");
     let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
-    let err = load_target_profile_by_name(&layout, "no-such-profile")
+    let probe = isolated_packaged_data_probe();
+    let err = load_target_profile_by_name(&layout, "no-such-profile", &probe)
         .expect_err("missing custom target must error");
     assert_eq!(err.code(), "INVALID_ARGUMENT");
     assert!(err.reason().contains("no-such-profile"));

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -720,6 +720,7 @@ fn run_upgrade_with_deps(
             &preview_store,
             query,
             command,
+            ctx.packaged_data_probe(),
         ));
     }
 
@@ -1403,6 +1404,9 @@ fn installed_origin_or_warn(
 
 /// Inspect existing RPM-backed component rows against rpmdb without mutating
 /// state. Callers decide whether to preview or apply the returned changes.
+// Keep every read-only evidence source explicit so preview and apply share the
+// same reconciliation path without hiding mutable dependencies in a bundle.
+#[allow(clippy::too_many_arguments)]
 fn inspect_rpm_reconciliations(
     layout: &FsLayout,
     store: &StateStore,
@@ -1411,6 +1415,7 @@ fn inspect_rpm_reconciliations(
     legacy_reconciliations: &[PlannedLegacyReconciliation],
     warnings: &mut Vec<String>,
     command: &str,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> ReconciliationInspection {
     let mut inspection = ReconciliationInspection::default();
 
@@ -1487,7 +1492,12 @@ fn inspect_rpm_reconciliations(
         // A same-version external RPM upgrade can still replace the packaged
         // component contract; compare it with the state snapshot so the drift
         // is reconciled even when the observation cache is current.
-        let manifest = inspect_datadir_contract_drift(layout, &installation.name, command);
+        let manifest = inspect_datadir_contract_drift(
+            layout,
+            &installation.name,
+            command,
+            packaged_data_probe,
+        );
         warnings.extend(manifest.warnings);
         let reason = match (!observation_current, manifest.drifted) {
             (true, true) => "RPM state and component manifest drift",
@@ -1572,6 +1582,7 @@ fn render_plan_preview(
     store: &StateStore,
     query: &dyn PackageQuery,
     command: &str,
+    packaged_data_probe: &crate::packaged::PackagedDataProbe,
 ) -> UpgradeResult {
     let mut updated: Vec<UpdatedItem> = Vec::new();
     if let Some(cli) = &plan.cli {
@@ -1632,6 +1643,7 @@ fn render_plan_preview(
         &plan.legacy_reconciliations,
         &mut warnings,
         command,
+        packaged_data_probe,
     );
     let reconciled = inspection
         .pending
@@ -1902,6 +1914,7 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         legacy_reconciliations,
         warnings,
         command,
+        ctx.packaged_data_probe(),
     );
     // Apply errors do not exclude a component from the sweep: a transient
     // post-transaction query may recover here and still reconcile state. If
@@ -2027,7 +2040,12 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
                 .map(|item| (item.name.as_str(), item.package.as_str())),
         )
     {
-        let refresh = refresh_datadir_contract_snapshot(layout, component, command);
+        let refresh = refresh_datadir_contract_snapshot(
+            layout,
+            component,
+            command,
+            ctx.packaged_data_probe(),
+        );
         let failure_detail = refresh.error_detail();
         warnings.extend(refresh.warnings);
         if let Some(detail) = failure_detail {
@@ -2046,7 +2064,12 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
             reconciled.push(item);
             continue;
         }
-        let refresh = refresh_datadir_contract_snapshot(layout, &item.name, command);
+        let refresh = refresh_datadir_contract_snapshot(
+            layout,
+            &item.name,
+            command,
+            ctx.packaged_data_probe(),
+        );
         let failure_detail = refresh.failure_detail();
         warnings.extend(refresh.warnings);
         if let Some(detail) = failure_detail {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -418,27 +418,21 @@ fn observed_evr<'a>(store: &'a StateStore, name: &str) -> Option<&'a str> {
 }
 
 fn system_ctx(prefix: PathBuf) -> CliContext {
-    CliContext {
-        install_mode: InstallMode::System,
-        prefix: Some(prefix),
-        json: false,
-        dry_run: false,
-        verbose: false,
-        quiet: true,
-        no_color: true,
-    }
+    crate::test_support::context_for_root(
+        &prefix,
+        InstallMode::System,
+        Some(prefix.clone()),
+        Default::default(),
+    )
 }
 
 fn user_ctx() -> CliContext {
-    CliContext {
-        install_mode: InstallMode::User,
-        prefix: None,
-        json: false,
-        dry_run: false,
-        verbose: false,
-        quiet: true,
-        no_color: true,
-    }
+    crate::test_support::context_for_root(
+        std::path::Path::new("/tmp/anolisa-upgrade-validation"),
+        InstallMode::User,
+        None,
+        Default::default(),
+    )
 }
 
 // ── argument parsing ─────────────────────────────────────────────────────────

--- a/src/anolisa/crates/anolisa-cli/src/context.rs
+++ b/src/anolisa/crates/anolisa-cli/src/context.rs
@@ -12,8 +12,11 @@
 
 use std::path::PathBuf;
 
+use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::privilege;
 use clap::ValueEnum;
+
+use crate::packaged::PackagedDataProbe;
 
 /// Where ANOLISA installs files: user-mode (`file-hierarchy(7)` under `$HOME`)
 /// or system-mode (FHS under `/usr/local`, redirectable via `--prefix`).
@@ -49,6 +52,25 @@ pub struct CliContext {
     pub verbose: bool,
     pub quiet: bool,
     pub no_color: bool,
+    layouts: ResolvedLayouts,
+    packaged_data_probe: PackagedDataProbe,
+}
+
+/// Filesystem layouts resolved once at the process boundary.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedLayouts {
+    writable: FsLayout,
+    visible_system: FsLayout,
+}
+
+impl ResolvedLayouts {
+    /// Build an explicit layout snapshot.
+    pub(crate) fn new(writable: FsLayout, visible_system: FsLayout) -> Self {
+        Self {
+            writable,
+            visible_system,
+        }
+    }
 }
 
 /// Resolve the effective install mode from the explicit CLI value and a
@@ -74,6 +96,14 @@ impl CliContext {
     pub fn from_cli(cli: &crate::commands::Cli) -> Self {
         let effective_uid = privilege::effective_uid();
         let effective_mode = resolve_install_mode(cli.install_mode, effective_uid);
+        let visible_system = FsLayout::system(cli.prefix.clone());
+        let writable = match effective_mode {
+            InstallMode::System => visible_system.clone(),
+            InstallMode::User => {
+                let home = anolisa_env::EnvService::detect().home;
+                FsLayout::user(home)
+            }
+        };
 
         Self {
             install_mode: effective_mode,
@@ -83,7 +113,58 @@ impl CliContext {
             verbose: cli.verbose,
             quiet: cli.quiet,
             no_color: cli.no_color,
+            layouts: ResolvedLayouts::new(writable, visible_system),
+            packaged_data_probe: PackagedDataProbe::detect(),
         }
+    }
+
+    /// Build a context around already-resolved process inputs.
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_resolved(
+        install_mode: InstallMode,
+        prefix: Option<PathBuf>,
+        json: bool,
+        dry_run: bool,
+        verbose: bool,
+        quiet: bool,
+        no_color: bool,
+        layouts: ResolvedLayouts,
+        packaged_data_probe: PackagedDataProbe,
+    ) -> Self {
+        Self {
+            install_mode,
+            prefix,
+            json,
+            dry_run,
+            verbose,
+            quiet,
+            no_color,
+            layouts,
+            packaged_data_probe,
+        }
+    }
+
+    /// Override packaged-data discovery for an isolated test context.
+    #[cfg(test)]
+    pub(crate) fn with_packaged_data_root(mut self, root: PathBuf) -> Self {
+        self.packaged_data_probe = PackagedDataProbe::from_inputs(Some(root), None);
+        self
+    }
+
+    /// Current invocation's writable filesystem layout.
+    pub(crate) fn layout(&self) -> &FsLayout {
+        &self.layouts.writable
+    }
+
+    /// System layout visible to a user-mode invocation.
+    pub(crate) fn visible_system_layout(&self) -> &FsLayout {
+        &self.layouts.visible_system
+    }
+
+    /// Packaged-data discovery inputs captured at process startup.
+    pub(crate) fn packaged_data_probe(&self) -> &PackagedDataProbe {
+        &self.packaged_data_probe
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/main.rs
+++ b/src/anolisa/crates/anolisa-cli/src/main.rs
@@ -9,6 +9,8 @@ mod progress;
 mod repo_config;
 mod resolution;
 mod response;
+#[cfg(test)]
+mod test_support;
 
 use std::io;
 use std::process::ExitCode;

--- a/src/anolisa/crates/anolisa-cli/src/packaged.rs
+++ b/src/anolisa/crates/anolisa-cli/src/packaged.rs
@@ -30,12 +30,62 @@
 //! over. That dev-tree fallback is the reason this helper returns
 //! `Option<PathBuf>` rather than panicking.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anolisa_platform::fs_layout::FsLayout;
 
 /// Name of the env var that overrides the packaged datadir lookup.
 pub const DATA_DIR_ENV: &str = "ANOLISA_DATA_DIR";
+
+/// Process inputs used to locate the packaged `share/anolisa/` tree.
+///
+/// Capture these once at the CLI boundary so command execution and tests do
+/// not observe process-global environment changes partway through a run.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PackagedDataProbe {
+    env_override: Option<PathBuf>,
+    executable: Option<PathBuf>,
+}
+
+impl PackagedDataProbe {
+    /// Capture the packaged-data inputs from the current process.
+    pub(crate) fn detect() -> Self {
+        Self {
+            env_override: std::env::var_os(DATA_DIR_ENV).map(PathBuf::from),
+            executable: std::env::current_exe().ok(),
+        }
+    }
+
+    /// Build a probe from explicit inputs.
+    #[cfg(test)]
+    pub(crate) fn from_inputs(env_override: Option<PathBuf>, executable: Option<PathBuf>) -> Self {
+        Self {
+            env_override,
+            executable,
+        }
+    }
+
+    /// Resolve the first existing packaged-data candidate for `layout`.
+    pub(crate) fn resolve(&self, layout: &FsLayout) -> Option<PathBuf> {
+        if let Some(candidate) = self.env_override.as_deref()
+            && candidate.is_dir()
+        {
+            return Some(candidate.to_path_buf());
+        }
+        if let Some(prefix) = self
+            .executable
+            .as_deref()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+        {
+            let candidate = prefix.join("share").join("anolisa");
+            if candidate.is_dir() {
+                return Some(candidate);
+            }
+        }
+        layout.datadir.is_dir().then(|| layout.datadir.clone())
+    }
+}
 
 /// Discover the packaged `share/anolisa/` root for the running binary.
 ///
@@ -43,82 +93,8 @@ pub const DATA_DIR_ENV: &str = "ANOLISA_DATA_DIR";
 /// existing directory. Callers must fall back to whatever non-packaged
 /// source they care about, such as dev-tree manifests. This helper
 /// deliberately does NOT consult those because it lives in a separate concern.
-pub fn packaged_datadir_root(layout: &FsLayout) -> Option<PathBuf> {
-    if let Some(env_dir) = std::env::var_os(DATA_DIR_ENV) {
-        let candidate = PathBuf::from(env_dir);
-        if candidate.is_dir() {
-            return Some(candidate);
-        }
-    }
-    if let Ok(exe) = std::env::current_exe() {
-        // <exe>.parent() == bin/, then .parent() == prefix. Datadir is
-        // sibling of bin/ named share/anolisa/.
-        if let Some(prefix) = exe.parent().and_then(|p| p.parent()) {
-            let candidate = prefix.join("share").join("anolisa");
-            if candidate.is_dir() {
-                return Some(candidate);
-            }
-        }
-    }
-    if layout.datadir.is_dir() {
-        return Some(layout.datadir.clone());
-    }
-    None
-}
-
-/// Crate-wide mutex for tests that mutate `ANOLISA_DATA_DIR`. Cargo runs
-/// tests within a crate concurrently, and `ANOLISA_DATA_DIR` is
-/// process-global, so every test that sets or reads it must hold this lock.
-#[cfg(test)]
-pub(crate) static DATA_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// RAII guard that sets `ANOLISA_DATA_DIR` on creation and restores (or
-/// removes) the original value on drop — even if the test panics.
-#[cfg(test)]
-pub(crate) struct DataDirEnvGuard {
-    _lock: std::sync::MutexGuard<'static, ()>,
-    saved: Option<std::ffi::OsString>,
-}
-
-#[cfg(test)]
-impl DataDirEnvGuard {
-    /// Acquire the env lock, save the current `ANOLISA_DATA_DIR`, and set
-    /// the new value.
-    pub(crate) fn set(value: &std::path::Path) -> Self {
-        let lock = DATA_DIR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let saved = std::env::var_os(DATA_DIR_ENV);
-        // SAFETY: guarded by DATA_DIR_ENV_LOCK.
-        unsafe {
-            std::env::set_var(DATA_DIR_ENV, value);
-        }
-        Self { _lock: lock, saved }
-    }
-
-    /// Acquire the env lock and remove `ANOLISA_DATA_DIR` so the test
-    /// runs as if no env override is set. The original value is restored
-    /// on drop.
-    pub(crate) fn clear() -> Self {
-        let lock = DATA_DIR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let saved = std::env::var_os(DATA_DIR_ENV);
-        // SAFETY: guarded by DATA_DIR_ENV_LOCK.
-        unsafe {
-            std::env::remove_var(DATA_DIR_ENV);
-        }
-        Self { _lock: lock, saved }
-    }
-}
-
-#[cfg(test)]
-impl Drop for DataDirEnvGuard {
-    fn drop(&mut self) {
-        // SAFETY: guarded by the lock held in self._lock.
-        unsafe {
-            match &self.saved {
-                Some(v) => std::env::set_var(DATA_DIR_ENV, v),
-                None => std::env::remove_var(DATA_DIR_ENV),
-            }
-        }
-    }
+pub fn packaged_datadir_root(layout: &FsLayout, probe: &PackagedDataProbe) -> Option<PathBuf> {
+    probe.resolve(layout)
 }
 
 #[cfg(test)]
@@ -132,8 +108,8 @@ mod tests {
     fn env_override_wins() {
         let tmp = tempdir().expect("tmp");
         let layout = FsLayout::system(Some(PathBuf::from("/nonexistent-anolisa-prefix")));
-        let _guard = DataDirEnvGuard::set(tmp.path());
-        let got = packaged_datadir_root(&layout);
+        let probe = PackagedDataProbe::from_inputs(Some(tmp.path().to_path_buf()), None);
+        let got = packaged_datadir_root(&layout, &probe);
         assert_eq!(got.as_deref(), Some(tmp.path()));
     }
 
@@ -142,22 +118,40 @@ mod tests {
     #[test]
     fn env_override_falls_through_when_missing() {
         let layout = FsLayout::system(Some(PathBuf::from("/nonexistent-anolisa-prefix")));
-        let _guard =
-            DataDirEnvGuard::set(std::path::Path::new("/definitely/does/not/exist/anolisa"));
-        let got = packaged_datadir_root(&layout);
+        let probe = PackagedDataProbe::from_inputs(
+            Some(PathBuf::from("/definitely/does/not/exist/anolisa")),
+            None,
+        );
+        let got = packaged_datadir_root(&layout, &probe);
         assert!(got.is_none(), "expected fallthrough, got {got:?}");
+    }
+
+    #[test]
+    fn executable_sibling_precedes_layout_datadir() {
+        let tmp = tempdir().expect("tmp");
+        let executable = tmp.path().join("prefix/bin/anolisa");
+        let packaged = tmp.path().join("prefix/share/anolisa");
+        fs::create_dir_all(executable.parent().expect("bin parent")).expect("mkdir bin");
+        fs::create_dir_all(&packaged).expect("mkdir packaged");
+        let layout = FsLayout::system(Some(tmp.path().join("layout")));
+        fs::create_dir_all(&layout.datadir).expect("mkdir layout datadir");
+        let probe = PackagedDataProbe::from_inputs(None, Some(executable));
+
+        let got = packaged_datadir_root(&layout, &probe);
+
+        assert_eq!(got.as_deref(), Some(packaged.as_path()));
     }
 
     /// Without env override, an existing layout.datadir wins over a
     /// missing exe-sibling probe.
     #[test]
     fn layout_datadir_used_when_it_exists() {
-        let _guard = DataDirEnvGuard::clear();
         let tmp = tempdir().expect("tmp");
         let prefix = tmp.path().to_path_buf();
         let layout = FsLayout::system(Some(prefix.clone()));
         fs::create_dir_all(&layout.datadir).expect("mkdir datadir");
-        let got = packaged_datadir_root(&layout);
+        let probe = PackagedDataProbe::from_inputs(None, None);
+        let got = packaged_datadir_root(&layout, &probe);
         assert_eq!(got.as_deref(), Some(layout.datadir.as_path()));
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -302,9 +302,14 @@ impl RepoConfig {
     pub(crate) fn load(
         layout: &FsLayout,
         dry_run: bool,
+        packaged_data_probe: &packaged::PackagedDataProbe,
     ) -> Result<RepoConfigLoadResult, RepoConfigProvisionError> {
         let url = repo_config_url();
-        Self::load_with_sources(RepoConfigSources::for_layout(layout), dry_run, &url)
+        Self::load_with_sources(
+            RepoConfigSources::for_layout(layout, packaged_data_probe),
+            dry_run,
+            &url,
+        )
     }
 
     fn load_with_sources(
@@ -755,9 +760,9 @@ pub(crate) struct RepoConfigSources {
 }
 
 impl RepoConfigSources {
-    fn for_layout(layout: &FsLayout) -> Self {
-        let packaged_root =
-            packaged::packaged_datadir_root(layout).unwrap_or_else(|| layout.datadir.clone());
+    fn for_layout(layout: &FsLayout, packaged_data_probe: &packaged::PackagedDataProbe) -> Self {
+        let packaged_root = packaged::packaged_datadir_root(layout, packaged_data_probe)
+            .unwrap_or_else(|| layout.datadir.clone());
         Self {
             etc: Some(layout.etc_dir.join(REPO_FILE)),
             packaged: Some(packaged_root.join(REPO_SUBDIR).join(REPO_FILE)),

--- a/src/anolisa/crates/anolisa-cli/src/response.rs
+++ b/src/anolisa/crates/anolisa-cli/src/response.rs
@@ -371,15 +371,15 @@ mod tests {
 
     #[test]
     fn diagnostics_found_propagates_exit_without_error_render() {
-        let ctx = CliContext {
-            install_mode: crate::context::InstallMode::User,
-            prefix: None,
-            json: true,
-            dry_run: false,
-            verbose: false,
-            quiet: false,
-            no_color: true,
-        };
+        let sandbox = crate::test_support::TestSandbox::new();
+        let ctx = sandbox.context_with(
+            crate::context::InstallMode::User,
+            crate::test_support::TestContextOptions {
+                json: true,
+                quiet: false,
+                ..Default::default()
+            },
+        );
         let err = CliError::DiagnosticsFound {
             command: "doctor".to_string(),
         };

--- a/src/anolisa/crates/anolisa-cli/src/test_support.rs
+++ b/src/anolisa/crates/anolisa-cli/src/test_support.rs
@@ -1,0 +1,205 @@
+//! Isolated filesystem and runtime inputs shared by CLI unit tests.
+
+use std::path::{Path, PathBuf};
+
+use anolisa_platform::fs_layout::FsLayout;
+
+use crate::context::{CliContext, InstallMode, ResolvedLayouts};
+use crate::packaged::PackagedDataProbe;
+
+/// Output and execution flags for an isolated test context.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TestContextOptions {
+    pub(crate) json: bool,
+    pub(crate) dry_run: bool,
+    pub(crate) verbose: bool,
+    pub(crate) quiet: bool,
+    pub(crate) no_color: bool,
+}
+
+impl Default for TestContextOptions {
+    fn default() -> Self {
+        Self {
+            json: false,
+            dry_run: false,
+            verbose: false,
+            quiet: true,
+            no_color: true,
+        }
+    }
+}
+
+/// Owns an isolated user layout, system layout, repository root, and fake bin.
+pub(crate) struct TestSandbox {
+    tmp: tempfile::TempDir,
+    user_layout: FsLayout,
+    system_layout: FsLayout,
+    repo_root: PathBuf,
+    fake_bin: PathBuf,
+}
+
+impl TestSandbox {
+    /// Create a sandbox whose writable paths are all below one temporary root.
+    pub(crate) fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("test sandbox");
+        let root = tmp.path();
+        let user_layout = isolated_user_layout(root);
+        let system_layout = FsLayout::system(Some(root.join("system")));
+        assert_layout_contained(&user_layout, root);
+        assert_layout_contained(&system_layout, root);
+        Self {
+            repo_root: root.join("repo"),
+            fake_bin: root.join("fake-bin"),
+            tmp,
+            user_layout,
+            system_layout,
+        }
+    }
+
+    /// Temporary root retained for the sandbox lifetime.
+    pub(crate) fn root(&self) -> &Path {
+        self.tmp.path()
+    }
+
+    /// Local repository root available to tests.
+    pub(crate) fn repo_root(&self) -> &Path {
+        &self.repo_root
+    }
+
+    /// Directory where tests may install fake executables.
+    pub(crate) fn fake_bin(&self) -> &Path {
+        &self.fake_bin
+    }
+
+    /// Build a context with default quiet, colorless test output.
+    pub(crate) fn context(&self, install_mode: InstallMode) -> CliContext {
+        self.context_with(install_mode, TestContextOptions::default())
+    }
+
+    /// Build a context with explicit output and execution flags.
+    pub(crate) fn context_with(
+        &self,
+        install_mode: InstallMode,
+        options: TestContextOptions,
+    ) -> CliContext {
+        let prefix = Some(self.system_layout.prefix.clone());
+        let writable = match install_mode {
+            InstallMode::System => self.system_layout.clone(),
+            InstallMode::User => self.user_layout.clone(),
+        };
+        CliContext::from_resolved(
+            install_mode,
+            prefix,
+            options.json,
+            options.dry_run,
+            options.verbose,
+            options.quiet,
+            options.no_color,
+            ResolvedLayouts::new(writable, self.system_layout.clone()),
+            PackagedDataProbe::from_inputs(None, None),
+        )
+    }
+}
+
+/// Build an isolated context around a temporary root owned by the caller.
+pub(crate) fn context_for_root(
+    root: &Path,
+    install_mode: InstallMode,
+    cli_prefix: Option<PathBuf>,
+    options: TestContextOptions,
+) -> CliContext {
+    let system_root = cli_prefix
+        .as_ref()
+        .filter(|prefix| prefix.is_absolute() && prefix.starts_with(root))
+        .cloned()
+        .unwrap_or_else(|| root.join("system"));
+    let system_layout = FsLayout::system(Some(system_root));
+    let writable = match install_mode {
+        InstallMode::System => system_layout.clone(),
+        InstallMode::User => isolated_user_layout(root),
+    };
+    assert_layout_contained(&writable, root);
+    assert_layout_contained(&system_layout, root);
+    CliContext::from_resolved(
+        install_mode,
+        cli_prefix,
+        options.json,
+        options.dry_run,
+        options.verbose,
+        options.quiet,
+        options.no_color,
+        ResolvedLayouts::new(writable, system_layout),
+        PackagedDataProbe::from_inputs(None, None),
+    )
+}
+
+fn isolated_user_layout(root: &Path) -> FsLayout {
+    FsLayout::user_with_overrides(
+        root.join("home"),
+        Some(root.join("xdg-data")),
+        Some(root.join("xdg-config")),
+        Some(root.join("xdg-state")),
+        Some(root.join("xdg-cache")),
+        Some(root.join("xdg-runtime")),
+    )
+}
+
+fn assert_layout_contained(layout: &FsLayout, root: &Path) {
+    for path in [
+        &layout.bin_dir,
+        &layout.lib_dir,
+        &layout.libexec_dir,
+        &layout.datadir,
+        &layout.etc_dir,
+        &layout.state_dir,
+        &layout.cache_dir,
+        &layout.log_dir,
+        &layout.backup_dir,
+        &layout.runtime_dir,
+        &layout.systemd_unit_dir,
+        &layout.systemd_user_unit_dir,
+    ] {
+        assert!(
+            path.starts_with(root),
+            "test layout path {} escapes sandbox {}",
+            path.display(),
+            root.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contexts_keep_writable_and_visible_system_layouts_contained() {
+        let sandbox = TestSandbox::new();
+        assert!(sandbox.repo_root().starts_with(sandbox.root()));
+        assert!(sandbox.fake_bin().starts_with(sandbox.root()));
+
+        for mode in [InstallMode::User, InstallMode::System] {
+            let ctx = sandbox.context(mode);
+            assert_layout_contained(ctx.layout(), sandbox.root());
+            assert_layout_contained(ctx.visible_system_layout(), sandbox.root());
+        }
+    }
+
+    #[test]
+    fn user_prefix_only_selects_the_visible_system_layout() {
+        let sandbox = TestSandbox::new();
+        let ctx = sandbox.context(InstallMode::User);
+
+        assert!(
+            ctx.layout()
+                .etc_dir
+                .starts_with(sandbox.root().join("xdg-config"))
+        );
+        assert!(
+            ctx.visible_system_layout()
+                .etc_dir
+                .starts_with(sandbox.root().join("system"))
+        );
+        assert_ne!(ctx.layout().prefix, ctx.visible_system_layout().prefix);
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/tests/broken_pipe.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/broken_pipe.rs
@@ -69,21 +69,9 @@ fn successful_stdout_paths_survive_an_immediately_closed_reader() {
 
 #[test]
 fn json_business_failure_keeps_exit_code_when_stdout_reader_closes() {
-    let prefix = tempfile::tempdir().expect("temporary prefix must be created");
-    let prefix = prefix.path().to_string_lossy();
-
-    assert_graceful_closed_stdout(
-        &[
-            "--json",
-            "--install-mode",
-            "user",
-            "--prefix",
-            &prefix,
-            "forget",
-            "definitely-missing",
-        ],
-        2,
-    );
+    // A targetless update fails before repository or state discovery, keeping
+    // this stdout regression independent of the invoking user's HOME.
+    assert_graceful_closed_stdout(&["--json", "update"], 2);
 }
 
 #[cfg(target_os = "linux")]

--- a/src/anolisa/crates/anolisa-cli/tests/common/mod.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/common/mod.rs
@@ -5,13 +5,91 @@
 #![allow(dead_code)]
 
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdout, Command, ExitStatus, Output, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
 
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
+const SCRUBBED_ANOLISA_ENV: &[&str] = &[
+    "ANOLISA_DATA_DIR",
+    "ANOLISA_GROUP",
+    "ANOLISA_PREFIX",
+    "ANOLISA_REPO_CONFIG_URL",
+    "ANOLISA_RPM_REPO_ID",
+    "ANOLISA_SLS_ACCOUNT_ID",
+];
+
+pub(crate) struct ProcessSandbox {
+    _tmp: tempfile::TempDir,
+    home: PathBuf,
+    data_home: PathBuf,
+    config_home: PathBuf,
+    state_home: PathBuf,
+    cache_home: PathBuf,
+    runtime_dir: PathBuf,
+    fake_bin: PathBuf,
+}
+
+impl ProcessSandbox {
+    pub(crate) fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("process sandbox");
+        let root = tmp.path();
+        let fake_bin = root.join("fake-bin");
+        std::fs::create_dir_all(&fake_bin).expect("fake bin");
+        Self {
+            home: root.join("home"),
+            data_home: root.join("xdg-data"),
+            config_home: root.join("xdg-config"),
+            state_home: root.join("xdg-state"),
+            cache_home: root.join("xdg-cache"),
+            runtime_dir: root.join("xdg-runtime"),
+            fake_bin,
+            _tmp: tmp,
+        }
+    }
+
+    pub(crate) fn run(&self, arguments: &[&str]) -> Output {
+        self.run_with_stdout(arguments, Stdio::piped())
+    }
+
+    pub(crate) fn run_with_stdout(&self, arguments: &[&str], stdout: Stdio) -> Output {
+        let mut command = self.command(arguments);
+        run_command(&mut command, stdout)
+    }
+
+    pub(crate) fn run_with_path_env(&self, arguments: &[&str], env: &[(&str, &Path)]) -> Output {
+        let mut command = self.command(arguments);
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        run_command(&mut command, Stdio::piped())
+    }
+
+    fn command(&self, arguments: &[&str]) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_anolisa"));
+        command.args(arguments);
+        for key in SCRUBBED_ANOLISA_ENV {
+            command.env_remove(key);
+        }
+        command
+            .env("HOME", &self.home)
+            .env("XDG_DATA_HOME", &self.data_home)
+            .env("XDG_CONFIG_HOME", &self.config_home)
+            .env("XDG_STATE_HOME", &self.state_home)
+            .env("XDG_CACHE_HOME", &self.cache_home)
+            .env("XDG_RUNTIME_DIR", &self.runtime_dir);
+
+        let mut path_entries = vec![self.fake_bin.clone()];
+        if let Some(path) = std::env::var_os("PATH") {
+            path_entries.extend(std::env::split_paths(&path));
+        }
+        let path = std::env::join_paths(path_entries).expect("isolated PATH");
+        command.env("PATH", path);
+        command
+    }
+}
 
 struct ChildGuard(Child);
 
@@ -58,25 +136,18 @@ fn receive_bounded(receiver: Receiver<io::Result<Vec<u8>>>, deadline: Instant) -
 }
 
 pub(crate) fn run(arguments: &[&str]) -> Output {
-    run_with_stdout(arguments, Stdio::piped())
+    ProcessSandbox::new().run(arguments)
 }
 
 pub(crate) fn run_with_stdout(arguments: &[&str], stdout: Stdio) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_anolisa"));
-    command.args(arguments);
-    run_command(command, stdout)
+    ProcessSandbox::new().run_with_stdout(arguments, stdout)
 }
 
 pub(crate) fn run_with_path_env(arguments: &[&str], env: &[(&str, &Path)]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_anolisa"));
-    command.args(arguments);
-    for (key, value) in env {
-        command.env(key, value);
-    }
-    run_command(command, Stdio::piped())
+    ProcessSandbox::new().run_with_path_env(arguments, env)
 }
 
-fn run_command(mut command: Command, stdout: Stdio) -> Output {
+fn run_command(command: &mut Command, stdout: Stdio) -> Output {
     let deadline = Instant::now() + PROCESS_TIMEOUT;
     let mut child = ChildGuard(
         command

--- a/src/anolisa/crates/anolisa-cli/tests/common/mod.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/common/mod.rs
@@ -4,6 +4,7 @@
 // intentionally uses a different subset of the shared process helpers.
 #![allow(dead_code)]
 
+use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdout, Command, ExitStatus, Output, Stdio};
@@ -12,14 +13,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
-const SCRUBBED_ANOLISA_ENV: &[&str] = &[
-    "ANOLISA_DATA_DIR",
-    "ANOLISA_GROUP",
-    "ANOLISA_PREFIX",
-    "ANOLISA_REPO_CONFIG_URL",
-    "ANOLISA_RPM_REPO_ID",
-    "ANOLISA_SLS_ACCOUNT_ID",
-];
+const ANOLISA_ENV_PREFIX: &str = "ANOLISA_";
+const ANOLISA_DATA_DIR_ENV: &str = "ANOLISA_DATA_DIR";
 
 pub(crate) struct ProcessSandbox {
     _tmp: tempfile::TempDir,
@@ -30,6 +25,7 @@ pub(crate) struct ProcessSandbox {
     cache_home: PathBuf,
     runtime_dir: PathBuf,
     fake_bin: PathBuf,
+    packaged_data: PathBuf,
 }
 
 impl ProcessSandbox {
@@ -37,7 +33,9 @@ impl ProcessSandbox {
         let tmp = tempfile::tempdir().expect("process sandbox");
         let root = tmp.path();
         let fake_bin = root.join("fake-bin");
+        let packaged_data = root.join("packaged-data");
         std::fs::create_dir_all(&fake_bin).expect("fake bin");
+        std::fs::create_dir_all(&packaged_data).expect("packaged data");
         Self {
             home: root.join("home"),
             data_home: root.join("xdg-data"),
@@ -46,6 +44,7 @@ impl ProcessSandbox {
             cache_home: root.join("xdg-cache"),
             runtime_dir: root.join("xdg-runtime"),
             fake_bin,
+            packaged_data,
             _tmp: tmp,
         }
     }
@@ -70,8 +69,10 @@ impl ProcessSandbox {
     fn command(&self, arguments: &[&str]) -> Command {
         let mut command = Command::new(env!("CARGO_BIN_EXE_anolisa"));
         command.args(arguments);
-        for key in SCRUBBED_ANOLISA_ENV {
-            command.env_remove(key);
+        for (key, _) in std::env::vars_os() {
+            if is_anolisa_env_key(&key) {
+                command.env_remove(key);
+            }
         }
         command
             .env("HOME", &self.home)
@@ -79,7 +80,8 @@ impl ProcessSandbox {
             .env("XDG_CONFIG_HOME", &self.config_home)
             .env("XDG_STATE_HOME", &self.state_home)
             .env("XDG_CACHE_HOME", &self.cache_home)
-            .env("XDG_RUNTIME_DIR", &self.runtime_dir);
+            .env("XDG_RUNTIME_DIR", &self.runtime_dir)
+            .env(ANOLISA_DATA_DIR_ENV, &self.packaged_data);
 
         let mut path_entries = vec![self.fake_bin.clone()];
         if let Some(path) = std::env::var_os("PATH") {
@@ -89,6 +91,10 @@ impl ProcessSandbox {
         command.env("PATH", path);
         command
     }
+}
+
+fn is_anolisa_env_key(key: &OsStr) -> bool {
+    key.to_string_lossy().starts_with(ANOLISA_ENV_PREFIX)
 }
 
 struct ChildGuard(Child);
@@ -164,5 +170,17 @@ fn run_command(command: &mut Command, stdout: Stdio) -> Output {
         status,
         stdout: receive_bounded(stdout, deadline),
         stderr: receive_bounded(stderr, deadline),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anolisa_env_prefix_matches_future_controls_without_overmatching() {
+        assert!(is_anolisa_env_key(OsStr::new("ANOLISA_DATA_DIR")));
+        assert!(is_anolisa_env_key(OsStr::new("ANOLISA_FUTURE_SETTING")));
+        assert!(!is_anolisa_env_key(OsStr::new("NOT_ANOLISA_SETTING")));
     }
 }

--- a/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
@@ -7,6 +7,7 @@
 //! under `data`. These tests drive the compiled binary and assert the full
 //! envelope, which in-crate unit tests cannot cover.
 
+use std::path::Path;
 use std::process::Output;
 
 mod common;
@@ -66,12 +67,33 @@ fn absent_uninstall_args<'a>(prefix: &'a str, extra: &[&'a str]) -> Vec<&'a str>
     args
 }
 
+fn seed_local_repo(prefix: &Path) {
+    let repo_v1 = prefix.join("repo/v1");
+    std::fs::create_dir_all(&repo_v1).expect("local repo");
+    std::fs::write(
+        repo_v1.join("components.toml"),
+        "schema_version = 1\ncomponents = []\n",
+    )
+    .expect("component index");
+    let etc = prefix.join("etc/anolisa");
+    std::fs::create_dir_all(&etc).expect("config dir");
+    std::fs::write(
+        etc.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+            repo_v1.display()
+        ),
+    )
+    .expect("repo config");
+}
+
 /// A dry-run of an absent component must report the same refusal a real run
 /// would — an error envelope with the actionable "not installed" reason —
 /// never a hollow successful preview.
 #[test]
 fn uninstall_dry_run_json_absent_component_reports_not_installed() {
     let tmp = tempfile::tempdir().expect("tempdir");
+    seed_local_repo(tmp.path());
     let prefix = tmp.path().to_str().expect("utf-8 prefix");
     let value = run_json(&absent_uninstall_args(prefix, &[]), 2);
 
@@ -97,6 +119,7 @@ fn uninstall_dry_run_json_absent_component_reports_not_installed() {
 #[test]
 fn uninstall_purge_dry_run_json_uses_same_contract() {
     let tmp = tempfile::tempdir().expect("tempdir");
+    seed_local_repo(tmp.path());
     let prefix = tmp.path().to_str().expect("utf-8 prefix");
     let value = run_json(&absent_uninstall_args(prefix, &["--purge"]), 0);
 


### PR DESCRIPTION
## Description

Fixes ANOLISA CLI tests leaking configuration, state, and fake binaries into real user HOME/XDG directories. The root cause was that filesystem layouts and packaged-data locations were re-resolved during command execution while tests also mutated process-global environment variables. `CliContext` now snapshots writable and visible-system layouts plus packaged-data discovery inputs at startup. Unit and process sandboxes inject explicit layouts, repositories, XDG paths, and PATH entries, while network-sensitive tests use local repositories. Production CLI flags, directory precedence, and JSON output remain unchanged.

## Related Issue

no-issue: locally reproduced regression discovered during a CLI test-isolation audit

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- Compared before/after content and permission fingerprints for the real ANOLISA config, state, data, cache, and user binary directories.

## Additional Notes

Verified that the installed `tokenless 0.7.1` state, managed files, and binary hashes remain unchanged after the full test suite.