### PR TITLE
fix(cosh-ng): [core,shell] harden streamed state

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -593,6 +593,16 @@ impl CoshCore {
                     },
                 })
                 .collect();
+
+            // An arguments-only streamed tool-call fragment cannot be executed or
+            // represented in the next provider request. Continuing would append an
+            // empty assistant message and ask the model again, eventually consuming
+            // the entire turn budget without making progress.
+            if tc_infos.is_empty() {
+                return Err(
+                    "Provider emitted an incomplete tool call without a function name".to_string(),
+                );
+            }
             self.messages
                 .push(Message::assistant_with_tool_calls(&text_buf, tc_infos));
 
@@ -1575,6 +1585,31 @@ mod tests {
             "{output_str}"
         );
         assert!(core.messages.len() >= 4);
+    }
+
+    #[tokio::test]
+    async fn incomplete_tool_call_stops_without_consuming_turn_budget() {
+        let provider = MockProvider::new(vec![vec![
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"command":"pwd"}"#.to_string(),
+            },
+            GenerateEvent::MessageEnd,
+        ]]);
+        let mut core = make_core(provider);
+        let mut output = Vec::new();
+        let mut reader = empty_reader().await;
+
+        let error = core
+            .handle_user_message("inspect this project", &mut reader, &mut output)
+            .await
+            .expect_err("an unnamed tool call must fail immediately");
+
+        assert_eq!(
+            error,
+            "Provider emitted an incomplete tool call without a function name"
+        );
+        assert_eq!(core.messages.len(), 1, "must not append an empty turn");
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -581,6 +581,15 @@ impl CoshCore {
                 return Ok(());
             }
 
+            if tool_calls
+                .iter()
+                .any(|tc| tc.name.is_empty() && !tc.arguments.is_empty())
+            {
+                return Err(
+                    "Provider emitted an incomplete tool call without a function name".to_string(),
+                );
+            }
+
             let tc_infos: Vec<crate::provider::ToolCallInfo> = tool_calls
                 .iter()
                 .filter(|tc| !tc.name.is_empty())
@@ -1610,6 +1619,40 @@ mod tests {
             "Provider emitted an incomplete tool call without a function name"
         );
         assert_eq!(core.messages.len(), 1, "must not append an empty turn");
+    }
+
+    #[tokio::test]
+    async fn mixed_tool_calls_stop_when_any_call_is_incomplete() {
+        let provider = MockProvider::new(vec![vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-valid".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"command":"pwd"}"#.to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 1,
+                arguments_delta: r#"{"command":"id"}"#.to_string(),
+            },
+            GenerateEvent::MessageEnd,
+        ]]);
+        let mut core = make_core(provider);
+        let mut output = Vec::new();
+        let mut reader = empty_reader().await;
+
+        let error = core
+            .handle_user_message("inspect this project", &mut reader, &mut output)
+            .await
+            .expect_err("any unnamed tool call with arguments must fail the turn");
+
+        assert_eq!(
+            error,
+            "Provider emitted an incomplete tool call without a function name"
+        );
+        assert_eq!(core.messages.len(), 1, "must not execute the named tool");
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -133,14 +134,39 @@ impl ContentGenerator for OpenAICompatProvider {
         let byte_stream = response.bytes_stream();
         let buffer = String::new();
         let event_queue: Vec<GenerateEvent> = Vec::new();
+        let stream_state = OpenAICompatStreamState::default();
 
         let event_stream = futures::stream::unfold(
-            (byte_stream, buffer, cancelled, event_queue, thinking_field),
-            move |(mut stream, mut buf, cancelled, mut pending, thinking_field)| async move {
+            (
+                byte_stream,
+                buffer,
+                cancelled,
+                event_queue,
+                thinking_field,
+                stream_state,
+            ),
+            move |(
+                mut stream,
+                mut buf,
+                cancelled,
+                mut pending,
+                thinking_field,
+                mut stream_state,
+            )| async move {
                 let tf = thinking_field.as_deref();
                 loop {
                     if let Some(event) = pending.pop() {
-                        return Some((event, (stream, buf, cancelled, pending, thinking_field)));
+                        return Some((
+                            event,
+                            (
+                                stream,
+                                buf,
+                                cancelled,
+                                pending,
+                                thinking_field,
+                                stream_state,
+                            ),
+                        ));
                     }
 
                     if cancelled.load(Ordering::SeqCst) {
@@ -159,20 +185,37 @@ impl ContentGenerator for OpenAICompatProvider {
                             if data.trim() == "[DONE]" {
                                 return Some((
                                     GenerateEvent::MessageEnd,
-                                    (stream, buf, cancelled, pending, thinking_field),
+                                    (
+                                        stream,
+                                        buf,
+                                        cancelled,
+                                        pending,
+                                        thinking_field,
+                                        stream_state,
+                                    ),
                                 ));
                             }
                             if let Ok(chunk) = serde_json::from_str::<Value>(data) {
-                                if let Some(mut events) =
-                                    parse_sse_chunk(&chunk, tf, defer_message_end)
-                                {
+                                if let Some(mut events) = parse_sse_chunk_with_state(
+                                    &chunk,
+                                    tf,
+                                    defer_message_end,
+                                    &mut stream_state,
+                                ) {
                                     if !events.is_empty() {
                                         let first = events.remove(0);
                                         events.reverse();
                                         pending = events;
                                         return Some((
                                             first,
-                                            (stream, buf, cancelled, pending, thinking_field),
+                                            (
+                                                stream,
+                                                buf,
+                                                cancelled,
+                                                pending,
+                                                thinking_field,
+                                                stream_state,
+                                            ),
                                         ));
                                     }
                                 }
@@ -188,7 +231,14 @@ impl ContentGenerator for OpenAICompatProvider {
                         Some(Err(e)) => {
                             return Some((
                                 GenerateEvent::Error(format!("stream error: {e}")),
-                                (stream, buf, cancelled, pending, thinking_field),
+                                (
+                                    stream,
+                                    buf,
+                                    cancelled,
+                                    pending,
+                                    thinking_field,
+                                    stream_state,
+                                ),
                             ));
                         }
                         None => {
@@ -198,9 +248,12 @@ impl ContentGenerator for OpenAICompatProvider {
                                 if let Some(data) = line.strip_prefix("data: ") {
                                     if data.trim() != "[DONE]" {
                                         if let Ok(chunk) = serde_json::from_str::<Value>(data) {
-                                            if let Some(mut events) =
-                                                parse_sse_chunk(&chunk, tf, defer_message_end)
-                                            {
+                                            if let Some(mut events) = parse_sse_chunk_with_state(
+                                                &chunk,
+                                                tf,
+                                                defer_message_end,
+                                                &mut stream_state,
+                                            ) {
                                                 if !events.is_empty() {
                                                     let first = events.remove(0);
                                                     events.reverse();
@@ -213,6 +266,7 @@ impl ContentGenerator for OpenAICompatProvider {
                                                             cancelled,
                                                             pending,
                                                             thinking_field,
+                                                            stream_state,
                                                         ),
                                                     ));
                                                 }
@@ -223,7 +277,14 @@ impl ContentGenerator for OpenAICompatProvider {
                             }
                             return Some((
                                 GenerateEvent::MessageEnd,
-                                (stream, buf, cancelled, pending, thinking_field),
+                                (
+                                    stream,
+                                    buf,
+                                    cancelled,
+                                    pending,
+                                    thinking_field,
+                                    stream_state,
+                                ),
                             ));
                         }
                     }
@@ -239,10 +300,30 @@ impl ContentGenerator for OpenAICompatProvider {
     }
 }
 
+#[derive(Default)]
+struct OpenAICompatStreamState {
+    argument_deltas_seen: HashSet<u32>,
+}
+
+#[cfg(test)]
 fn parse_sse_chunk(
     chunk: &Value,
     thinking_field: Option<&str>,
     defer_message_end: bool,
+) -> Option<Vec<GenerateEvent>> {
+    parse_sse_chunk_with_state(
+        chunk,
+        thinking_field,
+        defer_message_end,
+        &mut OpenAICompatStreamState::default(),
+    )
+}
+
+fn parse_sse_chunk_with_state(
+    chunk: &Value,
+    thinking_field: Option<&str>,
+    defer_message_end: bool,
+    stream_state: &mut OpenAICompatStreamState,
 ) -> Option<Vec<GenerateEvent>> {
     let mut events = Vec::new();
 
@@ -317,16 +398,22 @@ fn parse_sse_chunk(
                         });
                     }
 
-                    if let Some(args) = delta_function
+                    let delta_arguments = delta_function
                         .and_then(|function| function.get("arguments"))
-                        .and_then(|arguments| arguments.as_str())
-                        .or_else(|| {
-                            final_function
-                                .and_then(|function| function.get("arguments"))
-                                .and_then(|arguments| arguments.as_str())
-                        })
-                    {
-                        if !args.is_empty() {
+                        .and_then(|arguments| arguments.as_str());
+                    if let Some(args) = delta_arguments.filter(|args| !args.is_empty()) {
+                        stream_state.argument_deltas_seen.insert(index);
+                        events.push(GenerateEvent::ToolCallDelta {
+                            index,
+                            arguments_delta: args.to_string(),
+                        });
+                    } else if !stream_state.argument_deltas_seen.contains(&index) {
+                        if let Some(args) = final_function
+                            .and_then(|function| function.get("arguments"))
+                            .and_then(|arguments| arguments.as_str())
+                            .filter(|args| !args.is_empty())
+                        {
+                            stream_state.argument_deltas_seen.insert(index);
                             events.push(GenerateEvent::ToolCallDelta {
                                 index,
                                 arguments_delta: args.to_string(),
@@ -361,10 +448,13 @@ fn parse_sse_chunk(
                         id,
                         name: name.to_string(),
                     });
-                    if let Some(arguments) =
-                        function.get("arguments").and_then(|args| args.as_str())
-                    {
-                        if !arguments.is_empty() {
+                    if !stream_state.argument_deltas_seen.contains(&index) {
+                        if let Some(arguments) = function
+                            .get("arguments")
+                            .and_then(|args| args.as_str())
+                            .filter(|arguments| !arguments.is_empty())
+                        {
+                            stream_state.argument_deltas_seen.insert(index);
                             events.push(GenerateEvent::ToolCallDelta {
                                 index,
                                 arguments_delta: arguments.to_string(),
@@ -538,6 +628,118 @@ mod tests {
             GenerateEvent::ToolCallDelta { arguments_delta, .. } if arguments_delta == "{\"command\":\"pwd\"}"
         ));
         assert!(matches!(&events[2], GenerateEvent::MessageEnd));
+    }
+
+    #[test]
+    fn final_tool_call_snapshot_does_not_repeat_streamed_arguments() {
+        let first_chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "shell",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    }]
+                },
+                "finish_reason": null
+            }]
+        });
+        let final_chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "delta": {"tool_calls": [{"index": 0, "function": {}}]},
+                "message": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "shell",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+        let mut state = OpenAICompatStreamState::default();
+
+        let first = parse_sse_chunk_with_state(&first_chunk, None, false, &mut state)
+            .expect("first streamed tool-call chunk");
+        assert!(matches!(
+            &first[..],
+            [GenerateEvent::ToolCallStart { .. }, GenerateEvent::ToolCallDelta { arguments_delta, .. }]
+                if arguments_delta == "{\"command\":\"pwd\"}"
+        ));
+
+        let final_events = parse_sse_chunk_with_state(&final_chunk, None, false, &mut state)
+            .expect("final tool-call snapshot");
+        assert!(
+            !final_events
+                .iter()
+                .any(|event| matches!(event, GenerateEvent::ToolCallDelta { .. })),
+            "final tool-call snapshots must not repeat streamed arguments"
+        );
+        assert!(matches!(
+            final_events.last(),
+            Some(GenerateEvent::MessageEnd)
+        ));
+    }
+
+    #[test]
+    fn final_message_only_tool_call_does_not_repeat_streamed_arguments() {
+        let first_chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "shell",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    }]
+                },
+                "finish_reason": null
+            }]
+        });
+        let final_chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "shell",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+        let mut state = OpenAICompatStreamState::default();
+
+        let _ = parse_sse_chunk_with_state(&first_chunk, None, false, &mut state)
+            .expect("first streamed tool-call chunk");
+        let final_events = parse_sse_chunk_with_state(&final_chunk, None, false, &mut state)
+            .expect("final message-only tool-call snapshot");
+
+        assert!(
+            !final_events
+                .iter()
+                .any(|event| matches!(event, GenerateEvent::ToolCallDelta { .. })),
+            "message-only snapshots must not repeat streamed arguments"
+        );
+        assert!(matches!(
+            final_events.last(),
+            Some(GenerateEvent::MessageEnd)
+        ));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -303,6 +303,8 @@ impl ContentGenerator for OpenAICompatProvider {
 #[derive(Default)]
 struct OpenAICompatStreamState {
     argument_deltas_seen: HashSet<u32>,
+    started_tool_calls: HashSet<u32>,
+    emitted_text: HashMap<u32, String>,
 }
 
 #[cfg(test)]
@@ -329,6 +331,7 @@ fn parse_sse_chunk_with_state(
 
     if let Some(choices) = chunk.get("choices").and_then(|c| c.as_array()) {
         for choice in choices {
+            let choice_index = choice.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
             let empty_delta = Value::Null;
             let delta = choice.get("delta").unwrap_or(&empty_delta);
             if let Some(field) = thinking_field {
@@ -343,15 +346,27 @@ fn parse_sse_chunk_with_state(
                 .get("content")
                 .and_then(|c| c.as_str())
                 .filter(|content| !content.is_empty())
-                .or_else(|| {
-                    choice
-                        .get("message")
-                        .and_then(|message| message.get("content"))
-                        .and_then(|content| content.as_str())
-                        .filter(|content| !content.is_empty())
-                })
             {
+                stream_state
+                    .emitted_text
+                    .entry(choice_index)
+                    .or_default()
+                    .push_str(content);
                 events.push(GenerateEvent::TextDelta(content.to_string()));
+            } else if let Some(snapshot) = choice
+                .get("message")
+                .and_then(|message| message.get("content"))
+                .and_then(|content| content.as_str())
+                .filter(|content| !content.is_empty())
+            {
+                let emitted = stream_state.emitted_text.entry(choice_index).or_default();
+                let suffix = snapshot
+                    .strip_prefix(emitted.as_str())
+                    .or_else(|| emitted.is_empty().then_some(snapshot));
+                if let Some(suffix) = suffix.filter(|suffix| !suffix.is_empty()) {
+                    emitted.push_str(suffix);
+                    events.push(GenerateEvent::TextDelta(suffix.to_string()));
+                }
             }
 
             if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
@@ -391,11 +406,13 @@ fn parse_sse_chunk_with_state(
                             })
                             .unwrap_or("")
                             .to_string();
-                        events.push(GenerateEvent::ToolCallStart {
-                            index,
-                            id,
-                            name: name.to_string(),
-                        });
+                        if stream_state.started_tool_calls.insert(index) {
+                            events.push(GenerateEvent::ToolCallStart {
+                                index,
+                                id,
+                                name: name.to_string(),
+                            });
+                        }
                     }
 
                     let delta_arguments = delta_function
@@ -431,23 +448,24 @@ fn parse_sse_chunk_with_state(
                     let Some(function) = tc.get("function") else {
                         continue;
                     };
-                    let Some(name) = function
+                    let name = function
                         .get("name")
                         .and_then(|name| name.as_str())
-                        .filter(|name| !name.is_empty())
-                    else {
-                        continue;
-                    };
-                    let id = tc
-                        .get("id")
-                        .and_then(|id| id.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    events.push(GenerateEvent::ToolCallStart {
-                        index,
-                        id,
-                        name: name.to_string(),
-                    });
+                        .filter(|name| !name.is_empty());
+                    if let Some(name) = name {
+                        let id = tc
+                            .get("id")
+                            .and_then(|id| id.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if stream_state.started_tool_calls.insert(index) {
+                            events.push(GenerateEvent::ToolCallStart {
+                                index,
+                                id,
+                                name: name.to_string(),
+                            });
+                        }
+                    }
                     if !stream_state.argument_deltas_seen.contains(&index) {
                         if let Some(arguments) = function
                             .get("arguments")
@@ -683,6 +701,12 @@ mod tests {
                 .any(|event| matches!(event, GenerateEvent::ToolCallDelta { .. })),
             "final tool-call snapshots must not repeat streamed arguments"
         );
+        assert!(
+            !final_events
+                .iter()
+                .any(|event| matches!(event, GenerateEvent::ToolCallStart { .. })),
+            "final tool-call snapshots must not reopen an existing tool block"
+        );
         assert!(matches!(
             final_events.last(),
             Some(GenerateEvent::MessageEnd)
@@ -736,6 +760,12 @@ mod tests {
                 .any(|event| matches!(event, GenerateEvent::ToolCallDelta { .. })),
             "message-only snapshots must not repeat streamed arguments"
         );
+        assert!(
+            !final_events
+                .iter()
+                .any(|event| matches!(event, GenerateEvent::ToolCallStart { .. })),
+            "message-only snapshots must not reopen an existing tool block"
+        );
         assert!(matches!(
             final_events.last(),
             Some(GenerateEvent::MessageEnd)
@@ -771,6 +801,63 @@ mod tests {
             GenerateEvent::ToolCallDelta { arguments_delta, .. } if arguments_delta == "{\"command\":\"pwd\"}"
         ));
         assert!(matches!(&events[2], GenerateEvent::MessageEnd));
+    }
+
+    #[test]
+    fn final_message_text_snapshot_only_emits_the_unseen_suffix() {
+        let first_chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "Do"},
+                "finish_reason": null
+            }]
+        });
+        let final_chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "message": {"content": "Done"},
+                "finish_reason": "stop"
+            }]
+        });
+        let mut state = OpenAICompatStreamState::default();
+
+        let first = parse_sse_chunk_with_state(&first_chunk, None, false, &mut state)
+            .expect("first text chunk");
+        assert!(matches!(
+            &first[..],
+            [GenerateEvent::TextDelta(text)] if text == "Do"
+        ));
+
+        let final_events = parse_sse_chunk_with_state(&final_chunk, None, false, &mut state)
+            .expect("final text snapshot");
+        assert!(matches!(
+            &final_events[..],
+            [GenerateEvent::TextDelta(text), GenerateEvent::MessageEnd] if text == "ne"
+        ));
+    }
+
+    #[test]
+    fn message_only_unnamed_tool_call_forwards_arguments_for_rejection() {
+        let chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {"arguments": "{\"command\":\"pwd\"}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let events = parse_sse_chunk(&chunk, None, false).expect("tool call events");
+        assert!(matches!(
+            &events[..],
+            [GenerateEvent::ToolCallDelta { arguments_delta, .. }, GenerateEvent::MessageEnd]
+                if arguments_delta == "{\"command\":\"pwd\"}"
+        ));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
@@ -248,55 +248,135 @@ fn parse_sse_chunk(
 
     if let Some(choices) = chunk.get("choices").and_then(|c| c.as_array()) {
         for choice in choices {
-            if let Some(delta) = choice.get("delta") {
-                if let Some(field) = thinking_field {
-                    if let Some(text) = delta.get(field).and_then(|v| v.as_str()) {
-                        if !text.is_empty() {
-                            events.push(GenerateEvent::ThinkingDelta(text.to_string()));
+            let empty_delta = Value::Null;
+            let delta = choice.get("delta").unwrap_or(&empty_delta);
+            if let Some(field) = thinking_field {
+                if let Some(text) = delta.get(field).and_then(|v| v.as_str()) {
+                    if !text.is_empty() {
+                        events.push(GenerateEvent::ThinkingDelta(text.to_string()));
+                    }
+                }
+            }
+
+            if let Some(content) = delta
+                .get("content")
+                .and_then(|c| c.as_str())
+                .filter(|content| !content.is_empty())
+                .or_else(|| {
+                    choice
+                        .get("message")
+                        .and_then(|message| message.get("content"))
+                        .and_then(|content| content.as_str())
+                        .filter(|content| !content.is_empty())
+                })
+            {
+                events.push(GenerateEvent::TextDelta(content.to_string()));
+            }
+
+            if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
+                let final_tool_calls = choice
+                    .get("message")
+                    .and_then(|message| message.get("tool_calls"))
+                    .and_then(|calls| calls.as_array());
+                for tc in tool_calls {
+                    let index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
+                    let final_call = final_tool_calls.and_then(|calls| {
+                        calls.iter().find(|call| {
+                            call.get("index").and_then(|i| i.as_u64()).unwrap_or(0)
+                                == u64::from(index)
+                        })
+                    });
+
+                    let delta_function = tc.get("function");
+                    let final_function = final_call.and_then(|call| call.get("function"));
+                    if let Some(name) = delta_function
+                        .and_then(|function| function.get("name"))
+                        .and_then(|name| name.as_str())
+                        .filter(|name| !name.is_empty())
+                        .or_else(|| {
+                            final_function
+                                .and_then(|function| function.get("name"))
+                                .and_then(|name| name.as_str())
+                                .filter(|name| !name.is_empty())
+                        })
+                    {
+                        let id = tc
+                            .get("id")
+                            .and_then(|i| i.as_str())
+                            .or_else(|| {
+                                final_call
+                                    .and_then(|call| call.get("id"))
+                                    .and_then(|id| id.as_str())
+                            })
+                            .unwrap_or("")
+                            .to_string();
+                        events.push(GenerateEvent::ToolCallStart {
+                            index,
+                            id,
+                            name: name.to_string(),
+                        });
+                    }
+
+                    if let Some(args) = delta_function
+                        .and_then(|function| function.get("arguments"))
+                        .and_then(|arguments| arguments.as_str())
+                        .or_else(|| {
+                            final_function
+                                .and_then(|function| function.get("arguments"))
+                                .and_then(|arguments| arguments.as_str())
+                        })
+                    {
+                        if !args.is_empty() {
+                            events.push(GenerateEvent::ToolCallDelta {
+                                index,
+                                arguments_delta: args.to_string(),
+                            });
                         }
                     }
                 }
-
-                if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                    if !content.is_empty() {
-                        events.push(GenerateEvent::TextDelta(content.to_string()));
-                    }
-                }
-
-                if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
-                    for tc in tool_calls {
-                        let index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
-
-                        if let Some(function) = tc.get("function") {
-                            if let Some(name) = function.get("name").and_then(|n| n.as_str()) {
-                                let id = tc
-                                    .get("id")
-                                    .and_then(|i| i.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                events.push(GenerateEvent::ToolCallStart {
-                                    index,
-                                    id,
-                                    name: name.to_string(),
-                                });
-                            }
-
-                            if let Some(args) = function.get("arguments").and_then(|a| a.as_str()) {
-                                if !args.is_empty() {
-                                    events.push(GenerateEvent::ToolCallDelta {
-                                        index,
-                                        arguments_delta: args.to_string(),
-                                    });
-                                }
-                            }
+            } else if let Some(tool_calls) = choice
+                .get("message")
+                .and_then(|message| message.get("tool_calls"))
+                .and_then(|calls| calls.as_array())
+            {
+                for tc in tool_calls {
+                    let index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
+                    let Some(function) = tc.get("function") else {
+                        continue;
+                    };
+                    let Some(name) = function
+                        .get("name")
+                        .and_then(|name| name.as_str())
+                        .filter(|name| !name.is_empty())
+                    else {
+                        continue;
+                    };
+                    let id = tc
+                        .get("id")
+                        .and_then(|id| id.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    events.push(GenerateEvent::ToolCallStart {
+                        index,
+                        id,
+                        name: name.to_string(),
+                    });
+                    if let Some(arguments) =
+                        function.get("arguments").and_then(|args| args.as_str())
+                    {
+                        if !arguments.is_empty() {
+                            events.push(GenerateEvent::ToolCallDelta {
+                                index,
+                                arguments_delta: arguments.to_string(),
+                            });
                         }
                     }
                 }
+            }
 
-                if let Some(finish) = choice.get("finish_reason").and_then(|f| f.as_str()) {
-                    if (finish == "stop" || finish == "tool_calls") && !defer_message_end {
-                        events.push(GenerateEvent::MessageEnd);
-                    }
+            if let Some(finish) = choice.get("finish_reason").and_then(|f| f.as_str()) {
+                if (finish == "stop" || finish == "tool_calls") && !defer_message_end {
+                    events.push(GenerateEvent::MessageEnd);
                 }
             }
         }
@@ -357,6 +437,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_final_message_text_without_delta() {
+        let chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "message": {"content": "Repository analysis complete."},
+                "finish_reason": "stop"
+            }]
+        });
+
+        let events = parse_sse_chunk(&chunk, None, false).unwrap();
+        assert!(matches!(
+            &events[..],
+            [GenerateEvent::TextDelta(text), GenerateEvent::MessageEnd]
+                if text == "Repository analysis complete."
+        ));
+    }
+
+    #[test]
     fn parse_tool_call_chunk() {
         let chunk = serde_json::json!({
             "choices": [{
@@ -402,6 +501,74 @@ mod tests {
         assert!(
             matches!(&events[0], GenerateEvent::ToolCallDelta { arguments_delta, .. } if arguments_delta == "{\"command\":")
         );
+    }
+
+    #[test]
+    fn parse_final_message_tool_call_when_delta_has_only_arguments() {
+        let chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "function": {"arguments": "{\"command\":\"pwd\"}"}
+                    }]
+                },
+                "message": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "shell",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let events = parse_sse_chunk(&chunk, None, false).expect("tool call events");
+        assert!(matches!(
+            &events[0],
+            GenerateEvent::ToolCallStart { id, name, .. } if id == "call_1" && name == "shell"
+        ));
+        assert!(matches!(
+            &events[1],
+            GenerateEvent::ToolCallDelta { arguments_delta, .. } if arguments_delta == "{\"command\":\"pwd\"}"
+        ));
+        assert!(matches!(&events[2], GenerateEvent::MessageEnd));
+    }
+
+    #[test]
+    fn parse_tool_call_from_final_message_without_delta() {
+        let chunk = serde_json::json!({
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "shell",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let events = parse_sse_chunk(&chunk, None, false).expect("tool call events");
+        assert!(matches!(
+            &events[0],
+            GenerateEvent::ToolCallStart { id, name, .. } if id == "call_1" && name == "shell"
+        ));
+        assert!(matches!(
+            &events[1],
+            GenerateEvent::ToolCallDelta { arguments_delta, .. } if arguments_delta == "{\"command\":\"pwd\"}"
+        ));
+        assert!(matches!(&events[2], GenerateEvent::MessageEnd));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
@@ -28,7 +28,7 @@ mod session;
 
 pub(super) use recovery::{
     begin_session_attempt, commit_pending_session_for_scope, invalidate_resume_on_session_failure,
-    mark_recovery_failure, retain_session_after_context_limit_failure, session_scope_from_request,
+    mark_recovery_failure, retain_context_session, session_scope_from_request,
     terminal_events_for_session_commit, SessionResumeAttempt,
 };
 pub use recovery::{SessionRecovery, SessionRecoveryState, SessionRuntimeState};
@@ -611,7 +611,7 @@ fn start_cancellable_cosh_core_process(
             &terminal_events,
             &session_state,
         );
-        let retain_session = retain_session_after_context_limit_failure(&terminal_events);
+        let retain_session = retain_context_session(&terminal_events, parser.session_error_phase());
         let commit_outcome = commit_pending_session_for_scope(
             completed || retain_session,
             failed && !retain_session,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
@@ -28,8 +28,8 @@ mod session;
 
 pub(super) use recovery::{
     begin_session_attempt, commit_pending_session_for_scope, invalidate_resume_on_session_failure,
-    mark_recovery_failure, session_scope_from_request, terminal_events_for_session_commit,
-    SessionResumeAttempt,
+    mark_recovery_failure, retain_session_after_context_limit_failure, session_scope_from_request,
+    terminal_events_for_session_commit, SessionResumeAttempt,
 };
 pub use recovery::{SessionRecovery, SessionRecoveryState, SessionRuntimeState};
 pub use session::{
@@ -611,9 +611,10 @@ fn start_cancellable_cosh_core_process(
             &terminal_events,
             &session_state,
         );
+        let retain_session = retain_session_after_context_limit_failure(&terminal_events);
         let commit_outcome = commit_pending_session_for_scope(
-            completed,
-            failed,
+            completed || retain_session,
+            failed && !retain_session,
             &session_state,
             &pending_session_for_thread,
             &session_scope_for_thread,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery.rs
@@ -364,6 +364,19 @@ pub(in crate::adapter) fn commit_pending_session_for_scope(
     SessionCommitOutcome::Continue
 }
 
+/// Returns whether a failed turn still leaves a safely persisted session that
+/// must remain selectable for manual compaction.
+pub(in crate::adapter) fn retain_session_after_context_limit_failure(
+    terminal_events: &[AgentEvent],
+) -> bool {
+    terminal_events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::AgentFailed { error, .. } if error.starts_with("context_limit:")
+        )
+    })
+}
+
 pub(in crate::adapter) fn invalidate_resume_on_session_failure(
     attempt: &SessionResumeAttempt,
     session_error_code: Option<&str>,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery.rs
@@ -366,15 +366,17 @@ pub(in crate::adapter) fn commit_pending_session_for_scope(
 
 /// Returns whether a failed turn still leaves a safely persisted session that
 /// must remain selectable for manual compaction.
-pub(in crate::adapter) fn retain_session_after_context_limit_failure(
+pub(in crate::adapter) fn retain_context_session(
     terminal_events: &[AgentEvent],
+    session_error_phase: Option<&str>,
 ) -> bool {
-    terminal_events.iter().any(|event| {
-        matches!(
-            event,
-            AgentEvent::AgentFailed { error, .. } if error.starts_with("context_limit:")
-        )
-    })
+    session_error_phase != Some("persist")
+        && terminal_events.iter().any(|event| {
+            matches!(
+                event,
+                AgentEvent::AgentFailed { error, .. } if error.starts_with("context_limit:")
+            )
+        })
 }
 
 pub(in crate::adapter) fn invalidate_resume_on_session_failure(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery/tests.rs
@@ -179,7 +179,7 @@ fn context_limit_failure_retains_the_persisted_session_for_compaction() {
         error: "context_limit: effective context exceeds the emergency threshold".to_string(),
     }];
 
-    assert!(retain_session_after_context_limit_failure(&events));
+    assert!(retain_context_session(&events, None));
 }
 
 #[test]
@@ -189,7 +189,36 @@ fn ordinary_failure_does_not_retain_a_provider_session() {
         error: "API error 500".to_string(),
     }];
 
-    assert!(!retain_session_after_context_limit_failure(&events));
+    assert!(!retain_context_session(&events, None));
+}
+
+#[test]
+fn persist_failure_does_not_retain_a_context_limited_session() {
+    let events = vec![AgentEvent::AgentFailed {
+        run_id: "run-1".to_string(),
+        error: "context_limit: effective context exceeds the emergency threshold".to_string(),
+    }];
+    let state = Arc::new(Mutex::new(SessionRuntimeState::default()));
+    let attempt = begin_session_attempt(&state, None, SCOPE);
+    let retain = retain_context_session(&events, Some("persist"));
+
+    assert!(!retain);
+    assert_eq!(
+        commit_pending_session_for_scope(
+            retain,
+            !retain,
+            &state,
+            &Arc::new(Mutex::new(Some(NEW_ID.to_string()))),
+            SCOPE,
+            Some(true),
+            &attempt,
+        ),
+        SessionCommitOutcome::Continue
+    );
+    assert_eq!(
+        state.lock().expect("session state").active_session_id(),
+        None
+    );
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/recovery/tests.rs
@@ -173,6 +173,26 @@ fn successful_selected_restore_commits_atomically_and_clears_selection() {
 }
 
 #[test]
+fn context_limit_failure_retains_the_persisted_session_for_compaction() {
+    let events = vec![AgentEvent::AgentFailed {
+        run_id: "run-1".to_string(),
+        error: "context_limit: effective context exceeds the emergency threshold".to_string(),
+    }];
+
+    assert!(retain_session_after_context_limit_failure(&events));
+}
+
+#[test]
+fn ordinary_failure_does_not_retain_a_provider_session() {
+    let events = vec![AgentEvent::AgentFailed {
+        run_id: "run-1".to_string(),
+        error: "API error 500".to_string(),
+    }];
+
+    assert!(!retain_session_after_context_limit_failure(&events));
+}
+
+#[test]
 fn fresh_non_resumable_turn_preserves_unattempted_active_and_selection() {
     let state = selected_state();
     let attempt = begin_session_attempt(&state, None, SCOPE);

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
@@ -12,8 +12,8 @@ use super::claude::{
 };
 use super::cosh_core::{
     commit_pending_session_for_scope, invalidate_resume_on_session_failure, mark_recovery_failure,
-    retain_session_after_context_limit_failure, terminal_events_for_session_commit,
-    SessionResumeAttempt, SessionRuntimeState,
+    retain_context_session, terminal_events_for_session_commit, SessionResumeAttempt,
+    SessionRuntimeState,
 };
 use super::{
     agent_event_is_provider_progress, control_protocol, record_cancellation_pending_session,
@@ -143,7 +143,7 @@ pub(super) fn run_sync_cosh_core_process(
             &terminal_events,
             session_state,
         );
-        let retain_session = retain_session_after_context_limit_failure(&terminal_events);
+        let retain_session = retain_context_session(&terminal_events, parser.session_error_phase());
         let commit_outcome = commit_pending_session_for_scope(
             completed || retain_session,
             failed && !retain_session,
@@ -564,7 +564,7 @@ pub(super) fn start_control_protocol_cosh_core_process(
             &terminal_events,
             &session_state,
         );
-        let retain_session = retain_session_after_context_limit_failure(&terminal_events);
+        let retain_session = retain_context_session(&terminal_events, parser.session_error_phase());
         let commit_outcome = commit_pending_session_for_scope(
             completed || retain_session,
             failed && !retain_session,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
@@ -12,7 +12,8 @@ use super::claude::{
 };
 use super::cosh_core::{
     commit_pending_session_for_scope, invalidate_resume_on_session_failure, mark_recovery_failure,
-    terminal_events_for_session_commit, SessionResumeAttempt, SessionRuntimeState,
+    retain_session_after_context_limit_failure, terminal_events_for_session_commit,
+    SessionResumeAttempt, SessionRuntimeState,
 };
 use super::{
     agent_event_is_provider_progress, control_protocol, record_cancellation_pending_session,
@@ -142,9 +143,10 @@ pub(super) fn run_sync_cosh_core_process(
             &terminal_events,
             session_state,
         );
+        let retain_session = retain_session_after_context_limit_failure(&terminal_events);
         let commit_outcome = commit_pending_session_for_scope(
-            completed,
-            failed,
+            completed || retain_session,
+            failed && !retain_session,
             session_state,
             &pending_session,
             session_scope,
@@ -562,9 +564,10 @@ pub(super) fn start_control_protocol_cosh_core_process(
             &terminal_events,
             &session_state,
         );
+        let retain_session = retain_session_after_context_limit_failure(&terminal_events);
         let commit_outcome = commit_pending_session_for_scope(
-            completed,
-            failed,
+            completed || retain_session,
+            failed && !retain_session,
             &session_state,
             &pending_session_for_thread,
             &session_scope_for_thread,


### PR DESCRIPTION
## Description

Fix OpenAI-compatible streamed responses that place tool metadata or final text in `choices[].message`, preventing empty tool-call loops and missing post-tool replies. Preserve an already-persisted cosh-core session after the typed `context_limit:` failure so users can compact that session manually.

## Related Issue

closes #1685
closes #1687

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo test -p cosh-core`
- `cargo test -p cosh-shell`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Additional Notes

The session is retained only for the typed `context_limit:` failure. Ordinary provider failures still do not become resumable sessions.