### PR TITLE
fix(cosh-ng): [shell] avoid tab redraw

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -257,7 +257,6 @@ fn relay_native_passthrough(
         || starts_native_intercept_candidate(bytes, relay.native_line_state)
     {
         relay.line_buffer.push(bytes);
-        redraw_candidate_line(relay.input_events, relay.line_buffer);
         if native_candidate_should_return_to_shell(relay.input_classifier, relay.line_buffer) {
             return flush_candidate_line_to_shell(
                 relay.master,
@@ -268,6 +267,9 @@ fn relay_native_passthrough(
                 emit_activity,
             );
         }
+        // Control bytes such as Tab must reach readline without first changing
+        // the outer terminal cursor, whose display width differs from byte count.
+        redraw_candidate_line(relay.input_events, relay.line_buffer);
         return relay_candidate_line(relay, emit_activity);
     }
     // Non-slash input: send directly to PTY. Shell marker's preexec/

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -670,6 +670,44 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
 }
 
 #[test]
+fn native_slash_tab_is_not_redrawn_before_shell_completion() {
+    let (path, mut master) = output_file("native-slash-tab");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+    };
+
+    relay_passthrough_input(b"/ho", &mut relay).expect("buffer slash prefix");
+    relay_passthrough_input(b"\t", &mut relay).expect("send completion to shell");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::CandidateRedraw { input, .. } if input == b"/ho"
+    )));
+    assert!(events.iter().all(|event| !matches!(
+        event,
+        RawInputEvent::CandidateRedraw { input, .. } if input.contains(&b'\t')
+    )));
+    assert!(events.contains(&RawInputEvent::CandidateClearLine));
+    assert_eq!(fs::read(&path).expect("read test output"), b"/ho\t");
+    assert!(!line_buffer.is_active());
+    fs::remove_file(path).ok();
+}
+
+#[test]
 fn native_shell_input_reports_editing_then_empty_without_content() {
     let (path, mut master) = output_file("input-state");
     let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
## Description

Fix native slash-prefixed Tab completion display corruption in `cosh-shell`.
The relay now decides whether buffered input should return to readline before
emitting a candidate redraw, so control bytes cannot desynchronize terminal
cursor position from byte-count cleanup. Native shell completion remains
unchanged, while slash command discovery continues to be tracked in #1705.

## Related Issue

closes #1691

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test --package cosh-shell -- --test-threads=4`
- `cargo test --package cosh-shell --lib -- --test-threads=1`
- `cargo test --package cosh-shell --test shell_host raw_relay_bash_intercepts_fragmented_slash_while_typing`
- `cargo clippy --package cosh-shell --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`

## Additional Notes

`cargo clippy --package cosh-shell --all-targets -- -D warnings` currently
reports `clippy::collapsible_match` in the untouched
`crates/cosh-shell/src/recommendation/personal_process_group.rs:54`. Library
Clippy and the complete `cosh-shell` test suite pass.
