### PR TITLE
fix(cosh-ng): [shell] validate provider id

### DIFF
--- a/specs/cosh-ng-code-organization/large-file-inventory.md
+++ b/specs/cosh-ng-code-organization/large-file-inventory.md
@@ -28,12 +28,12 @@ new over-threshold file appears that is not listed here.
 |------:|------|-------|---------------------|
 | 1717 | `src/ui/agent_render/health.rs` | ui | Health banner rendering; pre-existing. Split per-severity renderers. |
 | 1628 | `src/diagnostics/health/collectors.rs` | diagnostics | Per-subsystem collectors; pre-existing. Split by collector family. |
-| 1378 | `src/auth/runtime.rs` | auth | Auth control-protocol runtime; pre-existing. Extract provider flows. |
 | 992 | `src/runtime/state.rs` | runtime | Central inline state; pre-existing. Extract per-domain state modules. |
 | 925 | `src/agent/heartbeat.rs` | agent | Heartbeat/status animation; pre-existing. Split timing from rendering. |
 | 912 | `src/evidence/output_policy.rs` | evidence | Output excerpt policy; pre-existing. Split bounding from classification. |
 | 906 | `src/adapter/fake.rs` | adapter | Test fake adapter; pre-existing. Split scripted-scenario builders. |
 | 898 | `src/ui/agent_render/approval.rs` | ui | Approval card rendering; pre-existing. Split per-card-kind renderers. |
+| 895 | `src/auth/runtime.rs` | auth | Auth control-protocol runtime; prompt rendering extracted to `auth/prompt.rs`. Extract provider-specific flows next. |
 | 886 | `src/activity/runtime.rs` | activity | Activity runtime; pre-existing. Extract lifecycle from bookkeeping. |
 | 859 | `src/agent/poll.rs` | agent | Agent run polling loop; pre-existing debt (main baseline 839). The compaction feature added the `compaction_recommended_v1` status capture; split event routing from rendering. |
 | 856 | `src/parser/mod.rs` | parser | Event parser (legacy `mod.rs`); pre-existing. Split per-event-kind parsers and rename off `mod.rs`. |

--- a/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
@@ -2,11 +2,13 @@ mod active_submission;
 mod capture;
 mod completion;
 mod delete_confirm;
+mod prompt;
 pub(crate) mod provider_display;
 mod provider_management;
 mod required;
 mod retry;
 pub(crate) mod runtime;
+mod validation;
 
 #[cfg(test)]
 mod runtime_tests;

--- a/src/cosh-ng/crates/cosh-shell/src/auth/prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/prompt.rs
@@ -1,0 +1,277 @@
+//! Rendering and lifecycle helpers for interactive auth prompts.
+
+use std::io::{self, Write};
+
+use crate::runtime::prelude::{
+    QuestionInputFeedback, QuestionPanelModel, QuestionSelectionMode, RatatuiInlineRenderer,
+};
+use crate::runtime::state::InlineState;
+
+use super::capture::auth_capture_id;
+use super::delete_confirm::render_delete_confirmation;
+use super::provider_management::provider_action_options;
+use super::runtime::AuthPhase;
+
+pub(super) fn render_current_auth_panel<W: Write>(
+    state: &mut InlineState,
+    output: &mut W,
+) -> io::Result<()> {
+    let Some(auth) = &state.auth.state else {
+        return Ok(());
+    };
+    let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+    let panel_id = auth_capture_id(auth);
+
+    match auth.phase {
+        AuthPhase::ManagingProviders => {
+            let mut options: Vec<String> = auth
+                .existing_providers
+                .iter()
+                .map(|provider| {
+                    let active_mark = if provider.is_active {
+                        "* [active] "
+                    } else {
+                        "  "
+                    };
+                    let model_info = if provider.model.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" - {}", provider.model)
+                    };
+                    let source_info = if provider.source == "system" {
+                        " [system]"
+                    } else {
+                        ""
+                    };
+                    format!(
+                        "{}{} - \"{}\"{}{}",
+                        active_mark, provider.label, provider.name, model_info, source_info
+                    )
+                })
+                .collect();
+            options.push("  + Add new provider".to_string());
+
+            let model = QuestionPanelModel {
+                id: &panel_id,
+                question: "\u{1f511} Provider Management \u{2014} Select your AI provider:",
+                options: &options,
+                selected_option: auth.selected_provider,
+                selected_options: &[],
+                custom_answer: "",
+                allow_free_text: false,
+                selection_mode: QuestionSelectionMode::Single,
+                input_feedback: QuestionInputFeedback::Disabled,
+            };
+            let height = renderer.write_question_panel(output, model)?;
+            state.questions.active_panel_height = height;
+            state.questions.active_panel_id = Some(panel_id.clone());
+        }
+        AuthPhase::ProviderAction { provider_idx } => {
+            let provider = &auth.existing_providers[provider_idx];
+            let title = format!(
+                "\u{1f511} {} \u{2014} \"{}\":",
+                provider.label, provider.name
+            );
+            let options = provider_action_options(
+                provider.is_active,
+                provider.editable,
+                provider.deletable(),
+            );
+            let model = QuestionPanelModel {
+                id: &panel_id,
+                question: &title,
+                options: &options,
+                selected_option: auth.selected_provider,
+                selected_options: &[],
+                custom_answer: "",
+                allow_free_text: false,
+                selection_mode: QuestionSelectionMode::Single,
+                input_feedback: QuestionInputFeedback::Disabled,
+            };
+            let height = renderer.write_question_panel(output, model)?;
+            state.questions.active_panel_height = height;
+            state.questions.active_panel_id = Some(panel_id.clone());
+        }
+        AuthPhase::ConfirmDelete { provider_idx } => {
+            let height =
+                render_delete_confirmation(auth, provider_idx, &panel_id, &renderer, output)?;
+            state.questions.active_panel_height = height;
+            state.questions.active_panel_id = Some(panel_id.clone());
+        }
+        AuthPhase::SelectingProvider => {
+            let options: Vec<String> = auth
+                .providers
+                .iter()
+                .map(|provider| provider.label.clone())
+                .collect();
+            let model = QuestionPanelModel {
+                id: &panel_id,
+                question: "\u{1f511} Authentication Required \u{2014} Select your AI provider:",
+                options: &options,
+                selected_option: auth.selected_provider,
+                selected_options: &[],
+                custom_answer: "",
+                allow_free_text: false,
+                selection_mode: QuestionSelectionMode::Single,
+                input_feedback: QuestionInputFeedback::Disabled,
+            };
+            let height = renderer.write_question_panel(output, model)?;
+            state.questions.active_panel_height = height;
+            state.questions.active_panel_id = Some(panel_id.clone());
+        }
+        AuthPhase::FillingField => {
+            let field = auth.current_field_info();
+            let label = field.map(|field| field.label.as_str()).unwrap_or("Value");
+            let is_secret = field.map(|field| field.secret).unwrap_or(false);
+            let hint_text = field.and_then(|field| field.hint.as_deref()).unwrap_or("");
+            let provider = auth.current_provider();
+            let is_editing = auth.editing_provider_name.is_some();
+            let action = if is_editing { "Edit" } else { "Enter" };
+            let mut question = format!(
+                "\u{1f511} {} \u{2014} {} {}:",
+                provider.label, action, label
+            );
+            if !hint_text.is_empty() {
+                question.push_str(&format!("\n  hint: {hint_text}"));
+            }
+            if let Some(error) = auth.field_error.as_deref() {
+                question.push_str(&format!("\n  error: {error}"));
+            }
+            if is_editing && !auth.field_input.is_empty() {
+                question.push_str("\n  (Enter to keep current value)");
+            }
+            if !auth.field_input.is_empty() {
+                let display = if is_secret {
+                    "\u{2022}".repeat(auth.field_input.len())
+                } else {
+                    auth.field_input.clone()
+                };
+                question.push_str(&format!("\n  > {display}"));
+            } else {
+                question.push_str("\n  > ");
+            }
+            let model = QuestionPanelModel {
+                id: &panel_id,
+                question: &question,
+                options: &[],
+                selected_option: 0,
+                selected_options: &[],
+                custom_answer: "",
+                allow_free_text: true,
+                selection_mode: QuestionSelectionMode::Single,
+                input_feedback: QuestionInputFeedback::Disabled,
+            };
+            let height = renderer.write_question_panel(output, model)?;
+            state.questions.active_panel_height = height;
+            state.questions.active_panel_id = Some(panel_id.clone());
+        }
+        AuthPhase::AliyunEcsChallenge {
+            ref instance_id,
+            ref console_url,
+        } => {
+            let mut question = format!(
+                "\u{1f511} Aliyun Authentication \u{2014} Authorize ECS RAM Role\n  \
+                 ECS Instance ID: {instance_id}\n  URL: {console_url}"
+            );
+            if let Some(qr) = generate_qr_text(console_url) {
+                question.push_str("\n\n");
+                question.push_str(&qr);
+            }
+            let options = vec!["I have authorized this ECS instance".to_string()];
+            let model = QuestionPanelModel {
+                id: &panel_id,
+                question: &question,
+                options: &options,
+                selected_option: 0,
+                selected_options: &[],
+                custom_answer: "",
+                allow_free_text: false,
+                selection_mode: QuestionSelectionMode::Single,
+                input_feedback: QuestionInputFeedback::Disabled,
+            };
+            let height = renderer.write_question_panel(output, model)?;
+            state.questions.active_panel_height = height;
+            state.questions.active_panel_id = Some(panel_id);
+        }
+    }
+    output.flush()
+}
+
+pub(super) fn clear_active_auth_panel<W: Write>(
+    state: &mut InlineState,
+    output: &mut W,
+) -> io::Result<()> {
+    let height = state.questions.active_panel_height;
+    if height == 0 {
+        state.questions.active_panel_id = None;
+        state.questions.active_panel_cursor_row = None;
+        state.questions.active_panel_width = None;
+        return Ok(());
+    }
+    write!(output, "\x1b[{height}A")?;
+    for row in 0..height {
+        write!(output, "\r\x1b[2K")?;
+        if row + 1 < height {
+            write!(output, "\x1b[1B")?;
+        }
+    }
+    if height > 1 {
+        write!(output, "\x1b[{}A", height - 1)?;
+    }
+    write!(output, "\r")?;
+    state.questions.active_panel_id = None;
+    state.questions.active_panel_height = 0;
+    state.questions.active_panel_cursor_row = None;
+    state.questions.active_panel_width = None;
+    Ok(())
+}
+
+fn generate_qr_text(data: &str) -> Option<String> {
+    use qrcode::QrCode;
+
+    let code = QrCode::new(data.as_bytes()).ok()?;
+    let width = code.width();
+    let colors = code.to_colors();
+    let margin = 2usize;
+    let total_width = width + 2 * margin;
+    let light_row: String = "\u{2588}".repeat(total_width);
+    let mut result = String::new();
+
+    for _ in 0..margin {
+        result.push_str(&light_row);
+        result.push('\n');
+    }
+
+    let mut y = 0;
+    while y < width {
+        for _ in 0..margin {
+            result.push('\u{2588}');
+        }
+        for x in 0..width {
+            let top_dark = colors[y * width + x] == qrcode::Color::Dark;
+            let bottom_dark = if y + 1 < width {
+                colors[(y + 1) * width + x] == qrcode::Color::Dark
+            } else {
+                false
+            };
+            result.push(match (top_dark, bottom_dark) {
+                (true, true) => ' ',
+                (true, false) => '\u{2584}',
+                (false, true) => '\u{2580}',
+                (false, false) => '\u{2588}',
+            });
+        }
+        for _ in 0..margin {
+            result.push('\u{2588}');
+        }
+        result.push('\n');
+        y += 2;
+    }
+
+    for _ in 0..margin {
+        result.push_str(&light_row);
+        result.push('\n');
+    }
+
+    Some(result)
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
@@ -6,8 +6,9 @@ use std::io::{self, Write};
 use crate::runtime::prelude::{AgentEvent, GovernedEvent, NoticePanelModel, RatatuiInlineRenderer};
 use crate::runtime::state::InlineState;
 
+use super::prompt::render_current_auth_panel;
 use super::provider_display::auth_required_providers_for_display;
-use super::runtime::{render_current_auth_panel, AuthBackend, AuthPhase, RuntimeAuthState};
+use super::runtime::{AuthBackend, AuthPhase, RuntimeAuthState};
 
 pub(crate) fn record_auth_required(
     state: &mut InlineState,
@@ -38,6 +39,7 @@ pub(crate) fn record_auth_required(
                 current_field: 0,
                 collected_values: HashMap::new(),
                 field_input: String::new(),
+                field_error: None,
                 existing_providers: Vec::new(),
                 editing_provider_name: None,
                 error_message: error_message.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
@@ -7,6 +7,7 @@ pub(super) fn restore_after_failed_submission(auth: &mut RuntimeAuthState) {
     auth.current_field = 0;
     auth.collected_values.clear();
     auth.field_input.clear();
+    auth.field_error = None;
     if let Some(provider_id) = auth.editing_provider_name.clone() {
         let fields = &auth.providers[auth.selected_provider].fields;
         // Slash auth prepends provider_id before edit mode, so retries preserve that identity.

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -5,21 +5,25 @@ use serde_json::json;
 
 use crate::adapter::AdapterInstance;
 use crate::auth::active_submission::finish_active_submission;
-use crate::auth::capture::{auth_capture_id, matches_auth_capture};
+use crate::auth::capture::matches_auth_capture;
 use crate::auth::completion::finish_auth_configuration;
 use crate::auth::delete_confirm::{
-    begin_delete_confirmation, focus_delete_confirmation, render_delete_confirmation,
-    render_delete_outcome, submit_delete_confirmation,
+    begin_delete_confirmation, focus_delete_confirmation, render_delete_outcome,
+    submit_delete_confirmation,
 };
+use crate::auth::prompt::{clear_active_auth_panel, render_current_auth_panel};
 use crate::auth::provider_management::{
     core_auth_activate, core_auth_configure, load_core_auth_state, provider_action_choice,
-    provider_action_options, ExistingProvider, ProviderAction,
+    ExistingProvider, ProviderAction,
 };
 use crate::auth::retry::restore_after_failed_submission;
+use crate::auth::validation::{
+    record_field_edit, record_field_submission, FieldSubmission, PROVIDER_ID_HINT,
+};
 use crate::runtime::dispatcher::stable_event_key;
 use crate::runtime::prelude::{
-    AuthFieldInfo, AuthProviderInfo, AuthResponse, NoticePanelModel, QuestionInputFeedback,
-    QuestionPanelModel, QuestionSelectionMode, RatatuiInlineRenderer, ShellEvent, ShellEventKind,
+    AuthFieldInfo, AuthProviderInfo, AuthResponse, NoticePanelModel, RatatuiInlineRenderer,
+    ShellEvent, ShellEventKind,
 };
 use crate::runtime::state::InlineState;
 
@@ -37,6 +41,8 @@ pub(crate) struct RuntimeAuthState {
     pub(crate) current_field: usize,
     pub(crate) collected_values: HashMap<String, String>,
     pub(crate) field_input: String,
+    /// Inline validation error for the field being filled; cleared on the next edit.
+    pub(crate) field_error: Option<String>,
     /// Existing providers loaded from config.toml (for ManagingProviders phase)
     pub(crate) existing_providers: Vec<ExistingProvider>,
     /// The section name of the provider being edited (None = new provider)
@@ -72,11 +78,11 @@ pub(crate) enum AuthPhase {
 }
 
 impl RuntimeAuthState {
-    fn current_provider(&self) -> &AuthProviderInfo {
+    pub(super) fn current_provider(&self) -> &AuthProviderInfo {
         &self.providers[self.selected_provider]
     }
 
-    fn current_field_info(&self) -> Option<&AuthFieldInfo> {
+    pub(super) fn current_field_info(&self) -> Option<&AuthFieldInfo> {
         self.current_provider().fields.get(self.current_field)
     }
 
@@ -169,6 +175,7 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
         current_field: 0,
         collected_values: HashMap::new(),
         field_input: String::new(),
+        field_error: None,
         existing_providers,
         editing_provider_name: None,
         error_message: None,
@@ -231,7 +238,7 @@ fn providers_with_provider_id_field(providers: Vec<AuthProviderInfo>) -> Vec<Aut
                 AuthFieldInfo {
                     name: "provider_id".to_string(),
                     label: "Provider ID".to_string(),
-                    hint: Some("Unique config id, e.g. qwen-prod".to_string()),
+                    hint: Some(PROVIDER_ID_HINT.to_string()),
                     secret: false,
                     required: true,
                     placeholder: Some(provider.id.clone()),
@@ -294,7 +301,7 @@ fn handle_auth_input<W: std::io::Write>(
         return Ok(false);
     }
     if auth.phase == AuthPhase::FillingField {
-        auth.field_input = text.to_string();
+        record_field_edit(auth, text);
         clear_active_auth_panel(state, output)?;
         render_current_auth_panel(state, output)?;
     }
@@ -486,8 +493,11 @@ fn handle_auth_answer<W: std::io::Write>(
                 raw_answer.to_string()
             };
             let field = auth.current_field_info().cloned();
-            if let Some(field) = field.clone() {
-                auth.collected_values.insert(field.name.clone(), value);
+            // Reject invalid input before any downstream work so the other fields survive.
+            if record_field_submission(auth, field.as_ref(), value) == FieldSubmission::Rejected {
+                clear_active_auth_panel(state, output)?;
+                render_current_auth_panel(state, output)?;
+                return Ok(true);
             }
             if should_apply_aliyun_prepare_after_field(
                 auth.backend,
@@ -663,202 +673,6 @@ fn send_auth_response<W: std::io::Write>(
     finish_auth_configuration(state, output, &provider_label)
 }
 
-pub(super) fn render_current_auth_panel<W: std::io::Write>(
-    state: &mut InlineState,
-    output: &mut W,
-) -> std::io::Result<()> {
-    let Some(auth) = &state.auth.state else {
-        return Ok(());
-    };
-    let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
-    let panel_id = auth_capture_id(auth);
-
-    match auth.phase {
-        AuthPhase::ManagingProviders => {
-            let mut options: Vec<String> = auth
-                .existing_providers
-                .iter()
-                .map(|ep| {
-                    let active_mark = if ep.is_active { "* [active] " } else { "  " };
-                    let model_info = if ep.model.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" - {}", ep.model)
-                    };
-                    let source_info = if ep.source == "system" {
-                        " [system]"
-                    } else {
-                        ""
-                    };
-                    format!(
-                        "{}{} - \"{}\"{}{}",
-                        active_mark, ep.label, ep.name, model_info, source_info
-                    )
-                })
-                .collect();
-            options.push("  + Add new provider".to_string());
-
-            let model = QuestionPanelModel {
-                id: &panel_id,
-                question: "\u{1f511} Provider Management \u{2014} Select your AI provider:",
-                options: &options,
-                selected_option: auth.selected_provider,
-                selected_options: &[],
-                custom_answer: "",
-                allow_free_text: false,
-                selection_mode: QuestionSelectionMode::Single,
-                input_feedback: QuestionInputFeedback::Disabled,
-            };
-            let height = renderer.write_question_panel(output, model)?;
-            state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(panel_id.clone());
-        }
-        AuthPhase::ProviderAction { provider_idx } => {
-            let ep = &auth.existing_providers[provider_idx];
-            let title = format!("\u{1f511} {} \u{2014} \"{}\":", ep.label, ep.name);
-            let options = provider_action_options(ep.is_active, ep.editable, ep.deletable());
-            let model = QuestionPanelModel {
-                id: &panel_id,
-                question: &title,
-                options: &options,
-                selected_option: auth.selected_provider,
-                selected_options: &[],
-                custom_answer: "",
-                allow_free_text: false,
-                selection_mode: QuestionSelectionMode::Single,
-                input_feedback: QuestionInputFeedback::Disabled,
-            };
-            let height = renderer.write_question_panel(output, model)?;
-            state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(panel_id.clone());
-        }
-        AuthPhase::ConfirmDelete { provider_idx } => {
-            let height =
-                render_delete_confirmation(auth, provider_idx, &panel_id, &renderer, output)?;
-            state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(panel_id.clone());
-        }
-        AuthPhase::SelectingProvider => {
-            let options: Vec<String> = auth.providers.iter().map(|p| p.label.clone()).collect();
-            let model = QuestionPanelModel {
-                id: &panel_id,
-                question: "\u{1f511} Authentication Required \u{2014} Select your AI provider:",
-                options: &options,
-                selected_option: auth.selected_provider,
-                selected_options: &[],
-                custom_answer: "",
-                allow_free_text: false,
-                selection_mode: QuestionSelectionMode::Single,
-                input_feedback: QuestionInputFeedback::Disabled,
-            };
-            let height = renderer.write_question_panel(output, model)?;
-            state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(panel_id.clone());
-        }
-        AuthPhase::FillingField => {
-            let field = auth.current_field_info();
-            let label = field.map(|f| f.label.as_str()).unwrap_or("Value");
-            let is_secret = field.map(|f| f.secret).unwrap_or(false);
-            let hint_text = field.and_then(|f| f.hint.as_deref()).unwrap_or("");
-            let provider = auth.current_provider();
-            let is_editing = auth.editing_provider_name.is_some();
-            let action = if is_editing { "Edit" } else { "Enter" };
-            let mut question = format!(
-                "\u{1f511} {} \u{2014} {} {}:",
-                provider.label, action, label
-            );
-            if !hint_text.is_empty() {
-                question.push_str(&format!("\n  hint: {}", hint_text));
-            }
-            if is_editing && !auth.field_input.is_empty() {
-                question.push_str("\n  (Enter to keep current value)");
-            }
-            if !auth.field_input.is_empty() {
-                let display = if is_secret {
-                    "\u{2022}".repeat(auth.field_input.len())
-                } else {
-                    auth.field_input.clone()
-                };
-                question.push_str(&format!("\n  > {}", display));
-            } else {
-                question.push_str("\n  > ");
-            }
-            let model = QuestionPanelModel {
-                id: &panel_id,
-                question: &question,
-                options: &[],
-                selected_option: 0,
-                selected_options: &[],
-                custom_answer: "",
-                allow_free_text: true,
-                selection_mode: QuestionSelectionMode::Single,
-                input_feedback: QuestionInputFeedback::Disabled,
-            };
-            let height = renderer.write_question_panel(output, model)?;
-            state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(panel_id.clone());
-        }
-        AuthPhase::AliyunEcsChallenge {
-            ref instance_id,
-            ref console_url,
-        } => {
-            let mut question = format!(
-                "\u{1f511} Aliyun Authentication \u{2014} Authorize ECS RAM Role\n  ECS Instance ID: {instance_id}\n  URL: {console_url}"
-            );
-            if let Some(qr) = generate_qr_text(console_url) {
-                question.push_str("\n\n");
-                question.push_str(&qr);
-            }
-            let options = vec!["I have authorized this ECS instance".to_string()];
-            let model = QuestionPanelModel {
-                id: &panel_id,
-                question: &question,
-                options: &options,
-                selected_option: 0,
-                selected_options: &[],
-                custom_answer: "",
-                allow_free_text: false,
-                selection_mode: QuestionSelectionMode::Single,
-                input_feedback: QuestionInputFeedback::Disabled,
-            };
-            let height = renderer.write_question_panel(output, model)?;
-            state.questions.active_panel_height = height;
-            state.questions.active_panel_id = Some(panel_id);
-        }
-    }
-    output.flush()?;
-    Ok(())
-}
-
-fn clear_active_auth_panel<W: std::io::Write>(
-    state: &mut InlineState,
-    output: &mut W,
-) -> std::io::Result<()> {
-    let height = state.questions.active_panel_height;
-    if height == 0 {
-        state.questions.active_panel_id = None;
-        state.questions.active_panel_cursor_row = None;
-        state.questions.active_panel_width = None;
-        return Ok(());
-    }
-    write!(output, "\x1b[{height}A")?;
-    for row in 0..height {
-        write!(output, "\r\x1b[2K")?;
-        if row + 1 < height {
-            write!(output, "\x1b[1B")?;
-        }
-    }
-    if height > 1 {
-        write!(output, "\x1b[{}A", height - 1)?;
-    }
-    write!(output, "\r")?;
-    state.questions.active_panel_id = None;
-    state.questions.active_panel_height = 0;
-    state.questions.active_panel_cursor_row = None;
-    state.questions.active_panel_width = None;
-    Ok(())
-}
-
 fn cancel_auth_panel<W: std::io::Write>(
     state: &mut InlineState,
     output: &mut W,
@@ -963,56 +777,6 @@ fn parse_card_id_usize(event: &ShellEvent) -> Option<(String, usize)> {
 fn parse_card_id_text(event: &ShellEvent) -> Option<(String, String)> {
     let (id, text) = event.input.as_deref()?.split_once(':')?;
     Some((id.trim().to_string(), text.to_string()))
-}
-
-fn generate_qr_text(data: &str) -> Option<String> {
-    use qrcode::QrCode;
-
-    let code = QrCode::new(data.as_bytes()).ok()?;
-    let width = code.width();
-    let colors = code.to_colors();
-    let margin = 2usize;
-    let total_width = width + 2 * margin;
-    let light_row: String = "\u{2588}".repeat(total_width);
-    let mut result = String::new();
-
-    for _ in 0..margin {
-        result.push_str(&light_row);
-        result.push('\n');
-    }
-
-    let mut y = 0;
-    while y < width {
-        for _ in 0..margin {
-            result.push('\u{2588}');
-        }
-        for x in 0..width {
-            let top_dark = colors[y * width + x] == qrcode::Color::Dark;
-            let bottom_dark = if y + 1 < width {
-                colors[(y + 1) * width + x] == qrcode::Color::Dark
-            } else {
-                false
-            };
-            result.push(match (top_dark, bottom_dark) {
-                (true, true) => ' ',
-                (true, false) => '\u{2584}',
-                (false, true) => '\u{2580}',
-                (false, false) => '\u{2588}',
-            });
-        }
-        for _ in 0..margin {
-            result.push('\u{2588}');
-        }
-        result.push('\n');
-        y += 2;
-    }
-
-    for _ in 0..margin {
-        result.push_str(&light_row);
-        result.push('\n');
-    }
-
-    Some(result)
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -1,5 +1,6 @@
 use super::retry::restore_after_failed_submission;
 use super::runtime::*;
+use super::validation::{record_field_edit, record_field_submission, FieldSubmission};
 use crate::runtime::prelude::{
     AgentEvent, AuthFieldInfo, AuthProviderInfo, GovernanceDecision, GovernancePolicyDecision,
     GovernedEvent, InlineState, RawInputCapture,
@@ -135,6 +136,109 @@ fn pending_auth_capture_isolates_each_auth_field() {
     };
 
     assert_ne!(first_id, second_id);
+}
+
+fn openai_compat_with_provider_id_field() -> AuthProviderInfo {
+    let mut provider = provider("openai_compat", "OpenAI Compatible");
+    provider.fields = vec![
+        AuthFieldInfo {
+            name: "provider_id".to_string(),
+            label: "Provider ID".to_string(),
+            hint: None,
+            secret: false,
+            required: true,
+            placeholder: None,
+        },
+        AuthFieldInfo {
+            name: "base_url".to_string(),
+            label: "Base URL".to_string(),
+            hint: None,
+            secret: false,
+            required: true,
+            placeholder: None,
+        },
+    ];
+    provider
+}
+
+fn filling_provider_id_state() -> InlineState {
+    let mut state = InlineState::default();
+    record_auth_required(
+        &mut state,
+        &[governed_auth_required(vec![
+            openai_compat_with_provider_id_field(),
+        ])],
+    );
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.phase = AuthPhase::FillingField;
+    auth.current_field = 0;
+    state
+}
+
+#[test]
+fn dotted_provider_id_submission_stays_on_the_provider_id_field() {
+    let mut state = filling_provider_id_state();
+    let auth = state.auth.state.as_mut().unwrap();
+    let field = auth.providers[0].fields[0].clone();
+
+    let outcome = record_field_submission(auth, Some(&field), "qwen3.7-max".to_string());
+
+    assert_eq!(outcome, FieldSubmission::Rejected);
+    // Still on Provider ID: Base URL / API Key / Model are never reached.
+    assert_eq!(auth.current_field, 0);
+    assert_eq!(auth.phase, AuthPhase::FillingField);
+    assert_eq!(auth.field_input, "qwen3.7-max");
+    assert!(!auth.collected_values.contains_key("provider_id"));
+    let error = auth.field_error.as_deref().expect("inline error recorded");
+    assert!(error.contains("letters, digits"), "{error}");
+}
+
+#[test]
+fn empty_and_non_ascii_provider_id_submissions_are_rejected() {
+    for value in ["", "\u{6a21}\u{578b}", "bad.provider"] {
+        let mut state = filling_provider_id_state();
+        let auth = state.auth.state.as_mut().unwrap();
+        let field = auth.providers[0].fields[0].clone();
+
+        let outcome = record_field_submission(auth, Some(&field), value.to_string());
+
+        assert_eq!(outcome, FieldSubmission::Rejected, "value={value:?}");
+        assert_eq!(auth.current_field, 0, "value={value:?}");
+        assert!(auth.collected_values.is_empty(), "value={value:?}");
+        assert!(auth.field_error.is_some(), "value={value:?}");
+    }
+}
+
+#[test]
+fn valid_provider_id_submission_is_recorded_without_error() {
+    for value in ["qwen-prod", "qwen_prod", "Qwen37"] {
+        let mut state = filling_provider_id_state();
+        let auth = state.auth.state.as_mut().unwrap();
+        let field = auth.providers[0].fields[0].clone();
+
+        let outcome = record_field_submission(auth, Some(&field), value.to_string());
+
+        assert_eq!(outcome, FieldSubmission::Accepted, "value={value:?}");
+        assert_eq!(
+            auth.collected_values.get("provider_id").map(String::as_str),
+            Some(value)
+        );
+        assert!(auth.field_error.is_none(), "value={value:?}");
+    }
+}
+
+#[test]
+fn editing_the_field_again_clears_the_previous_error() {
+    let mut state = filling_provider_id_state();
+    let auth = state.auth.state.as_mut().unwrap();
+    let field = auth.providers[0].fields[0].clone();
+    record_field_submission(auth, Some(&field), "qwen3.7-max".to_string());
+    assert!(auth.field_error.is_some());
+
+    record_field_edit(auth, "qwen3-7-max");
+
+    assert!(auth.field_error.is_none());
+    assert_eq!(auth.field_input, "qwen3-7-max");
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/auth/validation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/validation.rs
@@ -1,0 +1,139 @@
+//! Inline validation for the fields collected by the `/auth` flow.
+//!
+//! cosh-shell has no dependency on cosh-core, so the Provider ID rule is mirrored here to
+//! reject bad input the moment it is submitted instead of after every field was collected.
+//! cosh-core keeps its own check as the authoritative gate — this module only shortens the
+//! feedback loop.
+
+use crate::runtime::prelude::AuthFieldInfo;
+
+use super::runtime::RuntimeAuthState;
+
+/// Hint rendered under the Provider ID prompt; states the character rule up front.
+pub(super) const PROVIDER_ID_HINT: &str =
+    "Config name (not model name; letters, digits, '-' and '_' only), e.g. qwen-prod";
+
+const PROVIDER_ID_FIELD: &str = "provider_id";
+
+const PROVIDER_ID_EMPTY_ERROR: &str = "Provider ID cannot be empty.";
+
+const PROVIDER_ID_CHARSET_ERROR: &str =
+    "Provider ID allows letters, digits, '-' and '_' only (no '.').";
+
+/// Outcome of submitting the value of the field currently being filled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FieldSubmission {
+    /// Value stored; the caller may advance to the next field.
+    Accepted,
+    /// Value rejected; the caller must stay on the current field and re-render.
+    Rejected,
+}
+
+/// Mirrors cosh-core's `is_valid_provider_id`: ASCII letters, digits, `-` and `_`.
+///
+/// The character set is intentionally narrow because a provider id becomes a TOML table
+/// key (`[ai.providers.<id>]`), where a `.` would be parsed as table nesting.
+fn provider_id_error(value: &str) -> Option<&'static str> {
+    if value.is_empty() {
+        return Some(PROVIDER_ID_EMPTY_ERROR);
+    }
+    let valid = value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_');
+    (!valid).then_some(PROVIDER_ID_CHARSET_ERROR)
+}
+
+/// Returns the user-facing error for `value`, or `None` when the field accepts it.
+pub(super) fn field_error(field_name: &str, value: &str) -> Option<&'static str> {
+    match field_name {
+        PROVIDER_ID_FIELD => provider_id_error(value),
+        _ => None,
+    }
+}
+
+/// Applies an in-progress edit to the active field, dropping any stale inline error.
+pub(super) fn record_field_edit(auth: &mut RuntimeAuthState, text: &str) {
+    auth.field_input = text.to_string();
+    auth.field_error = None;
+}
+
+/// Stores a submitted field value, or rejects it inline without touching `collected_values`.
+///
+/// On rejection the raw input stays in `field_input` so the user can fix it in place, and
+/// `field_error` carries the reason for `render_current_auth_panel` to display.
+pub(super) fn record_field_submission(
+    auth: &mut RuntimeAuthState,
+    field: Option<&AuthFieldInfo>,
+    value: String,
+) -> FieldSubmission {
+    let Some(field) = field else {
+        auth.field_error = None;
+        return FieldSubmission::Accepted;
+    };
+    if let Some(error) = field_error(&field.name, &value) {
+        auth.field_input = value;
+        auth.field_error = Some(error.to_string());
+        return FieldSubmission::Rejected;
+    }
+    auth.field_error = None;
+    auth.collected_values.insert(field.name.clone(), value);
+    FieldSubmission::Accepted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{field_error, PROVIDER_ID_HINT};
+
+    #[test]
+    fn provider_id_rejects_dotted_and_non_ascii_values() {
+        for value in ["qwen3.7-max", "bad.provider", "claude-3.5-sonnet", ""] {
+            assert!(
+                field_error("provider_id", value).is_some(),
+                "expected rejection for {value:?}"
+            );
+        }
+        assert!(field_error("provider_id", "\u{6a21}\u{578b}").is_some());
+        assert!(field_error("provider_id", "qwen prod").is_some());
+    }
+
+    #[test]
+    fn provider_id_accepts_letters_digits_dash_and_underscore() {
+        for value in ["qwen-prod", "qwen_prod", "Qwen37", "q"] {
+            assert_eq!(
+                field_error("provider_id", value),
+                None,
+                "expected {value:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn dotted_error_names_the_allowed_characters() {
+        let error = field_error("provider_id", "qwen3.7-max").expect("dotted id rejected");
+        assert!(error.contains("letters, digits"), "{error}");
+        assert!(error.contains('.'), "{error}");
+    }
+
+    #[test]
+    fn other_fields_are_not_constrained_by_the_provider_id_rule() {
+        assert_eq!(
+            field_error(
+                "base_url",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            ),
+            None
+        );
+        assert_eq!(field_error("model", "qwen3.7-max"), None);
+        assert_eq!(field_error("api_key", ""), None);
+    }
+
+    #[test]
+    fn provider_id_hint_states_the_character_rule() {
+        assert!(
+            PROVIDER_ID_HINT.contains("letters, digits"),
+            "{PROVIDER_ID_HINT}"
+        );
+        assert!(PROVIDER_ID_HINT.contains("'-'"), "{PROVIDER_ID_HINT}");
+        assert!(PROVIDER_ID_HINT.contains('_'), "{PROVIDER_ID_HINT}");
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli.rs
@@ -18,6 +18,8 @@ mod animation;
 mod approval;
 #[path = "raw_cli/audit.rs"]
 mod audit;
+#[path = "raw_cli/auth.rs"]
+mod auth;
 #[path = "raw_cli/cancellation.rs"]
 mod cancellation;
 #[path = "raw_cli/compaction.rs"]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+/// Fake cosh-core exposing a single OpenAI Compatible template and logging registry traffic.
+///
+/// The template omits `provider_id` because slash auth injects it as the first field.
+const AUTH_REGISTRY_CORE: &str = r#"#!/bin/sh
+if [ "$1" = "--registry" ]; then
+  read -r request
+  printf '%s\n' "$request" >> "$AUTH_REGISTRY_LOG"
+  case "$request" in
+    *'"action":"state"'*)
+      printf '%s\n' '{"type":"registry_response","request_id":"reg","success":true,"data":{"templates":[{"id":"openai_compat","label":"OpenAI Compatible","fields":[{"name":"base_url","label":"Base URL","hint":null,"secret":false,"required":true,"placeholder":null},{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":true,"placeholder":null}]}],"saved_providers":[]}}'
+      ;;
+    *)
+      printf '%s\n' '{"type":"registry_response","request_id":"reg","success":true,"data":{"model":"main-model","configured":true}}'
+      ;;
+  esac
+  exit 0
+fi
+read -r init
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{}}}}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"auth-inline","model":"main-model","tools":[]}'
+printf '%s\n' '{"type":"result","subtype":"success","session_id":"auth-inline","is_error":false,"result":"done"}'
+"#;
+
+/// A dotted Provider ID must be rejected on the spot instead of at the final `configure`.
+#[test]
+fn raw_cli_auth_dotted_provider_id_stays_on_provider_id_field() {
+    let home = temp_shell_home("auth-dotted-provider-id");
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let cosh_core_path = bin_dir.join("cosh-core");
+    write_executable(&cosh_core_path, AUTH_REGISTRY_CORE);
+    let registry_log = home.join("registry.log");
+
+    let home_str = home.to_string_lossy().to_string();
+    let core_str = cosh_core_path.to_string_lossy().to_string();
+    let log_str = registry_log.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "cosh-core",
+        &[],
+        &[
+            ("HOME", &home_str),
+            ("COSH_CORE_PATH", &core_str),
+            ("AUTH_REGISTRY_LOG", &log_str),
+        ],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("Left/Right move | Enter send", b"\n".as_slice()),
+            ("Type answer | Enter send", b"qwen3.7-max\n".as_slice()),
+            ("Provider ID allows letters", b"".as_slice()),
+        ],
+    );
+    let requests = fs::read_to_string(&registry_log).unwrap_or_default();
+    let _ = fs::remove_dir_all(&home);
+
+    let compact = compact_terminal_words(&output);
+    // The rejected field keeps the focus: Base URL is never reached.
+    assert!(
+        compact.contains("Enter Provider ID"),
+        "expected Provider ID prompt: {output}"
+    );
+    assert!(
+        !compact.contains("Enter Base URL"),
+        "flow advanced past Provider ID: {output}"
+    );
+    assert!(
+        compact.contains("Provider ID allows letters, digits, '-' and '_' only (no '.')"),
+        "expected inline Provider ID error: {output}"
+    );
+    // The hint states the rule before the user types anything.
+    assert!(
+        compact.contains("Config name (not model name; letters, digits, '-' and '_' only)"),
+        "expected character rule in hint: {output}"
+    );
+    // Nothing reached cosh-core: no configure round-trip, no late failure panel.
+    assert!(
+        !requests.contains(r#""action":"configure""#),
+        "auth configure must not be called: {requests}"
+    );
+    assert!(
+        !output.contains("Credentials were not saved"),
+        "late core rejection panel should not appear: {output}"
+    );
+    assert!(
+        requests.contains(r#""action":"state""#),
+        "expected auth state query: {requests}"
+    );
+}


### PR DESCRIPTION
## Description

Validate `/auth` Provider IDs when the field is submitted instead of waiting
for the final core registry configuration call. Invalid input now remains
editable in the Provider ID field with a precise inline error, while the core
validation remains the authoritative persistence boundary.

The implementation keeps validation logic in the auth owner module, updates
the field hint, and adds unit and raw CLI regression coverage.

## Related Issue

closes #1764

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p cosh-core auth_configure_rejects_invalid_provider_id`
- `cargo test -p cosh-shell --bin cosh-shell auth::`
- `cargo test -p cosh-shell --test logic`
- `cargo test -p cosh-shell --test raw_cli raw_cli_auth_dotted_provider_id_stays_on_provider_id_field`
- `cargo clippy -p cosh-core --all-targets -- -D warnings`
- `cargo clippy -p cosh-shell --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`

## Additional Notes

Provider IDs remain restricted to ASCII letters, digits, `-`, and `_`.
Allowing dots would require a separate TOML key serialization and migration
design because the current ID is persisted as `[ai.providers.<id>]`.
