### PR TITLE
feat(cosh-ng): add /status, /about, and /stats commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -9,7 +9,7 @@ use crate::auth::capture::matches_auth_capture;
 use crate::auth::completion::finish_auth_configuration;
 use crate::auth::delete_confirm::{
     begin_delete_confirmation, focus_delete_confirmation, render_delete_outcome,
-    submit_delete_confirmation,
+    submit_delete_confirmation, DeleteConfirmationOutcome,
 };
 use crate::auth::menu::{
     has_manageable_entries, management_entry, management_entry_count, management_entry_index,
@@ -207,6 +207,20 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
 
     render_current_auth_panel(state, output)?;
     Ok(())
+}
+
+fn clear_observed_model_after_provider_change(state: &mut InlineState) {
+    state.personalization.foreground_model = None;
+}
+
+fn clear_observed_model_after_provider_delete(
+    state: &mut InlineState,
+    deleted_provider_was_active: bool,
+    outcome: &DeleteConfirmationOutcome,
+) {
+    if deleted_provider_was_active && matches!(outcome, DeleteConfirmationOutcome::Deleted { .. }) {
+        clear_observed_model_after_provider_change(state);
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -410,6 +424,7 @@ fn handle_auth_answer<W: std::io::Write>(
             match action {
                 ProviderAction::Activate => {
                     core_auth_activate(adapter, &existing.name).map_err(std::io::Error::other)?;
+                    clear_observed_model_after_provider_change(state);
                     // Clear and show confirmation
                     state.auth.state.take();
                     clear_active_auth_panel(state, output)?;
@@ -519,8 +534,17 @@ fn handle_auth_answer<W: std::io::Write>(
             Ok(true)
         }
         AuthPhase::ConfirmDelete { provider_idx } => {
+            let deleted_provider_was_active = auth
+                .existing_providers
+                .get(provider_idx)
+                .is_some_and(|provider| provider.is_active);
             let outcome = submit_delete_confirmation(adapter, auth, provider_idx)
                 .map_err(std::io::Error::other)?;
+            clear_observed_model_after_provider_delete(
+                state,
+                deleted_provider_was_active,
+                &outcome,
+            );
             clear_active_auth_panel(state, output)?;
             let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
             render_delete_outcome(&outcome, &renderer, output)?;
@@ -722,8 +746,12 @@ fn send_auth_response<W: std::io::Write>(
     };
 
     if let Some(active_run) = state.agent_run.active.as_ref() {
+        let result = active_run.handle.respond_auth(response);
+        if result.is_ok() {
+            clear_observed_model_after_provider_change(state);
+        }
         return finish_active_submission(
-            active_run.handle.respond_auth(response),
+            result,
             &auth.id,
             &mut state.auth.completed_ids,
             state.language,
@@ -751,6 +779,7 @@ fn send_auth_response<W: std::io::Write>(
                     render_current_auth_panel(state, output)?;
                     return Ok(());
                 }
+                clear_observed_model_after_provider_change(state);
             }
             AuthBackend::ActiveRun => {}
         }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -2,11 +2,12 @@
 
 use super::{
     apply_aliyun_prepare, begin_sysom_shortcut, clear_ecs_auth_source_for_manual_aliyun_edit,
+    clear_observed_model_after_provider_change, clear_observed_model_after_provider_delete,
     ecs_ram_role_prepare, handle_auth_answer, management_entry, render_auth_card_actions,
     should_apply_aliyun_prepare_after_field, should_apply_aliyun_prepare_for_edit,
     should_apply_aliyun_prepare_on_provider_selection, AuthBackend, AuthFieldInfo,
-    AuthManagementEntry, AuthPhase, AuthProviderInfo, CoreAuthPrepare, EcsRamRolePrepare,
-    ExistingProvider, InlineState, RuntimeAuthState, ShellEvent, SysomMenu,
+    AuthManagementEntry, AuthPhase, AuthProviderInfo, CoreAuthPrepare, DeleteConfirmationOutcome,
+    EcsRamRolePrepare, ExistingProvider, InlineState, RuntimeAuthState, ShellEvent, SysomMenu,
 };
 use crate::adapter::{AdapterInstance, FakeAgentAdapter};
 use crate::auth::capture::auth_capture_id;
@@ -303,6 +304,73 @@ fn active_run_aliyun_selection_can_prepare_without_provider_id_field() {
         "aliyun",
         Some("provider_id"),
     ));
+}
+
+#[test]
+fn provider_change_discards_the_previous_observed_model() {
+    let mut state = InlineState::default();
+    state.personalization.foreground_model = Some("previous-provider-model".to_string());
+
+    clear_observed_model_after_provider_change(&mut state);
+
+    assert_eq!(state.personalization.foreground_model, None);
+}
+
+#[test]
+fn deleting_the_active_provider_with_a_fallback_discards_the_observed_model() {
+    let mut state = InlineState::default();
+    state.personalization.foreground_model = Some("deleted-provider-model".to_string());
+    let outcome = DeleteConfirmationOutcome::Deleted {
+        provider_name: "deleted-provider".to_string(),
+        needs_reselection: false,
+    };
+
+    clear_observed_model_after_provider_delete(&mut state, true, &outcome);
+
+    assert_eq!(state.personalization.foreground_model, None);
+}
+
+#[test]
+fn deleting_the_active_provider_without_a_fallback_discards_the_observed_model() {
+    let mut state = InlineState::default();
+    state.personalization.foreground_model = Some("deleted-provider-model".to_string());
+    let outcome = DeleteConfirmationOutcome::Deleted {
+        provider_name: "deleted-provider".to_string(),
+        needs_reselection: true,
+    };
+
+    clear_observed_model_after_provider_delete(&mut state, true, &outcome);
+
+    assert_eq!(state.personalization.foreground_model, None);
+}
+
+#[test]
+fn cancelling_or_deleting_an_inactive_provider_keeps_the_observed_model() {
+    let mut state = InlineState::default();
+    state.personalization.foreground_model = Some("active-provider-model".to_string());
+
+    clear_observed_model_after_provider_delete(
+        &mut state,
+        true,
+        &DeleteConfirmationOutcome::Cancelled,
+    );
+    assert_eq!(
+        state.personalization.foreground_model.as_deref(),
+        Some("active-provider-model")
+    );
+
+    clear_observed_model_after_provider_delete(
+        &mut state,
+        false,
+        &DeleteConfirmationOutcome::Deleted {
+            provider_name: "inactive-provider".to_string(),
+            needs_reselection: false,
+        },
+    );
+    assert_eq!(
+        state.personalization.foreground_model.as_deref(),
+        Some("active-provider-model")
+    );
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -76,6 +76,51 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::HelpGroupRegistry => "Registry",
         MessageId::HelpSummaryExtensions => "list/manage cosh-core extensions",
         MessageId::HelpSummarySkills => "list/inspect cosh-core skills",
+        MessageId::HelpGroupStatus => "Status",
+        MessageId::HelpSummaryStatus => "show version, provider, model, and runtime status",
+        MessageId::HelpSummaryStats => "show model and tool session statistics",
+        MessageId::SlashValueUnavailable => "unavailable",
+        MessageId::SlashValueNotStarted => "not started",
+        MessageId::SlashValueIdle => "idle",
+        MessageId::SlashValueActive => "active",
+        MessageId::SlashStatusTitle => "Status",
+        MessageId::SlashStatusVersionLine => "cosh-shell: {version}",
+        MessageId::SlashStatusBackendLine => "Backend: {backend}",
+        MessageId::SlashStatusProviderLine => "Provider: {provider}",
+        MessageId::SlashStatusModelLine => "Model: {model}",
+        MessageId::SlashStatusSessionLine => "Session: {session}",
+        MessageId::SlashStatusOsLine => "OS: {os}",
+        MessageId::SlashStatusModesLine => {
+            "Modes: approval={approval}, analysis={analysis}"
+        }
+        MessageId::SlashStatusProviderUnavailableLine => {
+            "Provider details: unavailable from the current backend"
+        }
+        MessageId::SlashStatusFooter => {
+            "/about is an alias for /status. Use /stats [model|tools] for session statistics."
+        }
+        MessageId::SlashStatsTitle => "Session stats",
+        MessageId::SlashStatsModelTitle => "Model stats",
+        MessageId::SlashStatsToolsTitle => "Tool stats",
+        MessageId::SlashStatsModelLine => "Model: {model}",
+        MessageId::SlashStatsBackendLine => "Backend: {backend}",
+        MessageId::SlashStatsRunStateLine => "Agent run: {state}",
+        MessageId::SlashStatsToolTotalsLine => {
+            "Tools: {calls} calls, {successful} successful, {failed} failed, {pending} pending"
+        }
+        MessageId::SlashStatsNoToolCalls => {
+            "No tool calls have been recorded in this session."
+        }
+        MessageId::SlashStatsToolRow => {
+            "{name}: {calls} calls, {successful} successful, {failed} failed, {pending} pending"
+        }
+        MessageId::SlashStatsTelemetryUnavailable => {
+            "Token counts, API errors, and latency are not exposed by the current backend protocol."
+        }
+        MessageId::SlashStatsUsageLine => "Usage: /stats [model|tools]",
+        MessageId::SlashStatsFooter => {
+            "Statistics are read-only and cover data observed by this cosh-shell process."
+        }
         MessageId::SlashExtensionsTitle => "Extensions",
         MessageId::SlashSkillsTitle => "Skills",
         MessageId::SlashRegistryUnavailable => {

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -87,4 +87,5 @@ collect_message_ids!([
     routing_insight_ids,
     activity_untracked_ids,
     approval_turn_consent_ids,
+    status_query_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/help.rs
@@ -93,3 +93,41 @@ macro_rules! slash_parse_error_ids {
         );
     };
 }
+
+macro_rules! status_query_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            HelpGroupStatus,
+            HelpSummaryStatus,
+            HelpSummaryStats,
+            SlashValueUnavailable,
+            SlashValueNotStarted,
+            SlashValueIdle,
+            SlashValueActive,
+            SlashStatusTitle,
+            SlashStatusVersionLine,
+            SlashStatusBackendLine,
+            SlashStatusProviderLine,
+            SlashStatusModelLine,
+            SlashStatusSessionLine,
+            SlashStatusOsLine,
+            SlashStatusModesLine,
+            SlashStatusProviderUnavailableLine,
+            SlashStatusFooter,
+            SlashStatsTitle,
+            SlashStatsModelTitle,
+            SlashStatsToolsTitle,
+            SlashStatsModelLine,
+            SlashStatsBackendLine,
+            SlashStatsRunStateLine,
+            SlashStatsToolTotalsLine,
+            SlashStatsNoToolCalls,
+            SlashStatsToolRow,
+            SlashStatsTelemetryUnavailable,
+            SlashStatsUsageLine,
+            SlashStatsFooter,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -70,6 +70,47 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::HelpGroupRegistry => "Registry",
         MessageId::HelpSummaryExtensions => "列出/管理 cosh-core 扩展",
         MessageId::HelpSummarySkills => "列出/查看 cosh-core 技能",
+        MessageId::HelpGroupStatus => "状态",
+        MessageId::HelpSummaryStatus => "显示版本、服务商、模型和运行状态",
+        MessageId::HelpSummaryStats => "显示模型和工具的会话统计",
+        MessageId::SlashValueUnavailable => "不可用",
+        MessageId::SlashValueNotStarted => "未启动",
+        MessageId::SlashValueIdle => "空闲",
+        MessageId::SlashValueActive => "运行中",
+        MessageId::SlashStatusTitle => "状态",
+        MessageId::SlashStatusVersionLine => "cosh-shell: {version}",
+        MessageId::SlashStatusBackendLine => "后端: {backend}",
+        MessageId::SlashStatusProviderLine => "服务商: {provider}",
+        MessageId::SlashStatusModelLine => "模型: {model}",
+        MessageId::SlashStatusSessionLine => "会话: {session}",
+        MessageId::SlashStatusOsLine => "操作系统: {os}",
+        MessageId::SlashStatusModesLine => "模式: 审批={approval}，分析={analysis}",
+        MessageId::SlashStatusProviderUnavailableLine => {
+            "服务商详情: 当前后端未提供"
+        }
+        MessageId::SlashStatusFooter => {
+            "/about 是 /status 的别名。使用 /stats [model|tools] 查看会话统计。"
+        }
+        MessageId::SlashStatsTitle => "会话统计",
+        MessageId::SlashStatsModelTitle => "模型统计",
+        MessageId::SlashStatsToolsTitle => "工具统计",
+        MessageId::SlashStatsModelLine => "模型: {model}",
+        MessageId::SlashStatsBackendLine => "后端: {backend}",
+        MessageId::SlashStatsRunStateLine => "Agent 运行状态: {state}",
+        MessageId::SlashStatsToolTotalsLine => {
+            "工具: 调用 {calls} 次，成功 {successful} 次，失败 {failed} 次，待定 {pending} 次"
+        }
+        MessageId::SlashStatsNoToolCalls => "当前会话尚未记录工具调用。",
+        MessageId::SlashStatsToolRow => {
+            "{name}: 调用 {calls} 次，成功 {successful} 次，失败 {failed} 次，待定 {pending} 次"
+        }
+        MessageId::SlashStatsTelemetryUnavailable => {
+            "当前后端协议未提供 Token 数、API 错误和延迟数据。"
+        }
+        MessageId::SlashStatsUsageLine => "用法: /stats [model|tools]",
+        MessageId::SlashStatsFooter => {
+            "统计信息只读，覆盖当前 cosh-shell 进程已观测到的数据。"
+        }
         MessageId::SlashExtensionsTitle => "扩展",
         MessageId::SlashSkillsTitle => "技能",
         MessageId::SlashRegistryUnavailable => "此功能需要 cosh-core 后端支持。",

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -217,7 +217,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -235,7 +235,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -146,7 +146,7 @@ _cosh_emit_top_level_missing_marker() {
 _cosh_should_intercept_unknown() {
   local command="$1"
   case "$command" in
-    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       printf '%s' "slash"
       return 0
       ;;
@@ -164,7 +164,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac
@@ -423,7 +423,7 @@ _cosh_precmd_marker() {
 # Slash command function stubs — prevent "zsh: no such file or directory" for
 # commands starting with / that zsh would try to exec as an absolute path.
 # The actual interception and marker emission happens in _cosh_preexec_marker.
-for _cosh_sc in agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mode new recommendations select send-to-shell shell skills; do
+for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mode new recommendations select send-to-shell shell skills stats status; do
   functions[/$_cosh_sc]=':'
 done
 unset _cosh_sc

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -13,6 +13,7 @@ use crate::slash::parser::SlashCommand;
 use crate::slash::recommendations::render_recommendations_command;
 use crate::slash::session::render_session_command;
 use crate::slash::skills::render_skills_command;
+use crate::slash::status::{render_stats_command, render_status_command};
 
 pub(super) fn render_slash_command<W: Write>(
     command: SlashCommand<'_>,
@@ -82,6 +83,14 @@ pub(super) fn render_slash_command<W: Write>(
         }
         SlashCommand::Health => {
             render_health_command(state, shell_cwd, output)?;
+            Ok(true)
+        }
+        SlashCommand::Status => {
+            render_status_command(adapter, state, output)?;
+            Ok(true)
+        }
+        SlashCommand::Stats(arguments) => {
+            render_stats_command(arguments, adapter, state, output)?;
             Ok(true)
         }
     }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
@@ -22,3 +22,4 @@ pub(super) mod session;
 pub(super) mod skills;
 #[cfg(test)]
 mod skills_tests;
+pub(super) mod status;

--- a/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/notices.rs
@@ -77,6 +77,7 @@ pub(super) fn render_help<W: Write>(state: &InlineState, output: &mut W) -> std:
     let i18n = state.i18n();
     let mut groups = Vec::new();
     for (group, label_id) in [
+        ("Status", MessageId::HelpGroupStatus),
         ("Config", MessageId::HelpGroupConfig),
         ("Health", MessageId::HelpGroupHealth),
         ("Sessions", MessageId::HelpGroupSessions),

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -24,6 +24,8 @@ pub(super) enum SlashCommand<'a> {
     #[allow(dead_code)]
     Info(SlashInfoCommand),
     Health,
+    Status,
+    Stats(&'a str),
     Removed(RemovedCommand<'a>),
     Hint(&'a str),
     Unknown(&'a str),
@@ -84,6 +86,10 @@ impl<'a> SlashCommand<'a> {
             }
             "/debug" => Some(Self::Debug(parts.next())),
             "/health" => Some(Self::Health),
+            "/status" | "/about" => Some(Self::Status),
+            "/stats" => Some(Self::Stats(
+                input.strip_prefix("/stats").unwrap_or_default().trim(),
+            )),
             "/extensions" => {
                 let args = input
                     .strip_prefix("/extensions")
@@ -145,6 +151,9 @@ fn parser_owned_command(token: &str) -> bool {
             | "/config"
             | "/debug"
             | "/health"
+            | "/status"
+            | "/about"
+            | "/stats"
             | "/extensions"
             | "/skills"
             | "/session"
@@ -237,12 +246,27 @@ mod tests {
     }
 
     #[test]
+    fn status_about_and_stats_parse_as_read_only_commands() {
+        for command in ["/status", "/about"] {
+            assert!(
+                matches!(SlashCommand::parse(command), Ok(Some(SlashCommand::Status))),
+                "{command}"
+            );
+        }
+        match SlashCommand::parse("/stats tools") {
+            Ok(Some(SlashCommand::Stats(arguments))) => assert_eq!(arguments, "tools"),
+            _ => panic!("/stats tools did not parse as stats"),
+        }
+    }
+
+    #[test]
     fn quoted_arguments_are_rejected_for_parser_owned_commands() {
         for command in [
             "/mode approval \"trust confirm\"",
             "/mode approval 'trust confirm'",
             "/config language \"en US\"",
             "/health \"quick\"",
+            "/stats \"model\"",
             "/recommendations \"on\"",
         ] {
             assert!(

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -57,6 +57,30 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             state: SlashCommandState::Public,
         },
         SlashCommandSpec {
+            name: "/status",
+            usage: "/status",
+            summary_id: MessageId::HelpSummaryStatus,
+            group: Some("Status"),
+            scope: "read-only",
+            state: SlashCommandState::Public,
+        },
+        SlashCommandSpec {
+            name: "/about",
+            usage: "/about",
+            summary_id: MessageId::HelpSummaryStatus,
+            group: None,
+            scope: "read-only",
+            state: SlashCommandState::Hidden,
+        },
+        SlashCommandSpec {
+            name: "/stats",
+            usage: "/stats [model|tools]",
+            summary_id: MessageId::HelpSummaryStats,
+            group: Some("Status"),
+            scope: "read-only",
+            state: SlashCommandState::Public,
+        },
+        SlashCommandSpec {
             name: "/auth",
             usage: "/auth",
             summary_id: MessageId::HelpSummaryAuth,
@@ -347,6 +371,8 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(visible.contains(&"/config language [auto|en-US|zh-CN]"));
+        assert!(visible.contains(&"/status"));
+        assert!(visible.contains(&"/stats [model|tools]"));
         assert!(visible
             .iter()
             .any(|usage| usage.starts_with("/session [new|status|list|resume")));
@@ -401,6 +427,7 @@ mod tests {
             "/debug",
             "/resume",
             "/new",
+            "/about",
             "/skill",
             "/approval-mode",
             "/allow",

--- a/src/cosh-ng/crates/cosh-shell/src/slash/status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/status.rs
@@ -1,0 +1,458 @@
+//! Read-only runtime identity and session statistics slash commands.
+//!
+//! `/status` is the canonical command and `/about` is its compatibility alias.
+//! `/stats` reports only metrics that cosh-shell owns today. Provider token and
+//! latency telemetry are called out as unavailable instead of being inferred.
+
+use std::collections::BTreeMap;
+
+use crate::activity::runtime::{ToolInvocationPhase, ToolInvocationRecord};
+use crate::runtime::prelude::*;
+use crate::slash::panel::render_notice_panel;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct RuntimeIdentity {
+    provider_id: Option<String>,
+    provider_type: Option<String>,
+    model: Option<String>,
+    provider_details_available: bool,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ToolStats {
+    calls: usize,
+    successful: usize,
+    failed: usize,
+    pending: usize,
+}
+
+pub(super) fn render_status_command<W: Write>(
+    adapter: &AdapterInstance,
+    state: &InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let i18n = state.i18n();
+    let identity = runtime_identity(adapter, state);
+    let provider = provider_display(&identity)
+        .unwrap_or_else(|| i18n.t(MessageId::SlashValueUnavailable).to_string());
+    let model = identity
+        .model
+        .as_deref()
+        .unwrap_or_else(|| i18n.t(MessageId::SlashValueUnavailable));
+    let provider_session = adapter.committed_session_id();
+    let session = provider_session
+        .as_deref()
+        .or(state.shell_session_id.as_deref())
+        .unwrap_or_else(|| i18n.t(MessageId::SlashValueNotStarted));
+    let os = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
+
+    let mut body = vec![
+        i18n.format(
+            MessageId::SlashStatusVersionLine,
+            &[("version", env!("CARGO_PKG_VERSION"))],
+        ),
+        i18n.format(
+            MessageId::SlashStatusBackendLine,
+            &[("backend", adapter.name())],
+        ),
+        i18n.format(
+            MessageId::SlashStatusProviderLine,
+            &[("provider", &provider)],
+        ),
+        i18n.format(MessageId::SlashStatusModelLine, &[("model", model)]),
+        i18n.format(MessageId::SlashStatusSessionLine, &[("session", session)]),
+        i18n.format(MessageId::SlashStatusOsLine, &[("os", &os)]),
+        i18n.format(
+            MessageId::SlashStatusModesLine,
+            &[
+                ("approval", state.approval_mode.label()),
+                ("analysis", state.analysis_mode.label()),
+            ],
+        ),
+    ];
+    if !identity.provider_details_available {
+        body.push(
+            i18n.t(MessageId::SlashStatusProviderUnavailableLine)
+                .to_string(),
+        );
+    }
+
+    render_notice_panel(
+        output,
+        i18n.t(MessageId::SlashStatusTitle),
+        body,
+        Some(i18n.t(MessageId::SlashStatusFooter)),
+    )
+}
+
+pub(super) fn render_stats_command<W: Write>(
+    arguments: &str,
+    adapter: &AdapterInstance,
+    state: &InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    match arguments.split_whitespace().collect::<Vec<_>>().as_slice() {
+        [] => render_stats_summary(adapter, state, output),
+        ["model"] => render_model_stats(adapter, state, output),
+        ["tools"] => render_tool_stats(state, output),
+        _ => render_stats_usage(state, output),
+    }
+}
+
+fn render_stats_summary<W: Write>(
+    adapter: &AdapterInstance,
+    state: &InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let i18n = state.i18n();
+    let identity = runtime_identity(adapter, state);
+    let model = identity
+        .model
+        .as_deref()
+        .unwrap_or_else(|| i18n.t(MessageId::SlashValueUnavailable));
+    let active_run_id = state
+        .agent_run
+        .active
+        .as_ref()
+        .map(|run| run.request.id.as_str());
+    let totals = aggregate_tool_stats(&state.activity.tool_invocations, active_run_id);
+    let run_state = if state.agent_run.active.is_some() {
+        i18n.t(MessageId::SlashValueActive)
+    } else {
+        i18n.t(MessageId::SlashValueIdle)
+    };
+    let body = vec![
+        i18n.format(MessageId::SlashStatsModelLine, &[("model", model)]),
+        i18n.format(MessageId::SlashStatsRunStateLine, &[("state", run_state)]),
+        tool_totals_line(i18n, &totals),
+    ];
+
+    render_notice_panel(
+        output,
+        i18n.t(MessageId::SlashStatsTitle),
+        body,
+        Some(i18n.t(MessageId::SlashStatsFooter)),
+    )
+}
+
+fn render_model_stats<W: Write>(
+    adapter: &AdapterInstance,
+    state: &InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let i18n = state.i18n();
+    let identity = runtime_identity(adapter, state);
+    let model = identity
+        .model
+        .as_deref()
+        .unwrap_or_else(|| i18n.t(MessageId::SlashValueUnavailable));
+    let run_state = if state.agent_run.active.is_some() {
+        i18n.t(MessageId::SlashValueActive)
+    } else {
+        i18n.t(MessageId::SlashValueIdle)
+    };
+    let body = vec![
+        i18n.format(MessageId::SlashStatsModelLine, &[("model", model)]),
+        i18n.format(
+            MessageId::SlashStatsBackendLine,
+            &[("backend", adapter.name())],
+        ),
+        i18n.format(MessageId::SlashStatsRunStateLine, &[("state", run_state)]),
+        i18n.t(MessageId::SlashStatsTelemetryUnavailable)
+            .to_string(),
+    ];
+
+    render_notice_panel(
+        output,
+        i18n.t(MessageId::SlashStatsModelTitle),
+        body,
+        Some(i18n.t(MessageId::SlashStatsFooter)),
+    )
+}
+
+fn render_tool_stats<W: Write>(state: &InlineState, output: &mut W) -> std::io::Result<()> {
+    let i18n = state.i18n();
+    let active_run_id = state
+        .agent_run
+        .active
+        .as_ref()
+        .map(|run| run.request.id.as_str());
+    let by_name = tool_stats_by_name(&state.activity.tool_invocations, active_run_id);
+    let mut body = Vec::new();
+    if by_name.is_empty() {
+        body.push(i18n.t(MessageId::SlashStatsNoToolCalls).to_string());
+    } else {
+        for (name, stats) in &by_name {
+            body.push(i18n.format(
+                MessageId::SlashStatsToolRow,
+                &[
+                    ("name", name),
+                    ("calls", &stats.calls.to_string()),
+                    ("successful", &stats.successful.to_string()),
+                    ("failed", &stats.failed.to_string()),
+                    ("pending", &stats.pending.to_string()),
+                ],
+            ));
+        }
+        let totals = by_name
+            .values()
+            .fold(ToolStats::default(), |mut total, item| {
+                total.calls += item.calls;
+                total.successful += item.successful;
+                total.failed += item.failed;
+                total.pending += item.pending;
+                total
+            });
+        body.push(tool_totals_line(i18n, &totals));
+    }
+
+    render_notice_panel(
+        output,
+        i18n.t(MessageId::SlashStatsToolsTitle),
+        body,
+        Some(i18n.t(MessageId::SlashStatsFooter)),
+    )
+}
+
+fn render_stats_usage<W: Write>(state: &InlineState, output: &mut W) -> std::io::Result<()> {
+    render_notice_panel(
+        output,
+        state.i18n().t(MessageId::SlashStatsTitle),
+        vec![state.i18n().t(MessageId::SlashStatsUsageLine).to_string()],
+        Some(state.i18n().t(MessageId::SlashStatsFooter)),
+    )
+}
+
+fn tool_totals_line(i18n: I18n, totals: &ToolStats) -> String {
+    i18n.format(
+        MessageId::SlashStatsToolTotalsLine,
+        &[
+            ("calls", &totals.calls.to_string()),
+            ("successful", &totals.successful.to_string()),
+            ("failed", &totals.failed.to_string()),
+            ("pending", &totals.pending.to_string()),
+        ],
+    )
+}
+
+fn aggregate_tool_stats(
+    records: &[ToolInvocationRecord],
+    active_run_id: Option<&str>,
+) -> ToolStats {
+    tool_stats_by_name(records, active_run_id)
+        .into_values()
+        .fold(ToolStats::default(), |mut total, item| {
+            total.calls += item.calls;
+            total.successful += item.successful;
+            total.failed += item.failed;
+            total.pending += item.pending;
+            total
+        })
+}
+
+fn tool_stats_by_name(
+    records: &[ToolInvocationRecord],
+    active_run_id: Option<&str>,
+) -> BTreeMap<String, ToolStats> {
+    let mut stats = BTreeMap::<String, ToolStats>::new();
+    for record in records {
+        let item = stats.entry(record.tool_name.clone()).or_default();
+        record_tool_outcome(
+            item,
+            record.phase,
+            &record.status,
+            active_run_id == Some(record.run_id.as_str()),
+        );
+    }
+    stats
+}
+
+fn record_tool_outcome(
+    stats: &mut ToolStats,
+    phase: ToolInvocationPhase,
+    status: &str,
+    call_belongs_to_active_run: bool,
+) {
+    stats.calls += 1;
+    match phase {
+        ToolInvocationPhase::Call if call_belongs_to_active_run => stats.pending += 1,
+        ToolInvocationPhase::Call => stats.failed += 1,
+        ToolInvocationPhase::Result
+            if matches!(
+                status,
+                "error" | "failed" | "interrupted" | "denied" | "cancelled"
+            ) =>
+        {
+            stats.failed += 1;
+        }
+        ToolInvocationPhase::Result => stats.successful += 1,
+    }
+}
+
+fn runtime_identity(adapter: &AdapterInstance, state: &InlineState) -> RuntimeIdentity {
+    let observed_model = state.personalization.foreground_model.clone();
+    match adapter {
+        AdapterInstance::Fake(_) => RuntimeIdentity {
+            provider_id: Some("fake".to_string()),
+            provider_type: Some("test".to_string()),
+            model: observed_model.or_else(|| Some("fake".to_string())),
+            provider_details_available: true,
+        },
+        AdapterInstance::ClaudeCode(claude) => RuntimeIdentity {
+            provider_id: Some("claude-code".to_string()),
+            provider_type: Some("Claude Code".to_string()),
+            model: observed_model.or_else(|| Some(claude.model.clone())),
+            provider_details_available: true,
+        },
+        AdapterInstance::QwenCli(_) => RuntimeIdentity {
+            provider_id: Some("co".to_string()),
+            provider_type: Some("Qwen CLI".to_string()),
+            model: observed_model,
+            provider_details_available: true,
+        },
+        AdapterInstance::CoshCore(core) => {
+            match core.registry_query("auth", "state", serde_json::Value::Null) {
+                Ok(value) => core_identity_from_auth_state(&value, observed_model),
+                Err(_) => RuntimeIdentity {
+                    provider_id: Some("cosh-core".to_string()),
+                    model: observed_model,
+                    ..RuntimeIdentity::default()
+                },
+            }
+        }
+    }
+}
+
+fn core_identity_from_auth_state(
+    value: &serde_json::Value,
+    observed_model: Option<String>,
+) -> RuntimeIdentity {
+    let provider_id = value
+        .get("active_provider")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let provider = provider_id.as_deref().and_then(|active| {
+        value
+            .get("saved_providers")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|providers| {
+                providers.iter().find(|provider| {
+                    provider
+                        .get("provider_id")
+                        .and_then(serde_json::Value::as_str)
+                        == Some(active)
+                })
+            })
+    });
+    let provider_type = provider
+        .and_then(|provider| provider.get("provider_type"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let configured_model = provider
+        .and_then(|provider| provider.get("model"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|model| !model.trim().is_empty())
+        .map(str::to_string);
+
+    RuntimeIdentity {
+        provider_details_available: provider_id.is_none() || provider.is_some(),
+        provider_id,
+        provider_type,
+        model: observed_model.or(configured_model),
+    }
+}
+
+fn provider_display(identity: &RuntimeIdentity) -> Option<String> {
+    let provider_id = identity.provider_id.as_deref()?;
+    let Some(provider_type) = identity.provider_type.as_deref() else {
+        return Some(provider_id.to_string());
+    };
+    if provider_type == provider_id {
+        Some(provider_id.to_string())
+    } else {
+        Some(format!("{provider_id} ({provider_type})"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        core_identity_from_auth_state, provider_display, record_tool_outcome, RuntimeIdentity,
+        ToolStats,
+    };
+    use crate::activity::runtime::ToolInvocationPhase;
+
+    #[test]
+    fn core_identity_uses_active_provider_and_observed_model() {
+        let value = serde_json::json!({
+            "active_provider": "prod",
+            "saved_providers": [
+                {"provider_id": "other", "provider_type": "mock", "model": "wrong"},
+                {
+                    "provider_id": "prod",
+                    "provider_type": "openai_compat",
+                    "model": "configured-model"
+                }
+            ]
+        });
+
+        let identity = core_identity_from_auth_state(&value, Some("observed-model".to_string()));
+        assert_eq!(
+            identity,
+            RuntimeIdentity {
+                provider_id: Some("prod".to_string()),
+                provider_type: Some("openai_compat".to_string()),
+                model: Some("observed-model".to_string()),
+                provider_details_available: true,
+            }
+        );
+        assert_eq!(
+            provider_display(&identity).as_deref(),
+            Some("prod (openai_compat)")
+        );
+    }
+
+    #[test]
+    fn core_identity_falls_back_to_configured_model() {
+        let value = serde_json::json!({
+            "active_provider": "aliyun",
+            "saved_providers": [{
+                "provider_id": "aliyun",
+                "provider_type": "aliyun",
+                "model": "qwen3.7-plus"
+            }]
+        });
+
+        let identity = core_identity_from_auth_state(&value, None);
+        assert_eq!(identity.model.as_deref(), Some("qwen3.7-plus"));
+        assert_eq!(provider_display(&identity).as_deref(), Some("aliyun"));
+    }
+
+    #[test]
+    fn missing_active_provider_is_a_valid_unconfigured_state() {
+        let identity =
+            core_identity_from_auth_state(&serde_json::json!({"saved_providers": []}), None);
+
+        assert_eq!(identity.provider_id, None);
+        assert!(identity.provider_details_available);
+    }
+
+    #[test]
+    fn tool_stats_only_leave_current_run_calls_pending() {
+        let mut stats = ToolStats::default();
+        record_tool_outcome(&mut stats, ToolInvocationPhase::Call, "called", true);
+        record_tool_outcome(&mut stats, ToolInvocationPhase::Call, "called", false);
+        record_tool_outcome(&mut stats, ToolInvocationPhase::Result, "completed", false);
+        record_tool_outcome(
+            &mut stats,
+            ToolInvocationPhase::Result,
+            "interrupted",
+            false,
+        );
+
+        assert_eq!(stats.calls, 4);
+        assert_eq!(stats.successful, 1);
+        assert_eq!(stats.failed, 2);
+        assert_eq!(stats.pending, 1);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/slash.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/slash.rs
@@ -14,6 +14,7 @@ fn raw_cli_help_renders_slash_command_reference() {
     assert!(normalized.contains("Slash commands"), "{output}");
     // Group headers sit at column zero inside the panel.
     assert!(normalized.contains("│ Config"), "{output}");
+    assert!(normalized.contains("│ Status"), "{output}");
     assert!(normalized.contains("│ Modes"), "{output}");
     assert!(normalized.contains("│ Hooks"), "{output}");
     assert!(normalized.contains("│ Registry"), "{output}");
@@ -32,6 +33,8 @@ fn raw_cli_help_renders_slash_command_reference() {
         normalized.contains("/config language [auto|en-US|zh-CN]"),
         "{output}"
     );
+    assert!(normalized.contains("/status"), "{output}");
+    assert!(normalized.contains("/stats [model|tools]"), "{output}");
     assert!(
         normalized.contains("/mode approval [recommend|auto|trust]"),
         "{output}"
@@ -70,6 +73,77 @@ fn raw_cli_help_renders_slash_command_reference() {
     assert!(output.contains("Mode: auto."), "{output}");
     assert!(output.contains("after-help"), "{output}");
     assert!(!output.contains("bash: /help"), "{output}");
+}
+
+#[test]
+fn raw_cli_status_about_and_stats_render_without_reaching_bash() {
+    let output = run_raw_cli_with_env(
+        "fake",
+        "/status\n\
+         /about\n\
+         /stats\n\
+         /stats model\n\
+         /stats tools\n\
+         echo after-status-queries\n\
+         exit\n",
+        &[("COSH_SHELL_LANG", "en-US")],
+    );
+
+    assert!(output.contains("cosh-shell:"), "{output}");
+    assert!(output.contains("Backend: fake"), "{output}");
+    assert!(output.contains("Provider: fake (test)"), "{output}");
+    assert!(output.contains("Model: fake"), "{output}");
+    assert!(output.contains("Session stats"), "{output}");
+    assert!(output.contains("Model stats"), "{output}");
+    assert!(output.contains("Tool stats"), "{output}");
+    assert!(
+        output.contains("No tool calls have been recorded in this session."),
+        "{output}"
+    );
+    assert!(output.contains("after-status-queries"), "{output}");
+    for command in ["/status", "/about", "/stats"] {
+        assert!(
+            !output.contains(&format!("bash: {command}:")),
+            "{command} reached bash: {output}"
+        );
+        assert!(
+            !output.contains(&format!("bash: {command}: No such file or directory")),
+            "{command} reached bash: {output}"
+        );
+    }
+}
+
+#[test]
+fn raw_cli_zsh_status_about_and_stats_render_without_reaching_zsh() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[("COSH_SHELL_LANG", "en-US")],
+        vec![
+            (b"/status\n".to_vec(), Duration::ZERO),
+            (b"/about\n".to_vec(), Duration::from_millis(100)),
+            (b"/stats tools\n".to_vec(), Duration::from_millis(100)),
+            (
+                b"echo after-zsh-status-queries\n".to_vec(),
+                Duration::from_millis(100),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(100)),
+        ],
+    );
+
+    assert!(output.contains("Backend: fake"), "{output}");
+    assert!(output.contains("Tool stats"), "{output}");
+    assert!(output.contains("after-zsh-status-queries"), "{output}");
+    for command in ["/status", "/about", "/stats"] {
+        assert!(
+            !output.contains(&format!("zsh: no such file or directory: {command}")),
+            "{command} reached zsh: {output}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `/status` as the canonical runtime identity command and `/about` as its compatibility alias
- add `/stats`, `/stats model`, and `/stats tools` with session-owned model, run, and tool-call data
- register the commands in slash parsing, help, completion, and bash/zsh interception paths with English and Chinese copy
- keep provider telemetry honest by reporting unavailable fields instead of inferring token or latency data
- clear stale observed models after provider activation or active-provider deletion and only count unresolved calls from the active run as pending
- adapt the implementation to the current `main` marker/auth module split while preserving provider-auth retry recovery

## Why

The Rust cosh-shell rewrite did not register `/status`, `/about`, or `/stats`. As a result, these
commands fell through to the host shell and failed as filesystem paths, removing a common way to
inspect the active version, backend, provider, model, session, and tool activity.

This restores the missing query surface while using only runtime data that cosh-shell currently
owns.

Closes #1757.

## Validation

- `scripts/check-test-inventory.sh`
  - cosh-shell source tests: 2584 (floor 2573)
  - cosh-shell exact lib/bin overlap: 634 (ceiling 634)
  - necessity registry: 3714 stable source IDs
- `cargo test --locked --package cosh-shell --bin cosh-shell slash::status::tests -- --test-threads=1`
- parser and provider-change/delete exact unit regressions
- bash and zsh exact raw CLI regressions
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `crates/cosh-shell/scripts/check-layout.sh`
- [GitHub CI run 30245236928](https://github.com/alibaba/anolisa/actions/runs/30245236928)
  - `Test cosh-ng fast checks`: passed
  - `Test cosh-ng`: passed
  - `Build cosh-ng release`: passed
