### PR TITLE
feat(anolisa): component version selection for install with list --versions discovery

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -69,7 +69,8 @@ pub struct InstallArgs {
     /// With --all, stop on the first failure instead of continuing
     #[arg(long, requires = "all")]
     pub fail_fast: bool,
-    /// Install a specific version instead of the latest in the channel
+    /// Install a specific version instead of the latest (raw: distribution
+    /// index version; rpm: package version or full EVR)
     #[arg(long, value_name = "VERSION")]
     pub version: Option<String>,
     /// Backend override (raw | rpm | npm); defaults to repo.toml default_backend

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -732,14 +732,23 @@ fn resolve_fresh_delegated(
                 "component '{component}' is not an ANOLISA RPM component; use the ANOLISA component name and configure the repo-side component index or publish Provides: anolisa-component({component})"
             ),
         }),
-        [single] => Ok((
-            ProviderTarget::Delegated {
-                pm: NativePm::Rpm,
-                package: single.package.clone(),
-            },
-            single.package.clone(),
-            single.component.clone(),
-        )),
+        [single] => {
+            // An explicit --version becomes a dnf `name-version` pin in the
+            // planned transaction; refuse up front when the configured repo
+            // does not publish that version so the failure stays an argument
+            // error instead of a failed dnf transaction.
+            if let Some(version) = args.version.as_deref() {
+                verify_delegated_version_available(query, &single.package, version, command)?;
+            }
+            Ok((
+                ProviderTarget::Delegated {
+                    pm: NativePm::Rpm,
+                    package: single.package.clone(),
+                },
+                single.package.clone(),
+                single.component.clone(),
+            ))
+        }
         many => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
@@ -751,6 +760,49 @@ fn resolve_fresh_delegated(
             ),
         }),
     }
+}
+
+/// Preflight an explicit `--version` against the versions the configured
+/// RPM repository publishes: an unavailable version is refused with the
+/// published versions listed, instead of surfacing as a failed dnf
+/// transaction. An empty availability answer (no repoquery visibility)
+/// defers the verdict to the dnf transaction itself.
+fn verify_delegated_version_available(
+    query: &dyn PackageQuery,
+    package: &str,
+    version: &str,
+    command: &str,
+) -> Result<(), CliError> {
+    let available = query.query_available(package).map_err(|err| match err {
+        PackageQueryError::CommandMissing { command: bin } => {
+            rpm_tooling_missing_error(command, &bin, package)
+        }
+        err => pkg_query_err(err, command),
+    })?;
+    if available.is_empty() {
+        return Ok(());
+    }
+    // Accept the upstream version (`2.3.0`) or the full EVR spelling
+    // (`2.3.0-1.al8`) — both are valid dnf `name-version` pins.
+    let matched = available
+        .iter()
+        .any(|info| version == info.version.version || version == info.version.to_string());
+    if matched {
+        return Ok(());
+    }
+    let mut published: Vec<String> = available
+        .iter()
+        .map(|info| info.version.to_string())
+        .collect();
+    published.sort();
+    published.dedup();
+    Err(CliError::InvalidArgument {
+        command: command.to_string(),
+        reason: format!(
+            "version '{version}' of package '{package}' is not available from the configured RPM repository; published versions: {}",
+            published.join(", ")
+        ),
+    })
 }
 
 /// Execute an owned install plan (I1) through the raw backend.
@@ -1402,6 +1454,51 @@ package = "agent-sec-core"
         assert_eq!(
             exact_with_mapped_package,
             ("sec-core".to_string(), "agent-sec-core".to_string())
+        );
+    }
+
+    #[test]
+    fn version_preflight_accepts_published_spellings_and_defers_when_blind() {
+        let mut fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        fake.available = vec![pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")];
+        // Both the upstream version and the full EVR spelling are valid pins.
+        for version in ["2.3.0", "2.3.0-1.al8"] {
+            verify_delegated_version_available(&fake, "copilot-shell", version, "install")
+                .unwrap_or_else(|err| panic!("'{version}' must pass preflight: {err}"));
+        }
+
+        // No repoquery visibility: the dnf transaction gives the verdict.
+        let blind = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        );
+        verify_delegated_version_available(&blind, "copilot-shell", "9.9.9", "install")
+            .expect("empty availability must defer to dnf");
+    }
+
+    #[test]
+    fn install_unpublished_raw_version_lists_published_versions() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().join("sys");
+        let mut a = args("agentsight");
+        a.repo = Some(write_local_repo_component(
+            &tmp.path().join("repo"),
+            "agentsight",
+            "0.2.0",
+            &["system"],
+        ));
+        a.version = Some("9.9.9".to_string());
+
+        let err =
+            handle_with_fake_rpm(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("published versions: 0.2.0"),
+            "the refusal must list the published raw versions: {}",
+            err.reason()
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -24,6 +24,35 @@ use crate::response::CliError;
 use super::COMMAND;
 use super::render::{artifact_ext, artifact_type_wire, repo_config_err};
 use super::types::*;
+
+/// Fetch and parse the raw distribution index under `base_url`, filtered to
+/// artifact types the raw backend can install. Returns the parsed index and
+/// the fetched index URL for error reporting.
+///
+/// The index is always re-fetched (DownloadCache overwrites on conflict),
+/// so a republished repo is picked up without a cache flush. Shared with
+/// `list --versions`, which enumerates the same index resolution consults.
+pub(crate) fn fetch_installable_raw_index(
+    layout: &FsLayout,
+    base_url: &str,
+) -> Result<(DistributionIndex, String), CliError> {
+    let index_url = raw_index_url(base_url);
+    let cache = DownloadCache::new(layout.cache_dir.clone());
+    let downloaded_index = cache
+        .fetch(&index_url, None)
+        .map_err(|err| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!("failed to fetch distribution index {index_url}: {err}"),
+        })?;
+    let index = DistributionIndex::load(&downloaded_index.cached_path)
+        .map(installable_raw_index)
+        .map_err(|err| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!("failed to parse distribution index {index_url}: {err}"),
+        })?;
+    Ok((index, index_url))
+}
+
 pub(crate) fn resolve_raw(
     ctx: &CliContext,
     layout: &FsLayout,
@@ -39,22 +68,7 @@ pub(crate) fn resolve_raw(
         warnings,
     } = inputs;
 
-    // The index is always re-fetched (DownloadCache overwrites on conflict),
-    // so a republished repo is picked up without a cache flush.
-    let index_url = raw_index_url(&base_url);
-    let cache = DownloadCache::new(layout.cache_dir.clone());
-    let downloaded_index = cache
-        .fetch(&index_url, None)
-        .map_err(|err| CliError::Runtime {
-            command: COMMAND.to_string(),
-            reason: format!("failed to fetch distribution index {index_url}: {err}"),
-        })?;
-    let index = DistributionIndex::load(&downloaded_index.cached_path)
-        .map(installable_raw_index)
-        .map_err(|err| CliError::Runtime {
-            command: COMMAND.to_string(),
-            reason: format!("failed to parse distribution index {index_url}: {err}"),
-        })?;
+    let (index, index_url) = fetch_installable_raw_index(layout, &base_url)?;
 
     // The index is keyed by the backend-native package name so that
     // `package_map` / `--package` select between alternate publications.
@@ -69,15 +83,29 @@ pub(crate) fn resolve_raw(
         pkg_base: env.pkg_base.as_deref(),
         preferred_types: &[],
     };
-    let entry = index.resolve(&query).map_err(|err| CliError::InvalidArgument {
-        command: COMMAND.to_string(),
-        reason: format!(
+    let entry = index.resolve(&query).map_err(|err| {
+        let mut reason = format!(
             "cannot resolve package '{package}' (component '{component}', version {}, {}/{}, {} mode) from {index_url}: {err}",
             version.unwrap_or("latest"),
             env.os,
             env.arch,
             ctx.install_mode.as_str(),
-        ),
+        );
+        // An explicit --version that missed gets the discoverable choices
+        // appended, mirroring the rpm path's availability preflight.
+        if version.is_some() {
+            let published = index.matching_versions(&ResolveQuery {
+                version: None,
+                ..query.clone()
+            });
+            if !published.is_empty() {
+                reason.push_str(&format!("; published versions: {}", published.join(", ")));
+            }
+        }
+        CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason,
+        }
     })?;
 
     let wire_type = artifact_type_wire(&entry.artifact_type);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -635,6 +635,9 @@ pub struct FakeInstaller {
     pub install_succeeds: bool,
     pub installed: RefCell<Option<PackageInfo>>,
     pub install_calls: Cell<usize>,
+    /// dnf spec the install transaction must receive; defaults to the bare
+    /// package name, `--version` tests expect the `name-version` pin.
+    pub expected_install_spec: Option<String>,
     /// Optional lock path probed from inside `install`.
     pub lock_probe: Option<PathBuf>,
     pub lock_was_held: Cell<bool>,
@@ -655,6 +658,7 @@ impl FakeInstaller {
             install_succeeds: true,
             installed: RefCell::new(None),
             install_calls: Cell::new(0),
+            expected_install_spec: None,
             lock_probe: None,
             lock_was_held: Cell::new(false),
             package_appears_under_lock_path: None,
@@ -669,6 +673,10 @@ impl FakeInstaller {
     }
     pub fn failing_install(mut self) -> Self {
         self.install_succeeds = false;
+        self
+    }
+    pub fn expecting_install_spec(mut self, spec: &str) -> Self {
+        self.expected_install_spec = Some(spec.to_string());
         self
     }
     pub fn expect_lock_held(mut self, path: PathBuf) -> Self {
@@ -785,11 +793,11 @@ impl PackageQuery for FakeInstaller {
 impl PackageTransaction for FakeInstaller {
     fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
         self.install_calls.set(self.install_calls.get() + 1);
-        assert_eq!(
-            packages,
-            [self.package.as_str()],
-            "install targeted the wrong package"
-        );
+        let expected = self
+            .expected_install_spec
+            .as_deref()
+            .unwrap_or(self.package.as_str());
+        assert_eq!(packages, [expected], "install targeted the wrong package");
         if let Some(path) = &self.lock_probe {
             self.lock_was_held.set(matches!(
                 InstallLock::acquire(path),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -243,6 +243,78 @@ fn delegated_install_writes_a_managed_record() {
 }
 
 #[test]
+fn delegated_install_with_version_pins_the_dnf_spec() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let mut fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+    )
+    .expecting_install_spec("copilot-shell-2.2.0");
+    // The configured repo publishes two versions; --version selects the
+    // older one instead of the latest.
+    fake.available = vec![
+        pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    ];
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("2.2.0".to_string());
+
+    let outcome = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect("version-pinned delegated install ok");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 1, "dnf install must run once");
+
+    let store = load_store(&ctx);
+    let record = store
+        .find(ObjectKind::Component, "copilot-shell")
+        .expect("component recorded");
+    match &record.binding {
+        ProviderBinding::Delegated {
+            package,
+            last_observed,
+            ..
+        } => {
+            // The record keeps the canonical package name, not the pinned
+            // spec, so uninstall/update/repair keep addressing the rpmdb.
+            assert_eq!(package.resolved_name(), Some("copilot-shell"));
+            let observed = last_observed.as_ref().expect("fresh observation");
+            assert_eq!(observed.evr.as_deref(), Some("2.2.0-1.al8"));
+        }
+        other => panic!("expected a delegated binding, got {other:?}"),
+    }
+}
+
+#[test]
+fn delegated_install_unavailable_version_is_refused_before_dnf() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let mut fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    fake.available = vec![pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64")];
+    let mut a = args("copilot-shell");
+    a.backend = Some("rpm".to_string());
+    a.version = Some("9.9.9".to_string());
+
+    let err = install_component_with_deps("copilot-shell", &a, &ctx, &fake, &fake, true)
+        .expect_err("unpublished version must refuse before any transaction");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(
+        err.reason().contains("9.9.9") && err.reason().contains("2.3.0-1.al8"),
+        "the refusal must list the published versions: {}",
+        err.reason()
+    );
+    assert_eq!(fake.install_calls.get(), 0, "dnf must not run");
+    assert!(
+        load_store(&ctx)
+            .find(ObjectKind::Component, "copilot-shell")
+            .is_none(),
+        "refused install must not write state"
+    );
+}
+
+#[test]
 fn delegated_install_lock_failure_precedes_dnf() {
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
     let layout = common::resolve_layout(&ctx);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -6,6 +6,7 @@
 
 mod render;
 mod state_view;
+mod versions;
 
 #[cfg(test)]
 mod tests;
@@ -29,11 +30,17 @@ use self::state_view::{LocalProjection, project_component};
 
 const COMMAND: &str = "list";
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 pub struct ListArgs {
+    /// Component whose published versions to show (requires --versions)
+    #[arg(value_name = "COMPONENT", requires = "versions")]
+    pub component: Option<String>,
     /// Show only currently installed components
-    #[arg(long, alias = "enabled")]
+    #[arg(long, alias = "enabled", conflicts_with = "versions")]
     pub installed: bool,
+    /// List versions published for COMPONENT, per configured backend
+    #[arg(long, requires = "component")]
+    pub versions: bool,
 }
 
 // ── Wire / JSON output types ───────────────────────────────────────
@@ -87,6 +94,24 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
         })?;
 
     let view = StateView::load(ctx, COMMAND, StateVisibility::UserPlusSystem)?;
+
+    if args.versions {
+        // clap's `requires` pairing guarantees the component is present.
+        let component = args
+            .component
+            .as_deref()
+            .expect("clap requires COMPONENT together with --versions");
+        return versions::handle_versions(
+            component,
+            ctx,
+            &layout,
+            &env,
+            &repo_config,
+            &index,
+            &view,
+        );
+    }
+
     let rpm_query = match ctx.install_mode {
         InstallMode::System => Some(RpmPackageQuery::system()),
         InstallMode::User => None,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests.rs
@@ -5,3 +5,4 @@ mod projection_tracked;
 mod rows;
 mod scoped_rows;
 mod support;
+mod versions;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
@@ -11,7 +11,11 @@ use super::support::{
 #[test]
 fn index_builds_rows() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let rows = build_rows(&index, &args, &state, None);
     assert_eq!(rows.len(), 2);
@@ -31,7 +35,11 @@ fn index_builds_rows() {
 #[test]
 fn empty_state_all_not_installed() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let rows = build_rows(&index, &args, &state, None);
     for row in &rows {
@@ -43,7 +51,11 @@ fn empty_state_all_not_installed() {
 #[test]
 fn installed_component_shows_installed() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = state_with_owned_object(
         ObjectKind::Component,
         "tokenless",
@@ -61,7 +73,11 @@ fn installed_component_shows_installed() {
 #[test]
 fn adopted_rpm_component_shows_adopted() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = state_with_adopted_object(ObjectKind::Component, "agentsight");
     let rows = build_rows(&index, &args, &state, None);
 
@@ -72,7 +88,11 @@ fn adopted_rpm_component_shows_adopted() {
 #[test]
 fn compatibility_status_labels_are_preserved_before_local_projection() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = state_with_adopted_object(ObjectKind::Component, "agentsight");
 
     let rows = build_rows(&index, &args, &state, None);
@@ -86,7 +106,11 @@ fn compatibility_status_labels_are_preserved_before_local_projection() {
 #[test]
 fn adapter_object_does_not_mark_component_installed() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state =
         state_with_owned_object(ObjectKind::Adapter, "tokenless", LifecycleStatus::Installed);
     let rows = build_rows(&index, &args, &state, None);
@@ -97,7 +121,11 @@ fn adapter_object_does_not_mark_component_installed() {
 #[test]
 fn failed_component_shows_failed() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state =
         state_with_owned_object(ObjectKind::Component, "tokenless", LifecycleStatus::Failed);
     let rows = build_rows(&index, &args, &state, None);
@@ -108,7 +136,11 @@ fn failed_component_shows_failed() {
 #[test]
 fn disabled_component_shows_disabled() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = state_with_owned_object(
         ObjectKind::Component,
         "tokenless",
@@ -122,7 +154,11 @@ fn disabled_component_shows_disabled() {
 #[test]
 fn installed_filter_returns_only_installed() {
     let index = sample_index();
-    let args = ListArgs { installed: true };
+    let args = ListArgs {
+        component: None,
+        installed: true,
+        versions: false,
+    };
     let state = state_with_owned_object(
         ObjectKind::Component,
         "tokenless",
@@ -137,7 +173,11 @@ fn installed_filter_returns_only_installed() {
 #[test]
 fn installed_filter_includes_adopted_rpm_components() {
     let index = sample_index();
-    let args = ListArgs { installed: true };
+    let args = ListArgs {
+        component: None,
+        installed: true,
+        versions: false,
+    };
     let state = state_with_adopted_object(ObjectKind::Component, "agentsight");
     let rows = build_rows(&index, &args, &state, None);
     assert_eq!(rows.len(), 1);
@@ -148,7 +188,11 @@ fn installed_filter_includes_adopted_rpm_components() {
 #[test]
 fn installed_filter_with_empty_state_returns_empty() {
     let index = sample_index();
-    let args = ListArgs { installed: true };
+    let args = ListArgs {
+        component: None,
+        installed: true,
+        versions: false,
+    };
     let state = empty_state();
     let rows = build_rows(&index, &args, &state, None);
     assert!(rows.is_empty());
@@ -157,7 +201,11 @@ fn installed_filter_with_empty_state_returns_empty() {
 #[test]
 fn json_payload_uses_components_key() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let rows = build_rows(&index, &args, &state, None);
     let payload = ListPayload {
@@ -172,7 +220,11 @@ fn json_payload_uses_components_key() {
 #[test]
 fn json_payload_status_reflects_install_state() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = state_with_owned_object(
         ObjectKind::Component,
         "agentsight",
@@ -212,7 +264,11 @@ fn missing_optional_fields_use_defaults() {
             aliases: Vec::new(),
         }],
     };
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let rows = build_rows(&index, &args, &state, None);
     assert_eq!(rows.len(), 1);
@@ -243,7 +299,11 @@ fn unknown_backend_kind_preserved() {
             aliases: Vec::new(),
         }],
     };
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let rows = build_rows(&index, &args, &state, None);
     assert_eq!(rows[0].backends, vec!["custom-repo"]);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
@@ -6,7 +6,11 @@ use super::support::{FakeRpmQuery, empty_state, pkg_info, sample_index};
 #[test]
 fn row_json_retains_status_and_adds_local_fields() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let query = FakeRpmQuery {
         installed: vec![(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/rows.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/rows.rs
@@ -10,7 +10,11 @@ use super::support::{
 #[test]
 fn rows_use_local_projection_for_untracked_observed_rpm() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let query = FakeRpmQuery {
         installed: vec![(
@@ -35,20 +39,42 @@ fn rows_without_rpm_query_do_not_surface_observed_system_rpms() {
     let index = sample_index();
     let state = empty_state();
 
-    let all_rows = build_rows(&index, &ListArgs { installed: false }, &state, None);
+    let all_rows = build_rows(
+        &index,
+        &ListArgs {
+            component: None,
+            installed: false,
+            versions: false,
+        },
+        &state,
+        None,
+    );
     let sight = all_rows.iter().find(|r| r.name == "agentsight").unwrap();
     assert_eq!(sight.local_state, "not_installed");
     assert_eq!(sight.ownership, "none");
     assert_eq!(sight.rpm_package, None);
 
-    let installed_rows = build_rows(&index, &ListArgs { installed: true }, &state, None);
+    let installed_rows = build_rows(
+        &index,
+        &ListArgs {
+            component: None,
+            installed: true,
+            versions: false,
+        },
+        &state,
+        None,
+    );
     assert!(installed_rows.is_empty());
 }
 
 #[test]
 fn rows_ignore_rpm_query_failures() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = empty_state();
     let query = FakeRpmQuery {
         installed: Vec::new(),
@@ -65,7 +91,11 @@ fn rows_ignore_rpm_query_failures() {
 #[test]
 fn rows_use_status_action_for_tracked_rpm_observed_state() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = state_with_component_object(rpm_component_object(
         "agentsight",
         LifecycleStatus::Installed,
@@ -94,7 +124,11 @@ fn rows_use_status_action_for_tracked_rpm_observed_state() {
 #[test]
 fn rows_project_raw_and_rpm_managed_state_as_installed() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let query = FakeRpmQuery {
         installed: vec![(
             "agentsight".to_string(),
@@ -127,7 +161,11 @@ fn rows_project_raw_and_rpm_managed_state_as_installed() {
 #[test]
 fn rows_surface_rpm_drift_and_missing() {
     let index = sample_index();
-    let args = ListArgs { installed: false };
+    let args = ListArgs {
+        component: None,
+        installed: false,
+        versions: false,
+    };
     let state = state_with_component_object(rpm_component_object(
         "agentsight",
         LifecycleStatus::Installed,
@@ -166,7 +204,11 @@ fn rows_surface_rpm_drift_and_missing() {
 #[test]
 fn installed_filter_keeps_only_currently_installed_local_states() {
     let index = sample_index();
-    let args = ListArgs { installed: true };
+    let args = ListArgs {
+        component: None,
+        installed: true,
+        versions: false,
+    };
 
     let observed_rows = build_rows(
         &index,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/scoped_rows.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/scoped_rows.rs
@@ -14,7 +14,11 @@ use super::support::{
 #[test]
 fn user_view_installed_filter_keeps_system_provided_component() {
     let index = sample_index();
-    let args = ListArgs { installed: true };
+    let args = ListArgs {
+        component: None,
+        installed: true,
+        versions: false,
+    };
     let view = user_plus_system_view(
         StateStore::empty(),
         state_with_component_object(owned_component("agentsight", LifecycleStatus::Installed)),
@@ -37,7 +41,11 @@ fn user_view_installed_filter_keeps_system_provided_component() {
 #[test]
 fn user_record_shadows_system_record_in_list_rows() {
     let index = sample_index();
-    let args = ListArgs { installed: true };
+    let args = ListArgs {
+        component: None,
+        installed: true,
+        versions: false,
+    };
     let view = user_plus_system_view(
         state_with_component_object(owned_component("agentsight", LifecycleStatus::Installed)),
         state_with_component_object(delegated_component(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/versions.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/versions.rs
@@ -1,0 +1,223 @@
+//! Tests for `list <component> --versions` version discovery.
+
+use std::path::{Path, PathBuf};
+
+use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
+use clap::Parser;
+use tempfile::tempdir;
+
+use crate::commands::state_view::{StateView, StateVisibility};
+use crate::commands::tier1::list::ListArgs;
+use crate::commands::tier1::list::versions::{VersionSources, build_versions_payload};
+use crate::context::{CliContext, InstallMode};
+use crate::repo_config::RepoConfig;
+
+use super::support::{pkg_info, sample_index_with_aliases};
+
+/// Package query double with a controllable repoquery answer — the shared
+/// [`super::support::FakeRpmQuery`] models the rpmdb only.
+#[derive(Default)]
+struct FakeRepoQuery {
+    available: Vec<PackageInfo>,
+    installed: Option<PackageInfo>,
+}
+
+impl PackageQuery for FakeRepoQuery {
+    fn query_installed(&self, _package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+        Ok(self.installed.clone())
+    }
+
+    fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+        Ok(self.available.clone())
+    }
+
+    fn what_provides_installed(&self, _capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        Ok(Vec::new())
+    }
+}
+
+fn system_ctx(root: &Path, prefix: PathBuf) -> CliContext {
+    crate::test_support::context_for_root(
+        root,
+        InstallMode::System,
+        Some(prefix),
+        crate::test_support::TestContextOptions::default(),
+    )
+}
+
+/// Raw v1 repo whose index publishes two cosh versions; only the index
+/// matters — `matching_versions` never downloads artifacts.
+fn write_two_version_raw_repo(root: &Path) -> String {
+    let v1 = root.join("v1");
+    std::fs::create_dir_all(&v1).expect("create repo dirs");
+    let env = anolisa_env::EnvService::detect();
+    let entry = |version: &str| {
+        format!(
+            r#"
+[[entries]]
+component = "cosh"
+version = "{version}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "cosh-{version}.tar.gz"
+os = "{os}"
+arch = "{arch}"
+install_modes = ["system"]
+sha256 = "{sha}"
+"#,
+            os = env.os,
+            arch = env.arch,
+            sha = "0".repeat(64),
+        )
+    };
+    let index = format!(
+        "schema_version = 1\nchannel = \"stable\"\npublisher = \"test\"\n{}{}",
+        entry("0.1.0"),
+        entry("0.2.0"),
+    );
+    std::fs::write(v1.join("index.toml"), index).expect("write index");
+    format!("file://{}", v1.display())
+}
+
+fn repo_config_with(raw_base_url: &str) -> RepoConfig {
+    RepoConfig::from_toml_str(&format!(
+        r#"schema_version = 1
+default_backend = "raw"
+
+[backends.raw]
+base_url = "{raw_base_url}"
+
+[backends.rpm]
+base_url = "https://repo.example/anolisa"
+gpgcheck = false
+"#
+    ))
+    .expect("parse repo config")
+}
+
+#[test]
+fn versions_payload_lists_raw_and_rpm_versions_with_installed_marker() {
+    let tmp = tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path(), tmp.path().join("sys"));
+    let layout = crate::commands::common::resolve_layout(&ctx);
+    let env = anolisa_env::EnvService::detect();
+    let repo_config = repo_config_with(&write_two_version_raw_repo(&tmp.path().join("repo")));
+    let index = sample_index_with_aliases();
+    let view = StateView::load(&ctx, "list", StateVisibility::UserPlusSystem).expect("view");
+    let rpm_query = FakeRepoQuery {
+        available: vec![
+            pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        ],
+        installed: Some(pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64")),
+    };
+    let sources = VersionSources {
+        layout: &layout,
+        env: &env,
+        repo_config: &repo_config,
+        index: &index,
+        view: &view,
+        rpm_query: &rpm_query,
+    };
+
+    let payload = build_versions_payload("cosh", &ctx, &sources).expect("payload");
+
+    assert_eq!(payload.component, "cosh");
+    assert!(payload.warnings.is_empty(), "got: {:?}", payload.warnings);
+    assert_eq!(payload.backends.len(), 2);
+
+    let raw = &payload.backends[0];
+    assert_eq!(raw.backend, "raw");
+    assert_eq!(raw.package, "cosh");
+    // Highest-first: the head is what a bare `install` would pick.
+    let raw_versions: Vec<&str> = raw.versions.iter().map(|r| r.version.as_str()).collect();
+    assert_eq!(raw_versions, ["0.2.0", "0.1.0"]);
+    assert!(raw.versions.iter().all(|r| !r.installed));
+
+    let rpm = &payload.backends[1];
+    assert_eq!(rpm.backend, "rpm");
+    assert_eq!(rpm.package, "copilot-shell");
+    let rpm_versions: Vec<(&str, bool)> = rpm
+        .versions
+        .iter()
+        .map(|r| (r.version.as_str(), r.installed))
+        .collect();
+    assert_eq!(
+        rpm_versions,
+        [("2.3.0-1.al8", false), ("2.2.0-1.al8", true)],
+        "EVRs must be highest-first with the installed one marked"
+    );
+}
+
+#[test]
+fn versions_resolves_component_aliases() {
+    let tmp = tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path(), tmp.path().join("sys"));
+    let layout = crate::commands::common::resolve_layout(&ctx);
+    let env = anolisa_env::EnvService::detect();
+    let repo_config = repo_config_with(&write_two_version_raw_repo(&tmp.path().join("repo")));
+    let index = sample_index_with_aliases();
+    let view = StateView::load(&ctx, "list", StateVisibility::UserPlusSystem).expect("view");
+    let rpm_query = FakeRepoQuery::default();
+    let sources = VersionSources {
+        layout: &layout,
+        env: &env,
+        repo_config: &repo_config,
+        index: &index,
+        view: &view,
+        rpm_query: &rpm_query,
+    };
+
+    // `cosh-old` is a declared rpm-package alias of `cosh`.
+    let payload = build_versions_payload("cosh-old", &ctx, &sources).expect("payload");
+    assert_eq!(payload.component, "cosh");
+}
+
+#[test]
+fn versions_unknown_component_is_invalid_argument() {
+    let tmp = tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path(), tmp.path().join("sys"));
+    let layout = crate::commands::common::resolve_layout(&ctx);
+    let env = anolisa_env::EnvService::detect();
+    let repo_config = repo_config_with("https://example.com/anolisa");
+    let index = sample_index_with_aliases();
+    let view = StateView::load(&ctx, "list", StateVisibility::UserPlusSystem).expect("view");
+    let rpm_query = FakeRepoQuery::default();
+    let sources = VersionSources {
+        layout: &layout,
+        env: &env,
+        repo_config: &repo_config,
+        index: &index,
+        view: &view,
+        rpm_query: &rpm_query,
+    };
+
+    let err = build_versions_payload("no-such-component", &ctx, &sources)
+        .expect_err("unknown component must refuse");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(err.reason().contains("no-such-component"));
+}
+
+// ── clap surface pairing ─────────────────────────────────────────────
+
+#[test]
+fn versions_flag_requires_component() {
+    let err = ListArgs::try_parse_from(["list", "--versions"])
+        .expect_err("--versions without COMPONENT must be rejected");
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn component_positional_requires_versions_flag() {
+    let err = ListArgs::try_parse_from(["list", "cosh"])
+        .expect_err("bare COMPONENT without --versions must be rejected");
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn installed_filter_conflicts_with_versions() {
+    let err = ListArgs::try_parse_from(["list", "cosh", "--versions", "--installed"])
+        .expect_err("--installed makes no sense for a version listing");
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/versions.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/versions.rs
@@ -1,0 +1,300 @@
+//! `anolisa list <component> --versions` — published-version discovery.
+//!
+//! Read-only companion to `install --version`: resolves the input against
+//! the component index (exact name first, then the shared alias lookup),
+//! then asks each backend the component declares for the versions it
+//! publishes. Raw versions come from the distribution index that install
+//! resolution consults; rpm versions from `dnf repoquery` against the
+//! configured ANOLISA repository. A failing backend degrades to a warning
+//! so one unreachable source does not hide the other's answer.
+
+use std::collections::BTreeSet;
+
+use anolisa_core::ResolveQuery;
+use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError, rpm_evr_cmp};
+use anolisa_platform::rpm_query::RpmPackageQuery;
+use serde::Serialize;
+
+use crate::commands::state_view::StateView;
+use crate::commands::tier1::install::{
+    configured_rpm_repo_source, fetch_installable_raw_index, installed_version_label,
+};
+use crate::context::CliContext;
+use crate::repo_config::{HostVars, RepoConfig};
+use crate::resolution::{ComponentIndex, ComponentIndexEntry, lookup_component_alias};
+use crate::response::{CliError, render_json};
+
+use super::{COMMAND, render_warnings};
+
+/// JSON payload for one component's published versions.
+#[derive(Debug, Serialize)]
+pub(super) struct VersionsPayload {
+    pub(super) component: String,
+    pub(super) backends: Vec<BackendVersions>,
+    /// Omitted when empty, matching the `list` table envelope.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) warnings: Vec<String>,
+}
+
+/// Versions one backend publishes for the component.
+#[derive(Debug, Serialize)]
+pub(super) struct BackendVersions {
+    pub(super) backend: String,
+    /// Backend-native package the versions belong to (what `install
+    /// --version` will pin).
+    pub(super) package: String,
+    /// Highest-first, so the head is what a bare `install` would pick.
+    pub(super) versions: Vec<VersionRow>,
+}
+
+/// One published version and whether a visible installation matches it.
+#[derive(Debug, Serialize)]
+pub(super) struct VersionRow {
+    pub(super) version: String,
+    pub(super) installed: bool,
+}
+
+/// Read-only inputs for version discovery, grouped so tests can inject a
+/// fake package query without a live dnf.
+pub(super) struct VersionSources<'a> {
+    pub(super) layout: &'a FsLayout,
+    pub(super) env: &'a anolisa_env::EnvFacts,
+    pub(super) repo_config: &'a RepoConfig,
+    pub(super) index: &'a ComponentIndex,
+    pub(super) view: &'a StateView,
+    pub(super) rpm_query: &'a dyn PackageQuery,
+}
+
+pub(super) fn handle_versions(
+    input: &str,
+    ctx: &CliContext,
+    layout: &FsLayout,
+    env: &anolisa_env::EnvFacts,
+    repo_config: &RepoConfig,
+    index: &ComponentIndex,
+    view: &StateView,
+) -> Result<(), CliError> {
+    // repoquery against the configured ANOLISA repo when one exists, so the
+    // listed versions match what a delegated install can actually pull.
+    let rpm_query = match configured_rpm_repo_source(repo_config, env)
+        .map_err(|err| err.with_command(COMMAND))?
+    {
+        Some(repo) => RpmPackageQuery::system_with_repo(repo),
+        None => RpmPackageQuery::system(),
+    };
+    let sources = VersionSources {
+        layout,
+        env,
+        repo_config,
+        index,
+        view,
+        rpm_query: &rpm_query,
+    };
+    let payload = build_versions_payload(input, ctx, &sources)?;
+
+    if ctx.json {
+        return render_json(COMMAND, &payload);
+    }
+    if !ctx.quiet {
+        render_warnings(&payload.warnings);
+        render_human_versions(&payload);
+    }
+    Ok(())
+}
+
+/// Assemble the versions report for one component across its backends.
+pub(super) fn build_versions_payload(
+    input: &str,
+    ctx: &CliContext,
+    sources: &VersionSources<'_>,
+) -> Result<VersionsPayload, CliError> {
+    let entry =
+        resolve_index_entry(input, sources.index).ok_or_else(|| CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "unknown component '{input}': not in the component index — run `anolisa list` for available components"
+            ),
+        })?;
+
+    // Version labels of visible installations, for the `installed` marker on
+    // raw rows (rpm rows compare against the live rpmdb EVR instead).
+    let installed_labels: BTreeSet<String> = sources
+        .view
+        .visible_components()
+        .iter()
+        .filter(|record| record.object.name == entry.name)
+        .map(|record| installed_version_label(record.object))
+        .collect();
+
+    let mut warnings = Vec::new();
+    let mut backends = Vec::new();
+    for (kind, package) in declared_backends(entry, sources.repo_config) {
+        if !sources.repo_config.backends.contains_key(&kind) {
+            warnings.push(format!(
+                "backend '{kind}' of component '{}' is not configured in repo.toml; skipping",
+                entry.name
+            ));
+            continue;
+        }
+        match kind.as_str() {
+            "raw" => match raw_backend_versions(ctx, sources, &package) {
+                Ok(published) => backends.push(BackendVersions {
+                    backend: kind,
+                    versions: published
+                        .into_iter()
+                        .map(|version| VersionRow {
+                            installed: installed_labels.contains(&version),
+                            version,
+                        })
+                        .collect(),
+                    package,
+                }),
+                Err(err) => warnings.push(format!(
+                    "raw backend versions unavailable: {}",
+                    err.reason()
+                )),
+            },
+            "rpm" => match rpm_backend_versions(sources.rpm_query, &package) {
+                Ok((published, installed_evr)) => backends.push(BackendVersions {
+                    backend: kind,
+                    versions: published
+                        .into_iter()
+                        .map(|version| VersionRow {
+                            installed: installed_evr.as_deref() == Some(version.as_str()),
+                            version,
+                        })
+                        .collect(),
+                    package,
+                }),
+                Err(err) => warnings.push(format!("rpm backend versions unavailable: {err}")),
+            },
+            other => warnings.push(format!(
+                "backend '{other}' has no version listing support yet"
+            )),
+        }
+    }
+
+    Ok(VersionsPayload {
+        component: entry.name.clone(),
+        backends,
+        warnings,
+    })
+}
+
+/// Exact index name first, then the shared alias lookup — the same order
+/// install uses to resolve component identity.
+fn resolve_index_entry<'a>(
+    input: &str,
+    index: &'a ComponentIndex,
+) -> Option<&'a ComponentIndexEntry> {
+    if let Some(entry) = index.components.iter().find(|entry| entry.name == input) {
+        return Some(entry);
+    }
+    let canonical = lookup_component_alias(input, Some(index))?;
+    index
+        .components
+        .iter()
+        .find(|entry| entry.name == canonical)
+}
+
+/// Backend/package pairs to query: the component's declared backends, or —
+/// for an index entry without backend rows — the repo default backend with
+/// the component name as its package.
+fn declared_backends(
+    entry: &ComponentIndexEntry,
+    repo_config: &RepoConfig,
+) -> Vec<(String, String)> {
+    if entry.backends.is_empty() {
+        return vec![(repo_config.default_backend.clone(), entry.name.clone())];
+    }
+    entry
+        .backends
+        .iter()
+        .map(|backend| (backend.kind.clone(), backend.package.clone()))
+        .collect()
+}
+
+/// Versions the raw distribution index publishes for `package` on this host
+/// (same filters install resolution applies), highest-first.
+fn raw_backend_versions(
+    ctx: &CliContext,
+    sources: &VersionSources<'_>,
+    package: &str,
+) -> Result<Vec<String>, CliError> {
+    let Some(backend) = sources.repo_config.backends.get("raw") else {
+        // The caller only routes here for configured backends.
+        return Ok(Vec::new());
+    };
+    let host = HostVars {
+        os: sources.env.os.clone(),
+        arch: sources.env.arch.clone(),
+    };
+    let base_url = sources
+        .repo_config
+        .resolved_base_url("raw", backend, &host)
+        .map_err(|err| CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: err.to_string(),
+        })?;
+    let (index, _index_url) = fetch_installable_raw_index(sources.layout, &base_url)
+        .map_err(|err| err.with_command(COMMAND))?;
+    let query = ResolveQuery {
+        component: package,
+        version: None,
+        channel: None,
+        install_mode: ctx.install_mode.as_str(),
+        os: &sources.env.os,
+        arch: &sources.env.arch,
+        libc: sources.env.libc.as_deref(),
+        pkg_base: sources.env.pkg_base.as_deref(),
+        preferred_types: &[],
+    };
+    Ok(index.matching_versions(&query))
+}
+
+/// Published EVRs highest-first plus the installed EVR, from the injected
+/// package query (the live path queries the configured ANOLISA repo).
+fn rpm_backend_versions(
+    query: &dyn PackageQuery,
+    package: &str,
+) -> Result<(Vec<String>, Option<String>), PackageQueryError> {
+    let mut available = query.query_available(package)?;
+    available.sort_by(|a, b| rpm_evr_cmp(&b.version, &a.version));
+    let mut versions: Vec<String> = available
+        .iter()
+        .map(|info| info.version.to_string())
+        .collect();
+    versions.dedup();
+    let installed = query
+        .query_installed(package)?
+        .map(|info| info.version.to_string());
+    // An installed EVR the repo no longer publishes still belongs in the
+    // list (marked installed) so the picture stays complete.
+    if let Some(evr) = &installed
+        && !versions.iter().any(|version| version == evr)
+    {
+        versions.push(evr.clone());
+    }
+    Ok((versions, installed))
+}
+
+fn render_human_versions(payload: &VersionsPayload) {
+    println!("versions for {}:", payload.component);
+    for backend in &payload.backends {
+        println!("  {} (package {}):", backend.backend, backend.package);
+        if backend.versions.is_empty() {
+            println!("    (none published)");
+        }
+        for row in &backend.versions {
+            if row.installed {
+                println!("    {} (installed)", row.version);
+            } else {
+                println!("    {}", row.version);
+            }
+        }
+    }
+    if payload.backends.is_empty() {
+        println!("  (no queryable backend)");
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/executor.rs
+++ b/src/anolisa/crates/anolisa-core/src/executor.rs
@@ -305,8 +305,9 @@ fn prepare_delegated_recovery(
 /// # Errors
 ///
 /// Returns [`ExecutionError::InvalidRecoveryContract`] unless the plan has
-/// exactly one record transition and every package-bearing step contains the
-/// subject package.
+/// exactly one record transition and every package-bearing step names the
+/// subject package, either bare or as a version-pinned `name-version` spec
+/// (the form the install planner emits for an explicit `--version`).
 pub fn delegated_recovery_context(
     target: DelegatedExecutionTarget<'_>,
     steps: &[Step],
@@ -353,7 +354,10 @@ pub fn delegated_recovery_context(
             Step::NativeTransaction { packages, .. } | Step::Observe { packages } => Some(packages),
             _ => None,
         }) {
-            if !packages.iter().any(|candidate| candidate == package) {
+            if !packages
+                .iter()
+                .any(|candidate| spec_names_package(candidate, package))
+            {
                 return Err(ExecutionError::InvalidRecoveryContract {
                     reason: format!(
                         "subject package '{package}' is absent from delegated step packages [{}]",
@@ -369,6 +373,18 @@ pub fn delegated_recovery_context(
         package: package.map(str::to_string),
         record_action: *record_action,
     })
+}
+
+/// True when a step's package spec denotes the subject package: either the
+/// bare name or a dnf-style version-pinned spec (`name-<version>`, with the
+/// version part starting on a digit so sibling packages sharing the name as
+/// a dash prefix, e.g. `cosh` vs `cosh-ng`, are not conflated).
+fn spec_names_package(spec: &str, package: &str) -> bool {
+    spec == package
+        || spec
+            .strip_prefix(package)
+            .and_then(|rest| rest.strip_prefix('-'))
+            .is_some_and(|version| version.starts_with(|c: char| c.is_ascii_digit()))
 }
 
 /// Whether this executor interprets `step`.
@@ -510,6 +526,87 @@ mod tests {
         );
         assert_eq!(journal.steps[0].phase, PHASE_NATIVE_TXN);
         assert_eq!(journal.steps[0].action, "install");
+    }
+
+    #[test]
+    fn version_pinned_install_spec_reaches_the_txn_and_observe_keeps_the_name() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let query = query_present("cosh", "2.7.0");
+        let txn = FakeTxn::default();
+        let provider = DelegatedProvider::new(&query, &txn);
+        let mut sink = MemSink::default();
+        let mut journal = journal(tmp.path());
+
+        // The planner's I2 shape for `install --version 2.7.0`: the pin only
+        // lives in the transaction spec, observation uses the bare name.
+        let steps = vec![
+            Step::NativeTransaction {
+                pm: NativePm::Rpm,
+                action: NativeAction::Install,
+                packages: vec!["cosh-2.7.0".to_string()],
+            },
+            Step::Observe {
+                packages: vec!["cosh".to_string()],
+            },
+            Step::WriteRecord(RecordWrite::DelegatedManaged),
+        ];
+        let outcome = execute_delegated_steps(
+            &steps,
+            DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh")),
+            &provider,
+            &mut sink,
+            &mut journal,
+            NOW,
+        )
+        .expect("pinned execution ok");
+
+        assert_eq!(
+            txn.calls.borrow().as_slice(),
+            &[("install".to_string(), "cosh-2.7.0".to_string())]
+        );
+        let observation = outcome.observation.expect("observation absorbed");
+        assert_eq!(observation.evr.as_deref(), Some("2.7.0-1.al4"));
+        assert_eq!(journal.status, TransactionOutcomeStatus::Ok);
+    }
+
+    #[test]
+    fn recovery_context_accepts_pinned_specs_but_not_sibling_package_names() {
+        let pinned = vec![
+            Step::NativeTransaction {
+                pm: NativePm::Rpm,
+                action: NativeAction::Install,
+                packages: vec!["cosh-2.7.0".to_string()],
+            },
+            Step::Observe {
+                packages: vec!["cosh".to_string()],
+            },
+            Step::WriteRecord(RecordWrite::DelegatedManaged),
+        ];
+        let context = delegated_recovery_context(
+            DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh")),
+            &pinned,
+        )
+        .expect("pinned spec names the subject package");
+        assert_eq!(context.package.as_deref(), Some("cosh"));
+
+        // `cosh-ng` is a different package, not a version pin of `cosh`.
+        let sibling = vec![
+            Step::NativeTransaction {
+                pm: NativePm::Rpm,
+                action: NativeAction::Install,
+                packages: vec!["cosh-ng".to_string()],
+            },
+            Step::WriteRecord(RecordWrite::DelegatedManaged),
+        ];
+        let err = delegated_recovery_context(
+            DelegatedExecutionTarget::new(NativePm::Rpm, Some("cosh")),
+            &sibling,
+        )
+        .expect_err("sibling names must not be conflated with the subject");
+        assert!(matches!(
+            err,
+            ExecutionError::InvalidRecoveryContract { .. }
+        ));
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/planner.rs
+++ b/src/anolisa/crates/anolisa-core/src/planner.rs
@@ -468,18 +468,29 @@ fn plan_install(req: &InstallRequest, facts: &Facts) -> Result<Plan, PlanError> 
                     Step::EnableServices,
                     Step::WriteRecord(RecordWrite::Owned),
                 ])),
-                ProviderTarget::Delegated { pm, package } => Ok(Plan::execute(vec![
-                    // I2
-                    Step::NativeTransaction {
-                        pm: *pm,
-                        action: NativeAction::Install,
-                        packages: vec![package.clone()],
-                    },
-                    Step::Observe {
-                        packages: vec![package.clone()],
-                    },
-                    Step::WriteRecord(RecordWrite::DelegatedManaged),
-                ])),
+                ProviderTarget::Delegated { pm, package } => {
+                    // I2. An explicit `--version` pins the native transaction
+                    // to the dnf-style `name-version` spec. Only the
+                    // transaction carries the pin: the observe step and the
+                    // record keep the canonical package name, because the
+                    // native database is queried by name and the pinned EVR
+                    // is captured by the post-install observation.
+                    let spec = match &req.requested_version {
+                        Some(version) => format!("{package}-{version}"),
+                        None => package.clone(),
+                    };
+                    Ok(Plan::execute(vec![
+                        Step::NativeTransaction {
+                            pm: *pm,
+                            action: NativeAction::Install,
+                            packages: vec![spec],
+                        },
+                        Step::Observe {
+                            packages: vec![package.clone()],
+                        },
+                        Step::WriteRecord(RecordWrite::DelegatedManaged),
+                    ]))
+                }
             }
         }
     }
@@ -979,6 +990,30 @@ mod tests {
             steps,
             vec![
                 native_txn(NativeAction::Install),
+                observe(),
+                Step::WriteRecord(RecordWrite::DelegatedManaged),
+            ]
+        );
+    }
+
+    #[test]
+    fn i2_fresh_delegated_install_with_version_pins_the_transaction_spec() {
+        let f = facts();
+        let intent = Intent::Install(InstallRequest {
+            target: delegated_target(),
+            requested_version: Some("2.3.0".to_string()),
+        });
+        let steps = expect_steps(plan(&intent, &f));
+        assert_eq!(
+            steps,
+            vec![
+                Step::NativeTransaction {
+                    pm: NativePm::Rpm,
+                    action: NativeAction::Install,
+                    // The pin lives only in the transaction spec…
+                    packages: vec![format!("{PKG}-2.3.0")],
+                },
+                // …while observation and the record keep the bare name.
                 observe(),
                 Step::WriteRecord(RecordWrite::DelegatedManaged),
             ]


### PR DESCRIPTION
## Description

Adds component version selection to the install flow and a version discovery surface, closing the loop: discover published versions → pin one at install time → get actionable candidates when a pin misses.

Behavior:

- `anolisa install <component> --version <v>` now works on the rpm (delegated) backend: the dnf transaction is pinned to the `name-version` spec. The raw backend already honored `--version` via distribution index resolution.
- Only the native transaction step carries the pin. The observe step and the state record keep the canonical package name, so the actual installed EVR is captured from rpmdb after the transaction and uninstall/repair are unaffected.
- rpm preflight: the requested version is checked against `dnf repoquery` availability before any transaction. An unpublished version fails fast as `INVALID_ARGUMENT` with the published versions listed. When repoquery has no visibility (empty result), the decision is deferred to dnf itself.
- raw error path: an explicit `--version` that misses the index now appends `published versions: ...` from the same index query, matching the rpm side.
- New discovery surface: `anolisa list <component> --versions` lists the versions each configured backend publishes (raw distribution index and dnf repoquery), highest-first, with the installed version marked. Component aliases resolve the same way as install. Supports `--json`.
- CLI constraints: the positional `COMPONENT` and `--versions` require each other; `--versions` conflicts with `--installed`. Plain `anolisa list` behavior is unchanged.

## Design Note

The version pin is applied in the planner (install row I2) rather than rewritten in the executor, so the dry-run plan, the journal, and the recovery contract all describe exactly what the executor runs. The executor's delegated recovery contract is relaxed to accept `name-<version>` specs; the version segment must start with a digit so sibling packages (e.g. `cosh` vs `cosh-ng`) are never conflated.

Version discovery lives in `list/versions.rs`, separate from the row projection. The raw index fetch used by install resolution is extracted as `fetch_installable_raw_index` and shared, so discovery and resolution can never disagree about which index entries are installable. Per-backend query failures degrade to warnings instead of hiding the other backend's answer.

## Ship Note

- rpm versions are ordered with rpm EVR comparison; an installed EVR no longer published by the repo is kept in the list so the user still sees what they run.
- `update` does not take `--version` yet, while the planner I5 hint already points there; adding version selection to `update` is a natural follow-up.

## Test

- Unit (planner/executor): pinned `name-version` specs in the I2 plan; recovery contract accepts pinned specs and rejects sibling-package prefixes.
- Unit (install dispatch): rpm preflight accepts a published pin, rejects an unpublished one listing candidates, and defers when repoquery is empty; raw resolve error lists published versions.
- Unit (list versions): payload covers raw + rpm backends with installed marker; alias resolution; unknown component → `INVALID_ARGUMENT`; clap pairing/conflict constraints.
- Full gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` (no warnings), `cargo test --workspace` all passing; first commit verified to build standalone for bisect safety.
