### PR TITLE
fix(cosh-ng): [shell] harden HOOK prefix matching

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/approval/panel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/panel.rs
@@ -165,7 +165,7 @@ pub(crate) fn approval_focus_from_event(
     let index = selected.trim().parse::<usize>().ok()?;
     let is_hook = requests
         .iter()
-        .any(|r| r.id == id.trim() && r.subject.contains("HOOK:"));
+        .any(|r| r.id == id.trim() && r.subject.starts_with("HOOK:"));
     let action = if is_hook {
         hook_approval_action_at(index)?
     } else {

--- a/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
@@ -997,3 +997,80 @@ fn command_matches_trust_key_empty_set() {
     let trusted = HashSet::new();
     assert!(!command_matches_trust_key("npm test", &trusted));
 }
+
+fn card_focus_event(input: &str) -> crate::runtime::prelude::ShellEvent {
+    use crate::runtime::prelude::{ShellEvent, ShellEventKind};
+    ShellEvent {
+        kind: ShellEventKind::UserInputIntercepted,
+        session_id: "session-1".to_string(),
+        command_id: None,
+        command: None,
+        cwd: None,
+        end_cwd: None,
+        exit_code: None,
+        started_at_ms: Some(1),
+        ended_at_ms: None,
+        duration_ms: None,
+        terminal_output_ref: None,
+        terminal_output_bytes: None,
+        input: Some(input.to_string()),
+        component: Some("card".to_string()),
+        message: Some("focus".to_string()),
+        command_origin: None,
+        shell_environment_generation: None,
+        audit_identity: None,
+        routing: None,
+        capture: None,
+    }
+}
+
+#[test]
+fn infix_hook_marker_in_subject_keeps_normal_approval_actions() {
+    let mut spoofed = provider_tool_request("run_shell_command", None);
+    spoofed.subject = "tool HOOK: spoof".to_string();
+    let event = card_focus_event("req-1: 1");
+
+    let (id, action) = crate::approval::panel::approval_focus_from_event(&event, &[spoofed])
+        .expect("focus action");
+
+    assert_eq!(id, "req-1");
+    assert_eq!(
+        action,
+        crate::runtime::prelude::ApprovalPanelAction::AlwaysTrust
+    );
+}
+
+#[test]
+fn hook_prefixed_subject_resolves_hook_approval_actions() {
+    let mut hook_request = provider_tool_request("shell", None);
+    hook_request.subject = "HOOK:sandbox-guard".to_string();
+    let event = card_focus_event("req-1: 1");
+
+    let (id, action) = crate::approval::panel::approval_focus_from_event(&event, &[hook_request])
+        .expect("focus action");
+
+    assert_eq!(id, "req-1");
+    assert_eq!(action, crate::runtime::prelude::ApprovalPanelAction::Deny);
+}
+
+#[test]
+fn pending_card_capture_flags_hook_only_for_prefixed_subject() {
+    use crate::runtime::controller::pending_card_capture;
+    use crate::runtime::prelude::RawInputCapture;
+
+    let mut state = InlineState::default();
+    let mut spoofed = provider_tool_request("run_shell_command", None);
+    spoofed.subject = "tool HOOK: spoof".to_string();
+    state.approvals.requests.push(spoofed);
+
+    match pending_card_capture(&state) {
+        Some(RawInputCapture::Approval { is_hook, .. }) => assert!(!is_hook),
+        other => panic!("expected approval capture, got {other:?}"),
+    }
+
+    state.approvals.requests[0].subject = "HOOK:sandbox-guard".to_string();
+    match pending_card_capture(&state) {
+        Some(RawInputCapture::Approval { is_hook, .. }) => assert!(is_hook),
+        other => panic!("expected approval capture, got {other:?}"),
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
@@ -254,7 +254,7 @@ pub(crate) fn pending_card_capture(state: &InlineState) -> Option<RawInputCaptur
         .find(|request| request.status == ApprovalRequestStatus::Pending)
         .map(|request| RawInputCapture::Approval {
             id: request.id.clone(),
-            is_hook: request.subject.contains("HOOK:"),
+            is_hook: request.subject.starts_with("HOOK:"),
         })
 }
 


### PR DESCRIPTION
## Description

`8ce2cb82` tightened hook-approval detection from `contains("HOOK:")` to `starts_with("HOOK:")`, but only in the render layer (`ui/agent_render/approval.rs`). Two call sites were left behind: `runtime/controller.rs` (raw input capture) and `approval/panel.rs` (panel focus action resolution). A tool subject with an embedded `HOOK:` infix could still be treated as a hook approval on those paths (e.g. resolving hook panel actions, which drop AlwaysTrust and shift the action mapping). This PR closes both call sites and adds infix-spoof regression tests for each path.

Supplements: 8ce2cb82 ("fix(core,shell): add skill existence check and harden approval matching")

## Related Issue

no-issue: found during a docs-vs-code consistency audit; tracked in the cosh-ng rnd docs triage record (2026-07-25-cosh-ng-hook-prefix-contains).

## Type of Change

- [x] Bug fix (security hardening consistency)

## Scope

- [x] cosh-ng (cosh-shell)

## Testing

- `cargo test --locked -p cosh-shell --bin cosh-shell` — 1917 passed, 0 failed (includes 3 new regression tests: `infix_hook_marker_in_subject_keeps_normal_approval_actions`, `hook_prefixed_subject_resolves_hook_approval_actions`, `pending_card_capture_flags_hook_only_for_prefixed_subject`)
- `cargo fmt --all --check`, `cargo clippy -p cosh-shell --all-targets --locked` — clean
- `crates/cosh-shell/scripts/check-layout.sh` — unchanged result vs main (1 pre-existing violation group, no new group introduced)

## Remaining Risk

- Behavior change only affects subjects containing `HOOK:` at a non-zero offset; core generates the marker strictly as a prefix, so legitimate hook approvals are unaffected.