### PR TITLE
fix(cosh-ng): [shell] intercept recalled slash

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
@@ -51,8 +51,6 @@ fi
 _cosh_load_native_bash_history_if_empty
 
 _COSH_AT_PROMPT=0
-_COSH_LAST_HISTORY_NO=0
-_COSH_LAST_HISTORY_COMMAND=
 _COSH_IN_PROMPT_COMMAND=0
 _COSH_LAST_NATIVE_HISTORY_FILE=
 
@@ -399,9 +397,7 @@ _cosh_preexec_marker() {
       eval "$active_debug_trap" 2>/dev/null || true
       return 0
     fi
-    if [[ -n "$history_no" && -n "$command" && ( "$history_no" != "${_COSH_LAST_HISTORY_NO:-0}" || "$command" != "${_COSH_LAST_HISTORY_COMMAND:-}" ) ]]; then
-      _COSH_LAST_HISTORY_NO="$history_no"
-      _COSH_LAST_HISTORY_COMMAND="$command"
+    if [[ -n "$history_no" && -n "$command" ]]; then
       local display_command="$command"
       if _cosh_is_handoff_wrapper "$command"; then
         display_command="$(_cosh_unwrap_handoff_command "$command")"
@@ -435,7 +431,6 @@ _cosh_preexec_marker() {
           builtin history -d "$history_no" 2>/dev/null || true
         fi
         display_command="<redacted sensitive command>"
-        _COSH_LAST_HISTORY_COMMAND="$display_command"
       fi
       if [[ -n "${_COSH_HANDOFF_HISTORY_NO:-}" ]]; then
         _COSH_HANDOFF_HISTORY_COMMAND="$display_command"

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -169,6 +169,66 @@ fn raw_relay_bash_intercepts_fragmented_slash_while_typing() {
 }
 
 #[test]
+fn raw_relay_bash_intercepts_recalled_duplicate_slash_each_time() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-recalled-slash-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(
+        home.join(".bashrc"),
+        "export HISTFILE=\"$HOME/.bash_history\"\n\
+         export HISTSIZE=1000\n\
+         export HISTCONTROL=ignoredups\n\
+         shopt -s histappend\n",
+    )
+    .expect("bashrc");
+    std::fs::write(home.join(".bash_history"), "/skills detail xlsx\n").expect("history");
+
+    let config = ShellHostConfig::new("bash-recalled-slash-test", &work_dir)
+        .with_env("HOME", home.display().to_string());
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::write(b"\x1b[A".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::write(b"\n".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::write(b"\x1b[A".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::write(b"\n".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("recalled slash relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    let intercept_count = output
+        .events
+        .iter()
+        .filter(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some("/skills detail xlsx")
+                && event.component.as_deref() == Some("slash")
+        })
+        .count();
+    assert_eq!(intercept_count, 2, "{rendered_text}");
+    assert!(
+        !rendered_text.contains("bash: /skills: No such file or directory"),
+        "{rendered_text}"
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
 fn raw_relay_zsh_preserves_session_history() {
     if Command::new("zsh").arg("--version").output().is_err() {
         return;


### PR DESCRIPTION
## Description

Route every Bash prompt submission through the shell marker instead of suppressing
submissions whose history number and text match the previous command. Bash Readline
can preserve both values under `HISTCONTROL=ignoredups`, which allowed recalled slash
commands to reach Bash. A PTY regression test now recalls the same `/skills` command
twice and verifies both submissions are intercepted.

## Related Issue

closes #1696

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --package cosh-shell --test shell_host -- --test-threads=4`
- `cargo test --workspace --locked -- --test-threads=1`

## Additional Notes

The parallel workspace run exposed an unrelated HOME environment race between
existing tests. The affected test passed in isolation, and the complete serial
workspace run passed.
