### PR TITLE
fix(skillfs): prefix control socket errors

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -1025,12 +1025,12 @@ async fn cmd_mount(
     let control_plane_enabled = control_socket.is_some() || trusted_peer_exe.is_some();
     if control_plane_enabled {
         if !security {
-            return Err("control socket requires --security (the control socket \
+            return Err("--control-socket requires --security (the control socket \
                  writes activation state through the active resolver)"
                 .into());
         }
         if activation_mode != ActivationMode::File {
-            return Err("control socket requires --activation-mode file (the \
+            return Err("--control-socket requires --activation-mode file (the \
                  control socket writes activation files consumed by the \
                  file-based activation path)"
                 .into());
@@ -1964,7 +1964,9 @@ async fn cmd_mount(
         match (&effective_socket_path, &trusted_peer_exe) {
             (Some(socket_path), Some(exe_path)) => {
                 #[cfg(not(target_os = "linux"))]
-                return Err("control socket requires Linux (SO_PEERCRED, /proc/<pid>/exe)".into());
+                return Err(
+                    "--control-socket requires Linux (SO_PEERCRED, /proc/<pid>/exe)".into(),
+                );
 
                 #[cfg(target_os = "linux")]
                 {

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -2013,7 +2013,7 @@ fn control_socket_without_security_fails_startup() {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(
-        combined.contains("control socket requires --security"),
+        combined.contains("--control-socket requires --security"),
         "expected requires-security error, got: {combined}"
     );
 }
@@ -2042,7 +2042,7 @@ fn control_socket_without_activation_mode_file_fails_startup() {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(
-        combined.contains("control socket requires --activation-mode file"),
+        combined.contains("--control-socket requires --activation-mode file"),
         "expected requires-activation-mode-file error, got: {combined}"
     );
 }


### PR DESCRIPTION
## Description

Prefix all three control-socket prerequisite diagnostics with the public `--control-socket` flag name so tests and automation can match them consistently. Update the focused CLI startup assertions for the two Linux-reachable prerequisite paths. Preserve the current Hermes resolver compatibility and PrivateTmp validation behavior because the incompatibility expectation in #1735 predates #1517.

## Related Issue

fixes #1735

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `skillfs` (SkillFS)
- [ ] Multiple / Project-wide

## Checklist

- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective
- [x] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date

## Testing

Run from `src/skillfs`:

```bash
cargo +1.86.0 fmt --all -- --check
cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
cargo +1.86.0 test --workspace
scripts/test.sh
```

The focused `cli_startup_tests` suite passed all 69 tests, including both CLI- and config-sourced Hermes control-socket compatibility coverage. The FUSE smoke suite completed without skipping.

## Additional Notes

No Hermes incompatibility gate or PrivateTmp validation-order change is included. `cargo doc` was not required because this PR does not change public APIs or rustdoc.