### PR TITLE
feat(anolisa): pin rpm install versions

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -2998,6 +2998,7 @@ mod tests {
                     target: ProviderTarget::Delegated {
                         pm: NativePm::Rpm,
                         package: "copilot-shell".to_string(),
+                        artifact: None,
                     },
                     requested_version: None,
                 }),
@@ -3041,6 +3042,7 @@ mod tests {
                         target: ProviderTarget::Delegated {
                             pm: NativePm::Rpm,
                             package: "copilot-shell".to_string(),
+                            artifact: None,
                         },
                         requested_version: None,
                     }),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -952,6 +952,7 @@ mod tests {
             component_identity_pinned: false,
             family: "rpm".to_string(),
             native_package: Some(package.to_string()),
+            delegated_pin: None,
             scope: InstallationScope::System,
             now: NOW.to_string(),
             store: StateStore::empty(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -53,7 +53,9 @@ use super::owned_ops::{
 };
 use super::raw::resolve_raw;
 use super::render::repo_config_err;
-use super::rpm::{RpmTarget, rpm_package_candidates_with_index};
+use super::rpm::{
+    PinError, RpmTarget, resolve_pinned_candidate, rpm_package_candidates_with_index,
+};
 use super::types::{InstallOutcome, RawResolution, ResolveInputs};
 use super::{ANOLISA_RPM_REPO_ID, COMMAND, InstallArgs};
 
@@ -139,10 +141,35 @@ pub(crate) struct PlannedComponent {
     pub(crate) component_identity_pinned: bool,
     pub(crate) family: String,
     pub(crate) native_package: Option<String>,
+    /// Resolved candidate for a `--version`-pinned delegated install, carried
+    /// so the dry-run preview and JSON envelope report the real artifact.
+    /// `None` for unpinned installs and every owned install.
+    pub(crate) delegated_pin: Option<DelegatedPin>,
     pub(crate) scope: InstallationScope,
     pub(crate) now: String,
     pub(crate) store: StateStore,
     pub(crate) route: PlannedRoute,
+}
+
+/// Resolved metadata for a version-pinned delegated install, surfaced to the
+/// dry-run preview and the JSON envelope. Built from the repository candidate
+/// the pin selected, never from the raw `--version` argument alone.
+#[derive(Debug, Clone)]
+pub(crate) struct DelegatedPin {
+    /// The `--version` value the caller requested.
+    pub(crate) requested_version: String,
+    /// Upstream VERSION field of the selected candidate (equals
+    /// `requested_version`, restated for an unambiguous JSON contract).
+    pub(crate) resolved_version: String,
+    /// Full resolved EVR of the selected candidate.
+    pub(crate) resolved_evr: String,
+    /// Architecture of the selected candidate, checked against the freshly
+    /// installed package before the record commits.
+    pub(crate) resolved_arch: String,
+    /// Exact NEVRA handed to the native transaction.
+    pub(crate) artifact: String,
+    /// Source repository the candidate came from, when reported.
+    pub(crate) source_repo: Option<String>,
 }
 
 struct ResolvedInstallIdentity {
@@ -290,6 +317,7 @@ pub(crate) fn plan_component(
     let active_binding = store
         .find(ObjectKind::Component, &component)
         .map(|installation| installation.binding.clone());
+    let mut delegated_pin: Option<DelegatedPin> = None;
     let (target, native_package): (ProviderTarget, Option<String>) = match &active_binding {
         Some(binding) => target_for_active_record(binding, &family, args, &component),
         None if family == "raw" => {
@@ -321,11 +349,12 @@ pub(crate) fn plan_component(
                     ProviderTarget::Delegated {
                         pm: NativePm::Rpm,
                         package,
+                        artifact: None,
                     },
                     None,
                 )
             } else {
-                let (target, package, resolved_component) = resolve_fresh_delegated(
+                let fresh = resolve_fresh_delegated(
                     args,
                     &layout,
                     &env,
@@ -334,8 +363,9 @@ pub(crate) fn plan_component(
                     query,
                     &command,
                 )?;
-                component = resolved_component;
-                (target, Some(package))
+                component = fresh.component;
+                delegated_pin = fresh.pin;
+                (fresh.target, Some(fresh.package))
             }
         }
     };
@@ -409,6 +439,7 @@ pub(crate) fn plan_component(
         component_identity_pinned,
         family,
         native_package,
+        delegated_pin,
         scope,
         now,
         store,
@@ -433,6 +464,7 @@ fn execute_planned(
         component_identity_pinned,
         family,
         native_package,
+        delegated_pin,
         scope,
         now,
         store,
@@ -457,6 +489,10 @@ fn execute_planned(
                     backend: family,
                     action: "already-installed",
                     operation_id: None,
+                    requested_version: None,
+                    resolved_version: None,
+                    source_repo: None,
+                    artifact: None,
                     dry_run: ctx.dry_run,
                     plan: Vec::new(),
                 },
@@ -488,22 +524,31 @@ fn execute_planned(
         for warning in resolution.iter().flat_map(|r| r.warnings.iter()) {
             eprintln!("warning: {warning}");
         }
-        render_result(
-            ctx,
-            &InstallResultPayload {
-                component,
-                package: native_package,
-                version: resolution
-                    .as_ref()
-                    .map(|r| r.entry.version.clone())
-                    .or_else(|| args.version.clone()),
-                backend: family,
-                action: "planned",
-                operation_id: None,
-                dry_run: true,
-                plan: plan_labels,
-            },
-        )?;
+        // A pinned delegated dry-run reports the version it resolved against
+        // the repository, not the raw `--version` echo — the pin fields carry
+        // the exact candidate so the preview proves what would be installed.
+        let base_version = resolution
+            .as_ref()
+            .map(|r| r.entry.version.clone())
+            .or_else(|| args.version.clone());
+        let mut payload = InstallResultPayload {
+            component,
+            package: native_package,
+            version: base_version,
+            backend: family,
+            action: "planned",
+            operation_id: None,
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
+            dry_run: true,
+            plan: plan_labels,
+        };
+        if let Some(pin) = &delegated_pin {
+            payload = payload.with_pin(pin);
+        }
+        render_result(ctx, &payload)?;
         return Ok(InstallOutcome::Installed);
     }
 
@@ -544,6 +589,7 @@ fn execute_planned(
         &now,
         &steps,
         &plan_labels,
+        delegated_pin.as_ref(),
         &provider,
         &repo_config,
         is_root,
@@ -574,6 +620,7 @@ fn target_for_active_record(
                         .package
                         .clone()
                         .unwrap_or_else(|| component.to_string()),
+                    artifact: None,
                 }
             };
             (target, None)
@@ -590,9 +637,13 @@ fn target_for_active_record(
                     version: args.version.clone().unwrap_or_default(),
                 }
             } else {
+                // Version pins over an existing record are out of scope: the
+                // planner's active-record arms decide the outcome (I6–I9) and
+                // never re-resolve a pinned artifact.
                 ProviderTarget::Delegated {
                     pm: NativePm::Rpm,
                     package: package.clone(),
+                    artifact: None,
                 }
             };
             (target, Some(package))
@@ -698,9 +749,21 @@ fn system_probe_package(
     })
 }
 
+/// Fresh delegated resolution result: the provider target, its bare package,
+/// the resolved component name (aliases may re-map the input), and — when a
+/// `--version` was pinned — the resolved candidate metadata for reporting.
+struct FreshDelegated {
+    target: ProviderTarget,
+    package: String,
+    component: String,
+    pin: Option<DelegatedPin>,
+}
+
 /// Fresh delegated resolution: the component must resolve to exactly one
-/// ANOLISA RPM package. Returns the target, its package, and the resolved
-/// component name (aliases may re-map the input).
+/// ANOLISA RPM package. When `--version` is set, the bare package is further
+/// resolved to an exact repository candidate for the host architecture, and
+/// the resulting NEVRA becomes the native transaction's artifact spec while
+/// the bare package stays the observation/record identity.
 fn resolve_fresh_delegated(
     args: &InstallArgs,
     layout: &FsLayout,
@@ -709,7 +772,7 @@ fn resolve_fresh_delegated(
     component: &str,
     query: &dyn PackageQuery,
     command: &str,
-) -> Result<(ProviderTarget, String, String), CliError> {
+) -> Result<FreshDelegated, CliError> {
     let component_index = load_optional_component_index(layout, env, repo_config);
     let candidates = rpm_package_candidates_with_index(
         args.package.as_deref(),
@@ -732,14 +795,49 @@ fn resolve_fresh_delegated(
                 "component '{component}' is not an ANOLISA RPM component; use the ANOLISA component name and configure the repo-side component index or publish Provides: anolisa-component({component})"
             ),
         }),
-        [single] => Ok((
-            ProviderTarget::Delegated {
-                pm: NativePm::Rpm,
-                package: single.package.clone(),
-            },
-            single.package.clone(),
-            single.component.clone(),
-        )),
+        [single] => {
+            let package = single.package.clone();
+            let resolved_component = single.component.clone();
+            // A `--version` pin resolves the bare package to an exact
+            // repository candidate before any mutation; the NEVRA is the only
+            // value that reaches the native transaction. An unpinned install
+            // keeps `artifact` as `None` (repository default).
+            let (artifact, pin) = match args.version.as_deref() {
+                Some(version) => {
+                    let pinned = resolve_pinned_candidate(query, &package, version, &env.arch)
+                        .map_err(|err| {
+                            pin_error_to_cli(
+                                err,
+                                command,
+                                &resolved_component,
+                                &package,
+                                version,
+                                &env.arch,
+                            )
+                        })?;
+                    let pin = DelegatedPin {
+                        requested_version: version.to_string(),
+                        resolved_version: pinned.version.clone(),
+                        resolved_evr: pinned.evr.clone(),
+                        resolved_arch: pinned.arch.clone(),
+                        artifact: pinned.artifact.clone(),
+                        source_repo: pinned.source_repo.clone(),
+                    };
+                    (Some(pinned.artifact), Some(pin))
+                }
+                None => (None, None),
+            };
+            Ok(FreshDelegated {
+                target: ProviderTarget::Delegated {
+                    pm: NativePm::Rpm,
+                    package: package.clone(),
+                    artifact,
+                },
+                package,
+                component: resolved_component,
+                pin,
+            })
+        }
         many => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
@@ -750,6 +848,38 @@ fn resolve_fresh_delegated(
                     .join(", "),
             ),
         }),
+    }
+}
+
+/// Map a version-pin resolution failure to a CLI error. Runs during read-only
+/// planning, so every arm reports that nothing was changed and never widens
+/// the version constraint.
+fn pin_error_to_cli(
+    err: PinError,
+    command: &str,
+    component: &str,
+    package: &str,
+    version: &str,
+    arch: &str,
+) -> CliError {
+    match err {
+        PinError::Query(PackageQueryError::CommandMissing { command: bin }) => {
+            rpm_tooling_missing_error(command, &bin, component)
+        }
+        PinError::Query(err) => pkg_query_err(err, command),
+        PinError::VersionAbsent => CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "version '{version}' of component '{component}' (package '{package}') is not available in the configured ANOLISA RPM repository; nothing was changed — check `anolisa list` / the published versions and retry with an available `--version`"
+            ),
+        },
+        PinError::ArchUnsupported { offered } => CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "version '{version}' of component '{component}' (package '{package}') is not available for this host architecture '{arch}' (repository offers: {}); nothing was changed",
+                offered.join(", ")
+            ),
+        },
     }
 }
 
@@ -853,6 +983,10 @@ fn install_owned(
             backend: "raw".to_string(),
             action: "installed",
             operation_id: Some(operation_id),
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
             dry_run: false,
             plan: plan_labels.to_vec(),
         },
@@ -874,6 +1008,7 @@ fn install_delegated(
     now: &str,
     steps: &[Step],
     plan_labels: &[String],
+    delegated_pin: Option<&DelegatedPin>,
     provider: &DelegatedProvider,
     repo_config: &RepoConfig,
     is_root: bool,
@@ -928,16 +1063,17 @@ fn install_delegated(
         }),
         owned_artifact: None,
     };
+    // Pin the execution target to the resolved artifact so the executor both
+    // constrains the native transaction to the exact NEVRA and verifies the
+    // freshly installed EVR/arch before committing the record.
+    let mut exec_target = DelegatedExecutionTarget::new(NativePm::Rpm, Some(package));
+    if let Some(pin) = delegated_pin {
+        exec_target =
+            exec_target.with_pinned_artifact(&pin.artifact, &pin.resolved_evr, &pin.resolved_arch);
+    }
     let outcome = {
         let mut sink = StoreRecordSink::new(&mut store, state_path, context);
-        execute_delegated_steps(
-            steps,
-            DelegatedExecutionTarget::new(NativePm::Rpm, Some(package)),
-            provider,
-            &mut sink,
-            &mut journal,
-            now,
-        )
+        execute_delegated_steps(steps, exec_target, provider, &mut sink, &mut journal, now)
     }
     .map_err(|err| CliError::Runtime {
         command: command.to_string(),
@@ -973,19 +1109,24 @@ fn install_delegated(
     }
 
     let version = outcome.observation.as_ref().map(|o| o.version.clone());
-    render_result(
-        ctx,
-        &InstallResultPayload {
-            component: target.to_string(),
-            package: Some(package.to_string()),
-            version,
-            backend: "rpm".to_string(),
-            action: "installed",
-            operation_id: Some(operation_id),
-            dry_run: false,
-            plan: plan_labels.to_vec(),
-        },
-    )?;
+    let mut payload = InstallResultPayload {
+        component: target.to_string(),
+        package: Some(package.to_string()),
+        version,
+        backend: "rpm".to_string(),
+        action: "installed",
+        operation_id: Some(operation_id),
+        requested_version: None,
+        resolved_version: None,
+        source_repo: None,
+        artifact: None,
+        dry_run: false,
+        plan: plan_labels.to_vec(),
+    };
+    if let Some(pin) = delegated_pin {
+        payload = payload.with_pin(pin);
+    }
+    render_result(ctx, &payload)?;
     Ok(InstallOutcome::Installed)
 }
 
@@ -1272,6 +1413,12 @@ pub(crate) fn step_label(step: &Step) -> String {
 }
 
 /// JSON payload for a completed (or previewed, or idempotent) install.
+///
+/// The pin fields (`requested_version`, `resolved_version`, `source_repo`,
+/// `artifact`) are additive and only present for a version-pinned delegated
+/// install; `version` keeps its existing meaning (the effective/installed
+/// version) across every route, so the wire contract stays backward
+/// compatible.
 #[derive(Debug, Serialize)]
 struct InstallResultPayload {
     component: String,
@@ -1284,8 +1431,68 @@ struct InstallResultPayload {
     action: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     operation_id: Option<String>,
+    /// `--version` value the caller requested (version-pinned installs only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requested_version: Option<String>,
+    /// Full resolved EVR of the pinned candidate (version-pinned only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resolved_version: Option<String>,
+    /// Source repository the pinned candidate came from (version-pinned only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_repo: Option<String>,
+    /// Exact NEVRA handed to dnf (version-pinned only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifact: Option<String>,
     dry_run: bool,
     plan: Vec<String>,
+}
+
+impl InstallResultPayload {
+    /// Copy the resolved-candidate fields from a delegated version pin. The
+    /// pin's resolved EVR becomes `resolved_version`; `version` is set to the
+    /// upstream version so the existing field stays a clear, compatible
+    /// answer for pinned installs too.
+    fn with_pin(mut self, pin: &DelegatedPin) -> Self {
+        self.requested_version = Some(pin.requested_version.clone());
+        self.resolved_version = Some(pin.resolved_evr.clone());
+        self.source_repo = pin.source_repo.clone();
+        self.artifact = Some(pin.artifact.clone());
+        if self.version.is_none() {
+            self.version = Some(pin.resolved_version.clone());
+        }
+        self
+    }
+}
+
+/// Detail lines shown above the plan in a dry-run preview.
+///
+/// For a version-pinned delegated install this makes the resolved candidate
+/// explicit — bare package, requested version, resolved EVR, exact artifact,
+/// and source repository — so the preview proves what would be installed
+/// rather than echoing the request. Unpinned/owned installs contribute no pin
+/// fields and yield an empty list (the plan alone is shown).
+fn dry_run_detail_lines(payload: &InstallResultPayload) -> Vec<String> {
+    let mut lines = Vec::new();
+    // Only a version pin populates these; guard on `artifact` so unpinned and
+    // owned dry-runs render exactly as before (plan only).
+    if payload.artifact.is_some() {
+        if let Some(package) = &payload.package {
+            lines.push(format!("package: {package}"));
+        }
+        if let Some(requested) = &payload.requested_version {
+            lines.push(format!("requested version: {requested}"));
+        }
+        if let Some(resolved) = &payload.resolved_version {
+            lines.push(format!("resolved version: {resolved}"));
+        }
+        if let Some(artifact) = &payload.artifact {
+            lines.push(format!("artifact: {artifact}"));
+        }
+        if let Some(repo) = &payload.source_repo {
+            lines.push(format!("repository: {repo}"));
+        }
+    }
+    lines
 }
 
 fn render_result(ctx: &CliContext, payload: &InstallResultPayload) -> Result<(), CliError> {
@@ -1297,6 +1504,9 @@ fn render_result(ctx: &CliContext, payload: &InstallResultPayload) -> Result<(),
     }
     if payload.dry_run {
         println!("install {} (dry-run):", payload.component);
+        for line in dry_run_detail_lines(payload) {
+            println!("  {line}");
+        }
         for label in &payload.plan {
             println!("  - {label}");
         }
@@ -1325,6 +1535,131 @@ mod tests {
     use crate::repo_config::RepoConfig;
     use anolisa_platform::fs_layout::FsLayout;
     use tempfile::tempdir;
+
+    #[test]
+    fn pinned_payload_json_exposes_requested_resolved_repo_and_artifact() {
+        // The JSON envelope for a version-pinned install must carry the
+        // requested/resolved version, the source repo, the exact artifact, and
+        // the bare package — while keeping `version` as a compatible answer.
+        let pin = DelegatedPin {
+            requested_version: "0.6.2".to_string(),
+            resolved_version: "0.6.2".to_string(),
+            resolved_evr: "0.6.2-1.alnx4".to_string(),
+            resolved_arch: "x86_64".to_string(),
+            artifact: "agentsight-0.6.2-1.alnx4.x86_64".to_string(),
+            source_repo: Some("anolisa-configured".to_string()),
+        };
+        let payload = InstallResultPayload {
+            component: "agentsight".to_string(),
+            package: Some("agentsight".to_string()),
+            version: None,
+            backend: "rpm".to_string(),
+            action: "planned",
+            operation_id: None,
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
+            dry_run: true,
+            plan: vec!["dnf install agentsight-0.6.2-1.alnx4.x86_64".to_string()],
+        }
+        .with_pin(&pin);
+
+        let json = serde_json::to_value(&payload).expect("serialize payload");
+        assert_eq!(json["component"], "agentsight");
+        assert_eq!(json["package"], "agentsight");
+        assert_eq!(json["requested_version"], "0.6.2");
+        assert_eq!(json["resolved_version"], "0.6.2-1.alnx4");
+        assert_eq!(json["source_repo"], "anolisa-configured");
+        assert_eq!(json["artifact"], "agentsight-0.6.2-1.alnx4.x86_64");
+        // `version` stays present as the upstream version (compatible field).
+        assert_eq!(json["version"], "0.6.2");
+    }
+
+    #[test]
+    fn pinned_dry_run_detail_lines_show_package_resolved_version_and_artifact() {
+        // The human dry-run contract: bare package, requested version, resolved
+        // EVR, exact artifact, and source repository, each on its own line.
+        let pin = DelegatedPin {
+            requested_version: "0.6.2".to_string(),
+            resolved_version: "0.6.2".to_string(),
+            resolved_evr: "0.6.2-1.alnx4".to_string(),
+            resolved_arch: "x86_64".to_string(),
+            artifact: "agentsight-0.6.2-1.alnx4.x86_64".to_string(),
+            source_repo: Some("anolisa-configured".to_string()),
+        };
+        let payload = InstallResultPayload {
+            component: "agentsight".to_string(),
+            package: Some("agentsight".to_string()),
+            version: None,
+            backend: "rpm".to_string(),
+            action: "planned",
+            operation_id: None,
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
+            dry_run: true,
+            plan: Vec::new(),
+        }
+        .with_pin(&pin);
+
+        assert_eq!(
+            dry_run_detail_lines(&payload),
+            vec![
+                "package: agentsight".to_string(),
+                "requested version: 0.6.2".to_string(),
+                "resolved version: 0.6.2-1.alnx4".to_string(),
+                "artifact: agentsight-0.6.2-1.alnx4.x86_64".to_string(),
+                "repository: anolisa-configured".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn unpinned_dry_run_detail_lines_are_empty() {
+        // No pin → no detail lines; the unpinned/owned preview is unchanged.
+        let payload = InstallResultPayload {
+            component: "agentsight".to_string(),
+            package: Some("agentsight".to_string()),
+            version: Some("0.6.2".to_string()),
+            backend: "rpm".to_string(),
+            action: "planned",
+            operation_id: None,
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
+            dry_run: true,
+            plan: vec!["dnf install agentsight".to_string()],
+        };
+        assert!(dry_run_detail_lines(&payload).is_empty());
+    }
+
+    #[test]
+    fn unpinned_payload_json_omits_pin_fields() {
+        // Without a pin the additive fields must not appear, preserving the
+        // pre-existing wire contract for plain installs.
+        let payload = InstallResultPayload {
+            component: "agentsight".to_string(),
+            package: Some("agentsight".to_string()),
+            version: Some("0.6.2".to_string()),
+            backend: "rpm".to_string(),
+            action: "installed",
+            operation_id: None,
+            requested_version: None,
+            resolved_version: None,
+            source_repo: None,
+            artifact: None,
+            dry_run: false,
+            plan: Vec::new(),
+        };
+        let json = serde_json::to_value(&payload).expect("serialize payload");
+        assert!(json.get("requested_version").is_none());
+        assert!(json.get("resolved_version").is_none());
+        assert!(json.get("source_repo").is_none());
+        assert!(json.get("artifact").is_none());
+    }
 
     #[test]
     fn raw_resolution_does_not_rewrite_exact_state_identity() {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
@@ -7,6 +7,7 @@
 //! (`dispatch.rs`, `adopt.rs`); only the identity resolution lives here.
 
 use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use anolisa_platform::rpm_select::{PinnedSelection, nevra, select_pinned_candidate};
 
 use crate::repo_config::BackendConfig;
 use crate::resolution::{
@@ -67,6 +68,73 @@ pub(crate) fn rpm_package_candidates(
         input,
         ResolutionUse::Install,
     )
+}
+
+/// A repository candidate a `--version` pin resolved to.
+///
+/// Carries both the exact transaction spec (`artifact`) and the reporting
+/// fields the dry-run/JSON surface exposes; the bare package identity stays
+/// with the caller for observation and persisted state.
+#[derive(Debug, Clone)]
+pub(crate) struct PinnedRpm {
+    /// Exact NEVRA handed to the native transaction.
+    pub(crate) artifact: String,
+    /// Upstream VERSION field the pin matched (the `--version` value).
+    pub(crate) version: String,
+    /// Full resolved EVR (`[epoch:]version-release`) of the candidate.
+    pub(crate) evr: String,
+    /// Architecture of the selected candidate (used to verify the installed
+    /// build matches the pin).
+    pub(crate) arch: String,
+    /// Source repository the candidate came from, when reported.
+    pub(crate) source_repo: Option<String>,
+}
+
+/// Why a `--version` pin could not resolve to a host-compatible candidate.
+///
+/// Kept distinct from [`crate::response::CliError`] so the caller can attach
+/// the component/package/arch context it owns when rendering the message.
+pub(crate) enum PinError {
+    /// The repository query itself failed.
+    Query(PackageQueryError),
+    /// No candidate carried the requested version for any architecture.
+    VersionAbsent,
+    /// The version exists, but only for architectures this host cannot run.
+    ArchUnsupported {
+        /// Architectures the requested version is published for.
+        offered: Vec<String>,
+    },
+}
+
+/// Resolve `requested_version` of `package` to an exact repository candidate
+/// for `host_arch`, querying the configured ANOLISA RPM repository.
+///
+/// Delegates candidate selection to
+/// [`anolisa_platform::rpm_select::select_pinned_candidate`] (VERSION-field
+/// match, host-arch/`noarch` filter, highest-EVR pick) and renders the winner
+/// to a NEVRA. Never falls back to another version.
+///
+/// # Errors
+/// See [`PinError`]: a hard query failure, an absent version, or a version
+/// published only for other architectures.
+pub(crate) fn resolve_pinned_candidate(
+    query: &dyn PackageQuery,
+    package: &str,
+    requested_version: &str,
+    host_arch: &str,
+) -> Result<PinnedRpm, PinError> {
+    let candidates = query.query_available(package).map_err(PinError::Query)?;
+    match select_pinned_candidate(&candidates, requested_version, host_arch) {
+        PinnedSelection::Selected(info) => Ok(PinnedRpm {
+            artifact: nevra(&info),
+            version: info.version.version.clone(),
+            evr: info.version.to_string(),
+            arch: info.arch.clone(),
+            source_repo: info.origin.clone(),
+        }),
+        PinnedSelection::VersionAbsent => Err(PinError::VersionAbsent),
+        PinnedSelection::ArchUnsupported { offered } => Err(PinError::ArchUnsupported { offered }),
+    }
 }
 
 pub(crate) fn rpm_package_candidates_with_index(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -635,6 +635,12 @@ pub struct FakeInstaller {
     pub install_succeeds: bool,
     pub installed: RefCell<Option<PackageInfo>>,
     pub install_calls: Cell<usize>,
+    /// Package spec(s) each `install` call received, joined per call, so tests
+    /// can pin the exact NEVRA a version-pinned install hands to dnf.
+    pub install_specs: RefCell<Vec<String>>,
+    /// Expected `install` argument (comma-joined). When `None`, the fake
+    /// asserts the bare package name; a pinned test sets the expected NEVRA.
+    pub expected_install: Option<String>,
     /// Optional lock path probed from inside `install`.
     pub lock_probe: Option<PathBuf>,
     pub lock_was_held: Cell<bool>,
@@ -655,6 +661,8 @@ impl FakeInstaller {
             install_succeeds: true,
             installed: RefCell::new(None),
             install_calls: Cell::new(0),
+            install_specs: RefCell::new(Vec::new()),
+            expected_install: None,
             lock_probe: None,
             lock_was_held: Cell::new(false),
             package_appears_under_lock_path: None,
@@ -665,6 +673,18 @@ impl FakeInstaller {
     }
     pub fn with_origin(mut self, repo: &str) -> Self {
         self.origin = Some(repo.to_string());
+        self
+    }
+    /// Repository candidates `query_available` returns for the package, so a
+    /// version-pinned install can resolve a concrete NEVRA.
+    pub fn with_available(mut self, available: Vec<PackageInfo>) -> Self {
+        self.available = available;
+        self
+    }
+    /// Assert `install` receives this exact spec (e.g. a pinned NEVRA) instead
+    /// of the bare package name.
+    pub fn expecting_install(mut self, spec: &str) -> Self {
+        self.expected_install = Some(spec.to_string());
         self
     }
     pub fn failing_install(mut self) -> Self {
@@ -785,10 +805,15 @@ impl PackageQuery for FakeInstaller {
 impl PackageTransaction for FakeInstaller {
     fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
         self.install_calls.set(self.install_calls.get() + 1);
+        self.install_specs.borrow_mut().push(packages.join(","));
+        let expected = self
+            .expected_install
+            .clone()
+            .unwrap_or_else(|| self.package.clone());
         assert_eq!(
-            packages,
-            [self.package.as_str()],
-            "install targeted the wrong package"
+            packages.join(","),
+            expected,
+            "install targeted the wrong package/spec"
         );
         if let Some(path) = &self.lock_probe {
             self.lock_was_held.set(matches!(
@@ -967,6 +992,35 @@ pub fn pkg_info(name: &str, version: &str, release: Option<&str>, arch: &str) ->
         },
         arch: arch.to_string(),
         origin: None,
+    }
+}
+
+/// Host architecture the install pipeline resolves against, so version-pinned
+/// tests build candidates the running host actually accepts (aarch64 on this
+/// CI, x86_64 elsewhere) instead of hard-coding one arch.
+pub fn host_arch() -> String {
+    anolisa_env::EnvService::detect().arch
+}
+
+/// A repository candidate for a version-pinned availability query, carrying an
+/// origin (source repo) so the resolved-candidate reporting has a value.
+pub fn available_candidate(
+    name: &str,
+    epoch: Option<&str>,
+    version: &str,
+    release: &str,
+    arch: &str,
+    origin: &str,
+) -> PackageInfo {
+    PackageInfo {
+        name: name.to_string(),
+        version: PackageVersion {
+            epoch: epoch.map(str::to_string),
+            version: version.to_string(),
+            release: Some(release.to_string()),
+        },
+        arch: arch.to_string(),
+        origin: Some(origin.to_string()),
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -1035,6 +1035,11 @@ fn pinned_install_wrong_arch_fails_before_mutation() {
         "message must name the host architecture: {}",
         err.reason()
     );
+    assert!(
+        err.reason().contains("s390x"),
+        "message must name the architectures offered by the repository: {}",
+        err.reason()
+    );
     assert_eq!(fake.install_calls.get(), 0, "dnf must not run");
     assert!(
         load_store(&ctx)

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -810,3 +810,437 @@ fn seed_tracked_rpm(ctx: &CliContext, component: &str, ownership: Ownership) -> 
         .expect("seed tracked RPM state");
     object
 }
+
+// ---- Version-pinned RPM install (issue #1682) ----------------------------
+
+/// Repo config with an rpm backend and a `package_map`, written to disk so the
+/// full install pipeline (which loads repo.toml) sees the mapping. Used by the
+/// `--package` + `--version` composition test.
+fn system_ctx_with_rpm_package_map(pairs: &[(&str, &str)]) -> (tempfile::TempDir, CliContext) {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let prefix = tmp.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+    std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+    std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    let map = pairs
+        .iter()
+        .map(|(component, package)| format!("{component} = \"{package}\""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(
+        layout.etc_dir.join("repo.toml"),
+        format!(
+            r#"schema_version = 1
+default_backend = "raw"
+
+[backends.raw]
+base_url = "https://example.com/anolisa"
+
+[backends.rpm]
+base_url = "https://repo.example/anolisa"
+gpgcheck = false
+
+[backends.rpm.package_map]
+{map}
+"#
+        ),
+    )
+    .expect("write repo.toml");
+    let ctx = ctx_with_prefix(false, Some(prefix));
+    (tmp, ctx)
+}
+
+#[test]
+fn pinned_delegated_install_passes_exact_nevra_and_records_bare_package() {
+    // The repo publishes 0.6.2 and a newer 0.7.0; pinning 0.6.2 must hand the
+    // exact 0.6.2 NEVRA to dnf, while observation and the persisted record
+    // keep the bare package identity.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "0.6.2", Some("1.al8"), &arch),
+    )
+    .with_origin("anolisa-configured")
+    .with_available(vec![
+        available_candidate(
+            "copilot-shell",
+            None,
+            "0.6.2",
+            "1.al8",
+            &arch,
+            "anolisa-configured",
+        ),
+        available_candidate(
+            "copilot-shell",
+            None,
+            "0.7.0",
+            "1.al8",
+            &arch,
+            "anolisa-configured",
+        ),
+    ])
+    .expecting_install(&format!("copilot-shell-0.6.2-1.al8.{arch}"));
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    let outcome = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect("pinned install ok");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 1, "dnf install must run once");
+    assert_eq!(
+        fake.install_specs.borrow().as_slice(),
+        &[format!("copilot-shell-0.6.2-1.al8.{arch}")],
+        "the exact pinned NEVRA must reach dnf, not the bare package"
+    );
+
+    let store = load_store(&ctx);
+    let record = store
+        .find(ObjectKind::Component, "copilot-shell")
+        .expect("component recorded");
+    match &record.binding {
+        ProviderBinding::Delegated {
+            package,
+            last_observed,
+            ..
+        } => {
+            // Identity and observation stay on the bare package — the NEVRA
+            // never leaks into persisted state.
+            assert_eq!(package.resolved_name(), Some("copilot-shell"));
+            let observed = last_observed.as_ref().expect("fresh observation");
+            assert_eq!(observed.evr.as_deref(), Some("0.6.2-1.al8"));
+        }
+        other => panic!("expected a delegated binding, got {other:?}"),
+    }
+}
+
+#[test]
+fn pinned_install_selects_highest_release_for_requested_version() {
+    // One version, several releases: the highest EVR release is the one that
+    // reaches dnf.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "0.6.2", Some("10.al8"), &arch),
+    )
+    .with_available(vec![
+        available_candidate(
+            "copilot-shell",
+            None,
+            "0.6.2",
+            "1.al8",
+            &arch,
+            "anolisa-configured",
+        ),
+        available_candidate(
+            "copilot-shell",
+            None,
+            "0.6.2",
+            "10.al8",
+            &arch,
+            "anolisa-configured",
+        ),
+        available_candidate(
+            "copilot-shell",
+            None,
+            "0.6.2",
+            "2.al8",
+            &arch,
+            "anolisa-configured",
+        ),
+    ])
+    .expecting_install(&format!("copilot-shell-0.6.2-10.al8.{arch}"));
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect("pinned install ok");
+    assert_eq!(
+        fake.install_specs.borrow().as_slice(),
+        &[format!("copilot-shell-0.6.2-10.al8.{arch}")]
+    );
+}
+
+#[test]
+fn pinned_install_missing_version_fails_before_txn_journal_and_state() {
+    // The requested version is absent (repo only has 0.7.0): the install must
+    // fail before dnf runs, before a journal is written, and before any state
+    // record — and never retry without the version constraint.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let layout = common::resolve_layout(&ctx);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "0.7.0", Some("1.al8"), &arch),
+    )
+    .with_available(vec![available_candidate(
+        "copilot-shell",
+        None,
+        "0.7.0",
+        "1.al8",
+        &arch,
+        "anolisa-configured",
+    )]);
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    let err = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect_err("a missing pinned version must fail");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(err.reason().contains("0.6.2"), "got: {}", err.reason());
+    assert_eq!(fake.install_calls.get(), 0, "dnf must not run");
+    assert!(
+        load_store(&ctx)
+            .find(ObjectKind::Component, "copilot-shell")
+            .is_none(),
+        "a missing version must not claim a record"
+    );
+    assert!(
+        load_journals(&layout).is_empty(),
+        "a missing version must not open a journal"
+    );
+}
+
+#[test]
+fn pinned_install_wrong_arch_fails_before_mutation() {
+    // The version exists, but only for an architecture this host cannot run.
+    // The refusal names the version and the host arch and changes nothing.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "0.6.2", Some("1.al8"), &arch),
+    )
+    .with_available(vec![available_candidate(
+        "copilot-shell",
+        None,
+        "0.6.2",
+        "1.al8",
+        "s390x",
+        "anolisa-configured",
+    )]);
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    let err = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect_err("a host-incompatible version must fail");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(
+        err.reason().contains("architecture") && err.reason().contains(&arch),
+        "message must name the host architecture: {}",
+        err.reason()
+    );
+    assert_eq!(fake.install_calls.get(), 0, "dnf must not run");
+    assert!(
+        load_store(&ctx)
+            .find(ObjectKind::Component, "copilot-shell")
+            .is_none()
+    );
+}
+
+#[test]
+fn pinned_delegated_dry_run_shows_resolved_candidate_without_txn_or_state() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(true);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "0.6.2", Some("1.al8"), &arch),
+    )
+    .with_available(vec![
+        available_candidate(
+            "copilot-shell",
+            None,
+            "0.6.2",
+            "1.al8",
+            &arch,
+            "anolisa-configured",
+        ),
+        available_candidate(
+            "copilot-shell",
+            None,
+            "0.7.0",
+            "1.al8",
+            &arch,
+            "anolisa-configured",
+        ),
+    ]);
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    let outcome = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, false)
+        .expect("pinned dry-run ok");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 0, "dry-run must not run dnf");
+    assert!(
+        load_store(&ctx)
+            .find(ObjectKind::Component, "copilot-shell")
+            .is_none(),
+        "dry-run must not persist state"
+    );
+}
+
+#[test]
+fn pinned_dry_run_still_validates_against_the_repository() {
+    // Dry-run resolves against real repository candidates, so an absent
+    // version fails in dry-run just as it would for a real install — it does
+    // not blindly echo the request.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(true);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "0.7.0", Some("1.al8"), &arch),
+    )
+    .with_available(vec![available_candidate(
+        "copilot-shell",
+        None,
+        "0.7.0",
+        "1.al8",
+        &arch,
+        "anolisa-configured",
+    )]);
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    let err = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, false)
+        .expect_err("dry-run must validate the pinned version");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(err.reason().contains("0.6.2"), "got: {}", err.reason());
+}
+
+#[test]
+fn pinned_install_handles_a_non_zero_epoch() {
+    // A non-zero epoch on the winning candidate renders into the NEVRA in the
+    // `name-epoch:version-release.arch` form dnf accepts.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let arch = host_arch();
+    let mut installs_to = pkg_info("copilot-shell", "0.6.2", Some("1.al8"), &arch);
+    installs_to.version.epoch = Some("2".to_string());
+    let fake = FakeInstaller::new("copilot-shell", installs_to)
+        .with_available(vec![available_candidate(
+            "copilot-shell",
+            Some("2"),
+            "0.6.2",
+            "1.al8",
+            &arch,
+            "anolisa-configured",
+        )])
+        .expecting_install(&format!("copilot-shell-2:0.6.2-1.al8.{arch}"));
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect("pinned install ok");
+    assert_eq!(
+        fake.install_specs.borrow().as_slice(),
+        &[format!("copilot-shell-2:0.6.2-1.al8.{arch}")]
+    );
+}
+
+#[test]
+fn pinned_install_composes_with_package_override() {
+    // `--package` selects the backend package; `--version` then pins against
+    // that package's candidates. The override NEVRA reaches dnf while the
+    // component name stays the addressed one.
+    let (_tmp, ctx) = system_ctx_with_rpm_package_map(&[("cosh", "site-copilot")]);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "site-copilot",
+        pkg_info("site-copilot", "0.6.2", Some("1.al8"), &arch),
+    )
+    .with_available(vec![available_candidate(
+        "site-copilot",
+        None,
+        "0.6.2",
+        "1.al8",
+        &arch,
+        "anolisa-configured",
+    )])
+    .expecting_install(&format!("site-copilot-0.6.2-1.al8.{arch}"));
+    let mut a = args("cosh");
+    a.backend = Some("rpm".to_string());
+    a.package = Some("site-copilot".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    install_component_with_deps("cosh", &a, &ctx, &fake, &fake, true).expect("pinned install ok");
+    assert_eq!(
+        fake.install_specs.borrow().as_slice(),
+        &[format!("site-copilot-0.6.2-1.al8.{arch}")]
+    );
+    let store = load_store(&ctx);
+    let record = store
+        .find(ObjectKind::Component, "cosh")
+        .expect("component recorded under the addressed name");
+    match &record.binding {
+        ProviderBinding::Delegated { package, .. } => {
+            assert_eq!(package.resolved_name(), Some("site-copilot"));
+        }
+        other => panic!("expected a delegated binding, got {other:?}"),
+    }
+}
+
+#[test]
+fn unpinned_delegated_install_passes_bare_package() {
+    // Regression guard: without `--version` the native transaction still
+    // receives the bare package name (repository default), unchanged by the
+    // version-pinning work.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let arch = host_arch();
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), &arch),
+    );
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+
+    install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect("unpinned install ok");
+    assert_eq!(
+        fake.install_specs.borrow().as_slice(),
+        &["copilot-shell".to_string()],
+        "an unpinned install must send the bare package name"
+    );
+}
+
+#[test]
+fn pinned_install_refuses_state_when_dnf_installs_a_different_evr() {
+    // End-to-end guard: the pin resolves 0.6.2, but dnf actually lands 0.7.0
+    // (module stream / Obsoletes). The command must fail toward repair and
+    // must not persist a record for the wrong version.
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let arch = host_arch();
+    // Candidate resolves to 0.6.2, but the rpmdb reports 0.7.0 after install.
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "0.7.0", Some("1.al8"), &arch),
+    )
+    .with_available(vec![available_candidate(
+        "copilot-shell",
+        None,
+        "0.6.2",
+        "1.al8",
+        &arch,
+        "anolisa-configured",
+    )])
+    .expecting_install(&format!("copilot-shell-0.6.2-1.al8.{arch}"));
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("0.6.2".to_string());
+
+    let err = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect_err("a wrong installed EVR must fail");
+    assert!(err.reason().contains("repair"), "got: {}", err.reason());
+    assert!(
+        load_store(&ctx)
+            .find(ObjectKind::Component, "copilot-shell")
+            .is_none(),
+        "the wrong version must not be recorded"
+    );
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -1074,11 +1074,18 @@ fn recover_journal(
                     .unwrap_or_else(|| observation.version.clone());
                 let arch_ok = observation.arch.as_deref() == Some(pin.arch.as_str());
                 if observed_evr != pin.evr || !arch_ok {
-                    let observed_arch = observation.arch.as_deref().unwrap_or("unknown-arch");
+                    let observed_build = match observation
+                        .arch
+                        .as_deref()
+                        .filter(|arch| !arch.trim().is_empty())
+                    {
+                        Some(arch) => format!("{observed_evr} ({arch})"),
+                        None => format!("{observed_evr} (architecture unavailable from rpmdb)"),
+                    };
                     return Err(CliError::Runtime {
                         command: command.to_string(),
                         reason: format!(
-                            "the interrupted {} of '{target}' pinned '{}', but package '{package}' is installed as {observed_evr} ({observed_arch}); refusing to record a different version — reconcile manually (e.g. `dnf install {}`) then re-run `anolisa repair {target}`",
+                            "the interrupted {} of '{target}' pinned '{}', but package '{package}' is installed as {observed_build}; refusing to record a different version — reconcile manually (e.g. `dnf install {}`) then re-run `anolisa repair {target}`",
                             journal.operation, pin.artifact, pin.artifact
                         ),
                     });
@@ -3877,6 +3884,48 @@ mod tests {
                 .expect("reload journal")
                 .is_pending(),
             "a refused recovery must leave the journal pending"
+        );
+    }
+
+    #[test]
+    fn pinned_install_journal_reports_when_rpmdb_arch_is_unavailable() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&ctx);
+        let journal_path = write_pinned_install_journal(
+            &layout,
+            "cosh",
+            "copilot-shell",
+            "copilot-shell-2.6.0-1.al4.x86_64",
+            "2.6.0-1.al4",
+            "x86_64",
+        );
+        let fake = FakeRpm::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.6.0", Some("1.al4"), "")),
+        );
+
+        let err = repair_with_deps("cosh", &ctx, &fake, &fake, false)
+            .expect_err("a missing rpmdb architecture must not satisfy the pin");
+        assert!(
+            err.reason().contains("architecture unavailable from rpmdb"),
+            "got: {}",
+            err.reason()
+        );
+        assert!(
+            !err.reason().contains("unknown-arch"),
+            "a sentinel must not look like an rpm architecture: {}",
+            err.reason()
+        );
+        assert!(
+            load_store(&ctx)
+                .find(ObjectKind::Component, "cosh")
+                .is_none()
+        );
+        assert!(
+            Transaction::load_journal(&journal_path)
+                .expect("reload journal")
+                .is_pending()
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -1061,6 +1061,29 @@ fn recover_journal(
         .map_err(|err| probe_error(err, command, target))?
     {
         NativeProbe::Present { observation, .. } => {
+            // A pinned operation resolved a specific artifact. Recovery must
+            // hold the same guarantee as the in-process path: refuse to record
+            // a package whose installed EVR/arch differs from the pin (a
+            // different build committed before the crash, or the wrong version
+            // is present). The journal is left pending for manual reconcile —
+            // recovery never falls back to whatever is installed.
+            if let Some(pin) = &recovery.pinned {
+                let observed_evr = observation
+                    .evr
+                    .clone()
+                    .unwrap_or_else(|| observation.version.clone());
+                let arch_ok = observation.arch.as_deref() == Some(pin.arch.as_str());
+                if observed_evr != pin.evr || !arch_ok {
+                    let observed_arch = observation.arch.as_deref().unwrap_or("unknown-arch");
+                    return Err(CliError::Runtime {
+                        command: command.to_string(),
+                        reason: format!(
+                            "the interrupted {} of '{target}' pinned '{}', but package '{package}' is installed as {observed_evr} ({observed_arch}); refusing to record a different version — reconcile manually (e.g. `dnf install {}`) then re-run `anolisa repair {target}`",
+                            journal.operation, pin.artifact, pin.artifact
+                        ),
+                    });
+                }
+            }
             ensure_recovery_write_authorized(
                 &store,
                 target,
@@ -1213,27 +1236,52 @@ fn delegated_recovery_context(
                 "the explicit record transition conflicts with the journal steps",
             ));
         }
-        if let Some(package) = context.package.as_deref()
-            && journal
-                .steps
-                .iter()
-                .filter(|step| {
-                    step.phase == anolisa_core::executor::PHASE_NATIVE_TXN
-                        || step.phase == anolisa_core::executor::PHASE_OBSERVE
-                })
-                .any(|step| {
-                    !step
-                        .target
-                        .split(',')
-                        .map(str::trim)
-                        .any(|candidate| candidate == package)
-                })
-        {
-            return Err(unsafe_recovery_contract_error(
-                journal,
-                command,
-                "the explicit package identity conflicts with the journal steps",
-            ));
+        if let Some(package) = context.package.as_deref() {
+            // The observe step re-observes the bare package; the native
+            // transaction step names the pinned artifact (NEVRA) when the
+            // operation was version-pinned, otherwise the bare package.
+            //
+            // A pinned operation is never a merged batch, so both its native
+            // and observe steps must resolve to *exactly* one target — the
+            // pinned artifact and the bare package respectively. A journal
+            // whose pinned native step also lists another package is malformed
+            // and must not recover. Only an unpinned batch native step keeps
+            // membership semantics (a shared transaction names the whole
+            // batch, and this subject need only appear among them).
+            let contains = |step: &anolisa_core::transaction::TransactionStep, needle: &str| {
+                step.target
+                    .split(',')
+                    .map(str::trim)
+                    .any(|candidate| candidate == needle)
+            };
+            let resolves_exactly = |step: &anolisa_core::transaction::TransactionStep,
+                                    expected: &str| {
+                let mut targets = step
+                    .target
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|target| !target.is_empty());
+                targets.next() == Some(expected) && targets.next().is_none()
+            };
+            let conflict = journal.steps.iter().any(|step| {
+                if step.phase == anolisa_core::executor::PHASE_NATIVE_TXN {
+                    match &context.pinned {
+                        Some(pin) => !resolves_exactly(step, &pin.artifact),
+                        None => !contains(step, package),
+                    }
+                } else if step.phase == anolisa_core::executor::PHASE_OBSERVE {
+                    !resolves_exactly(step, package)
+                } else {
+                    false
+                }
+            });
+            if conflict {
+                return Err(unsafe_recovery_contract_error(
+                    journal,
+                    command,
+                    "the explicit package identity conflicts with the journal steps",
+                ));
+            }
         }
         return Ok(Some(context.clone()));
     }
@@ -1360,6 +1408,7 @@ fn delegated_recovery_context(
         pm: NativePm::Rpm,
         package,
         record_action: action,
+        pinned: None,
     }))
 }
 
@@ -2265,13 +2314,13 @@ mod tests {
     use std::path::PathBuf;
 
     use anolisa_core::domain::LifecycleStatus;
-    use anolisa_core::executor::PHASE_NATIVE_TXN;
+    use anolisa_core::executor::{PHASE_NATIVE_TXN, PHASE_OBSERVE};
     use anolisa_core::owned_executor::PHASE_FILES;
     use anolisa_core::state::{
         FileOwner, InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus,
         OwnedFile, OwnedFileKind, Ownership, RpmMetadata,
     };
-    use anolisa_core::transaction::TransactionStep;
+    use anolisa_core::transaction::{DelegatedPinnedArtifact, TransactionStep};
     use anolisa_platform::pkg_query::{PackageInfo, PackageVersion};
 
     use crate::context::InstallMode;
@@ -3677,6 +3726,7 @@ mod tests {
                     pm: NativePm::Rpm,
                     package: Some(package.to_string()),
                     record_action,
+                    pinned: None,
                 },
                 steps,
             )
@@ -3684,6 +3734,283 @@ mod tests {
         let path = journal.journal_path.clone();
         drop(journal);
         path
+    }
+
+    /// A version-pinned install journal interrupted after dnf committed but
+    /// before the record: NEVRA native step, bare observe step, and a pinned
+    /// recovery contract — exactly what the executor persists.
+    fn write_pinned_install_journal(
+        layout: &FsLayout,
+        subject: &str,
+        package: &str,
+        artifact: &str,
+        evr: &str,
+        arch: &str,
+    ) -> PathBuf {
+        let state_path = layout.state_dir.join("installed.toml");
+        let journal_dir = rpm_install::journal_dir(layout);
+        let mut journal =
+            Transaction::begin_with_subject("install", Some(subject), state_path, &journal_dir)
+                .expect("begin journal");
+        journal
+            .record_delegated_steps(
+                DelegatedRecoveryContext {
+                    pm: NativePm::Rpm,
+                    package: Some(package.to_string()),
+                    record_action: DelegatedRecordAction::WriteManaged,
+                    pinned: Some(DelegatedPinnedArtifact {
+                        artifact: artifact.to_string(),
+                        evr: evr.to_string(),
+                        arch: arch.to_string(),
+                    }),
+                },
+                [
+                    TransactionStep::planned(PHASE_NATIVE_TXN, artifact, "install", None),
+                    TransactionStep::planned(PHASE_OBSERVE, package, "observe", None),
+                    TransactionStep::planned(
+                        anolisa_core::executor::PHASE_RECORD,
+                        "state",
+                        "write-delegated-managed",
+                        None,
+                    ),
+                ],
+            )
+            .expect("record pinned recovery contract");
+        let path = journal.journal_path.clone();
+        drop(journal);
+        path
+    }
+
+    #[test]
+    fn pinned_install_journal_recovers_when_the_installed_evr_matches() {
+        // Crash after dnf committed the pinned artifact: repair re-observes the
+        // bare package, confirms the EVR/arch matches the durable pin, and
+        // commits the managed record for the exact version.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&ctx);
+        let journal_path = write_pinned_install_journal(
+            &layout,
+            "cosh",
+            "copilot-shell",
+            "copilot-shell-2.6.0-1.al4.x86_64",
+            "2.6.0-1.al4",
+            "x86_64",
+        );
+        let fake = FakeRpm::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.6.0", Some("1.al4"), "x86_64")),
+        );
+
+        repair_with_deps("cosh", &ctx, &fake, &fake, false)
+            .expect("a matching pinned install must recover");
+
+        let store = load_store(&ctx);
+        let record = store
+            .find(ObjectKind::Component, "cosh")
+            .expect("record committed");
+        match &record.binding {
+            ProviderBinding::Delegated {
+                package,
+                last_observed,
+                ..
+            } => {
+                assert_eq!(package.resolved_name(), Some("copilot-shell"));
+                assert_eq!(
+                    last_observed.as_ref().and_then(|o| o.evr.as_deref()),
+                    Some("2.6.0-1.al4")
+                );
+            }
+            other => panic!("expected a delegated binding, got {other:?}"),
+        }
+        assert_eq!(
+            Transaction::load_journal(&journal_path)
+                .expect("reload journal")
+                .status,
+            TransactionOutcomeStatus::Ok
+        );
+    }
+
+    #[test]
+    fn pinned_install_journal_refuses_recovery_on_evr_mismatch() {
+        // Crash left a different EVR installed than the pin resolved. Recovery
+        // must refuse to record the wrong version and leave the journal pending
+        // for manual reconciliation — never fall back to what is present.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&ctx);
+        let journal_path = write_pinned_install_journal(
+            &layout,
+            "cosh",
+            "copilot-shell",
+            "copilot-shell-2.6.0-1.al4.x86_64",
+            "2.6.0-1.al4",
+            "x86_64",
+        );
+        // rpmdb reports 2.7.0, not the pinned 2.6.0.
+        let fake = FakeRpm::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.7.0", Some("1.al4"), "x86_64")),
+        );
+
+        let err = repair_with_deps("cosh", &ctx, &fake, &fake, false)
+            .expect_err("a mismatched installed EVR must not be recovered");
+        assert!(
+            err.reason().contains("2.7.0-1.al4"),
+            "got: {}",
+            err.reason()
+        );
+        assert!(
+            err.reason().contains("copilot-shell-2.6.0-1.al4.x86_64"),
+            "got: {}",
+            err.reason()
+        );
+        assert!(
+            load_store(&ctx)
+                .find(ObjectKind::Component, "cosh")
+                .is_none(),
+            "the wrong version must not be recorded"
+        );
+        // The journal stays pending so the user can reconcile and retry.
+        assert!(
+            Transaction::load_journal(&journal_path)
+                .expect("reload journal")
+                .is_pending(),
+            "a refused recovery must leave the journal pending"
+        );
+    }
+
+    #[test]
+    fn pinned_journal_with_a_mixed_native_target_is_not_recovered() {
+        // A pinned native step must resolve to exactly the artifact. A journal
+        // whose native target smuggles in another package alongside the NEVRA
+        // is malformed and must stay pending, not recover.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let layout = common::resolve_layout(&ctx);
+        let state_path = layout.state_dir.join("installed.toml");
+        let journal_dir = rpm_install::journal_dir(&layout);
+        let mut journal =
+            Transaction::begin_with_subject("install", Some("cosh"), state_path, &journal_dir)
+                .expect("begin journal");
+        journal
+            .record_delegated_steps(
+                DelegatedRecoveryContext {
+                    pm: NativePm::Rpm,
+                    package: Some("copilot-shell".to_string()),
+                    record_action: DelegatedRecordAction::WriteManaged,
+                    pinned: Some(DelegatedPinnedArtifact {
+                        artifact: "copilot-shell-2.6.0-1.al4.x86_64".to_string(),
+                        evr: "2.6.0-1.al4".to_string(),
+                        arch: "x86_64".to_string(),
+                    }),
+                },
+                [
+                    TransactionStep::planned(
+                        PHASE_NATIVE_TXN,
+                        "copilot-shell-2.6.0-1.al4.x86_64,unrelated-package",
+                        "install",
+                        None,
+                    ),
+                    TransactionStep::planned(PHASE_OBSERVE, "copilot-shell", "observe", None),
+                    TransactionStep::planned(
+                        anolisa_core::executor::PHASE_RECORD,
+                        "state",
+                        "write-delegated-managed",
+                        None,
+                    ),
+                ],
+            )
+            .expect("record malformed pinned contract");
+        let journal_path = journal.journal_path.clone();
+        drop(journal);
+        let fake = FakeRpm::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.6.0", Some("1.al4"), "x86_64")),
+        );
+
+        let err = repair_with_deps("cosh", &ctx, &fake, &fake, false)
+            .expect_err("a mixed pinned native target must not recover");
+        assert!(
+            err.reason().contains("cannot recover"),
+            "got: {}",
+            err.reason()
+        );
+        assert!(
+            load_store(&ctx)
+                .find(ObjectKind::Component, "cosh")
+                .is_none()
+        );
+        assert!(
+            Transaction::load_journal(&journal_path)
+                .expect("reload journal")
+                .is_pending()
+        );
+    }
+
+    #[test]
+    fn unpinned_journal_with_a_mixed_observe_target_is_not_recovered() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(&ctx, Vec::new());
+        let layout = common::resolve_layout(&ctx);
+        let state_path = layout.state_dir.join("installed.toml");
+        let journal_dir = rpm_install::journal_dir(&layout);
+        let mut journal =
+            Transaction::begin_with_subject("install", Some("cosh"), state_path, &journal_dir)
+                .expect("begin journal");
+        journal
+            .record_delegated_steps(
+                DelegatedRecoveryContext {
+                    pm: NativePm::Rpm,
+                    package: Some("copilot-shell".to_string()),
+                    record_action: DelegatedRecordAction::WriteManaged,
+                    pinned: None,
+                },
+                [
+                    TransactionStep::planned(PHASE_NATIVE_TXN, "copilot-shell", "install", None),
+                    TransactionStep::planned(
+                        PHASE_OBSERVE,
+                        "copilot-shell,foreign-package",
+                        "observe",
+                        None,
+                    ),
+                    TransactionStep::planned(
+                        anolisa_core::executor::PHASE_RECORD,
+                        "state",
+                        "write-delegated-managed",
+                        None,
+                    ),
+                ],
+            )
+            .expect("record malformed unpinned contract");
+        let journal_path = journal.journal_path.clone();
+        drop(journal);
+        let fake = FakeRpm::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "2.6.0", Some("1.al4"), "x86_64")),
+        );
+
+        let err = repair_with_deps("cosh", &ctx, &fake, &fake, false)
+            .expect_err("a mixed observe target must not recover");
+
+        assert!(
+            err.reason().contains("cannot recover"),
+            "got: {}",
+            err.reason()
+        );
+        assert!(
+            load_store(&ctx)
+                .find(ObjectKind::Component, "cosh")
+                .is_none(),
+            "an unsafe recovery contract must not create a record"
+        );
+        assert!(
+            Transaction::load_journal(&journal_path)
+                .expect("reload journal")
+                .is_pending(),
+            "an unsafe recovery contract must remain pending"
+        );
     }
 
     #[test]
@@ -3715,6 +4042,7 @@ mod tests {
             pm: NativePm::Rpm,
             package: Some("unrelated".to_string()),
             record_action: DelegatedRecordAction::Drop,
+            pinned: None,
         });
         journal
             .record_step(TransactionStep::planned(
@@ -3765,6 +4093,7 @@ mod tests {
             pm: NativePm::Rpm,
             package: Some("copilot-shell".to_string()),
             record_action: DelegatedRecordAction::Drop,
+            pinned: None,
         });
         journal
             .record_step(TransactionStep::planned(
@@ -3826,6 +4155,7 @@ mod tests {
                     pm: NativePm::Rpm,
                     package: Some("skillfs".to_string()),
                     record_action: DelegatedRecordAction::Drop,
+                    pinned: None,
                 },
                 [TransactionStep::planned(
                     anolisa_core::owned_executor::PHASE_RECORD,
@@ -3881,6 +4211,7 @@ mod tests {
             pm: NativePm::Rpm,
             package: Some("copilot-shell".to_string()),
             record_action: DelegatedRecordAction::Drop,
+            pinned: None,
         });
         fs::write(
             &journal.journal_path,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_install.rs
@@ -438,6 +438,7 @@ mod tests {
                     pm: NativePm::Rpm,
                     package: Some("copilot-shell".to_string()),
                     record_action: DelegatedRecordAction::WriteManaged,
+                    pinned: None,
                 },
                 [
                     TransactionStep::planned(INSTALL_PHASE, "copilot-shell", INSTALL_ACTION, None),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -359,6 +359,7 @@ fn begin_delegated_pending(
                 pm: NativePm::Rpm,
                 package: Some(package.to_string()),
                 record_action,
+                pinned: None,
             },
             [
                 TransactionStep::planned("delegated-txn", transaction_target, operation, None),

--- a/src/anolisa/crates/anolisa-core/src/executor.rs
+++ b/src/anolisa/crates/anolisa-core/src/executor.rs
@@ -20,8 +20,8 @@ use crate::domain::{NativePm, Observation};
 use crate::planner::{NativeProbe, RecordWrite, Step};
 use crate::providers::{DelegatedProvider, ProviderError};
 use crate::transaction::{
-    DelegatedRecordAction, DelegatedRecoveryContext, Transaction, TransactionError,
-    TransactionOutcomeStatus, TransactionStep,
+    DelegatedPinnedArtifact, DelegatedRecordAction, DelegatedRecoveryContext, Transaction,
+    TransactionError, TransactionOutcomeStatus, TransactionStep,
 };
 
 /// Journal phase label for native package-manager transactions.
@@ -40,13 +40,44 @@ pub const PHASE_RECORD: &str = "delegated-record";
 pub struct DelegatedExecutionTarget<'a> {
     pm: NativePm,
     package: Option<&'a str>,
+    /// Exact native transaction spec a version pin resolved to (an RPM NEVRA).
+    /// `None` means the transaction targets the bare `package`. When set, it
+    /// is the *only* non-bare package a [`Step::NativeTransaction`] may carry,
+    /// so the recovery contract can validate the transaction against the
+    /// subject instead of trusting whatever the plan holds.
+    transaction_spec: Option<&'a str>,
+    /// EVR the pinned candidate resolved to. When set, the freshly observed
+    /// package's EVR must match before the record is written — guarding
+    /// against the native manager installing a different build (module
+    /// stream, `Obsoletes`, solver choice) than the pin requested.
+    expected_evr: Option<&'a str>,
+    /// Arch the pinned candidate resolved to; checked together with
+    /// `expected_evr`.
+    expected_arch: Option<&'a str>,
 }
 
 impl<'a> DelegatedExecutionTarget<'a> {
     /// Builds a target from the authoritative package manager and this
     /// journal subject's resolved package, when one exists.
     pub fn new(pm: NativePm, package: Option<&'a str>) -> Self {
-        Self { pm, package }
+        Self {
+            pm,
+            package,
+            transaction_spec: None,
+            expected_evr: None,
+            expected_arch: None,
+        }
+    }
+
+    /// Pin the target to an exact resolved artifact: `spec` (a NEVRA) becomes
+    /// the only non-bare package the native transaction may carry, and the
+    /// post-install observation must match `evr`/`arch` before the record
+    /// commits.
+    pub fn with_pinned_artifact(mut self, spec: &'a str, evr: &'a str, arch: &'a str) -> Self {
+        self.transaction_spec = Some(spec);
+        self.expected_evr = Some(evr);
+        self.expected_arch = Some(arch);
+        self
     }
 }
 
@@ -121,6 +152,17 @@ pub enum ExecutionError {
     /// An observation step failed outright (query error).
     #[error("native observation failed: {0}")]
     ObserveFailed(#[source] ProviderError),
+    /// The freshly installed package's EVR/arch does not match the pinned
+    /// artifact — the native manager installed a different build than the
+    /// `--version` pin requested. The transaction committed, so the journal
+    /// stays `Partial` and the record is never written to the wrong version.
+    #[error("pinned version mismatch: expected {expected}, installed {observed}")]
+    PinnedVersionMismatch {
+        /// The EVR (and arch) the pin resolved to.
+        expected: String,
+        /// The EVR (and arch) actually observed after the transaction.
+        observed: String,
+    },
     /// The record commit failed after the native transaction succeeded. The
     /// package state is real but untracked; the journal is left `Partial`
     /// and `repair` reconciles.
@@ -206,16 +248,19 @@ pub fn execute_delegated_steps_resumed(
                 Err(source) => {
                     journal.mark_failed(idx, &source.to_string())?;
                     native_effect_may_exist |= native_failure_may_have_changed_host(&source);
-                    // Forward-only: re-observe instead of undoing. A probe
-                    // that fails too is dropped — this is diagnostics, not
-                    // a second chance to fail.
-                    let reobserved = packages
-                        .iter()
+                    // Forward-only: re-observe instead of undoing. Re-observe
+                    // the *bare* package identity, not the transaction spec — a
+                    // pinned transaction targets a NEVRA, but rpmdb is keyed by
+                    // the bare name, so `observe(NEVRA)` would spuriously read
+                    // Absent. A probe that fails too is dropped — this is
+                    // diagnostics, not a second chance to fail.
+                    let reobserved = reobservation_identities(steps, &target, packages)
+                        .into_iter()
                         .filter_map(|package| {
                             provider
-                                .observe(package, observed_at)
+                                .observe(&package, observed_at)
                                 .ok()
-                                .map(|probe| (package.clone(), probe))
+                                .map(|probe| (package, probe))
                         })
                         .collect();
                     journal.finish(fail_status(native_effect_may_exist))?;
@@ -227,7 +272,44 @@ pub fn execute_delegated_steps_resumed(
                     match provider.observe(package, observed_at) {
                         Ok(NativeProbe::Present {
                             observation: fresh, ..
-                        }) => observation = Some(fresh),
+                        }) => {
+                            // A version pin must install exactly the resolved
+                            // artifact. If the native manager landed a
+                            // different EVR/arch (module stream, Obsoletes,
+                            // solver choice), the transaction has already
+                            // committed — keep the journal `Partial` and refuse
+                            // to persist the wrong version rather than silently
+                            // accepting it (never fall back).
+                            if let Some(expected_evr) = target.expected_evr {
+                                let observed_evr =
+                                    fresh.evr.clone().unwrap_or_else(|| fresh.version.clone());
+                                let arch_ok = match (target.expected_arch, fresh.arch.as_deref()) {
+                                    (Some(want), Some(got)) => want == got,
+                                    (Some(_), None) => false,
+                                    (None, _) => true,
+                                };
+                                if observed_evr != expected_evr || !arch_ok {
+                                    let observed = format!(
+                                        "{observed_evr} ({})",
+                                        fresh.arch.as_deref().unwrap_or("unknown-arch")
+                                    );
+                                    let expected = format!(
+                                        "{expected_evr} ({})",
+                                        target.expected_arch.unwrap_or("unknown-arch")
+                                    );
+                                    journal.mark_failed(
+                                        idx,
+                                        &format!("pinned {expected} but observed {observed}"),
+                                    )?;
+                                    journal.finish(fail_status(native_effect_may_exist))?;
+                                    return Err(ExecutionError::PinnedVersionMismatch {
+                                        expected,
+                                        observed,
+                                    });
+                                }
+                            }
+                            observation = Some(fresh);
+                        }
                         Ok(probe) => {
                             let found = match probe {
                                 NativeProbe::MultipleVersions { .. } => {
@@ -305,8 +387,9 @@ fn prepare_delegated_recovery(
 /// # Errors
 ///
 /// Returns [`ExecutionError::InvalidRecoveryContract`] unless the plan has
-/// exactly one record transition and every package-bearing step contains the
-/// subject package.
+/// exactly one record transition, every `Observe` step names the subject
+/// package, and every `NativeTransaction` package is either the subject
+/// package or the target's pinned artifact spec.
 pub fn delegated_recovery_context(
     target: DelegatedExecutionTarget<'_>,
     steps: &[Step],
@@ -349,26 +432,112 @@ pub fn delegated_recovery_context(
         });
     }
     if let Some(package) = package {
-        for packages in steps.iter().filter_map(|step| match step {
-            Step::NativeTransaction { packages, .. } | Step::Observe { packages } => Some(packages),
-            _ => None,
-        }) {
-            if !packages.iter().any(|candidate| candidate == package) {
-                return Err(ExecutionError::InvalidRecoveryContract {
-                    reason: format!(
-                        "subject package '{package}' is absent from delegated step packages [{}]",
-                        packages.join(", ")
-                    ),
-                });
+        // Fail-closed identity check, validated per step kind so a version pin
+        // neither widens nor degrades what the transaction may touch:
+        //
+        // - `Observe` carries the bare package identity (what the record and
+        //   any recovery re-observe); it must be exactly the subject. A list
+        //   that also names another package would let that package's
+        //   observation overwrite the subject's and land the wrong version in
+        //   the record, so a foreign entry is rejected, not merely tolerated.
+        // - `NativeTransaction` carries the specs handed to the native manager.
+        //   With a pin, every package must be *exactly* the pinned artifact —
+        //   a bare-package transaction under a pin would let the solver pick
+        //   the latest build, so it is rejected here, before any side effect.
+        //   Without a pin, every package must be the bare subject. Either way
+        //   the step must carry at least one package.
+        for step in steps {
+            match step {
+                Step::Observe { packages } => {
+                    if packages.is_empty() || packages.iter().any(|candidate| candidate != package)
+                    {
+                        return Err(ExecutionError::InvalidRecoveryContract {
+                            reason: format!(
+                                "delegated observe packages [{}] must be exactly the subject '{package}'",
+                                packages.join(", ")
+                            ),
+                        });
+                    }
+                }
+                Step::NativeTransaction { packages, .. } => {
+                    if packages.is_empty() {
+                        return Err(ExecutionError::InvalidRecoveryContract {
+                            reason: "delegated native transaction has no packages".to_string(),
+                        });
+                    }
+                    for candidate in packages {
+                        let allowed = match target.transaction_spec {
+                            Some(spec) => candidate == spec,
+                            None => candidate == package,
+                        };
+                        if !allowed {
+                            let expectation = match target.transaction_spec {
+                                Some(spec) => format!("the pinned artifact '{spec}'"),
+                                None => format!("the subject '{package}'"),
+                            };
+                            return Err(ExecutionError::InvalidRecoveryContract {
+                                reason: format!(
+                                    "delegated native transaction package '{candidate}' does not match {expectation}"
+                                ),
+                            });
+                        }
+                    }
+                }
+                _ => {}
             }
         }
     }
+
+    // Persist the pin contract (spec + expected EVR/arch) so a `repair` after
+    // a crash validates the NEVRA transaction step and re-checks the installed
+    // version, instead of committing whatever is present.
+    let pinned = match (
+        target.transaction_spec,
+        target.expected_evr,
+        target.expected_arch,
+    ) {
+        (Some(artifact), Some(evr), Some(arch)) => Some(DelegatedPinnedArtifact {
+            artifact: artifact.to_string(),
+            evr: evr.to_string(),
+            arch: arch.to_string(),
+        }),
+        _ => None,
+    };
 
     Ok(DelegatedRecoveryContext {
         pm: target.pm,
         package: package.map(str::to_string),
         record_action: *record_action,
+        pinned,
     })
+}
+
+/// Bare package identities to re-observe after a failed native transaction.
+///
+/// The transaction may have targeted a NEVRA (version pin), but rpmdb is keyed
+/// by the bare name, so recovery diagnostics must probe the bare identity. The
+/// plan's `Observe` steps carry exactly that; when the plan has none
+/// (uninstall's remove), the target's subject package — or, as a last resort,
+/// the transaction packages themselves — is used.
+fn reobservation_identities(
+    steps: &[Step],
+    target: &DelegatedExecutionTarget<'_>,
+    txn_packages: &[String],
+) -> Vec<String> {
+    let observe: Vec<String> = steps
+        .iter()
+        .flat_map(|step| match step {
+            Step::Observe { packages } => packages.clone(),
+            _ => Vec::new(),
+        })
+        .collect();
+    if !observe.is_empty() {
+        return observe;
+    }
+    if let Some(package) = target.package {
+        return vec![package.to_string()];
+    }
+    txn_packages.to_vec()
 }
 
 /// Whether this executor interprets `step`.
@@ -512,6 +681,219 @@ mod tests {
         assert_eq!(journal.steps[0].action, "install");
     }
 
+    /// Pinned install plan: the transaction targets the exact NEVRA, the
+    /// observation and record use the bare package.
+    fn pinned_install_steps(nevra: &str, package: &str) -> Vec<Step> {
+        vec![
+            Step::NativeTransaction {
+                pm: NativePm::Rpm,
+                action: NativeAction::Install,
+                packages: vec![nevra.to_string()],
+            },
+            Step::Observe {
+                packages: vec![package.to_string()],
+            },
+            Step::WriteRecord(RecordWrite::DelegatedManaged),
+        ]
+    }
+
+    #[test]
+    fn delegated_pinned_install_transacts_nevra_but_observes_bare_package() {
+        // The pinned plan hands the exact NEVRA to dnf while re-observing the
+        // bare package; the recovery contract validates the NEVRA against the
+        // target's pinned spec (not a blanket skip).
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let query = query_present("cosh", "2.7.0");
+        let txn = FakeTxn::default();
+        let provider = DelegatedProvider::new(&query, &txn);
+        let mut sink = MemSink::default();
+        let mut journal = journal(tmp.path());
+
+        let steps = pinned_install_steps("cosh-2.7.0-1.al4.x86_64", "cosh");
+        let target = DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh"))
+            .with_pinned_artifact("cosh-2.7.0-1.al4.x86_64", "2.7.0-1.al4", "x86_64");
+        let outcome =
+            execute_delegated_steps(&steps, target, &provider, &mut sink, &mut journal, NOW)
+                .expect("pinned execution ok");
+
+        // dnf received the NEVRA; the observation and record used the bare name.
+        assert_eq!(
+            txn.calls.borrow().as_slice(),
+            &[("install".to_string(), "cosh-2.7.0-1.al4.x86_64".to_string())]
+        );
+        let (write, observation) = &sink.writes[0];
+        assert_eq!(*write, RecordWrite::DelegatedManaged);
+        assert_eq!(
+            observation.as_ref().expect("observation").evr.as_deref(),
+            Some("2.7.0-1.al4")
+        );
+        assert!(outcome.observation.is_some());
+        assert_eq!(journal.status, TransactionOutcomeStatus::Ok);
+    }
+
+    #[test]
+    fn pinned_install_refuses_record_when_observed_evr_differs() {
+        // dnf committed a different EVR than the pin requested (e.g. an
+        // Obsoletes / module-stream jump to 0.7.0). The record must not be
+        // written to the wrong version; the journal stays Partial for repair.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        // The pin targets 2.7.0, but the rpmdb reports 0.7.0 installed.
+        let query = query_present("cosh", "0.7.0");
+        let txn = FakeTxn::default();
+        let provider = DelegatedProvider::new(&query, &txn);
+        let mut sink = MemSink::default();
+        let mut journal = journal(tmp.path());
+
+        let steps = pinned_install_steps("cosh-2.7.0-1.al4.x86_64", "cosh");
+        let target = DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh"))
+            .with_pinned_artifact("cosh-2.7.0-1.al4.x86_64", "2.7.0-1.al4", "x86_64");
+        let err = execute_delegated_steps(&steps, target, &provider, &mut sink, &mut journal, NOW)
+            .expect_err("a mismatched installed EVR must fail");
+
+        match err {
+            ExecutionError::PinnedVersionMismatch { expected, observed } => {
+                assert!(expected.contains("2.7.0-1.al4"), "expected: {expected}");
+                assert!(observed.contains("0.7.0-1.al4"), "observed: {observed}");
+            }
+            other => panic!("expected PinnedVersionMismatch, got {other:?}"),
+        }
+        // The transaction committed, so the journal is Partial and no record
+        // was written — repair reconciles rather than trusting a wrong version.
+        assert!(sink.writes.is_empty(), "wrong version must not be recorded");
+        assert_eq!(journal.status, TransactionOutcomeStatus::Partial);
+    }
+
+    #[test]
+    fn pinned_transaction_failure_reobserves_the_bare_package() {
+        // A pinned transaction targets a NEVRA; on failure the forward-only
+        // re-observation must probe the bare package (rpmdb is keyed by name),
+        // not the NEVRA, or it would spuriously read Absent.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        // dnf partially landed the bare package before failing.
+        let query = query_present("cosh", "2.7.0");
+        let txn = FakeTxn {
+            fail: vec!["install"],
+            ..FakeTxn::default()
+        };
+        let provider = DelegatedProvider::new(&query, &txn);
+        let mut sink = MemSink::default();
+        let mut journal = journal(tmp.path());
+
+        let steps = pinned_install_steps("cosh-2.7.0-1.al4.x86_64", "cosh");
+        let target = DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh"))
+            .with_pinned_artifact("cosh-2.7.0-1.al4.x86_64", "2.7.0-1.al4", "x86_64");
+        let err = execute_delegated_steps(&steps, target, &provider, &mut sink, &mut journal, NOW)
+            .expect_err("failed transaction must surface");
+
+        match err {
+            ExecutionError::TransactionFailed { reobserved, .. } => {
+                // Keyed by the bare package, and it resolved to Present — the
+                // NEVRA would have read Absent from the name-keyed rpmdb.
+                assert_eq!(reobserved.len(), 1);
+                assert_eq!(reobserved[0].0, "cosh");
+                assert!(matches!(reobserved[0].1, NativeProbe::Present { .. }));
+            }
+            other => panic!("expected TransactionFailed, got {other:?}"),
+        }
+        assert!(sink.writes.is_empty());
+    }
+
+    #[test]
+    fn recovery_contract_rejects_unrelated_transaction_package() {
+        // Fail-closed: a plan whose transaction names an unrelated package must
+        // be rejected even though its Observe/record name the subject — the
+        // executor must never run a native transaction on a foreign package.
+        let unrelated = vec![
+            Step::NativeTransaction {
+                pm: NativePm::Rpm,
+                action: NativeAction::Install,
+                packages: vec!["unrelated-package".to_string()],
+            },
+            Step::Observe {
+                packages: vec!["cosh".to_string()],
+            },
+            Step::WriteRecord(RecordWrite::DelegatedManaged),
+        ];
+        let err = delegated_recovery_context(
+            DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh")),
+            &unrelated,
+        )
+        .expect_err("an unrelated transaction package must be rejected");
+        assert!(matches!(
+            err,
+            ExecutionError::InvalidRecoveryContract { .. }
+        ));
+    }
+
+    #[test]
+    fn recovery_contract_rejects_bare_transaction_under_a_pin() {
+        // A pinned target whose transaction degraded to the bare package would
+        // let the solver pick the latest build; the contract must reject it
+        // before any dnf call, not discover the drift only post-observation.
+        let bare_under_pin = pinned_install_steps("cosh", "cosh");
+        let target = DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh"))
+            .with_pinned_artifact("cosh-2.7.0-1.al4.x86_64", "2.7.0-1.al4", "x86_64");
+        let err = delegated_recovery_context(target, &bare_under_pin)
+            .expect_err("a bare transaction under a pin must be rejected");
+        assert!(matches!(
+            err,
+            ExecutionError::InvalidRecoveryContract { .. }
+        ));
+    }
+
+    #[test]
+    fn recovery_contract_rejects_empty_transaction() {
+        // A native transaction with no packages installs nothing yet would pass
+        // a per-package loop vacuously; reject it up front.
+        let empty = vec![
+            Step::NativeTransaction {
+                pm: NativePm::Rpm,
+                action: NativeAction::Install,
+                packages: Vec::new(),
+            },
+            Step::Observe {
+                packages: vec!["cosh".to_string()],
+            },
+            Step::WriteRecord(RecordWrite::DelegatedManaged),
+        ];
+        let err = delegated_recovery_context(
+            DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh")),
+            &empty,
+        )
+        .expect_err("an empty native transaction must be rejected");
+        assert!(matches!(
+            err,
+            ExecutionError::InvalidRecoveryContract { .. }
+        ));
+    }
+
+    #[test]
+    fn recovery_contract_rejects_observe_with_a_foreign_package() {
+        // An Observe listing the subject *and* a foreign package would let the
+        // foreign observation overwrite the subject's and record the wrong
+        // version; the contract must reject the mixed list.
+        let mixed = vec![
+            Step::NativeTransaction {
+                pm: NativePm::Rpm,
+                action: NativeAction::Install,
+                packages: vec!["cosh".to_string()],
+            },
+            Step::Observe {
+                packages: vec!["cosh".to_string(), "foreign".to_string()],
+            },
+            Step::WriteRecord(RecordWrite::DelegatedManaged),
+        ];
+        let err = delegated_recovery_context(
+            DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh")),
+            &mixed,
+        )
+        .expect_err("a mixed observe list must be rejected");
+        assert!(matches!(
+            err,
+            ExecutionError::InvalidRecoveryContract { .. }
+        ));
+    }
+
     #[test]
     fn txn_failure_is_forward_only_and_reobserves() {
         let tmp = tempfile::tempdir().expect("tmpdir");
@@ -619,6 +1001,7 @@ mod tests {
                 pm: NativePm::Rpm,
                 package: Some("cosh".to_string()),
                 record_action: DelegatedRecordAction::WriteManaged,
+                pinned: None,
             })
         );
     }

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -751,6 +751,7 @@ mod tests {
             pm: NativePm::Rpm,
             package: Some("copilot-shell".to_string()),
             record_action: DelegatedRecordAction::WriteManaged,
+            pinned: None,
         });
         assert!(!is_legacy_rpm_install_journal(&delegated));
 

--- a/src/anolisa/crates/anolisa-core/src/planner.rs
+++ b/src/anolisa/crates/anolisa-core/src/planner.rs
@@ -53,7 +53,18 @@ pub enum ProviderTarget {
     /// Raw artifact ANOLISA will own.
     Owned { version: String },
     /// Native package transaction ANOLISA will request.
-    Delegated { pm: NativePm, package: String },
+    Delegated {
+        pm: NativePm,
+        /// Bare package identity: the name used for rpmdb observation and the
+        /// persisted delegated record. Never carries version/arch decoration.
+        package: String,
+        /// Exact native-manager transaction spec (an RPM NEVRA) when a
+        /// `--version` pin resolved to a concrete repository candidate. `None`
+        /// installs the repository default. Kept separate from `package` so a
+        /// pin reaches only the [`Step::NativeTransaction`] — the observation,
+        /// the `DelegatedIdentity`, and persisted state stay on the bare name.
+        artifact: Option<String>,
+    },
 }
 
 /// Update parameters resolved by the observe stage.
@@ -468,12 +479,19 @@ fn plan_install(req: &InstallRequest, facts: &Facts) -> Result<Plan, PlanError> 
                     Step::EnableServices,
                     Step::WriteRecord(RecordWrite::Owned),
                 ])),
-                ProviderTarget::Delegated { pm, package } => Ok(Plan::execute(vec![
-                    // I2
+                ProviderTarget::Delegated {
+                    pm,
+                    package,
+                    artifact,
+                } => Ok(Plan::execute(vec![
+                    // I2: the native transaction targets the pinned artifact
+                    // (exact NEVRA) when a version was resolved, otherwise the
+                    // bare package (repository default). Observation and the
+                    // record always use the bare package identity.
                     Step::NativeTransaction {
                         pm: *pm,
                         action: NativeAction::Install,
-                        packages: vec![package.clone()],
+                        packages: vec![artifact.clone().unwrap_or_else(|| package.clone())],
                     },
                     Step::Observe {
                         packages: vec![package.clone()],
@@ -869,6 +887,15 @@ mod tests {
         ProviderTarget::Delegated {
             pm: NativePm::Rpm,
             package: PKG.to_string(),
+            artifact: None,
+        }
+    }
+
+    fn delegated_pinned_target(artifact: &str) -> ProviderTarget {
+        ProviderTarget::Delegated {
+            pm: NativePm::Rpm,
+            package: PKG.to_string(),
+            artifact: Some(artifact.to_string()),
         }
     }
 
@@ -986,6 +1013,27 @@ mod tests {
     }
 
     #[test]
+    fn i2_pinned_delegated_install_targets_artifact_but_observes_bare_package() {
+        // A version pin renders the native transaction to the exact NEVRA
+        // while observation stays on the bare package identity.
+        let f = facts();
+        let artifact = format!("{PKG}-1.2.3-4.al8.x86_64");
+        let steps = expect_steps(plan(&install(delegated_pinned_target(&artifact)), &f));
+        assert_eq!(
+            steps,
+            vec![
+                Step::NativeTransaction {
+                    pm: NativePm::Rpm,
+                    action: NativeAction::Install,
+                    packages: vec![artifact.clone()],
+                },
+                observe(),
+                Step::WriteRecord(RecordWrite::DelegatedManaged),
+            ]
+        );
+    }
+
+    #[test]
     fn i3_existing_system_package_is_never_silently_adopted() {
         let mut f = facts();
         f.native = present();
@@ -1090,6 +1138,7 @@ mod tests {
             target: ProviderTarget::Delegated {
                 pm: NativePm::Rpm,
                 package: "other".to_string(),
+                artifact: None,
             },
             requested_version: None,
         });

--- a/src/anolisa/crates/anolisa-core/src/transaction.rs
+++ b/src/anolisa/crates/anolisa-core/src/transaction.rs
@@ -104,6 +104,27 @@ pub struct DelegatedRecoveryContext {
     pub package: Option<String>,
     /// Record transition intended by the interrupted operation.
     pub record_action: DelegatedRecordAction,
+    /// Version-pin contract, present only when the interrupted operation
+    /// pinned a specific artifact. Persisted so a `repair` after a crash can
+    /// validate the native transaction step against the exact NEVRA and refuse
+    /// to record a package whose installed EVR/arch does not match the pin —
+    /// the durable counterpart to the in-process check, so recovery never
+    /// falls back to whatever version happens to be present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<DelegatedPinnedArtifact>,
+}
+
+/// The exact artifact a version-pinned delegated operation resolved to,
+/// carried in the journal so crash recovery can reconstruct the pin without
+/// re-resolving the repository (which may have advanced in the meantime).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DelegatedPinnedArtifact {
+    /// Exact NEVRA the native transaction targeted.
+    pub artifact: String,
+    /// EVR the freshly installed package must match before the record commits.
+    pub evr: String,
+    /// Arch the freshly installed package must match.
+    pub arch: String,
 }
 
 /// Discriminator for rollback strategies. Each variant pairs with the
@@ -963,6 +984,7 @@ mod tests {
             pm: NativePm::Rpm,
             package: Some("copilot-shell".to_string()),
             record_action: DelegatedRecordAction::WriteManaged,
+            pinned: None,
         };
         let steps = [TransactionStep::planned(
             "delegated-txn",
@@ -994,6 +1016,7 @@ mod tests {
                     pm: NativePm::Rpm,
                     package: Some("another-package".to_string()),
                     record_action: DelegatedRecordAction::WriteManaged,
+                    pinned: None,
                 },
                 [TransactionStep::planned(
                     "delegated-record",
@@ -1018,6 +1041,7 @@ mod tests {
             pm: NativePm::Rpm,
             package: Some("skillfs".to_string()),
             record_action: DelegatedRecordAction::WriteManaged,
+            pinned: None,
         });
         tx.persist().expect("persist malformed fixture");
 

--- a/src/anolisa/crates/anolisa-platform/src/lib.rs
+++ b/src/anolisa/crates/anolisa-platform/src/lib.rs
@@ -13,5 +13,6 @@ pub mod pkg_transaction;
 pub mod privilege;
 pub mod rpm_query;
 pub mod rpm_repo;
+pub mod rpm_select;
 pub mod rpm_transaction;
 pub mod systemd;

--- a/src/anolisa/crates/anolisa-platform/src/rpm_select.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_select.rs
@@ -1,0 +1,238 @@
+//! Version-pinned RPM candidate selection.
+//!
+//! Resolves what a `--version` pin means against the candidates a repository
+//! query returned: it matches the RPM VERSION field (not the whole EVR), keeps
+//! only builds this host can run (`host_arch` or `noarch`), and breaks ties by
+//! highest EVR via [`rpm_evr_cmp`]. The winner renders to an exact NEVRA for
+//! the native transaction, while the caller keeps the bare package name for
+//! rpmdb observation and persisted state — the pin never leaks into identity.
+
+use crate::pkg_query::{PackageInfo, rpm_evr_cmp};
+
+/// Outcome of resolving a `--version` pin against repository candidates.
+///
+/// The two failure branches are distinguished so the caller can render an
+/// actionable message: an absent version is a bad `--version`, while an
+/// arch-only miss names both the version and the host architecture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinnedSelection {
+    /// A host-compatible candidate matched the requested version.
+    Selected(PackageInfo),
+    /// No candidate carried the requested VERSION for any architecture.
+    VersionAbsent,
+    /// The version exists, but only for architectures this host cannot run.
+    /// Carries the offered arches (sorted, de-duplicated) for the message.
+    ArchUnsupported {
+        /// Architectures the requested version is published for.
+        offered: Vec<String>,
+    },
+}
+
+/// Select the version-pinned candidate for `host_arch`.
+///
+/// `requested_version` is matched against [`PackageInfo`]'s `version.version`
+/// (the RPM VERSION field) exactly — a `--version 0.6.2` never widens to an
+/// EVR such as `0.6.2-2`. Among candidates that both match the version and run
+/// on the host (`host_arch` or `noarch`), the highest EVR wins deterministically
+/// via [`rpm_evr_cmp`]; an EVR tie prefers the exact host arch, then orders by
+/// arch name so the choice is stable. The version match is never relaxed.
+pub fn select_pinned_candidate(
+    candidates: &[PackageInfo],
+    requested_version: &str,
+    host_arch: &str,
+) -> PinnedSelection {
+    let version_matches: Vec<&PackageInfo> = candidates
+        .iter()
+        .filter(|c| c.version.version == requested_version)
+        .collect();
+    if version_matches.is_empty() {
+        return PinnedSelection::VersionAbsent;
+    }
+
+    let best = version_matches
+        .iter()
+        .copied()
+        .filter(|c| c.arch == host_arch || c.arch == "noarch")
+        .max_by(|a, b| {
+            rpm_evr_cmp(&a.version, &b.version)
+                // On equal EVR, prefer the exact host arch over noarch, then
+                // fall back to arch-name order for a deterministic result.
+                .then_with(|| host_rank(a, host_arch).cmp(&host_rank(b, host_arch)))
+                .then_with(|| a.arch.cmp(&b.arch))
+        });
+
+    match best {
+        Some(info) => PinnedSelection::Selected(info.clone()),
+        None => {
+            let mut offered: Vec<String> = version_matches.iter().map(|c| c.arch.clone()).collect();
+            offered.sort();
+            offered.dedup();
+            PinnedSelection::ArchUnsupported { offered }
+        }
+    }
+}
+
+/// Rank giving the exact host arch precedence over `noarch` on an EVR tie.
+fn host_rank(info: &PackageInfo, host_arch: &str) -> u8 {
+    u8::from(info.arch == host_arch)
+}
+
+/// Render `info` to the exact NEVRA a native transaction accepts as a pinned
+/// target: `name-[epoch:]version-release.arch` (the epoch and release are
+/// emitted by [`PackageInfo`]'s version [`Display`], so an epoch-bearing
+/// candidate yields `name-epoch:version-release.arch`).
+///
+/// [`Display`]: std::fmt::Display
+pub fn nevra(info: &PackageInfo) -> String {
+    format!("{}-{}.{}", info.name, info.version, info.arch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pkg_query::PackageVersion;
+
+    fn candidate(version: &str, release: &str, arch: &str) -> PackageInfo {
+        candidate_epoch(None, version, release, arch)
+    }
+
+    fn candidate_epoch(
+        epoch: Option<&str>,
+        version: &str,
+        release: &str,
+        arch: &str,
+    ) -> PackageInfo {
+        PackageInfo {
+            name: "agentsight".to_string(),
+            version: PackageVersion {
+                epoch: epoch.map(str::to_string),
+                version: version.to_string(),
+                release: Some(release.to_string()),
+            },
+            arch: arch.to_string(),
+            origin: Some("anolisa-configured".to_string()),
+        }
+    }
+
+    #[test]
+    fn pins_requested_version_over_a_newer_build() {
+        // The repo offers 0.6.2 and a newer 0.7.0; a 0.6.2 pin resolves to
+        // 0.6.2, never the newer candidate.
+        let candidates = vec![
+            candidate("0.6.2", "1.alnx4", "x86_64"),
+            candidate("0.7.0", "1.alnx4", "x86_64"),
+        ];
+        let selection = select_pinned_candidate(&candidates, "0.6.2", "x86_64");
+        let PinnedSelection::Selected(info) = selection else {
+            panic!("expected a selected candidate, got {selection:?}");
+        };
+        assert_eq!(info.version.version, "0.6.2");
+        assert_eq!(nevra(&info), "agentsight-0.6.2-1.alnx4.x86_64");
+    }
+
+    #[test]
+    fn matches_version_field_not_the_full_evr() {
+        // "0.6.2" must not match a candidate whose VERSION is "0.6.20".
+        let candidates = vec![candidate("0.6.20", "1.alnx4", "x86_64")];
+        assert_eq!(
+            select_pinned_candidate(&candidates, "0.6.2", "x86_64"),
+            PinnedSelection::VersionAbsent
+        );
+    }
+
+    #[test]
+    fn picks_highest_release_for_one_version() {
+        // Several releases of the same version: the highest EVR wins by
+        // rpm_evr_cmp (release 10 outranks release 2, which is numeric).
+        let candidates = vec![
+            candidate("0.6.2", "2.alnx4", "x86_64"),
+            candidate("0.6.2", "10.alnx4", "x86_64"),
+            candidate("0.6.2", "1.alnx4", "x86_64"),
+        ];
+        let PinnedSelection::Selected(info) =
+            select_pinned_candidate(&candidates, "0.6.2", "x86_64")
+        else {
+            panic!("expected a selected candidate");
+        };
+        assert_eq!(nevra(&info), "agentsight-0.6.2-10.alnx4.x86_64");
+    }
+
+    #[test]
+    fn higher_epoch_outranks_higher_release() {
+        // A non-zero epoch dominates the EVR ordering regardless of release.
+        let candidates = vec![
+            candidate("0.6.2", "9.alnx4", "x86_64"),
+            candidate_epoch(Some("1"), "0.6.2", "1.alnx4", "x86_64"),
+        ];
+        let PinnedSelection::Selected(info) =
+            select_pinned_candidate(&candidates, "0.6.2", "x86_64")
+        else {
+            panic!("expected a selected candidate");
+        };
+        assert_eq!(info.version.epoch.as_deref(), Some("1"));
+        assert_eq!(nevra(&info), "agentsight-1:0.6.2-1.alnx4.x86_64");
+    }
+
+    #[test]
+    fn keeps_host_arch_and_noarch_but_excludes_others() {
+        // aarch64 host: the aarch64 and noarch builds are eligible, the
+        // x86_64 build is excluded even though it carries the same version.
+        let candidates = vec![
+            candidate("0.6.2", "1.alnx4", "x86_64"),
+            candidate("0.6.2", "1.alnx4", "aarch64"),
+        ];
+        let PinnedSelection::Selected(info) =
+            select_pinned_candidate(&candidates, "0.6.2", "aarch64")
+        else {
+            panic!("expected a selected candidate");
+        };
+        assert_eq!(info.arch, "aarch64");
+
+        let noarch = vec![candidate("0.6.2", "1.alnx4", "noarch")];
+        let PinnedSelection::Selected(info) = select_pinned_candidate(&noarch, "0.6.2", "aarch64")
+        else {
+            panic!("expected the noarch candidate to be host-compatible");
+        };
+        assert_eq!(info.arch, "noarch");
+    }
+
+    #[test]
+    fn version_present_only_for_foreign_arch_is_arch_unsupported() {
+        // The version exists, but only for x86_64 — an aarch64 host cannot use
+        // it, and the miss names the offered arch rather than falling back.
+        let candidates = vec![
+            candidate("0.6.2", "1.alnx4", "x86_64"),
+            candidate("0.6.2", "2.alnx4", "x86_64"),
+        ];
+        assert_eq!(
+            select_pinned_candidate(&candidates, "0.6.2", "aarch64"),
+            PinnedSelection::ArchUnsupported {
+                offered: vec!["x86_64".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn prefers_exact_host_arch_over_noarch_on_evr_tie() {
+        // Same EVR published as both host-arch and noarch: the exact host arch
+        // is chosen so the installed artifact is the native build.
+        let candidates = vec![
+            candidate("0.6.2", "1.alnx4", "noarch"),
+            candidate("0.6.2", "1.alnx4", "aarch64"),
+        ];
+        let PinnedSelection::Selected(info) =
+            select_pinned_candidate(&candidates, "0.6.2", "aarch64")
+        else {
+            panic!("expected a selected candidate");
+        };
+        assert_eq!(info.arch, "aarch64");
+    }
+
+    #[test]
+    fn no_candidates_is_version_absent() {
+        assert_eq!(
+            select_pinned_candidate(&[], "0.6.2", "x86_64"),
+            PinnedSelection::VersionAbsent
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-platform/src/rpm_select.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_select.rs
@@ -41,17 +41,9 @@ pub fn select_pinned_candidate(
     requested_version: &str,
     host_arch: &str,
 ) -> PinnedSelection {
-    let version_matches: Vec<&PackageInfo> = candidates
+    let best = candidates
         .iter()
         .filter(|c| c.version.version == requested_version)
-        .collect();
-    if version_matches.is_empty() {
-        return PinnedSelection::VersionAbsent;
-    }
-
-    let best = version_matches
-        .iter()
-        .copied()
         .filter(|c| c.arch == host_arch || c.arch == "noarch")
         .max_by(|a, b| {
             rpm_evr_cmp(&a.version, &b.version)
@@ -64,7 +56,14 @@ pub fn select_pinned_candidate(
     match best {
         Some(info) => PinnedSelection::Selected(info.clone()),
         None => {
-            let mut offered: Vec<String> = version_matches.iter().map(|c| c.arch.clone()).collect();
+            let mut offered: Vec<String> = candidates
+                .iter()
+                .filter(|c| c.version.version == requested_version)
+                .map(|c| c.arch.clone())
+                .collect();
+            if offered.is_empty() {
+                return PinnedSelection::VersionAbsent;
+            }
             offered.sort();
             offered.dedup();
             PinnedSelection::ArchUnsupported { offered }

--- a/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_transaction.rs
@@ -320,6 +320,31 @@ mod tests {
     }
 
     #[test]
+    fn install_with_repo_places_pinned_nevra_after_repository_packages_install() {
+        // A version-pinned install hands an exact NEVRA in place of the bare
+        // package; it must land immediately after `repository-packages <repo>
+        // install`, unchanged, so dnf pulls exactly that build from the
+        // configured repo.
+        let t = txn_with_repo(
+            "install",
+            "agentsight-0.6.2-1.alnx4.x86_64",
+            &[
+                "-y",
+                "--repofrompath=anolisa-configured,http://repo.example/alinux/4/agentic-os/x86_64/os",
+                "--enablerepo=anolisa-configured",
+                "--setopt=anolisa-configured.gpgcheck=1",
+                "repository-packages",
+                "anolisa-configured",
+                "install",
+                "agentsight-0.6.2-1.alnx4.x86_64",
+            ],
+            ok_out(Some(0), "Installed:\n  agentsight\n", ""),
+        );
+        t.install(&["agentsight-0.6.2-1.alnx4.x86_64"])
+            .expect("pinned install ok");
+    }
+
+    #[test]
     fn install_many_packages_share_one_dnf_invocation() {
         // The whole point of the multi-package contract: one dnf process sees
         // the full set, so the solver resolves it as a single transaction.


### PR DESCRIPTION
## Description

Add strict version pinning for fresh RPM-backed component installs. The RPM
backend now resolves `--version` against the configured repository, filters
candidates for the host architecture, selects the highest matching EVR, and
passes the exact NEVRA to dnf without falling back to another version.

Package identity remains the bare RPM name for observation and persisted state.
After installation, ANOLISA verifies the observed EVR and architecture before
writing state, and persists the pin contract in the journal so crash recovery
enforces the same guarantee. Dry-run and JSON output expose the requested
version, resolved EVR, package, repository, and artifact.

## Related Issue

closes #1682

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `anolisa` (anolisa-cli)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa/` after rebasing onto `up/main` at `b58c5484`:

```bash
cargo fmt --all -- --check
cargo check --locked
cargo clippy --all-targets --locked -- -D warnings
cargo test --locked --workspace
cargo doc --workspace --no-deps
```

All commands completed successfully on macOS arm64. The workspace test run
completed with zero failures.

Coverage includes:

- selecting the requested VERSION instead of a newer repository version;
- selecting the highest release and respecting non-zero epochs;
- filtering host-architecture and `noarch` candidates;
- rejecting missing versions and unsupported architectures before mutation;
- passing an exact NEVRA to the native transaction;
- preserving the bare package name for rpmdb observation and state;
- refusing state writes when the installed EVR or architecture differs;
- persisting and enforcing the pin during journal recovery;
- rejecting malformed pinned and unpinned recovery contracts;
- rendering resolved package, EVR, repository, and artifact data;
- preserving existing unpinned and merged-batch behavior.

## Additional Notes

No new command or flag was introduced; the existing `install --version` help
remains accurate, so no standalone user-guide update is required.

Existing-component version updates or downgrades, `install --all --version`,
and bootstrap asset locking remain outside this PR.

### Ship Note

- Changed: RPM-backed `anolisa install --version` now installs the exact resolved package build and never falls back to the repository default.
- Known limitations: Version changes for already tracked components and batch version pinning are outside this change.
- Not covered: Real dnf/rpmdb smoke testing on Alibaba Cloud Linux.
- Verification: `cargo fmt --all -- --check`, `cargo check --locked`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked --workspace`, and `cargo doc --workspace --no-deps`.
