### PR TITLE
fix(cosh-ng): [shell] hide receipt audit ref

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/approval/cards.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/cards.rs
@@ -25,17 +25,13 @@ pub(crate) fn render_approval_journal<W: Write>(
             command_block_id: entry.command_block_id.as_deref(),
             redaction_status: entry.redaction_status,
             assessment: entry.assessment.as_ref().map(assessment_summary_model),
+            audit_ref: entry.audit_ref.as_deref(),
         })
         .collect::<Vec<_>>();
     RatatuiInlineRenderer::for_terminal()
         .with_language(state.language)
-        .write_approval_journal_panel(output, ApprovalJournalPanelModel { entries: &entries })?;
-    for entry in &state.approvals.journal {
-        if let Some(audit_ref) = &entry.audit_ref {
-            writeln!(output, "audit_ref[{}]: {audit_ref}", entry.id)?;
-        }
-    }
-    Ok(())
+        .write_approval_journal_panel(output, ApprovalJournalPanelModel { entries: &entries })
+        .map(|_| ())
 }
 
 pub(super) fn write_approval_receipt<W: Write>(
@@ -88,11 +84,8 @@ pub(super) fn write_approval_receipt<W: Write>(
                 preview: &request.preview,
                 message,
             },
-        )?;
-    if let Some(audit_ref) = &request.audit_ref {
-        writeln!(output, "audit_ref: {audit_ref}")?;
-    }
-    Ok(())
+        )
+        .map(|_| ())
 }
 
 fn approval_receipt_is_negative(status: ApprovalRequestStatus) -> bool {
@@ -191,12 +184,10 @@ pub(crate) fn render_approval_details<W: Write>(
                 command_block_id: request.command_block_id.as_deref(),
                 redaction_status: request.redaction_status,
                 assessment: request.assessment.as_ref().map(assessment_summary_model),
+                audit_ref: request.audit_ref.as_deref(),
             },
-        )?;
-    if let Some(audit_ref) = &request.audit_ref {
-        writeln!(output, "audit_ref: {audit_ref}")?;
-    }
-    Ok(())
+        )
+        .map(|_| ())
 }
 
 fn assessment_summary_model(
@@ -265,6 +256,20 @@ mod tests {
         let old_provider_native_text = ["Provider-native shell", " tool allowed"].concat();
         assert!(!text.contains(&old_foreground_text), "{text}");
         assert!(!text.contains(&old_provider_native_text), "{text}");
+    }
+
+    #[test]
+    fn approval_receipt_never_emits_audit_reference() {
+        let mut request = approved_bash_request(None);
+        request.audit_ref = Some("audit-event-1".to_string());
+        let mut output = Vec::new();
+
+        write_approval_receipt(Language::ZhCn, &request, "已自动批准", &mut output).unwrap();
+
+        let text = String::from_utf8(output).unwrap();
+        assert!(!text.contains("audit_ref"), "{text}");
+        assert!(!text.contains("audit-event-1"), "{text}");
+        assert!(text.contains("Bash tool 已发送到 shell"), "{text}");
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval.rs
@@ -856,6 +856,31 @@ pub(super) fn approval_content_width(width: u16) -> usize {
     width.saturating_sub(4).max(20) as usize
 }
 
+/// Renders the `audit_ref` row for the approval details and journal panels.
+///
+/// Both surfaces must derive their panel height from the same row count, so the
+/// reference is wrapped here instead of at each call site. Event ids are longer
+/// than the 40-column minimum panel, and a truncated id cannot be traced back to
+/// the audit log — so the row wraps rather than clipping at the border.
+///
+/// Returns an empty vec when no reference exists, which keeps the panel height
+/// unchanged and avoids a placeholder row.
+pub(super) fn audit_ref_rows(audit_ref: Option<&str>, content_width: usize) -> Vec<String> {
+    let Some(audit_ref) = audit_ref else {
+        return Vec::new();
+    };
+    let text = audit_ref_line(audit_ref);
+    // One row beyond the worst case keeps `wrapped_preview_rows` from
+    // ellipsizing an id that must stay verbatim.
+    let max_rows = display_width(&text).div_ceil(content_width.max(20)) + 1;
+    wrapped_preview_rows(&text, content_width, max_rows)
+}
+
+/// Field name is a stable technical identifier shared with `/audit`; never localize it.
+pub(super) fn audit_ref_line(audit_ref: &str) -> String {
+    format!("audit_ref: {audit_ref}")
+}
+
 fn max_preview_rows(expanded: bool) -> usize {
     if expanded {
         6

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_details.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_details.rs
@@ -9,7 +9,7 @@ use ratatui::{
 };
 
 use super::{
-    approval::{approval_content_width, wrapped_preview_rows},
+    approval::{approval_content_width, audit_ref_line, audit_ref_rows, wrapped_preview_rows},
     buffer_to_lines, buffer_to_styled_lines, RatatuiInlineRenderer,
 };
 
@@ -30,6 +30,9 @@ pub struct ApprovalDetailsPanelModel<'a> {
     pub command_block_id: Option<&'a str>,
     pub redaction_status: Option<&'a str>,
     pub assessment: Option<CommandAssessmentSummaryModel<'a>>,
+    /// Audit event ID linked to this approval projection. Rendered only when
+    /// present so the pull-based audit log never adds a placeholder row.
+    pub audit_ref: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -165,6 +168,9 @@ impl RatatuiInlineRenderer {
         if let Some(assessment) = model.assessment {
             lines.insert(6, assessment_summary_line(&i18n, assessment));
         }
+        if let Some(audit_ref) = model.audit_ref {
+            lines.insert(6, audit_ref_line(audit_ref));
+        }
         lines
     }
 }
@@ -182,7 +188,8 @@ fn approval_details_panel_height(
         .assessment
         .map(|assessment| assessment_summary_rows(i18n, assessment, content_width).len() as u16)
         .unwrap_or(0);
-    11 + preview_rows + assessment_rows
+    let audit_rows = audit_ref_rows(model.audit_ref, content_width).len() as u16;
+    11 + preview_rows + assessment_rows + audit_rows
 }
 
 fn render_approval_details_panel(
@@ -217,6 +224,9 @@ fn render_approval_details_panel(
             assessment_summary_rows(i18n, assessment, inner.width.saturating_sub(2) as usize)
         })
         .unwrap_or_default();
+    // Same content width as `approval_details_panel_height`, so a wrapped
+    // reference can never exceed its allocated rows.
+    let audit_rows = audit_ref_rows(model.audit_ref, inner.width as usize);
     let risk = i18n.format(
         crate::MessageId::ApprovalRiskSuffix,
         &[("risk", model.risk)],
@@ -227,6 +237,7 @@ fn render_approval_details_panel(
         Constraint::Length(1),
         Constraint::Length(1),
         Constraint::Length(1),
+        Constraint::Length(audit_rows.len() as u16),
         Constraint::Length(assessment_rows.len() as u16),
         Constraint::Length(1),
         Constraint::Length(1),
@@ -334,6 +345,15 @@ fn render_approval_details_panel(
         ),
     ]))
     .render(chunks[4], buffer);
+    if !audit_rows.is_empty() {
+        Paragraph::new(Text::from(
+            audit_rows
+                .into_iter()
+                .map(|line| Line::from(Span::raw(line)))
+                .collect::<Vec<_>>(),
+        ))
+        .render(chunks[5], buffer);
+    }
     if !assessment_rows.is_empty() {
         Paragraph::new(Text::from(
             assessment_rows
@@ -341,10 +361,10 @@ fn render_approval_details_panel(
                 .map(|line| Line::from(Span::raw(line)))
                 .collect::<Vec<_>>(),
         ))
-        .render(chunks[5], buffer);
+        .render(chunks[6], buffer);
     }
     Paragraph::new(i18n.t(crate::MessageId::ApprovalDetailsDefaultDenyLine))
-        .render(chunks[6], buffer);
+        .render(chunks[7], buffer);
     Paragraph::new(Line::from(vec![
         Span::styled(
             format!(
@@ -355,24 +375,24 @@ fn render_approval_details_panel(
         ),
         Span::raw(user_facing_subject(i18n, model.subject)),
     ]))
-    .render(chunks[7], buffer);
+    .render(chunks[8], buffer);
     Paragraph::new(Line::from(Span::styled(
         format!("{}:", user_facing_preview_label(i18n, &model)),
         Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::BOLD),
     )))
-    .render(chunks[8], buffer);
+    .render(chunks[9], buffer);
     Paragraph::new(Text::from(
         preview_rows
             .into_iter()
             .map(|line| Line::from(Span::raw(line)))
             .collect::<Vec<_>>(),
     ))
-    .render(chunks[9], buffer);
+    .render(chunks[10], buffer);
     Paragraph::new(i18n.t(crate::MessageId::ApprovalExecutableToolPolicy))
         .wrap(Wrap { trim: true })
-        .render(chunks[10], buffer);
+        .render(chunks[11], buffer);
 }
 
 fn assessment_summary_line(

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_journal.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_journal.rs
@@ -9,7 +9,7 @@ use ratatui::{
 };
 
 use super::{
-    approval::{approval_content_width, wrapped_preview_rows},
+    approval::{approval_content_width, audit_ref_line, audit_ref_rows, wrapped_preview_rows},
     approval_details::CommandAssessmentSummaryModel,
     buffer_to_lines, buffer_to_styled_lines, RatatuiInlineRenderer,
 };
@@ -32,6 +32,9 @@ pub struct ApprovalJournalEntryModel<'a> {
     pub command_block_id: Option<&'a str>,
     pub redaction_status: Option<&'a str>,
     pub assessment: Option<CommandAssessmentSummaryModel<'a>>,
+    /// Audit event ID linked to this approval entry. Rendered inside the owning
+    /// entry only when present so the pull-based audit log adds no placeholder.
+    pub audit_ref: Option<&'a str>,
 }
 
 #[derive(Debug, Clone)]
@@ -159,6 +162,9 @@ impl RatatuiInlineRenderer {
                     .tool_use_id
                     .unwrap_or(i18n.t(crate::MessageId::ApprovalDetailsNoneValue))
             ));
+            if let Some(audit_ref) = entry.audit_ref {
+                lines.push(format!("  {}", audit_ref_line(audit_ref)));
+            }
             lines.push(format!(
                 "  {}: {}",
                 i18n.t(crate::MessageId::ApprovalJournalActorLabel),
@@ -217,7 +223,8 @@ fn approval_journal_panel_height(
             )
             .len()
             .max(1) as u16;
-            separator_rows + 8 + assessment_rows + preview_rows
+            let audit_rows = audit_ref_rows(entry.audit_ref, content_width).len() as u16;
+            separator_rows + 8 + assessment_rows + preview_rows + audit_rows
         })
         .sum::<u16>();
     2 + row_count
@@ -373,6 +380,11 @@ fn render_approval_journal_panel(
                     .to_string(),
             ),
         ]));
+        // Same content width as `approval_journal_panel_height`, so wrapped
+        // reference rows never push the trailing entry rows out of the panel.
+        for row in audit_ref_rows(entry.audit_ref, inner.width as usize) {
+            lines.push(Line::from(Span::raw(row)));
+        }
         lines.push(Line::from(vec![
             Span::styled(
                 format!("{}: ", i18n.t(crate::MessageId::ApprovalJournalActorLabel)),

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/approval.rs
@@ -726,6 +726,7 @@ fn approval_details_panel_renders_structured_request_context() {
                 output_stability: "stable-snapshot",
                 output_exposure: "may-contain-command-line",
             }),
+            audit_ref: None,
         })
         .join("\n");
 
@@ -784,6 +785,7 @@ fn approval_details_panel_uses_zh_catalog_labels() {
                 output_stability: "stable-snapshot",
                 output_exposure: "may-contain-command-line",
             }),
+            audit_ref: None,
         })
         .join("\n");
 
@@ -833,6 +835,7 @@ fn approval_details_panel_keeps_cjk_and_emoji_borders_aligned() {
             command_block_id: None,
             redaction_status: None,
             assessment: None,
+            audit_ref: None,
         })
         .join("\n");
 
@@ -841,6 +844,268 @@ fn approval_details_panel_keeps_cjk_and_emoji_borders_aligned() {
     assert!(text.contains("中文-smoke.txt"), "{text}");
     assert_rendered_width(&text, 54);
     assert_box_lines_aligned(&text, 54);
+}
+
+#[test]
+fn approval_details_panel_renders_audit_reference_inside_panel() {
+    let renderer = RatatuiInlineRenderer::with_width(70);
+    let text = renderer
+        .approval_details_panel_lines(ApprovalDetailsPanelModel {
+            id: "req-7",
+            run_id: "run-12",
+            source: "agent",
+            kind: "tool request",
+            status: "approved",
+            risk: "medium",
+            subject: "tool Bash",
+            preview_label: "Tool input",
+            preview: "ls -la",
+            request_id: Some("ctrl-7"),
+            tool_use_id: Some("toolu-7"),
+            execution_path: Some("foreground_shell_pty"),
+            command_block_id: Some("cmd-7"),
+            redaction_status: Some("ref_only"),
+            assessment: None,
+            audit_ref: Some("audit-event-1"),
+        })
+        .join("\n");
+
+    assert!(text.contains("audit_ref: audit-event-1"), "{text}");
+    // The reference must live inside the panel body, never after the closing border.
+    let closing_border = text.lines().next_back().unwrap_or_default();
+    assert!(closing_border.contains('└'), "{text}");
+    assert!(!closing_border.contains("audit_ref"), "{text}");
+    assert!(text.contains("ls -la"), "{text}");
+    assert!(text.contains("Policy: user approval is required"), "{text}");
+    assert_rendered_width(&text, 70);
+    assert_box_lines_aligned(&text, 70);
+}
+
+/// Real audit event ids are UUIDs, so `audit_ref: <uuid>` is 47 columns wide.
+const UUID_AUDIT_REF: &str = "cd8a7e91-a95d-4c4f-bb0f-646f4b154310";
+
+/// Strips borders and padding so a wrapped reference can be matched as one value.
+fn panel_content_without_layout(text: &str) -> String {
+    text.chars()
+        .filter(|ch| !ch.is_whitespace() && !"│┌┐└┘─".contains(*ch))
+        .collect()
+}
+
+#[test]
+fn approval_details_panel_wraps_audit_reference_at_minimum_width() {
+    // The 40-column minimum panel is narrower than `audit_ref: <uuid>`; the id
+    // must wrap instead of being clipped, or it cannot be traced in the audit log.
+    let renderer = RatatuiInlineRenderer::with_width(40);
+    let model = ApprovalDetailsPanelModel {
+        id: "req-7",
+        run_id: "run-12",
+        source: "agent",
+        kind: "tool request",
+        status: "approved",
+        risk: "medium",
+        subject: "tool Bash",
+        preview_label: "Tool input",
+        preview: "ls -la",
+        request_id: None,
+        tool_use_id: None,
+        execution_path: None,
+        command_block_id: None,
+        redaction_status: None,
+        assessment: None,
+        audit_ref: Some(UUID_AUDIT_REF),
+    };
+    let with_ref = renderer.approval_details_panel_lines(model.clone());
+    let without_ref = renderer.approval_details_panel_lines(ApprovalDetailsPanelModel {
+        audit_ref: None,
+        ..model
+    });
+    let text = with_ref.join("\n");
+
+    assert!(
+        panel_content_without_layout(&text).contains(&format!("audit_ref:{UUID_AUDIT_REF}")),
+        "{text}"
+    );
+    assert!(!text.contains(" ..."), "{text}");
+    // The wrapped rows must be budgeted, not stolen from the rows below.
+    assert_eq!(with_ref.len(), without_ref.len() + 2, "{text}");
+    assert!(text.contains("Policy:"), "{text}");
+    assert_rendered_width(&text, 40);
+    assert_box_lines_aligned(&text, 40);
+}
+
+#[test]
+fn approval_journal_panel_wraps_audit_reference_at_minimum_width() {
+    // The journal body is a wrapping Paragraph, so a reference that spans two
+    // rows must be counted twice in the panel height or the trailing entry rows
+    // (actor, preview hash, subject, preview) get clipped.
+    let renderer = RatatuiInlineRenderer::with_width(40);
+    let mut entries = audit_ref_journal_entries();
+    entries[0].audit_ref = Some(UUID_AUDIT_REF);
+    let with_ref =
+        renderer.approval_journal_panel_lines(ApprovalJournalPanelModel { entries: &entries });
+    entries[0].audit_ref = None;
+    let without_ref =
+        renderer.approval_journal_panel_lines(ApprovalJournalPanelModel { entries: &entries });
+    let text = with_ref.join("\n");
+
+    assert!(
+        panel_content_without_layout(&text).contains(&format!("audit_ref:{UUID_AUDIT_REF}")),
+        "{text}"
+    );
+    assert!(!text.contains(" ..."), "{text}");
+    assert_eq!(with_ref.len(), without_ref.len() + 2, "{text}");
+    assert_rendered_width(&text, 40);
+    assert_box_lines_aligned(&text, 40);
+}
+
+#[test]
+fn approval_details_panel_keeps_borders_aligned_with_uuid_audit_reference() {
+    // Real audit event ids are UUIDs; the widest realistic reference must still
+    // fit the narrow-terminal panel without breaking the border.
+    let renderer = RatatuiInlineRenderer::with_width(54).with_language(crate::Language::ZhCn);
+    let text = renderer
+        .approval_details_panel_lines(ApprovalDetailsPanelModel {
+            id: "req-宽",
+            run_id: "run-中文-1",
+            source: "agent",
+            kind: "tool request",
+            status: "approved",
+            risk: "medium",
+            subject: "tool Bash",
+            preview_label: "Tool 输入",
+            preview: "cat /tmp/cosh-shell-中文-smoke.txt && echo 🧪",
+            request_id: None,
+            tool_use_id: None,
+            execution_path: None,
+            command_block_id: None,
+            redaction_status: None,
+            assessment: None,
+            audit_ref: Some("cd8a7e91-a95d-4c4f-bb0f-646f4b154310"),
+        })
+        .join("\n");
+
+    assert!(
+        text.contains("audit_ref: cd8a7e91-a95d-4c4f-bb0f-646f4b154310"),
+        "{text}"
+    );
+    assert!(text.contains("中文-smoke.txt"), "{text}");
+    assert_rendered_width(&text, 54);
+    assert_box_lines_aligned(&text, 54);
+}
+
+#[test]
+fn styled_approval_details_write_keeps_audit_reference_inside_panel() {
+    let renderer = RatatuiInlineRenderer {
+        width: 70,
+        plain: false,
+        styled: true,
+        language: crate::Language::EnUs,
+    };
+    let mut output = Vec::new();
+
+    renderer
+        .write_approval_details_panel(
+            &mut output,
+            ApprovalDetailsPanelModel {
+                id: "req-7",
+                run_id: "run-12",
+                source: "agent",
+                kind: "tool request",
+                status: "approved",
+                risk: "medium",
+                subject: "tool Bash",
+                preview_label: "Tool input",
+                preview: "ls -la",
+                request_id: None,
+                tool_use_id: None,
+                execution_path: None,
+                command_block_id: None,
+                redaction_status: None,
+                assessment: None,
+                audit_ref: Some("audit-event-1"),
+            },
+        )
+        .expect("render approval details panel");
+
+    let text = String::from_utf8(output).expect("utf8 panel");
+    let clean = strip_ansi_escape(&text);
+    assert!(text.contains("\x1b["), "{text:?}");
+    assert!(clean.contains("audit_ref: audit-event-1"), "{clean}");
+    let closing_border = clean.trim_end().lines().next_back().unwrap_or_default();
+    assert!(closing_border.contains('└'), "{clean}");
+    assert!(!closing_border.contains("audit_ref"), "{clean}");
+}
+
+#[test]
+fn approval_details_panel_omits_audit_reference_when_absent() {
+    let renderer = RatatuiInlineRenderer::with_width(70);
+    let model = ApprovalDetailsPanelModel {
+        id: "req-7",
+        run_id: "run-12",
+        source: "agent",
+        kind: "tool request",
+        status: "approved",
+        risk: "medium",
+        subject: "tool Bash",
+        preview_label: "Tool input",
+        preview: "ls -la",
+        request_id: Some("ctrl-7"),
+        tool_use_id: Some("toolu-7"),
+        execution_path: Some("foreground_shell_pty"),
+        command_block_id: Some("cmd-7"),
+        redaction_status: Some("ref_only"),
+        assessment: None,
+        audit_ref: None,
+    };
+    let without_ref = renderer.approval_details_panel_lines(model.clone());
+    let with_ref = renderer.approval_details_panel_lines(ApprovalDetailsPanelModel {
+        audit_ref: Some("audit-event-1"),
+        ..model
+    });
+
+    let text = without_ref.join("\n");
+    assert!(!text.contains("audit_ref"), "{text}");
+    // A missing reference must not leave a blank placeholder row behind.
+    assert_eq!(without_ref.len() + 1, with_ref.len(), "{text}");
+    assert_rendered_width(&text, 70);
+    assert_box_lines_aligned(&text, 70);
+}
+
+#[test]
+fn plain_approval_details_panel_keeps_audit_reference() {
+    let renderer = RatatuiInlineRenderer::plain_with_width(70);
+    let model = ApprovalDetailsPanelModel {
+        id: "req-7",
+        run_id: "run-12",
+        source: "agent",
+        kind: "tool request",
+        status: "approved",
+        risk: "medium",
+        subject: "tool Bash",
+        preview_label: "Tool input",
+        preview: "ls -la",
+        request_id: None,
+        tool_use_id: None,
+        execution_path: None,
+        command_block_id: None,
+        redaction_status: None,
+        assessment: None,
+        audit_ref: Some("audit-event-1"),
+    };
+    let text = renderer
+        .approval_details_panel_lines(model.clone())
+        .join("\n");
+
+    assert!(text.contains("audit_ref: audit-event-1"), "{text}");
+    assert!(!text.contains('┌'), "{text}");
+
+    let without_ref = renderer
+        .approval_details_panel_lines(ApprovalDetailsPanelModel {
+            audit_ref: None,
+            ..model
+        })
+        .join("\n");
+    assert!(!without_ref.contains("audit_ref"), "{without_ref}");
 }
 
 #[test]
@@ -873,6 +1138,7 @@ fn approval_journal_panel_renders_decision_history() {
                 output_stability: "stable-snapshot",
                 output_exposure: "normal",
             }),
+            audit_ref: None,
         },
         ApprovalJournalEntryModel {
             id: "req-2",
@@ -891,6 +1157,7 @@ fn approval_journal_panel_renders_decision_history() {
             command_block_id: None,
             redaction_status: None,
             assessment: None,
+            audit_ref: None,
         },
     ];
     let text = renderer
@@ -942,6 +1209,7 @@ fn approval_journal_panel_uses_zh_catalog_labels() {
         command_block_id: Some("cmd-1"),
         redaction_status: Some("ref_only"),
         assessment: None,
+        audit_ref: None,
     }];
     let text = renderer
         .approval_journal_panel_lines(ApprovalJournalPanelModel { entries: &entries })
@@ -984,6 +1252,7 @@ fn approval_journal_panel_keeps_cjk_and_emoji_borders_aligned() {
         command_block_id: None,
         redaction_status: None,
         assessment: None,
+        audit_ref: None,
     }];
     let text = renderer
         .approval_journal_panel_lines(ApprovalJournalPanelModel { entries: &entries })
@@ -995,6 +1264,132 @@ fn approval_journal_panel_keeps_cjk_and_emoji_borders_aligned() {
     assert!(text.contains("中文-smoke.txt"), "{text}");
     assert_rendered_width(&text, 54);
     assert_box_lines_aligned(&text, 54);
+}
+
+fn audit_ref_journal_entries() -> Vec<ApprovalJournalEntryModel<'static>> {
+    vec![
+        ApprovalJournalEntryModel {
+            id: "req-1",
+            run_id: "run-1",
+            source: "agent",
+            decision: "approved",
+            kind: "tool request",
+            risk: "medium",
+            subject: "tool shell",
+            preview: "git status",
+            preview_hash: "fnv1a64:test0001",
+            request_id: Some("ctrl-1"),
+            tool_use_id: Some("toolu-1"),
+            actor: "agent-auto",
+            execution_path: Some("foreground_shell_pty"),
+            command_block_id: Some("cmd-1"),
+            redaction_status: Some("ref_only"),
+            assessment: None,
+            audit_ref: Some("audit-event-1"),
+        },
+        ApprovalJournalEntryModel {
+            id: "req-2",
+            run_id: "run-1",
+            source: "agent",
+            decision: "denied",
+            kind: "shell command request",
+            risk: "high",
+            subject: "shell command",
+            preview: "rm -rf /tmp/cosh-shell-should-not-run",
+            preview_hash: "fnv1a64:test0002",
+            request_id: None,
+            tool_use_id: None,
+            actor: "user",
+            execution_path: Some("not_executed_denied"),
+            command_block_id: None,
+            redaction_status: None,
+            assessment: None,
+            audit_ref: None,
+        },
+    ]
+}
+
+/// Splits the rendered journal at the `req-2` header so each entry's rows can be
+/// asserted independently.
+fn split_journal_entries(text: &str) -> (String, String) {
+    let lines = text.lines().collect::<Vec<_>>();
+    let boundary = lines
+        .iter()
+        .position(|line| line.contains("req-2"))
+        .expect("req-2 entry header");
+    (lines[..boundary].join("\n"), lines[boundary..].join("\n"))
+}
+
+#[test]
+fn approval_journal_panel_scopes_audit_reference_to_owning_entry() {
+    let renderer = RatatuiInlineRenderer::with_width(88);
+    let entries = audit_ref_journal_entries();
+    let lines =
+        renderer.approval_journal_panel_lines(ApprovalJournalPanelModel { entries: &entries });
+    let text = lines.join("\n");
+
+    assert_eq!(text.matches("audit_ref").count(), 1, "{text}");
+    let (first, second) = split_journal_entries(&text);
+    assert!(first.contains("audit_ref: audit-event-1"), "{first}");
+    assert!(!second.contains("audit_ref"), "{second}");
+    // Nothing may trail the closing border of the panel.
+    assert!(
+        lines.last().is_some_and(|line| line.contains('└')),
+        "{text}"
+    );
+    assert!(
+        second.contains("rm -rf /tmp/cosh-shell-should-not-run"),
+        "{second}"
+    );
+    assert_rendered_width(&text, 88);
+    assert_box_lines_aligned(&text, 88);
+}
+
+#[test]
+fn styled_approval_journal_write_scopes_audit_reference_to_owning_entry() {
+    let renderer = RatatuiInlineRenderer {
+        width: 88,
+        plain: false,
+        styled: true,
+        language: crate::Language::EnUs,
+    };
+    let entries = audit_ref_journal_entries();
+    let mut output = Vec::new();
+
+    renderer
+        .write_approval_journal_panel(&mut output, ApprovalJournalPanelModel { entries: &entries })
+        .expect("render approval journal panel");
+
+    let text = String::from_utf8(output).expect("utf8 panel");
+    let clean = strip_ansi_escape(&text);
+    assert!(text.contains("\x1b["), "{text:?}");
+    assert_eq!(clean.matches("audit_ref").count(), 1, "{clean}");
+    let (first, second) = split_journal_entries(clean.trim_end());
+    assert!(first.contains("audit_ref: audit-event-1"), "{first}");
+    assert!(!second.contains("audit_ref"), "{second}");
+    assert!(
+        second
+            .trim_end()
+            .lines()
+            .next_back()
+            .is_some_and(|line| line.contains('└')),
+        "{clean}"
+    );
+}
+
+#[test]
+fn plain_approval_journal_panel_scopes_audit_reference_to_owning_entry() {
+    let renderer = RatatuiInlineRenderer::plain_with_width(88);
+    let entries = audit_ref_journal_entries();
+    let text = renderer
+        .approval_journal_panel_lines(ApprovalJournalPanelModel { entries: &entries })
+        .join("\n");
+
+    assert_eq!(text.matches("audit_ref").count(), 1, "{text}");
+    let (first, second) = split_journal_entries(&text);
+    assert!(first.contains("audit_ref: audit-event-1"), "{first}");
+    assert!(!second.contains("audit_ref"), "{second}");
+    assert!(!text.contains('┌'), "{text}");
 }
 
 #[test]
@@ -1017,6 +1412,7 @@ fn plain_approval_journal_panel_keeps_decision_history() {
         command_block_id: None,
         redaction_status: None,
         assessment: None,
+        audit_ref: None,
     }];
     let text = renderer
         .approval_journal_panel_lines(ApprovalJournalPanelModel { entries: &entries })

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -54,7 +54,7 @@ check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 71
 check_source_floor cosh-core 672
-check_source_floor cosh-shell 2503
+check_source_floor cosh-shell 2514
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
 echo "ignored tests: $ignored_count"
@@ -63,7 +63,7 @@ if [[ "$ignored_count" -ne 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 620
+check_overlap_ceiling cosh-shell cosh-shell 630
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Description

Automatic approval receipts no longer print a bare `audit_ref` below the
rendered card. User-pulled approval details and journal entries retain the
reference inside their owning panels, including plain, styled, localized, and
minimum-width layouts. Regression coverage also verifies that absent references
add no placeholder rows and refreshes the test inventory guard.

## Related Issue

closes #1805

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`
- `scripts/check-test-inventory.sh`
- `python3 -m unittest discover -s e2e/tests -v`
- `python3 e2e/run.py --plan --profile local`
- `scripts/run-test-gates.sh fast`
- `cargo test --locked -p cosh-shell --test shell_host -- --test-threads=1`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release --locked`

The integration gate passed the core, logic, and protocol targets. Its
`raw_cli` target passed 381 tests and hit the pre-existing
`raw_cli_details_approvals_records_denied_not_executed` failure caused by the
`Approval req-1` marker introduced in `ca7abe28`; the same exact failure was
reproduced from a clean `up/main` worktree. The remaining `shell_host` target
was then run separately and passed 81 tests with one intentional ignore.

## Additional Notes

No user-facing documentation or lock-file changes are required.
