### PR TITLE
fix(cosh-ng): [shell] clarify suggestion controls

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/slash/recommendations.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/recommendations.rs
@@ -92,8 +92,8 @@ fn set_enabled<W: Write>(
                     .to_string(),
                     localized(
                         &state.i18n(),
-                        "Command failure insights are controlled separately with /mode analysis.",
-                        "失败命令 Insight 由 /mode analysis 单独控制。",
+                        "Command failure insights are controlled separately with /mode analysis manual.",
+                        "失败命令 Insight 由 /mode analysis manual 单独控制。",
                     )
                     .to_string(),
                 ]

--- a/src/cosh-ng/crates/cosh-shell/src/slash/recommendations_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/recommendations_tests.rs
@@ -104,8 +104,9 @@ fn off_panel_points_to_mode_analysis_for_failure_insights() {
         "panel output: {normalized}"
     );
     assert!(
-        normalized
-            .contains("Command failure insights are controlled separately with /mode analysis."),
+        normalized.contains(
+            "Command failure insights are controlled separately with /mode analysis manual."
+        ),
         "panel output: {normalized}"
     );
 
@@ -160,8 +161,9 @@ fn off_panel_hint_stays_accurate_in_manual_mode() {
         .collect::<Vec<_>>()
         .join(" ");
     assert!(
-        normalized
-            .contains("Command failure insights are controlled separately with /mode analysis."),
+        normalized.contains(
+            "Command failure insights are controlled separately with /mode analysis manual."
+        ),
         "panel output: {normalized}"
     );
     assert!(

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/recommendation.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/recommendation.rs
@@ -162,6 +162,51 @@ fn raw_cli_fresh_home_initializes_recommendation_store() {
 }
 
 #[test]
+fn raw_cli_recommendations_off_renders_insight_cross_reference_hint() {
+    let home = temp_shell_home("recommendation-off-insight-hint");
+    let home_guard = TestDirectoryGuard::new(home.clone());
+    let home_str = home.to_string_lossy().to_string();
+    // Drive the real slash pipeline: off -> on -> clear. The cross-reference line
+    // must be rendered by the successful `off` result and by nothing else, so it
+    // catches a regression that drops the production wiring (a helper-only test
+    // would stay green). `on` and `clear` succeed but must not carry the hint.
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_STARTUP_BANNER", "1"),
+            ("COSH_SHELL_HEALTH_SCAN", "disabled"),
+            ("COSH_SHELL_LANG", "en-US"),
+            ("COSH_RECOMMENDATIONS_ENABLED", "1"),
+        ],
+        &home,
+        &[
+            (
+                "Prompt recommendations are on; the current AI uses recent Shell and Agent activity.",
+                b"/recommendations off\n",
+            ),
+            (
+                "Prompt recommendations are off and local recommendation data was cleared.",
+                b"/recommendations on\n",
+            ),
+            ("Prompt recommendations are on.", b"/recommendations clear\n"),
+            ("Local recommendation data was cleared.", b"exit\n"),
+        ],
+    );
+
+    let hint = "Command failure insights are controlled separately with /mode analysis manual.";
+    assert!(
+        output
+            .contains("Prompt recommendations are off and local recommendation data was cleared."),
+        "{output}"
+    );
+    // Rendered exactly once — emitted by `off`, withheld from `on` and `clear`.
+    assert_eq!(output.matches(hint).count(), 1, "{output}");
+    home_guard.remove();
+}
+
+#[test]
 fn raw_cli_selects_recommendation_without_executing_it() {
     let output = run_raw_cli_serial_with_args_env_and_delayed_input(
         "fake",


### PR DESCRIPTION
## Description

`/recommendations` controls only the AI personalization system (personalized
prompt recommendations from usage history). The `Insight: ...` message and the
ghost suggestion shown after a failed command belong to a separate system that
is controlled by `/mode analysis`. The `/help` text and the two panels never
made this split visible, so `/recommendations off` was read as "turn off all
suggestion UI" and the still-rendered Insight looked like a bug.

This change clarifies the scope of both commands without changing any behavior:

- `/help` now describes `/recommendations` as personalized prompt
  recommendations, and `/mode analysis` as the control for passive suggestions
  and command-failure insights (the `Insight:` line after a failed command),
  in both English and Chinese.
- The `/recommendations off` panel appends a hint pointing to
  `/mode analysis manual` for command-failure insights.
- The `/mode analysis manual` panel appends a hint pointing to
  `/recommendations off` for personalization, so the two independent switches
  stay mutually discoverable.

## Related Issue

closes #1717

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test --package cosh-shell --lib` — 899 passed (includes the help/panel
  text contract tests).
- `cargo test --package cosh-shell --test raw_cli -- --test-threads=4` for the
  `slash::`, `mode::`, and `recommendation::` groups — all passed, including a
  behavior regression test that drives `/recommendations off` and asserts the
  rendered cross-reference footer is emitted exactly once (not on `on`/`clear`).
- `cargo test --package cosh-shell --lib i18n::` — 7 passed (catalog parity and
  discriminant stability intact; no `MessageId` variants were added).
- `cargo fmt --check -p cosh-shell` and
  `cargo clippy --package cosh-shell --all-targets -- -D warnings` — clean.

## Additional Notes

Text-only change: no runtime behavior, control flow, or `MessageId`
discriminants were modified. The cross-reference on `/mode analysis manual`
reuses the existing `AnalysisModeManualFooter` string rather than introducing a
new catalog entry, to keep the enum discriminants stable.