### PR TITLE
fix(cosh-ng): [core,shell] harden auth

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::time::Duration;
 
 use tokio::io::AsyncBufReadExt;
@@ -195,6 +196,74 @@ pub fn apply_auth_credentials(config: &mut CoreConfig, response: &AuthResponse) 
             .providers
             .insert(response.provider_id.clone(), provider);
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RemoveAuthProviderError {
+    NotFound,
+    NotEditable,
+}
+
+impl fmt::Display for RemoveAuthProviderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => formatter.write_str("provider not found"),
+            Self::NotEditable => formatter.write_str("provider is not removable"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemovedAuthProvider {
+    pub(crate) active_provider: Option<String>,
+}
+
+pub(crate) fn remove_auth_provider(
+    config: &mut CoreConfig,
+    provider_id: &str,
+) -> Result<RemovedAuthProvider, RemoveAuthProviderError> {
+    if !config.user_ai.providers.contains_key(provider_id) {
+        return Err(if config.ai.providers.contains_key(provider_id) {
+            RemoveAuthProviderError::NotEditable
+        } else {
+            RemoveAuthProviderError::NotFound
+        });
+    }
+
+    let was_active = config.ai.active_provider.as_deref() == Some(provider_id);
+    config.user_ai.providers.remove(provider_id);
+    if config.user_ai.active_provider.as_deref() == Some(provider_id) {
+        config.user_ai.active_provider = None;
+    }
+
+    if let Some(system_provider) = config.system_ai.providers.get(provider_id).cloned() {
+        config
+            .ai
+            .providers
+            .insert(provider_id.to_string(), system_provider);
+    } else {
+        config.ai.providers.remove(provider_id);
+    }
+
+    if was_active {
+        let active_provider = config
+            .system_ai
+            .active_provider
+            .clone()
+            .filter(|fallback| config.ai.providers.contains_key(fallback));
+        config.ai.active_provider = active_provider.clone();
+        config.ai.active_model = active_provider.as_ref().and_then(|fallback| {
+            config
+                .ai
+                .providers
+                .get(fallback)
+                .and_then(|provider| provider.model.clone())
+        });
+    }
+
+    Ok(RemovedAuthProvider {
+        active_provider: config.ai.active_provider.clone(),
+    })
 }
 
 /// Result of waiting for auth, including any stdin lines consumed during the wait.
@@ -453,6 +522,96 @@ mod tests {
                 .get("user-provider")
                 .and_then(|provider| provider.api_key.as_deref()),
             Some("sk-user")
+        );
+    }
+
+    #[test]
+    fn remove_auth_provider_drops_user_credentials_and_active_selection() {
+        let provider = ProviderConfig {
+            provider_type: Some("dashscope".to_string()),
+            api_key: Some("sk-user".to_string()),
+            model: Some("user-model".to_string()),
+            ..Default::default()
+        };
+        let mut config = CoreConfig::default();
+        config.ai.active_provider = Some("user-provider".to_string());
+        config.ai.active_model = Some("user-model".to_string());
+        config
+            .ai
+            .providers
+            .insert("user-provider".to_string(), provider.clone());
+        config.user_ai.active_provider = Some("user-provider".to_string());
+        config
+            .user_ai
+            .providers
+            .insert("user-provider".to_string(), provider);
+
+        let removed = remove_auth_provider(&mut config, "user-provider").unwrap();
+
+        assert_eq!(removed.active_provider, None);
+        assert_eq!(config.ai.active_provider, None);
+        assert_eq!(config.ai.active_model, None);
+        assert!(!config.ai.providers.contains_key("user-provider"));
+        assert!(!config.user_ai.providers.contains_key("user-provider"));
+    }
+
+    #[test]
+    fn remove_auth_provider_reveals_system_provider_with_same_id() {
+        let system_provider = ProviderConfig {
+            provider_type: Some("dashscope".to_string()),
+            api_key: Some("sk-system".to_string()),
+            model: Some("system-model".to_string()),
+            ..Default::default()
+        };
+        let user_provider = ProviderConfig {
+            provider_type: Some("openai".to_string()),
+            api_key: Some("sk-user".to_string()),
+            model: Some("user-model".to_string()),
+            ..Default::default()
+        };
+        let mut config = CoreConfig::default();
+        config.ai.active_provider = Some("shared".to_string());
+        config
+            .ai
+            .providers
+            .insert("shared".to_string(), user_provider.clone());
+        config
+            .system_ai
+            .providers
+            .insert("shared".to_string(), system_provider);
+        config.system_ai.active_provider = Some("shared".to_string());
+        config.user_ai.active_provider = Some("shared".to_string());
+        config
+            .user_ai
+            .providers
+            .insert("shared".to_string(), user_provider);
+
+        let removed = remove_auth_provider(&mut config, "shared").unwrap();
+
+        assert_eq!(removed.active_provider.as_deref(), Some("shared"));
+        assert_eq!(
+            config
+                .ai
+                .providers
+                .get("shared")
+                .and_then(|provider| provider.api_key.as_deref()),
+            Some("sk-system")
+        );
+        assert_eq!(config.ai.active_model.as_deref(), Some("system-model"));
+        assert_eq!(config.user_ai.active_provider, None);
+    }
+
+    #[test]
+    fn remove_auth_provider_rejects_system_provider() {
+        let mut config = CoreConfig::default();
+        config
+            .ai
+            .providers
+            .insert("system-provider".to_string(), ProviderConfig::default());
+
+        assert_eq!(
+            remove_auth_provider(&mut config, "system-provider"),
+            Err(RemoveAuthProviderError::NotEditable)
         );
     }
 

--- a/src/cosh-ng/crates/cosh-core/src/registry.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry.rs
@@ -195,6 +195,31 @@ fn handle_auth(
                 error: None,
             }
         }
+        "delete" => {
+            let provider_id = params
+                .get("provider_id")
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+            if provider_id.is_empty() {
+                return registry_error(request_id, "missing provider_id");
+            }
+            let removed = match crate::auth::remove_auth_provider(config, provider_id) {
+                Ok(removed) => removed,
+                Err(error) => return registry_error(request_id, &error.to_string()),
+            };
+            if let Err(error) = crate::config::persist_config(config) {
+                return registry_error(request_id, &format!("failed to persist config: {error}"));
+            }
+            OutputMessage::RegistryResponse {
+                request_id: request_id.to_string(),
+                success: true,
+                data: Some(serde_json::json!({
+                    "deleted_provider": provider_id,
+                    "active_provider": removed.active_provider,
+                })),
+                error: None,
+            }
+        }
         "prepare" => {
             let provider_type = params
                 .get("provider_type")
@@ -912,5 +937,36 @@ mod tests {
         assert!(!success);
         assert!(error.unwrap().contains("not editable"));
         assert!(!config.user_ai.providers.contains_key("system-provider"));
+    }
+
+    #[test]
+    fn auth_delete_rejects_system_provider() {
+        let mut config = CoreConfig::default();
+        config.ai.providers.insert(
+            "system-provider".to_string(),
+            ProviderConfig {
+                provider_type: Some("dashscope".to_string()),
+                api_key: Some("sk-system".to_string()),
+                ..Default::default()
+            },
+        );
+        config.system_ai = AiConfig {
+            providers: config.ai.providers.clone(),
+            ..Default::default()
+        };
+
+        let response = handle_auth(
+            "test-1",
+            "delete",
+            &serde_json::json!({ "provider_id": "system-provider" }),
+            &mut config,
+        );
+
+        let OutputMessage::RegistryResponse { success, error, .. } = response else {
+            panic!("unexpected response: {response:?}");
+        };
+        assert!(!success);
+        assert!(error.unwrap().contains("not removable"));
+        assert!(config.ai.providers.contains_key("system-provider"));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
@@ -290,6 +290,49 @@ api_key = "sk-project"
 }
 
 #[test]
+fn registry_auth_delete_removes_user_provider_and_credentials() {
+    let home = tempfile::tempdir().expect("temp home");
+    let home_config_dir = home.path().join(".copilot-shell");
+    std::fs::create_dir_all(&home_config_dir).unwrap();
+    let config_path = home_config_dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[ai]
+active_provider = "remove-me"
+
+[ai.providers.keep-me]
+type = "dashscope"
+api_key = "sk-keep"
+
+[ai.providers.remove-me]
+type = "openai"
+api_key = "sk-remove"
+model = "remove-model"
+"#,
+    )
+    .unwrap();
+
+    let response = run_registry_request_with_context(
+        "auth",
+        "delete",
+        serde_json::json!({ "provider_id": "remove-me" }),
+        home.path(),
+        None,
+    );
+
+    assert_eq!(response["success"], true);
+    assert_eq!(response["data"]["deleted_provider"], "remove-me");
+    assert!(response["data"]["active_provider"].is_null());
+
+    let persisted = std::fs::read_to_string(&config_path).unwrap();
+    assert!(!persisted.contains("[ai.providers.remove-me]"));
+    assert!(!persisted.contains("sk-remove"));
+    assert!(persisted.contains("[ai.providers.keep-me]"));
+    assert!(persisted.contains("sk-keep"));
+}
+
+#[test]
 fn registry_unknown_domain_returns_error() {
     let resp = run_registry_request("unknown_domain", "list", Value::Null);
     assert_eq!(resp["type"], "registry_response");

--- a/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
@@ -1,0 +1,88 @@
+//! Input-capture identities and routing for the multi-step auth flow.
+
+use crate::runtime::prelude::RawInputCapture;
+use crate::runtime::state::InlineState;
+
+use super::delete_confirm::DELETE_CONFIRM_OPTION_COUNT;
+use super::provider_management::{provider_action_options, ExistingProvider};
+use super::runtime::{AuthPhase, RuntimeAuthState};
+
+pub(super) fn auth_capture_id(auth: &RuntimeAuthState) -> String {
+    let scope = match &auth.phase {
+        AuthPhase::ManagingProviders => "manage".to_string(),
+        AuthPhase::ProviderAction { provider_idx } => format!("action-{provider_idx}"),
+        AuthPhase::ConfirmDelete { provider_idx } => format!("delete-{provider_idx}"),
+        AuthPhase::SelectingProvider => "select".to_string(),
+        AuthPhase::FillingField => format!("field-{}", auth.current_field),
+        AuthPhase::AliyunEcsChallenge { .. } => "aliyun-challenge".to_string(),
+    };
+    format!("{}@{scope}", auth.id)
+}
+
+pub(super) fn matches_auth_capture(auth: &RuntimeAuthState, capture_id: &str) -> bool {
+    capture_id == auth.id || capture_id == auth_capture_id(auth)
+}
+
+pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCapture> {
+    let auth = state.auth.state.as_ref()?;
+    match &auth.phase {
+        AuthPhase::ManagingProviders => Some(RawInputCapture::Question {
+            id: auth_capture_id(auth),
+            option_count: auth.existing_providers.len() + 1,
+            allow_free_text: false,
+            multiple: false,
+            secret: false,
+        }),
+        AuthPhase::ProviderAction { provider_idx } => {
+            let existing = auth.existing_providers.get(*provider_idx);
+            let option_count = provider_action_options(
+                existing.is_some_and(|provider| provider.is_active),
+                existing.map(|provider| provider.editable).unwrap_or(true),
+                existing.is_some_and(ExistingProvider::deletable),
+            )
+            .len();
+            Some(RawInputCapture::Question {
+                id: auth_capture_id(auth),
+                option_count,
+                allow_free_text: false,
+                multiple: false,
+                secret: false,
+            })
+        }
+        AuthPhase::ConfirmDelete { .. } => Some(RawInputCapture::Question {
+            id: auth_capture_id(auth),
+            option_count: DELETE_CONFIRM_OPTION_COUNT,
+            allow_free_text: false,
+            multiple: false,
+            secret: false,
+        }),
+        AuthPhase::SelectingProvider => Some(RawInputCapture::Question {
+            id: auth_capture_id(auth),
+            option_count: auth.providers.len(),
+            allow_free_text: false,
+            multiple: false,
+            secret: false,
+        }),
+        AuthPhase::FillingField => {
+            let secret = auth
+                .providers
+                .get(auth.selected_provider)
+                .and_then(|provider| provider.fields.get(auth.current_field))
+                .is_some_and(|field| field.secret);
+            Some(RawInputCapture::Question {
+                id: auth_capture_id(auth),
+                option_count: 0,
+                allow_free_text: true,
+                multiple: false,
+                secret,
+            })
+        }
+        AuthPhase::AliyunEcsChallenge { .. } => Some(RawInputCapture::Question {
+            id: auth_capture_id(auth),
+            option_count: 1,
+            allow_free_text: false,
+            multiple: false,
+            secret: false,
+        }),
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/delete_confirm.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/delete_confirm.rs
@@ -1,0 +1,126 @@
+//! Destructive provider-delete confirmation and result rendering.
+
+use std::io::{self, Write};
+
+use crate::adapter::AdapterInstance;
+use crate::runtime::prelude::{
+    NoticePanelModel, QuestionInputFeedback, QuestionPanelModel, QuestionSelectionMode,
+    RatatuiInlineRenderer,
+};
+
+use super::provider_management::{core_auth_delete, load_core_auth_state};
+use super::runtime::{AuthPhase, RuntimeAuthState};
+
+pub(super) const DELETE_CONFIRM_OPTION_COUNT: usize = 2;
+const DELETE_OPTION_INDEX: usize = 1;
+
+pub(super) fn begin_delete_confirmation(auth: &mut RuntimeAuthState, provider_idx: usize) {
+    auth.phase = AuthPhase::ConfirmDelete { provider_idx };
+    auth.selected_provider = 0;
+}
+
+pub(super) fn focus_delete_confirmation(auth: &mut RuntimeAuthState, selected: usize) {
+    auth.selected_provider = selected.min(DELETE_CONFIRM_OPTION_COUNT - 1);
+}
+
+pub(super) enum DeleteConfirmationOutcome {
+    Cancelled,
+    Deleted {
+        provider_name: String,
+        needs_reselection: bool,
+    },
+}
+
+pub(super) fn submit_delete_confirmation(
+    adapter: &AdapterInstance,
+    auth: &mut RuntimeAuthState,
+    provider_idx: usize,
+) -> Result<DeleteConfirmationOutcome, String> {
+    if auth.selected_provider != DELETE_OPTION_INDEX {
+        auth.phase = AuthPhase::ProviderAction { provider_idx };
+        auth.selected_provider = 0;
+        return Ok(DeleteConfirmationOutcome::Cancelled);
+    }
+
+    let existing = auth
+        .existing_providers
+        .get(provider_idx)
+        .cloned()
+        .ok_or_else(|| "provider selection is no longer valid".to_string())?;
+    core_auth_delete(adapter, &existing.name)?;
+    let AdapterInstance::CoshCore(cosh_core) = adapter else {
+        return Err("auth registry requires cosh-core backend".to_string());
+    };
+    let core_state = load_core_auth_state(cosh_core)?;
+    auth.existing_providers = core_state.existing_providers;
+    auth.phase = AuthPhase::ManagingProviders;
+    auth.selected_provider = 0;
+    let needs_reselection = existing.is_active
+        && !auth
+            .existing_providers
+            .iter()
+            .any(|provider| provider.is_active);
+
+    Ok(DeleteConfirmationOutcome::Deleted {
+        provider_name: existing.name,
+        needs_reselection,
+    })
+}
+
+pub(super) fn render_delete_confirmation<W: Write>(
+    auth: &RuntimeAuthState,
+    provider_idx: usize,
+    panel_id: &str,
+    renderer: &RatatuiInlineRenderer,
+    output: &mut W,
+) -> io::Result<usize> {
+    let provider = auth
+        .existing_providers
+        .get(provider_idx)
+        .ok_or_else(|| io::Error::other("provider selection is no longer valid"))?;
+    let question = format!(
+        "Delete provider \"{}\"?\nThis removes its saved credentials and cannot be undone.",
+        provider.name
+    );
+    let options = vec!["Cancel".to_string(), "Delete provider".to_string()];
+    renderer.write_question_panel(
+        output,
+        QuestionPanelModel {
+            id: panel_id,
+            question: &question,
+            options: &options,
+            selected_option: auth.selected_provider,
+            selected_options: &[],
+            custom_answer: "",
+            allow_free_text: false,
+            selection_mode: QuestionSelectionMode::Single,
+            input_feedback: QuestionInputFeedback::Disabled,
+        },
+    )
+}
+
+pub(super) fn render_delete_outcome<W: Write>(
+    outcome: &DeleteConfirmationOutcome,
+    renderer: &RatatuiInlineRenderer,
+    output: &mut W,
+) -> io::Result<()> {
+    let DeleteConfirmationOutcome::Deleted {
+        provider_name,
+        needs_reselection,
+    } = outcome
+    else {
+        return Ok(());
+    };
+    let mut body = vec![format!("Removed provider \"{provider_name}\".")];
+    if *needs_reselection {
+        body.push("Select a provider to make it active.".to_string());
+    }
+    renderer.write_notice_panel(
+        output,
+        NoticePanelModel {
+            title: "Provider deleted",
+            body,
+            footer: None,
+        },
+    )
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
@@ -1,5 +1,9 @@
+mod capture;
 mod completion;
+mod delete_confirm;
 pub(crate) mod provider_display;
+mod provider_management;
+mod retry;
 pub(crate) mod runtime;
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/auth/provider_management.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/provider_management.rs
@@ -1,0 +1,269 @@
+//! Provider state and registry operations for the `/auth` management flow.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::adapter::{AdapterInstance, CoshCoreAdapter};
+use crate::runtime::prelude::{AuthProviderInfo, AuthResponse};
+
+/// A configured provider displayed by the provider-management panel.
+#[derive(Debug, Clone)]
+pub(crate) struct ExistingProvider {
+    pub(crate) name: String,
+    pub(crate) provider_type: String,
+    pub(crate) label: String,
+    pub(crate) model: String,
+    pub(crate) is_active: bool,
+    pub(crate) editable: bool,
+    pub(crate) source: String,
+    pub(crate) base_url: Option<String>,
+    pub(crate) api_key_mask: Option<String>,
+    pub(crate) access_key_id_mask: Option<String>,
+    pub(crate) access_key_secret_mask: Option<String>,
+    pub(crate) security_token_mask: Option<String>,
+    pub(crate) auth_source: Option<String>,
+}
+
+impl ExistingProvider {
+    pub(super) fn deletable(&self) -> bool {
+        self.source == "user"
+    }
+}
+
+pub(super) struct CoreAuthState {
+    pub(super) templates: Vec<AuthProviderInfo>,
+    pub(super) existing_providers: Vec<ExistingProvider>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryAuthState {
+    templates: Vec<AuthProviderInfo>,
+    #[serde(default)]
+    saved_providers: Vec<CoreSavedProvider>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CoreSavedProvider {
+    provider_id: String,
+    provider_type: Option<String>,
+    model: Option<String>,
+    base_url: Option<String>,
+    auth_source: Option<String>,
+    active: bool,
+    #[serde(default = "default_provider_source")]
+    source: String,
+    #[serde(default = "default_provider_editable")]
+    editable: bool,
+    #[serde(default)]
+    api_key_len: usize,
+    #[serde(default)]
+    access_key_id_len: usize,
+    #[serde(default)]
+    access_key_secret_len: usize,
+    #[serde(default)]
+    security_token_len: usize,
+}
+
+fn default_provider_source() -> String {
+    "user".to_string()
+}
+
+fn default_provider_editable() -> bool {
+    true
+}
+
+fn secret_mask(len: usize) -> String {
+    "•".repeat(len)
+}
+
+fn label_for_provider_type(provider_type: &str) -> &'static str {
+    match provider_type {
+        "dashscope" => "DashScope (\u{767e}\u{70bc})",
+        "aliyun" => "Aliyun Authentication",
+        _ => "OpenAI Compatible",
+    }
+}
+
+impl From<CoreSavedProvider> for ExistingProvider {
+    fn from(provider: CoreSavedProvider) -> Self {
+        let provider_type = provider
+            .provider_type
+            .unwrap_or_else(|| "openai_compat".to_string());
+        let model = provider.model.unwrap_or_default();
+        Self {
+            name: provider.provider_id,
+            label: label_for_provider_type(&provider_type).to_string(),
+            provider_type,
+            model,
+            is_active: provider.active,
+            editable: provider.editable,
+            source: provider.source,
+            base_url: provider.base_url,
+            api_key_mask: (provider.api_key_len > 0).then(|| secret_mask(provider.api_key_len)),
+            access_key_id_mask: (provider.access_key_id_len > 0)
+                .then(|| secret_mask(provider.access_key_id_len)),
+            access_key_secret_mask: (provider.access_key_secret_len > 0)
+                .then(|| secret_mask(provider.access_key_secret_len)),
+            security_token_mask: (provider.security_token_len > 0)
+                .then(|| secret_mask(provider.security_token_len)),
+            auth_source: provider.auth_source,
+        }
+    }
+}
+
+pub(super) fn load_core_auth_state(cosh_core: &CoshCoreAdapter) -> Result<CoreAuthState, String> {
+    let value = cosh_core.registry_query("auth", "state", Value::Null)?;
+    let state: RegistryAuthState =
+        serde_json::from_value(value).map_err(|error| format!("invalid auth state: {error}"))?;
+    let mut existing_providers: Vec<ExistingProvider> = state
+        .saved_providers
+        .into_iter()
+        .map(ExistingProvider::from)
+        .collect();
+    existing_providers.sort_by(|left, right| {
+        right
+            .is_active
+            .cmp(&left.is_active)
+            .then(left.name.cmp(&right.name))
+    });
+    Ok(CoreAuthState {
+        templates: state.templates,
+        existing_providers,
+    })
+}
+
+pub(super) fn core_auth_activate(
+    adapter: &AdapterInstance,
+    provider_id: &str,
+) -> Result<(), String> {
+    let AdapterInstance::CoshCore(cosh_core) = adapter else {
+        return Err("auth registry requires cosh-core backend".to_string());
+    };
+    cosh_core
+        .registry_query("auth", "activate", json!({ "provider_id": provider_id }))
+        .map(|_| ())
+}
+
+pub(super) fn core_auth_delete(adapter: &AdapterInstance, provider_id: &str) -> Result<(), String> {
+    let AdapterInstance::CoshCore(cosh_core) = adapter else {
+        return Err("auth registry requires cosh-core backend".to_string());
+    };
+    cosh_core
+        .registry_query("auth", "delete", json!({ "provider_id": provider_id }))
+        .map(|_| ())
+}
+
+pub(super) fn core_auth_configure(
+    adapter: &AdapterInstance,
+    response: &AuthResponse,
+) -> Result<(), String> {
+    let AdapterInstance::CoshCore(cosh_core) = adapter else {
+        return Err("auth registry requires cosh-core backend".to_string());
+    };
+    cosh_core
+        .registry_query(
+            "auth",
+            "configure",
+            json!({
+                "provider_id": response.provider_id,
+                "provider_type": response.provider_type,
+                "values": response.values,
+            }),
+        )
+        .map(|_| ())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProviderAction {
+    Activate,
+    Edit,
+    Delete,
+    Cancel,
+}
+
+impl ProviderAction {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Activate => "Set as active provider",
+            Self::Edit => "Edit configuration",
+            Self::Delete => "Delete provider",
+            Self::Cancel => "Cancel",
+        }
+    }
+}
+
+pub(super) fn provider_actions(
+    is_active: bool,
+    editable: bool,
+    deletable: bool,
+) -> Vec<ProviderAction> {
+    let mut actions = Vec::new();
+    if !is_active {
+        actions.push(ProviderAction::Activate);
+    }
+    if editable {
+        actions.push(ProviderAction::Edit);
+    }
+    if deletable {
+        actions.push(ProviderAction::Delete);
+    }
+    actions.push(ProviderAction::Cancel);
+    actions
+}
+
+pub(super) fn provider_action_options(
+    is_active: bool,
+    editable: bool,
+    deletable: bool,
+) -> Vec<String> {
+    provider_actions(is_active, editable, deletable)
+        .into_iter()
+        .map(|action| action.label().to_string())
+        .collect()
+}
+
+pub(super) fn provider_action_choice(
+    is_active: bool,
+    editable: bool,
+    deletable: bool,
+    selected: usize,
+) -> ProviderAction {
+    provider_actions(is_active, editable, deletable)
+        .get(selected)
+        .copied()
+        .unwrap_or(ProviderAction::Cancel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{provider_action_choice, provider_action_options, ProviderAction};
+
+    #[test]
+    fn user_provider_actions_include_delete() {
+        assert_eq!(
+            provider_action_options(false, true, true),
+            vec![
+                "Set as active provider",
+                "Edit configuration",
+                "Delete provider",
+                "Cancel",
+            ]
+        );
+        assert_eq!(
+            provider_action_choice(false, true, true, 2),
+            ProviderAction::Delete
+        );
+    }
+
+    #[test]
+    fn system_provider_actions_exclude_edit_and_delete() {
+        assert_eq!(
+            provider_action_options(false, false, false),
+            vec!["Set as active provider", "Cancel"]
+        );
+        assert_eq!(
+            provider_action_choice(false, false, false, 1),
+            ProviderAction::Cancel
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
@@ -1,0 +1,21 @@
+//! State restoration after an auth configuration submission fails.
+
+use super::runtime::{AuthPhase, RuntimeAuthState};
+
+pub(super) fn restore_after_failed_submission(auth: &mut RuntimeAuthState) {
+    auth.phase = AuthPhase::FillingField;
+    auth.current_field = 0;
+    auth.collected_values.clear();
+    auth.field_input.clear();
+    if let Some(provider_id) = auth.editing_provider_name.clone() {
+        let fields = &auth.providers[auth.selected_provider].fields;
+        // Slash auth prepends provider_id before edit mode, so retries preserve that identity.
+        debug_assert_eq!(
+            fields.first().map(|field| field.name.as_str()),
+            Some("provider_id")
+        );
+        auth.collected_values
+            .insert("provider_id".to_string(), provider_id);
+        auth.current_field = 1.min(fields.len());
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -1,71 +1,30 @@
 use std::collections::{HashMap, HashSet};
 
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::json;
 
-use crate::adapter::{AdapterInstance, CoshCoreAdapter};
+use crate::adapter::AdapterInstance;
+use crate::auth::capture::{auth_capture_id, matches_auth_capture};
 use crate::auth::completion::finish_auth_configuration;
+use crate::auth::delete_confirm::{
+    begin_delete_confirmation, focus_delete_confirmation, render_delete_confirmation,
+    render_delete_outcome, submit_delete_confirmation,
+};
 use crate::auth::provider_display::auth_required_providers_for_display;
+use crate::auth::provider_management::{
+    core_auth_activate, core_auth_configure, load_core_auth_state, provider_action_choice,
+    provider_action_options, ExistingProvider, ProviderAction,
+};
+use crate::auth::retry::restore_after_failed_submission;
 use crate::runtime::dispatcher::stable_event_key;
 use crate::runtime::prelude::{
     AgentEvent, AuthFieldInfo, AuthProviderInfo, AuthResponse, GovernedEvent, NoticePanelModel,
     QuestionInputFeedback, QuestionPanelModel, QuestionSelectionMode, RatatuiInlineRenderer,
-    RawInputCapture, ShellEvent, ShellEventKind,
+    ShellEvent, ShellEventKind,
 };
 use crate::runtime::state::InlineState;
 
-/// An existing provider loaded from config.toml for the ManagingProviders phase.
-#[derive(Debug, Clone)]
-pub(crate) struct ExistingProvider {
-    pub(crate) name: String,          // section name (e.g. "default")
-    pub(crate) provider_type: String, // type field value
-    pub(crate) label: String,         // display name based on type
-    pub(crate) model: String,         // current model
-    pub(crate) is_active: bool,       // whether this is the active_provider
-    pub(crate) editable: bool,
-    pub(crate) source: String,
-    pub(crate) base_url: Option<String>,
-    pub(crate) api_key_mask: Option<String>,
-    pub(crate) access_key_id_mask: Option<String>,
-    pub(crate) access_key_secret_mask: Option<String>,
-    pub(crate) security_token_mask: Option<String>,
-    pub(crate) auth_source: Option<String>,
-}
-
-fn secret_mask(len: usize) -> String {
-    "•".repeat(len)
-}
-
-fn label_for_provider_type(provider_type: &str) -> &'static str {
-    match provider_type {
-        "dashscope" => "DashScope (\u{767e}\u{70bc})",
-        "aliyun" => "Aliyun Authentication",
-        _ => "OpenAI Compatible",
-    }
-}
-
-fn provider_action_options(is_active: bool, editable: bool) -> Vec<String> {
-    match (is_active, editable) {
-        (true, true) => vec!["Edit configuration".to_string(), "Cancel".to_string()],
-        (true, false) => vec!["Cancel".to_string()],
-        (false, true) => vec![
-            "Set as active provider".to_string(),
-            "Edit configuration".to_string(),
-            "Cancel".to_string(),
-        ],
-        (false, false) => vec!["Set as active provider".to_string(), "Cancel".to_string()],
-    }
-}
-
-fn provider_action_choice(is_active: bool, editable: bool, selected: usize) -> &'static str {
-    match (is_active, editable, selected) {
-        (true, true, 0) => "edit",
-        (true, _, _) => "cancel",
-        (false, _, 0) => "activate",
-        (false, true, 1) => "edit",
-        _ => "cancel",
-    }
-}
+pub(crate) use crate::auth::capture::pending_auth_capture;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeAuthState {
@@ -97,6 +56,10 @@ pub(crate) enum AuthPhase {
     ManagingProviders,
     /// Action menu after selecting an existing provider
     ProviderAction {
+        provider_idx: usize,
+    },
+    /// Require explicit confirmation before removing a user-owned provider.
+    ConfirmDelete {
         provider_idx: usize,
     },
     SelectingProvider,
@@ -184,62 +147,6 @@ pub(crate) fn render_auth_panel<W: std::io::Write>(
     Ok(())
 }
 
-pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCapture> {
-    let auth = state.auth.state.as_ref()?;
-    match &auth.phase {
-        AuthPhase::ManagingProviders => Some(RawInputCapture::Question {
-            id: auth.id.clone(),
-            option_count: auth.existing_providers.len() + 1,
-            allow_free_text: false,
-            multiple: false,
-            secret: false,
-        }),
-        AuthPhase::ProviderAction { provider_idx } => {
-            let existing = auth.existing_providers.get(*provider_idx);
-            let option_count = provider_action_options(
-                existing.is_some_and(|provider| provider.is_active),
-                existing.map(|provider| provider.editable).unwrap_or(true),
-            )
-            .len();
-            Some(RawInputCapture::Question {
-                id: auth.id.clone(),
-                option_count,
-                allow_free_text: false,
-                multiple: false,
-                secret: false,
-            })
-        }
-        AuthPhase::SelectingProvider => Some(RawInputCapture::Question {
-            id: auth.id.clone(),
-            option_count: auth.providers.len(),
-            allow_free_text: false,
-            multiple: false,
-            secret: false,
-        }),
-        AuthPhase::FillingField => {
-            let secret = auth
-                .providers
-                .get(auth.selected_provider)
-                .and_then(|provider| provider.fields.get(auth.current_field))
-                .is_some_and(|field| field.secret);
-            Some(RawInputCapture::Question {
-                id: auth.id.clone(),
-                option_count: 0,
-                allow_free_text: true,
-                multiple: false,
-                secret,
-            })
-        }
-        AuthPhase::AliyunEcsChallenge { .. } => Some(RawInputCapture::Question {
-            id: auth.id.clone(),
-            option_count: 1,
-            allow_free_text: false,
-            multiple: false,
-            secret: false,
-        }),
-    }
-}
-
 pub(crate) fn has_pending_auth(state: &InlineState) -> bool {
     state.auth.state.is_some()
 }
@@ -299,12 +206,7 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
     );
     let id = format!("auth-{request_id}");
 
-    let mut existing_providers: Vec<ExistingProvider> = core_state
-        .saved_providers
-        .into_iter()
-        .map(ExistingProvider::from)
-        .collect();
-    existing_providers.sort_by(|a, b| b.is_active.cmp(&a.is_active).then(a.name.cmp(&b.name)));
+    let existing_providers = core_state.existing_providers;
 
     // If there are existing providers, start in ManagingProviders phase
     let phase = if existing_providers.is_empty() {
@@ -329,74 +231,6 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
 
     render_current_auth_panel(state, output)?;
     Ok(())
-}
-
-#[derive(Debug, Deserialize)]
-struct CoreAuthState {
-    templates: Vec<AuthProviderInfo>,
-    #[serde(default)]
-    saved_providers: Vec<CoreSavedProvider>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CoreSavedProvider {
-    provider_id: String,
-    provider_type: Option<String>,
-    model: Option<String>,
-    base_url: Option<String>,
-    auth_source: Option<String>,
-    active: bool,
-    #[serde(default = "default_provider_source")]
-    source: String,
-    #[serde(default = "default_provider_editable")]
-    editable: bool,
-    #[serde(default)]
-    api_key_len: usize,
-    #[serde(default)]
-    access_key_id_len: usize,
-    #[serde(default)]
-    access_key_secret_len: usize,
-    #[serde(default)]
-    security_token_len: usize,
-}
-
-fn default_provider_source() -> String {
-    "user".to_string()
-}
-
-fn default_provider_editable() -> bool {
-    true
-}
-
-fn load_core_auth_state(cosh_core: &CoshCoreAdapter) -> Result<CoreAuthState, String> {
-    let value = cosh_core.registry_query("auth", "state", Value::Null)?;
-    serde_json::from_value(value).map_err(|e| format!("invalid auth state: {e}"))
-}
-
-fn core_auth_activate(adapter: &AdapterInstance, provider_id: &str) -> Result<(), String> {
-    let AdapterInstance::CoshCore(cosh_core) = adapter else {
-        return Err("auth registry requires cosh-core backend".to_string());
-    };
-    cosh_core
-        .registry_query("auth", "activate", json!({ "provider_id": provider_id }))
-        .map(|_| ())
-}
-
-fn core_auth_configure(adapter: &AdapterInstance, response: &AuthResponse) -> Result<(), String> {
-    let AdapterInstance::CoshCore(cosh_core) = adapter else {
-        return Err("auth registry requires cosh-core backend".to_string());
-    };
-    cosh_core
-        .registry_query(
-            "auth",
-            "configure",
-            json!({
-                "provider_id": response.provider_id,
-                "provider_type": response.provider_type,
-                "values": response.values,
-            }),
-        )
-        .map(|_| ())
 }
 
 #[derive(Debug, Deserialize)]
@@ -442,33 +276,6 @@ fn core_auth_prepare(
     serde_json::from_value(value).map_err(|e| format!("invalid auth prepare response: {e}"))
 }
 
-impl From<CoreSavedProvider> for ExistingProvider {
-    fn from(provider: CoreSavedProvider) -> Self {
-        let provider_type = provider
-            .provider_type
-            .unwrap_or_else(|| "openai_compat".to_string());
-        let model = provider.model.unwrap_or_default();
-        ExistingProvider {
-            name: provider.provider_id,
-            label: label_for_provider_type(&provider_type).to_string(),
-            provider_type,
-            model,
-            is_active: provider.active,
-            editable: provider.editable,
-            source: provider.source,
-            base_url: provider.base_url,
-            api_key_mask: (provider.api_key_len > 0).then(|| secret_mask(provider.api_key_len)),
-            access_key_id_mask: (provider.access_key_id_len > 0)
-                .then(|| secret_mask(provider.access_key_id_len)),
-            access_key_secret_mask: (provider.access_key_secret_len > 0)
-                .then(|| secret_mask(provider.access_key_secret_len)),
-            security_token_mask: (provider.security_token_len > 0)
-                .then(|| secret_mask(provider.security_token_len)),
-            auth_source: provider.auth_source,
-        }
-    }
-}
-
 fn providers_with_provider_id_field(providers: Vec<AuthProviderInfo>) -> Vec<AuthProviderInfo> {
     providers
         .into_iter()
@@ -498,7 +305,7 @@ fn handle_auth_focus<W: std::io::Write>(
     let Some(auth) = state.auth.state.as_mut() else {
         return Ok(false);
     };
-    if auth.id != id {
+    if !matches_auth_capture(auth, id) {
         return Ok(false);
     }
     match auth.phase {
@@ -510,6 +317,11 @@ fn handle_auth_focus<W: std::io::Write>(
         }
         AuthPhase::ProviderAction { .. } => {
             auth.selected_provider = selected;
+            clear_active_auth_panel(state, output)?;
+            render_current_auth_panel(state, output)?;
+        }
+        AuthPhase::ConfirmDelete { .. } => {
+            focus_delete_confirmation(auth, selected);
             clear_active_auth_panel(state, output)?;
             render_current_auth_panel(state, output)?;
         }
@@ -532,7 +344,7 @@ fn handle_auth_input<W: std::io::Write>(
     let Some(auth) = state.auth.state.as_mut() else {
         return Ok(false);
     };
-    if auth.id != id {
+    if !matches_auth_capture(auth, id) {
         return Ok(false);
     }
     if auth.phase == AuthPhase::FillingField {
@@ -553,7 +365,7 @@ fn handle_auth_answer<W: std::io::Write>(
     let Some(auth) = state.auth.state.as_mut() else {
         return Ok(false);
     };
-    if auth.id != id {
+    if !matches_auth_capture(auth, id) {
         return Ok(false);
     }
 
@@ -583,11 +395,13 @@ fn handle_auth_answer<W: std::io::Write>(
             let existing = auth.existing_providers[provider_idx].clone();
             let is_active = existing.is_active;
             let editable = existing.editable;
+            let deletable = existing.deletable();
 
-            let action = provider_action_choice(is_active, editable, auth.selected_provider);
+            let action =
+                provider_action_choice(is_active, editable, deletable, auth.selected_provider);
 
             match action {
-                "activate" => {
+                ProviderAction::Activate => {
                     core_auth_activate(adapter, &existing.name).map_err(std::io::Error::other)?;
                     // Clear and show confirmation
                     state.auth.state.take();
@@ -613,7 +427,7 @@ fn handle_auth_answer<W: std::io::Write>(
                     }
                     output.flush()?;
                 }
-                "edit" => {
+                ProviderAction::Edit => {
                     // Enter edit mode for this provider
                     let provider_type = existing.provider_type.as_str();
                     let template_idx = auth
@@ -678,7 +492,12 @@ fn handle_auth_answer<W: std::io::Write>(
                     clear_active_auth_panel(state, output)?;
                     render_current_auth_panel(state, output)?;
                 }
-                _ => {
+                ProviderAction::Delete => {
+                    begin_delete_confirmation(auth, provider_idx);
+                    clear_active_auth_panel(state, output)?;
+                    render_current_auth_panel(state, output)?;
+                }
+                ProviderAction::Cancel => {
                     // Cancel -> back to ManagingProviders
                     auth.phase = AuthPhase::ManagingProviders;
                     auth.selected_provider = provider_idx;
@@ -686,6 +505,15 @@ fn handle_auth_answer<W: std::io::Write>(
                     render_current_auth_panel(state, output)?;
                 }
             }
+            Ok(true)
+        }
+        AuthPhase::ConfirmDelete { provider_idx } => {
+            let outcome = submit_delete_confirmation(adapter, auth, provider_idx)
+                .map_err(std::io::Error::other)?;
+            clear_active_auth_panel(state, output)?;
+            let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+            render_delete_outcome(&outcome, &renderer, output)?;
+            render_current_auth_panel(state, output)?;
             Ok(true)
         }
         AuthPhase::SelectingProvider => {
@@ -834,9 +662,9 @@ fn send_auth_response<W: std::io::Write>(
     state: &mut InlineState,
     output: &mut W,
 ) -> std::io::Result<()> {
-    let auth = state.auth.state.take().expect("auth state present");
-    state.auth.completed_ids.insert(auth.id.clone());
+    let mut auth = state.auth.state.take().expect("auth state present");
     let provider = &auth.providers[auth.selected_provider];
+    let provider_label = provider.label.clone();
     let provider_id = auth
         .editing_provider_name
         .clone()
@@ -846,7 +674,7 @@ fn send_auth_response<W: std::io::Write>(
         request_id: auth.request_id.clone(),
         provider_id: provider_id.clone(),
         provider_type: Some(provider.id.clone()),
-        values: auth.collected_values,
+        values: auth.collected_values.clone(),
         persist: true,
     };
 
@@ -864,6 +692,7 @@ fn send_auth_response<W: std::io::Write>(
                     footer: None,
                 },
             )?;
+            state.auth.completed_ids.insert(auth.id);
             output.flush()?;
             return Ok(());
         }
@@ -873,13 +702,29 @@ fn send_auth_response<W: std::io::Write>(
                 let adapter = adapter.ok_or_else(|| {
                     std::io::Error::other("missing adapter for cosh-core auth registry")
                 })?;
-                core_auth_configure(adapter, &response).map_err(std::io::Error::other)?;
+                if let Err(error) = core_auth_configure(adapter, &response) {
+                    restore_after_failed_submission(&mut auth);
+                    state.auth.state = Some(auth);
+                    let renderer =
+                        RatatuiInlineRenderer::for_terminal().with_language(state.language);
+                    renderer.write_notice_panel(
+                        output,
+                        NoticePanelModel {
+                            title: "Credentials were not saved",
+                            body: vec![error, "Review the values and try again.".to_string()],
+                            footer: None,
+                        },
+                    )?;
+                    render_current_auth_panel(state, output)?;
+                    return Ok(());
+                }
             }
             AuthBackend::ActiveRun => {}
         }
     }
 
-    finish_auth_configuration(state, output, &provider.label)
+    state.auth.completed_ids.insert(auth.id);
+    finish_auth_configuration(state, output, &provider_label)
 }
 
 fn render_current_auth_panel<W: std::io::Write>(
@@ -890,6 +735,7 @@ fn render_current_auth_panel<W: std::io::Write>(
         return Ok(());
     };
     let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+    let panel_id = auth_capture_id(auth);
 
     match auth.phase {
         AuthPhase::ManagingProviders => {
@@ -917,7 +763,7 @@ fn render_current_auth_panel<W: std::io::Write>(
             options.push("  + Add new provider".to_string());
 
             let model = QuestionPanelModel {
-                id: &auth.id,
+                id: &panel_id,
                 question: "\u{1f511} Provider Management \u{2014} Select your AI provider:",
                 options: &options,
                 selected_option: auth.selected_provider,
@@ -929,14 +775,14 @@ fn render_current_auth_panel<W: std::io::Write>(
             };
             let height = renderer.write_question_panel(output, model)?;
             state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(auth.id.clone());
+            state.questions.active_panel_id = Some(panel_id.clone());
         }
         AuthPhase::ProviderAction { provider_idx } => {
             let ep = &auth.existing_providers[provider_idx];
             let title = format!("\u{1f511} {} \u{2014} \"{}\":", ep.label, ep.name);
-            let options = provider_action_options(ep.is_active, ep.editable);
+            let options = provider_action_options(ep.is_active, ep.editable, ep.deletable());
             let model = QuestionPanelModel {
-                id: &auth.id,
+                id: &panel_id,
                 question: &title,
                 options: &options,
                 selected_option: auth.selected_provider,
@@ -948,12 +794,18 @@ fn render_current_auth_panel<W: std::io::Write>(
             };
             let height = renderer.write_question_panel(output, model)?;
             state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(auth.id.clone());
+            state.questions.active_panel_id = Some(panel_id.clone());
+        }
+        AuthPhase::ConfirmDelete { provider_idx } => {
+            let height =
+                render_delete_confirmation(auth, provider_idx, &panel_id, &renderer, output)?;
+            state.questions.active_panel_height = height;
+            state.questions.active_panel_id = Some(panel_id.clone());
         }
         AuthPhase::SelectingProvider => {
             let options: Vec<String> = auth.providers.iter().map(|p| p.label.clone()).collect();
             let model = QuestionPanelModel {
-                id: &auth.id,
+                id: &panel_id,
                 question: "\u{1f511} Authentication Required \u{2014} Select your AI provider:",
                 options: &options,
                 selected_option: auth.selected_provider,
@@ -965,7 +817,7 @@ fn render_current_auth_panel<W: std::io::Write>(
             };
             let height = renderer.write_question_panel(output, model)?;
             state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(auth.id.clone());
+            state.questions.active_panel_id = Some(panel_id.clone());
         }
         AuthPhase::FillingField => {
             let field = auth.current_field_info();
@@ -996,7 +848,7 @@ fn render_current_auth_panel<W: std::io::Write>(
                 question.push_str("\n  > ");
             }
             let model = QuestionPanelModel {
-                id: &auth.id,
+                id: &panel_id,
                 question: &question,
                 options: &[],
                 selected_option: 0,
@@ -1008,7 +860,7 @@ fn render_current_auth_panel<W: std::io::Write>(
             };
             let height = renderer.write_question_panel(output, model)?;
             state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(auth.id.clone());
+            state.questions.active_panel_id = Some(panel_id.clone());
         }
         AuthPhase::AliyunEcsChallenge {
             ref instance_id,
@@ -1023,7 +875,7 @@ fn render_current_auth_panel<W: std::io::Write>(
             }
             let options = vec!["I have authorized this ECS instance".to_string()];
             let model = QuestionPanelModel {
-                id: &auth.id,
+                id: &panel_id,
                 question: &question,
                 options: &options,
                 selected_option: 0,
@@ -1035,7 +887,7 @@ fn render_current_auth_panel<W: std::io::Write>(
             };
             let height = renderer.write_question_panel(output, model)?;
             state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(auth.id.clone());
+            state.questions.active_panel_id = Some(panel_id);
         }
     }
     output.flush()?;
@@ -1146,8 +998,12 @@ pub(crate) fn render_auth_card_actions<W: std::io::Write>(
             }
             Some("cancel") | Some("question_cancel") => {
                 if let Some(cancel_id) = event.input.as_deref() {
-                    let auth_id = state.auth.state.as_ref().map(|a| a.id.clone());
-                    if auth_id.as_deref() == Some(cancel_id.trim()) {
+                    let matches_pending = state
+                        .auth
+                        .state
+                        .as_ref()
+                        .is_some_and(|auth| matches_auth_capture(auth, cancel_id.trim()));
+                    if matches_pending {
                         cancel_auth_panel(state, output)?;
                     }
                 }
@@ -1226,39 +1082,11 @@ fn generate_qr_text(data: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        clear_ecs_auth_source_for_manual_aliyun_edit, provider_action_choice,
-        provider_action_options, should_apply_aliyun_prepare_after_field,
+        clear_ecs_auth_source_for_manual_aliyun_edit, should_apply_aliyun_prepare_after_field,
         should_apply_aliyun_prepare_for_edit, should_apply_aliyun_prepare_on_provider_selection,
         AuthBackend, ExistingProvider,
     };
     use std::collections::HashMap;
-
-    #[test]
-    fn provider_action_options_hide_edit_for_non_editable_providers() {
-        assert_eq!(
-            provider_action_options(true, true),
-            vec!["Edit configuration", "Cancel"]
-        );
-        assert_eq!(provider_action_options(true, false), vec!["Cancel"]);
-        assert_eq!(
-            provider_action_options(false, true),
-            vec!["Set as active provider", "Edit configuration", "Cancel"]
-        );
-        assert_eq!(
-            provider_action_options(false, false),
-            vec!["Set as active provider", "Cancel"]
-        );
-    }
-
-    #[test]
-    fn provider_action_choice_never_edits_non_editable_providers() {
-        assert_eq!(provider_action_choice(true, true, 0), "edit");
-        assert_eq!(provider_action_choice(true, false, 0), "cancel");
-        assert_eq!(provider_action_choice(false, true, 0), "activate");
-        assert_eq!(provider_action_choice(false, true, 1), "edit");
-        assert_eq!(provider_action_choice(false, false, 0), "activate");
-        assert_eq!(provider_action_choice(false, false, 1), "cancel");
-    }
 
     #[test]
     fn core_registry_aliyun_add_waits_for_provider_id_before_prepare() {

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -1,3 +1,4 @@
+use super::retry::restore_after_failed_submission;
 use super::runtime::*;
 use crate::runtime::prelude::{
     AgentEvent, AuthFieldInfo, AuthProviderInfo, GovernanceDecision, GovernancePolicyDecision,
@@ -67,4 +68,114 @@ fn pending_auth_capture_marks_secret_fields() {
         pending_auth_capture(&state),
         Some(RawInputCapture::Question { secret: true, .. })
     ));
+}
+
+#[test]
+fn pending_auth_capture_isolates_each_auth_field() {
+    let mut provider = provider("openai_compat", "OpenAI Compatible");
+    provider.fields = vec![
+        AuthFieldInfo {
+            name: "base_url".to_string(),
+            label: "Base URL".to_string(),
+            hint: None,
+            secret: false,
+            required: true,
+            placeholder: None,
+        },
+        AuthFieldInfo {
+            name: "model".to_string(),
+            label: "Model".to_string(),
+            hint: None,
+            secret: false,
+            required: true,
+            placeholder: None,
+        },
+    ];
+    let mut state = InlineState::default();
+    record_auth_required(&mut state, &[governed_auth_required(vec![provider])]);
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.phase = AuthPhase::FillingField;
+
+    let RawInputCapture::Question { id: first_id, .. } = pending_auth_capture(&state).unwrap()
+    else {
+        panic!("expected question capture");
+    };
+    state.auth.state.as_mut().unwrap().current_field = 1;
+    let RawInputCapture::Question { id: second_id, .. } = pending_auth_capture(&state).unwrap()
+    else {
+        panic!("expected question capture");
+    };
+
+    assert_ne!(first_id, second_id);
+}
+
+#[test]
+fn failed_submission_restarts_with_clean_values() {
+    let mut provider = provider("openai_compat", "OpenAI Compatible");
+    provider.fields.push(AuthFieldInfo {
+        name: "provider_id".to_string(),
+        label: "Provider ID".to_string(),
+        hint: None,
+        secret: false,
+        required: true,
+        placeholder: None,
+    });
+    let mut state = InlineState::default();
+    record_auth_required(&mut state, &[governed_auth_required(vec![provider])]);
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.phase = AuthPhase::FillingField;
+    auth.current_field = 1;
+    auth.collected_values
+        .insert("provider_id".to_string(), "bad.provider".to_string());
+    auth.field_input = "stale-model".to_string();
+
+    restore_after_failed_submission(auth);
+
+    assert_eq!(auth.phase, AuthPhase::FillingField);
+    assert_eq!(auth.current_field, 0);
+    assert!(auth.collected_values.is_empty());
+    assert!(auth.field_input.is_empty());
+}
+
+#[test]
+fn failed_edit_submission_preserves_provider_identity() {
+    let mut provider = provider("openai_compat", "OpenAI Compatible");
+    provider.fields = vec![
+        AuthFieldInfo {
+            name: "provider_id".to_string(),
+            label: "Provider ID".to_string(),
+            hint: None,
+            secret: false,
+            required: true,
+            placeholder: None,
+        },
+        AuthFieldInfo {
+            name: "api_key".to_string(),
+            label: "API Key".to_string(),
+            hint: None,
+            secret: true,
+            required: true,
+            placeholder: None,
+        },
+    ];
+    let mut state = InlineState::default();
+    record_auth_required(&mut state, &[governed_auth_required(vec![provider])]);
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.phase = AuthPhase::FillingField;
+    auth.current_field = 2;
+    auth.editing_provider_name = Some("existing-provider".to_string());
+    auth.collected_values
+        .insert("api_key".to_string(), "stale-key".to_string());
+    auth.field_input = "stale-value".to_string();
+
+    restore_after_failed_submission(auth);
+
+    assert_eq!(auth.phase, AuthPhase::FillingField);
+    assert_eq!(auth.current_field, 1);
+    assert_eq!(
+        auth.collected_values.get("provider_id").map(String::as_str),
+        Some("existing-provider")
+    );
+    assert!(!auth.collected_values.contains_key("api_key"));
+    assert!(auth.field_input.is_empty());
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -185,6 +185,7 @@ impl CardInputState {
                 }
                 b'\r' | b'\n' => {
                     let event = self.submit(capture);
+                    let submitted = event.is_some();
                     let preserve_for_retry = matches!(
                         (&event, capture),
                         (
@@ -199,6 +200,11 @@ impl CardInputState {
                         self.free_text.clear();
                     }
                     idx += 1;
+                    if submitted {
+                        // State transitions are applied by the main loop; suppress a burst of
+                        // duplicate submits against the capture snapshot used for this batch.
+                        break;
+                    }
                 }
                 0x7f | 0x08 => {
                     if self.free_text.pop().is_some() {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -52,6 +52,33 @@ fn question_capture_preserves_answer_for_delivery_retry() {
 }
 
 #[test]
+fn question_capture_emits_one_submission_per_input_batch() {
+    let capture = RawInputCapture::Question {
+        id: "q-burst".to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    };
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let events = state.consume(&capture, b"main\n\n");
+
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, RawInputEvent::CardAnswer(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        state.consume(&capture, b"\n"),
+        vec![RawInputEvent::CardAnswer("main".to_string())]
+    );
+}
+
+#[test]
 fn question_capture_custom_option_empty_submit_emits_attempt() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/foreground.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/foreground.rs
@@ -45,7 +45,7 @@ fn raw_cli_approved_bash_tool_prints_native_command_and_stdout() {
     let output = run_raw_cli_ask_with_delayed_input(vec![
         (b"?? stream pwd tool approval\n".to_vec(), Duration::ZERO),
         (b"\n".to_vec(), Duration::from_millis(1_200)),
-        (b"exit\n".to_vec(), Duration::from_millis(300)),
+        (b"exit\n".to_vec(), Duration::from_millis(1_000)),
     ]);
     let expected_cwd = env!("CARGO_MANIFEST_DIR");
 


### PR DESCRIPTION
## Description

This fixes two auth provider lifecycle failures across interactive field capture and provider deletion. Field capture now isolates each phase and suppresses duplicate submissions from a single input batch while preserving retry behavior. Provider deletion is restricted to user-owned providers, requires explicit confirmation, removes persisted credentials, and repairs the active-provider selection without deleting a same-ID system definition.

## Related Issue

closes #1769
closes #1770

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/cosh-ng`:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=4`
- `cargo build --workspace --release`
- `crates/cosh-shell/scripts/check-layout.sh`

The `[core]` commit was also checked independently in a detached worktree. Targeted auth, card-capture, and registry protocol tests cover retry cleanup, batched Enter input, confirmation defaults, user-provider deletion, credential removal, and active-provider fallback.

## Additional Notes

The history is split by crate boundary: `94223a90` contains the `cosh-core` registry and persistence changes, while `5a43316c` contains the `cosh-shell` interaction and state-management changes.

To address the large-file review, delete confirmation, capture routing, and retry restoration now live in `auth/delete_confirm.rs`, `auth/capture.rs`, and `auth/retry.rs`. This reduces `auth/runtime.rs` from the 1367-line base to 1195 lines and keeps the new provider-delete path out of the registered large-file debt; no waiver was added.

The issues meet at the `/auth` provider lifecycle boundary but have separate causes: #1769 is an interactive capture-state problem, while #1770 requires coordinated shell and registry state cleanup.