### PR TITLE
fix(cosh-ng): [core,shell] validate auth

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -1,16 +1,15 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::time::Duration;
-
-use tokio::io::AsyncBufReadExt;
 
 use crate::config::{CoreConfig, ProviderConfig};
-use crate::protocol::{
-    AuthField, AuthProvider, ControlResponseBody, InputMessage, ShellControlRequest,
-};
+use crate::protocol::{AuthField, AuthProvider};
 
-/// Timeout for waiting for auth response from Shell.
-pub const AUTH_TIMEOUT: Duration = Duration::from_secs(300);
+mod exchange;
+mod validation;
+
+pub(crate) use exchange::request_validated_auth;
+pub(crate) use validation::AuthConfigValidationError;
+use validation::{validate_auth_response, validate_base_url};
 
 /// Returns the builtin provider templates for the auth UI.
 pub fn builtin_auth_providers() -> Vec<AuthProvider> {
@@ -117,26 +116,47 @@ pub struct AuthResponse {
     pub persist: bool,
 }
 
-/// Apply auth credentials to the config, rebuilding provider settings.
-pub fn apply_auth_credentials(config: &mut CoreConfig, response: &AuthResponse) {
+/// Applies validated auth credentials and rebuilds provider settings.
+///
+/// # Errors
+///
+/// Returns an error when a required credential field is missing or a supplied
+/// base URL is malformed.
+pub(crate) fn apply_auth_credentials(
+    config: &mut CoreConfig,
+    response: &AuthResponse,
+) -> Result<(), AuthConfigValidationError> {
     let template_id = response
         .provider_type
         .as_deref()
         .unwrap_or(response.provider_id.as_str());
     let template = builtin_auth_providers()
         .into_iter()
-        .find(|p| p.id == template_id);
+        .find(|provider| provider.id == template_id);
+    match template.as_ref() {
+        Some(template) => validate_auth_response(template, response)?,
+        None => {
+            let base_url = response
+                .values
+                .get("base_url")
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| {
+                    AuthConfigValidationError::MissingRequiredField("base_url".to_string())
+                })?;
+            validate_base_url(base_url)?;
+        }
+    }
 
     let (base_url, provider_type, default_model) = match template {
-        Some(ref t) => (
+        Some(template) => (
             response
                 .values
                 .get("base_url")
                 .cloned()
-                .or_else(|| t.builtin_base_url.clone())
+                .or(template.builtin_base_url)
                 .unwrap_or_default(),
-            t.builtin_provider_type.clone(),
-            t.builtin_default_model.clone(),
+            template.builtin_provider_type,
+            template.builtin_default_model,
         ),
         None => (
             response.values.get("base_url").cloned().unwrap_or_default(),
@@ -196,6 +216,7 @@ pub fn apply_auth_credentials(config: &mut CoreConfig, response: &AuthResponse) 
             .providers
             .insert(response.provider_id.clone(), provider);
     }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -266,92 +287,6 @@ pub(crate) fn remove_auth_provider(
     })
 }
 
-/// Result of waiting for auth, including any stdin lines consumed during the wait.
-pub struct AuthWaitResult {
-    pub response: Option<AuthResponse>,
-    /// Lines consumed from stdin during auth wait that should be replayed.
-    pub buffered_lines: Vec<String>,
-}
-
-/// Wait for an auth response from Shell via stdin JSONL.
-/// Returns the auth response (if any) and any non-auth messages that were
-/// consumed from stdin during the wait (so callers can replay them).
-pub async fn wait_for_auth_response<R: AsyncBufReadExt + Unpin>(
-    expected_request_id: &str,
-    reader: &mut tokio::io::Lines<R>,
-) -> AuthWaitResult {
-    let mut buffered_lines: Vec<String> = Vec::new();
-    let result = tokio::time::timeout(AUTH_TIMEOUT, async {
-        while let Ok(Some(line)) = reader.next_line().await {
-            let line = line.trim().to_string();
-            if line.is_empty() {
-                continue;
-            }
-            let msg: InputMessage = match serde_json::from_str(&line) {
-                Ok(m) => m,
-                Err(_) => {
-                    // Let the headless input loop emit the protocol error.
-                    buffered_lines.push(line);
-                    continue;
-                }
-            };
-            match msg {
-                InputMessage::ControlResponse { response } => {
-                    if response.request_id != expected_request_id {
-                        continue;
-                    }
-                    return parse_auth_response(&response.response);
-                }
-                InputMessage::ControlRequest { request, .. } => {
-                    if matches!(request, ShellControlRequest::Interrupt) {
-                        return None;
-                    }
-                    // Buffer non-interrupt control requests for later
-                    buffered_lines.push(line);
-                }
-                _ => {
-                    // Buffer user messages and other lines for later replay
-                    buffered_lines.push(line);
-                }
-            }
-        }
-        None
-    })
-    .await;
-
-    match result {
-        Ok(response) => AuthWaitResult {
-            response,
-            buffered_lines,
-        },
-        Err(_) => {
-            tracing::warn!("Auth timeout after {}s", AUTH_TIMEOUT.as_secs());
-            AuthWaitResult {
-                response: None,
-                buffered_lines,
-            }
-        }
-    }
-}
-
-/// Parse auth-specific fields from the ControlResponseBody.
-fn parse_auth_response(body: &ControlResponseBody) -> Option<AuthResponse> {
-    // Check if user denied
-    if body.behavior.as_deref() == Some("deny") {
-        return None;
-    }
-
-    let provider_id = body.provider_id.as_ref()?;
-    let values = body.values.clone().unwrap_or_default();
-
-    Some(AuthResponse {
-        provider_id: provider_id.clone(),
-        provider_type: body.provider_type.clone(),
-        values,
-        persist: body.persist.unwrap_or(true),
-    })
-}
-
 /// Check if an error string indicates an auth failure (401/403).
 pub fn is_auth_error(error: &str) -> bool {
     error.contains("401") || error.contains("403") || error.contains("Unauthorized")
@@ -360,33 +295,6 @@ pub fn is_auth_error(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::io::AsyncWriteExt;
-
-    #[tokio::test]
-    async fn buffers_invalid_jsonl_during_auth_wait() {
-        let (mut input, output) = tokio::io::duplex(1024);
-        input
-            .write_all(b"token=must-not-echo\n")
-            .await
-            .expect("write invalid JSONL");
-        input
-            .write_all(
-                br#"{"type":"control_response","response":{"subtype":"auth","request_id":"auth-init","response":{"provider_id":"dashscope","values":{"api_key":"test-key"},"persist":false}}}"#,
-            )
-            .await
-            .expect("write auth response");
-        input
-            .write_all(b"\n")
-            .await
-            .expect("terminate auth response");
-        drop(input);
-
-        let mut lines = tokio::io::BufReader::new(output).lines();
-        let result = wait_for_auth_response("auth-init", &mut lines).await;
-
-        assert_eq!(result.buffered_lines, vec!["token=must-not-echo"]);
-        assert!(result.response.is_some(), "expected auth response");
-    }
 
     #[test]
     fn builtin_providers_have_correct_ids() {
@@ -427,7 +335,7 @@ mod tests {
             values: HashMap::from([("api_key".to_string(), "sk-test123".to_string())]),
             persist: true,
         };
-        apply_auth_credentials(&mut config, &response);
+        apply_auth_credentials(&mut config, &response).unwrap();
 
         assert_eq!(config.ai.active_provider.as_deref(), Some("dashscope"));
         let p = config.ai.providers.get("dashscope").unwrap();
@@ -452,10 +360,11 @@ mod tests {
                     "https://api.openai.com/v1".to_string(),
                 ),
                 ("api_key".to_string(), "sk-openai".to_string()),
+                ("model".to_string(), "gpt-4o".to_string()),
             ]),
             persist: false,
         };
-        apply_auth_credentials(&mut config, &response);
+        apply_auth_credentials(&mut config, &response).unwrap();
 
         assert_eq!(config.ai.active_provider.as_deref(), Some("openai_compat"));
         let p = config.ai.providers.get("openai_compat").unwrap();
@@ -474,7 +383,7 @@ mod tests {
             persist: true,
         };
 
-        apply_auth_credentials(&mut config, &response);
+        apply_auth_credentials(&mut config, &response).unwrap();
 
         assert_eq!(config.ai.active_provider.as_deref(), Some("qwen-prod"));
         assert!(config.ai.providers.contains_key("qwen-prod"));
@@ -486,6 +395,80 @@ mod tests {
             provider.base_url.as_deref(),
             Some("https://dashscope.aliyuncs.com/compatible-mode/v1")
         );
+    }
+
+    #[test]
+    fn apply_unknown_provider_preserves_generic_fallback() {
+        let mut config = CoreConfig::default();
+        let response = AuthResponse {
+            provider_id: "custom-provider".to_string(),
+            provider_type: Some("custom-provider".to_string()),
+            values: HashMap::from([
+                (
+                    "base_url".to_string(),
+                    "https://api.example.com/v1".to_string(),
+                ),
+                ("api_key".to_string(), "sk-custom".to_string()),
+                ("model".to_string(), "custom-model".to_string()),
+            ]),
+            persist: true,
+        };
+
+        apply_auth_credentials(&mut config, &response).unwrap();
+
+        let provider = config.ai.providers.get("custom-provider").unwrap();
+        assert_eq!(provider.provider_type.as_deref(), Some("generic"));
+        assert_eq!(
+            provider.base_url.as_deref(),
+            Some("https://api.example.com/v1")
+        );
+        assert_eq!(provider.model.as_deref(), Some("custom-model"));
+    }
+
+    #[test]
+    fn apply_unknown_provider_rejects_invalid_base_url() {
+        let mut config = CoreConfig::default();
+        let response = AuthResponse {
+            provider_id: "custom-provider".to_string(),
+            provider_type: Some("custom-provider".to_string()),
+            values: HashMap::from([(
+                "base_url".to_string(),
+                "file:///tmp/custom-provider".to_string(),
+            )]),
+            persist: true,
+        };
+
+        assert_eq!(
+            apply_auth_credentials(&mut config, &response),
+            Err(AuthConfigValidationError::InvalidBaseUrl)
+        );
+        assert!(config.ai.providers.is_empty());
+        assert!(config.user_ai.providers.is_empty());
+    }
+
+    #[test]
+    fn apply_unknown_provider_requires_base_url() {
+        for values in [
+            HashMap::new(),
+            HashMap::from([("base_url".to_string(), " ".to_string())]),
+        ] {
+            let mut config = CoreConfig::default();
+            let response = AuthResponse {
+                provider_id: "custom-provider".to_string(),
+                provider_type: Some("custom-provider".to_string()),
+                values,
+                persist: true,
+            };
+
+            assert_eq!(
+                apply_auth_credentials(&mut config, &response),
+                Err(AuthConfigValidationError::MissingRequiredField(
+                    "base_url".to_string()
+                ))
+            );
+            assert!(config.ai.providers.is_empty());
+            assert!(config.user_ai.providers.is_empty());
+        }
     }
 
     #[test]
@@ -506,7 +489,7 @@ mod tests {
             persist: true,
         };
 
-        apply_auth_credentials(&mut config, &response);
+        apply_auth_credentials(&mut config, &response).unwrap();
 
         assert!(config.ai.providers.contains_key("system-provider"));
         assert!(config.ai.providers.contains_key("user-provider"));
@@ -621,48 +604,5 @@ mod tests {
         assert!(is_auth_error("HTTP 403 Forbidden"));
         assert!(is_auth_error("Unauthorized access"));
         assert!(!is_auth_error("API error 500: internal server error"));
-    }
-
-    #[test]
-    fn parse_auth_response_deny() {
-        let body = ControlResponseBody {
-            behavior: Some("deny".to_string()),
-            message: None,
-            result: None,
-            tool_use_id: None,
-            updated_permissions: None,
-            answer: None,
-            selected_options: None,
-            provider_id: None,
-            provider_type: None,
-            values: None,
-            persist: None,
-        };
-        assert!(parse_auth_response(&body).is_none());
-    }
-
-    #[test]
-    fn parse_auth_response_success() {
-        let body = ControlResponseBody {
-            behavior: None,
-            message: None,
-            result: None,
-            tool_use_id: None,
-            updated_permissions: None,
-            answer: None,
-            selected_options: None,
-            provider_id: Some("dashscope".to_string()),
-            provider_type: None,
-            values: Some(HashMap::from([(
-                "api_key".to_string(),
-                "sk-xxx".to_string(),
-            )])),
-            persist: Some(true),
-        };
-        let resp = parse_auth_response(&body).unwrap();
-        assert_eq!(resp.provider_id, "dashscope");
-        assert_eq!(resp.provider_type, None);
-        assert_eq!(resp.values.get("api_key").unwrap(), "sk-xxx");
-        assert!(resp.persist);
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/auth/exchange.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth/exchange.rs
@@ -1,0 +1,254 @@
+//! Auth control-protocol exchange with deterministic validation and retry.
+
+use std::io::Write;
+use std::time::Duration;
+
+use tokio::io::AsyncBufReadExt;
+
+use crate::config::CoreConfig;
+use crate::protocol::{
+    AuthReason, ControlResponseBody, InputMessage, OutputMessage, ShellControlRequest,
+};
+
+use super::{apply_auth_credentials, builtin_auth_providers, AuthResponse};
+
+const AUTH_TIMEOUT: Duration = Duration::from_secs(300);
+
+struct AuthWaitResult {
+    response: Option<AuthResponse>,
+    buffered_lines: Vec<String>,
+}
+
+pub(crate) async fn request_validated_auth<W, R>(
+    config: &mut CoreConfig,
+    reader: &mut tokio::io::Lines<R>,
+    writer: &mut W,
+    request_id: &str,
+    initial_reason: AuthReason,
+    initial_error: Option<String>,
+    buffered_lines: &mut Vec<String>,
+) -> Option<AuthResponse>
+where
+    W: Write,
+    R: AsyncBufReadExt + Unpin,
+{
+    let mut attempt = 0_u32;
+    let mut reason = initial_reason;
+    let mut error_message = initial_error;
+
+    loop {
+        let current_request_id = if attempt == 0 {
+            request_id.to_string()
+        } else {
+            format!("{request_id}-retry-{attempt}")
+        };
+        let message = OutputMessage::auth_required(
+            &current_request_id,
+            reason.clone(),
+            error_message.take(),
+            builtin_auth_providers(),
+        );
+        emit(writer, &message);
+
+        let auth_result = wait_for_auth_response(&current_request_id, reader).await;
+        buffered_lines.extend(auth_result.buffered_lines);
+        let response = auth_result.response?;
+
+        match apply_auth_credentials(config, &response) {
+            Ok(()) => return Some(response),
+            Err(error) => {
+                tracing::warn!("invalid auth response: {error}");
+                reason = AuthReason::Invalid;
+                error_message = Some(error.to_string());
+                attempt = attempt.saturating_add(1);
+            }
+        }
+    }
+}
+
+async fn wait_for_auth_response<R: AsyncBufReadExt + Unpin>(
+    expected_request_id: &str,
+    reader: &mut tokio::io::Lines<R>,
+) -> AuthWaitResult {
+    let mut buffered_lines = Vec::new();
+    let result = tokio::time::timeout(AUTH_TIMEOUT, async {
+        while let Ok(Some(line)) = reader.next_line().await {
+            let line = line.trim().to_string();
+            if line.is_empty() {
+                continue;
+            }
+            let message: InputMessage = match serde_json::from_str(&line) {
+                Ok(message) => message,
+                Err(_) => {
+                    // Let the headless input loop emit the protocol error.
+                    buffered_lines.push(line);
+                    continue;
+                }
+            };
+            match message {
+                InputMessage::ControlResponse { response } => {
+                    if response.request_id == expected_request_id {
+                        return parse_auth_response(&response.response);
+                    }
+                }
+                InputMessage::ControlRequest { request, .. } => {
+                    if matches!(request, ShellControlRequest::Interrupt) {
+                        return None;
+                    }
+                    buffered_lines.push(line);
+                }
+                _ => buffered_lines.push(line),
+            }
+        }
+        None
+    })
+    .await;
+
+    match result {
+        Ok(response) => AuthWaitResult {
+            response,
+            buffered_lines,
+        },
+        Err(_) => {
+            tracing::warn!("Auth timeout after {}s", AUTH_TIMEOUT.as_secs());
+            AuthWaitResult {
+                response: None,
+                buffered_lines,
+            }
+        }
+    }
+}
+
+fn parse_auth_response(body: &ControlResponseBody) -> Option<AuthResponse> {
+    if body.behavior.as_deref() == Some("deny") {
+        return None;
+    }
+
+    Some(AuthResponse {
+        provider_id: body.provider_id.clone()?,
+        provider_type: body.provider_type.clone(),
+        values: body.values.clone().unwrap_or_default(),
+        persist: body.persist.unwrap_or(true),
+    })
+}
+
+fn emit<W: Write>(writer: &mut W, message: &OutputMessage) {
+    if let Ok(json) = serde_json::to_string(message) {
+        let _ = writeln!(writer, "{json}");
+        let _ = writer.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn buffers_invalid_jsonl_during_auth_wait() {
+        let (mut input, output) = tokio::io::duplex(1024);
+        input
+            .write_all(b"token=must-not-echo\n")
+            .await
+            .expect("write invalid JSONL");
+        input
+            .write_all(
+                br#"{"type":"control_response","response":{"subtype":"auth","request_id":"auth-init","response":{"provider_id":"dashscope","values":{"api_key":"test-key"},"persist":false}}}"#,
+            )
+            .await
+            .expect("write auth response");
+        input
+            .write_all(b"\n")
+            .await
+            .expect("terminate auth response");
+        drop(input);
+
+        let mut lines = tokio::io::BufReader::new(output).lines();
+        let result = wait_for_auth_response("auth-init", &mut lines).await;
+
+        assert_eq!(result.buffered_lines, vec!["token=must-not-echo"]);
+        assert!(result.response.is_some(), "expected auth response");
+    }
+
+    #[tokio::test]
+    async fn invalid_response_requests_retry_before_returning_success() {
+        let (mut input, output) = tokio::io::duplex(4096);
+        input
+            .write_all(
+                br#"{"type":"control_response","response":{"subtype":"auth","request_id":"auth-test","response":{"provider_id":"test","provider_type":"openai_compat","values":{"base_url":"bad-url","api_key":"test-key","model":"test-model"},"persist":false}}}
+{"type":"control_response","response":{"subtype":"auth","request_id":"auth-test-retry-1","response":{"provider_id":"test","provider_type":"openai_compat","values":{"base_url":"https://api.example.com/v1","api_key":"test-key","model":"test-model"},"persist":false}}}
+"#,
+            )
+            .await
+            .expect("write auth responses");
+        drop(input);
+
+        let mut lines = tokio::io::BufReader::new(output).lines();
+        let mut protocol_output = Vec::new();
+        let mut config = CoreConfig::default();
+        let response = request_validated_auth(
+            &mut config,
+            &mut lines,
+            &mut protocol_output,
+            "auth-test",
+            AuthReason::NotConfigured,
+            None,
+            &mut Vec::new(),
+        )
+        .await
+        .expect("valid retry response");
+
+        assert_eq!(response.provider_id, "test");
+        let messages = String::from_utf8(protocol_output).expect("protocol output");
+        let lines = messages.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains(r#""reason":"not_configured""#));
+        assert!(lines[1].contains(r#""reason":"invalid""#));
+        assert!(lines[1].contains("invalid base_url"));
+        assert!(config.ai.providers.contains_key("test"));
+    }
+
+    #[test]
+    fn parse_auth_response_deny() {
+        let body = ControlResponseBody {
+            behavior: Some("deny".to_string()),
+            message: None,
+            result: None,
+            tool_use_id: None,
+            updated_permissions: None,
+            answer: None,
+            selected_options: None,
+            provider_id: None,
+            provider_type: None,
+            values: None,
+            persist: None,
+        };
+        assert!(parse_auth_response(&body).is_none());
+    }
+
+    #[test]
+    fn parse_auth_response_success() {
+        let body = ControlResponseBody {
+            behavior: None,
+            message: None,
+            result: None,
+            tool_use_id: None,
+            updated_permissions: None,
+            answer: None,
+            selected_options: None,
+            provider_id: Some("dashscope".to_string()),
+            provider_type: None,
+            values: Some(HashMap::from([(
+                "api_key".to_string(),
+                "sk-xxx".to_string(),
+            )])),
+            persist: Some(true),
+        };
+        let response = parse_auth_response(&body).expect("auth response");
+        assert_eq!(response.provider_id, "dashscope");
+        assert_eq!(response.provider_type, None);
+        assert_eq!(response.values.get("api_key").unwrap(), "sk-xxx");
+        assert!(response.persist);
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/auth/validation.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth/validation.rs
@@ -1,0 +1,202 @@
+//! Deterministic validation for auth values before they mutate configuration.
+
+use std::fmt;
+
+use crate::protocol::AuthProvider;
+
+use super::AuthResponse;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AuthConfigValidationError {
+    MissingRequiredField(String),
+    InvalidBaseUrl,
+}
+
+impl fmt::Display for AuthConfigValidationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingRequiredField(field) => {
+                write!(formatter, "missing required auth field: {field}")
+            }
+            Self::InvalidBaseUrl => formatter
+                .write_str("invalid base_url: expected an http:// or https:// URL with a host"),
+        }
+    }
+}
+
+impl std::error::Error for AuthConfigValidationError {}
+
+pub(super) fn validate_auth_response(
+    template: &AuthProvider,
+    response: &AuthResponse,
+) -> Result<(), AuthConfigValidationError> {
+    let uses_ecs_ram_role = template.id == "aliyun"
+        && response.values.get("auth_source").map(String::as_str) == Some("ecs_ram_role");
+
+    for field in &template.fields {
+        if uses_ecs_ram_role && matches!(field.name.as_str(), "access_key_id" | "access_key_secret")
+        {
+            continue;
+        }
+        let missing = match response.values.get(&field.name) {
+            Some(value) => value.trim().is_empty(),
+            None => true,
+        };
+        if field.required && missing {
+            return Err(AuthConfigValidationError::MissingRequiredField(
+                field.name.clone(),
+            ));
+        }
+    }
+
+    let base_url = response
+        .values
+        .get("base_url")
+        .map(String::as_str)
+        .or(template.builtin_base_url.as_deref());
+    if let Some(base_url) = base_url {
+        validate_base_url(base_url)?;
+    }
+    Ok(())
+}
+
+pub(super) fn validate_base_url(base_url: &str) -> Result<(), AuthConfigValidationError> {
+    let url =
+        reqwest::Url::parse(base_url).map_err(|_| AuthConfigValidationError::InvalidBaseUrl)?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return Err(AuthConfigValidationError::InvalidBaseUrl);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::auth::builtin_auth_providers;
+
+    fn response(provider_type: &str, values: &[(&str, &str)]) -> AuthResponse {
+        AuthResponse {
+            provider_id: "test-provider".to_string(),
+            provider_type: Some(provider_type.to_string()),
+            values: values
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                .collect::<HashMap<_, _>>(),
+            persist: true,
+        }
+    }
+
+    fn template(provider_type: &str) -> AuthProvider {
+        builtin_auth_providers()
+            .into_iter()
+            .find(|provider| provider.id == provider_type)
+            .unwrap()
+    }
+
+    #[test]
+    fn rejects_malformed_base_url() {
+        let template = template("openai_compat");
+        let response = response(
+            "openai_compat",
+            &[
+                (
+                    "base_url",
+                    "error-testhttps://dashscope.aliyuncs.com/compatible-mode/v1",
+                ),
+                ("api_key", "sk-test"),
+                ("model", "qwen-test"),
+            ],
+        );
+
+        assert_eq!(
+            validate_auth_response(&template, &response),
+            Err(AuthConfigValidationError::InvalidBaseUrl)
+        );
+    }
+
+    #[test]
+    fn rejects_non_http_base_url() {
+        let template = template("openai_compat");
+        let response = response(
+            "openai_compat",
+            &[
+                ("base_url", "file:///tmp/openai"),
+                ("api_key", "sk-test"),
+                ("model", "qwen-test"),
+            ],
+        );
+
+        assert_eq!(
+            validate_auth_response(&template, &response),
+            Err(AuthConfigValidationError::InvalidBaseUrl)
+        );
+    }
+
+    #[test]
+    fn rejects_base_url_without_host() {
+        let template = template("openai_compat");
+        let response = response(
+            "openai_compat",
+            &[
+                ("base_url", "https://"),
+                ("api_key", "sk-test"),
+                ("model", "qwen-test"),
+            ],
+        );
+
+        assert_eq!(
+            validate_auth_response(&template, &response),
+            Err(AuthConfigValidationError::InvalidBaseUrl)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_required_credentials() {
+        let template = template("openai_compat");
+        let response = response(
+            "openai_compat",
+            &[
+                ("base_url", "https://api.example.com/v1"),
+                ("api_key", " "),
+                ("model", "qwen-test"),
+            ],
+        );
+
+        assert_eq!(
+            validate_auth_response(&template, &response),
+            Err(AuthConfigValidationError::MissingRequiredField(
+                "api_key".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_missing_required_model() {
+        let template = template("openai_compat");
+        let response = response(
+            "openai_compat",
+            &[
+                ("base_url", "https://api.example.com/v1"),
+                ("api_key", "sk-test"),
+                ("model", ""),
+            ],
+        );
+
+        assert_eq!(
+            validate_auth_response(&template, &response),
+            Err(AuthConfigValidationError::MissingRequiredField(
+                "model".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn accepts_aliyun_ecs_ram_role_without_manual_credentials() {
+        let template = template("aliyun");
+        let response = response("aliyun", &[("auth_source", "ecs_ram_role")]);
+
+        assert_eq!(validate_auth_response(&template, &response), Ok(()));
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -11,9 +11,7 @@ use cosh_platform::audit::LoadedPolicy;
 use cosh_types::audit::{AuditOutcomeStatus, AuditProviderData, AuditToolData, Outcome};
 
 use crate::audit::{CoreAuditRecorder, CoreAuditScope};
-use crate::auth::{
-    apply_auth_credentials, builtin_auth_providers, is_auth_error, wait_for_auth_response,
-};
+use crate::auth::is_auth_error;
 use crate::compaction::CompactionRuntime;
 use crate::config::{self, CoreConfig};
 use crate::context::ContextBuilder;
@@ -26,6 +24,7 @@ use crate::provider::{ContentGenerator, GenerateConfig, GenerateEvent, Message};
 use crate::tool::{ToolContext, ToolKind, ToolRegistry, ToolResult};
 use crate::truncator::OutputTruncator;
 
+mod auth;
 mod extensions;
 
 pub struct CoshCore {
@@ -1665,71 +1664,6 @@ impl CoshCore {
             }
         }
         ApprovalResult::Interrupted
-    }
-
-    /// Attempt to re-authenticate by sending auth_required to Shell.
-    /// Returns true if re-auth succeeded and provider was rebuilt.
-    async fn try_reauth<W, R>(&mut self, reader: &mut tokio::io::Lines<R>, writer: &mut W) -> bool
-    where
-        W: Write,
-        R: AsyncBufReadExt + Unpin,
-    {
-        use crate::protocol::AuthReason;
-
-        let request_id = self.next_request_id();
-        let providers = builtin_auth_providers();
-
-        let auth_msg = OutputMessage::auth_required(
-            &request_id,
-            AuthReason::Invalid,
-            Some("API authentication failed (401/403)".to_string()),
-            providers,
-        );
-        self.emit(writer, &auth_msg);
-
-        let auth_result = wait_for_auth_response(&request_id, reader).await;
-        // Note: buffered_lines during mid-session re-auth are discarded since
-        // the retry loop will re-send if needed.
-        let response = match auth_result.response {
-            Some(r) => r,
-            None => return false,
-        };
-
-        apply_auth_credentials(&mut self.config, &response);
-
-        if response.persist {
-            if let Err(e) = config::persist_config(&self.config) {
-                tracing::warn!("failed to persist config: {e}");
-            }
-        }
-
-        // Rebuild provider
-        let resolved = self.config.resolve_provider();
-        if resolved.provider_type == "aliyun" {
-            if resolved.auth_source.as_deref() == Some("ecs_ram_role") {
-                self.provider =
-                    Box::new(crate::provider::sysom::SysomProvider::from_ecs_ram_role());
-            } else if !resolved.access_key_id.is_empty() && !resolved.access_key_secret.is_empty() {
-                self.provider = Box::new(crate::provider::sysom::SysomProvider::new(
-                    &resolved.access_key_id,
-                    &resolved.access_key_secret,
-                    resolved.security_token.as_deref(),
-                ));
-            } else {
-                tracing::warn!("Aliyun auth response missing AK/SK");
-                return false;
-            }
-        } else {
-            let profile = crate::provider::profile::profile_from_name(&resolved.provider_type);
-            self.provider = Box::new(crate::provider::openai_compat::OpenAICompatProvider::new(
-                &resolved.base_url,
-                &resolved.api_key,
-                profile,
-            ));
-        }
-
-        self.emit(writer, &OutputMessage::system_status("auth_ok"));
-        true
     }
 }
 

--- a/src/cosh-ng/crates/cosh-core/src/core/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/auth.rs
@@ -1,0 +1,67 @@
+//! Mid-session authentication retry and provider replacement.
+
+use super::*;
+use crate::auth::request_validated_auth;
+use crate::protocol::AuthReason;
+
+impl CoshCore {
+    /// Attempts to re-authenticate and rebuild the active provider.
+    pub(super) async fn try_reauth<W, R>(
+        &mut self,
+        reader: &mut tokio::io::Lines<R>,
+        writer: &mut W,
+    ) -> bool
+    where
+        W: Write,
+        R: AsyncBufReadExt + Unpin,
+    {
+        let request_id = self.next_request_id();
+        let mut discarded_lines = Vec::new();
+        let response = request_validated_auth(
+            &mut self.config,
+            reader,
+            writer,
+            &request_id,
+            AuthReason::Invalid,
+            Some("API authentication failed (401/403)".to_string()),
+            &mut discarded_lines,
+        )
+        .await;
+        let Some(response) = response else {
+            return false;
+        };
+
+        if response.persist {
+            if let Err(error) = config::persist_config(&self.config) {
+                tracing::warn!("failed to persist config: {error}");
+            }
+        }
+
+        let resolved = self.config.resolve_provider();
+        if resolved.provider_type == "aliyun" {
+            if resolved.auth_source.as_deref() == Some("ecs_ram_role") {
+                self.provider =
+                    Box::new(crate::provider::sysom::SysomProvider::from_ecs_ram_role());
+            } else if !resolved.access_key_id.is_empty() && !resolved.access_key_secret.is_empty() {
+                self.provider = Box::new(crate::provider::sysom::SysomProvider::new(
+                    &resolved.access_key_id,
+                    &resolved.access_key_secret,
+                    resolved.security_token.as_deref(),
+                ));
+            } else {
+                tracing::warn!("Aliyun auth response missing AK/SK");
+                return false;
+            }
+        } else {
+            let profile = crate::provider::profile::profile_from_name(&resolved.provider_type);
+            self.provider = Box::new(crate::provider::openai_compat::OpenAICompatProvider::new(
+                &resolved.base_url,
+                &resolved.api_key,
+                profile,
+            ));
+        }
+
+        self.emit(writer, &OutputMessage::system_status("auth_ok"));
+        true
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -3,16 +3,19 @@ use std::path::PathBuf;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-use crate::auth::{apply_auth_credentials, builtin_auth_providers, wait_for_auth_response};
 use crate::cli::CliArgs;
 use crate::compaction::{ContextBudget, ModelCapability};
-use crate::config::{self, CoreConfig};
+use crate::config::CoreConfig;
 use crate::core::CoshCore;
 use crate::extension::{ExtensionManager, RuntimeSnapshotBuilder};
 use crate::metrics::TurnMetrics;
-use crate::protocol::{AuthReason, InputMessage, OutputMessage, ShellControlRequest};
+use crate::protocol::{InputMessage, OutputMessage, ShellControlRequest};
 use crate::session::{PersistedSession, ProviderSessionId, SessionError, SessionStore};
 use crate::sls;
+
+mod auth;
+
+use auth::request_auth;
 
 pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> {
     apply_cli_overrides(args, &mut config);
@@ -675,58 +678,6 @@ fn load_runtime_config(args: &CliArgs, workspace: &std::path::Path) -> CoreConfi
     };
     apply_cli_overrides(args, &mut config);
     config
-}
-
-/// Request authentication from Shell via the control protocol.
-/// Returns a Provider if auth succeeds, None otherwise.
-/// Buffered lines consumed during auth wait are appended to `buffered`.
-async fn request_auth<W, R>(
-    config: &mut CoreConfig,
-    lines: &mut tokio::io::Lines<R>,
-    writer: &mut W,
-    buffered: &mut Vec<String>,
-) -> Option<Box<dyn crate::provider::ContentGenerator>>
-where
-    W: std::io::Write,
-    R: AsyncBufReadExt + Unpin,
-{
-    let request_id = "auth-init";
-    let providers = builtin_auth_providers();
-
-    let auth_msg =
-        OutputMessage::auth_required(request_id, AuthReason::NotConfigured, None, providers);
-
-    // Emit auth request
-    if let Ok(json) = serde_json::to_string(&auth_msg) {
-        let _ = writeln!(writer, "{json}");
-        let _ = writer.flush();
-    }
-
-    // Wait for response
-    let auth_result = wait_for_auth_response(request_id, lines).await;
-    buffered.extend(auth_result.buffered_lines);
-
-    let response = auth_result.response?;
-
-    // Apply credentials
-    apply_auth_credentials(config, &response);
-
-    // Persist if requested
-    if response.persist {
-        if let Err(e) = config::persist_config(config) {
-            tracing::warn!("failed to persist config: {e}");
-        }
-    }
-
-    // Emit success status
-    let status_msg = OutputMessage::system_status("auth_ok");
-    if let Ok(json) = serde_json::to_string(&status_msg) {
-        let _ = writeln!(writer, "{json}");
-        let _ = writer.flush();
-    }
-
-    // Create provider from new config
-    Some(crate::create_provider(config))
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-core/src/headless/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless/auth.rs
@@ -1,0 +1,45 @@
+//! Startup authentication exchange for the headless runtime.
+
+use std::io::Write;
+
+use tokio::io::AsyncBufReadExt;
+
+use crate::auth::request_validated_auth;
+use crate::config::{self, CoreConfig};
+use crate::protocol::{AuthReason, OutputMessage};
+
+/// Requests credentials until they validate or the shell cancels the exchange.
+pub(super) async fn request_auth<W, R>(
+    config: &mut CoreConfig,
+    lines: &mut tokio::io::Lines<R>,
+    writer: &mut W,
+    buffered: &mut Vec<String>,
+) -> Option<Box<dyn crate::provider::ContentGenerator>>
+where
+    W: Write,
+    R: AsyncBufReadExt + Unpin,
+{
+    let response = request_validated_auth(
+        config,
+        lines,
+        writer,
+        "auth-init",
+        AuthReason::NotConfigured,
+        None,
+        buffered,
+    )
+    .await?;
+
+    if response.persist {
+        if let Err(error) = config::persist_config(config) {
+            tracing::warn!("failed to persist config: {error}");
+        }
+    }
+
+    if let Ok(json) = serde_json::to_string(&OutputMessage::system_status("auth_ok")) {
+        let _ = writeln!(writer, "{json}");
+        let _ = writer.flush();
+    }
+
+    Some(crate::create_provider(config))
+}

--- a/src/cosh-ng/crates/cosh-core/src/registry.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry.rs
@@ -918,6 +918,33 @@ mod tests {
     }
 
     #[test]
+    fn auth_configure_rejects_invalid_base_url_without_mutating_config() {
+        let mut config = CoreConfig::default();
+        let response = handle_auth(
+            "test-1",
+            "configure",
+            &serde_json::json!({
+                "provider_id": "bad-url",
+                "provider_type": "openai_compat",
+                "values": {
+                    "base_url": "error-testhttps://api.example.com/v1",
+                    "api_key": "sk-user",
+                    "model": "qwen-test"
+                }
+            }),
+            &mut config,
+        );
+
+        let OutputMessage::RegistryResponse { success, error, .. } = response else {
+            panic!("unexpected response: {response:?}");
+        };
+        assert!(!success);
+        assert!(error.unwrap().contains("invalid base_url"));
+        assert!(config.ai.providers.is_empty());
+        assert!(config.user_ai.providers.is_empty());
+    }
+
+    #[test]
     fn auth_configure_rejects_system_provider_overwrite() {
         let mut config = CoreConfig::default();
         config.ai.providers.insert(

--- a/src/cosh-ng/crates/cosh-core/src/registry/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry/auth.rs
@@ -242,7 +242,9 @@ pub(super) fn handle_auth(
                 values,
                 persist: true,
             };
-            crate::auth::apply_auth_credentials(config, &response);
+            if let Err(error) = crate::auth::apply_auth_credentials(config, &response) {
+                return registry_error(request_id, &error.to_string());
+            }
             if let Err(e) = crate::config::persist_config(config) {
                 return registry_error(request_id, &format!("failed to persist config: {e}"));
             }

--- a/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
@@ -838,6 +838,37 @@ api_key = "sk-project"
 }
 
 #[test]
+fn registry_auth_configure_rejects_invalid_base_url_without_writing_config() {
+    let home = tempfile::tempdir().expect("temp home");
+    let config_path = home.path().join(".copilot-shell/config.toml");
+
+    let response = run_registry_request_with_context(
+        "auth",
+        "configure",
+        serde_json::json!({
+            "provider_id": "bad-url",
+            "provider_type": "openai_compat",
+            "values": {
+                "base_url": "error-testhttps://api.example.com/v1",
+                "api_key": "sk-test",
+                "model": "qwen-test"
+            }
+        }),
+        home.path(),
+        None,
+    );
+
+    assert_eq!(response["success"], false);
+    assert!(
+        response["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("invalid base_url")),
+        "{response}"
+    );
+    assert!(!config_path.exists());
+}
+
+#[test]
 fn registry_auth_delete_removes_user_provider_and_credentials() {
     let home = tempfile::tempdir().expect("temp home");
     let home_config_dir = home.path().join(".copilot-shell");

--- a/src/cosh-ng/crates/cosh-shell/src/auth/active_submission.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/active_submission.rs
@@ -1,0 +1,55 @@
+//! Active-run auth submission without a premature persistence confirmation.
+
+use std::collections::HashSet;
+use std::io::{self, Write};
+
+use crate::runtime::prelude::{Language, NoticePanelModel, RatatuiInlineRenderer};
+
+pub(super) fn finish_active_submission<W: Write>(
+    result: Result<(), String>,
+    auth_id: &str,
+    completed_ids: &mut HashSet<String>,
+    language: Language,
+    output: &mut W,
+) -> io::Result<()> {
+    if result.is_err() {
+        let renderer = RatatuiInlineRenderer::for_terminal().with_language(language);
+        renderer.write_notice_panel(
+            output,
+            NoticePanelModel {
+                title: "Auth failed",
+                body: vec![
+                    "Unable to send credentials to cosh-core.".to_string(),
+                    "Run /auth again after the current run finishes.".to_string(),
+                ],
+                footer: None,
+            },
+        )?;
+    }
+
+    completed_ids.insert(auth_id.to_string());
+    output.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_submission_does_not_claim_credentials_were_saved() {
+        let mut output = Vec::new();
+        let mut completed_ids = HashSet::new();
+
+        finish_active_submission(
+            Ok(()),
+            "auth-1",
+            &mut completed_ids,
+            Language::EnUs,
+            &mut output,
+        )
+        .expect("finish active submission");
+
+        assert!(output.is_empty());
+        assert!(completed_ids.contains("auth-1"));
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
@@ -1,8 +1,10 @@
+mod active_submission;
 mod capture;
 mod completion;
 mod delete_confirm;
 pub(crate) mod provider_display;
 mod provider_management;
+mod required;
 mod retry;
 pub(crate) mod runtime;
 

--- a/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
@@ -1,0 +1,75 @@
+//! Active-run auth request state and validation-error rendering.
+
+use std::collections::HashMap;
+use std::io::{self, Write};
+
+use crate::runtime::prelude::{AgentEvent, GovernedEvent, NoticePanelModel, RatatuiInlineRenderer};
+use crate::runtime::state::InlineState;
+
+use super::provider_display::auth_required_providers_for_display;
+use super::runtime::{render_current_auth_panel, AuthBackend, AuthPhase, RuntimeAuthState};
+
+pub(crate) fn record_auth_required(
+    state: &mut InlineState,
+    governed_events: &[GovernedEvent],
+) -> Vec<String> {
+    let mut ids = Vec::new();
+    for event in governed_events {
+        if let AgentEvent::AuthRequired {
+            request_id,
+            error_message,
+            providers,
+            ..
+        } = &event.event
+        {
+            if state.auth.state.is_some() {
+                continue;
+            }
+            let id = format!("auth-{request_id}");
+            if state.auth.completed_ids.contains(&id) {
+                continue;
+            }
+            state.auth.state = Some(RuntimeAuthState {
+                id: id.clone(),
+                request_id: request_id.clone(),
+                phase: AuthPhase::SelectingProvider,
+                providers: auth_required_providers_for_display(providers),
+                selected_provider: 0,
+                current_field: 0,
+                collected_values: HashMap::new(),
+                field_input: String::new(),
+                existing_providers: Vec::new(),
+                editing_provider_name: None,
+                error_message: error_message.clone(),
+                backend: AuthBackend::ActiveRun,
+            });
+            ids.push(id);
+        }
+    }
+    ids
+}
+
+pub(crate) fn render_auth_panel<W: Write>(
+    state: &mut InlineState,
+    ids: &[String],
+    output: &mut W,
+) -> io::Result<()> {
+    for id in ids {
+        let Some(auth) = state.auth.state.as_ref().filter(|auth| auth.id == *id) else {
+            continue;
+        };
+        if let Some(error) = auth.error_message.clone() {
+            let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+            renderer.write_notice_panel(
+                output,
+                NoticePanelModel {
+                    title: "Credentials were not saved",
+                    body: vec![error, "Review the values and try again.".to_string()],
+                    footer: None,
+                },
+            )?;
+        }
+        render_current_auth_panel(state, output)?;
+    }
+    Ok(())
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -4,13 +4,13 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::adapter::AdapterInstance;
+use crate::auth::active_submission::finish_active_submission;
 use crate::auth::capture::{auth_capture_id, matches_auth_capture};
 use crate::auth::completion::finish_auth_configuration;
 use crate::auth::delete_confirm::{
     begin_delete_confirmation, focus_delete_confirmation, render_delete_confirmation,
     render_delete_outcome, submit_delete_confirmation,
 };
-use crate::auth::provider_display::auth_required_providers_for_display;
 use crate::auth::provider_management::{
     core_auth_activate, core_auth_configure, load_core_auth_state, provider_action_choice,
     provider_action_options, ExistingProvider, ProviderAction,
@@ -18,13 +18,13 @@ use crate::auth::provider_management::{
 use crate::auth::retry::restore_after_failed_submission;
 use crate::runtime::dispatcher::stable_event_key;
 use crate::runtime::prelude::{
-    AgentEvent, AuthFieldInfo, AuthProviderInfo, AuthResponse, GovernedEvent, NoticePanelModel,
-    QuestionInputFeedback, QuestionPanelModel, QuestionSelectionMode, RatatuiInlineRenderer,
-    ShellEvent, ShellEventKind,
+    AuthFieldInfo, AuthProviderInfo, AuthResponse, NoticePanelModel, QuestionInputFeedback,
+    QuestionPanelModel, QuestionSelectionMode, RatatuiInlineRenderer, ShellEvent, ShellEventKind,
 };
 use crate::runtime::state::InlineState;
 
 pub(crate) use crate::auth::capture::pending_auth_capture;
+pub(crate) use crate::auth::required::{record_auth_required, render_auth_panel};
 
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeAuthState {
@@ -41,11 +41,12 @@ pub(crate) struct RuntimeAuthState {
     pub(crate) existing_providers: Vec<ExistingProvider>,
     /// The section name of the provider being edited (None = new provider)
     pub(crate) editing_provider_name: Option<String>,
-    backend: AuthBackend,
+    pub(super) error_message: Option<String>,
+    pub(super) backend: AuthBackend,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AuthBackend {
+pub(super) enum AuthBackend {
     ActiveRun,
     CoreRegistry,
 }
@@ -89,62 +90,6 @@ pub(crate) struct AuthState {
     pub(crate) state: Option<RuntimeAuthState>,
     pub(crate) handled_card_events: HashSet<String>,
     pub(crate) completed_ids: HashSet<String>,
-}
-
-pub(crate) fn record_auth_required(
-    state: &mut InlineState,
-    governed_events: &[GovernedEvent],
-) -> Vec<String> {
-    let mut ids = Vec::new();
-    for event in governed_events {
-        if let AgentEvent::AuthRequired {
-            request_id,
-            providers,
-            ..
-        } = &event.event
-        {
-            if state.auth.state.is_some() {
-                continue;
-            }
-            let id = format!("auth-{request_id}");
-            if state.auth.completed_ids.contains(&id) {
-                continue;
-            }
-            let providers = auth_required_providers_for_display(providers);
-            state.auth.state = Some(RuntimeAuthState {
-                id: id.clone(),
-                request_id: request_id.clone(),
-                phase: AuthPhase::SelectingProvider,
-                providers,
-                selected_provider: 0,
-                current_field: 0,
-                collected_values: HashMap::new(),
-                field_input: String::new(),
-                existing_providers: Vec::new(),
-                editing_provider_name: None,
-                backend: AuthBackend::ActiveRun,
-            });
-            ids.push(id);
-        }
-    }
-    ids
-}
-
-pub(crate) fn render_auth_panel<W: std::io::Write>(
-    state: &mut InlineState,
-    ids: &[String],
-    output: &mut W,
-) -> std::io::Result<()> {
-    for id in ids {
-        let Some(auth) = &state.auth.state else {
-            continue;
-        };
-        if auth.id != *id {
-            continue;
-        }
-        render_current_auth_panel(state, output)?;
-    }
-    Ok(())
 }
 
 pub(crate) fn has_pending_auth(state: &InlineState) -> bool {
@@ -226,6 +171,7 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
         field_input: String::new(),
         existing_providers,
         editing_provider_name: None,
+        error_message: None,
         backend: AuthBackend::CoreRegistry,
     });
 
@@ -679,23 +625,13 @@ fn send_auth_response<W: std::io::Write>(
     };
 
     if let Some(active_run) = state.agent_run.active.as_ref() {
-        if active_run.handle.respond_auth(response.clone()).is_err() {
-            let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
-            renderer.write_notice_panel(
-                output,
-                NoticePanelModel {
-                    title: "Auth failed",
-                    body: vec![
-                        "Unable to send credentials to cosh-core.".to_string(),
-                        "Run /auth again after the current run finishes.".to_string(),
-                    ],
-                    footer: None,
-                },
-            )?;
-            state.auth.completed_ids.insert(auth.id);
-            output.flush()?;
-            return Ok(());
-        }
+        return finish_active_submission(
+            active_run.handle.respond_auth(response),
+            &auth.id,
+            &mut state.auth.completed_ids,
+            state.language,
+            output,
+        );
     } else {
         match auth.backend {
             AuthBackend::CoreRegistry => {
@@ -727,7 +663,7 @@ fn send_auth_response<W: std::io::Write>(
     finish_auth_configuration(state, output, &provider_label)
 }
 
-fn render_current_auth_panel<W: std::io::Write>(
+pub(super) fn render_current_auth_panel<W: std::io::Write>(
     state: &mut InlineState,
     output: &mut W,
 ) -> std::io::Result<()> {

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -14,20 +14,48 @@ fn provider(id: &str, label: &str) -> AuthProviderInfo {
 }
 
 fn governed_auth_required(providers: Vec<AuthProviderInfo>) -> GovernedEvent {
+    governed_auth_required_with_error("req-1", providers, None)
+}
+
+fn governed_auth_required_with_error(
+    request_id: &str,
+    providers: Vec<AuthProviderInfo>,
+    error_message: Option<&str>,
+) -> GovernedEvent {
     GovernedEvent {
         decision: GovernanceDecision::Display,
         policy_decision: GovernancePolicyDecision::DisplayOnly,
         event: AgentEvent::AuthRequired {
             run_id: "run-1".into(),
-            request_id: "req-1".into(),
+            request_id: request_id.into(),
             reason: "test".into(),
-            error_message: None,
+            error_message: error_message.map(str::to_string),
             providers,
         },
         reason: "test".into(),
         display_text: "test".into(),
         auto_execute: false,
     }
+}
+
+#[test]
+fn retry_auth_request_surfaces_validation_error() {
+    let mut state = InlineState::default();
+    state.auth.completed_ids.insert("auth-req-1".to_string());
+    let event = governed_auth_required_with_error(
+        "req-1-retry-1",
+        vec![provider("openai_compat", "OpenAI Compatible")],
+        Some("invalid base_url"),
+    );
+
+    let ids = record_auth_required(&mut state, &[event]);
+    let mut output = Vec::new();
+    render_auth_panel(&mut state, &ids, &mut output).expect("render retry auth");
+
+    assert_eq!(ids, vec!["auth-req-1-retry-1".to_string()]);
+    assert!(String::from_utf8(output)
+        .expect("utf8 auth panel")
+        .contains("invalid base_url"));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Validate authentication values before they mutate or persist provider configuration. A shared core exchange now retries startup and active-run validation failures with a fresh `auth_required` request, and Shell surfaces the validation error without claiming that rejected credentials were saved. Built-in templates enforce their required fields, while generic providers retain compatibility but require a valid HTTP(S) Base URL.

## Related Issue

closes #1771

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [ ] For `blaze`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cosh-core`
- `cargo test -p cosh-shell --lib`
- `cargo test -p cosh-shell --bin cosh-shell`
- `cargo test -p cosh-shell --test protocol`
- `crates/cosh-shell/scripts/check-layout.sh`

Regression coverage verifies invalid-response retry, Shell error rendering without premature success, generic-provider missing/blank Base URLs, required built-in fields, malformed URLs, and the ECS RAM Role exception. One shell test initially hit a transient `Text file busy` while spawning a freshly rebuilt binary and passed on an exact rerun.

## Additional Notes

This PR intentionally keeps preflight deterministic and offline. Provider-specific API-key and model connectivity checks require separate timeout, progress, and opt-out behavior.