### PR TITLE
fix(ckpt): reject mounted workspace root and document interop

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
@@ -197,6 +197,46 @@ With SkillFS enabled, the runtime entry point of Skill Ledger is handled by the 
 3. The daemon refreshes `.skill-meta/activation.json` based on the signed manifest, current file state, user decisions, and the activation policy, and writes xattr on a best-effort basis.
 4. If the current risky version cannot be activated directly, the activation metadata points to the previous trusted `pass` / `warn` snapshot; if no trusted fallback exists, it points to a safe pending-review stub; `target: null` is written only for user `block` decisions or fail-safe scenarios.
 
+**Version requirement: SkillFS must be 0.4.0 or newer.**
+
+Since 0.4.0, the `skill_ledger.skillfs_notify_change` call in step 2 uses
+**notify v2**, whose business payload carries exactly four fields:
+`canonicalSkillDir`, `skillId`, `eventKind`, and `paths`. This is a **breaking
+upgrade with no fallback path** — the daemon rejects any request whose
+`schemaVersion` is not `2`, and SkillFS performs no version negotiation. The two
+components must therefore be upgraded together:
+
+- SkillFS older than 0.4.0 sends notify v1 only, which the current daemon rejects
+  request by request;
+- a failed notify delivery is only a warning on the SkillFS side and never stops
+  the FUSE service.
+
+A version mismatch therefore fails **silently**: newly installed Skills stay
+hidden and neither side reports an obvious error. When diagnosing, first confirm
+that `skillfs --version` is 0.4.0 or newer.
+
+**Two sockets, opposite directions.** Most joint-deployment wiring mistakes come
+from conflating them:
+
+| Socket | Listener | Default path | Purpose |
+|---|---|---|---|
+| daemon socket | agent-sec-core daemon | `$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock` (override with `AGENT_SEC_DAEMON_SOCKET`) | SkillFS points `--notify-socket` here to send change notifications |
+| control socket | SkillFS | `/run/user/<uid>/skillfs/control.sock` | The daemon queries `skill.resolveLiveSource` back through it and writes activation metadata |
+
+Do **not** customize the control socket path. The Ledger resolver client only
+probes the default path above; no configuration key makes it follow a path given
+to `--control-socket`, and changing it makes Ledger silently fall back to host
+mode. SkillFS and the daemon must also run under the same effective UID.
+
+Under the Hermes layout the activation flow carries nested identities
+(`category/skill`) rather than flat skill names, and `skillId` keeps both
+components.
+
+For the full protocol definition, canonical path semantics, and deployment
+boundaries, see
+[Skill Ledger's SkillFS integration design](../../../../../src/agent-sec-core/docs/design/SKILL_LEDGER_SKILLFS_INTEGRATION_zh.md)
+(Chinese only) and the [SkillFS user guide](../../runtime/skillfs.md).
+
 ### Compatibility Path: Hook / Capability Policy
 
 When the Agent loads a Skill, the OpenClaw, Hermes, and copilot-shell hooks resolve the Skill directory, run `agent-sec-cli skill-ledger show <skill_dir>`, and let the unified `policy` control the user-visible behavior. These hooks consume only the `message` in the summary:

--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -241,6 +241,20 @@ In activation file mode, activation JSON expresses fallback and hidden states.
 It does not write current/live state. If a skill has no activation JSON or
 activation xattr in this mode, SkillFS treats it as hidden by fail-safe default.
 
+### Permission Sources
+
+Visibility decides **which** content is read; permissions decide **whether** it
+can be read or written. Since 0.4.0 the two are resolved from different sources:
+
+| Operation | Permission source |
+| --- | --- |
+| Agent-visible read | The activated target's own permissions — for fallback, the snapshot's |
+| Write | The live source's permissions |
+
+A skill can therefore be readable through its snapshot while its live source is
+not writable. If you relied on reads following live-source permissions before
+0.4.0, review the permission bits on your snapshots.
+
 ## Read-Time Transforms
 
 After the activation target is resolved, `SKILL.md` bytes pass through an
@@ -437,7 +451,7 @@ skillfs mount /path/to/skills /mnt/skillfs \
   --foreground \
   --security \
   --activation-mode file \
-  --notify-socket /run/skill-ledger.sock \
+  --notify-socket "$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock" \
   --activation-events-log /var/log/skillfs/activation-events.jsonl \
   --activation-reload-mode poll
 ```
@@ -455,6 +469,14 @@ Agent or installer writes through SkillFS
 `--activation-reload-mode poll` requires `--notify-socket` or
 `--activation-events-log`, because SkillFS needs a trigger source for polling.
 
+`--notify-socket` points at a socket the **external daemon** listens on, not one
+SkillFS creates. In a joint deployment with Skill Ledger this is the
+agent-sec-core daemon endpoint, which defaults to
+`$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock` and can be overridden with
+`AGENT_SEC_DAEMON_SOCKET`. Note that a failed notify delivery is only a warning
+and never stops the FUSE service, so pointing at the wrong path shows up as
+skills staying hidden rather than as an obvious error.
+
 For in-place activation and notify mounts, set `--ledger-backing-root` to a
 daemon-visible backing source path and enable the authenticated resolver.
 Notify v2 carries canonical identity only, so startup rejects an in-place
@@ -467,7 +489,7 @@ skillfs mount /path/to/skills /path/to/skills \
   --security-mode \
   --security \
   --activation-mode file \
-  --notify-socket /run/skill-ledger.sock \
+  --notify-socket "$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock" \
   --trusted-peer-exe /usr/bin/python3.11 \
   --ledger-backing-root /run/user/$UID/skillfs-ledger/source
 ```
@@ -526,6 +548,14 @@ active endpoint; only a confirmed-stale socket that SkillFS owns is reclaimed.
 
 No `register`, `mountId`, or `generation` handshake is required — the endpoint
 is stable per UID and the resolver is queried directly.
+
+> **Do not use a custom endpoint in a joint deployment with Skill Ledger.** The
+> Skill Ledger resolver client only probes the default
+> `/run/user/<uid>/skillfs/control.sock`; no configuration key or command-line
+> option makes it follow a custom path. If you point `--control-socket` or
+> `[control_socket].path` elsewhere, Ledger fails to find the default socket and
+> silently falls back to host mode, canonical path resolution stops working, and
+> neither side reports an error. This is a current M1 limitation.
 
 Supported JSONL request examples:
 
@@ -659,14 +689,19 @@ shares the same file for compatibility.
 | `--foreground` | Run in the foreground |
 | `--managed` | Start a detached supervised mount |
 | `--security-mode` | Require source and mountpoint to be the same path |
+| `--skill-layout <MODE>` | `auto` (default, detect Hermes from source-root markers), `flat`, or `hermes`; `hermes` is incompatible with `--decision-command` |
 | `--security` | Enable security integration |
 | `--activation-mode file` | Consume activation JSON/xattr state |
 | `--activation-reload-mode poll` | Poll activation after notify triggers |
 | `--notify-socket <PATH>` | Send mutation events to an external daemon |
 | `--activation-events-log <PATH>` | Write activation protocol events as JSONL |
 | `--audit-log <PATH>` | Write filesystem audit events as JSONL |
-| `--control-socket <PATH>` | Override the control socket endpoint (default: `/run/user/<uid>/skillfs/control.sock`) |
+| `--audit-queue-capacity <N>` | Queue size for the audit writer thread; `0` uses the built-in default, and it only applies with `--audit-log` |
+| `--events-log <PATH>` | Write legacy security decision events as JSONL; only applies with `--security --decision-command` |
+| `--control-socket <PATH>` | Override the control socket endpoint (default: `/run/user/<uid>/skillfs/control.sock`); do not use in a joint deployment with Skill Ledger |
 | `--trusted-peer-exe <PATH>` | Pin the trusted control socket peer (enables the control plane on the default endpoint if no path is given) |
+| `--trusted-peer-uid <UID>` | Additionally constrain the control socket peer's UID (from `SO_PEERCRED`) |
+| `--trusted-peer-gid <GID>` | Additionally constrain the control socket peer's GID (from `SO_PEERCRED`) |
 | `--trusted-writer-exe <PATH>` | Pin a trusted mount-path writer |
 | `--ledger-backing-root <PATH>` | Provide a daemon-visible source view |
 | `--decision-command <CMD>` | Use legacy external decision mode |

--- a/docs/user-guide/en/runtime/ws-ckpt.md
+++ b/docs/user-guide/en/runtime/ws-ckpt.md
@@ -168,9 +168,35 @@ ws-ckpt config -g --enable-auto-cleanup --auto-cleanup-keep 20
 > **WARNING**: The workspace path configured for ws-ckpt must NOT be:
 > - The root path (`/`)
 > - Inside the daemon's mount_path
+> - An active mount point (see below)
 > - The Agent startup directory or any parent directory (validated at plugin level)
 >
 > These constraints are enforced by the daemon. Attempts to use invalid paths will be rejected.
+
+### The workspace root cannot be a mount point
+
+Initializing a workspace moves the original directory aside as a backup, and
+`rename(2)` fails with `EBUSY` on a directory that is itself a mount point. Any
+filesystem type is affected, not just FUSE.
+
+The common case is an in-place SkillFS mount, where the source and the mountpoint
+are the same directory. Unmount it first:
+
+```bash
+skillfs stop /path/to/workspace      # in-place SkillFS mount
+fusermount3 -u /path/to/workspace    # any other FUSE mount
+```
+
+This applies to `init` and to the first `checkpoint` on an unmanaged path, which
+auto-initializes. Once a workspace is initialized, later `checkpoint`, `rollback`,
+`list`, and `diff` operations are unaffected.
+
+Only the workspace root itself is rejected. A mount nested *inside* the workspace
+does not block `init`, but the outcome is rarely what you want: the mount stays
+attached to the backup directory that `init` moves aside, while the new workspace
+receives a plain copy of the mount's contents — subsequent writes land in the
+copy, not on the mounted filesystem, and the two silently diverge. Unmount nested
+mounts before initializing, or keep mount points outside the workspace tree.
 
 ---
 

--- a/docs/user-guide/en/troubleshooting.md
+++ b/docs/user-guide/en/troubleshooting.md
@@ -187,6 +187,39 @@ ws-ckpt config set workspace.path /home/user/projects/my-project
 
 ---
 
+**Symptom**: `ws-ckpt checkpoint` or `init` fails with "workspace root is an
+active mount point", or on older versions with "failed to rename original
+directory to backup: Device or resource busy (os error 16)"
+
+**Cause**: Initializing a workspace moves the original directory aside as a
+backup, and `rename(2)` fails with `EBUSY` on a directory that is itself a mount
+point. The usual trigger is mounting SkillFS in-place and then snapshotting the
+same path.
+
+**Solution**: Confirm whether the path is a mount point, unmount it, and retry:
+
+```bash
+# Confirm whether it is a mount point
+findmnt /path/to/workspace
+
+# In-place SkillFS mount
+skillfs stop /path/to/workspace
+
+# Any other FUSE mount
+fusermount3 -u /path/to/workspace
+
+ws-ckpt checkpoint -w /path/to/workspace -s my-snapshot
+```
+
+Only the workspace root itself is rejected. A mount nested inside the workspace
+does not block `init`, but the mount stays attached to the backup directory moved
+aside during initialization while the new workspace only receives a plain copy of
+its contents — unmount nested mounts first, or keep mount points outside the
+workspace tree. Mounting SkillFS after the workspace is already initialized also
+leaves later snapshots working.
+
+---
+
 ### SkillFS Issues
 
 **Symptom**: `skillfs mount` fails with "FUSE not available"

--- a/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
@@ -197,6 +197,37 @@ Skill Ledger 推荐与 SkillFS 联合使用：SkillFS 捕获 Skill 变更，通�
 3. daemon 根据签名 manifest、当前文件状态、用户决策和 activation policy 刷新 `.skill-meta/activation.json`，并尽力同步写入 xattr。
 4. 若当前风险版本不可直接激活，activation metadata 会指向上一个可信 `pass` / `warn` snapshot；若没有可信 fallback，则指向安全 pending review stub；用户 `block` 决策或 fail-safe 场景才写 `target: null`。
 
+**版本要求：SkillFS 必须 ≥ 0.4.0。**
+
+第 2 步的 `skill_ledger.skillfs_notify_change` 从 0.4.0 起使用 **notify v2**：业务
+payload 只有 `canonicalSkillDir`、`skillId`、`eventKind` 和 `paths` 四个字段。这是一次
+**没有回退路径的破坏性升级** —— daemon 明确拒绝 `schemaVersion != 2` 的请求，SkillFS 侧
+也不做版本协商。因此两个组件必须协调升级：
+
+- 0.4.0 之前的 SkillFS 只发送 notify v1，会被当前 daemon 逐条拒绝；
+- notify 投递失败在 SkillFS 侧只是 warning，不会中断 FUSE 服务。
+
+版本不匹配的表现因此是**静默失效**：新装的 Skill 一直停留在 hidden，两侧都没有明显
+报错。排查时先确认 `skillfs --version` ≥ 0.4.0。
+
+**两个 socket，方向相反。** 联合部署最常见的接线错误来自把它们混为一谈：
+
+| Socket | 谁监听 | 默认路径 | 用途 |
+|---|---|---|---|
+| daemon socket | agent-sec-core daemon | `$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock`（`AGENT_SEC_DAEMON_SOCKET` 可覆盖） | SkillFS 用 `--notify-socket` 指向这里，发送变更通知 |
+| control socket | SkillFS | `/run/user/<uid>/skillfs/control.sock` | daemon 反向查询 `skill.resolveLiveSource`，并写 activation 元数据 |
+
+control socket 的路径**不要自定义**。Ledger 的 resolver 客户端只探测上表中的默认路径，
+没有配置项可以让它跟随 `--control-socket` 指定的其他路径；改了之后 Ledger 会静默按
+host 模式处理。SkillFS 与 daemon 还必须运行在相同 effective UID 下。
+
+Hermes 布局下 activation 流程携带的是嵌套身份（`category/skill`），而非扁平 skill 名；
+`skillId` 会保留两个分量。
+
+完整的协议定义、canonical path 语义和部署边界见
+[Skill Ledger 的 SkillFS 集成设计](../../../../../src/agent-sec-core/docs/design/SKILL_LEDGER_SKILLFS_INTEGRATION_zh.md)
+与 [SkillFS 用户指南](../../runtime/skillfs.md)。
+
 ### 兼容路径：Hook / capability policy
 
 当 Agent 加载 Skill 时，OpenClaw、Hermes 和 copilot-shell hook 会解析 Skill 目录，执行 `agent-sec-cli skill-ledger show <skill_dir>`，并由统一 `policy` 控制可见行为。这些 hook 只消费 summary 中的 `message`：

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -228,6 +228,18 @@ Activation file mode 下，Activation JSON 表达 fallback 和 hidden 两种状�
 current/live 状态。如果该模式下某个 skill 没有 activation JSON 或 activation
 xattr，SkillFS 会按 fail-safe 默认值将其视为 hidden。
 
+### 权限判定来源
+
+可见性决定读**哪一份**内容，权限决定**能不能**读写。自 0.4.0 起两者的判定来源是分开的：
+
+| 操作 | 权限来源 |
+| --- | --- |
+| Agent 可见的读取 | 当前激活目标的权限，即 fallback 时用 snapshot 自身的权限 |
+| 写入 | live source 的权限 |
+
+因此一个 skill 可能 snapshot 可读、live source 不可写。升级到 0.4.0 前若依赖读取跟随
+live source 权限，需要复核 snapshot 的权限位。
+
 ## 读时转换
 
 在解析出激活目标之后，`SKILL.md` 字节会先经过一条固定顺序的转换流水线，再交给
@@ -397,7 +409,7 @@ skillfs mount /path/to/skills /mnt/skillfs \
   --foreground \
   --security \
   --activation-mode file \
-  --notify-socket /run/skill-ledger.sock \
+  --notify-socket "$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock" \
   --activation-events-log /var/log/skillfs/activation-events.jsonl \
   --activation-reload-mode poll
 ```
@@ -415,6 +427,12 @@ Agent 或 installer 通过 SkillFS 写入
 `--activation-reload-mode poll` 需要 `--notify-socket` 或
 `--activation-events-log`，因为 SkillFS 需要触发源来启动 polling。
 
+`--notify-socket` 指向的是**外部 daemon 监听的** socket，而不是 SkillFS 自己创建的
+socket。与 Skill Ledger 联合部署时，它就是 agent-sec-core daemon 的 endpoint，默认为
+`$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock`，可用 `AGENT_SEC_DAEMON_SOCKET` 覆盖。
+注意 notify 投递失败只记 warning，不会中断 FUSE 服务，因此指向错误路径的表现是 skill
+一直停留在 hidden 而没有明显报错。
+
 对于 in-place activation 和 notify mount，需要设置 `--ledger-backing-root`，给
 daemon 一个可见的 backing source path，并启用 authenticated resolver。Notify v2
 只携带 canonical identity，因此缺少 `--trusted-peer-exe` 的 in-place notify 配置会
@@ -426,7 +444,7 @@ skillfs mount /path/to/skills /path/to/skills \
   --security-mode \
   --security \
   --activation-mode file \
-  --notify-socket /run/skill-ledger.sock \
+  --notify-socket "$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock" \
   --trusted-peer-exe /usr/bin/python3.11 \
   --ledger-backing-root /run/user/$UID/skillfs-ledger/source
 ```
@@ -480,6 +498,12 @@ peer 为配置错误；两者都没有则 control plane 保持关闭。默认 en
 
 无需 `register`、`mountId` 或 `generation` 握手——endpoint 按 UID 稳定，resolver
 可直接查询。
+
+> **与 Skill Ledger 联合部署时不要使用自定义 endpoint。** Skill Ledger 的 resolver
+> 客户端只探测默认的 `/run/user/<uid>/skillfs/control.sock`，没有任何配置项或命令行
+> 参数可以让它跟随自定义路径。如果用 `--control-socket` 或 `[control_socket].path`
+> 指定了其他路径，Ledger 找不到默认 socket 会静默按 host 模式处理，canonical path
+> 解析随之失效，且两侧都不会报错。这是当前 M1 的限制。
 
 支持的 JSONL 请求示例：
 
@@ -594,14 +618,19 @@ mount-session summary 仍共享同一个文件。
 | `--foreground` | 前台运行 |
 | `--managed` | 启动 detached supervised mount |
 | `--security-mode` | 要求 source 和 mountpoint 是同一路径 |
+| `--skill-layout <MODE>` | `auto`（默认，按 source-root marker 探测 Hermes）、`flat` 或 `hermes`；`hermes` 与 `--decision-command` 互斥 |
 | `--security` | 启用安全集成 |
 | `--activation-mode file` | 消费 activation JSON/xattr 状态 |
 | `--activation-reload-mode poll` | notify trigger 后 poll activation |
 | `--notify-socket <PATH>` | 向外部 daemon 发送 mutation event |
 | `--activation-events-log <PATH>` | 写 activation protocol events JSONL |
 | `--audit-log <PATH>` | 写 filesystem audit events JSONL |
-| `--control-socket <PATH>` | 覆盖 control socket endpoint（默认 `/run/user/<uid>/skillfs/control.sock`） |
+| `--audit-queue-capacity <N>` | audit writer 线程队列长度；`0` 用内置默认值，仅配合 `--audit-log` 生效 |
+| `--events-log <PATH>` | 写旧 decision 流程的 security decision events JSONL，仅配合 `--security --decision-command` 生效 |
+| `--control-socket <PATH>` | 覆盖 control socket endpoint（默认 `/run/user/<uid>/skillfs/control.sock`）；与 Skill Ledger 联合部署时不要使用 |
 | `--trusted-peer-exe <PATH>` | 固定可信 control socket peer（未给 path 时在默认 endpoint 启用 control plane） |
+| `--trusted-peer-uid <UID>` | 额外约束 control socket peer 的 UID（取自 `SO_PEERCRED`） |
+| `--trusted-peer-gid <GID>` | 额外约束 control socket peer 的 GID（取自 `SO_PEERCRED`） |
 | `--trusted-writer-exe <PATH>` | 固定可信 mount-path writer |
 | `--ledger-backing-root <PATH>` | 提供 daemon 可见的 source view |
 | `--decision-command <CMD>` | 使用旧 external decision 模式 |

--- a/docs/user-guide/zh/runtime/ws-ckpt.md
+++ b/docs/user-guide/zh/runtime/ws-ckpt.md
@@ -168,9 +168,31 @@ ws-ckpt config -g --enable-auto-cleanup --auto-cleanup-keep 20
 > **警告**：ws-ckpt 配置的工作区路径**不能**是：
 > - 根路径（`/`）
 > - daemon mount_path 内部的路径
+> - 活跃的挂载点（见下文）
 > - Agent 启动目录或其父目录（在 plugin 层校验）
 >
 > 这些约束由 daemon 代码强制执行。使用无效路径将被拒绝。
+
+### 工作区根目录不能是挂载点
+
+初始化工作区时会把原目录改名后作为备份，而 `rename(2)` 对「自身是挂载点」的目录会返回
+`EBUSY`。这与文件系统类型无关，不只是 FUSE。
+
+最常见的情况是 in-place 模式的 SkillFS 挂载 —— 此时 source 和 mountpoint 是同一个目录。
+先卸载再操作：
+
+```bash
+skillfs stop /path/to/workspace      # in-place SkillFS 挂载
+fusermount3 -u /path/to/workspace    # 其他 FUSE 挂载
+```
+
+该约束作用于 `init`，以及在未纳管路径上首次执行的 `checkpoint`（会自动初始化）。工作区
+初始化完成之后，后续的 `checkpoint`、`rollback`、`list`、`diff` 都不受影响。
+
+被拒绝的只有工作区根目录本身。工作区**内部**的嵌套挂载不会阻止 `init`，但结果通常不是
+你想要的：挂载会留在 `init` 改名移走的备份目录上，新工作区里只有挂载内容的普通副本 ——
+后续写入落在副本上而不是挂载的文件系统里，两边会静默分叉。初始化前先卸载嵌套挂载，
+或让挂载点保持在工作区目录树之外。
 
 ---
 

--- a/docs/user-guide/zh/troubleshooting.md
+++ b/docs/user-guide/zh/troubleshooting.md
@@ -187,6 +187,35 @@ ws-ckpt config set workspace.path /home/user/projects/my-project
 
 ---
 
+**现象**：`ws-ckpt checkpoint` 或 `init` 失败，提示 "workspace root is an active
+mount point"，旧版本上表现为 "failed to rename original directory to backup:
+Device or resource busy (os error 16)"
+
+**原因**：初始化工作区要把原目录改名后作为备份，而 `rename(2)` 对「自身是挂载点」的
+目录会返回 `EBUSY`。最常见的触发方式是先用 in-place 模式挂载了 SkillFS，再对同一路径
+打快照。
+
+**解决**：先确认该路径是不是挂载点，卸载后重试：
+
+```bash
+# 确认是否为挂载点
+findmnt /path/to/workspace
+
+# in-place SkillFS 挂载
+skillfs stop /path/to/workspace
+
+# 其他 FUSE 挂载
+fusermount3 -u /path/to/workspace
+
+ws-ckpt checkpoint -w /path/to/workspace -s my-snapshot
+```
+
+被拒绝的只有工作区根目录本身。工作区内部的嵌套挂载不会阻止 `init`，但挂载会留在初始化
+时改名移走的备份目录上，新工作区里只有其内容的普通副本 —— 初始化前先卸载嵌套挂载，或让
+挂载点保持在工作区目录树之外。工作区初始化完成后再挂载 SkillFS 不影响后续快照。
+
+---
+
 ### SkillFS 问题
 
 **现象**：`skillfs mount` 失败，提示 "FUSE not available"

--- a/src/skillfs/docs/skills/skillfs-mount/SKILL.md
+++ b/src/skillfs/docs/skills/skillfs-mount/SKILL.md
@@ -29,12 +29,14 @@ description: >
 运行脚本分析历史调用频次，按调用次数决定哪些 skill 进主视图：
 
 ```bash
-# 分析 openclaw session 日志中的 skill 使用频次
-python3 <skill_dir>/scripts/openclaw_skill_cnt.py
+# 分析 openclaw session 日志中的 skill 使用频次（默认读 ~/.openclaw）
+python3 <skill_dir>/scripts/skill_usage_from_session_logs.py
 
-# 分析 copilot-shell (cosh) 的 skill 调用统计
-python3 <skill_dir>/scripts/cosh_skill_cnt.py
+# 分析 copilot-shell (cosh) chat 日志中的 skill 调用统计（默认读 ~/.copilot-shell）
+python3 <skill_dir>/scripts/skill_usage_from_chat_logs.py
 ```
+
+两个脚本都支持 `--logs-dir` 指向自定义日志目录。
 
 输出示例：
 ```
@@ -89,8 +91,9 @@ skills = ["weather", "notion", ...]
 
 **按分析结果手动调整**：直接编辑 views.toml，在两个 skills 列表之间移动 skill 名称。
 
-> ⚠️ views.toml 中的字符串必须与各 SKILL.md frontmatter 的 `name:` 字段完全一致，
-> 否则该技能将从视图中消失。
+> ⚠️ views.toml 中的字符串必须与 skill 的**目录名**完全一致，否则该技能将从视图中
+> 消失。目录名是权威的 skill key；`SKILL.md` frontmatter 里的 `name:` 只是展示元数据，
+> 不参与视图匹配，重命名目录后也不会覆盖目录 key。
 
 ---
 
@@ -109,6 +112,13 @@ ls ~/.openclaw/skills/    # 应只显示主视图 skill + skill-discover
 
 挂载时自动将未出现在 views.toml 中的新 skill 追加到默认视图。
 
+需要长期保持挂载时改用 managed 模式：它启动一个 detached supervisor，worker 意外退出后
+会自动重挂，不需要自己管理 pid file。
+
+```bash
+skillfs mount ~/.openclaw/skills ~/.openclaw/skills --managed
+```
+
 ---
 
 ### STEP 4：验证挂载状态
@@ -126,7 +136,11 @@ tail -f /tmp/skillfs-$(cat /tmp/skillfs.pid).log
 ### STEP 5：卸载
 
 ```bash
-# 优雅卸载（推荐）
+# managed 挂载：用 stop 停止 supervisor 并卸载
+# 非 managed 或残留挂载：stop 也会直接卸载，可作为通用兜底
+skillfs stop ~/.openclaw/skills
+
+# 前台挂载也可以直接向进程发信号
 kill -TERM $(cat /tmp/skillfs.pid)
 sleep 1
 
@@ -143,8 +157,12 @@ PID 文件在卸载成功后自动删除。
 
 ## 关键说明
 
-- SkillFS 是**只读**文件系统；挂载期间 views.toml 对 FUSE 不可见，需修改时先卸载
+- SkillFS **不是只读**文件系统：挂载期间对 skill 的写入（含 install / update / remove）
+  会透传到底层 source 树，写 `SKILL.md` 还会触发重新解析
+- 但 views.toml 是例外：挂载期间它对 FUSE 不可见，需修改时先卸载
 - 不生成 views.toml 也可直接挂载，此时所有 skill 均在主视图中可见
+- 该工作区不能同时作为 ws-ckpt 工作区根初始化 —— in-place 挂载会让 `rename(2)` 返回
+  `EBUSY`。先 `init` 再挂载，或先卸载再 `init`
 
 ---
 
@@ -154,6 +172,6 @@ PID 文件在卸载成功后自动删除。
 |------|----------|
 | `Package fuse3 was not found` | `yum install -y fuse3 fuse3-devel` |
 | `Transport endpoint is not connected` | `fusermount3 -u <mountpoint>` 后重新挂载 |
-| skill 消失于列表 | 统一 SKILL.md `name:` 与 views.toml 字符串 |
+| skill 消失于列表 | 统一 skill 目录名与 views.toml 字符串（不是 SKILL.md 的 `name:`） |
 | skill-discover 不完整 | 重新运行 `skillfs classify` 或手动编辑 views.toml |
 | 原地挂载后无法写 views.toml | 先卸载，编辑，再重新挂载 |

--- a/src/ws-ckpt/README.md
+++ b/src/ws-ckpt/README.md
@@ -44,6 +44,12 @@ ws-ckpt/
 - btrfs filesystem
 - Rust 1.70+
 
+The workspace root must not be an active mount point. Initialization moves the
+original directory aside as a backup, and `rename(2)` fails with `EBUSY` on a
+directory that is itself a mount point — most often an in-place SkillFS mount.
+Unmount it (`skillfs stop <PATH>`, or `fusermount3 -u <PATH>`) before `init` or
+the first `checkpoint`.
+
 ### Build
 
 ```bash

--- a/src/ws-ckpt/README_zh.md
+++ b/src/ws-ckpt/README_zh.md
@@ -44,6 +44,10 @@ ws-ckpt/
 - btrfs 文件系统
 - Rust 1.70+
 
+工作区根目录不能是活跃的挂载点。初始化时会把原目录改名后作为备份，而 `rename(2)` 对
+「自身是挂载点」的目录会返回 `EBUSY` —— 最常见的是 in-place 模式的 SkillFS 挂载。执行
+`init` 或首次 `checkpoint` 前先卸载（`skillfs stop <PATH>` 或 `fusermount3 -u <PATH>`）。
+
 ### 编译
 
 ```bash

--- a/src/ws-ckpt/src/crates/daemon/src/util.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/util.rs
@@ -408,6 +408,21 @@ pub(crate) async fn guard_cwd_occupants(workspace: &str) -> Option<ws_ckpt_commo
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn is_mounted_detects_real_mount_point() {
+        // `/proc` is a mount point on every supported (Linux) host, and a fresh
+        // temp dir never is. Guards the workspace-root check in `init`.
+        assert!(is_mounted("/proc").await.unwrap());
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_mounted(dir.path().to_str().unwrap()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn is_mounted_ignores_path_below_mount_point() {
+        // Only the mount point itself blocks rename(2); descendants are fine.
+        assert!(!is_mounted("/proc/self").await.unwrap());
+    }
+
     #[test]
     fn unescape_space_and_tab() {
         assert_eq!(unescape_proc_mount("/mnt/my\\040dir"), "/mnt/my dir");

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -296,6 +296,22 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
 
     let abs_path_str = abs_path.to_string_lossy().to_string();
 
+    // Every backend's init moves the original directory aside as a backup, and
+    // rename(2) returns EBUSY for a directory that is itself a mount point. Any
+    // filesystem qualifies (an in-place SkillFS over-mount is the common case).
+    // Reject here so the operator gets an actionable message instead of the raw
+    // "failed to rename original directory to backup: Device or resource busy".
+    if crate::util::is_mounted(&abs_path_str).await? {
+        return Ok(error_resp(
+            ErrorCode::InvalidPath,
+            format!(
+                "workspace root is an active mount point: {}; initialize a \
+                 subdirectory of the mount instead, or unmount it first and re-run",
+                abs_path.display()
+            ),
+        ));
+    }
+
     if let Some(resp) = crate::util::guard_cwd_occupants(&abs_path_str).await {
         return Ok(resp);
     }


### PR DESCRIPTION
## Description

Issue #1266 asked for documented usage restrictions when SkillFS and ws-ckpt are
combined. While confirming the root cause, an audit of the surrounding docs turned
up several adjacent gaps in the SkillFS 0.4.0 / Skill Ledger integration, so this
PR covers both.

**Root cause of #1266.** The failure is not in checkpointing but in workspace
*init*: every backend moves the original directory aside as a backup
(`btrfs_base.rs:83`, `btrfs_loop.rs:66`), and `rename(2)` returns `EBUSY` on a
directory that is itself a mount point. The reporter reached it through
`checkpoint` → `auto_init_workspace`. Two clarifications versus the issue title:

- It is **not SkillFS-specific** — any mount type at the workspace root fails.
- It is **init-time only**. `rollback`, `list`, `diff`, and later `checkpoint`s on
  an already-initialized workspace are unaffected, and only in-place SkillFS
  mounts (source == mountpoint) collide.

Documentation alone was not enough: the raw error mentioned neither mount points
nor unmounting. `ws-ckpt` already had a `/proc/mounts` mount-point detector
(`util::is_mounted`) and an `init` preflight block immediately before the rename,
so the guard is a small addition at the natural insertion point.

**Adjacent findings also fixed here.** SkillFS 0.4.0 made notify v2 a breaking
upgrade with no fallback — the Ledger daemon rejects `schemaVersion != 2` — but
that requirement was recorded only in an internal design doc reachable from Rust
source comments, not from any user-facing page. Combined with `--notify-socket`
examples using a placeholder path and no warning that Ledger only probes the
*default* control socket, a documented setup could fail silently (notify delivery
failure is warning-only, so skills just stay hidden).

## Related Issue

closes #1266

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Scope

- [x] `ckpt` (ws-ckpt)
- [x] `skillfs` (SkillFS)
- [x] Multiple / Project-wide

## Changes

Two commits, code and docs kept separate.

**`fix(ckpt): reject mounted workspace root at init`**

- `workspace_mgr.rs`: preflight `is_mounted()` check in `init`, before
  `init_workspace`, so the request is rejected before any state is created. The
  error names the remedy (`skillfs stop` / `fusermount3 -u` / `umount`).
- `util.rs`: tests covering `is_mounted` discrimination — a real mount point
  (`/proc`), a plain temp dir, and a path *below* a mount (`/proc/self`).

**`docs(docs): correct skillfs interop and 0.4.0 docs`** (zh and en in step)

- `skill-ledger.md`: notify v2 lockstep and `skillfs >= 0.4.0`; a table of the two
  sockets involved (daemon socket vs control socket, opposite directions), since
  conflating them is the most common wiring error; the "custom control socket
  silently degrades Ledger to host mode" caveat; Hermes nested identities; links
  to the previously-orphaned integration design doc.
- `runtime/skillfs.md`: replaced the `/run/skill-ledger.sock` placeholder with the
  endpoint the Ledger daemon actually listens on; added the control-socket caveat;
  documented the 0.4.0 read/write permission split (reads follow the activated
  snapshot, writes follow live source), which had no user-facing coverage; added
  `--skill-layout`, `--audit-queue-capacity`, `--events-log`, and
  `--trusted-peer-uid/-gid`, none of which were documented.
- `runtime/ws-ckpt.md`, `troubleshooting.md`, `src/ws-ckpt/README{,_zh}.md`: the
  mount-point restriction, framed as init-time and mount-type-agnostic to match
  the code. The old `Device or resource busy` string is included so searches land
  on the entry. The SkillFS side already documented this; a user arriving from the
  ws-ckpt direction found nothing.
- `skillfs-mount/SKILL.md`: fixed two analysis commands that named scripts which
  do not exist (`openclaw_skill_cnt.py` / `cosh_skill_cnt.py` →
  `skill_usage_from_session_logs.py` / `skill_usage_from_chat_logs.py`); corrected
  views.toml guidance that contradicted the authoritative directory-name key rule;
  corrected the "SkillFS is read-only" claim; added managed mode and
  `skillfs stop`.

## Testing

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets` (ws-ckpt) — no warnings
- `cargo test --workspace` (ws-ckpt) — 421 passed, 0 failed, 6 ignored
- Both corrected `skillfs-mount` script commands run to completion (exit 0); the
  previously documented names did not exist at all
- Relative links added to `skill-ledger.md` verified to resolve

The guard itself cannot be exercised end-to-end without privileges to create a
mount, so the added tests cover the predicate it depends on rather than the full
rejection path.

## Additional Notes

Two related items deliberately left out of this PR:

1. **`index.toml` does not publish skillfs 0.4.0** (only 0.3.0 / 0.3.2 / 0.3.3),
   while `Cargo.toml` and `component.toml` are 0.4.0. No doc pins a version, so
   there is no false claim, but `anolisa install skillfs` yields 0.3.3 — which
   emits notify v1 and is rejected by the v2-only Ledger daemon. Publishing needs
   the real artifact's `sha256`/`size`, so it belongs to the release flow.
2. **No ws-ckpt CHANGELOG entry**, since `ckpt/v0.4.2` is already tagged and an
   entry implies opening a `0.4.3` section plus a version bump — a release
   decision left to the maintainers.
