### PR TITLE
fix(cosh-ng): [shell] add sysom /auth shortcut

### DIFF
--- a/specs/cosh-ng-code-organization/large-file-inventory.md
+++ b/specs/cosh-ng-code-organization/large-file-inventory.md
@@ -33,7 +33,7 @@ new over-threshold file appears that is not listed here.
 | 912 | `src/evidence/output_policy.rs` | evidence | Output excerpt policy; pre-existing. Split bounding from classification. |
 | 906 | `src/adapter/fake.rs` | adapter | Test fake adapter; pre-existing. Split scripted-scenario builders. |
 | 898 | `src/ui/agent_render/approval.rs` | ui | Approval card rendering; pre-existing. Split per-card-kind renderers. |
-| 895 | `src/auth/runtime.rs` | auth | Auth control-protocol runtime; prompt rendering extracted to `auth/prompt.rs`. Extract provider-specific flows next. |
+| 871 | `src/auth/runtime.rs` | auth | Auth control-protocol runtime; prompt rendering extracted to `auth/prompt.rs`. Extract provider-specific flows next. |
 | 886 | `src/activity/runtime.rs` | activity | Activity runtime; pre-existing. Extract lifecycle from bookkeeping. |
 | 859 | `src/agent/poll.rs` | agent | Agent run polling loop; pre-existing debt (main baseline 839). The compaction feature added the `compaction_recommended_v1` status capture; split event routing from rendering. |
 | 856 | `src/parser/mod.rs` | parser | Event parser (legacy `mod.rs`); pre-existing. Split per-event-kind parsers and rename off `mod.rs`. |

--- a/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
@@ -4,6 +4,7 @@ use crate::runtime::prelude::RawInputCapture;
 use crate::runtime::state::InlineState;
 
 use super::delete_confirm::DELETE_CONFIRM_OPTION_COUNT;
+use super::menu::management_entry_count;
 use super::provider_management::{provider_action_options, ExistingProvider};
 use super::runtime::{AuthPhase, RuntimeAuthState};
 
@@ -28,7 +29,7 @@ pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCaptur
     match &auth.phase {
         AuthPhase::ManagingProviders => Some(RawInputCapture::Question {
             id: auth_capture_id(auth),
-            option_count: auth.existing_providers.len() + 1,
+            option_count: management_entry_count(&auth.sysom, auth.existing_providers.len()),
             allow_free_text: false,
             multiple: false,
             secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/auth/delete_confirm.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/delete_confirm.rs
@@ -53,6 +53,9 @@ pub(super) fn submit_delete_confirmation(
     };
     let core_state = load_core_auth_state(cosh_core)?;
     auth.existing_providers = core_state.existing_providers;
+    // Re-derive the SysOM slot from the reloaded list: deleting the promoted RAM-role
+    // provider must bring the shortcut back rather than relabel its replacement.
+    auth.sysom.sync(&mut auth.existing_providers);
     auth.phase = AuthPhase::ManagingProviders;
     auth.selected_provider = 0;
     let needs_reselection = existing.is_active

--- a/src/cosh-ng/crates/cosh-shell/src/auth/menu.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/menu.rs
@@ -1,0 +1,406 @@
+//! Top-level `/auth` management menu: row model, ordering and SysOM placement.
+//!
+//! The management panel mixes three kinds of rows — the SysOM free-trial shortcut (offered
+//! only on an ECS instance), the saved providers, and `+ Add new provider`. Rendering, input
+//! capture and answer dispatch all derive their indices from [`management_entries`] so that
+//! no call site has to offset by hand when the SysOM row appears.
+
+use std::collections::HashMap;
+
+use super::provider_management::ExistingProvider;
+
+/// Label of the SysOM free-trial row, reused for a saved RAM-role provider promoted to the
+/// first slot so both spellings of "already on ECS" read the same.
+const SYSOM_ENTRY_LABEL: &str = "SysOM (free trial, uses this ECS instance's RAM role)";
+
+const ADD_NEW_PROVIDER_LABEL: &str = "  + Add new provider";
+
+// SysOM is not a provider type of its own: it is the `aliyun` provider authenticated through
+// the instance RAM role instead of a manual AK/SK pair.
+const ECS_RAM_ROLE_PROVIDER_TYPE: &str = "aliyun";
+const ECS_RAM_ROLE_AUTH_SOURCE: &str = "ecs_ram_role";
+
+/// ECS RAM-role challenge prefetched by `/auth` from the core `auth.prepare` action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct EcsRamRolePrepare {
+    pub(super) instance_id: String,
+    pub(super) console_url: String,
+    /// Credential values the core wants persisted, e.g. `auth_source=ecs_ram_role`.
+    pub(super) values: HashMap<String, String>,
+}
+
+/// Successful Aliyun prepare result cached for the lifetime of the `/auth` flow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PrefetchedAliyunPrepare {
+    Manual,
+    EcsRamRole(EcsRamRolePrepare),
+}
+
+/// SysOM placement in the top-level menu plus the challenge the shortcut reuses.
+///
+/// `Default` is the non-ECS shape: no shortcut row, no promotion, and no prefetched
+/// challenge, which keeps every menu index identical to the pre-SysOM behaviour.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct SysomMenu {
+    /// Successful `auth.prepare`, retained so manual Aliyun setup does not probe again.
+    prepare: Option<PrefetchedAliyunPrepare>,
+    /// A saved RAM-role provider holds the first slot, so no shortcut row is added.
+    promoted: bool,
+}
+
+impl SysomMenu {
+    /// Menu for a host whose `auth.prepare` reported `ecs_ram_role`.
+    pub(super) fn on_ecs(prepare: EcsRamRolePrepare) -> Self {
+        Self {
+            prepare: Some(PrefetchedAliyunPrepare::EcsRamRole(prepare)),
+            promoted: false,
+        }
+    }
+
+    /// Menu for a host whose `auth.prepare` selected manual Aliyun credentials.
+    pub(super) fn on_manual() -> Self {
+        Self {
+            prepare: Some(PrefetchedAliyunPrepare::Manual),
+            promoted: false,
+        }
+    }
+
+    /// The prefetched result, so Aliyun preparation runs once per `/auth`.
+    pub(super) fn prefetched(&self) -> Option<&PrefetchedAliyunPrepare> {
+        self.prepare.as_ref()
+    }
+
+    /// Whether the first saved provider is an already-configured SysOM setup.
+    pub(super) fn promoted(&self) -> bool {
+        self.promoted
+    }
+
+    fn shows_shortcut(&self) -> bool {
+        matches!(
+            self.prepare.as_ref(),
+            Some(PrefetchedAliyunPrepare::EcsRamRole(_))
+        ) && !self.promoted
+    }
+
+    /// Moves a saved `aliyun` + `ecs_ram_role` provider to the first slot instead of
+    /// offering a shortcut that would configure a second copy of it.
+    ///
+    /// Idempotent, and cheap enough to re-run whenever the saved provider list is
+    /// reloaded (for example after a delete) so the promoted slot never goes stale.
+    pub(super) fn sync(&mut self, providers: &mut Vec<ExistingProvider>) {
+        self.promoted = false;
+        if !matches!(
+            self.prepare.as_ref(),
+            Some(PrefetchedAliyunPrepare::EcsRamRole(_))
+        ) {
+            return;
+        }
+        let Some(index) = providers.iter().position(is_ecs_ram_role_provider) else {
+            return;
+        };
+        let provider = providers.remove(index);
+        providers.insert(0, provider);
+        self.promoted = true;
+    }
+}
+
+fn is_ecs_ram_role_provider(provider: &ExistingProvider) -> bool {
+    provider.provider_type == ECS_RAM_ROLE_PROVIDER_TYPE
+        && provider.auth_source.as_deref() == Some(ECS_RAM_ROLE_AUTH_SOURCE)
+}
+
+/// A selectable row of the top-level `/auth` management panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AuthManagementEntry {
+    /// Configure SysOM through this instance's RAM role (ECS hosts without one saved).
+    SysomShortcut,
+    /// Act on `existing_providers[index]`.
+    Existing(usize),
+    /// Start the template picker for a brand-new provider.
+    AddNew,
+}
+
+/// Rows of the management panel, in display order.
+pub(super) fn management_entries(
+    sysom: &SysomMenu,
+    existing_count: usize,
+) -> Vec<AuthManagementEntry> {
+    let mut entries = Vec::with_capacity(existing_count + 2);
+    if sysom.shows_shortcut() {
+        entries.push(AuthManagementEntry::SysomShortcut);
+    }
+    entries.extend((0..existing_count).map(AuthManagementEntry::Existing));
+    entries.push(AuthManagementEntry::AddNew);
+    entries
+}
+
+pub(super) fn management_entry_count(sysom: &SysomMenu, existing_count: usize) -> usize {
+    management_entries(sysom, existing_count).len()
+}
+
+/// The row at `selected`, falling back to `AddNew` for an out-of-range selection.
+pub(super) fn management_entry(
+    sysom: &SysomMenu,
+    existing_count: usize,
+    selected: usize,
+) -> AuthManagementEntry {
+    management_entries(sysom, existing_count)
+        .get(selected)
+        .copied()
+        .unwrap_or(AuthManagementEntry::AddNew)
+}
+
+/// Selection index of `entry`, used when returning to the panel from a nested phase.
+pub(super) fn management_entry_index(
+    sysom: &SysomMenu,
+    existing_count: usize,
+    entry: AuthManagementEntry,
+) -> usize {
+    management_entries(sysom, existing_count)
+        .iter()
+        .position(|candidate| *candidate == entry)
+        .unwrap_or(0)
+}
+
+/// Whether the panel has anything to manage besides `+ Add new provider`.
+///
+/// `/auth` skips straight to the template picker when it does not, which is what a
+/// non-ECS host with no saved provider still gets.
+pub(super) fn has_manageable_entries(sysom: &SysomMenu, existing_count: usize) -> bool {
+    management_entry_count(sysom, existing_count) > 1
+}
+
+/// Rendered option strings for the management panel, aligned with [`management_entries`].
+pub(super) fn management_options(sysom: &SysomMenu, providers: &[ExistingProvider]) -> Vec<String> {
+    management_entries(sysom, providers.len())
+        .into_iter()
+        .map(|entry| match entry {
+            AuthManagementEntry::SysomShortcut => format!("  {SYSOM_ENTRY_LABEL}"),
+            AuthManagementEntry::Existing(index) => {
+                existing_provider_option(sysom, providers, index)
+            }
+            AuthManagementEntry::AddNew => ADD_NEW_PROVIDER_LABEL.to_string(),
+        })
+        .collect()
+}
+
+/// Display label of a saved provider; the promoted RAM-role entry reads as SysOM.
+pub(super) fn existing_provider_label(
+    sysom: &SysomMenu,
+    providers: &[ExistingProvider],
+    index: usize,
+) -> String {
+    if sysom.promoted() && index == 0 {
+        return SYSOM_ENTRY_LABEL.to_string();
+    }
+    providers
+        .get(index)
+        .map(|provider| provider.label.clone())
+        .unwrap_or_default()
+}
+
+fn existing_provider_option(
+    sysom: &SysomMenu,
+    providers: &[ExistingProvider],
+    index: usize,
+) -> String {
+    let Some(provider) = providers.get(index) else {
+        return String::new();
+    };
+    let active_mark = if provider.is_active {
+        "* [active] "
+    } else {
+        "  "
+    };
+    let model_info = if provider.model.is_empty() {
+        String::new()
+    } else {
+        format!(" - {}", provider.model)
+    };
+    let source_info = if provider.source == "system" {
+        " [system]"
+    } else {
+        ""
+    };
+    format!(
+        "{}{} - \"{}\"{}{}",
+        active_mark,
+        existing_provider_label(sysom, providers, index),
+        provider.name,
+        model_info,
+        source_info
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        existing_provider_label, has_manageable_entries, management_entries, management_entry,
+        management_entry_count, management_entry_index, management_options, AuthManagementEntry,
+        EcsRamRolePrepare, SysomMenu, SYSOM_ENTRY_LABEL,
+    };
+    use crate::auth::provider_management::ExistingProvider;
+    use std::collections::HashMap;
+
+    fn saved(name: &str, provider_type: &str, auth_source: Option<&str>) -> ExistingProvider {
+        ExistingProvider {
+            name: name.to_string(),
+            provider_type: provider_type.to_string(),
+            label: match provider_type {
+                "dashscope" => "DashScope (\u{767e}\u{70bc})".to_string(),
+                "aliyun" => "Aliyun Authentication".to_string(),
+                _ => "OpenAI Compatible".to_string(),
+            },
+            model: "qwen3.7-plus".to_string(),
+            is_active: true,
+            editable: true,
+            source: "user".to_string(),
+            base_url: None,
+            api_key_mask: None,
+            access_key_id_mask: None,
+            access_key_secret_mask: None,
+            security_token_mask: None,
+            auth_source: auth_source.map(str::to_string),
+        }
+    }
+
+    fn on_ecs() -> SysomMenu {
+        SysomMenu::on_ecs(EcsRamRolePrepare {
+            instance_id: "i-test".to_string(),
+            console_url: "https://example.invalid/guide".to_string(),
+            values: HashMap::from([("auth_source".to_string(), "ecs_ram_role".to_string())]),
+        })
+    }
+
+    #[test]
+    fn ecs_without_saved_providers_offers_sysom_first() {
+        let sysom = on_ecs();
+
+        assert!(has_manageable_entries(&sysom, 0));
+        assert_eq!(
+            management_entries(&sysom, 0),
+            vec![
+                AuthManagementEntry::SysomShortcut,
+                AuthManagementEntry::AddNew
+            ]
+        );
+        let options = management_options(&sysom, &[]);
+        assert!(options[0].contains(SYSOM_ENTRY_LABEL), "{options:?}");
+        assert!(options[1].contains("+ Add new provider"), "{options:?}");
+    }
+
+    #[test]
+    fn ecs_with_saved_provider_shifts_indices_by_the_sysom_row() {
+        let sysom = on_ecs();
+        let providers = vec![saved("qwen-prod", "dashscope", None)];
+
+        assert_eq!(
+            management_entries(&sysom, providers.len()),
+            vec![
+                AuthManagementEntry::SysomShortcut,
+                AuthManagementEntry::Existing(0),
+                AuthManagementEntry::AddNew,
+            ]
+        );
+        assert_eq!(
+            management_entry(&sysom, providers.len(), 0),
+            AuthManagementEntry::SysomShortcut
+        );
+        assert_eq!(
+            management_entry(&sysom, providers.len(), 1),
+            AuthManagementEntry::Existing(0)
+        );
+        assert_eq!(
+            management_entry(&sysom, providers.len(), 2),
+            AuthManagementEntry::AddNew
+        );
+        // Returning from the action menu must land back on the same saved provider.
+        assert_eq!(
+            management_entry_index(&sysom, providers.len(), AuthManagementEntry::Existing(0)),
+            1
+        );
+        let options = management_options(&sysom, &providers);
+        assert!(options[1].contains("qwen-prod"), "{options:?}");
+    }
+
+    #[test]
+    fn saved_ecs_ram_role_provider_is_promoted_instead_of_duplicated() {
+        let mut sysom = on_ecs();
+        let mut providers = vec![
+            saved("qwen-prod", "dashscope", None),
+            saved("sysom-trial", "aliyun", Some("ecs_ram_role")),
+        ];
+
+        sysom.sync(&mut providers);
+
+        assert!(sysom.promoted());
+        assert_eq!(providers[0].name, "sysom-trial");
+        assert_eq!(
+            management_entries(&sysom, providers.len()),
+            vec![
+                AuthManagementEntry::Existing(0),
+                AuthManagementEntry::Existing(1),
+                AuthManagementEntry::AddNew,
+            ]
+        );
+        let options = management_options(&sysom, &providers);
+        assert!(options[0].contains(SYSOM_ENTRY_LABEL), "{options:?}");
+        assert!(options[0].contains("sysom-trial"), "{options:?}");
+        assert!(
+            !options
+                .iter()
+                .skip(1)
+                .any(|o| o.contains(SYSOM_ENTRY_LABEL)),
+            "{options:?}"
+        );
+        assert_eq!(
+            existing_provider_label(&sysom, &providers, 0),
+            SYSOM_ENTRY_LABEL
+        );
+    }
+
+    #[test]
+    fn non_ecs_menu_keeps_saved_providers_then_add_new() {
+        let mut sysom = SysomMenu::default();
+        let mut providers = vec![saved("qwen-prod", "dashscope", None)];
+
+        sysom.sync(&mut providers);
+
+        assert!(!sysom.promoted());
+        assert_eq!(
+            management_entries(&sysom, providers.len()),
+            vec![
+                AuthManagementEntry::Existing(0),
+                AuthManagementEntry::AddNew
+            ]
+        );
+        assert_eq!(management_entry_count(&sysom, providers.len()), 2);
+        let options = management_options(&sysom, &providers);
+        assert!(!options.iter().any(|o| o.contains("SysOM")), "{options:?}");
+        assert_eq!(
+            options[0],
+            "* [active] DashScope (\u{767e}\u{70bc}) - \"qwen-prod\" - qwen3.7-plus"
+        );
+    }
+
+    #[test]
+    fn non_ecs_leaves_a_saved_ram_role_provider_where_it_was() {
+        let mut sysom = SysomMenu::default();
+        let mut providers = vec![
+            saved("qwen-prod", "dashscope", None),
+            saved("sysom-trial", "aliyun", Some("ecs_ram_role")),
+        ];
+
+        sysom.sync(&mut providers);
+
+        assert!(!sysom.promoted());
+        assert_eq!(providers[0].name, "qwen-prod");
+        let options = management_options(&sysom, &providers);
+        assert!(!options.iter().any(|o| o.contains("SysOM")), "{options:?}");
+    }
+
+    #[test]
+    fn non_ecs_without_saved_providers_has_nothing_to_manage() {
+        assert!(!has_manageable_entries(&SysomMenu::default(), 0));
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/mod.rs
@@ -2,6 +2,7 @@ mod active_submission;
 mod capture;
 mod completion;
 mod delete_confirm;
+mod menu;
 mod prompt;
 pub(crate) mod provider_display;
 mod provider_management;

--- a/src/cosh-ng/crates/cosh-shell/src/auth/prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/prompt.rs
@@ -9,6 +9,7 @@ use crate::runtime::state::InlineState;
 
 use super::capture::auth_capture_id;
 use super::delete_confirm::render_delete_confirmation;
+use super::menu::{existing_provider_label, management_options};
 use super::provider_management::provider_action_options;
 use super::runtime::AuthPhase;
 
@@ -24,32 +25,7 @@ pub(super) fn render_current_auth_panel<W: Write>(
 
     match auth.phase {
         AuthPhase::ManagingProviders => {
-            let mut options: Vec<String> = auth
-                .existing_providers
-                .iter()
-                .map(|provider| {
-                    let active_mark = if provider.is_active {
-                        "* [active] "
-                    } else {
-                        "  "
-                    };
-                    let model_info = if provider.model.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" - {}", provider.model)
-                    };
-                    let source_info = if provider.source == "system" {
-                        " [system]"
-                    } else {
-                        ""
-                    };
-                    format!(
-                        "{}{} - \"{}\"{}{}",
-                        active_mark, provider.label, provider.name, model_info, source_info
-                    )
-                })
-                .collect();
-            options.push("  + Add new provider".to_string());
+            let options = management_options(&auth.sysom, &auth.existing_providers);
 
             let model = QuestionPanelModel {
                 id: &panel_id,
@@ -70,7 +46,8 @@ pub(super) fn render_current_auth_panel<W: Write>(
             let provider = &auth.existing_providers[provider_idx];
             let title = format!(
                 "\u{1f511} {} \u{2014} \"{}\":",
-                provider.label, provider.name
+                existing_provider_label(&auth.sysom, &auth.existing_providers, provider_idx),
+                provider.name
             );
             let options = provider_action_options(
                 provider.is_active,

--- a/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
@@ -6,6 +6,7 @@ use std::io::{self, Write};
 use crate::runtime::prelude::{AgentEvent, GovernedEvent, NoticePanelModel, RatatuiInlineRenderer};
 use crate::runtime::state::InlineState;
 
+use super::menu::SysomMenu;
 use super::prompt::render_current_auth_panel;
 use super::provider_display::auth_required_providers_for_display;
 use super::runtime::{AuthBackend, AuthPhase, RuntimeAuthState};
@@ -44,6 +45,8 @@ pub(crate) fn record_auth_required(
                 editing_provider_name: None,
                 error_message: error_message.clone(),
                 backend: AuthBackend::ActiveRun,
+                // The active-run flow never shows the management menu.
+                sysom: SysomMenu::default(),
             });
             ids.push(id);
         }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -11,6 +11,10 @@ use crate::auth::delete_confirm::{
     begin_delete_confirmation, focus_delete_confirmation, render_delete_outcome,
     submit_delete_confirmation,
 };
+use crate::auth::menu::{
+    has_manageable_entries, management_entry, management_entry_count, management_entry_index,
+    AuthManagementEntry, EcsRamRolePrepare, PrefetchedAliyunPrepare, SysomMenu,
+};
 use crate::auth::prompt::{clear_active_auth_panel, render_current_auth_panel};
 use crate::auth::provider_management::{
     core_auth_activate, core_auth_configure, load_core_auth_state, provider_action_choice,
@@ -49,6 +53,9 @@ pub(crate) struct RuntimeAuthState {
     pub(crate) editing_provider_name: Option<String>,
     pub(super) error_message: Option<String>,
     pub(super) backend: AuthBackend,
+    /// SysOM placement plus the Aliyun prepare result prefetched for this `/auth`.
+    /// Default (non-ECS) leaves every menu index and phase transition unchanged.
+    pub(super) sysom: SysomMenu,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -157,13 +164,16 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
     );
     let id = format!("auth-{request_id}");
 
-    let existing_providers = core_state.existing_providers;
+    let mut existing_providers = core_state.existing_providers;
+    let mut sysom = prefetch_sysom_menu(adapter);
+    sysom.sync(&mut existing_providers);
 
-    // If there are existing providers, start in ManagingProviders phase
-    let phase = if existing_providers.is_empty() {
-        AuthPhase::SelectingProvider
-    } else {
+    // Saved providers or the SysOM shortcut give the management panel something to show;
+    // otherwise go straight to the template picker as before.
+    let phase = if has_manageable_entries(&sysom, existing_providers.len()) {
         AuthPhase::ManagingProviders
+    } else {
+        AuthPhase::SelectingProvider
     };
 
     state.auth.state = Some(RuntimeAuthState {
@@ -180,6 +190,7 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
         editing_provider_name: None,
         error_message: None,
         backend: AuthBackend::CoreRegistry,
+        sysom,
     });
 
     render_current_auth_panel(state, output)?;
@@ -229,6 +240,33 @@ fn core_auth_prepare(
     serde_json::from_value(value).map_err(|e| format!("invalid auth prepare response: {e}"))
 }
 
+/// Detects an ECS host once per `/auth` so the menu can offer the SysOM free trial.
+///
+/// This is a recommendation, not a requirement: a failed, unsupported or `manual` prepare
+/// yields the default (non-ECS) menu instead of breaking `/auth`.
+fn prefetch_sysom_menu(adapter: &AdapterInstance) -> SysomMenu {
+    match core_auth_prepare(adapter, "aliyun") {
+        Ok(prepare) if prepare.mode == "manual" => SysomMenu::on_manual(),
+        Ok(prepare) => ecs_ram_role_prepare(prepare)
+            .map(SysomMenu::on_ecs)
+            .unwrap_or_default(),
+        Err(error) => {
+            // The panel fails open, but the cause must survive: without this a metadata
+            // timeout or a protocol mismatch is indistinguishable from "not on ECS".
+            tracing::debug!("auth prepare for the SysOM menu entry failed: {error}");
+            SysomMenu::default()
+        }
+    }
+}
+
+fn ecs_ram_role_prepare(prepare: CoreAuthPrepare) -> Option<EcsRamRolePrepare> {
+    (prepare.mode == "ecs_ram_role").then(|| EcsRamRolePrepare {
+        instance_id: prepare.instance_id.unwrap_or_default(),
+        console_url: prepare.console_url.unwrap_or_default(),
+        values: prepare.values,
+    })
+}
+
 fn providers_with_provider_id_field(providers: Vec<AuthProviderInfo>) -> Vec<AuthProviderInfo> {
     providers
         .into_iter()
@@ -263,8 +301,8 @@ fn handle_auth_focus<W: std::io::Write>(
     }
     match auth.phase {
         AuthPhase::ManagingProviders => {
-            let max = auth.existing_providers.len(); // last item = "+ Add new"
-            auth.selected_provider = selected.min(max);
+            let entries = management_entry_count(&auth.sysom, auth.existing_providers.len());
+            auth.selected_provider = selected.min(entries.saturating_sub(1));
             clear_active_auth_panel(state, output)?;
             render_current_auth_panel(state, output)?;
         }
@@ -324,24 +362,28 @@ fn handle_auth_answer<W: std::io::Write>(
 
     match auth.phase {
         AuthPhase::ManagingProviders => {
-            let idx = auth.selected_provider;
-            if idx < auth.existing_providers.len() {
-                // Selected an existing provider -> show action menu
-                auth.phase = AuthPhase::ProviderAction { provider_idx: idx };
-                auth.selected_provider = 0;
-                clear_active_auth_panel(state, output)?;
-                render_current_auth_panel(state, output)?;
-            } else {
-                // Selected "+ Add new provider" -> go to SelectingProvider
-                auth.selected_provider = 0;
-                auth.editing_provider_name = None;
-                auth.phase = AuthPhase::SelectingProvider;
-                auth.current_field = 0;
-                auth.collected_values.clear();
-                auth.field_input.clear();
-                clear_active_auth_panel(state, output)?;
-                render_current_auth_panel(state, output)?;
+            let entry = management_entry(
+                &auth.sysom,
+                auth.existing_providers.len(),
+                auth.selected_provider,
+            );
+            match entry {
+                AuthManagementEntry::Existing(provider_idx) => {
+                    // Selected an existing provider -> show action menu
+                    auth.phase = AuthPhase::ProviderAction { provider_idx };
+                    auth.selected_provider = 0;
+                }
+                // The SysOM shortcut is the aliyun template with the ECS challenge already
+                // in hand; a template list without `aliyun` falls back to the picker.
+                AuthManagementEntry::SysomShortcut => {
+                    if !begin_sysom_shortcut(auth) {
+                        begin_new_provider(auth);
+                    }
+                }
+                AuthManagementEntry::AddNew => begin_new_provider(auth),
             }
+            clear_active_auth_panel(state, output)?;
+            render_current_auth_panel(state, output)?;
             Ok(true)
         }
         AuthPhase::ProviderAction { provider_idx } => {
@@ -451,9 +493,13 @@ fn handle_auth_answer<W: std::io::Write>(
                     render_current_auth_panel(state, output)?;
                 }
                 ProviderAction::Cancel => {
-                    // Cancel -> back to ManagingProviders
+                    // Cancel -> back to ManagingProviders, on the same row we came from
                     auth.phase = AuthPhase::ManagingProviders;
-                    auth.selected_provider = provider_idx;
+                    auth.selected_provider = management_entry_index(
+                        &auth.sysom,
+                        auth.existing_providers.len(),
+                        AuthManagementEntry::Existing(provider_idx),
+                    );
                     clear_active_auth_panel(state, output)?;
                     render_current_auth_panel(state, output)?;
                 }
@@ -550,6 +596,40 @@ fn handle_auth_answer<W: std::io::Write>(
     }
 }
 
+/// Resets the flow so the next answer picks a template for a brand-new provider.
+fn begin_new_provider(auth: &mut RuntimeAuthState) {
+    auth.selected_provider = 0;
+    auth.editing_provider_name = None;
+    auth.phase = AuthPhase::SelectingProvider;
+    auth.current_field = 0;
+    auth.collected_values.clear();
+    auth.field_input.clear();
+}
+
+/// Starts the SysOM free trial on the `aliyun` template, or reports `false` when the core
+/// offers no such template.
+///
+/// The Provider ID is still collected first: the shortcut must not silently overwrite an
+/// existing configuration with a fixed id. The prefetched ECS challenge is applied once
+/// that id validates, in the same place the manual aliyun flow would probe for it.
+fn begin_sysom_shortcut(auth: &mut RuntimeAuthState) -> bool {
+    let Some(template_idx) = auth
+        .providers
+        .iter()
+        .position(|provider| provider.id == "aliyun")
+    else {
+        return false;
+    };
+    auth.selected_provider = template_idx;
+    auth.editing_provider_name = None;
+    auth.phase = AuthPhase::FillingField;
+    auth.current_field = 0;
+    auth.collected_values.clear();
+    auth.field_input.clear();
+    auth.field_error = None;
+    true
+}
+
 fn load_current_field_input(auth: &mut RuntimeAuthState) {
     let field_name = auth.current_field_info().map(|f| f.name.clone());
     if let Some(name) = field_name {
@@ -592,14 +672,22 @@ fn clear_ecs_auth_source_for_manual_aliyun_edit(
     }
 }
 
+/// Switches the flow to the ECS RAM-role challenge, or reports `false` for manual AK/SK.
+///
+/// Reuses the challenge `/auth` already prefetched when there is one, so selecting the
+/// SysOM shortcut does not probe the ECS metadata service a second time.
 fn apply_aliyun_prepare(
     adapter: &AdapterInstance,
     auth: &mut RuntimeAuthState,
 ) -> Result<bool, String> {
-    let prepare = core_auth_prepare(adapter, "aliyun")?;
-    if prepare.mode != "ecs_ram_role" {
-        return Ok(false);
-    }
+    let prepare = match auth.sysom.prefetched() {
+        Some(PrefetchedAliyunPrepare::Manual) => return Ok(false),
+        Some(PrefetchedAliyunPrepare::EcsRamRole(prepare)) => prepare.clone(),
+        None => match ecs_ram_role_prepare(core_auth_prepare(adapter, "aliyun")?) {
+            Some(prepare) => prepare,
+            None => return Ok(false),
+        },
+    };
     for (key, value) in prepare.values {
         auth.collected_values.insert(key, value);
     }
@@ -607,8 +695,8 @@ fn apply_aliyun_prepare(
     auth.collected_values.remove("access_key_secret");
     auth.collected_values.remove("security_token");
     auth.phase = AuthPhase::AliyunEcsChallenge {
-        instance_id: prepare.instance_id.unwrap_or_default(),
-        console_url: prepare.console_url.unwrap_or_default(),
+        instance_id: prepare.instance_id,
+        console_url: prepare.console_url,
     };
     Ok(true)
 }
@@ -780,116 +868,4 @@ fn parse_card_id_text(event: &ShellEvent) -> Option<(String, String)> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        clear_ecs_auth_source_for_manual_aliyun_edit, should_apply_aliyun_prepare_after_field,
-        should_apply_aliyun_prepare_for_edit, should_apply_aliyun_prepare_on_provider_selection,
-        AuthBackend, ExistingProvider,
-    };
-    use std::collections::HashMap;
-
-    #[test]
-    fn core_registry_aliyun_add_waits_for_provider_id_before_prepare() {
-        assert!(!should_apply_aliyun_prepare_on_provider_selection(
-            AuthBackend::CoreRegistry
-        ));
-        assert!(should_apply_aliyun_prepare_after_field(
-            AuthBackend::CoreRegistry,
-            false,
-            "aliyun",
-            Some("provider_id"),
-        ));
-    }
-
-    #[test]
-    fn active_run_aliyun_selection_can_prepare_without_provider_id_field() {
-        assert!(should_apply_aliyun_prepare_on_provider_selection(
-            AuthBackend::ActiveRun
-        ));
-        assert!(!should_apply_aliyun_prepare_after_field(
-            AuthBackend::ActiveRun,
-            false,
-            "aliyun",
-            Some("provider_id"),
-        ));
-    }
-
-    #[test]
-    fn manual_aliyun_edit_does_not_apply_ecs_prepare() {
-        let manual = ExistingProvider {
-            name: "aliyun-manual".to_string(),
-            provider_type: "aliyun".to_string(),
-            label: "Aliyun Authentication".to_string(),
-            model: "qwen3.7-plus".to_string(),
-            is_active: true,
-            editable: true,
-            source: "user".to_string(),
-            base_url: None,
-            api_key_mask: None,
-            access_key_id_mask: Some("••••".to_string()),
-            access_key_secret_mask: Some("••••••".to_string()),
-            security_token_mask: None,
-            auth_source: None,
-        };
-        let ecs = ExistingProvider {
-            auth_source: Some("ecs_ram_role".to_string()),
-            access_key_id_mask: None,
-            access_key_secret_mask: None,
-            ..manual.clone()
-        };
-
-        assert!(!should_apply_aliyun_prepare_for_edit(&manual));
-        assert!(should_apply_aliyun_prepare_for_edit(&ecs));
-    }
-
-    #[test]
-    fn ecs_aliyun_manual_fallback_clears_auth_source() {
-        let ecs = ExistingProvider {
-            name: "aliyun-ecs".to_string(),
-            provider_type: "aliyun".to_string(),
-            label: "Aliyun Authentication".to_string(),
-            model: "qwen3.7-plus".to_string(),
-            is_active: true,
-            editable: true,
-            source: "user".to_string(),
-            base_url: None,
-            api_key_mask: None,
-            access_key_id_mask: None,
-            access_key_secret_mask: None,
-            security_token_mask: None,
-            auth_source: Some("ecs_ram_role".to_string()),
-        };
-        let manual = ExistingProvider {
-            auth_source: None,
-            ..ecs.clone()
-        };
-        let mut ecs_values = HashMap::from([
-            ("auth_source".to_string(), "ecs_ram_role".to_string()),
-            ("access_key_id".to_string(), "manual-ak".to_string()),
-            ("access_key_secret".to_string(), "manual-sk".to_string()),
-            ("security_token".to_string(), "manual-token".to_string()),
-        ]);
-        let mut manual_values = ecs_values.clone();
-
-        clear_ecs_auth_source_for_manual_aliyun_edit(&ecs, &mut ecs_values);
-        clear_ecs_auth_source_for_manual_aliyun_edit(&manual, &mut manual_values);
-
-        assert!(!ecs_values.contains_key("auth_source"));
-        assert_eq!(
-            ecs_values.get("access_key_id").map(String::as_str),
-            Some("manual-ak")
-        );
-        assert_eq!(
-            ecs_values.get("access_key_secret").map(String::as_str),
-            Some("manual-sk")
-        );
-        assert_eq!(
-            ecs_values.get("security_token").map(String::as_str),
-            Some("manual-token")
-        );
-        assert_eq!(
-            manual_values.get("auth_source").map(String::as_str),
-            Some("ecs_ram_role")
-        );
-    }
-}
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -1,0 +1,384 @@
+//! Unit tests for the `/auth` slash-command state machine.
+
+use super::{
+    apply_aliyun_prepare, begin_sysom_shortcut, clear_ecs_auth_source_for_manual_aliyun_edit,
+    ecs_ram_role_prepare, handle_auth_answer, management_entry,
+    should_apply_aliyun_prepare_after_field, should_apply_aliyun_prepare_for_edit,
+    should_apply_aliyun_prepare_on_provider_selection, AuthBackend, AuthManagementEntry, AuthPhase,
+    AuthProviderInfo, CoreAuthPrepare, EcsRamRolePrepare, ExistingProvider, InlineState,
+    RuntimeAuthState, SysomMenu,
+};
+use crate::adapter::{AdapterInstance, FakeAgentAdapter};
+use std::collections::HashMap;
+
+/// Any registry round-trip through this adapter fails, so reaching the ECS metadata
+/// service a second time turns into a visible error instead of a silent probe.
+fn adapter_without_registry() -> AdapterInstance {
+    AdapterInstance::Fake(FakeAgentAdapter)
+}
+
+fn template(id: &str) -> AuthProviderInfo {
+    AuthProviderInfo {
+        id: id.to_string(),
+        label: id.to_string(),
+        fields: Vec::new(),
+    }
+}
+
+fn ecs_prepare() -> EcsRamRolePrepare {
+    EcsRamRolePrepare {
+        instance_id: "i-test-1".to_string(),
+        console_url: "https://example.invalid/guide/cosh?instance=i-test-1".to_string(),
+        values: HashMap::from([("auth_source".to_string(), "ecs_ram_role".to_string())]),
+    }
+}
+
+fn slash_auth_state(templates: &[&str], sysom: SysomMenu) -> RuntimeAuthState {
+    RuntimeAuthState {
+        id: "auth-slash".to_string(),
+        request_id: "slash".to_string(),
+        phase: AuthPhase::ManagingProviders,
+        providers: templates.iter().copied().map(template).collect(),
+        selected_provider: 0,
+        current_field: 0,
+        collected_values: HashMap::new(),
+        field_input: String::new(),
+        field_error: None,
+        existing_providers: Vec::new(),
+        editing_provider_name: None,
+        error_message: None,
+        backend: AuthBackend::CoreRegistry,
+        sysom,
+    }
+}
+
+#[test]
+fn manual_prepare_mode_is_not_an_ecs_challenge() {
+    assert!(ecs_ram_role_prepare(CoreAuthPrepare {
+        mode: "manual".to_string(),
+        instance_id: None,
+        console_url: None,
+        values: HashMap::new(),
+    })
+    .is_none());
+
+    let prepare = ecs_ram_role_prepare(CoreAuthPrepare {
+        mode: "ecs_ram_role".to_string(),
+        instance_id: Some("i-test-1".to_string()),
+        console_url: Some("https://example.invalid/guide".to_string()),
+        values: HashMap::from([("auth_source".to_string(), "ecs_ram_role".to_string())]),
+    })
+    .expect("ecs mode is a challenge");
+    assert_eq!(prepare.instance_id, "i-test-1");
+    assert_eq!(
+        prepare.values.get("auth_source").map(String::as_str),
+        Some("ecs_ram_role")
+    );
+
+    let mut auth = slash_auth_state(&["aliyun"], SysomMenu::on_manual());
+    assert!(
+        !apply_aliyun_prepare(&adapter_without_registry(), &mut auth)
+            .expect("cached manual prepare needs no registry")
+    );
+    assert_eq!(auth.phase, AuthPhase::ManagingProviders);
+}
+
+#[test]
+fn sysom_shortcut_starts_the_aliyun_template_at_provider_id() {
+    let mut auth = slash_auth_state(
+        &["dashscope", "openai_compat", "aliyun"],
+        SysomMenu::on_ecs(ecs_prepare()),
+    );
+
+    assert!(begin_sysom_shortcut(&mut auth));
+
+    // The aliyun template is reused as-is; SysOM is not a provider type of its own.
+    assert_eq!(auth.current_provider().id, "aliyun");
+    assert_eq!(auth.phase, AuthPhase::FillingField);
+    // Field 0 is the injected Provider ID, so the shortcut cannot overwrite a config.
+    assert_eq!(auth.current_field, 0);
+    assert!(auth.editing_provider_name.is_none());
+    assert!(auth.collected_values.is_empty());
+}
+
+#[test]
+fn sysom_shortcut_without_an_aliyun_template_reports_failure() {
+    let mut auth = slash_auth_state(&["dashscope"], SysomMenu::on_ecs(ecs_prepare()));
+
+    assert!(!begin_sysom_shortcut(&mut auth));
+    assert_eq!(auth.phase, AuthPhase::ManagingProviders);
+}
+
+#[test]
+fn prefetched_challenge_is_applied_without_probing_ecs_again() {
+    let mut auth = slash_auth_state(&["aliyun"], SysomMenu::on_ecs(ecs_prepare()));
+    auth.collected_values
+        .insert("provider_id".to_string(), "sysom-trial".to_string());
+    auth.collected_values
+        .insert("access_key_id".to_string(), "stale-ak".to_string());
+
+    let applied = apply_aliyun_prepare(&adapter_without_registry(), &mut auth)
+        .expect("cached prepare needs no registry");
+
+    assert!(applied);
+    assert_eq!(
+        auth.phase,
+        AuthPhase::AliyunEcsChallenge {
+            instance_id: "i-test-1".to_string(),
+            console_url: "https://example.invalid/guide/cosh?instance=i-test-1".to_string(),
+        }
+    );
+    assert_eq!(
+        auth.collected_values.get("auth_source").map(String::as_str),
+        Some("ecs_ram_role")
+    );
+    assert!(!auth.collected_values.contains_key("access_key_id"));
+    assert_eq!(
+        auth.collected_values.get("provider_id").map(String::as_str),
+        Some("sysom-trial")
+    );
+}
+
+/// Slash-auth state on an ECS host with one saved DashScope provider.
+fn ecs_state_with_saved_dashscope() -> InlineState {
+    let mut auth = slash_auth_state(
+        &["dashscope", "openai_compat", "aliyun"],
+        SysomMenu::on_ecs(ecs_prepare()),
+    );
+    auth.existing_providers = vec![saved_dashscope()];
+    let mut state = InlineState::default();
+    state.auth.state = Some(auth);
+    state
+}
+
+fn saved_dashscope() -> ExistingProvider {
+    ExistingProvider {
+        name: "qwen-prod".to_string(),
+        provider_type: "dashscope".to_string(),
+        label: "DashScope".to_string(),
+        model: "qwen3.7-plus".to_string(),
+        is_active: true,
+        editable: true,
+        source: "user".to_string(),
+        base_url: None,
+        api_key_mask: Some("\u{2022}\u{2022}".to_string()),
+        access_key_id_mask: None,
+        access_key_secret_mask: None,
+        security_token_mask: None,
+        auth_source: None,
+    }
+}
+
+/// Answers the panel with the row currently selected, discarding the rendered output.
+fn answer_selected_row(state: &mut InlineState) {
+    let id = state.auth.state.as_ref().expect("auth state").id.clone();
+    let mut output = Vec::new();
+    assert!(
+        handle_auth_answer(&adapter_without_registry(), state, &id, "", &mut output)
+            .expect("panel answer"),
+        "answer was not routed to the auth panel"
+    );
+}
+
+#[test]
+fn menu_rows_below_the_shortcut_still_open_their_provider_action_menu() {
+    let mut state = ecs_state_with_saved_dashscope();
+    // Row 2 of [SysOM, qwen-prod, + Add new provider].
+    state
+        .auth
+        .state
+        .as_mut()
+        .expect("auth state")
+        .selected_provider = 1;
+
+    answer_selected_row(&mut state);
+
+    let auth = state.auth.state.as_ref().expect("auth state");
+    assert_eq!(auth.phase, AuthPhase::ProviderAction { provider_idx: 0 });
+}
+
+#[test]
+fn the_last_menu_row_still_adds_a_new_provider() {
+    let mut state = ecs_state_with_saved_dashscope();
+    state
+        .auth
+        .state
+        .as_mut()
+        .expect("auth state")
+        .selected_provider = 2;
+
+    answer_selected_row(&mut state);
+
+    let auth = state.auth.state.as_ref().expect("auth state");
+    assert_eq!(auth.phase, AuthPhase::SelectingProvider);
+    assert_eq!(auth.selected_provider, 0);
+}
+
+#[test]
+fn the_first_menu_row_starts_the_sysom_shortcut() {
+    let mut state = ecs_state_with_saved_dashscope();
+
+    answer_selected_row(&mut state);
+
+    let auth = state.auth.state.as_ref().expect("auth state");
+    assert_eq!(auth.phase, AuthPhase::FillingField);
+    assert_eq!(auth.current_provider().id, "aliyun");
+    assert_eq!(auth.current_field, 0);
+}
+
+#[test]
+fn cancelling_a_provider_action_returns_to_the_row_it_came_from() {
+    let mut state = ecs_state_with_saved_dashscope();
+    {
+        let auth = state.auth.state.as_mut().expect("auth state");
+        auth.phase = AuthPhase::ProviderAction { provider_idx: 0 };
+        // An active provider offers Edit, Delete, Cancel.
+        auth.selected_provider = 2;
+    }
+
+    answer_selected_row(&mut state);
+
+    let auth = state.auth.state.as_ref().expect("auth state");
+    assert_eq!(auth.phase, AuthPhase::ManagingProviders);
+    // Row 2, not row 1: the SysOM shortcut occupies the first slot.
+    assert_eq!(auth.selected_provider, 1);
+}
+
+#[test]
+fn deleting_the_promoted_provider_restores_the_shortcut_row() {
+    let mut auth = slash_auth_state(&["aliyun"], SysomMenu::on_ecs(ecs_prepare()));
+    auth.existing_providers = vec![ExistingProvider {
+        name: "sysom-trial".to_string(),
+        provider_type: "aliyun".to_string(),
+        auth_source: Some("ecs_ram_role".to_string()),
+        ..saved_dashscope()
+    }];
+    auth.sysom.sync(&mut auth.existing_providers);
+    assert!(auth.sysom.promoted());
+
+    // What `submit_delete_confirmation` does after reloading the saved providers.
+    auth.existing_providers = vec![saved_dashscope()];
+    auth.sysom.sync(&mut auth.existing_providers);
+
+    assert!(!auth.sysom.promoted());
+    assert_eq!(
+        management_entry(&auth.sysom, auth.existing_providers.len(), 0),
+        AuthManagementEntry::SysomShortcut
+    );
+}
+
+#[test]
+fn without_a_prefetched_challenge_prepare_still_asks_the_registry() {
+    let mut auth = slash_auth_state(&["aliyun"], SysomMenu::default());
+
+    let error = apply_aliyun_prepare(&adapter_without_registry(), &mut auth)
+        .expect_err("registry is consulted when nothing was prefetched");
+
+    assert!(error.contains("cosh-core"), "{error}");
+    assert_eq!(auth.phase, AuthPhase::ManagingProviders);
+}
+
+#[test]
+fn core_registry_aliyun_add_waits_for_provider_id_before_prepare() {
+    assert!(!should_apply_aliyun_prepare_on_provider_selection(
+        AuthBackend::CoreRegistry
+    ));
+    assert!(should_apply_aliyun_prepare_after_field(
+        AuthBackend::CoreRegistry,
+        false,
+        "aliyun",
+        Some("provider_id"),
+    ));
+}
+
+#[test]
+fn active_run_aliyun_selection_can_prepare_without_provider_id_field() {
+    assert!(should_apply_aliyun_prepare_on_provider_selection(
+        AuthBackend::ActiveRun
+    ));
+    assert!(!should_apply_aliyun_prepare_after_field(
+        AuthBackend::ActiveRun,
+        false,
+        "aliyun",
+        Some("provider_id"),
+    ));
+}
+
+#[test]
+fn manual_aliyun_edit_does_not_apply_ecs_prepare() {
+    let manual = ExistingProvider {
+        name: "aliyun-manual".to_string(),
+        provider_type: "aliyun".to_string(),
+        label: "Aliyun Authentication".to_string(),
+        model: "qwen3.7-plus".to_string(),
+        is_active: true,
+        editable: true,
+        source: "user".to_string(),
+        base_url: None,
+        api_key_mask: None,
+        access_key_id_mask: Some("••••".to_string()),
+        access_key_secret_mask: Some("••••••".to_string()),
+        security_token_mask: None,
+        auth_source: None,
+    };
+    let ecs = ExistingProvider {
+        auth_source: Some("ecs_ram_role".to_string()),
+        access_key_id_mask: None,
+        access_key_secret_mask: None,
+        ..manual.clone()
+    };
+
+    assert!(!should_apply_aliyun_prepare_for_edit(&manual));
+    assert!(should_apply_aliyun_prepare_for_edit(&ecs));
+}
+
+#[test]
+fn ecs_aliyun_manual_fallback_clears_auth_source() {
+    let ecs = ExistingProvider {
+        name: "aliyun-ecs".to_string(),
+        provider_type: "aliyun".to_string(),
+        label: "Aliyun Authentication".to_string(),
+        model: "qwen3.7-plus".to_string(),
+        is_active: true,
+        editable: true,
+        source: "user".to_string(),
+        base_url: None,
+        api_key_mask: None,
+        access_key_id_mask: None,
+        access_key_secret_mask: None,
+        security_token_mask: None,
+        auth_source: Some("ecs_ram_role".to_string()),
+    };
+    let manual = ExistingProvider {
+        auth_source: None,
+        ..ecs.clone()
+    };
+    let mut ecs_values = HashMap::from([
+        ("auth_source".to_string(), "ecs_ram_role".to_string()),
+        ("access_key_id".to_string(), "manual-ak".to_string()),
+        ("access_key_secret".to_string(), "manual-sk".to_string()),
+        ("security_token".to_string(), "manual-token".to_string()),
+    ]);
+    let mut manual_values = ecs_values.clone();
+
+    clear_ecs_auth_source_for_manual_aliyun_edit(&ecs, &mut ecs_values);
+    clear_ecs_auth_source_for_manual_aliyun_edit(&manual, &mut manual_values);
+
+    assert!(!ecs_values.contains_key("auth_source"));
+    assert_eq!(
+        ecs_values.get("access_key_id").map(String::as_str),
+        Some("manual-ak")
+    );
+    assert_eq!(
+        ecs_values.get("access_key_secret").map(String::as_str),
+        Some("manual-sk")
+    );
+    assert_eq!(
+        ecs_values.get("security_token").map(String::as_str),
+        Some("manual-token")
+    );
+    assert_eq!(
+        manual_values.get("auth_source").map(String::as_str),
+        Some("ecs_ram_role")
+    );
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
@@ -88,3 +88,342 @@ fn raw_cli_auth_dotted_provider_id_stays_on_provider_id_field() {
         "expected auth state query: {requests}"
     );
 }
+
+/// Fake cosh-core for the `/auth` management menu.
+///
+/// Serves the scripted `auth.state` / `auth.prepare` replies from the environment so a
+/// single script covers ECS and non-ECS hosts, and appends every request to
+/// `$AUTH_REGISTRY_LOG` so tests can count ECS probes.
+const AUTH_MENU_CORE: &str = r#"#!/bin/sh
+if [ "$1" = "--registry" ]; then
+  read -r request
+  printf '%s\n' "$request" >> "$AUTH_REGISTRY_LOG"
+  case "$request" in
+    *'"action":"state"'*)
+      printf '%s\n' "$AUTH_STATE"
+      ;;
+    *'"action":"prepare"'*)
+      printf '%s\n' "$AUTH_PREPARE"
+      ;;
+    *)
+      printf '%s\n' '{"type":"registry_response","request_id":"reg","success":true,"data":{"authorized":true,"model":"main-model","configured":true}}'
+      ;;
+  esac
+  exit 0
+fi
+read -r init
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{}}}}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"auth-inline","model":"main-model","tools":[]}'
+printf '%s\n' '{"type":"result","subtype":"success","session_id":"auth-inline","is_error":false,"result":"done"}'
+"#;
+
+/// The builtin template order cosh-core reports: DashScope, OpenAI Compatible, Aliyun.
+const AUTH_TEMPLATES: &str = r#"[{"id":"dashscope","label":"DashScope (百炼)","fields":[{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]},{"id":"openai_compat","label":"OpenAI Compatible","fields":[{"name":"base_url","label":"Base URL","hint":null,"secret":false,"required":true,"placeholder":null},{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":true,"placeholder":null}]},{"id":"aliyun","label":"Aliyun Authentication","fields":[{"name":"access_key_id","label":"Access Key ID","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"access_key_secret","label":"Access Key Secret","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]}]"#;
+
+const SAVED_NONE: &str = "[]";
+
+const SAVED_DASHSCOPE: &str = r#"[{"provider_id":"qwen-prod","provider_type":"dashscope","source":"user","editable":true,"auth_source":null,"model":"qwen3.7-plus","base_url":null,"api_key_len":8,"active":true}]"#;
+
+/// A saved SysOM setup is the `aliyun` provider with `auth_source=ecs_ram_role`.
+const SAVED_DASHSCOPE_AND_ECS: &str = r#"[{"provider_id":"qwen-prod","provider_type":"dashscope","source":"user","editable":true,"auth_source":null,"model":"qwen3.7-plus","base_url":null,"api_key_len":8,"active":true},{"provider_id":"sysom-trial","provider_type":"aliyun","source":"user","editable":true,"auth_source":"ecs_ram_role","model":"qwen3.7-plus","base_url":null,"active":false}]"#;
+
+const ECS_PREPARE: &str = r#"{"type":"registry_response","request_id":"reg","success":true,"data":{"mode":"ecs_ram_role","instance_id":"i-fake-ecs-1","console_url":"https://alinux.console.aliyun.com/cn-test/guide/cosh?instance=i-fake-ecs-1","values":{"auth_source":"ecs_ram_role"}}}"#;
+
+const MANUAL_PREPARE: &str =
+    r#"{"type":"registry_response","request_id":"reg","success":true,"data":{"mode":"manual"}}"#;
+
+const FAILING_PREPARE: &str = r#"{"type":"registry_response","request_id":"reg","success":false,"error":"ecs metadata service unavailable"}"#;
+
+const SYSOM_ROW: &str = "SysOM (free trial, uses this ECS instance's RAM role)";
+
+fn auth_state_response(saved_providers: &str) -> String {
+    format!(
+        r#"{{"type":"registry_response","request_id":"reg","success":true,"data":{{"templates":{AUTH_TEMPLATES},"saved_providers":{saved_providers}}}}}"#
+    )
+}
+
+/// Drives `/auth` against the scripted core and returns `(terminal output, registry log)`.
+fn run_auth_menu_flow(
+    name: &str,
+    saved_providers: &str,
+    prepare: &str,
+    steps: &[(&str, &[u8])],
+) -> (String, String) {
+    let home = temp_shell_home(name);
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let cosh_core_path = bin_dir.join("cosh-core");
+    write_executable(&cosh_core_path, AUTH_MENU_CORE);
+    let registry_log = home.join("registry.log");
+
+    let home_str = home.to_string_lossy().to_string();
+    let core_str = cosh_core_path.to_string_lossy().to_string();
+    let log_str = registry_log.to_string_lossy().to_string();
+    let state = auth_state_response(saved_providers);
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "cosh-core",
+        &[],
+        &[
+            ("HOME", &home_str),
+            ("COSH_CORE_PATH", &core_str),
+            ("AUTH_REGISTRY_LOG", &log_str),
+            ("AUTH_STATE", &state),
+            ("AUTH_PREPARE", prepare),
+        ],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        steps,
+    );
+    let requests = fs::read_to_string(&registry_log).unwrap_or_default();
+    let _ = fs::remove_dir_all(&home);
+    (output, requests)
+}
+
+fn action_count(requests: &str, action: &str) -> usize {
+    requests.matches(&format!(r#""action":"{action}""#)).count()
+}
+
+/// On ECS the free trial is the first thing `/auth` offers, even with nothing configured.
+#[test]
+fn raw_cli_auth_ecs_offers_sysom_first_without_saved_providers() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-ecs-no-saved",
+        SAVED_NONE,
+        ECS_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("Provider Management"), "{output}");
+    // Selected by default: the panel marks the current row with '>'.
+    assert!(compact.contains(&format!("> [1] {SYSOM_ROW}")), "{output}");
+    assert!(compact.contains("[2] + Add new provider"), "{output}");
+    // The template picker must not be what an ECS user sees first.
+    assert!(!compact.contains("Authentication Required"), "{output}");
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+}
+
+/// The SysOM row shifts the saved providers down without breaking their action menus.
+#[test]
+fn raw_cli_auth_ecs_keeps_saved_provider_reachable_below_sysom() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-ecs-saved-dashscope",
+        SAVED_DASHSCOPE,
+        ECS_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"\x1b[C\n".as_slice()),
+            ("\"qwen-prod\":", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains(&format!("> [1] {SYSOM_ROW}")), "{output}");
+    assert!(compact.contains("[2] * [active] DashScope"), "{output}");
+    assert!(compact.contains("[3] + Add new provider"), "{output}");
+    // Row 2 opened the saved provider's action menu, not the SysOM shortcut.
+    assert!(compact.contains("Edit configuration"), "{output}");
+    assert!(compact.contains("Delete provider"), "{output}");
+    assert!(!compact.contains("Enter Provider ID"), "{output}");
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+}
+
+/// An already-configured RAM-role provider is promoted instead of duplicated.
+#[test]
+fn raw_cli_auth_ecs_promotes_configured_ram_role_provider() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-ecs-saved-ram-role",
+        SAVED_DASHSCOPE_AND_ECS,
+        ECS_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"\n".as_slice()),
+            ("\"sysom-trial\":", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    // Row 1 is the saved provider wearing the SysOM label, and there is no extra row for it.
+    assert!(
+        compact.contains(&format!("> [1] {SYSOM_ROW} - \"sysom-trial\"")),
+        "{output}"
+    );
+    assert!(!compact.contains(&format!("[2] {SYSOM_ROW}")), "{output}");
+    assert!(compact.contains("[2] * [active] DashScope"), "{output}");
+    assert!(compact.contains("[3] + Add new provider"), "{output}");
+    // Selecting it opens the ordinary action menu instead of re-running the setup flow.
+    assert!(compact.contains("Set as active provider"), "{output}");
+    assert!(compact.contains("Edit configuration"), "{output}");
+    assert!(compact.contains("Delete provider"), "{output}");
+    assert!(!compact.contains("Enter Provider ID"), "{output}");
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+    assert_eq!(action_count(&requests, "delete"), 0, "{requests}");
+}
+
+/// A non-ECS host keeps the template picker and its `dashscope, openai_compat, aliyun` order.
+#[test]
+fn raw_cli_auth_non_ecs_without_saved_providers_keeps_template_order() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-non-ecs-no-saved",
+        SAVED_NONE,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("Authentication Required", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("> [1] DashScope"), "{output}");
+    assert!(compact.contains("[2] OpenAI Compatible"), "{output}");
+    assert!(compact.contains("[3] Aliyun Authentication"), "{output}");
+    assert!(!compact.contains("SysOM"), "{output}");
+    assert!(!compact.contains("Provider Management"), "{output}");
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+}
+
+/// A non-ECS host keeps "saved providers + Add new provider", including Edit.
+#[test]
+fn raw_cli_auth_non_ecs_keeps_saved_providers_then_add_new() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-non-ecs-saved",
+        SAVED_DASHSCOPE,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"\n".as_slice()),
+            ("Edit configuration", b"\n".as_slice()),
+            ("Edit API Key", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("> [1] * [active] DashScope"), "{output}");
+    assert!(compact.contains("[2] + Add new provider"), "{output}");
+    assert!(!compact.contains("[3] + Add new provider"), "{output}");
+    assert!(!compact.contains("SysOM"), "{output}");
+    // Edit still pre-fills the masked API key and offers to keep it.
+    assert!(compact.contains("Edit API Key"), "{output}");
+    assert!(compact.contains("Enter to keep current value"), "{output}");
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+}
+
+/// The shortcut is not a blank cheque: the Provider ID rule still applies to it.
+#[test]
+fn raw_cli_auth_sysom_shortcut_still_validates_provider_id() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-sysom-bad-id",
+        SAVED_NONE,
+        ECS_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"\n".as_slice()),
+            ("Enter Provider ID", b"bad.provider\n".as_slice()),
+            ("Provider ID allows letters", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(
+        compact.contains("Provider ID allows letters, digits, '-' and '_' only (no '.')"),
+        "{output}"
+    );
+    // A rejected id must not reach the challenge or the registry.
+    assert!(!compact.contains("ECS Instance ID"), "{output}");
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+}
+
+/// The shortcut reuses the challenge `/auth` prefetched and configures aliyun + RAM role.
+#[test]
+fn raw_cli_auth_sysom_shortcut_reuses_prefetched_challenge() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-sysom-shortcut",
+        SAVED_NONE,
+        ECS_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"\n".as_slice()),
+            ("Enter Provider ID", b"sysom-trial\n".as_slice()),
+            ("ECS Instance ID", b"\n".as_slice()),
+            ("Auth configured", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("i-fake-ecs-1"), "{output}");
+    assert!(compact.contains("Auth configured"), "{output}");
+    // The ECS metadata service is probed once, when `/auth` builds the menu.
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+    let configure = requests
+        .lines()
+        .find(|line| line.contains(r#""action":"configure""#))
+        .unwrap_or_else(|| panic!("expected configure request: {requests}"));
+    assert!(
+        configure.contains(r#""provider_type":"aliyun""#),
+        "{configure}"
+    );
+    assert!(
+        configure.contains(r#""provider_id":"sysom-trial""#),
+        "{configure}"
+    );
+    assert!(
+        configure.contains(r#""auth_source":"ecs_ram_role""#),
+        "{configure}"
+    );
+    // No manual credential ever entered the flow, so none may be persisted.
+    assert!(!configure.contains("access_key_id"), "{configure}");
+    assert!(!configure.contains("security_token"), "{configure}");
+}
+
+/// A failing `auth.prepare` is a missing recommendation, not a broken `/auth`.
+#[test]
+fn raw_cli_auth_prepare_failure_falls_back_to_the_existing_menu() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-prepare-failure",
+        SAVED_DASHSCOPE,
+        FAILING_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("+ Add new provider", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("Provider Management"), "{output}");
+    assert!(compact.contains("> [1] * [active] DashScope"), "{output}");
+    assert!(compact.contains("[2] + Add new provider"), "{output}");
+    assert!(!compact.contains("SysOM"), "{output}");
+    assert!(!compact.contains("Auth unavailable"), "{output}");
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+}
+
+/// Manual Aliyun AK/SK stays available off ECS, with the secret fields still masked.
+#[test]
+fn raw_cli_auth_non_ecs_aliyun_falls_back_to_manual_keys() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-non-ecs-aliyun-manual",
+        SAVED_NONE,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("Authentication Required", b"\x1b[C\x1b[C\n".as_slice()),
+            ("Enter Provider ID", b"aliyun-manual\n".as_slice()),
+            ("Enter Access Key ID", b"AK-TEST-VALUE\n".as_slice()),
+            ("Enter Access Key Secret", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("Enter Access Key ID"), "{output}");
+    assert!(compact.contains("Enter Access Key Secret"), "{output}");
+    assert!(!compact.contains("ECS Instance ID"), "{output}");
+    // Secret fields are echoed as bullets, never as the typed key.
+    assert!(!compact.contains("AK-TEST-VALUE"), "{output}");
+    assert!(compact.contains('\u{2022}'), "{output}");
+    // The successful startup result is reused after the Provider ID is accepted.
+    assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 672
-check_source_floor cosh-shell 2478
+check_source_floor cosh-shell 2503
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"


### PR DESCRIPTION
## Description

Promote the SysOM free-trial path to the first row of the top-level `/auth`
menu when cosh-shell detects an ECS RAM-role challenge. The slash flow now
prefetches and reuses the existing Aliyun `auth.prepare` result, while an
already configured RAM-role provider is promoted instead of duplicated.
Non-ECS hosts keep the existing provider ordering and menu behavior.

## Related Issue

closes #1802

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p cosh-shell --lib` — 1023 passed
- `cargo test -p cosh-shell --bin cosh-shell` — 1951 passed
- `cargo test -p cosh-shell --test logic` — 8 passed
- `cargo test -p cosh-shell --test raw_cli auth -- --nocapture` — 10 passed
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check`

## Additional Notes

- A pre-existing shell-host assertion is locale-sensitive under `zh_CN` and
  reproduces on `main`; the same test passes with `LC_ALL=C.UTF-8`.
- Non-ECS `/auth` performs one additional best-effort `auth.prepare` registry
  round trip to determine whether the SysOM shortcut should be shown.
