### PR TITLE
fix(cosh-ng): [shell] preserve empty enter

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/health/env_collector_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/health/env_collector_tests.rs
@@ -1,13 +1,10 @@
 use super::*;
 
 /// Single process-wide lock for every test that mutates HOME or credential
-/// env vars. All such tests MUST share this one mutex; using separate
-/// mutexes lets tests race on the same global env and read each other's
-/// config.toml.
-fn env_guard() -> std::sync::MutexGuard<'static, ()> {
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
-}
+/// env vars, shared with env-reading tests in other modules via
+/// `crate::diagnostics::test_env`; using separate mutexes lets tests race on
+/// the same global env and read each other's config.toml.
+use crate::diagnostics::test_env::env_guard;
 
 #[test]
 fn classify_provider_covers_known_and_unknown_adapters() {

--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/mod.rs
@@ -1,3 +1,5 @@
 pub(crate) mod bundle;
 pub(crate) mod doctor;
 pub(crate) mod health;
+#[cfg(test)]
+pub(crate) mod test_env;

--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/test_env.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/test_env.rs
@@ -1,0 +1,14 @@
+//! Process-wide lock for tests that touch process environment variables.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Serializes tests that read or mutate shared env vars such as HOME.
+///
+/// Env mutators must hold the guard for their whole set-use-restore span;
+/// readers whose assertions depend on a stable env (e.g. HOME redaction)
+/// must hold it across the read and the assertion. Separate per-module
+/// locks cannot prevent these tests from observing each other's mutations.
+pub(crate) fn env_guard() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
+}

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/context_window.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/context_window.rs
@@ -554,6 +554,9 @@ mod tests {
 
     #[test]
     fn provider_safe_command_facts_redact_home_in_working_directories() {
+        // Hold the shared env lock: doctor env-collector tests swap HOME to
+        // temp dirs in parallel, which would break the redaction assertion.
+        let _guard = crate::diagnostics::test_env::env_guard();
         let Some(home) = std::env::var("HOME").ok().filter(|home| !home.is_empty()) else {
             return;
         };

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/generation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/generation.rs
@@ -1,0 +1,144 @@
+//! Shared generation counter for real user bytes written to the shell PTY.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Monotonic counter shared between the input relay and the PTY output loop.
+///
+/// The relay bumps it *before* writing user bytes to the PTY master, so any
+/// PTY output produced in response to those bytes is only readable after the
+/// bump. The output loop compares snapshots against this counter to expire
+/// stale prompt-replay state without depending on channel drain timing.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct UserPtyInputGeneration(Arc<AtomicU64>);
+
+impl UserPtyInputGeneration {
+    /// Records one batch of user bytes about to reach the PTY; returns the
+    /// new generation.
+    pub(crate) fn bump(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    pub(crate) fn current(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
+const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
+// Default `operate-and-get-next` binding: accepts the current line exactly
+// like Enter, so it must be treated as a submission candidate.
+const CTRL_O: u8 = 0x0f;
+
+/// Counts line-submission candidates in relayed user bytes.
+///
+/// This is a heuristic over-approximation of readline's logical accept-line:
+/// CR, LF, and Ctrl-O (bash's default `operate-and-get-next`) count; custom
+/// `.inputrc` bindings to `accept-line` cannot be enumerated from the byte
+/// stream and stay uncovered. Over-counts (e.g. Ctrl-O typed inside a
+/// foreground program) are reconciled by the prompt-replay tracker once the
+/// shell idles at a prompt.
+///
+/// Newlines inside a bracketed paste are inserted literally by readline and
+/// never produce a prompt boundary, so they are excluded. Paste delimiters
+/// split across writes are buffered until they can be classified.
+#[derive(Debug, Default)]
+pub(super) struct LineSubmitCounter {
+    in_bracketed_paste: bool,
+    pending_delimiter: Vec<u8>,
+}
+
+impl LineSubmitCounter {
+    pub(super) fn count(&mut self, bytes: &[u8]) -> usize {
+        let mut scan = std::mem::take(&mut self.pending_delimiter);
+        scan.extend_from_slice(bytes);
+        let mut submits = 0;
+        let mut idx = 0;
+        while idx < scan.len() {
+            let rest = &scan[idx..];
+            if rest.starts_with(BRACKETED_PASTE_START) {
+                self.in_bracketed_paste = true;
+                idx += BRACKETED_PASTE_START.len();
+                continue;
+            }
+            if rest.starts_with(BRACKETED_PASTE_END) {
+                self.in_bracketed_paste = false;
+                idx += BRACKETED_PASTE_END.len();
+                continue;
+            }
+            if is_paste_delimiter_prefix(rest) {
+                // Keep the partial delimiter for the next write; ESC-sequence
+                // prefixes never contain CR/LF, so nothing is under-counted.
+                self.pending_delimiter = rest.to_vec();
+                return submits;
+            }
+            if matches!(scan[idx], b'\r' | b'\n' | CTRL_O) && !self.in_bracketed_paste {
+                submits += 1;
+            }
+            idx += 1;
+        }
+        submits
+    }
+}
+
+fn is_paste_delimiter_prefix(bytes: &[u8]) -> bool {
+    bytes.len() < BRACKETED_PASTE_START.len()
+        && (BRACKETED_PASTE_START.starts_with(bytes) || BRACKETED_PASTE_END.starts_with(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LineSubmitCounter, UserPtyInputGeneration};
+
+    #[test]
+    fn bump_is_visible_through_clones() {
+        let generation = UserPtyInputGeneration::default();
+        let shared = generation.clone();
+
+        assert_eq!(generation.current(), 0);
+        assert_eq!(shared.bump(), 1);
+        assert_eq!(generation.current(), 1);
+    }
+
+    #[test]
+    fn line_submit_counter_counts_cr_and_lf() {
+        let mut counter = LineSubmitCounter::default();
+
+        assert_eq!(counter.count(b"ls -la\r"), 1);
+        assert_eq!(counter.count(b"\r\r"), 2);
+        assert_eq!(counter.count(b"abc"), 0);
+    }
+
+    #[test]
+    fn line_submit_counter_counts_ctrl_o_as_submission() {
+        let mut counter = LineSubmitCounter::default();
+
+        assert_eq!(counter.count(b"ls -la\x0f"), 1);
+        assert_eq!(counter.count(b"\x1b[200~\x0f\x1b[201~"), 0);
+    }
+
+    #[test]
+    fn line_submit_counter_ignores_newlines_inside_bracketed_paste() {
+        let mut counter = LineSubmitCounter::default();
+
+        assert_eq!(counter.count(b"\x1b[200~line1\nline2\x1b[201~\r"), 1);
+    }
+
+    #[test]
+    fn line_submit_counter_tracks_paste_state_across_writes() {
+        let mut counter = LineSubmitCounter::default();
+
+        assert_eq!(counter.count(b"\x1b[200~one\n"), 0);
+        assert_eq!(counter.count(b"two\n\x1b[201~"), 0);
+        assert_eq!(counter.count(b"\r"), 1);
+    }
+
+    #[test]
+    fn line_submit_counter_buffers_split_paste_delimiter() {
+        let mut counter = LineSubmitCounter::default();
+
+        assert_eq!(counter.count(b"\x1b[20"), 0);
+        assert_eq!(counter.count(b"0~in\n"), 0);
+        assert_eq!(counter.count(b"\x1b[201~\r"), 1);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -3,6 +3,7 @@ use crate::input::InterceptReason;
 mod capture_bridge;
 mod card_capture;
 mod event_parser;
+mod generation;
 mod mode;
 mod pty;
 mod relay;
@@ -10,6 +11,7 @@ mod relay_action;
 mod spawn;
 
 pub(crate) use event_parser::redact_extension_setting_value;
+pub(crate) use generation::UserPtyInputGeneration;
 pub(crate) use mode::{update_input_mode, RawInputMode};
 pub use mode::{PromptGhostCandidate, PromptGhostRoute, RawInputCapture, RawObserverAction};
 pub(crate) use pty::{
@@ -26,6 +28,13 @@ pub(super) const ESC: u8 = 0x1b;
 pub(crate) enum RawInputEvent {
     ShellInputActivity {
         empty: bool,
+    },
+    /// User bytes the relay wrote to the PTY: the write generation plus how
+    /// many line submissions (accept-line CR/LF) the write carried. Anchors
+    /// prompt replay state so real user input expires stale replays.
+    PtyUserWrite {
+        generation: u64,
+        line_submits: usize,
     },
     CtrlC,
     Esc,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
@@ -8,5 +8,5 @@ pub use implementation::{RawInputCapture, RawObserverAction, RawRelayAction};
 pub(crate) use implementation::{
     redact_extension_setting_value, set_pty_winsize, signal_foreground_process_group,
     signal_process_group, spawn_raw_action_relay, spawn_raw_input_relay, update_input_mode,
-    write_all_pty, PromptGhostRoute, RawInputEvent, RawInputMode,
+    write_all_pty, PromptGhostRoute, RawInputEvent, RawInputMode, UserPtyInputGeneration,
 };

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -10,6 +10,7 @@ use super::event_parser::{
     redact_extension_setting_value, starts_intercept_candidate, starts_native_intercept_candidate,
     CandidateLineBuffer, CandidateLineStatus, NativeLineState,
 };
+use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::{write_all_pty, PromptGhostRoute, RawInputEvent, RawInputMode, CTRL_C};
 
 pub(super) struct InputRelayContext<'a> {
@@ -17,9 +18,32 @@ pub(super) struct InputRelayContext<'a> {
     pub(super) input_classifier: &'a InputClassifier,
     pub(super) input_events: &'a Sender<RawInputEvent>,
     pub(super) input_mode: &'a Arc<Mutex<RawInputMode>>,
+    pub(super) input_generation: &'a UserPtyInputGeneration,
+    pub(super) line_submits: &'a mut LineSubmitCounter,
     pub(super) line_buffer: &'a mut CandidateLineBuffer,
     pub(super) native_line_state: &'a mut NativeLineState,
     pub(super) exit_tracker: &'a mut ExplicitExitTracker,
+}
+
+/// Writes real user bytes to the PTY, bumping the shared input generation
+/// first so replayed-prompt state armed for an older generation expires
+/// before the resulting PTY output can be parsed. The event also reports how
+/// many line submissions the write carried, so the output loop can match
+/// them against shell prompt boundaries.
+pub(super) fn write_user_bytes_to_pty(
+    master: &mut File,
+    input_generation: &UserPtyInputGeneration,
+    line_submits: &mut LineSubmitCounter,
+    input_events: &Sender<RawInputEvent>,
+    bytes: &[u8],
+) -> io::Result<()> {
+    let line_submits = line_submits.count(bytes);
+    let generation = input_generation.bump();
+    let _ = input_events.send(RawInputEvent::PtyUserWrite {
+        generation,
+        line_submits,
+    });
+    write_all_pty(master, bytes)
 }
 
 pub(super) fn send_raw_input_events(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
@@ -81,7 +105,13 @@ fn relay_passthrough_input_with_activity(
         send_shell_input_state(relay.native_line_state.is_empty(), relay.input_events);
     }
     relay.exit_tracker.observe_shell_bytes(bytes);
-    write_all_pty(relay.master, bytes)?;
+    write_user_bytes_to_pty(
+        relay.master,
+        relay.input_generation,
+        relay.line_submits,
+        relay.input_events,
+        bytes,
+    )?;
     Ok(false)
 }
 
@@ -163,12 +193,24 @@ pub(super) fn relay_prompt_ghost_input(
                 relay
                     .exit_tracker
                     .observe_shell_bytes(ghost_text.as_bytes());
-                write_all_pty(relay.master, ghost_text.as_bytes())?;
+                write_user_bytes_to_pty(
+                    relay.master,
+                    relay.input_generation,
+                    relay.line_submits,
+                    relay.input_events,
+                    ghost_text.as_bytes(),
+                )?;
                 if !remainder.is_empty() {
                     send_raw_input_events(remainder, relay.input_events);
                     relay.native_line_state.observe_shell_bytes(remainder);
                     relay.exit_tracker.observe_shell_bytes(remainder);
-                    write_all_pty(relay.master, remainder)?;
+                    write_user_bytes_to_pty(
+                        relay.master,
+                        relay.input_generation,
+                        relay.line_submits,
+                        relay.input_events,
+                        remainder,
+                    )?;
                 }
             }
             PromptGhostRoute::AgentIntercept { suggestion_id } => {
@@ -258,14 +300,7 @@ fn relay_native_passthrough(
     {
         relay.line_buffer.push(bytes);
         if native_candidate_should_return_to_shell(relay.input_classifier, relay.line_buffer) {
-            return flush_candidate_line_to_shell(
-                relay.master,
-                relay.input_events,
-                relay.line_buffer,
-                relay.native_line_state,
-                relay.exit_tracker,
-                emit_activity,
-            );
+            return flush_candidate_line_to_shell(relay, emit_activity);
         }
         // Control bytes such as Tab must reach readline without first changing
         // the outer terminal cursor, whose display width differs from byte count.
@@ -280,7 +315,13 @@ fn relay_native_passthrough(
         send_shell_input_state(relay.native_line_state.is_empty(), relay.input_events);
     }
     relay.exit_tracker.observe_shell_bytes(bytes);
-    write_all_pty(relay.master, bytes)?;
+    write_user_bytes_to_pty(
+        relay.master,
+        relay.input_generation,
+        relay.line_submits,
+        relay.input_events,
+        bytes,
+    )?;
     Ok(false)
 }
 
@@ -297,14 +338,7 @@ fn relay_candidate_line(
             send_shell_input_state(true, relay.input_events);
             Ok(true)
         }
-        CandidateLineStatus::Unsafe => flush_candidate_line_to_shell(
-            relay.master,
-            relay.input_events,
-            relay.line_buffer,
-            relay.native_line_state,
-            relay.exit_tracker,
-            emit_activity,
-        ),
+        CandidateLineStatus::Unsafe => flush_candidate_line_to_shell(relay, emit_activity),
         CandidateLineStatus::Complete { line, line_len } => {
             let force_agent_intercept = relay.line_buffer.force_agent_intercept;
             let suggestion_id = relay.line_buffer.forced_agent_suggestion_id.clone();
@@ -357,7 +391,13 @@ fn relay_candidate_line(
                         );
                     }
                     relay.exit_tracker.observe_shell_bytes(&bytes);
-                    write_all_pty(relay.master, &bytes)?;
+                    write_user_bytes_to_pty(
+                        relay.master,
+                        relay.input_generation,
+                        relay.line_submits,
+                        relay.input_events,
+                        &bytes,
+                    )?;
                     if !remainder.is_empty() {
                         relay_passthrough_input_with_activity(&remainder, relay, emit_activity)?;
                     }
@@ -377,22 +417,24 @@ fn relay_candidate_line(
 }
 
 fn flush_candidate_line_to_shell(
-    master: &mut File,
-    input_events: &Sender<RawInputEvent>,
-    line_buffer: &mut CandidateLineBuffer,
-    native_line_state: &mut NativeLineState,
-    exit_tracker: &mut ExplicitExitTracker,
+    relay: &mut InputRelayContext<'_>,
     emit_activity: bool,
 ) -> io::Result<bool> {
-    let bytes = line_buffer.take();
-    let _ = input_events.send(RawInputEvent::CandidateClearLine);
-    send_raw_input_events(&bytes, input_events);
-    native_line_state.observe_shell_bytes(&bytes);
+    let bytes = relay.line_buffer.take();
+    let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
+    send_raw_input_events(&bytes, relay.input_events);
+    relay.native_line_state.observe_shell_bytes(&bytes);
     if emit_activity && !bytes.is_empty() {
-        send_shell_input_state(native_line_state.is_empty(), input_events);
+        send_shell_input_state(relay.native_line_state.is_empty(), relay.input_events);
     }
-    exit_tracker.observe_shell_bytes(&bytes);
-    write_all_pty(master, &bytes)?;
+    relay.exit_tracker.observe_shell_bytes(&bytes);
+    write_user_bytes_to_pty(
+        relay.master,
+        relay.input_generation,
+        relay.line_submits,
+        relay.input_events,
+        &bytes,
+    )?;
     Ok(false)
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -4,8 +4,9 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use super::super::generation::LineSubmitCounter;
 use super::super::spawn::{finish_input_relay, relay_input_bytes, RawInputRelayState};
-use super::super::{PromptGhostCandidate, RawRelayAction};
+use super::super::{PromptGhostCandidate, RawRelayAction, UserPtyInputGeneration};
 use super::*;
 
 fn output_file(label: &str) -> (std::path::PathBuf, File) {
@@ -100,6 +101,7 @@ impl SelectionRelay {
             event_tx,
             InputClassifier::default(),
             input_mode.clone(),
+            UserPtyInputGeneration::default(),
         );
         Self {
             path,
@@ -157,6 +159,7 @@ impl DelayRelay {
             event_tx,
             InputClassifier::default(),
             input_mode.clone(),
+            UserPtyInputGeneration::default(),
         );
         Self {
             path,
@@ -283,6 +286,7 @@ fn selection_bare_escape_times_out_without_waiting_for_another_key() {
         event_tx,
         InputClassifier::default(),
         input_mode.clone(),
+        UserPtyInputGeneration::default(),
     );
 
     input_tx.send(b"\x1b".to_vec()).expect("send escape");
@@ -323,6 +327,7 @@ fn selection_action_wait_flushes_escape_at_the_deadline() {
         tx,
         InputClassifier::default(),
         input_mode.clone(),
+        UserPtyInputGeneration::default(),
     );
 
     expect_prompt_ghost_dismissal(&rx);
@@ -754,11 +759,15 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
@@ -783,7 +792,15 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
         rx.try_iter().collect::<Vec<_>>(),
         vec![
             RawInputEvent::PromptGhostClear,
-            RawInputEvent::ShellInputActivity { empty: true }
+            RawInputEvent::PtyUserWrite {
+                generation: 1,
+                line_submits: 0,
+            },
+            RawInputEvent::ShellInputActivity { empty: true },
+            RawInputEvent::PtyUserWrite {
+                generation: 2,
+                line_submits: 0,
+            },
         ]
     );
     assert!(!line_buffer.force_agent_intercept);
@@ -803,11 +820,15 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
@@ -841,11 +862,15 @@ fn native_shell_input_reports_editing_then_empty_without_content() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
@@ -858,7 +883,15 @@ fn native_shell_input_reports_editing_then_empty_without_content() {
         rx.try_iter().collect::<Vec<_>>(),
         vec![
             RawInputEvent::ShellInputActivity { empty: false },
+            RawInputEvent::PtyUserWrite {
+                generation: 1,
+                line_submits: 0,
+            },
             RawInputEvent::ShellInputActivity { empty: true },
+            RawInputEvent::PtyUserWrite {
+                generation: 2,
+                line_submits: 0,
+            },
         ]
     );
     fs::remove_file(path).ok();
@@ -879,11 +912,15 @@ fn agent_prompt_tab_stays_local_until_enter_and_keeps_suggestion_id() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
@@ -946,11 +983,15 @@ fn selection_enter_submits_the_active_prompt_without_shell_execution() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
@@ -989,11 +1030,15 @@ fn clearing_accepted_agent_prompt_emits_binding_dismissal() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
@@ -1025,11 +1070,15 @@ fn unsupported_arrow_after_agent_prompt_tab_cancels_without_writing_to_shell() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
@@ -1072,11 +1121,15 @@ fn split_cursor_sequences_after_agent_prompt_tab_never_reach_shell() {
         let mut native_line_state = NativeLineState::default();
         let mut exit_tracker = ExplicitExitTracker::default();
         let classifier = InputClassifier::default();
+        let input_generation = UserPtyInputGeneration::default();
+        let mut line_submits = LineSubmitCounter::default();
         let mut relay = InputRelayContext {
             master: &mut master,
             input_classifier: &classifier,
             input_events: &tx,
             input_mode: &input_mode,
+            input_generation: &input_generation,
+            line_submits: &mut line_submits,
             line_buffer: &mut line_buffer,
             native_line_state: &mut native_line_state,
             exit_tracker: &mut exit_tracker,
@@ -1115,11 +1168,15 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
         input_events: &tx,
         input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
         line_buffer: &mut line_buffer,
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -13,12 +13,13 @@ use crate::input::InputClassifier;
 use super::capture_bridge::consume_captured_input;
 use super::card_capture::CardInputState;
 use super::event_parser::{CandidateLineBuffer, NativeLineState};
+use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::{current_raw_input_mode, RawInputMode};
 use super::pty::{set_pty_winsize, signal_process_group, write_all_pty};
 use super::relay::{
     dismiss_prompt_ghost_input, relay_delayed_input, relay_passthrough_input,
-    relay_prompt_ghost_input, send_held_input_events, send_raw_input_events, ExplicitExitTracker,
-    InputRelayContext,
+    relay_prompt_ghost_input, send_held_input_events, send_raw_input_events,
+    write_user_bytes_to_pty, ExplicitExitTracker, InputRelayContext,
 };
 use super::{PromptGhostRoute, RawInputEvent, RawRelayAction, ESC};
 
@@ -55,8 +56,19 @@ pub(super) struct RawInputRelayState {
     line_buffer: CandidateLineBuffer,
     native_line_state: NativeLineState,
     exit_tracker: ExplicitExitTracker,
+    input_generation: UserPtyInputGeneration,
+    line_submits: LineSubmitCounter,
     pending_prompt_ghost_escape: Option<PendingPromptGhostEscape>,
     pending_delay_escape: Option<PendingDelayEscape>,
+}
+
+impl RawInputRelayState {
+    fn with_generation(input_generation: UserPtyInputGeneration) -> Self {
+        Self {
+            input_generation,
+            ..Self::default()
+        }
+    }
 }
 
 enum InputRead {
@@ -74,6 +86,7 @@ pub(crate) fn spawn_raw_input_relay<R>(
     input_events: Sender<RawInputEvent>,
     input_classifier: InputClassifier,
     input_mode: Arc<Mutex<RawInputMode>>,
+    input_generation: UserPtyInputGeneration,
 ) -> JoinHandle<io::Result<()>>
 where
     R: Read + Send + 'static,
@@ -83,7 +96,7 @@ where
         // The relay must wake without a later keystroke to resolve a bare ESC.
         thread::spawn(move || read_input_chunks(input, read_tx));
 
-        let mut state = RawInputRelayState::default();
+        let mut state = RawInputRelayState::with_generation(input_generation);
         loop {
             let input = match receive_input(&read_rx, &state) {
                 Ok(input) => input,
@@ -370,7 +383,13 @@ fn relay_input_for_mode(
             send_raw_input_events(bytes, input_events);
             state.native_line_state.observe_shell_bytes(bytes);
             state.exit_tracker.observe_shell_bytes(bytes);
-            write_all_pty(master, bytes)?;
+            write_user_bytes_to_pty(
+                master,
+                &state.input_generation,
+                &mut state.line_submits,
+                input_events,
+                bytes,
+            )?;
         }
     }
     Ok(())
@@ -388,6 +407,8 @@ fn input_relay_context<'a>(
         input_classifier,
         input_events,
         input_mode,
+        input_generation: &state.input_generation,
+        line_submits: &mut state.line_submits,
         line_buffer: &mut state.line_buffer,
         native_line_state: &mut state.native_line_state,
         exit_tracker: &mut state.exit_tracker,
@@ -492,7 +513,13 @@ pub(super) fn finish_input_relay(
         state,
     )?;
     if !state.exit_tracker.saw_explicit_exit() {
-        write_all_pty(master, b"exit\n")?;
+        write_user_bytes_to_pty(
+            master,
+            &state.input_generation,
+            &mut state.line_submits,
+            input_events,
+            b"exit\n",
+        )?;
     }
     Ok(())
 }
@@ -542,9 +569,10 @@ pub(crate) fn spawn_raw_action_relay(
     input_events: Sender<RawInputEvent>,
     input_classifier: InputClassifier,
     input_mode: Arc<Mutex<RawInputMode>>,
+    input_generation: UserPtyInputGeneration,
 ) -> JoinHandle<io::Result<()>> {
     thread::spawn(move || {
-        let mut state = RawInputRelayState::default();
+        let mut state = RawInputRelayState::with_generation(input_generation);
         for action in actions {
             flush_pending_prompt_ghost_escape(
                 false,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker.rs
@@ -496,6 +496,9 @@ _cosh_prompt_command() {
     IFS= read -r _COSH_ACTIVE_DEBUG_TRAP < "$trap_snapshot_file" || _COSH_ACTIVE_DEBUG_TRAP=""
     rm -f -- "$trap_snapshot_file" 2>/dev/null || true
   fi
+  # The next visible shell bytes are the prompt paint. Keep this marker after
+  # every user PROMPT_COMMAND so its output cannot masquerade as the prompt.
+  _cosh_emit_marker "prompt_ready" "" "$status" false
   _COSH_IN_PROMPT_COMMAND=0
   return "$status"
 }
@@ -881,6 +884,11 @@ _cosh_precmd_marker() {
   _cosh_clear_handoff_request
   unset _COSH_HANDOFF_ACTIVE 2>/dev/null || true
   _cosh_emit_marker "precmd" "" "$exit_status" false
+  # Only claim prompt readiness while this remains the final precmd hook.
+  # Hooks appended later may still emit output or block before zsh paints.
+  if [[ "${precmd_functions[-1]:-}" == "_cosh_precmd_marker" ]]; then
+    _cosh_emit_marker "prompt_ready" "" "$exit_status" false
+  fi
 }
 
 # ── Hook setup (re-set after user rcfile may have overridden) ──

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -41,6 +41,15 @@ struct CurrentCommand {
     shell_environment_generation: Option<u64>,
 }
 
+/// Why a display cut was recorded, so consumers can tell an intercepted
+/// input (shell has not painted a prompt for it yet) apart from a real
+/// prompt boundary (precmd/shell-ready).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DisplayCutKind {
+    Intercept,
+    PromptBoundary,
+}
+
 #[derive(Debug)]
 pub(super) struct OscParser {
     pub(super) session_id: String,
@@ -54,8 +63,9 @@ pub(super) struct OscParser {
     current: Option<CurrentCommand>,
     command_seq: usize,
     intervention_cuts: Vec<usize>,
-    intervention_display_cuts: Vec<usize>,
+    intervention_display_cuts: Vec<(usize, DisplayCutKind)>,
     last_prompt_display_start: Option<usize>,
+    prompt_ready_display_start: Option<usize>,
     pub(super) captured_output_ref_bytes: usize,
     pending_command_origin: Option<PendingCommandOrigin>,
     pending_handoff_echo: Option<PendingHandoffEcho>,
@@ -102,6 +112,7 @@ impl OscParser {
             intervention_cuts: Vec::new(),
             intervention_display_cuts: Vec::new(),
             last_prompt_display_start: None,
+            prompt_ready_display_start: None,
             captured_output_ref_bytes: 0,
             pending_command_origin: None,
             pending_handoff_echo: None,
@@ -218,15 +229,20 @@ impl OscParser {
         let timestamp = marker.timestamp_ms.unwrap_or_else(now_ms);
 
         match marker.event.as_str() {
+            "prompt_ready" => {
+                self.prompt_ready_display_start = Some(self.display.len());
+            }
             "intercept" => {
                 let input = marker.command.unwrap_or_default();
                 let reason = marker
                     .reason
                     .unwrap_or_else(|| "natural_language".to_string());
                 self.intervention_cuts.push(self.clean.len());
-                self.intervention_display_cuts.push(self.display.len());
+                self.intervention_display_cuts
+                    .push((self.display.len(), DisplayCutKind::Intercept));
                 self.push_intercept_event(&session_id, input, marker.cwd, &reason);
                 self.current = None;
+                self.prompt_ready_display_start = None;
             }
             "preexec" => {
                 let command = marker.command.unwrap_or_default();
@@ -259,9 +275,11 @@ impl OscParser {
                 self.events.push(event);
             }
             "precmd" => {
+                self.prompt_ready_display_start = None;
                 let Some(current) = self.current.take() else {
                     self.intervention_cuts.push(self.clean.len());
-                    self.intervention_display_cuts.push(self.display.len());
+                    self.intervention_display_cuts
+                        .push((self.display.len(), DisplayCutKind::PromptBoundary));
                     self.last_prompt_display_start = Some(self.display.len());
                     self.events.push(ShellEvent {
                         kind: ShellEventKind::ShellReady,
@@ -294,7 +312,8 @@ impl OscParser {
                 let output = self.clean[current.output_start..].to_vec();
                 let output_ref = self.capture_command_output_ref(&current.id, &output)?;
                 self.intervention_cuts.push(self.clean.len());
-                self.intervention_display_cuts.push(self.display.len());
+                self.intervention_display_cuts
+                    .push((self.display.len(), DisplayCutKind::PromptBoundary));
                 self.last_prompt_display_start = Some(self.display.len());
                 let kind = if status == 0 {
                     ShellEventKind::CommandCompleted
@@ -591,8 +610,14 @@ impl OscParser {
             .count()
     }
 
-    pub(super) fn drain_intervention_display_cuts(&mut self) -> Vec<usize> {
+    pub(super) fn drain_intervention_display_cuts(&mut self) -> Vec<(usize, DisplayCutKind)> {
         std::mem::take(&mut self.intervention_display_cuts)
+    }
+
+    /// True while a marker-tracked foreground command is running (between
+    /// its preexec and precmd markers).
+    pub(super) fn has_active_foreground_command(&self) -> bool {
+        self.current.is_some()
     }
 
     pub(super) fn last_prompt_display(&self) -> &[u8] {
@@ -603,6 +628,13 @@ impl OscParser {
             return &[];
         }
         &self.display[start..]
+    }
+
+    /// True after the shell's post-hook marker is followed by visible prompt
+    /// bytes, excluding output produced by user prompt hooks.
+    pub(super) fn has_prompt_painted_since_ready(&self) -> bool {
+        self.prompt_ready_display_start
+            .is_some_and(|start| start < self.display.len())
     }
 
     pub(super) fn push_intercept_event(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -91,6 +91,48 @@ fn bash_preexec_marker_skips_completion_with_comp_type_guard() {
 }
 
 #[test]
+fn prompt_ready_markers_follow_user_prompt_hooks() {
+    let bash = bash_marker_script();
+    let prompt_command = bash
+        .find("_cosh_run_user_prompt_command \"$status\"")
+        .expect("bash user prompt command");
+    let bash_ready = bash
+        .find("_cosh_emit_marker \"prompt_ready\"")
+        .expect("bash prompt-ready marker");
+    assert!(prompt_command < bash_ready);
+
+    let zsh = zsh_marker_script();
+    let precmd = zsh
+        .find("_cosh_emit_marker \"precmd\"")
+        .expect("zsh precmd marker");
+    let zsh_ready = zsh
+        .find("_cosh_emit_marker \"prompt_ready\"")
+        .expect("zsh prompt-ready marker");
+    assert!(precmd < zsh_ready);
+    assert!(zsh[..zsh_ready].ends_with(
+        "if [[ \"${precmd_functions[-1]:-}\" == \"_cosh_precmd_marker\" ]]; then\n    "
+    ));
+}
+
+#[test]
+fn prompt_hook_output_does_not_count_as_a_painted_prompt() {
+    let mut parser = parser_for_test("prompt-ready");
+    feed_precmd(&mut parser, 0);
+
+    parser
+        .feed(b"hook output")
+        .expect("feed prompt hook output");
+    assert!(!parser.has_prompt_painted_since_ready());
+
+    let ready = b"\x1b]1337;COSH;{\"event\":\"prompt_ready\",\"token\":\"test-marker-token\"}\x07";
+    parser.feed(ready).expect("feed prompt-ready marker");
+    assert!(!parser.has_prompt_painted_since_ready());
+
+    parser.feed(b"prompt> ").expect("feed prompt paint");
+    assert!(parser.has_prompt_painted_since_ready());
+}
+
+#[test]
 fn parser_clean_strips_zsh_bracketed_paste_and_applies_backspace() {
     let mut parser = parser_for_test("clean-zsh-control");
     let input =

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/prompt_replay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/prompt_replay.rs
@@ -1,5 +1,208 @@
 use std::borrow::Cow;
+use std::time::{Duration, Instant};
 
+use crate::raw_input::UserPtyInputGeneration;
+
+/// PTY silence at a painted, idle prompt after which unmatched submissions
+/// are written off as consumed by a foreground program. Readline echoes
+/// queued typeahead within milliseconds of painting a prompt, so once the
+/// prompt is up a fresh idle gap this long means no shell response is still
+/// pending.
+const IDLE_RECONCILE_WINDOW: Duration = Duration::from_millis(200);
+
+/// Prompt replay dedup state tied to the user PTY input generation.
+///
+/// A synthesized prompt (panel restore or handoff) arms a pending replay
+/// prefix so the shell's late echo of the same prompt is not painted twice.
+/// Real user input must expire that state before its PTY response is parsed:
+/// the relay bumps the shared generation before writing to the PTY, so the
+/// echo of an empty Enter (bracketed-paste toggles + CRLF + fresh prompt) is
+/// never mistaken for the replayed prompt.
+///
+/// Line submissions are matched one-to-one against shell prompt boundaries
+/// (precmd), so neither typeahead entered while a foreground command runs
+/// nor several Enters in one relay write can be acknowledged before the
+/// shell actually consumed them. Two exceptions keep the ledger honest:
+///
+/// - A submission whose line the DEBUG trap intercepted still produces a
+///   precmd, but its whole response *is* the prompt repaint the replay is
+///   armed to strip, so it does not block arming.
+/// - Submissions consumed by a foreground program (e.g. `read`, a REPL, a
+///   password prompt) never produce a boundary; those are written off once
+///   the shell has painted a prompt and idles at it, so one interactive
+///   command cannot disable replay dedup for the whole session.
+///
+/// The ledger only decides whether dedup arms; input safety does not rest
+/// on it. [`strip_replayed_prompt_prefix`] fails open: it removes bytes only
+/// when a slice opens with the armed prompt verbatim, so a wrong arm costs
+/// at most a duplicate prompt paint and can never swallow the response to a
+/// user submission.
+#[derive(Debug)]
+pub(super) struct PromptReplayTracker {
+    input_generation: UserPtyInputGeneration,
+    /// Highest generation the relay reported as written to the PTY.
+    last_written: u64,
+    /// Line submissions written to the PTY whose shell response (a prompt
+    /// boundary) has not been observed yet.
+    outstanding_submits: usize,
+    /// Submissions whose line was intercepted by the DEBUG trap: their only
+    /// remaining response is the prompt repaint that replay dedup strips.
+    pending_intercepts: usize,
+    /// When the most recent relay write event was drained; gates idle
+    /// reconciliation so a just-written submission is never written off.
+    last_write_seen: Option<Instant>,
+    idle_reconcile_window: Duration,
+    pending_prompt: Option<Vec<u8>>,
+    armed_at: u64,
+}
+
+impl PromptReplayTracker {
+    pub(super) fn new(input_generation: UserPtyInputGeneration) -> Self {
+        Self {
+            input_generation,
+            last_written: 0,
+            outstanding_submits: 0,
+            pending_intercepts: 0,
+            last_write_seen: None,
+            idle_reconcile_window: IDLE_RECONCILE_WINDOW,
+            pending_prompt: None,
+            armed_at: 0,
+        }
+    }
+
+    /// Records a relay-reported PTY write. The event travels through the
+    /// channel ahead of the PTY echo it triggers, so an armed replay from an
+    /// older generation can also be expired here.
+    pub(super) fn observe_user_write(&mut self, generation: u64, line_submits: usize) {
+        self.last_written = generation;
+        self.outstanding_submits = self.outstanding_submits.saturating_add(line_submits);
+        self.last_write_seen = Some(Instant::now());
+        if self.pending_prompt.is_some() && generation != self.armed_at {
+            self.pending_prompt = None;
+        }
+    }
+
+    /// Marks a shell prompt boundary (precmd/shell-ready): the shell
+    /// consumed exactly one submitted line and finished responding to it.
+    /// Boundaries without a matching submission (e.g. a Ctrl-C prompt
+    /// repaint) are ignored by the saturating decrement.
+    pub(super) fn observe_prompt_boundary(&mut self) {
+        self.outstanding_submits = self.outstanding_submits.saturating_sub(1);
+        self.pending_intercepts = self.pending_intercepts.saturating_sub(1);
+    }
+
+    /// Marks a DEBUG-trap intercept: the just-submitted line was killed and
+    /// the shell will only answer it with a precmd plus a prompt repaint —
+    /// exactly what an armed replay strips — so that submission must not
+    /// block arming.
+    pub(super) fn observe_intercept_cut(&mut self) {
+        self.pending_intercepts = self.pending_intercepts.saturating_add(1);
+    }
+
+    /// Writes off submissions that will never produce a prompt boundary
+    /// because a foreground program consumed them (or a submission byte was
+    /// over-counted, e.g. Ctrl-O inside a pager).
+    ///
+    /// Requires causal evidence that readline is back in control before the
+    /// silence window counts: no marker-tracked command running, every relay
+    /// write drained, and prompt bytes painted after the shell's post-hook
+    /// `prompt_ready` marker (`prompt_painted`). The precmd marker fires before
+    /// the user's own PROMPT_COMMAND body and the PS1 paint, so
+    /// boundary-plus-silence alone (e.g. a slow PROMPT_COMMAND) proves nothing
+    /// about queued typeahead.
+    /// Once the prompt is up, readline echoes queued submissions within
+    /// milliseconds, so a genuinely pending one cannot survive the window;
+    /// without this write-off one `read`/REPL interaction would disable
+    /// replay dedup for the rest of the session. Even a premature write-off
+    /// is bounded by the strip fail-open to a duplicate prompt paint.
+    pub(super) fn reconcile_idle_at_prompt(
+        &mut self,
+        command_running: bool,
+        prompt_painted: bool,
+        last_pty_output: Option<Instant>,
+    ) {
+        if (self.outstanding_submits == 0 && self.pending_intercepts == 0)
+            || command_running
+            || !prompt_painted
+        {
+            return;
+        }
+        if self.input_generation.current() != self.last_written {
+            return;
+        }
+        let now = Instant::now();
+        let settled = |at: Option<Instant>| {
+            at.is_none_or(|at| now.saturating_duration_since(at) >= self.idle_reconcile_window)
+        };
+        if settled(self.last_write_seen) && settled(last_pty_output) {
+            self.outstanding_submits = 0;
+            self.pending_intercepts = 0;
+        }
+    }
+
+    /// Arms replay dedup for a synthesized prompt (panel restore or handoff
+    /// prompt echo).
+    ///
+    /// Refuses to arm while any user input still has an unparsed PTY response:
+    /// a submitted line without its prompt boundary yet (typeahead during a
+    /// foreground command, several Enters in one write) or a write the output
+    /// loop has not drained. This keeps replay matching accurate; the strip
+    /// fail-open independently guarantees that a wrong arm cannot swallow an
+    /// accept-line response. Submissions the DEBUG trap intercepted are
+    /// exempt: their only response is the repaint this arm exists to strip.
+    ///
+    /// Known limit: custom `.inputrc` bindings to `accept-line` other than
+    /// CR/LF/Ctrl-O are invisible to the submission counter, so a boundary
+    /// or intercept they produce can let this arm over a queued Enter. The
+    /// strip fail-open bounds that mistake to a duplicate prompt paint: the
+    /// Enter's response never opens with the prompt bytes, so it is passed
+    /// through verbatim.
+    pub(super) fn arm_for_replay(&mut self, prompt: &[u8]) {
+        let current = self.input_generation.current();
+        if current != self.last_written || self.outstanding_submits > self.pending_intercepts {
+            return;
+        }
+        self.arm(prompt, current);
+    }
+
+    fn arm(&mut self, prompt: &[u8], generation: u64) {
+        self.pending_prompt = Some(prompt.to_vec());
+        self.armed_at = generation;
+    }
+
+    /// Strips the armed replay prefix from PTY display output, expiring the
+    /// state first when user input was written after arming.
+    pub(super) fn strip<'a>(&mut self, bytes: &'a [u8]) -> &'a [u8] {
+        self.expire_on_user_input();
+        strip_replayed_prompt_prefix(bytes, &mut self.pending_prompt)
+    }
+
+    fn expire_on_user_input(&mut self) {
+        if self.pending_prompt.is_some() && self.input_generation.current() != self.armed_at {
+            self.pending_prompt = None;
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_armed(&self) -> bool {
+        self.pending_prompt.is_some()
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_idle_reconcile_window(&mut self, window: Duration) {
+        self.idle_reconcile_window = window;
+    }
+}
+
+/// Strips the armed replayed prompt from the next PTY display slice.
+///
+/// Fail-open contract: bytes are removed only when the slice opens with the
+/// replayed prompt verbatim (or its zsh partial-line-marker variant). Any
+/// other non-empty slice disarms the replay and passes through untouched.
+/// Readline answers an accepted line with CR/LF and/or a bracketed-paste
+/// disable *before* the next prompt paint, so an accept-line response can
+/// never open with the prompt bytes: a wrongly armed replay costs at most a
+/// duplicate prompt paint and never swallows the response to user input.
 pub(super) fn strip_replayed_prompt_prefix<'a>(
     bytes: &'a [u8],
     replayed_prompt_prefix: &mut Option<Vec<u8>>,
@@ -7,47 +210,21 @@ pub(super) fn strip_replayed_prompt_prefix<'a>(
     let Some(raw_prompt) = replayed_prompt_prefix.as_deref() else {
         return bytes;
     };
+    if bytes.is_empty() {
+        return bytes;
+    }
 
     let replay_prompt = prompt_replay_bytes(raw_prompt);
-    let replay_start = leading_replay_separator_len(bytes);
-    let replay_bytes = &bytes[replay_start..];
-    if !bytes.is_empty() && replay_bytes.is_empty() {
-        return replay_bytes;
-    }
-    let stripped = if replay_bytes.starts_with(raw_prompt) {
-        Some(&replay_bytes[raw_prompt.len()..])
-    } else if replay_prompt.len() != raw_prompt.len() && replay_bytes.starts_with(replay_prompt) {
-        Some(&replay_bytes[replay_prompt.len()..])
+    let stripped = if bytes.starts_with(raw_prompt) {
+        Some(&bytes[raw_prompt.len()..])
+    } else if replay_prompt.len() != raw_prompt.len() && bytes.starts_with(replay_prompt) {
+        Some(&bytes[replay_prompt.len()..])
     } else {
         None
     };
 
-    if let Some(rest) = stripped {
-        if !rest.is_empty() && leading_replay_separator_len(rest) == rest.len() {
-            return &rest[rest.len()..];
-        }
-    }
-
-    if !bytes.is_empty() || stripped.is_some() {
-        *replayed_prompt_prefix = None;
-    }
+    *replayed_prompt_prefix = None;
     stripped.unwrap_or(bytes)
-}
-
-fn leading_replay_separator_len(bytes: &[u8]) -> usize {
-    let mut idx = 0;
-    while idx < bytes.len() {
-        if matches!(bytes[idx], b'\r' | b'\n') {
-            idx += 1;
-            continue;
-        }
-        if bytes[idx..].starts_with(b"\x1b[?2004h") || bytes[idx..].starts_with(b"\x1b[?2004l") {
-            idx += b"\x1b[?2004h".len();
-            continue;
-        }
-        break;
-    }
-    idx
 }
 
 pub(super) fn prompt_replay_bytes(prompt: &[u8]) -> &[u8] {
@@ -193,57 +370,79 @@ mod tests {
     }
 
     #[test]
-    fn replayed_prompt_prefix_suppression_tolerates_leading_newline() {
+    fn replayed_prompt_prefix_fails_open_on_leading_newline() {
         let mut replayed = Some(b"prompt> ".to_vec());
 
+        // A CR/LF before the prompt is an accept-line response, not the
+        // replay echo: it must reach the terminal and disarm the replay.
         assert_eq!(
             strip_replayed_prompt_prefix(b"\r\nprompt> echo after\r\n", &mut replayed),
-            b"echo after\r\n"
+            b"\r\nprompt> echo after\r\n"
         );
         assert!(replayed.is_none());
     }
 
     #[test]
-    fn replayed_prompt_prefix_suppression_tolerates_bracketed_paste_toggle() {
+    fn replayed_prompt_prefix_fails_open_on_bracketed_paste_disable() {
         let mut replayed = Some(b"prompt> \x1b[?2004h".to_vec());
 
+        // ESC[?2004l is only emitted when readline accepts a line; the
+        // whole slice is a user submission response and passes through.
         assert_eq!(
             strip_replayed_prompt_prefix(
                 b"\x1b[?2004l\r\nprompt> \x1b[?2004hecho after\r\n",
                 &mut replayed
             ),
-            b"echo after\r\n"
+            b"\x1b[?2004l\r\nprompt> \x1b[?2004hecho after\r\n"
         );
         assert!(replayed.is_none());
     }
 
     #[test]
-    fn replayed_prompt_prefix_suppression_keeps_pending_after_control_only_slice() {
+    fn replayed_prompt_prefix_fails_open_on_control_only_slice() {
         let mut replayed = Some(b"prompt> \x1b[?2004h".to_vec());
 
+        // A control-only slice (paste toggle + CRLF) is the first half of a
+        // split accept-line response: pass it through verbatim and disarm so
+        // the follow-up prompt paint is never swallowed either.
         assert_eq!(
             strip_replayed_prompt_prefix(b"\x1b[?2004l\r\n", &mut replayed),
-            b""
-        );
-        assert!(replayed.is_some());
-        assert_eq!(
-            strip_replayed_prompt_prefix(b"prompt> \x1b[?2004hecho after\r\n", &mut replayed),
-            b"echo after\r\n"
+            b"\x1b[?2004l\r\n"
         );
         assert!(replayed.is_none());
+        assert_eq!(
+            strip_replayed_prompt_prefix(b"prompt> \x1b[?2004hecho after\r\n", &mut replayed),
+            b"prompt> \x1b[?2004hecho after\r\n"
+        );
     }
 
     #[test]
-    fn replayed_prompt_prefix_suppression_keeps_pending_after_prompt_control_only_slice() {
+    fn replayed_prompt_prefix_strips_one_prompt_and_keeps_trailing_accept_line() {
         let mut replayed = Some(b"prompt> \x1b[?2004h".to_vec());
 
+        // The slice opens with the replayed prompt, so that echo is deduped;
+        // the trailing accept-line bytes belong to a user Enter and survive,
+        // as does the fresh prompt in the next slice (one arm strips at most
+        // one prompt paint).
         assert_eq!(
             strip_replayed_prompt_prefix(b"prompt> \x1b[?2004h\x1b[?2004l\r\n", &mut replayed),
-            b""
+            b"\x1b[?2004l\r\n"
         );
-        assert!(replayed.is_some());
+        assert!(replayed.is_none());
         assert_eq!(
             strip_replayed_prompt_prefix(b"prompt> \x1b[?2004hecho after\r\n", &mut replayed),
+            b"prompt> \x1b[?2004hecho after\r\n"
+        );
+    }
+
+    #[test]
+    fn replayed_prompt_prefix_survives_empty_slice() {
+        let mut replayed = Some(b"prompt> ".to_vec());
+
+        assert_eq!(strip_replayed_prompt_prefix(b"", &mut replayed), b"");
+        assert!(replayed.is_some());
+        assert_eq!(
+            strip_replayed_prompt_prefix(b"prompt> echo after\r\n", &mut replayed),
             b"echo after\r\n"
         );
         assert!(replayed.is_none());

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -6,21 +6,21 @@ use std::process::Child;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use nix::libc;
 use nix::pty::Winsize;
 
 use crate::raw_input::{
     set_pty_winsize, signal_foreground_process_group, signal_process_group, update_input_mode,
-    write_all_pty, RawInputEvent, RawInputMode, RawObserverAction,
+    write_all_pty, RawInputEvent, RawInputMode, RawObserverAction, UserPtyInputGeneration,
 };
 use crate::types::{ShellEvent, ShellEventKind, ShellHandoffRequest};
 
 use super::model::current_terminal_winsize;
-use super::osc::OscParser;
+use super::osc::{DisplayCutKind, OscParser};
 use super::prompt_replay::{
-    prompt_prefixed_replay_bytes, prompt_replay_bytes, strip_replayed_prompt_prefix,
+    prompt_prefixed_replay_bytes, prompt_replay_bytes, PromptReplayTracker,
 };
 
 mod input_events;
@@ -41,6 +41,7 @@ pub(super) fn read_raw_until_exit<W: Write, F>(
     event_observer: &mut F,
     input_events: &Receiver<RawInputEvent>,
     input_mode: &Arc<Mutex<RawInputMode>>,
+    input_generation: &UserPtyInputGeneration,
     last_winsize: &mut Winsize,
     prompt: &str,
     recovery_request_file: &Path,
@@ -52,7 +53,8 @@ where
     let mut buffer = [0_u8; 8192];
     let mut display_start = parser.display.len();
     let mut native_candidate_echoed_len = 0;
-    let mut replayed_prompt_prefix: Option<Vec<u8>> = None;
+    let mut prompt_replay = PromptReplayTracker::new(input_generation.clone());
+    let mut last_pty_output: Option<Instant> = None;
     let mut pending_terminal_restore = PendingTerminalRecovery::default();
     let mut pending_prompt_restore = None;
     loop {
@@ -71,6 +73,7 @@ where
             output,
             prompt,
             &mut native_candidate_echoed_len,
+            &mut prompt_replay,
         )?;
         let mut observer_action = merge_pending_prompt_restore(
             event_observer(&parser.events, output)?,
@@ -85,7 +88,7 @@ where
             input_mode,
             observer_action,
             &mut display_start,
-            &mut replayed_prompt_prefix,
+            &mut prompt_replay,
             &mut pending_terminal_restore,
             recovery_request_file,
             handoff_request_file,
@@ -98,7 +101,7 @@ where
                 parser,
                 output,
                 &mut display_start,
-                &mut replayed_prompt_prefix,
+                &mut prompt_replay,
                 input_mode,
             )?;
             output.flush()?;
@@ -107,8 +110,19 @@ where
             match master.read(&mut buffer) {
                 Ok(0) => break,
                 Ok(n) => {
+                    last_pty_output = Some(Instant::now());
                     parser.feed(&buffer[..n])?;
-                    for cut in parser.drain_intervention_display_cuts() {
+                    for (cut, cut_kind) in parser.drain_intervention_display_cuts() {
+                        // Only a real prompt boundary (precmd) confirms the
+                        // shell finished responding to the relay writes seen
+                        // so far; an intercepted line's remaining response is
+                        // just the prompt repaint replay dedup strips.
+                        match cut_kind {
+                            DisplayCutKind::PromptBoundary => {
+                                prompt_replay.observe_prompt_boundary()
+                            }
+                            DisplayCutKind::Intercept => prompt_replay.observe_intercept_cut(),
+                        }
                         let cut = cut.min(parser.display.len());
                         if !hold_shell_output && cut > display_start {
                             write_display_slice(
@@ -116,7 +130,7 @@ where
                                 output,
                                 display_start,
                                 cut,
-                                &mut replayed_prompt_prefix,
+                                &mut prompt_replay,
                             )?;
                             output.flush()?;
                             display_start = cut;
@@ -134,7 +148,7 @@ where
                             input_mode,
                             observer_action,
                             &mut display_start,
-                            &mut replayed_prompt_prefix,
+                            &mut prompt_replay,
                             &mut pending_terminal_restore,
                             recovery_request_file,
                             handoff_request_file,
@@ -150,7 +164,7 @@ where
                                 parser,
                                 output,
                                 &mut display_start,
-                                &mut replayed_prompt_prefix,
+                                &mut prompt_replay,
                                 input_mode,
                             )?;
                             output.flush()?;
@@ -169,7 +183,7 @@ where
                         input_mode,
                         observer_action,
                         &mut display_start,
-                        &mut replayed_prompt_prefix,
+                        &mut prompt_replay,
                         &mut pending_terminal_restore,
                         recovery_request_file,
                         handoff_request_file,
@@ -182,7 +196,7 @@ where
                             parser,
                             output,
                             &mut display_start,
-                            &mut replayed_prompt_prefix,
+                            &mut prompt_replay,
                             input_mode,
                         )?;
                         output.flush()?;
@@ -197,7 +211,7 @@ where
                         parser,
                         output,
                         &mut display_start,
-                        &mut replayed_prompt_prefix,
+                        &mut prompt_replay,
                     )?;
                     return Ok(());
                 }
@@ -212,7 +226,7 @@ where
                 parser,
                 output,
                 &mut display_start,
-                &mut replayed_prompt_prefix,
+                &mut prompt_replay,
             )?;
             return Ok(());
         }
@@ -231,6 +245,7 @@ where
             output,
             prompt,
             &mut native_candidate_echoed_len,
+            &mut prompt_replay,
         )?;
         observer_action = merge_pending_prompt_restore(
             event_observer(&parser.events, output)?,
@@ -245,7 +260,7 @@ where
             input_mode,
             observer_action,
             &mut display_start,
-            &mut replayed_prompt_prefix,
+            &mut prompt_replay,
             &mut pending_terminal_restore,
             recovery_request_file,
             handoff_request_file,
@@ -258,11 +273,21 @@ where
                 parser,
                 output,
                 &mut display_start,
-                &mut replayed_prompt_prefix,
+                &mut prompt_replay,
                 input_mode,
             )?;
             output.flush()?;
         }
+        // The PTY is drained (WouldBlock) at this point: write off
+        // submissions a foreground program consumed once the shell has
+        // painted a prompt after the last boundary and idles at it. A bare
+        // precmd is not enough — the user's PROMPT_COMMAND and PS1 paint run
+        // after the marker, so silence alone must never clear the ledger.
+        prompt_replay.reconcile_idle_at_prompt(
+            parser.has_active_foreground_command(),
+            parser.has_prompt_painted_since_ready(),
+            last_pty_output,
+        );
         thread::sleep(Duration::from_millis(10));
     }
 }
@@ -273,14 +298,14 @@ fn release_held_shell_output<W: Write, F>(
     parser: &OscParser,
     output: &mut W,
     display_start: &mut usize,
-    replayed_prompt_prefix: &mut Option<Vec<u8>>,
+    prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()>
 where
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
 {
     drain_observer_until_released(event_observer, events, output)?;
     if parser.display.len() > *display_start {
-        write_pending_display(parser, output, display_start, replayed_prompt_prefix)?;
+        write_pending_display(parser, output, display_start, prompt_replay)?;
         output.flush()?;
     }
     Ok(())
@@ -290,16 +315,10 @@ fn write_pending_display<W: Write>(
     parser: &OscParser,
     output: &mut W,
     display_start: &mut usize,
-    replayed_prompt_prefix: &mut Option<Vec<u8>>,
+    prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
     let display_end = parser.display.len();
-    write_display_slice(
-        parser,
-        output,
-        *display_start,
-        display_end,
-        replayed_prompt_prefix,
-    )?;
+    write_display_slice(parser, output, *display_start, display_end, prompt_replay)?;
     *display_start = display_end;
     Ok(())
 }
@@ -308,10 +327,10 @@ fn write_pending_display_preserving_prompt_ghost<W: Write>(
     parser: &OscParser,
     output: &mut W,
     display_start: &mut usize,
-    replayed_prompt_prefix: &mut Option<Vec<u8>>,
+    prompt_replay: &mut PromptReplayTracker,
     input_mode: &Arc<Mutex<RawInputMode>>,
 ) -> io::Result<()> {
-    write_pending_display(parser, output, display_start, replayed_prompt_prefix)?;
+    write_pending_display(parser, output, display_start, prompt_replay)?;
     let ghost = input_mode.lock().ok().and_then(|mode| match &*mode {
         RawInputMode::PromptGhost { text, route } => Some((
             text.clone(),
@@ -338,12 +357,9 @@ fn write_display_slice<W: Write>(
     output: &mut W,
     display_start: usize,
     display_end: usize,
-    replayed_prompt_prefix: &mut Option<Vec<u8>>,
+    prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
-    let bytes = strip_replayed_prompt_prefix(
-        &parser.display[display_start..display_end],
-        replayed_prompt_prefix,
-    );
+    let bytes = prompt_replay.strip(&parser.display[display_start..display_end]);
     let prompt = parser.last_prompt_display();
     output.write_all(&prompt_prefixed_replay_bytes(bytes, prompt))
 }
@@ -468,7 +484,7 @@ fn resolve_pty_emit<W: Write>(
     input_mode: &Arc<Mutex<RawInputMode>>,
     action: RawObserverAction,
     display_start: &mut usize,
-    replayed_prompt_prefix: &mut Option<Vec<u8>>,
+    prompt_replay: &mut PromptReplayTracker,
     pending_terminal_restore: &mut PendingTerminalRecovery,
     recovery_request_file: &Path,
     handoff_request_file: &Path,
@@ -482,7 +498,7 @@ fn resolve_pty_emit<W: Write>(
                 output,
                 request,
                 display_start,
-                replayed_prompt_prefix,
+                prompt_replay,
                 pending_terminal_restore,
                 handoff_request_file,
                 false,
@@ -497,7 +513,7 @@ fn resolve_pty_emit<W: Write>(
                 output,
                 request,
                 display_start,
-                replayed_prompt_prefix,
+                prompt_replay,
                 pending_terminal_restore,
                 handoff_request_file,
                 true,
@@ -533,11 +549,11 @@ fn resolve_pty_emit<W: Write>(
                 });
             }
             if parser.display.len() > *display_start {
-                write_pending_display(parser, output, display_start, replayed_prompt_prefix)?;
+                write_pending_display(parser, output, display_start, prompt_replay)?;
             } else {
                 output.write_all(prompt)?;
                 mark_pending_prompt_replayed(parser, raw_prompt, display_start);
-                *replayed_prompt_prefix = Some(raw_prompt.to_vec());
+                prompt_replay.arm_for_replay(raw_prompt);
             }
             if let Some(text) = &ghost_text {
                 let selection = matches!(
@@ -567,19 +583,14 @@ fn emit_to_pty<W: Write>(
     output: &mut W,
     request: ShellHandoffRequest,
     display_start: &mut usize,
-    replayed_prompt_prefix: &mut Option<Vec<u8>>,
+    prompt_replay: &mut PromptReplayTracker,
     pending_terminal_restore: &mut PendingTerminalRecovery,
     handoff_request_file: &Path,
     restore_prompt: bool,
 ) -> io::Result<()> {
     output.flush()?;
     if restore_prompt {
-        restore_prompt_display_before_handoff(
-            parser,
-            output,
-            display_start,
-            replayed_prompt_prefix,
-        )?;
+        restore_prompt_display_before_handoff(parser, output, display_start, prompt_replay)?;
     }
     let bytes = request.pty_bytes().map_err(|message| {
         io::Error::new(
@@ -601,10 +612,10 @@ fn restore_prompt_display_before_handoff<W: Write>(
     parser: &OscParser,
     output: &mut W,
     display_start: &mut usize,
-    replayed_prompt_prefix: &mut Option<Vec<u8>>,
+    prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
     if parser.display.len() > *display_start {
-        write_pending_display(parser, output, display_start, replayed_prompt_prefix)?;
+        write_pending_display(parser, output, display_start, prompt_replay)?;
         output.flush()?;
         return Ok(());
     }
@@ -617,7 +628,7 @@ fn restore_prompt_display_before_handoff<W: Write>(
     output.write_all(prompt)?;
     output.flush()?;
     mark_pending_prompt_replayed(parser, raw_prompt, display_start);
-    *replayed_prompt_prefix = Some(raw_prompt.to_vec());
+    prompt_replay.arm_for_replay(raw_prompt);
     Ok(())
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc::Receiver;
 
 use crate::raw_input::RawInputEvent;
 
-use super::{clear_prompt_ghost_line, OscParser};
+use super::{clear_prompt_ghost_line, OscParser, PromptReplayTracker};
 
 pub(super) fn drain_raw_input_events<W: Write>(
     input_events: &Receiver<RawInputEvent>,
@@ -13,6 +13,7 @@ pub(super) fn drain_raw_input_events<W: Write>(
     output: &mut W,
     prompt: &str,
     native_candidate_echoed_len: &mut usize,
+    prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
     let native_mode = prompt.is_empty();
     while let Ok(event) = input_events.try_recv() {
@@ -20,6 +21,10 @@ pub(super) fn drain_raw_input_events<W: Write>(
             RawInputEvent::ShellInputActivity { empty } => {
                 parser.push_shell_input_activity_event(empty)
             }
+            RawInputEvent::PtyUserWrite {
+                generation,
+                line_submits,
+            } => prompt_replay.observe_user_write(generation, line_submits),
             RawInputEvent::CtrlC => parser.push_control_event("ctrl_c"),
             RawInputEvent::Esc => parser.push_control_event("esc"),
             RawInputEvent::CandidateRedraw { input, hint } => {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
@@ -1,10 +1,17 @@
 use super::*;
+use crate::raw_input::UserPtyInputGeneration;
 
 const TEST_MARKER_TOKEN: &str = "test-marker-token";
 
 fn parser_for_test(name: &str) -> OscParser {
     let dir = std::env::temp_dir().join(format!("cosh-raw-relay-{name}"));
     OscParser::new(name.to_string(), dir, TEST_MARKER_TOKEN.to_string())
+}
+
+fn tracker_for_test() -> (UserPtyInputGeneration, PromptReplayTracker) {
+    let generation = UserPtyInputGeneration::default();
+    let tracker = PromptReplayTracker::new(generation.clone());
+    (generation, tracker)
 }
 
 fn feed_shell_ready(parser: &mut OscParser) {
@@ -23,33 +30,344 @@ fn handoff_prompt_restore_strips_duplicate_prompt_echo() {
     feed_shell_ready(&mut parser);
     parser.feed(b"bash-4.4$ ").expect("feed prompt");
     let mut display_start = parser.display.len();
-    let mut replayed_prompt_prefix = None;
+    let (_generation, mut prompt_replay) = tracker_for_test();
     let mut output = Vec::new();
 
     restore_prompt_display_before_handoff(
         &parser,
         &mut output,
         &mut display_start,
-        &mut replayed_prompt_prefix,
+        &mut prompt_replay,
     )
     .expect("restore prompt");
 
     assert_eq!(String::from_utf8_lossy(&output), "bash-4.4$ ");
-    assert_eq!(replayed_prompt_prefix.as_deref(), Some(&b"bash-4.4$ "[..]));
+    assert!(prompt_replay.is_armed());
 
     parser
         .feed(b"bash-4.4$ echo ok\r\n")
         .expect("feed echoed handoff");
-    write_pending_display(
+    write_pending_display(&parser, &mut output, &mut display_start, &mut prompt_replay)
+        .expect("write echoed handoff");
+
+    assert_eq!(String::from_utf8_lossy(&output), "bash-4.4$ echo ok\r\n");
+    assert!(!prompt_replay.is_armed());
+}
+
+#[test]
+fn user_pty_input_expires_armed_prompt_replay_before_echo_is_parsed() {
+    let mut parser = parser_for_test("user-input-expires-replay");
+    feed_shell_ready(&mut parser);
+    parser.feed(b"prompt> \x1b[?2004h").expect("feed prompt");
+    let mut display_start = parser.display.len();
+    let (generation, mut prompt_replay) = tracker_for_test();
+    let mut output = Vec::new();
+
+    restore_prompt_display_before_handoff(
         &parser,
         &mut output,
         &mut display_start,
-        &mut replayed_prompt_prefix,
+        &mut prompt_replay,
     )
-    .expect("write echoed handoff");
+    .expect("restore prompt");
+    assert!(prompt_replay.is_armed());
 
-    assert_eq!(String::from_utf8_lossy(&output), "bash-4.4$ echo ok\r\n");
-    assert!(replayed_prompt_prefix.is_none());
+    // A real empty Enter: the relay bumps the generation before writing to
+    // the PTY, so its echo (bracketed-paste toggle + CRLF + fresh prompt)
+    // must not be deduplicated as the replayed prompt.
+    generation.bump();
+    parser
+        .feed(b"\x1b[?2004l\r\r\n")
+        .expect("feed empty enter accept");
+    write_pending_display(&parser, &mut output, &mut display_start, &mut prompt_replay)
+        .expect("write empty enter accept");
+    parser
+        .feed(b"prompt> \x1b[?2004h")
+        .expect("feed fresh prompt");
+    write_pending_display(&parser, &mut output, &mut display_start, &mut prompt_replay)
+        .expect("write fresh prompt");
+
+    assert_eq!(
+        String::from_utf8_lossy(&output),
+        "prompt> \x1b[?2004h\x1b[?2004l\r\r\nprompt> \x1b[?2004h"
+    );
+    assert!(!prompt_replay.is_armed());
+}
+
+#[test]
+fn relay_write_event_expires_armed_prompt_replay() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+
+    // The write event for a user keystroke travels through the event
+    // channel ahead of the echo bytes it triggers.
+    prompt_replay.observe_user_write(generation.bump(), 1);
+
+    assert!(!prompt_replay.is_armed());
+}
+
+#[test]
+fn prompt_restore_refuses_to_arm_while_user_input_response_is_unparsed() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // An empty Enter reached the PTY inside the Delay window; no prompt
+    // boundary has confirmed its response was parsed yet.
+    generation.bump();
+
+    prompt_replay.arm_for_replay(b"prompt> ");
+
+    assert!(!prompt_replay.is_armed());
+}
+
+#[test]
+fn handoff_refuses_to_arm_over_pending_user_input() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // A user write raced in after the output loop's last event drain and
+    // before the handoff prompt restore runs: bump -> arm -> user echo.
+    generation.bump();
+    prompt_replay.arm_for_replay(b"prompt> \x1b[?2004h");
+    assert!(!prompt_replay.is_armed());
+
+    // The user's accept-line echo must pass through untouched.
+    assert_eq!(
+        prompt_replay.strip(b"\x1b[?2004l\r\r\n"),
+        b"\x1b[?2004l\r\r\n"
+    );
+    assert_eq!(
+        prompt_replay.strip(b"prompt> \x1b[?2004h"),
+        b"prompt> \x1b[?2004h"
+    );
+}
+
+#[test]
+fn prompt_restore_arms_again_after_the_response_reaches_a_prompt_boundary() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+
+    // precmd boundary: the Enter response is fully parsed.
+    prompt_replay.observe_prompt_boundary();
+    prompt_replay.arm_for_replay(b"prompt> ");
+
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn typeahead_submission_blocks_arm_until_its_own_prompt_boundary() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // A command line, then an empty Enter typed ahead while it runs; both
+    // write events are drained before the command's precmd arrives.
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_user_write(generation.bump(), 1);
+
+    // The command's precmd only accounts for the command's own submission,
+    // so a command insight or handoff must not arm over the queued Enter.
+    prompt_replay.observe_prompt_boundary();
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+
+    // The empty Enter's own boundary settles the ledger.
+    prompt_replay.observe_prompt_boundary();
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn several_enters_in_one_write_block_arm_until_all_boundaries_arrive() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // One relay write carrying two accept-line keys (e.g. "\r\r").
+    prompt_replay.observe_user_write(generation.bump(), 2);
+
+    prompt_replay.observe_prompt_boundary();
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+
+    prompt_replay.observe_prompt_boundary();
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn boundary_without_a_matching_submission_is_ignored() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // A Ctrl-C style prompt repaint yields a boundary with no submission.
+    prompt_replay.observe_prompt_boundary();
+
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+
+    prompt_replay.observe_prompt_boundary();
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn intercepted_submission_does_not_block_arming_over_its_repaint() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // A recalled slash line is submitted and killed by the DEBUG trap; its
+    // precmd has not arrived when the panel's RestorePrompt fires, but its
+    // only remaining response is the repaint the arm exists to strip.
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_intercept_cut();
+
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn typeahead_enter_still_blocks_arming_alongside_an_intercept() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // Recalled slash + empty Enter in one write: only the slash line was
+    // intercepted; the Enter's response is still pending.
+    prompt_replay.observe_user_write(generation.bump(), 2);
+    prompt_replay.observe_intercept_cut();
+
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+}
+
+#[test]
+fn uncounted_custom_accept_line_intercept_never_swallows_typeahead_enter() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    // `.inputrc` binds C-x to accept-line: the intercepted slash line's
+    // submission is invisible to the byte counter, so the typeahead Enter in
+    // the same write is the only counted submit and the intercept cut lets
+    // the panel restore arm over it.
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_intercept_cut();
+    prompt_replay.arm_for_replay(b"prompt> \x1b[?2004h");
+    assert!(prompt_replay.is_armed());
+
+    // Bash's post-intercept repaint opens with the prompt and is deduped.
+    assert_eq!(prompt_replay.strip(b"prompt> \x1b[?2004h"), b"");
+    // The queued Enter's response never opens with the prompt bytes, so the
+    // mis-attributed arm cannot swallow it: toggle, CRLF, and the fresh
+    // prompt all reach the terminal verbatim.
+    assert_eq!(
+        prompt_replay.strip(b"\x1b[?2004l\r\r\n"),
+        b"\x1b[?2004l\r\r\n"
+    );
+    assert_eq!(
+        prompt_replay.strip(b"prompt> \x1b[?2004h"),
+        b"prompt> \x1b[?2004h"
+    );
+}
+
+#[test]
+fn foreground_consumed_submission_is_written_off_at_an_idle_prompt() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+    prompt_replay.set_idle_reconcile_window(Duration::from_millis(0));
+
+    // `read value` (one submit) plus "hello\r" consumed by `read` itself:
+    // only the command's precmd arrives, leaving a permanent +1 balance.
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_prompt_boundary();
+
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+
+    // Shell idles at the painted prompt: the orphaned submission is
+    // reconciled and replay dedup recovers for the rest of the session.
+    prompt_replay.reconcile_idle_at_prompt(false, true, None);
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn idle_reconcile_is_refused_while_a_command_is_running() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+    prompt_replay.set_idle_reconcile_window(Duration::from_millis(0));
+
+    // Command submitted, then a typeahead Enter while it runs.
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_prompt_boundary();
+
+    // A long-running command keeps the PTY silent, but the typeahead Enter
+    // is still queued: it must not be written off.
+    prompt_replay.reconcile_idle_at_prompt(true, true, None);
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+}
+
+#[test]
+fn idle_reconcile_is_refused_until_the_prompt_is_painted() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+    prompt_replay.set_idle_reconcile_window(Duration::from_millis(0));
+
+    // Command plus a typeahead Enter; the command's precmd marker arrived
+    // but the user's slow PROMPT_COMMAND still runs, so no prompt bytes are
+    // painted and readline has not consumed the queued Enter yet.
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    prompt_replay.observe_prompt_boundary();
+
+    // However long the silence lasts, the ledger must survive until the
+    // shell actually paints a prompt: a precmd marker alone is not consent.
+    prompt_replay.reconcile_idle_at_prompt(false, false, None);
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+
+    // Once the prompt is painted, readline echoes the queued Enter and its
+    // own boundary settles the ledger through the normal path.
+    prompt_replay.observe_prompt_boundary();
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn idle_reconcile_waits_for_pty_and_relay_silence() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+
+    prompt_replay.observe_user_write(generation.bump(), 1);
+
+    // A write just drained: the reconcile window has not elapsed, so the
+    // pending submission survives (its echo may still be in flight).
+    prompt_replay.reconcile_idle_at_prompt(false, true, Some(Instant::now()));
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+
+    prompt_replay.set_idle_reconcile_window(Duration::from_millis(0));
+    prompt_replay.reconcile_idle_at_prompt(false, true, None);
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(prompt_replay.is_armed());
+}
+
+#[test]
+fn idle_reconcile_is_refused_while_a_write_is_undrained() {
+    let (generation, mut prompt_replay) = tracker_for_test();
+    prompt_replay.set_idle_reconcile_window(Duration::from_millis(0));
+
+    prompt_replay.observe_user_write(generation.bump(), 1);
+    // A second write bumped the shared generation but its event has not
+    // been drained yet: the ledger is not settled.
+    generation.bump();
+
+    prompt_replay.reconcile_idle_at_prompt(false, true, None);
+    prompt_replay.arm_for_replay(b"prompt> ");
+    assert!(!prompt_replay.is_armed());
+}
+
+#[test]
+fn prompt_restore_arms_when_no_user_input_followed_the_intercept() {
+    let (_generation, mut prompt_replay) = tracker_for_test();
+
+    prompt_replay.arm_for_replay(b"prompt> ");
+
+    assert!(prompt_replay.is_armed());
 }
 
 #[test]
@@ -108,7 +426,7 @@ fn prompt_fragment_after_restore_keeps_ghost_last_on_screen() {
         .expect("feed title fragment");
     let mut output = Vec::new();
     let mut display_start = 0;
-    let mut replayed_prompt_prefix = None;
+    let (_generation, mut prompt_replay) = tracker_for_test();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
     let mut pending_terminal_restore = PendingTerminalRecovery::default();
     let mut null = File::open("/dev/null").expect("open null");
@@ -125,7 +443,7 @@ fn prompt_fragment_after_restore_keeps_ghost_last_on_screen() {
             ghost_route: Default::default(),
         },
         &mut display_start,
-        &mut replayed_prompt_prefix,
+        &mut prompt_replay,
         &mut pending_terminal_restore,
         Path::new("/tmp/cosh-test-recovery"),
         Path::new("/tmp/cosh-test-handoff"),
@@ -140,7 +458,7 @@ fn prompt_fragment_after_restore_keeps_ghost_last_on_screen() {
         &parser,
         &mut output,
         &mut display_start,
-        &mut replayed_prompt_prefix,
+        &mut prompt_replay,
         &input_mode,
     )
     .expect("write prompt fragment");

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -10,7 +10,7 @@ use nix::libc;
 use crate::input::InputClassifier;
 use crate::raw_input::{
     spawn_raw_action_relay, spawn_raw_input_relay, RawInputEvent, RawInputMode, RawObserverAction,
-    RawRelayAction,
+    RawRelayAction, UserPtyInputGeneration,
 };
 use crate::types::ShellEvent;
 
@@ -67,8 +67,15 @@ where
         output,
         event_observer,
         config.input_classifier.clone(),
-        |master, _, input_events, input_classifier, input_mode| {
-            spawn_raw_input_relay(input, master, input_events, input_classifier, input_mode)
+        |master, _, input_events, input_classifier, input_mode, input_generation| {
+            spawn_raw_input_relay(
+                input,
+                master,
+                input_events,
+                input_classifier,
+                input_mode,
+                input_generation,
+            )
         },
     )
 }
@@ -90,8 +97,15 @@ where
         output,
         event_observer,
         config.input_classifier.clone(),
-        |master, _, input_events, input_classifier, input_mode| {
-            spawn_raw_input_relay(input, master, input_events, input_classifier, input_mode)
+        |master, _, input_events, input_classifier, input_mode, input_generation| {
+            spawn_raw_input_relay(
+                input,
+                master,
+                input_events,
+                input_classifier,
+                input_mode,
+                input_generation,
+            )
         },
     )
 }
@@ -121,7 +135,7 @@ where
         output,
         |_, _| Ok(RawObserverAction::Continue),
         config.input_classifier.clone(),
-        |master, child_pid, input_events, input_classifier, input_mode| {
+        |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -129,6 +143,7 @@ where
                 input_events,
                 input_classifier,
                 input_mode,
+                input_generation,
             )
         },
     )
@@ -154,7 +169,7 @@ where
             Ok(RawObserverAction::Continue)
         },
         config.input_classifier.clone(),
-        |master, child_pid, input_events, input_classifier, input_mode| {
+        |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -162,6 +177,7 @@ where
                 input_events,
                 input_classifier,
                 input_mode,
+                input_generation,
             )
         },
     )
@@ -183,7 +199,7 @@ where
         output,
         event_observer,
         config.input_classifier.clone(),
-        |master, child_pid, input_events, input_classifier, input_mode| {
+        |master, child_pid, input_events, input_classifier, input_mode, input_generation| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -191,6 +207,7 @@ where
                 input_events,
                 input_classifier,
                 input_mode,
+                input_generation,
             )
         },
     )
@@ -213,6 +230,7 @@ where
         Sender<RawInputEvent>,
         InputClassifier,
         Arc<Mutex<RawInputMode>>,
+        UserPtyInputGeneration,
     ) -> JoinHandle<io::Result<()>>,
 {
     let mut session = start_session(config)?;
@@ -235,12 +253,14 @@ where
     let input_master = session.master.try_clone()?;
     let (input_event_sender, input_event_receiver) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let input_generation = UserPtyInputGeneration::default();
     let _input_thread = spawn_driver(
         input_master,
         session.child.id(),
         input_event_sender,
         input_classifier,
         Arc::clone(&input_mode),
+        input_generation.clone(),
     );
     let mut last_winsize = config.winsize;
     let relay_prompt = if config.native_mode {
@@ -257,6 +277,7 @@ where
         &mut event_observer,
         &input_event_receiver,
         &input_mode,
+        &input_generation,
         &mut last_winsize,
         relay_prompt,
         &session.recovery_request_file,

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli.rs
@@ -50,6 +50,8 @@ mod mode;
 mod native;
 #[path = "raw_cli/passthrough.rs"]
 mod passthrough;
+#[path = "raw_cli/prompt_replay.rs"]
+mod prompt_replay;
 #[path = "raw_cli/provider_handoff/mod.rs"]
 mod provider_handoff;
 #[path = "raw_cli/provider_tools.rs"]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/prompt_replay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/prompt_replay.rs
@@ -1,0 +1,554 @@
+//! Regression coverage for prompt replay after slash panels: a real empty
+//! Enter must repaint a fresh prompt line instead of being deduplicated as a
+//! replayed prompt echo (issue #1698).
+
+use super::*;
+use std::path::PathBuf;
+
+const PROMPT: &str = "cosh-replay$ ";
+
+/// Temporary shell HOME with a pinned prompt; removed on drop so repeated
+/// runs do not leak `cosh-raw-cli-paste-*` trees under the temp dir.
+struct TempReplayHome {
+    root: PathBuf,
+    home: String,
+    inputrc: String,
+}
+
+impl TempReplayHome {
+    fn new(label: &str, inputrc: &str) -> Self {
+        let root = temp_shell_home(label);
+        let inputrc_path = root.join(".inputrc");
+        fs::write(&inputrc_path, inputrc).expect("write test INPUTRC");
+        // Non-isolated shells source the user rc files; pin a deterministic
+        // prompt and delay PROMPT_COMMAND so the accept-line bytes (CRLF +
+        // bracketed-paste toggle) and the next prompt arrive in separate PTY
+        // reads, like a real shell with a non-trivial PROMPT_COMMAND.
+        fs::write(
+            root.join(".bashrc"),
+            format!("PS1='{PROMPT}'\nPROMPT_COMMAND='sleep 0.05'\n"),
+        )
+        .expect("write test bashrc");
+        fs::write(
+            root.join(".zshrc"),
+            format!("PROMPT='{PROMPT}'\nprecmd() {{ sleep 0.05; }}\n"),
+        )
+        .expect("write test zshrc");
+        Self {
+            home: root.to_string_lossy().into_owned(),
+            inputrc: inputrc_path.to_string_lossy().into_owned(),
+            root,
+        }
+    }
+
+    /// Seeds bash history so `Up` recalls a slash command through the
+    /// DEBUG-trap intercept path instead of the raw candidate relay.
+    fn seed_bash_history(&self, line: &str) {
+        fs::write(
+            self.root.join(".bashrc"),
+            format!(
+                "PS1='{PROMPT}'\nPROMPT_COMMAND='sleep 0.05'\n\
+                 export HISTFILE=\"$HOME/.bash_history\"\n\
+                 export HISTSIZE=1000\nshopt -s histappend\n"
+            ),
+        )
+        .expect("write history-enabled bashrc");
+        fs::write(self.root.join(".bash_history"), format!("{line}\n"))
+            .expect("write seeded history");
+    }
+
+    /// Emits hook output and then delays PROMPT_COMMAND long enough to outlast
+    /// the idle-reconcile window before the PS1 paint.
+    fn set_bash_prompt_command_delay(&self, seconds: &str) {
+        fs::write(
+            self.root.join(".bashrc"),
+            format!(
+                "PS1='{PROMPT}'\n\
+                 PROMPT_COMMAND='printf prompt-hook-output; sleep {seconds}'\n"
+            ),
+        )
+        .expect("write delayed-prompt bashrc");
+    }
+}
+
+impl Drop for TempReplayHome {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+/// Slice between the end of the skills panel and the sentinel echo, where the
+/// empty-Enter response must appear.
+fn between_panel_and_sentinel<'a>(output: &'a str, sentinel: &str) -> &'a str {
+    between_marker_and_sentinel(output, "Skills", sentinel)
+}
+
+fn between_marker_and_sentinel<'a>(output: &'a str, marker: &str, sentinel: &str) -> &'a str {
+    let panel = output.find(marker).expect("panel marker");
+    let after_panel = &output[panel..];
+    let sentinel_at = after_panel
+        .find(sentinel)
+        .map(|idx| panel + idx)
+        .expect("sentinel echo");
+    &output[panel..sentinel_at]
+}
+
+fn assert_no_prompt_run_on(output: &str, sentinel: &str) {
+    let normalized = strip_ansi_escape(between_panel_and_sentinel(output, sentinel));
+    for line in normalized.split(['\r', '\n']) {
+        assert!(
+            count_occurrences(line, PROMPT.trim_end()) <= 1,
+            "two prompts written on one line: {line:?}\n{output:?}"
+        );
+    }
+}
+
+/// Asserts the empty Enter produced a fresh prompt line: two prompts after the
+/// panel (the synthesized replay and the one bash paints after Enter), never
+/// glued on one visible line, with a line break between them.
+fn assert_empty_enter_repaints_prompt(output: &str, sentinel: &str) {
+    let between = between_panel_and_sentinel(output, sentinel);
+    let normalized = strip_ansi_escape(between);
+    let prompt_positions = normalized
+        .match_indices(PROMPT.trim_end())
+        .map(|(idx, _)| idx)
+        .collect::<Vec<_>>();
+    assert!(
+        prompt_positions.len() >= 2,
+        "empty Enter did not repaint a prompt after the panel\n{output:?}"
+    );
+    for pair in prompt_positions.windows(2) {
+        assert!(
+            normalized[pair[0]..pair[1]].contains('\n'),
+            "empty Enter CRLF was swallowed; prompts run on together\n{output:?}"
+        );
+    }
+}
+
+#[test]
+fn raw_cli_bash_bracketed_paste_empty_enter_after_slash_panel_repaints_prompt() {
+    let home = TempReplayHome::new("paste-on", "set enable-bracketed-paste on\n");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            // The isolated-mode fallback writes the prompt inline and skips
+            // the RestorePrompt replay path this regression must exercise.
+            ("COSH_SHELL_ISOLATED", "0"),
+        ],
+        vec![
+            // Let the initial prompt render before typing the slash command,
+            // as a real user would.
+            (
+                b"/skills disable xlsx\r".to_vec(),
+                Duration::from_millis(600),
+            ),
+            // Wait for the panel and the synthesized prompt replay to finish
+            // before sending the lone empty Enter.
+            (b"\r".to_vec(), Duration::from_millis(800)),
+            (
+                b"echo replay-sentinel-on\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    // Raw bytes: readline emits ESC[?2004l when the empty Enter is accepted;
+    // the toggle must reach the outer terminal instead of being consumed as a
+    // replay separator.
+    let between = between_panel_and_sentinel(&output, "replay-sentinel-on");
+    assert!(
+        count_occurrences(between, "\u{1b}[?2004l") >= 1,
+        "bracketed paste disable of the empty Enter was swallowed\n{output:?}"
+    );
+    assert_empty_enter_repaints_prompt(&output, "replay-sentinel-on");
+    assert!(output.contains("replay-sentinel-on"), "{output}");
+}
+
+#[test]
+fn raw_cli_bash_bracketed_paste_empty_enter_within_delay_window_is_not_swallowed() {
+    let home = TempReplayHome::new("paste-delay", "set enable-bracketed-paste on\n");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+        ],
+        vec![
+            // The empty Enter rides in the same chunk as the slash command, so
+            // it is relayed to bash while the panel still holds shell output.
+            (
+                b"/skills disable xlsx\r\r".to_vec(),
+                Duration::from_millis(600),
+            ),
+            (
+                b"echo replay-sentinel-delay\n".to_vec(),
+                Duration::from_millis(800),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    let between = between_panel_and_sentinel(&output, "replay-sentinel-delay");
+    assert!(
+        count_occurrences(between, "\u{1b}[?2004l") >= 1,
+        "bracketed paste disable of the early empty Enter was swallowed\n{output:?}"
+    );
+    assert!(
+        between.contains("\r\r\n") || between.contains("\r\n"),
+        "early empty Enter CRLF was swallowed\n{output:?}"
+    );
+    assert_no_prompt_run_on(&output, "replay-sentinel-delay");
+    assert!(output.contains("replay-sentinel-delay"), "{output}");
+}
+
+#[test]
+fn raw_cli_bash_recalled_slash_with_same_chunk_empty_enter_is_not_swallowed() {
+    let home = TempReplayHome::new("paste-recall", "set enable-bracketed-paste on\n");
+    // The recalled line reaches bash itself, so the intercept travels the
+    // DEBUG-trap marker path (an `intercept` display cut, not a candidate
+    // relay intercept); the trailing empty Enter shares the same PTY write.
+    home.seed_bash_history("/skills disable xlsx");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+        ],
+        vec![
+            // Up-arrow recalls the seeded slash command from bash history.
+            (b"\x1b[A".to_vec(), Duration::from_millis(600)),
+            // Submit it and the empty Enter in one chunk (one relay write).
+            (b"\r\r".to_vec(), Duration::from_millis(300)),
+            (
+                b"echo replay-sentinel-recall\n".to_vec(),
+                Duration::from_millis(1000),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    assert!(
+        !output.contains("bash: /skills"),
+        "recalled slash leaked to bash\n{output:?}"
+    );
+    let between = between_panel_and_sentinel(&output, "replay-sentinel-recall");
+    assert!(
+        count_occurrences(between, "\u{1b}[?2004l") >= 1,
+        "bracketed paste disable of the empty Enter was swallowed\n{output:?}"
+    );
+    assert!(
+        between.contains("\r\r\n") || between.contains("\r\n"),
+        "empty Enter CRLF after the recalled slash was swallowed\n{output:?}"
+    );
+    assert_no_prompt_run_on(&output, "replay-sentinel-recall");
+    assert!(output.contains("replay-sentinel-recall"), "{output}");
+}
+
+#[test]
+fn raw_cli_bash_typeahead_empty_enter_during_failing_command_survives_prompt_restore() {
+    let home = TempReplayHome::new("paste-typeahead", "set enable-bracketed-paste on\n");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_ANALYSIS_MODE", "auto"),
+        ],
+        vec![
+            // A slightly delayed failing command that triggers the
+            // failed-command prompt restore flow.
+            (
+                b"sh -c 'sleep 0.6; ls /nonexistent-replay-typeahead'\n".to_vec(),
+                Duration::from_millis(600),
+            ),
+            // Empty Enter typed ahead while the command is still running: its
+            // write event is drained before the command's precmd arrives.
+            (b"\r".to_vec(), Duration::from_millis(300)),
+            (
+                b"echo replay-sentinel-typeahead\n".to_vec(),
+                Duration::from_millis(2000),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    // The failed-command flow restores the prompt after the command
+    // completes; that restore must not swallow the queued empty Enter's
+    // response.
+    let between = between_marker_and_sentinel(
+        &output,
+        "No such file or directory",
+        "replay-sentinel-typeahead",
+    );
+    assert!(
+        count_occurrences(between, "\u{1b}[?2004l") >= 1,
+        "bracketed paste disable of the typeahead empty Enter was swallowed\n{output:?}"
+    );
+    assert!(
+        between.contains("\r\r\n") || between.contains("\r\n"),
+        "typeahead empty Enter CRLF was swallowed\n{output:?}"
+    );
+    let normalized = strip_ansi_escape(between);
+    assert!(
+        normalized.contains(PROMPT.trim_end()),
+        "typeahead empty Enter did not repaint a prompt\n{output:?}"
+    );
+    for line in normalized.split(['\r', '\n']) {
+        assert!(
+            count_occurrences(line, PROMPT.trim_end()) <= 1,
+            "two prompts written on one line: {line:?}\n{output:?}"
+        );
+    }
+    assert!(output.contains("replay-sentinel-typeahead"), "{output}");
+}
+
+#[test]
+fn raw_cli_bash_ctrl_o_submission_with_typeahead_empty_enter_is_not_swallowed() {
+    let home = TempReplayHome::new("paste-ctrl-o", "set enable-bracketed-paste on\n");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_ANALYSIS_MODE", "auto"),
+        ],
+        vec![
+            // Submit a delayed failing command with Ctrl-O
+            // (operate-and-get-next), bash's default non-Enter accept-line
+            // binding, so the submission carries no CR/LF at all.
+            (
+                b"sh -c 'sleep 0.6; ls /nonexistent-replay-ctrl-o'\x0f".to_vec(),
+                Duration::from_millis(600),
+            ),
+            // Empty Enter typed ahead while the command is still running.
+            (b"\r".to_vec(), Duration::from_millis(300)),
+            (
+                b"echo replay-sentinel-ctrl-o\n".to_vec(),
+                Duration::from_millis(2000),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    // The prompt restore after the failed command must not treat the
+    // Ctrl-O-submitted command's precmd as acknowledging the queued Enter.
+    let between = between_marker_and_sentinel(
+        &output,
+        "No such file or directory",
+        "replay-sentinel-ctrl-o",
+    );
+    assert!(
+        count_occurrences(between, "\u{1b}[?2004l") >= 1,
+        "bracketed paste disable of the typeahead empty Enter was swallowed\n{output:?}"
+    );
+    assert!(
+        between.contains("\r\r\n") || between.contains("\r\n"),
+        "typeahead empty Enter CRLF was swallowed\n{output:?}"
+    );
+    let normalized = strip_ansi_escape(between);
+    assert!(
+        normalized.contains(PROMPT.trim_end()),
+        "typeahead empty Enter did not repaint a prompt\n{output:?}"
+    );
+    for line in normalized.split(['\r', '\n']) {
+        assert!(
+            count_occurrences(line, PROMPT.trim_end()) <= 1,
+            "two prompts written on one line: {line:?}\n{output:?}"
+        );
+    }
+    assert!(output.contains("replay-sentinel-ctrl-o"), "{output}");
+}
+
+#[test]
+fn raw_cli_bash_slow_prompt_command_does_not_write_off_queued_enter() {
+    let home = TempReplayHome::new("paste-slow-precmd", "set enable-bracketed-paste on\n");
+    // The precmd marker fires before the user's PROMPT_COMMAND body and the
+    // PS1 paint. The body first emits output (which must not count as a
+    // painted prompt), then stays silent for 500ms — far past the 200ms
+    // idle-reconcile window while the queued Enter is still unconsumed by
+    // readline. The ledger must survive and the Enter response must pass.
+    home.set_bash_prompt_command_delay("0.5");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_ANALYSIS_MODE", "auto"),
+        ],
+        vec![
+            (
+                b"sh -c 'sleep 0.6; ls /nonexistent-replay-slow-precmd'\n".to_vec(),
+                Duration::from_millis(900),
+            ),
+            // Empty Enter typed ahead while the command still runs; it stays
+            // queued through the whole PROMPT_COMMAND delay.
+            (b"\r".to_vec(), Duration::from_millis(300)),
+            (
+                b"echo replay-sentinel-slow-precmd\n".to_vec(),
+                Duration::from_millis(3000),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    let between = between_marker_and_sentinel(
+        &output,
+        "No such file or directory",
+        "replay-sentinel-slow-precmd",
+    );
+    assert!(
+        count_occurrences(between, "\u{1b}[?2004l") >= 1,
+        "bracketed paste disable of the queued Enter was swallowed during \
+         a slow PROMPT_COMMAND\n{output:?}"
+    );
+    assert!(
+        between.contains("\r\r\n") || between.contains("\r\n"),
+        "queued Enter CRLF was swallowed during a slow PROMPT_COMMAND\n{output:?}"
+    );
+    let normalized = strip_ansi_escape(between);
+    assert!(
+        normalized.contains(PROMPT.trim_end()),
+        "queued Enter did not repaint a prompt after the slow PROMPT_COMMAND\n{output:?}"
+    );
+    for line in normalized.split(['\r', '\n']) {
+        assert!(
+            count_occurrences(line, PROMPT.trim_end()) <= 1,
+            "two prompts written on one line: {line:?}\n{output:?}"
+        );
+    }
+    assert!(output.contains("replay-sentinel-slow-precmd"), "{output}");
+}
+
+#[test]
+fn raw_cli_bash_replay_dedup_recovers_after_foreground_program_consumed_enter() {
+    let home = TempReplayHome::new("paste-read", "set enable-bracketed-paste on\n");
+    // The recalled slash reaches bash and is killed by the DEBUG trap, so
+    // bash repaints a real prompt afterwards: replay dedup must arm to strip
+    // it, making a stuck submission ledger visible as a duplicate prompt.
+    home.seed_bash_history("/skills disable xlsx");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+        ],
+        vec![
+            // A foreground `read` consumes the second Enter itself: the
+            // submission ledger would otherwise stay off by one forever.
+            (b"read value\r".to_vec(), Duration::from_millis(600)),
+            (b"hello\r".to_vec(), Duration::from_millis(400)),
+            // Idle at the prompt long enough for the write-off, then recall
+            // the slash from history (twice up: past this session's `read
+            // value` entry): replay dedup must have recovered.
+            (b"\x1b[A\x1b[A".to_vec(), Duration::from_millis(800)),
+            (b"\r".to_vec(), Duration::from_millis(300)),
+            (
+                b"echo replay-sentinel-read\n".to_vec(),
+                Duration::from_millis(1200),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    // With a stuck ledger the panel's prompt restore cannot arm, so bash's
+    // late post-intercept repaint (prompt plus the recalled line text) is
+    // painted a second time after the synthesized replay.
+    let between = between_panel_and_sentinel(&output, "replay-sentinel-read");
+    let normalized = strip_ansi_escape(between);
+    let recalled = count_occurrences(&normalized, "/skills disable xlsx");
+    assert!(
+        recalled <= 1,
+        "replay dedup stayed disabled after a foreground `read`: \
+         the recalled line was painted {recalled} times after the panel\n{output:?}"
+    );
+    let prompts = count_occurrences(&normalized, PROMPT.trim_end());
+    assert!(
+        prompts <= 2,
+        "replay dedup stayed disabled after a foreground `read`: \
+         {prompts} prompts painted after the panel\n{output:?}"
+    );
+    assert!(output.contains("replay-sentinel-read"), "{output}");
+}
+
+#[test]
+fn raw_cli_bash_bracketed_paste_off_empty_enter_after_slash_panel_repaints_prompt() {
+    let home = TempReplayHome::new("paste-off", "set enable-bracketed-paste off\n");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home.home.as_str()),
+            ("INPUTRC", home.inputrc.as_str()),
+            ("COSH_SHELL_ISOLATED", "0"),
+        ],
+        vec![
+            (
+                b"/skills disable xlsx\r".to_vec(),
+                Duration::from_millis(600),
+            ),
+            (b"\r".to_vec(), Duration::from_millis(800)),
+            (
+                b"echo replay-sentinel-off\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    let between = between_panel_and_sentinel(&output, "replay-sentinel-off");
+    assert!(
+        !between.contains("\u{1b}[?2004l"),
+        "bracketed paste should be off in the baseline run\n{output:?}"
+    );
+    assert_empty_enter_repaints_prompt(&output, "replay-sentinel-off");
+    assert!(output.contains("replay-sentinel-off"), "{output}");
+}
+
+#[test]
+fn raw_cli_zsh_empty_enter_after_slash_panel_repaints_prompt() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let home = TempReplayHome::new("paste-zsh", "");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[("HOME", home.home.as_str()), ("COSH_SHELL_ISOLATED", "0")],
+        vec![
+            (
+                b"/skills disable xlsx\r".to_vec(),
+                Duration::from_millis(600),
+            ),
+            (b"\r".to_vec(), Duration::from_millis(800)),
+            (
+                b"echo replay-sentinel-zsh\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+
+    assert_no_prompt_run_on(&output, "replay-sentinel-zsh");
+    assert!(output.contains("replay-sentinel-zsh"), "{output}");
+    assert!(
+        !output.contains("zsh: no such file or directory: /skills"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
## Description

Fix prompt replay deduplication swallowing the first empty Enter after a slash
panel. User PTY writes now carry submission candidates that are paired with
prompt boundaries and intercepts, while replay stripping fails open unless the
next display slice starts with the exact armed prompt. A post-hook
`prompt_ready` marker prevents slow or output-producing prompt hooks from
authorizing ledger reconciliation before readline regains control.

The regression suite covers bracketed-paste modes, fragmented relay writes,
Ctrl-O, custom accept-line bindings, foreground input consumers, slow
`PROMPT_COMMAND` hooks, Bash, and Zsh. A shared test environment lock also
prevents concurrent HOME mutation from making the full unit suite flaky.

## Related Issue

closes #1698

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cosh-shell --lib` (972 passed)
- `cargo test -p cosh-shell --test logic` (8 passed)
- `cargo test -p cosh-shell --test protocol` (56 passed)
- `cargo test -p cosh-shell --test raw_cli -- --test-threads=4`
  (380 passed, 1 ignored)
- `cargo test -p cosh-shell --test shell_host -- --test-threads=4`
  (47 passed, 1 ignored)
- `crates/cosh-shell/scripts/check-layout.sh`
- `cargo doc --workspace --no-deps`

## Additional Notes

Replay stripping now prefers safety over aggressive deduplication. If a late
native prompt is preceded by CR/LF or a bracketed-paste toggle, it is passed
through instead of stripped; this may draw one duplicate prompt but cannot
discard a user submission response.