### PR TITLE
fix(cosh-ng): [core] preserve tool arguments

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -20,12 +20,21 @@ use crate::hook::{HookDecision, HookNotification, HookSystem};
 use crate::loop_detect::LoopDetector;
 use crate::metrics::TurnMetrics;
 use crate::protocol::{InputMessage, OutputMessage, ShellContext, ShellControlRequest};
-use crate::provider::{ContentGenerator, GenerateConfig, GenerateEvent, Message};
+use crate::provider::{
+    ContentGenerator, GenerateConfig, GenerateEvent, Message, MAX_TOOL_CALL_INDEX,
+};
+use crate::tool::ask_user_question;
 use crate::tool::{ToolContext, ToolKind, ToolRegistry, ToolResult};
 use crate::truncator::OutputTruncator;
 
+use self::tool_execution::{
+    hash_bytes, hash_json, invalid_arguments_message, json_shape, parse_in_band_question,
+    parse_tool_arguments, InBandQuestion,
+};
+
 mod auth;
 mod extensions;
+mod tool_execution;
 
 pub struct CoshCore {
     pub config: CoreConfig,
@@ -458,10 +467,24 @@ impl CoshCore {
             let mut suppress_stream_text = false;
             let mut tool_call_seen = false;
             let mut message_end_seen = false;
+            // Only the in-band question route may hide assistant text. With the
+            // question tool disabled the marker can never become a question, so
+            // suppressing the text would drop the reply with nothing to replace it.
+            let in_band_questions_enabled = self.tools.supports_ask_user_question();
 
             self.emit(writer, &OutputMessage::stream_message_start());
 
             while let Some(event) = stream.next().await {
+                // Tool indices size `tool_calls` below, so an out-of-range index
+                // would let one malformed frame allocate billions of slots. Fail
+                // the stream instead of trusting or silently dropping it.
+                let event = match event.tool_call_index() {
+                    Some(index) if index > MAX_TOOL_CALL_INDEX => GenerateEvent::Error(format!(
+                        "provider reported tool call index {index}, above the supported \
+                         maximum of {MAX_TOOL_CALL_INDEX}"
+                    )),
+                    _ => event,
+                };
                 match event {
                     GenerateEvent::ThinkingDelta(delta) => {
                         if !thinking_block_started {
@@ -485,7 +508,7 @@ impl CoshCore {
                         }
                         text_buf.push_str(&delta);
                         if !suppress_stream_text && !tool_call_seen {
-                            if text_buf.contains("COSH_QUESTION:") {
+                            if in_band_questions_enabled && text_buf.contains("COSH_QUESTION:") {
                                 suppress_stream_text = true;
                             } else {
                                 self.emit(
@@ -515,6 +538,7 @@ impl CoshCore {
                         tool_calls[idx].name = name.clone();
                         tool_calls[idx].block_index = block_index;
                         tool_calls[idx].block_closed = false;
+                        tool_calls[idx].start_seen = true;
                         self.emit(
                             writer,
                             &OutputMessage::stream_tool_use_start(block_index, &id, &name),
@@ -535,10 +559,12 @@ impl CoshCore {
                             &OutputMessage::stream_tool_use_delta(bi, &arguments_delta),
                         );
                         tool_calls[idx].arguments.push_str(&arguments_delta);
+                        tool_calls[idx].delta_count += 1;
                     }
                     GenerateEvent::ToolCallEnd { index } => {
                         let idx = index as usize;
                         if idx < tool_calls.len() {
+                            tool_calls[idx].end_seen = true;
                             let bi = tool_calls[idx].block_index;
                             self.emit(writer, &OutputMessage::stream_block_stop(bi));
                             tool_calls[idx].block_closed = true;
@@ -672,7 +698,7 @@ impl CoshCore {
             }
             let emit_visible_text = tool_calls.is_empty()
                 && !text_buf.is_empty()
-                && !text_buf.contains("COSH_QUESTION:");
+                && !(in_band_questions_enabled && text_buf.contains("COSH_QUESTION:"));
             let _ = block_index;
             self.emit(writer, &OutputMessage::stream_message_stop());
 
@@ -685,30 +711,49 @@ impl CoshCore {
 
             if tool_calls.is_empty() {
                 if self.tools.supports_ask_user_question() {
-                    if let Some(synthetic) = parse_cosh_question_text(&text_buf) {
-                        let result = self
-                            .handle_ask_user("synthetic-ask", &synthetic, reader, writer)
-                            .await;
-                        if result.is_error {
+                    match parse_in_band_question(&text_buf) {
+                        InBandQuestion::Valid(synthetic) => {
+                            let result = self.handle_ask_user(&synthetic, reader, writer).await;
+                            if result.is_error {
+                                self.messages.push(Message::assistant(&text_buf));
+                                self.audit.record_turn_terminal(
+                                    turn_scope,
+                                    AuditOutcomeStatus::Failed,
+                                    Some("question_failed"),
+                                );
+                                return Ok(());
+                            }
+                            self.messages.push(Message::assistant(&text_buf));
+                            self.messages.push(Message::user(&format!(
+                                "User answered the question: {}",
+                                result.output
+                            )));
+                            self.audit.record_turn_terminal(
+                                turn_scope,
+                                AuditOutcomeStatus::Success,
+                                Some("question_answered"),
+                            );
+                            continue;
+                        }
+                        // The marker already suppressed the visible text, so a
+                        // rejected payload must fail the turn loudly instead of
+                        // ending it as an ordinary answer the user never saw.
+                        InBandQuestion::Invalid(error) => {
+                            tracing::warn!(
+                                provider_type = %resolved_provider.provider_type,
+                                validation_error_code = error.code(),
+                                text_bytes = text_buf.len(),
+                                "rejected in-band COSH_QUESTION payload"
+                            );
                             self.messages.push(Message::assistant(&text_buf));
                             self.audit.record_turn_terminal(
                                 turn_scope,
                                 AuditOutcomeStatus::Failed,
-                                Some("question_failed"),
+                                Some("question_invalid"),
                             );
-                            return Ok(());
+                            return Err(tool_execution::in_band_question_error(error));
                         }
-                        self.messages.push(Message::assistant(&text_buf));
-                        self.messages.push(Message::user(&format!(
-                            "User answered the question: {}",
-                            result.output
-                        )));
-                        self.audit.record_turn_terminal(
-                            turn_scope,
-                            AuditOutcomeStatus::Success,
-                            Some("question_answered"),
-                        );
-                        continue;
+                        InBandQuestion::Absent => {}
                     }
                 }
 
@@ -790,45 +835,83 @@ impl CoshCore {
                     continue;
                 }
 
-                let params: serde_json::Value =
-                    serde_json::from_str(&tc.arguments).unwrap_or(serde_json::Value::Null);
-                let tool_data = AuditToolData {
-                    tool_kind: self
-                        .tools
-                        .get(&tc.name)
-                        .map(|tool| format!("{:?}", tool.kind()).to_ascii_lowercase())
-                        .unwrap_or_else(|| "virtual".to_string()),
-                    input_shape: Some(json_shape(&params).to_string()),
-                    input_hash: Some(hash_json(&params)),
-                    ..AuditToolData::default()
-                };
+                let tool_kind = self
+                    .tools
+                    .get(&tc.name)
+                    .map(|tool| format!("{:?}", tool.kind()).to_ascii_lowercase())
+                    .unwrap_or_else(|| "virtual".to_string());
                 let tool_scope = CoreAuditScope::tool(&run_id, &turn_id, &tc.id);
-                self.audit
-                    .record_tool_requested(tool_scope, &tc.name, &tool_data);
 
-                if tc.name == "ask_user_question" && self.tools.supports_ask_user_question() {
-                    self.audit
-                        .record_tool_execution_started(tool_scope, &tc.name, &tool_data)?;
-                    let tool_start = Instant::now();
-                    let result = self.handle_ask_user(&tc.id, &params, reader, writer).await;
-                    self.audit.record_tool_terminal(
-                        tool_scope,
-                        &tc.name,
-                        &tool_data,
-                        result.is_error,
-                        tool_start.elapsed().as_millis() as u64,
-                        result.output.len() as u64,
-                    );
-                    self.messages.push(Message::tool_result(
-                        &tc.id,
-                        &result.output,
-                        result.is_error,
-                    ));
+                if tc.name == ask_user_question::TOOL_NAME
+                    && self.tools.supports_ask_user_question()
+                {
+                    let dispatched = self
+                        .dispatch_ask_user_tool_call(
+                            tool_scope,
+                            tc,
+                            &resolved_provider.provider_type,
+                            &tool_kind,
+                            reader,
+                            writer,
+                        )
+                        .await?;
+                    if let Some(result) = dispatched {
+                        self.messages.push(Message::tool_result(
+                            &tc.id,
+                            &result.output,
+                            result.is_error,
+                        ));
+                    }
                     if interrupted {
                         return Ok(());
                     }
                     continue;
                 }
+
+                let parsed_params = parse_tool_arguments(&tc.arguments);
+                let tool_data = AuditToolData {
+                    tool_kind,
+                    input_shape: Some(match &parsed_params {
+                        Ok(params) => json_shape(params).to_string(),
+                        Err(error) => error.audit_shape().to_string(),
+                    }),
+                    input_hash: Some(match &parsed_params {
+                        Ok(params) => hash_json(params),
+                        Err(_) => hash_bytes(tc.arguments.as_bytes()),
+                    }),
+                    ..AuditToolData::default()
+                };
+                self.audit
+                    .record_tool_requested(tool_scope, &tc.name, &tool_data);
+
+                let params = match parsed_params {
+                    Ok(params) => params,
+                    Err(parse_error) => {
+                        // Executing a tool with `null` parameters used to look like
+                        // a call with every field absent; fail the call instead so
+                        // the model can re-issue it.
+                        tracing::warn!(
+                            provider_type = %resolved_provider.provider_type,
+                            tool_call_id = %tc.id,
+                            tool_name = %tc.name,
+                            start_seen = tc.start_seen,
+                            delta_count = tc.delta_count,
+                            end_seen = tc.end_seen,
+                            argument_bytes = tc.arguments.len(),
+                            json_parse_status = parse_error.json_parse_status(),
+                            validation_error_code = parse_error.code(),
+                            "rejected malformed tool arguments"
+                        );
+                        self.reject_tool_arguments(
+                            tool_scope,
+                            &tc.name,
+                            &tc.id,
+                            &tool_data,
+                            invalid_arguments_message(&tc.name, &parse_error),
+                        );
+                        continue;
+                    }
+                };
 
                 if self
                     .tools
@@ -1311,72 +1394,6 @@ impl CoshCore {
         }
     }
 
-    async fn handle_ask_user<W, R>(
-        &self,
-        _tool_use_id: &str,
-        params: &serde_json::Value,
-        reader: &mut tokio::io::Lines<R>,
-        writer: &mut W,
-    ) -> ToolResult
-    where
-        W: Write,
-        R: AsyncBufReadExt + Unpin,
-    {
-        let question = params
-            .get("question")
-            .and_then(|v| v.as_str())
-            .unwrap_or("Agent needs your input")
-            .to_string();
-        let options: Vec<crate::protocol::AskUserOption> = params
-            .get("options")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|item| {
-                        let label = item
-                            .get("label")
-                            .and_then(|l| l.as_str())
-                            .or_else(|| item.as_str())?;
-                        Some(crate::protocol::AskUserOption {
-                            label: label.to_string(),
-                            description: item
-                                .get("description")
-                                .and_then(|d| d.as_str())
-                                .map(|s| s.to_string()),
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        let allow_free_text = params
-            .get("allow_free_text")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-        let multi_select = params
-            .get("multi_select")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-
-        let request_id = self.next_request_id();
-        self.emit(
-            writer,
-            &OutputMessage::ControlRequest {
-                request_id: request_id.clone(),
-                request: crate::protocol::CoreControlRequest::AskUser {
-                    question,
-                    options,
-                    allow_free_text,
-                    multi_select,
-                },
-            },
-        );
-
-        match self.wait_for_answer(&request_id, reader).await {
-            Some(answer) => ToolResult::success(answer),
-            None => ToolResult::error("User did not answer (interrupted or disconnected)"),
-        }
-    }
-
     async fn wait_for_answer<R: AsyncBufReadExt + Unpin>(
         &self,
         expected_request_id: &str,
@@ -1708,30 +1725,6 @@ fn approval_audit_outcome(approval: &ApprovalResult) -> (AuditOutcomeStatus, &'s
     }
 }
 
-fn json_shape(value: &serde_json::Value) -> &'static str {
-    match value {
-        serde_json::Value::Null => "null",
-        serde_json::Value::Bool(_) => "boolean",
-        serde_json::Value::Number(_) => "number",
-        serde_json::Value::String(_) => "string",
-        serde_json::Value::Array(_) => "array",
-        serde_json::Value::Object(_) => "object",
-    }
-}
-
-fn hash_json(value: &serde_json::Value) -> String {
-    use sha2::{Digest, Sha256};
-
-    let bytes = serde_json::to_vec(value).unwrap_or_default();
-    let digest = Sha256::digest(bytes);
-    let mut output = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        use std::fmt::Write as _;
-        let _ = write!(output, "{byte:02x}");
-    }
-    output
-}
-
 #[derive(Default, Clone)]
 struct PendingToolCall {
     id: String,
@@ -1739,12 +1732,12 @@ struct PendingToolCall {
     arguments: String,
     block_index: u32,
     block_closed: bool,
-}
-
-fn parse_cosh_question_text(text: &str) -> Option<serde_json::Value> {
-    let marker = "COSH_QUESTION:";
-    let json_text = text.split_once(marker)?.1.trim().lines().next()?.trim();
-    serde_json::from_str(json_text).ok()
+    /// Stream-shape facts kept for bounded diagnostics when arguments are
+    /// rejected: they distinguish "provider never sent arguments" from
+    /// "arguments arrived but were malformed".
+    start_seen: bool,
+    delta_count: u32,
+    end_seen: bool,
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -409,6 +409,45 @@ async fn provider_eof_without_terminal_fails_the_request_and_turn() {
     assert!(!event_types.contains(&"provider.request.completed"));
 }
 
+/// Pending-call state is sized from the provider's index, so an out-of-range
+/// index must fail the turn rather than allocate a slot per reported position.
+#[tokio::test]
+async fn out_of_range_tool_call_index_fails_the_turn() {
+    for index in [MAX_TOOL_CALL_INDEX + 1, u32::MAX] {
+        let provider = MockProvider::new(vec![vec![
+            GenerateEvent::ToolCallStart {
+                index,
+                id: "call-1".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index,
+                arguments_delta: r#"{"command":"ls"}"#.to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index },
+            GenerateEvent::MessageEnd,
+        ]]);
+        let mut core = make_core(provider);
+        core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+        let mut output = Vec::new();
+        let mut reader = empty_reader().await;
+
+        let error = core
+            .handle_user_message("hi", &mut reader, &mut output)
+            .await
+            .expect_err("index {index} must fail the turn");
+        assert!(error.contains(&index.to_string()), "{error}");
+        assert!(
+            error.contains(&MAX_TOOL_CALL_INDEX.to_string()),
+            "the limit must be named: {error}"
+        );
+        assert!(
+            core.audit.captured_event_types().contains(&"turn.failed"),
+            "index {index} must be audited as a failed turn"
+        );
+    }
+}
+
 #[tokio::test]
 async fn unknown_tool_returns_error_result() {
     let provider = MockProvider::new(vec![
@@ -1488,5 +1527,563 @@ async fn thinking_delta_emits_stream_event() {
     assert_eq!(
         v.pointer("/event/delta/thinking").and_then(|t| t.as_str()),
         Some("Step 1: analyze...")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ask_user_question argument validation
+// ---------------------------------------------------------------------------
+
+/// One malformed `ask_user_question` call, as it would arrive from a provider.
+struct AskUserRejectionCase {
+    label: &'static str,
+    /// `None` models a `ToolCallStart` that never received argument deltas.
+    arguments: Option<&'static str>,
+    expected_code: &'static str,
+}
+
+/// Drive one turn that issues `ask_user_question` with `arguments`, followed by
+/// a plain-text turn. Returns the emitted stdout and the resulting core.
+async fn run_ask_user_turn(arguments: Option<&str>) -> (String, CoshCore) {
+    let mut first_turn = vec![GenerateEvent::ToolCallStart {
+        index: 0,
+        id: "call-ask".to_string(),
+        name: "ask_user_question".to_string(),
+    }];
+    if let Some(arguments) = arguments {
+        first_turn.push(GenerateEvent::ToolCallDelta {
+            index: 0,
+            arguments_delta: arguments.to_string(),
+        });
+    }
+    first_turn.push(GenerateEvent::ToolCallEnd { index: 0 });
+    first_turn.push(GenerateEvent::MessageEnd);
+
+    let provider = MockProvider::new(vec![
+        first_turn,
+        vec![
+            GenerateEvent::TextDelta("Recovered without a question.".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let tools = ToolRegistry::with_defaults_for_test();
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("what now?", &mut reader, &mut output)
+        .await
+        .expect("turn completes");
+
+    (String::from_utf8(output).unwrap(), core)
+}
+
+fn tool_result_text(core: &CoshCore, tool_call_id: &str) -> String {
+    core.messages
+        .iter()
+        .find(|m| m.role == "tool" && m.tool_call_id.as_deref() == Some(tool_call_id))
+        .expect("tool result appended to the provider conversation")
+        .content
+        .as_text()
+}
+
+#[tokio::test]
+async fn malformed_ask_user_arguments_never_reach_the_user() {
+    let cases = [
+        AskUserRejectionCase {
+            label: "no argument delta after tool call start",
+            arguments: None,
+            expected_code: "empty_arguments",
+        },
+        AskUserRejectionCase {
+            label: "empty arguments",
+            arguments: Some(""),
+            expected_code: "empty_arguments",
+        },
+        AskUserRejectionCase {
+            label: "truncated json",
+            arguments: Some(r#"{"question":"How should local chan"#),
+            expected_code: "invalid_json",
+        },
+        AskUserRejectionCase {
+            label: "non-object root",
+            arguments: Some(r#"["How should local changes be handled?"]"#),
+            expected_code: "root_not_object",
+        },
+        AskUserRejectionCase {
+            label: "empty object",
+            arguments: Some("{}"),
+            expected_code: "missing_question",
+        },
+        AskUserRejectionCase {
+            label: "null question",
+            arguments: Some(r#"{"question":null}"#),
+            expected_code: "question_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "null options",
+            arguments: Some(r#"{"question":"Pick one","options":null}"#),
+            expected_code: "options_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "null allow_free_text",
+            arguments: Some(r#"{"question":"Pick one","allow_free_text":null}"#),
+            expected_code: "allow_free_text_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "number question",
+            arguments: Some(r#"{"question":7}"#),
+            expected_code: "question_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "array question",
+            arguments: Some(r#"{"question":["one","two"]}"#),
+            expected_code: "question_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "object question",
+            arguments: Some(r#"{"question":{"text":"pick one"}}"#),
+            expected_code: "question_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "empty question string",
+            arguments: Some(r#"{"question":""}"#),
+            expected_code: "empty_question",
+        },
+        AskUserRejectionCase {
+            label: "whitespace question string",
+            arguments: Some(r#"{"question":"   "}"#),
+            expected_code: "empty_question",
+        },
+        AskUserRejectionCase {
+            label: "claude-style nested questions",
+            arguments: Some(
+                r#"{"questions":[{"question":"How should local changes be handled?","header":"Local changes","options":[{"label":"Stash"}],"multiSelect":false}]}"#,
+            ),
+            expected_code: "unsupported_nested_questions",
+        },
+        AskUserRejectionCase {
+            label: "options wrong type",
+            arguments: Some(r#"{"question":"Pick one","options":{"label":"Stash"}}"#),
+            expected_code: "options_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "option label wrong type",
+            arguments: Some(r#"{"question":"Pick one","options":[{"label":42}]}"#),
+            expected_code: "option_invalid",
+        },
+        AskUserRejectionCase {
+            label: "option description wrong type",
+            arguments: Some(
+                r#"{"question":"Pick one","options":[{"label":"Stash","description":[]}]}"#,
+            ),
+            expected_code: "option_invalid",
+        },
+        AskUserRejectionCase {
+            label: "allow_free_text wrong type",
+            arguments: Some(r#"{"question":"Pick one","allow_free_text":"true"}"#),
+            expected_code: "allow_free_text_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "multi_select wrong type",
+            arguments: Some(r#"{"question":"Pick one","multi_select":"no"}"#),
+            expected_code: "multi_select_wrong_type",
+        },
+        AskUserRejectionCase {
+            label: "no answer path",
+            arguments: Some(r#"{"question":"Pick one","allow_free_text":false,"options":[]}"#),
+            expected_code: "no_answer_path",
+        },
+    ];
+
+    for case in cases {
+        let (output, core) = run_ask_user_turn(case.arguments).await;
+
+        assert!(
+            !output.contains(r#""subtype":"ask_user""#),
+            "case {}: no ask_user control request may be emitted, got {output}",
+            case.label
+        );
+        assert!(
+            !output.contains("control_request"),
+            "case {}: rejected arguments must not open any control request, got {output}",
+            case.label
+        );
+        assert!(
+            !output.contains("Agent needs your input"),
+            "case {}: generic fallback leaked into output",
+            case.label
+        );
+
+        let tool_text = tool_result_text(&core, "call-ask");
+        assert!(
+            tool_text.contains(&format!("code={}", case.expected_code)),
+            "case {}: expected code={} in {tool_text}",
+            case.label,
+            case.expected_code
+        );
+
+        let event_types = core.audit.captured_event_types();
+        assert!(
+            event_types.contains(&"tool.requested"),
+            "case {}: rejection must still be audited as requested",
+            case.label
+        );
+        assert!(
+            event_types.contains(&"tool.failed"),
+            "case {}: rejection must be audited as failed",
+            case.label
+        );
+        assert!(
+            !event_types.contains(&"tool.execution.started"),
+            "case {}: rejected arguments must not start an execution",
+            case.label
+        );
+
+        assert_eq!(
+            (
+                core.metrics.tool_calls_total,
+                core.metrics.tool_calls_fail,
+                core.metrics.tool_calls_success
+            ),
+            (1, 1, 0),
+            "case {}: a rejected question counts once, as a failure",
+            case.label
+        );
+
+        let last = core.messages.last().expect("assistant reply");
+        assert_eq!(last.role, "assistant", "case {}", case.label);
+        assert!(
+            last.content
+                .as_text()
+                .contains("Recovered without a question."),
+            "case {}: the provider turn after the tool error must still run",
+            case.label
+        );
+    }
+}
+
+#[tokio::test]
+async fn valid_ask_user_arguments_still_produce_a_question_and_answer() {
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-ask".to_string(),
+                name: "ask_user_question".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"question":"How should local changes be handled?","options":[{"label":"Stash","description":"git stash"},{"label":"Discard"}],"allow_free_text":false,"multi_select":true}"#.to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("Stashing then.".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let tools = ToolRegistry::with_defaults_for_test();
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+    let input = "{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"req-0\",\"response\":{\"answer\":\"Stash\"}}}\n";
+    let mut reader = BufReader::new(input.as_bytes()).lines();
+    let mut output = Vec::new();
+
+    core.handle_user_message("what now?", &mut reader, &mut output)
+        .await
+        .expect("turn completes");
+
+    let output_str = String::from_utf8(output).unwrap();
+    let request_line = output_str
+        .lines()
+        .find(|line| line.contains("\"subtype\":\"ask_user\""))
+        .expect("ask_user control request");
+    let request: serde_json::Value = serde_json::from_str(request_line).unwrap();
+    assert_eq!(
+        request
+            .pointer("/request/question")
+            .and_then(|v| v.as_str()),
+        Some("How should local changes be handled?")
+    );
+    assert_eq!(
+        request
+            .pointer("/request/options/0/description")
+            .and_then(|v| v.as_str()),
+        Some("git stash")
+    );
+    assert_eq!(
+        request
+            .pointer("/request/allow_free_text")
+            .and_then(|v| v.as_bool()),
+        Some(false)
+    );
+    assert_eq!(
+        request
+            .pointer("/request/multi_select")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+
+    assert_eq!(tool_result_text(&core, "call-ask"), "Stash");
+    let event_types = core.audit.captured_event_types();
+    assert!(event_types.contains(&"tool.execution.started"));
+    assert!(event_types.contains(&"tool.completed"));
+    // Answered questions count like any other tool call, so a single rejected
+    // question cannot make the tool look like it always fails.
+    assert_eq!(core.metrics.tool_calls_total, 1);
+    assert_eq!(core.metrics.tool_calls_success, 1);
+    assert_eq!(core.metrics.tool_calls_fail, 0);
+}
+
+#[tokio::test]
+async fn malformed_tool_arguments_fail_without_executing_the_tool() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-shell".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"command":"ls -l"#.to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("Retrying with valid arguments.".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::clone(&calls),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("list files", &mut reader, &mut output)
+        .await
+        .expect("turn completes");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "malformed arguments must not reach the tool"
+    );
+    let tool_text = tool_result_text(&core, "call-shell");
+    assert!(
+        tool_text.contains("code=invalid_json"),
+        "expected a diagnosable tool error, got {tool_text}"
+    );
+    let event_types = core.audit.captured_event_types();
+    assert!(event_types.contains(&"tool.requested"));
+    assert!(event_types.contains(&"tool.failed"));
+    assert!(!event_types.contains(&"tool.execution.started"));
+}
+
+/// Tools that take no parameters legitimately arrive with empty arguments, which
+/// must stay executable after the malformed-argument tightening.
+#[tokio::test]
+async fn empty_arguments_still_invoke_a_regular_tool() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-shell".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("Done.".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::clone(&calls),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("run it", &mut reader, &mut output)
+        .await
+        .expect("turn completes");
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+/// The in-band `COSH_QUESTION:` text protocol shares the tool's validation, so a
+/// schema-incompatible payload must not become a question — and because the
+/// marker suppresses the assistant text, the turn must fail visibly instead of
+/// ending as an ordinary reply the user never saw.
+#[tokio::test]
+async fn cosh_question_text_with_unsupported_schema_fails_visibly() {
+    for (label, payload, expected_code) in [
+        (
+            "unsupported schema",
+            r#"{"prompt":"How should local changes be handled?"}"#,
+            "missing_question",
+        ),
+        (
+            "explicit null question",
+            r#"{"question":null}"#,
+            "question_wrong_type",
+        ),
+        ("truncated json", r#"{"question":"How sho"#, "invalid_json"),
+        ("no payload", "", "empty_arguments"),
+        (
+            "unanswerable question",
+            r#"{"question":"Pick one","allow_free_text":false,"options":[]}"#,
+            "no_answer_path",
+        ),
+    ] {
+        let provider = MockProvider::new(vec![vec![
+            GenerateEvent::TextDelta(format!("COSH_QUESTION:{payload}")),
+            GenerateEvent::MessageEnd,
+        ]]);
+
+        let mut config = CoreConfig::default();
+        config.agent.approval_mode = "trust".to_string();
+        let tools = ToolRegistry::with_defaults_for_test();
+        let mut core = CoshCore::new(config, Box::new(provider), tools);
+        core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+        let mut reader = empty_reader().await;
+        let mut output = Vec::new();
+
+        let error = core
+            .handle_user_message("what now?", &mut reader, &mut output)
+            .await
+            .expect_err("an invalid in-band question must fail the turn");
+
+        assert!(
+            error.contains(&format!("code={expected_code}")),
+            "case {label}: expected code={expected_code} in {error}"
+        );
+        assert!(
+            !error.contains(payload) || payload.is_empty(),
+            "case {label}: the rejected payload must not be echoed: {error}"
+        );
+
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(
+            !output_str.contains(r#""subtype":"ask_user""#),
+            "case {label}: {output_str}"
+        );
+        assert!(
+            !output_str.contains("Agent needs your input"),
+            "case {label}: {output_str}"
+        );
+        // The marker suppressed the text, so nothing may be presented as a
+        // finished assistant answer either.
+        assert!(
+            !output_str.contains(r#""type":"assistant""#),
+            "case {label}: suppressed text must not surface as an answer: {output_str}"
+        );
+    }
+}
+
+/// With the question tool disabled the marker cannot become a question, so the
+/// text must stay visible instead of being suppressed with nothing to replace it.
+#[tokio::test]
+async fn cosh_question_text_stays_visible_when_questions_are_disabled() {
+    let provider = MockProvider::new(vec![vec![
+        GenerateEvent::TextDelta(
+            "COSH_QUESTION:{\"prompt\":\"How should local changes be handled?\"}".to_string(),
+        ),
+        GenerateEvent::MessageEnd,
+    ]]);
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::new(AtomicUsize::new(0)),
+    }));
+    tools
+        .retain_selected_tools("shell")
+        .expect("selection drops the question tool");
+    assert!(!tools.supports_ask_user_question());
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("what now?", &mut reader, &mut output)
+        .await
+        .expect("turn completes as an ordinary reply");
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        output_str.contains(r#""type":"assistant""#),
+        "the reply must not be swallowed: {output_str}"
+    );
+    assert!(
+        !output_str.contains(r#""subtype":"ask_user""#),
+        "{output_str}"
+    );
+}
+
+#[tokio::test]
+async fn cosh_question_text_with_valid_schema_still_asks() {
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::TextDelta(
+                "COSH_QUESTION:{\"question\":\"Which branch?\",\"options\":[{\"label\":\"main\"}]}"
+                    .to_string(),
+            ),
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("Using main.".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let tools = ToolRegistry::with_defaults_for_test();
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    let input = "{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"req-0\",\"response\":{\"answer\":\"main\"}}}\n";
+    let mut reader = BufReader::new(input.as_bytes()).lines();
+    let mut output = Vec::new();
+
+    core.handle_user_message("what now?", &mut reader, &mut output)
+        .await
+        .expect("turn completes");
+
+    let output_str = String::from_utf8(output).unwrap();
+    let request_line = output_str
+        .lines()
+        .find(|line| line.contains(r#""subtype":"ask_user""#))
+        .expect("ask_user control request");
+    let request: serde_json::Value = serde_json::from_str(request_line).unwrap();
+    assert_eq!(
+        request
+            .pointer("/request/question")
+            .and_then(|v| v.as_str()),
+        Some("Which branch?")
     );
 }

--- a/src/cosh-ng/crates/cosh-core/src/core/tool_execution.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tool_execution.rs
@@ -1,0 +1,384 @@
+//! Tool-argument admission and the interactive-question dispatch.
+//!
+//! Everything here decides whether a provider-issued call may run at all:
+//! argument parsing, bounded audit shapes and digests, the rejection path, and
+//! the two routes that can reach the user with a question (the
+//! `ask_user_question` tool call and the in-band `COSH_QUESTION:` text).
+//!
+//! It lives beside `core.rs` rather than inside it because the turn loop is
+//! already at its size budget, and because these are the checks a reviewer wants
+//! to read as one unit: a gap between them is how a malformed call became a
+//! valid-looking prompt.
+
+use std::io::Write;
+use std::time::Instant;
+
+use tokio::io::AsyncBufReadExt;
+
+use cosh_types::audit::AuditToolData;
+
+use crate::audit::CoreAuditScope;
+use crate::protocol::OutputMessage;
+use crate::tool::ask_user_question::{
+    self, AskUserArgumentError, AskUserQuestionParams, AskUserRejectionDiagnostics,
+};
+use crate::tool::ToolResult;
+
+use super::{CoshCore, PendingToolCall};
+
+/// Marker introducing an in-band question inside assistant text.
+const IN_BAND_MARKER: &str = "COSH_QUESTION:";
+
+/// What the assistant's plain text carries on the in-band question route.
+///
+/// The marker suppresses ordinary text output, so an invalid payload must be
+/// distinguishable from "no question at all" — otherwise the turn would end
+/// silently, showing the user neither a question nor a reason.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum InBandQuestion {
+    /// No marker in the text: an ordinary assistant reply.
+    Absent,
+    /// A payload that passed the same validation as the tool call.
+    Valid(AskUserQuestionParams),
+    /// A payload that must be surfaced as a failure, never as a question.
+    Invalid(AskUserArgumentError),
+}
+
+/// Classify assistant text that may carry an in-band question.
+///
+/// Shares [`ask_user_question::validate_value`] with the tool-call route, so
+/// neither can produce a question the user is unable to answer.
+pub(super) fn parse_in_band_question(text: &str) -> InBandQuestion {
+    let Some((_, after_marker)) = text.split_once(IN_BAND_MARKER) else {
+        return InBandQuestion::Absent;
+    };
+    let Some(json_text) = after_marker.trim().lines().next().map(str::trim) else {
+        return InBandQuestion::Invalid(AskUserArgumentError::EmptyArguments);
+    };
+    if json_text.is_empty() {
+        return InBandQuestion::Invalid(AskUserArgumentError::EmptyArguments);
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json_text) else {
+        return InBandQuestion::Invalid(AskUserArgumentError::InvalidJson);
+    };
+    match ask_user_question::validate_value(&value) {
+        Ok(params) => InBandQuestion::Valid(params),
+        Err(error) => InBandQuestion::Invalid(error),
+    }
+}
+
+/// Turn-terminating message for an in-band question that failed validation.
+///
+/// Carries the stable code and the expected shape only: the payload may hold
+/// session content.
+pub(super) fn in_band_question_error(error: AskUserArgumentError) -> String {
+    format!(
+        "Provider emitted an invalid {IN_BAND_MARKER} payload [code={}]: {}. No question was shown.",
+        error.code(),
+        error.guidance()
+    )
+}
+
+/// Why a tool call's arguments were refused before execution.
+///
+/// Both variants carry shapes and codes only — never the payload, which can hold
+/// session content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ArgumentError {
+    /// The payload was not valid JSON.
+    InvalidJson,
+    /// The payload parsed, but its root was not the declared object.
+    RootNotObject { shape: &'static str },
+}
+
+impl ArgumentError {
+    /// Stable code for logs, audit reasons, and the tool-result text.
+    pub(super) fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidJson => "invalid_json",
+            Self::RootNotObject { .. } => "arguments_not_object",
+        }
+    }
+
+    /// JSON parse status recorded for the call, matching the ask-user codes.
+    pub(super) fn json_parse_status(&self) -> &'static str {
+        match self {
+            Self::InvalidJson => ask_user_question::JSON_PARSE_INVALID,
+            // The bytes did parse; only the shape was wrong.
+            Self::RootNotObject { .. } => ask_user_question::JSON_PARSE_OK,
+        }
+    }
+
+    /// Audit `input_shape` for a rejected call.
+    pub(super) fn audit_shape(&self) -> &'static str {
+        match self {
+            Self::InvalidJson => "unparsed",
+            Self::RootNotObject { shape } => shape,
+        }
+    }
+
+    /// One clause naming what was wrong, safe to show the model.
+    fn summary(&self) -> String {
+        match self {
+            Self::InvalidJson => "arguments were not valid JSON".to_string(),
+            Self::RootNotObject { shape } => {
+                format!("arguments were a JSON {shape}, not an object")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ArgumentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.summary())
+    }
+}
+
+/// Parse tool arguments as received from the provider.
+///
+/// Empty or whitespace-only arguments mean "no arguments" — the convention
+/// providers use for zero-parameter tools — and become an empty object. Every
+/// tool declares an object root, so a payload that parses to `null`, an array, or
+/// a scalar is refused rather than passed through: `null` makes every field look
+/// merely absent to the tool implementation, and the other roots would reach an
+/// MCP server as arguments it never declared.
+///
+/// # Errors
+///
+/// Returns [`ArgumentError`] when non-empty arguments are not valid JSON, or
+/// when they parse to anything other than an object.
+pub(super) fn parse_tool_arguments(raw: &str) -> Result<serde_json::Value, ArgumentError> {
+    if raw.trim().is_empty() {
+        return Ok(serde_json::Value::Object(serde_json::Map::new()));
+    }
+    let value: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| ArgumentError::InvalidJson)?;
+    if !value.is_object() {
+        return Err(ArgumentError::RootNotObject {
+            shape: json_shape(&value),
+        });
+    }
+    Ok(value)
+}
+
+/// Tool-result text for a tool call whose arguments were refused.
+///
+/// Carries no fragment of the rejected payload: malformed arguments can still
+/// contain session content.
+pub(super) fn invalid_arguments_message(tool_name: &str, error: &ArgumentError) -> String {
+    format!(
+        "{tool_name} arguments rejected [code={}]: {}. \
+         The tool was not executed; re-issue the call with one complete JSON object matching \
+         the declared schema.",
+        error.code(),
+        error.summary()
+    )
+}
+
+pub(super) fn json_shape(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+pub(super) fn hash_json(value: &serde_json::Value) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    hash_bytes(&bytes)
+}
+
+pub(super) fn hash_bytes(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}
+
+impl CoshCore {
+    /// Run one `ask_user_question` tool call, or reject its arguments.
+    ///
+    /// Returns the tool result when a question was actually shown, and `None`
+    /// when the call was rejected before execution.
+    ///
+    /// # Errors
+    ///
+    /// Propagates audit-recording failures, which abort the turn.
+    pub(super) async fn dispatch_ask_user_tool_call<W, R>(
+        &mut self,
+        scope: CoreAuditScope<'_>,
+        call: &PendingToolCall,
+        provider_type: &str,
+        tool_kind: &str,
+        reader: &mut tokio::io::Lines<R>,
+        writer: &mut W,
+    ) -> Result<Option<ToolResult>, String>
+    where
+        W: Write,
+        R: AsyncBufReadExt + Unpin,
+    {
+        let report = ask_user_question::inspect_arguments(&call.arguments);
+        let tool_data = AuditToolData {
+            tool_kind: tool_kind.to_string(),
+            input_shape: Some(
+                report
+                    .root
+                    .as_ref()
+                    .map(|root| json_shape(root))
+                    .unwrap_or(report.json_parse_status)
+                    .to_string(),
+            ),
+            input_hash: Some(match &report.root {
+                Some(root) => hash_json(root),
+                None => hash_bytes(call.arguments.as_bytes()),
+            }),
+            ..AuditToolData::default()
+        };
+        self.audit
+            .record_tool_requested(scope, &call.name, &tool_data);
+
+        let params = match report.outcome {
+            Ok(params) => params,
+            Err(error) => {
+                // No control request is emitted: a question the user cannot
+                // answer would block the run, and a generic placeholder would
+                // hide the real cause.
+                ask_user_question::log_rejection(&AskUserRejectionDiagnostics {
+                    provider_type,
+                    tool_call_id: &call.id,
+                    tool_name: &call.name,
+                    start_seen: call.start_seen,
+                    delta_count: call.delta_count,
+                    end_seen: call.end_seen,
+                    argument_bytes: report.argument_bytes,
+                    json_parse_status: report.json_parse_status,
+                    validation_error_code: error.code(),
+                    question_shape: report.question_shape,
+                });
+                self.reject_tool_arguments(
+                    scope,
+                    &call.name,
+                    &call.id,
+                    &tool_data,
+                    error.tool_error_message(),
+                );
+                return Ok(None);
+            }
+        };
+
+        self.audit
+            .record_tool_execution_started(scope, &call.name, &tool_data)?;
+        let tool_start = Instant::now();
+        let result = self.handle_ask_user(&params, reader, writer).await;
+        let duration_ms = tool_start.elapsed().as_millis() as u64;
+        self.audit.record_tool_terminal(
+            scope,
+            &call.name,
+            &tool_data,
+            result.is_error,
+            duration_ms,
+            result.output.len() as u64,
+        );
+        // Counted like any other tool call so a single rejection cannot make the
+        // question tool look like it always fails.
+        self.note_tool_call_metrics(result.is_error, duration_ms);
+        Ok(Some(result))
+    }
+
+    /// Record one completed tool call in the per-turn metrics.
+    pub(super) fn note_tool_call_metrics(&mut self, is_error: bool, duration_ms: u64) {
+        self.metrics.tool_calls_total += 1;
+        self.metrics.tool_calls_duration_ms += duration_ms;
+        if is_error {
+            self.metrics.tool_calls_fail += 1;
+        } else {
+            self.metrics.tool_calls_success += 1;
+        }
+    }
+
+    /// Fail a tool call whose arguments were rejected before execution.
+    ///
+    /// Audits the call as failed without a `tool.execution.started` record and
+    /// appends an error tool result, so the model can re-issue a valid call
+    /// instead of the run stalling on an unusable one.
+    pub(super) fn reject_tool_arguments(
+        &mut self,
+        scope: CoreAuditScope<'_>,
+        tool_name: &str,
+        tool_call_id: &str,
+        tool_data: &AuditToolData,
+        message: String,
+    ) {
+        self.note_tool_call_metrics(true, 0);
+        let result = ToolResult::error(message);
+        self.audit.record_tool_terminal(
+            scope,
+            tool_name,
+            tool_data,
+            result.is_error,
+            0,
+            result.output.len() as u64,
+        );
+        self.messages.push(crate::provider::Message::tool_result(
+            tool_call_id,
+            &result.output,
+            result.is_error,
+        ));
+    }
+
+    /// Emit an interactive question and wait for the user's answer.
+    ///
+    /// Takes already-validated params: every fallback that could invent question
+    /// text lives in `tool::ask_user_question`, so a malformed tool call can
+    /// never reach the user as a generic prompt.
+    pub(super) async fn handle_ask_user<W, R>(
+        &self,
+        params: &AskUserQuestionParams,
+        reader: &mut tokio::io::Lines<R>,
+        writer: &mut W,
+    ) -> ToolResult
+    where
+        W: Write,
+        R: AsyncBufReadExt + Unpin,
+    {
+        let options: Vec<crate::protocol::AskUserOption> = params
+            .options
+            .iter()
+            .map(|option| crate::protocol::AskUserOption {
+                label: option.label.clone(),
+                description: option.description.clone(),
+            })
+            .collect();
+
+        let request_id = self.next_request_id();
+        self.emit(
+            writer,
+            &OutputMessage::ControlRequest {
+                request_id: request_id.clone(),
+                request: crate::protocol::CoreControlRequest::AskUser {
+                    question: params.question.clone(),
+                    options,
+                    allow_free_text: params.allow_free_text,
+                    multi_select: params.multi_select,
+                },
+            },
+        );
+
+        match self.wait_for_answer(&request_id, reader).await {
+            Some(answer) => ToolResult::success(answer),
+            None => ToolResult::error("User did not answer (interrupted or disconnected)"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "tool_execution/tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-core/src/core/tool_execution/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tool_execution/tests.rs
@@ -1,0 +1,124 @@
+use super::*;
+
+#[test]
+fn text_without_the_marker_carries_no_question() {
+    assert_eq!(
+        parse_in_band_question("Here is the plan, no question needed."),
+        InBandQuestion::Absent
+    );
+    assert_eq!(parse_in_band_question(""), InBandQuestion::Absent);
+}
+
+#[test]
+fn marked_text_with_a_valid_payload_shares_the_tool_contract() {
+    let InBandQuestion::Valid(params) = parse_in_band_question(
+        "Deciding.\nCOSH_QUESTION:{\"question\":\"Which branch?\",\"options\":[{\"label\":\"main\"}]}",
+    ) else {
+        panic!("valid payload must produce a question");
+    };
+    assert_eq!(params.question, "Which branch?");
+    assert_eq!(params.options.len(), 1);
+    assert!(params.allow_free_text, "omitted optional keeps its default");
+}
+
+/// The marker suppresses the visible assistant text, so every rejected payload
+/// must be reported as a failure rather than collapsing into `Absent`.
+#[test]
+fn marked_text_with_an_unusable_payload_is_invalid_not_absent() {
+    let cases: &[(&str, AskUserArgumentError)] = &[
+        ("COSH_QUESTION:", AskUserArgumentError::EmptyArguments),
+        ("COSH_QUESTION:   ", AskUserArgumentError::EmptyArguments),
+        (
+            "COSH_QUESTION:{\"question\":\"Which bra",
+            AskUserArgumentError::InvalidJson,
+        ),
+        (
+            "COSH_QUESTION:{\"prompt\":\"Which branch?\"}",
+            AskUserArgumentError::MissingQuestion,
+        ),
+        (
+            "COSH_QUESTION:{\"question\":null}",
+            AskUserArgumentError::QuestionWrongType,
+        ),
+        (
+            "COSH_QUESTION:{\"question\":\"Which branch?\",\"allow_free_text\":false}",
+            AskUserArgumentError::NoAnswerPath,
+        ),
+        (
+            "COSH_QUESTION:[{\"question\":\"Which branch?\"}]",
+            AskUserArgumentError::RootNotObject,
+        ),
+    ];
+
+    for (text, expected) in cases {
+        assert_eq!(
+            parse_in_band_question(text),
+            InBandQuestion::Invalid(*expected),
+            "payload {text:?} must be reported as invalid"
+        );
+    }
+}
+
+/// The failure text is what the user sees, so it must name the cause without
+/// echoing a payload that may contain session content.
+#[test]
+fn in_band_error_names_the_code_without_echoing_the_payload() {
+    let message = in_band_question_error(AskUserArgumentError::MissingQuestion);
+    assert!(message.contains("code=missing_question"), "{message}");
+    assert!(message.contains("COSH_QUESTION"), "{message}");
+    assert!(message.contains("No question was shown"), "{message}");
+}
+
+#[test]
+fn empty_arguments_are_an_empty_object_and_malformed_ones_are_errors() {
+    assert_eq!(
+        parse_tool_arguments("  \n"),
+        Ok(serde_json::Value::Object(serde_json::Map::new()))
+    );
+    assert_eq!(
+        parse_tool_arguments(r#"{"command":"ls"#),
+        Err(ArgumentError::InvalidJson)
+    );
+    assert_eq!(
+        parse_tool_arguments(r#"{"command":"ls"}"#),
+        Ok(serde_json::json!({"command": "ls"}))
+    );
+}
+
+/// Every tool declares an object root. A non-object payload parses cleanly, so
+/// without this check it would pass admission and reach the tool — as `null`
+/// (every field looks absent) or as arguments an MCP server never declared.
+#[test]
+fn parsed_arguments_that_are_not_an_object_are_rejected() {
+    let cases: &[(&str, &str)] = &[
+        ("null", "null"),
+        ("[]", "array"),
+        (r#"[{"command":"ls"}]"#, "array"),
+        ("7", "number"),
+        ("true", "boolean"),
+        (r#""command""#, "string"),
+    ];
+
+    for (raw, shape) in cases {
+        assert_eq!(
+            parse_tool_arguments(raw),
+            Err(ArgumentError::RootNotObject { shape }),
+            "payload {raw:?} must be refused"
+        );
+    }
+}
+
+#[test]
+fn rejection_message_carries_a_code_and_no_payload() {
+    let malformed = invalid_arguments_message("shell", &ArgumentError::InvalidJson);
+    assert!(malformed.contains("code=invalid_json"), "{malformed}");
+    assert!(malformed.contains("shell"), "{malformed}");
+
+    let wrong_root =
+        invalid_arguments_message("shell", &ArgumentError::RootNotObject { shape: "array" });
+    assert!(
+        wrong_root.contains("code=arguments_not_object"),
+        "{wrong_root}"
+    );
+    assert!(wrong_root.contains("JSON array"), "{wrong_root}");
+}

--- a/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
@@ -188,6 +188,29 @@ pub enum GenerateEvent {
     Error(String),
 }
 
+/// Highest tool-call index a provider may report within one message.
+///
+/// Consumers size per-call state by index (`Vec` slots keyed by position), so an
+/// unbounded index turns one malformed frame into a multi-billion-entry
+/// allocation. No real turn issues more than a few dozen parallel calls, so
+/// anything past this limit is a protocol violation rather than a large message.
+pub const MAX_TOOL_CALL_INDEX: u32 = 127;
+
+impl GenerateEvent {
+    /// The tool-call index this event addresses, if it addresses one.
+    ///
+    /// Lets a consumer bound-check every index-bearing event in one place
+    /// instead of repeating the guard in each match arm.
+    pub fn tool_call_index(&self) -> Option<u32> {
+        match self {
+            Self::ToolCallStart { index, .. }
+            | Self::ToolCallDelta { index, .. }
+            | Self::ToolCallEnd { index } => Some(*index),
+            _ => None,
+        }
+    }
+}
+
 pub type GenerateStream = Pin<Box<dyn Stream<Item = GenerateEvent> + Send>>;
 
 #[async_trait]

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
@@ -3,10 +3,8 @@
 //! Uses ACS3-HMAC-SHA256 signing and parses the cumulative SSE stream format
 //! into incremental `GenerateEvent`s compatible with `ContentGenerator` trait.
 
-use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream};
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -19,9 +17,11 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use super::{
-    ContentGenerator, GenerateConfig, GenerateEvent, GenerateStream, Message, ToolDeclaration,
-};
+use super::{ContentGenerator, GenerateConfig, GenerateStream, Message, ToolDeclaration};
+
+use self::stream::sysom_event_stream;
+
+mod stream;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -326,10 +326,14 @@ impl SysomProvider {
             return Err(format!("SysOM API error {status}: {text}"));
         }
 
-        Ok(sysom_event_stream(
-            response.bytes_stream(),
-            Arc::clone(&self.cancelled),
-        ))
+        let cancelled = Arc::clone(&self.cancelled);
+        // Normalizing to owned bytes keeps the SSE state machine testable with a
+        // plain in-memory stream instead of a live HTTP response.
+        let byte_stream = response
+            .bytes_stream()
+            .map(|chunk| chunk.map(|bytes| bytes.to_vec()).map_err(|e| e.to_string()));
+
+        Ok(sysom_event_stream(Box::pin(byte_stream), cancelled))
     }
 
     /// Check if an error indicates STS credential expiration.
@@ -382,249 +386,6 @@ fn is_sts_error(error: &str) -> bool {
     error.contains("InvalidSecurityToken")
         || error.contains("SecurityTokenExpired")
         || error.contains("InvalidAccessKeyId")
-}
-
-// ---------------------------------------------------------------------------
-// SSE parsing helpers
-// ---------------------------------------------------------------------------
-
-#[derive(Default)]
-struct SseParseState {
-    last_content_len: usize,
-    last_tool_use_count: usize,
-    /// Track accumulated arguments length per tool index
-    last_tool_args_len: Vec<usize>,
-    message_ended: bool,
-    /// Latest usage info (updated every frame, emitted at stream end)
-    latest_usage: Option<(u32, u32, u32)>,
-}
-
-/// Byte-stream → `GenerateEvent` conversion state.
-struct SysomStreamState<S> {
-    source: Pin<Box<S>>,
-    /// Bytes received but not yet split into a complete SSE frame.
-    buf: String,
-    parse: SseParseState,
-    /// Events already decoded and waiting to be yielded, in emission order.
-    pending: VecDeque<GenerateEvent>,
-    /// Set once `source` reported EOF (or a transport error): a `Stream` gives
-    /// no guarantee about being polled again after it terminates.
-    source_done: bool,
-    cancelled: Arc<AtomicBool>,
-}
-
-/// Convert a raw SSE byte stream into incremental `GenerateEvent`s.
-///
-/// Terminal-event contract: the stream always ends with `MessageEnd`, preceded
-/// by `Usage` when the API reported token counts — `cosh-core` treats a stream
-/// without `MessageEnd` as `unexpected_eof` and aborts the turn before running
-/// any tool call the model requested. Both events are therefore queued together
-/// the moment the byte stream reaches EOF, and drained from `pending` without
-/// touching the exhausted source again.
-fn sysom_event_stream<S, B, E>(byte_stream: S, cancelled: Arc<AtomicBool>) -> GenerateStream
-where
-    S: futures::Stream<Item = Result<B, E>> + Send + 'static,
-    B: AsRef<[u8]> + Send + 'static,
-    E: std::fmt::Display + Send + 'static,
-{
-    let state = SysomStreamState {
-        source: Box::pin(byte_stream),
-        buf: String::new(),
-        parse: SseParseState::default(),
-        pending: VecDeque::new(),
-        source_done: false,
-        cancelled,
-    };
-
-    Box::pin(futures::stream::unfold(state, |mut state| async move {
-        loop {
-            if state.cancelled.load(Ordering::SeqCst) {
-                return Some((GenerateEvent::Cancelled, state));
-            }
-            if let Some(event) = state.pending.pop_front() {
-                return Some((event, state));
-            }
-            if state.source_done {
-                return None;
-            }
-
-            // Decode one complete SSE frame (frames are separated by "\n\n").
-            if let Some(pos) = state.buf.find("\n\n") {
-                let frame = state.buf[..pos].to_string();
-                state.buf = state.buf[pos + 2..].to_string();
-                if !frame.trim().is_empty() {
-                    drain_sse_frame(&frame, &mut state.parse, &mut state.pending);
-                }
-                continue;
-            }
-
-            match state.source.next().await {
-                Some(Ok(bytes)) => {
-                    state.buf.push_str(&String::from_utf8_lossy(bytes.as_ref()));
-                }
-                Some(Err(e)) => {
-                    // A transport error kills the underlying body; the core
-                    // aborts the turn on Error, so no terminal event follows.
-                    state.source_done = true;
-                    return Some((GenerateEvent::Error(format!("stream error: {e}")), state));
-                }
-                None => {
-                    state.source_done = true;
-                    // A final frame may arrive without its "\n\n" terminator.
-                    let tail = state.buf.trim().to_string();
-                    state.buf.clear();
-                    if !tail.is_empty() {
-                        drain_sse_frame(&tail, &mut state.parse, &mut state.pending);
-                    }
-                    if let Some((prompt, completion, total)) = state.parse.latest_usage.take() {
-                        state.pending.push_back(GenerateEvent::Usage {
-                            prompt_tokens: prompt,
-                            completion_tokens: completion,
-                            total_tokens: total,
-                        });
-                    }
-                    state.pending.push_back(GenerateEvent::MessageEnd);
-                }
-            }
-        }
-    }))
-}
-
-/// Queue every incremental event a single cumulative SSE frame contributes.
-///
-/// `parse_sysom_sse_event` reports at most one event per call, so a frame that
-/// advances both the text and a tool's arguments needs repeated calls. Each
-/// call returning an event advances a monotonically growing parse cursor
-/// (content length, tool count, argument length), so the loop terminates.
-fn drain_sse_frame(frame: &str, parse: &mut SseParseState, pending: &mut VecDeque<GenerateEvent>) {
-    while let Some(event) = parse_sysom_sse_event(frame, parse) {
-        pending.push_back(event);
-    }
-}
-
-/// Parse a single SSE event block (lines between \n\n).
-/// Returns a GenerateEvent if the block contains useful data.
-fn parse_sysom_sse_event(block: &str, state: &mut SseParseState) -> Option<GenerateEvent> {
-    if state.message_ended {
-        return None;
-    }
-
-    let mut event_type = String::new();
-    let mut data_str = String::new();
-
-    for line in block.lines() {
-        if let Some(val) = line.strip_prefix("event:") {
-            event_type = val.trim().to_string();
-        } else if let Some(val) = line.strip_prefix("data:") {
-            data_str = val.trim().to_string();
-        }
-        // id: line is ignored
-    }
-
-    if event_type == "Failed" {
-        state.message_ended = true;
-        return Some(GenerateEvent::Error(format!(
-            "SysOM stream failed: {}",
-            data_str
-        )));
-    }
-
-    if event_type != "OK" || data_str.is_empty() {
-        return None;
-    }
-
-    let data: Value = serde_json::from_str(&data_str).ok()?;
-
-    let choices = data.get("choices").and_then(|c| c.as_array());
-
-    // --- Text delta (cumulative → incremental) ---
-    if let Some(choices_arr) = choices {
-        if let Some(message) = choices_arr.first().and_then(|c| c.get("message")) {
-            let content = message
-                .get("content")
-                .and_then(|c| c.as_str())
-                .unwrap_or("");
-            if content.len() > state.last_content_len {
-                let delta = &content[state.last_content_len..];
-                state.last_content_len = content.len();
-                return Some(GenerateEvent::TextDelta(delta.to_string()));
-            }
-
-            // --- Tool use (cumulative tool_use array) ---
-            if let Some(tool_use) = message.get("tool_use").and_then(|t| t.as_array()) {
-                if !tool_use.is_empty() {
-                    // New tool call appeared
-                    if tool_use.len() > state.last_tool_use_count {
-                        let new_tc = &tool_use[state.last_tool_use_count];
-                        state.last_tool_use_count = tool_use.len();
-                        state.last_tool_args_len.push(0);
-
-                        let id = new_tc
-                            .get("id")
-                            .and_then(|i| i.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        let name = new_tc
-                            .get("function")
-                            .and_then(|f| f.get("name"))
-                            .and_then(|n| n.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        let index =
-                            new_tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
-
-                        return Some(GenerateEvent::ToolCallStart { index, id, name });
-                    }
-
-                    // Check for arguments growth on last tool call
-                    let last_idx = tool_use.len() - 1;
-                    if let Some(tc) = tool_use.get(last_idx) {
-                        let args = tc
-                            .get("function")
-                            .and_then(|f| f.get("arguments"))
-                            .and_then(|a| a.as_str())
-                            .unwrap_or("");
-                        let prev_len = state.last_tool_args_len.get(last_idx).copied().unwrap_or(0);
-                        if args.len() > prev_len {
-                            let delta = &args[prev_len..];
-                            if let Some(slot) = state.last_tool_args_len.get_mut(last_idx) {
-                                *slot = args.len();
-                            }
-                            return Some(GenerateEvent::ToolCallDelta {
-                                index: last_idx as u32,
-                                arguments_delta: delta.to_string(),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // If no content/tool delta, check if this is the final frame
-    // (no new content growth + has usage = stream is done)
-    if let Some(usage) = data.get("usage").and_then(|u| u.as_object()) {
-        // SysOM returns usage on every frame, but we only emit Usage event
-        // when content has stopped growing (i.e., this parse produced no text delta above)
-        let prompt = usage
-            .get("prompt_tokens")
-            .or_else(|| usage.get("input_tokens"))
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        let completion = usage
-            .get("completion_tokens")
-            .or_else(|| usage.get("output_tokens"))
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        let total = usage
-            .get("total_tokens")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        // Store latest usage but don't emit yet — only emit when stream ends
-        state.latest_usage = Some((prompt, completion, total));
-    }
-
-    None
 }
 
 // ---------------------------------------------------------------------------
@@ -761,190 +522,5 @@ fn hex_hmac_sha256(key: &[u8], data: &[u8]) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::task::{Context, Poll};
-
-    /// Render one `event: OK` SSE frame, terminator included.
-    fn frame(payload: Value) -> String {
-        format!("event: OK\ndata: {payload}\n\n")
-    }
-
-    async fn collect_events(chunks: Vec<String>) -> Vec<GenerateEvent> {
-        let source = futures::stream::iter(chunks.into_iter().map(Ok::<String, String>));
-        let mut stream = sysom_event_stream(source, Arc::new(AtomicBool::new(false)));
-        let mut events = Vec::new();
-        while let Some(event) = stream.next().await {
-            events.push(event);
-        }
-        events
-    }
-
-    #[tokio::test]
-    async fn usage_only_final_frame_still_terminates_with_message_end() {
-        let events = collect_events(vec![
-            frame(serde_json::json!({
-                "choices": [{"message": {"content": "hello"}}]
-            })),
-            frame(serde_json::json!({
-                "choices": [{"message": {"content": "hello"}}],
-                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
-            })),
-        ])
-        .await;
-
-        assert!(
-            matches!(
-                &events[..],
-                [
-                    GenerateEvent::TextDelta(text),
-                    GenerateEvent::Usage {
-                        prompt_tokens: 11,
-                        completion_tokens: 7,
-                        total_tokens: 18,
-                    },
-                    GenerateEvent::MessageEnd,
-                ] if text == "hello"
-            ),
-            "unexpected events: {events:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn stream_without_usage_terminates_with_message_end() {
-        let events = collect_events(vec![frame(serde_json::json!({
-            "choices": [{"message": {"content": "hi"}}]
-        }))])
-        .await;
-
-        assert!(
-            matches!(
-                &events[..],
-                [GenerateEvent::TextDelta(text), GenerateEvent::MessageEnd] if text == "hi"
-            ),
-            "unexpected events: {events:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn unterminated_final_frame_is_flushed_before_message_end() {
-        let last = frame(serde_json::json!({
-            "choices": [{"message": {"content": "done"}}],
-            "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4}
-        }));
-        let events = collect_events(vec![last.trim_end().to_string()]).await;
-
-        assert!(
-            matches!(
-                &events[..],
-                [
-                    GenerateEvent::TextDelta(text),
-                    GenerateEvent::Usage { total_tokens: 4, .. },
-                    GenerateEvent::MessageEnd,
-                ] if text == "done"
-            ),
-            "unexpected events: {events:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn tool_call_with_final_usage_reaches_message_end() {
-        let events = collect_events(vec![
-            frame(serde_json::json!({
-                "choices": [{"message": {"tool_use": [{
-                    "id": "call_1",
-                    "index": 0,
-                    "function": {"name": "read_file", "arguments": ""}
-                }]}}]
-            })),
-            frame(serde_json::json!({
-                "choices": [{"message": {"tool_use": [{
-                    "id": "call_1",
-                    "index": 0,
-                    "function": {"name": "read_file", "arguments": "{\"path\":\"/tmp/a\"}"}
-                }]}}],
-                "usage": {"prompt_tokens": 20, "completion_tokens": 9, "total_tokens": 29}
-            })),
-        ])
-        .await;
-
-        assert!(
-            matches!(
-                &events[..],
-                [
-                    GenerateEvent::ToolCallStart { index: 0, id, name },
-                    GenerateEvent::ToolCallDelta { index: 0, arguments_delta },
-                    GenerateEvent::Usage { total_tokens: 29, .. },
-                    GenerateEvent::MessageEnd,
-                ] if id == "call_1" && name == "read_file"
-                    && arguments_delta == "{\"path\":\"/tmp/a\"}"
-            ),
-            "unexpected events: {events:?}"
-        );
-    }
-
-    /// Byte stream that panics if polled again after reporting EOF.
-    struct PanicOnRepoll {
-        chunks: std::vec::IntoIter<String>,
-        exhausted: bool,
-    }
-
-    impl futures::Stream for PanicOnRepoll {
-        type Item = Result<String, String>;
-
-        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            assert!(!self.exhausted, "byte stream polled after EOF");
-            match self.chunks.next() {
-                Some(chunk) => Poll::Ready(Some(Ok(chunk))),
-                None => {
-                    self.exhausted = true;
-                    Poll::Ready(None)
-                }
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn byte_stream_is_not_polled_after_eof() {
-        let source = PanicOnRepoll {
-            chunks: vec![frame(serde_json::json!({
-                "choices": [{"message": {"content": "x"}}],
-                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
-            }))]
-            .into_iter(),
-            exhausted: false,
-        };
-
-        let mut stream = sysom_event_stream(source, Arc::new(AtomicBool::new(false)));
-        let mut events = Vec::new();
-        while let Some(event) = stream.next().await {
-            events.push(event);
-        }
-
-        assert!(
-            matches!(events.last(), Some(GenerateEvent::MessageEnd)),
-            "unexpected events: {events:?}"
-        );
-    }
-
-    #[test]
-    fn region_id_strips_single_zone_suffix() {
-        assert_eq!(
-            region_id_from_zone_id("cn-hangzhou-j").as_deref(),
-            Some("cn-hangzhou")
-        );
-        assert_eq!(
-            region_id_from_zone_id("cn-beijing").as_deref(),
-            Some("cn-beijing")
-        );
-        assert_eq!(region_id_from_zone_id(""), None);
-    }
-
-    #[test]
-    fn generate_console_url_uses_region_and_instance_id() {
-        assert_eq!(
-            generate_console_url("i-test123", "cn-hangzhou"),
-            "https://alinux.console.aliyun.com/cn-hangzhou/guide/cosh?instance=i-test123"
-        );
-    }
-}
+#[path = "sysom/tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/stream.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/stream.rs
@@ -1,0 +1,762 @@
+//! Cumulative SSE state machine for the SysOM stream format.
+//!
+//! SysOM frames are cumulative snapshots rather than deltas, so reassembly is
+//! stateful: text and tool arguments must extend what was already seen, tool
+//! identity must stay stable across frames, and a failure frame must be
+//! summarized without echoing its payload. Keeping that machine here leaves
+//! `sysom.rs` to transport, signing, and metadata concerns.
+
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use futures::StreamExt;
+use serde_json::Value;
+
+use super::super::{GenerateEvent, GenerateStream, MAX_TOOL_CALL_INDEX};
+use super::hex_sha256;
+
+/// Byte stream feeding the SSE state machine. Errors are pre-stringified so the
+/// state machine is independent of the transport.
+pub(super) type SysomByteStream =
+    Pin<Box<dyn futures::Stream<Item = Result<Vec<u8>, String>> + Send>>;
+
+/// Bounded SysOM stream failure.
+///
+/// Variants carry counts only. The raw SSE payload, assistant text, and tool
+/// arguments may contain session content, so they are never embedded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SysomStreamError {
+    /// A frame's bytes were not valid UTF-8, even once fully reassembled.
+    InvalidUtf8 {
+        byte_offset: usize,
+        block_bytes: usize,
+    },
+    /// A single SSE block exceeded [`MAX_SSE_BLOCK_BYTES`], terminated or not.
+    BlockTooLarge { buffered_bytes: usize, limit: usize },
+    /// An `OK` frame's `data:` payload was not valid JSON.
+    MalformedJson,
+    /// An `OK` frame's payload parsed but its root was not a JSON object.
+    RootWrongType,
+    /// `choices` was present but not an array of choice objects.
+    ChoicesWrongType,
+    /// `choices[0].message` was present but not an object.
+    MessageWrongType,
+    /// `message.tool_use` was present but not an array.
+    ToolUseWrongType,
+    /// `choices[0].message.content` was present but not a string.
+    ContentWrongType,
+    /// Cumulative assistant text stopped extending its previous snapshot.
+    ContentRewritten {
+        previous_bytes: usize,
+        new_bytes: usize,
+    },
+    /// A `tool_use` entry was not an object.
+    ToolEntryWrongType { position: usize },
+    /// `index` was present but not an integer within [`MAX_TOOL_CALL_INDEX`].
+    ToolIndexInvalid { position: usize },
+    /// `id` or `function.name` was present but not a string.
+    ToolIdentityWrongType { index: u32 },
+    /// The frame that first revealed a tool carried no usable `id`/`function.name`.
+    ToolIdentityMissing { index: u32 },
+    /// A later frame reported a different `id` or `function.name` for the index.
+    ToolIdentityChanged { index: u32 },
+    /// `function.arguments` was present but not a string.
+    ArgumentsWrongType { index: u32 },
+    /// Cumulative tool arguments stopped extending their previous snapshot.
+    ArgumentsRewritten {
+        index: u32,
+        previous_bytes: usize,
+        new_bytes: usize,
+    },
+}
+
+impl std::fmt::Display for SysomStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidUtf8 {
+                byte_offset,
+                block_bytes,
+            } => write!(
+                f,
+                "SysOM stream: frame payload was not valid UTF-8 (first invalid byte at offset \
+                 {byte_offset} of {block_bytes})"
+            ),
+            Self::BlockTooLarge {
+                buffered_bytes,
+                limit,
+            } => write!(
+                f,
+                "SysOM stream: event block of {buffered_bytes} bytes exceeds the {limit} byte \
+                 limit"
+            ),
+            Self::MalformedJson => write!(f, "SysOM stream: frame payload was not valid JSON"),
+            Self::RootWrongType => {
+                write!(f, "SysOM stream: frame payload was not a JSON object")
+            }
+            Self::ChoicesWrongType => {
+                write!(
+                    f,
+                    "SysOM stream: choices was not an array of choice objects"
+                )
+            }
+            Self::MessageWrongType => {
+                write!(f, "SysOM stream: choice message was not an object")
+            }
+            Self::ToolUseWrongType => {
+                write!(f, "SysOM stream: tool_use was not an array")
+            }
+            Self::ContentWrongType => {
+                write!(f, "SysOM stream: message content was not a string")
+            }
+            Self::ContentRewritten {
+                previous_bytes,
+                new_bytes,
+            } => write!(
+                f,
+                "SysOM stream: cumulative content is not an extension of the previous frame \
+                 (previous {previous_bytes} bytes, new {new_bytes} bytes)"
+            ),
+            Self::ToolEntryWrongType { position } => write!(
+                f,
+                "SysOM stream: tool_use entry at position {position} was not an object"
+            ),
+            Self::ToolIndexInvalid { position } => write!(
+                f,
+                "SysOM stream: tool_use entry at position {position} carried an index that is not \
+                 an integer in 0..={MAX_TOOL_CALL_INDEX}"
+            ),
+            Self::ToolIdentityWrongType { index } => write!(
+                f,
+                "SysOM stream: tool {index} id or function name was not a string"
+            ),
+            Self::ToolIdentityMissing { index } => write!(
+                f,
+                "SysOM stream: tool {index} was first seen without an id and function name"
+            ),
+            Self::ToolIdentityChanged { index } => write!(
+                f,
+                "SysOM stream: tool {index} changed its id or function name between frames"
+            ),
+            Self::ArgumentsWrongType { index } => {
+                write!(f, "SysOM stream: tool {index} arguments were not a string")
+            }
+            Self::ArgumentsRewritten {
+                index,
+                previous_bytes,
+                new_bytes,
+            } => write!(
+                f,
+                "SysOM stream: tool {index} cumulative arguments are not an extension of the \
+                 previous frame (previous {previous_bytes} bytes, new {new_bytes} bytes)"
+            ),
+        }
+    }
+}
+
+/// Per-tool cumulative state, keyed by the provider-reported tool index.
+#[derive(Default)]
+struct SseToolState {
+    /// Provider `index`, or the array position when the provider omits it.
+    index: u32,
+    /// Tool call id from the frame that first revealed this tool. Later frames
+    /// must repeat it, because Core has already bound the id to this slot.
+    id: String,
+    /// Function name from the frame that first revealed this tool.
+    name: String,
+    /// Last complete cumulative arguments snapshot for this tool.
+    arguments: String,
+    /// Whether `ToolCallEnd` has already been emitted.
+    ended: bool,
+}
+
+#[derive(Default)]
+struct SseParseState {
+    /// Last complete cumulative assistant text; new snapshots must extend it.
+    last_content: String,
+    /// Tool state in first-seen order, addressed by provider index.
+    tools: Vec<SseToolState>,
+    /// Whether a `Failed` frame already ended the message; later frames are
+    /// ignored.
+    message_ended: bool,
+    /// Set on every terminal path — EOF, parse failure, provider failure,
+    /// transport error, cancellation. Once set, the stream stops reading and
+    /// returns `None` after draining what is already queued.
+    stream_ended: bool,
+    /// Latest usage info (SysOM repeats it per frame, emitted once at EOF).
+    latest_usage: Option<(u32, u32, u32)>,
+}
+
+impl SseParseState {
+    fn tool_mut(&mut self, index: u32) -> Option<&mut SseToolState> {
+        self.tools.iter_mut().find(|tool| tool.index == index)
+    }
+}
+
+/// Convert one SSE event block (the text before a blank-line terminator) into
+/// zero or more incremental events.
+///
+/// SysOM frames are cumulative: a single frame can carry new assistant text, a
+/// newly visible tool call, and that call's complete arguments at once. Emitting
+/// only the first of those loses the arguments whenever no later frame repeats
+/// the tool call, so every observation in the frame is returned in order:
+/// `TextDelta`, then `ToolCallStart` / `ToolCallDelta` per tool.
+///
+/// # Errors
+///
+/// Returns a bounded [`SysomStreamError`] when the payload is not valid JSON,
+/// carries wrong field types, or when a cumulative snapshot shrinks or is
+/// rewritten — silently concatenating a rewritten snapshot would corrupt the
+/// reassembled arguments.
+fn parse_sysom_sse_events(
+    block: &str,
+    state: &mut SseParseState,
+) -> Result<Vec<GenerateEvent>, SysomStreamError> {
+    if state.message_ended {
+        return Ok(Vec::new());
+    }
+
+    let mut event_type = String::new();
+    // SSE allows one event to spread its payload over several `data:` lines,
+    // joined by newlines. Keeping only the last line would truncate a
+    // pretty-printed or split payload to its final fragment.
+    let mut data_str = String::new();
+    let mut has_data = false;
+
+    for line in block.lines() {
+        if let Some(val) = line.strip_prefix("event:") {
+            event_type = val.trim().to_string();
+        } else if let Some(val) = line.strip_prefix("data:") {
+            if has_data {
+                data_str.push('\n');
+            }
+            // Per the SSE spec only a single leading space is separator.
+            data_str.push_str(val.strip_prefix(' ').unwrap_or(val));
+            has_data = true;
+        }
+        // id: line is ignored
+    }
+
+    if event_type == "Failed" {
+        state.message_ended = true;
+        // A provider failure is terminal: EOF bookkeeping must not follow it
+        // with a clean `MessageEnd` over a turn that failed.
+        state.stream_ended = true;
+        return Ok(vec![GenerateEvent::Error(format!(
+            "SysOM stream failed: {}",
+            failure_summary(&data_str)
+        ))]);
+    }
+
+    if event_type != "OK" || data_str.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let data: Value =
+        serde_json::from_str(&data_str).map_err(|_| SysomStreamError::MalformedJson)?;
+    // A non-object root has no place for `choices` or `usage`; treating it as
+    // "nothing in this frame" would let malformed provider output finish the
+    // turn with a clean `MessageEnd`.
+    if !data.is_object() {
+        return Err(SysomStreamError::RootWrongType);
+    }
+
+    let mut events = Vec::new();
+    // Absent or null containers mean "nothing in this frame", but a present
+    // container of the wrong shape is a schema violation: skipping it would
+    // drop the frame's text or tool calls while the turn still finishes
+    // cleanly — the silent-loss class this parser exists to refuse.
+    let message = match data.get("choices") {
+        None | Some(Value::Null) => None,
+        Some(Value::Array(choices)) => match choices.first() {
+            None | Some(Value::Null) => None,
+            Some(Value::Object(choice)) => match choice.get("message") {
+                None | Some(Value::Null) => None,
+                Some(message @ Value::Object(_)) => Some(message),
+                Some(_) => return Err(SysomStreamError::MessageWrongType),
+            },
+            Some(_) => return Err(SysomStreamError::ChoicesWrongType),
+        },
+        Some(_) => return Err(SysomStreamError::ChoicesWrongType),
+    };
+
+    if let Some(message) = message {
+        if let Some(delta) = take_content_delta(message, state)? {
+            events.push(GenerateEvent::TextDelta(delta));
+        }
+        match message.get("tool_use") {
+            None | Some(Value::Null) => {}
+            Some(Value::Array(tool_use)) => collect_tool_events(tool_use, state, &mut events)?,
+            Some(_) => return Err(SysomStreamError::ToolUseWrongType),
+        }
+    }
+
+    if let Some(usage) = data.get("usage").and_then(|u| u.as_object()) {
+        let prompt = usage
+            .get("prompt_tokens")
+            .or_else(|| usage.get("input_tokens"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let completion = usage
+            .get("completion_tokens")
+            .or_else(|| usage.get("output_tokens"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let total = usage
+            .get("total_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        state.latest_usage = Some((prompt, completion, total));
+    }
+
+    Ok(events)
+}
+
+/// Extract the newly appended assistant text from a cumulative frame.
+fn take_content_delta(
+    message: &Value,
+    state: &mut SseParseState,
+) -> Result<Option<String>, SysomStreamError> {
+    // A frame that omits `content` (or sends null/empty) carries no snapshot:
+    // treat it as "no change" instead of a rewrite, since providers may drop the
+    // field once they switch to streaming tool calls.
+    let content = match message.get("content") {
+        None | Some(Value::Null) => return Ok(None),
+        Some(Value::String(text)) if text.is_empty() => return Ok(None),
+        Some(Value::String(text)) => text.as_str(),
+        Some(_) => return Err(SysomStreamError::ContentWrongType),
+    };
+
+    let Some(delta) = content.strip_prefix(state.last_content.as_str()) else {
+        return Err(SysomStreamError::ContentRewritten {
+            previous_bytes: state.last_content.len(),
+            new_bytes: content.len(),
+        });
+    };
+    if delta.is_empty() {
+        return Ok(None);
+    }
+    let delta = delta.to_string();
+    state.last_content = content.to_string();
+    Ok(Some(delta))
+}
+
+/// Read an optional tool identity field.
+///
+/// Absent, null, and blank are all "not reported in this frame"; a non-string is a
+/// schema violation, because silently coercing it would invent an identity.
+fn identity_field(value: Option<&Value>, index: u32) -> Result<Option<&str>, SysomStreamError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(text)) if text.trim().is_empty() => Ok(None),
+        Some(Value::String(text)) => Ok(Some(text.as_str())),
+        Some(_) => Err(SysomStreamError::ToolIdentityWrongType { index }),
+    }
+}
+
+/// Append start/delta events for every tool call observed in a cumulative frame.
+fn collect_tool_events(
+    tool_use: &[Value],
+    state: &mut SseParseState,
+    events: &mut Vec<GenerateEvent>,
+) -> Result<(), SysomStreamError> {
+    for (position, entry) in tool_use.iter().enumerate() {
+        if !entry.is_object() {
+            return Err(SysomStreamError::ToolEntryWrongType { position });
+        }
+        // Provider index is authoritative; the array position is only a fallback
+        // for providers that omit it entirely. A present but unusable index is a
+        // hard error: falling back to the position would misroute deltas into a
+        // slot the provider never named. The upper bound matters because Core
+        // sizes its pending-call vector from this number.
+        let index = match entry.get("index") {
+            // An array longer than the protocol allows is itself out of range.
+            None if position > MAX_TOOL_CALL_INDEX as usize => {
+                return Err(SysomStreamError::ToolIndexInvalid { position })
+            }
+            None => position as u32,
+            Some(value) => match value.as_u64() {
+                Some(index) if index <= u64::from(MAX_TOOL_CALL_INDEX) => index as u32,
+                _ => return Err(SysomStreamError::ToolIndexInvalid { position }),
+            },
+        };
+
+        // As with `content`, a missing or empty arguments field is "no snapshot
+        // in this frame" rather than a snapshot that shrank to nothing.
+        let arguments = match entry.get("function").and_then(|f| f.get("arguments")) {
+            None | Some(Value::Null) => None,
+            Some(Value::String(args)) if args.is_empty() => None,
+            Some(Value::String(args)) => Some(args.as_str()),
+            Some(_) => return Err(SysomStreamError::ArgumentsWrongType { index }),
+        };
+
+        let id = identity_field(entry.get("id"), index)?;
+        let name = identity_field(entry.get("function").and_then(|f| f.get("name")), index)?;
+
+        match state.tool_mut(index) {
+            // Core keys tool results by id and dispatches by name, so a slot that
+            // starts without both would accumulate arguments it can never execute.
+            None => {
+                let (Some(id), Some(name)) = (id, name) else {
+                    return Err(SysomStreamError::ToolIdentityMissing { index });
+                };
+                state.tools.push(SseToolState {
+                    index,
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    ..SseToolState::default()
+                });
+                events.push(GenerateEvent::ToolCallStart {
+                    index,
+                    id: id.to_string(),
+                    name: name.to_string(),
+                });
+            }
+            // Later frames may omit the identity, but must not contradict it:
+            // subsequent arguments still land in the slot opened above.
+            Some(tool) => {
+                let id_conflict = id.is_some_and(|id| id != tool.id);
+                let name_conflict = name.is_some_and(|name| name != tool.name);
+                if id_conflict || name_conflict {
+                    return Err(SysomStreamError::ToolIdentityChanged { index });
+                }
+            }
+        }
+
+        let Some(arguments) = arguments else {
+            continue;
+        };
+        // `tool_mut` was just ensured to exist for this index.
+        let Some(tool) = state.tool_mut(index) else {
+            continue;
+        };
+        let Some(delta) = arguments.strip_prefix(tool.arguments.as_str()) else {
+            return Err(SysomStreamError::ArgumentsRewritten {
+                index,
+                previous_bytes: tool.arguments.len(),
+                new_bytes: arguments.len(),
+            });
+        };
+        if delta.is_empty() {
+            continue;
+        }
+        let delta = delta.to_string();
+        tool.arguments = arguments.to_string();
+        events.push(GenerateEvent::ToolCallDelta {
+            index,
+            arguments_delta: delta,
+        });
+    }
+    Ok(())
+}
+
+/// Terminal events for a stream that reached EOF without an explicit failure:
+/// close every open tool call, then report usage, then end the message.
+fn sysom_eof_events(state: &mut SseParseState) -> Vec<GenerateEvent> {
+    let mut events = Vec::new();
+    for tool in &mut state.tools {
+        if !tool.ended {
+            tool.ended = true;
+            events.push(GenerateEvent::ToolCallEnd { index: tool.index });
+        }
+    }
+    if let Some((prompt_tokens, completion_tokens, total_tokens)) = state.latest_usage.take() {
+        events.push(GenerateEvent::Usage {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+        });
+    }
+    events.push(GenerateEvent::MessageEnd);
+    state.stream_ended = true;
+    events
+}
+
+/// Describe a provider failure payload without echoing any of it.
+///
+/// Even a short prefix of the raw `data:` field can hold credentials, prompt text,
+/// or the question the user was about to be asked, so the summary carries only an
+/// allowlisted error code, the payload size, and a truncated digest for support.
+fn failure_summary(data: &str) -> String {
+    let trimmed = data.trim();
+    let bytes = trimmed.len();
+    match forwardable_error_code(trimmed) {
+        Some(code) => format!("provider error code {code} ({bytes} byte payload)"),
+        None => format!(
+            "no recognizable provider error code ({bytes} byte payload, sha256:{})",
+            digest_prefix(trimmed.as_bytes())
+        ),
+    }
+}
+
+/// Provider error codes that may be reported verbatim.
+///
+/// This is an exact allowlist rather than a character filter, because a filter is
+/// not a privacy boundary: `sk-live-abc123` and `10.0.0.7` are also short and
+/// opaque, so a syntax rule would forward secrets that happen to arrive in a
+/// `code` field. Extend this list only with codes documented by the provider.
+const FORWARDABLE_ERROR_CODES: &[&str] = &[
+    "AccessDenied",
+    "Forbidden",
+    "InternalError",
+    "InvalidAccessKeyId",
+    "InvalidApiKey",
+    "InvalidParameter",
+    "MissingParameter",
+    "ModelNotFound",
+    "QuotaExhausted",
+    "RequestTimeout",
+    "ServiceUnavailable",
+    "Throttling",
+    "Throttling.Api",
+    "Throttling.User",
+    "Unauthorized",
+    "context_length_exceeded",
+    "insufficient_quota",
+    "invalid_request_error",
+    "rate_limit_exceeded",
+    "server_error",
+];
+
+/// Match a failure payload's error code against [`FORWARDABLE_ERROR_CODES`].
+///
+/// Returns the matched `&'static str`, never the payload's own bytes, so an
+/// unknown or crafted code cannot reach the caller even in part.
+fn forwardable_error_code(data: &str) -> Option<&'static str> {
+    let value: Value = serde_json::from_str(data).ok()?;
+    let candidate = ["code", "Code", "error_code", "errorCode"]
+        .iter()
+        .find_map(|key| value.get(*key).and_then(|v| v.as_str()))
+        .or_else(|| {
+            value
+                .get("error")
+                .and_then(|error| error.get("code"))
+                .and_then(|v| v.as_str())
+        })?;
+    FORWARDABLE_ERROR_CODES
+        .iter()
+        .find(|known| known.eq_ignore_ascii_case(candidate))
+        .copied()
+}
+
+/// First 16 hex chars of the payload digest: enough to correlate two reports of
+/// the same failure, not reversible into the payload.
+fn digest_prefix(bytes: &[u8]) -> String {
+    hex_sha256(bytes).chars().take(16).collect()
+}
+
+/// Drive the cumulative SSE state machine over a byte stream.
+///
+/// Events parsed from one frame are queued and drained before the next frame is
+/// read, so a frame that produces several events never loses any of them.
+pub(super) fn sysom_event_stream(
+    bytes: SysomByteStream,
+    cancelled: Arc<AtomicBool>,
+) -> GenerateStream {
+    let initial = SysomStreamState {
+        bytes,
+        buf: Vec::new(),
+        scanned: 0,
+        cancelled,
+        parse: SseParseState::default(),
+        pending: VecDeque::new(),
+    };
+
+    Box::pin(futures::stream::unfold(initial, |mut state| async move {
+        loop {
+            // Cancellation is terminal: report it once, drop anything still
+            // queued, and end the stream instead of repeating `Cancelled` on
+            // every subsequent poll.
+            if state.cancelled.load(Ordering::SeqCst) && !state.parse.stream_ended {
+                state.parse.stream_ended = true;
+                state.pending.clear();
+                return Some((GenerateEvent::Cancelled, state));
+            }
+            // Pending events queued before the stream ended (EOF terminal
+            // events included) drain exactly once before `None`.
+            if let Some(event) = state.pending.pop_front() {
+                return Some((event, state));
+            }
+            if state.parse.stream_ended {
+                return None;
+            }
+
+            if let Some((pos, delimiter)) = state.take_block_end() {
+                // A terminator does not lift the ceiling: decoding an oversized
+                // block would still copy an arbitrarily large payload into the
+                // String, parse state, and event pipeline.
+                if pos > MAX_SSE_BLOCK_BYTES {
+                    state.parse.stream_ended = true;
+                    let error = SysomStreamError::BlockTooLarge {
+                        buffered_bytes: pos,
+                        limit: MAX_SSE_BLOCK_BYTES,
+                    };
+                    return Some((GenerateEvent::Error(error.to_string()), state));
+                }
+                let event_block = match decode_block(&state.buf[..pos]) {
+                    Ok(text) => text.to_string(),
+                    Err(e) => {
+                        state.parse.stream_ended = true;
+                        return Some((GenerateEvent::Error(e.to_string()), state));
+                    }
+                };
+                state.buf.drain(..pos + delimiter);
+
+                if event_block.trim().is_empty() {
+                    continue;
+                }
+                match parse_sysom_sse_events(&event_block, &mut state.parse) {
+                    Ok(events) => state.pending.extend(events),
+                    Err(e) => {
+                        state.parse.stream_ended = true;
+                        return Some((GenerateEvent::Error(e.to_string()), state));
+                    }
+                }
+                continue;
+            }
+
+            // Reached only when the whole buffer holds no terminator, so every
+            // buffered byte belongs to one unfinished block. A peer that never
+            // sends a blank line would otherwise grow this buffer without bound.
+            if state.buf.len() > MAX_SSE_BLOCK_BYTES {
+                state.parse.stream_ended = true;
+                let error = SysomStreamError::BlockTooLarge {
+                    buffered_bytes: state.buf.len(),
+                    limit: MAX_SSE_BLOCK_BYTES,
+                };
+                return Some((GenerateEvent::Error(error.to_string()), state));
+            }
+
+            match state.bytes.next().await {
+                // Buffered as bytes, not text: HTTP chunk boundaries fall wherever
+                // the network puts them, and decoding a chunk that ends mid
+                // character would substitute U+FFFD inside otherwise valid JSON —
+                // silently corrupting non-ASCII question text, paths, or arguments.
+                Some(Ok(chunk)) => {
+                    state.buf.extend_from_slice(&chunk);
+                }
+                Some(Err(e)) => {
+                    // Transport failures are terminal too: nothing after a
+                    // broken connection can be trusted to extend the turn.
+                    state.parse.stream_ended = true;
+                    return Some((GenerateEvent::Error(format!("stream error: {e}")), state));
+                }
+                None => {
+                    // Flush a trailing frame that arrived without its blank line.
+                    let trailing = match decode_block(&state.buf) {
+                        Ok(text) => text.to_string(),
+                        Err(e) => {
+                            state.parse.stream_ended = true;
+                            return Some((GenerateEvent::Error(e.to_string()), state));
+                        }
+                    };
+                    state.buf.clear();
+                    if !trailing.trim().is_empty() {
+                        let event_block = trailing.trim().to_string();
+                        match parse_sysom_sse_events(&event_block, &mut state.parse) {
+                            Ok(events) => state.pending.extend(events),
+                            Err(e) => {
+                                state.parse.stream_ended = true;
+                                return Some((GenerateEvent::Error(e.to_string()), state));
+                            }
+                        }
+                    }
+                    // A trailing `Failed` frame already ended the stream: EOF
+                    // bookkeeping must not queue a successful `MessageEnd`
+                    // right after its error.
+                    if !state.parse.stream_ended {
+                        let terminal = sysom_eof_events(&mut state.parse);
+                        state.pending.extend(terminal);
+                    }
+                    continue;
+                }
+            }
+        }
+    }))
+}
+
+/// Largest single SSE block accepted, with or without its terminator.
+///
+/// Frames are cumulative snapshots, so a long answer legitimately produces large
+/// frames; the limit only needs to sit far above that to stop a peer from
+/// growing the buffer — or a decoded block — without bound.
+const MAX_SSE_BLOCK_BYTES: usize = 4 * 1024 * 1024;
+
+/// Decode one complete SSE block.
+///
+/// Decoding happens per block rather than per chunk, so a multi-byte character
+/// split across two HTTP chunks is reassembled before it is interpreted.
+///
+/// # Errors
+///
+/// Returns [`SysomStreamError::InvalidUtf8`] when the reassembled block is still
+/// not valid UTF-8. Lossy decoding is not an option: a replacement character
+/// inside a JSON string leaves the frame syntactically valid, so corrupted
+/// question text, paths, or tool arguments would reach execution looking clean.
+fn decode_block(bytes: &[u8]) -> Result<&str, SysomStreamError> {
+    std::str::from_utf8(bytes).map_err(|error| SysomStreamError::InvalidUtf8 {
+        byte_offset: error.valid_up_to(),
+        block_bytes: bytes.len(),
+    })
+}
+
+struct SysomStreamState {
+    bytes: SysomByteStream,
+    /// Raw, still-undecoded bytes: see [`decode_block`].
+    buf: Vec<u8>,
+    /// How much of `buf` is already known to hold no block terminator.
+    scanned: usize,
+    cancelled: Arc<AtomicBool>,
+    parse: SseParseState,
+    /// Events parsed from the current frame that still need to be yielded.
+    pending: VecDeque<GenerateEvent>,
+}
+
+impl SysomStreamState {
+    /// Offset and byte length of the delimiter terminating the first buffered
+    /// block, if any.
+    ///
+    /// SSE lines end in LF or CRLF, so a block terminator is any two
+    /// consecutive line endings: `\n\n`, `\n\r\n`, `\r\n\n`, or `\r\n\r\n`.
+    ///
+    /// Resumes from the last scan position so each byte is examined a bounded
+    /// number of times no matter how the provider chunks the stream; without
+    /// that, a long unterminated block would be rescanned from the start per
+    /// chunk.
+    fn take_block_end(&mut self) -> Option<(usize, usize)> {
+        for position in self.scanned..self.buf.len() {
+            let Some(first) = line_end_at(&self.buf, position) else {
+                continue;
+            };
+            let Some(second) = line_end_at(&self.buf, position + first) else {
+                continue;
+            };
+            // The caller consumes through the terminator, so the next scan
+            // starts at the beginning of what remains.
+            self.scanned = 0;
+            return Some((position, first + second));
+        }
+        // Keep the final bytes in view: the longest delimiter is four bytes,
+        // so up to three of them may already be buffered while the rest is
+        // still in flight in the next chunk.
+        self.scanned = self.buf.len().saturating_sub(3);
+        None
+    }
+}
+
+/// Byte length of the LF or CRLF line ending starting at `position`, if any.
+///
+/// A trailing `\r` alone is not a line ending: the `\n` completing it may
+/// still be in flight, so it stays buffered until the next chunk decides.
+fn line_end_at(buf: &[u8], position: usize) -> Option<usize> {
+    match buf.get(position)? {
+        b'\n' => Some(1),
+        b'\r' if buf.get(position + 1) == Some(&b'\n') => Some(2),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "stream/tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/stream/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/stream/tests.rs
@@ -1,0 +1,1289 @@
+//! Cumulative SSE reassembly: event ordering, tool identity, bounded failures.
+
+use super::*;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+const ASK_ARGS: &str = r#"{"question":"How should local changes be handled?"}"#;
+
+/// Render events as compact strings so ordering assertions read as one list.
+fn summarize(events: &[GenerateEvent]) -> Vec<String> {
+    events
+        .iter()
+        .map(|event| match event {
+            GenerateEvent::TextDelta(text) => format!("text:{text}"),
+            GenerateEvent::ThinkingDelta(text) => format!("thinking:{text}"),
+            GenerateEvent::ToolCallStart { index, id, name } => {
+                format!("start:{index}:{id}:{name}")
+            }
+            GenerateEvent::ToolCallDelta {
+                index,
+                arguments_delta,
+            } => format!("delta:{index}:{arguments_delta}"),
+            GenerateEvent::ToolCallEnd { index } => format!("end:{index}"),
+            GenerateEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+                total_tokens,
+            } => format!("usage:{prompt_tokens}:{completion_tokens}:{total_tokens}"),
+            GenerateEvent::MessageEnd => "message_end".to_string(),
+            GenerateEvent::Cancelled => "cancelled".to_string(),
+            GenerateEvent::Error(message) => format!("error:{message}"),
+        })
+        .collect()
+}
+
+fn frame(data: Value) -> String {
+    format!("event: OK\ndata: {data}\n\n")
+}
+
+fn tool_entry(index: u32, id: &str, name: &str, arguments: &str) -> Value {
+    serde_json::json!({
+        "index": index,
+        "id": id,
+        "type": "function",
+        "function": { "name": name, "arguments": arguments },
+    })
+}
+
+fn message_frame(content: Option<&str>, tool_use: Vec<Value>) -> Value {
+    let mut message = serde_json::Map::new();
+    if let Some(content) = content {
+        message.insert("content".to_string(), serde_json::json!(content));
+    }
+    if !tool_use.is_empty() {
+        message.insert("tool_use".to_string(), serde_json::json!(tool_use));
+    }
+    serde_json::json!({ "choices": [{ "message": Value::Object(message) }] })
+}
+
+fn parse(block: &str, state: &mut SseParseState) -> Vec<String> {
+    summarize(&parse_sysom_sse_events(block, state).expect("frame parses"))
+}
+
+fn parse_err(block: &str, state: &mut SseParseState) -> SysomStreamError {
+    parse_sysom_sse_events(block, state).expect_err("frame must be rejected")
+}
+
+async fn collect_stream(frames: Vec<String>) -> Vec<String> {
+    collect_byte_chunks(frames.into_iter().map(String::into_bytes).collect()).await
+}
+
+/// Feed the state machine raw chunks, so tests can place a chunk boundary
+/// anywhere — including inside a multi-byte character.
+async fn collect_byte_chunks(chunks: Vec<Vec<u8>>) -> Vec<String> {
+    collect_stream_items(chunks.into_iter().map(Ok).collect(), false).await
+}
+
+/// Feed raw stream items — including transport errors — and collect to EOF,
+/// optionally with the cancellation flag already raised.
+async fn collect_stream_items(items: Vec<Result<Vec<u8>, String>>, cancelled: bool) -> Vec<String> {
+    let bytes: SysomByteStream = Box::pin(futures::stream::iter(items));
+    let stream = sysom_event_stream(bytes, Arc::new(AtomicBool::new(cancelled)));
+    summarize(&stream.collect::<Vec<_>>().await)
+}
+
+/// The incident shape: the first frame that reveals the tool call already holds
+/// complete arguments and no later frame repeats it.
+#[tokio::test]
+async fn first_tool_frame_with_complete_arguments_reaches_core() {
+    let frames = vec![
+        frame(message_frame(Some("Let me check with you first."), vec![])),
+        frame(message_frame(
+            Some("Let me check with you first."),
+            vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+        )),
+    ];
+
+    assert_eq!(
+        collect_stream(frames).await,
+        vec![
+            "text:Let me check with you first.".to_string(),
+            "start:0:call-1:ask_user_question".to_string(),
+            format!("delta:0:{ASK_ARGS}"),
+            "end:0".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+}
+
+/// HTTP chunk boundaries land wherever the network puts them. Decoding per chunk
+/// would insert U+FFFD inside a character that spans two chunks, corrupting
+/// Chinese question text or paths while leaving the JSON syntactically valid.
+#[tokio::test]
+async fn multibyte_characters_survive_every_chunk_boundary() {
+    let question = "是否保留本地改动？";
+    let arguments = format!(r#"{{"question":"{question}","options":[{{"label":"保留"}}]}}"#);
+    let block = frame(message_frame(
+        Some("正在检查本地改动……"),
+        vec![tool_entry(0, "call-1", "ask_user_question", &arguments)],
+    ));
+
+    let whole = collect_byte_chunks(vec![block.clone().into_bytes()]).await;
+    assert!(
+        whole.iter().any(|event| event.contains(question)),
+        "baseline must carry the question text: {whole:?}"
+    );
+
+    let raw = block.as_bytes();
+    for split in 1..raw.len() {
+        let events = collect_byte_chunks(vec![raw[..split].to_vec(), raw[split..].to_vec()]).await;
+        assert_eq!(
+            events, whole,
+            "chunk split at byte {split} changed the stream"
+        );
+        assert!(
+            !events.iter().any(|event| event.contains('\u{fffd}')),
+            "chunk split at byte {split} corrupted a character: {events:?}"
+        );
+    }
+}
+
+/// Reassembly cannot repair bytes the provider never encoded correctly. Replacing
+/// them with U+FFFD would keep the JSON valid, so corrupted text or arguments
+/// would reach execution looking clean — the frame must be refused instead.
+#[tokio::test]
+async fn invalid_utf8_is_refused_rather_than_repaired() {
+    // The bad byte sits inside a JSON string, so the frame stays parseable.
+    let cases: &[(&str, &[u8], &[u8])] = &[
+        (
+            "content",
+            br#"event: OK
+data: {"choices":[{"message":{"content":"local diff "#,
+            br#""}}]}
+
+"#,
+        ),
+        (
+            "arguments",
+            br#"event: OK
+data: {"choices":[{"message":{"tool_use":[{"index":0,"id":"call-1","function":{"name":"ask_user_question","arguments":"{\"question\":\"keep "#,
+            br#"?\"}"}}]}}]}
+
+"#,
+        ),
+    ];
+
+    for (field, head, tail) in cases {
+        let mut raw = head.to_vec();
+        // A lone continuation byte: invalid however the stream is chunked.
+        raw.push(0xff);
+        raw.extend_from_slice(tail);
+        let block_bytes = raw.len() - 2;
+
+        for chunks in [
+            vec![raw.clone()],
+            vec![raw[..head.len()].to_vec(), raw[head.len()..].to_vec()],
+        ] {
+            let events = collect_byte_chunks(chunks).await;
+            assert_eq!(
+                events,
+                vec![format!(
+                    "error:{}",
+                    SysomStreamError::InvalidUtf8 {
+                        byte_offset: head.len(),
+                        block_bytes,
+                    }
+                )],
+                "invalid {field} bytes must fail the stream"
+            );
+            assert!(
+                !events.iter().any(|event| event.contains('\u{fffd}')),
+                "invalid {field} bytes must not be repaired: {events:?}"
+            );
+        }
+    }
+}
+
+/// Nothing forces the peer to ever send `\n\n`, so the buffer needs its own
+/// ceiling; a single huge chunk and a long drip of small ones must both hit it.
+#[tokio::test]
+async fn unterminated_blocks_are_bounded() {
+    let oversized = vec![b'x'; MAX_SSE_BLOCK_BYTES + 1];
+    let events = collect_byte_chunks(vec![oversized]).await;
+    assert_eq!(
+        events,
+        vec![format!(
+            "error:{}",
+            SysomStreamError::BlockTooLarge {
+                buffered_bytes: MAX_SSE_BLOCK_BYTES + 1,
+                limit: MAX_SSE_BLOCK_BYTES,
+            }
+        )]
+    );
+
+    let chunk_bytes = 64 * 1024;
+    let drip = vec![vec![b'x'; chunk_bytes]; MAX_SSE_BLOCK_BYTES / chunk_bytes + 2];
+    let events = collect_byte_chunks(drip).await;
+    match events.as_slice() {
+        [only] => {
+            assert!(only.starts_with("error:"), "{only}");
+            assert!(only.contains("exceeds the"), "{only}");
+        }
+        other => panic!("expected a single bounded error, got {other:?}"),
+    }
+
+    // A block just under the limit still parses: the ceiling is not a size cap on
+    // legitimately large cumulative frames.
+    let padding = "y".repeat(MAX_SSE_BLOCK_BYTES - 4096);
+    let large = frame(message_frame(Some(&padding), vec![]));
+    assert!(large.len() < MAX_SSE_BLOCK_BYTES, "fixture must fit");
+    assert_eq!(
+        collect_byte_chunks(vec![large.into_bytes()]).await,
+        vec![format!("text:{padding}"), "message_end".to_string()]
+    );
+}
+
+/// A terminator must not lift the ceiling: an oversized block followed by
+/// `\n\n` in the same chunk would otherwise be decoded and copied whole.
+#[tokio::test]
+async fn oversized_terminated_block_is_rejected_before_decoding() {
+    let mut chunk = vec![b'x'; MAX_SSE_BLOCK_BYTES + 1];
+    chunk.extend_from_slice(b"\n\n");
+    assert_eq!(
+        collect_byte_chunks(vec![chunk]).await,
+        vec![format!(
+            "error:{}",
+            SysomStreamError::BlockTooLarge {
+                buffered_bytes: MAX_SSE_BLOCK_BYTES + 1,
+                limit: MAX_SSE_BLOCK_BYTES,
+            }
+        )]
+    );
+}
+
+/// The per-block ceiling must not reject a chunk that carries several small
+/// blocks whose combined size exceeds the limit.
+#[tokio::test]
+async fn multiple_blocks_in_one_chunk_all_parse() {
+    let chunk = format!(
+        "{}{}",
+        frame(message_frame(Some("hi"), vec![])),
+        frame(message_frame(
+            Some("hi"),
+            vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+        ))
+    );
+
+    assert_eq!(
+        collect_byte_chunks(vec![chunk.into_bytes()]).await,
+        vec![
+            "text:hi".to_string(),
+            "start:0:call-1:ask_user_question".to_string(),
+            format!("delta:0:{ASK_ARGS}"),
+            "end:0".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+}
+
+/// SSE permits CRLF line endings; a CRLF stream must not buffer until EOF and
+/// collapse its events, and the four-byte delimiter must survive any chunk
+/// boundary — including every split inside the delimiter itself.
+#[tokio::test]
+async fn crlf_delimited_events_parse_at_every_chunk_boundary() {
+    let raw = format!(
+        "{}{}",
+        frame(message_frame(Some("Checking."), vec![])),
+        frame(message_frame(
+            Some("Checking."),
+            vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+        ))
+    )
+    .replace('\n', "\r\n")
+    .into_bytes();
+    let expected = vec![
+        "text:Checking.".to_string(),
+        "start:0:call-1:ask_user_question".to_string(),
+        format!("delta:0:{ASK_ARGS}"),
+        "end:0".to_string(),
+        "message_end".to_string(),
+    ];
+
+    assert_eq!(collect_byte_chunks(vec![raw.clone()]).await, expected);
+    for split in 1..raw.len() {
+        assert_eq!(
+            collect_byte_chunks(vec![raw[..split].to_vec(), raw[split..].to_vec()]).await,
+            expected,
+            "chunk split at byte {split} changed the CRLF stream"
+        );
+    }
+}
+
+#[test]
+fn single_frame_keeps_text_start_and_delta_in_order() {
+    let mut state = SseParseState::default();
+    let block = frame(message_frame(
+        Some("Checking."),
+        vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+    ));
+
+    assert_eq!(
+        parse(&block, &mut state),
+        vec![
+            "text:Checking.".to_string(),
+            "start:0:call-1:ask_user_question".to_string(),
+            format!("delta:0:{ASK_ARGS}"),
+        ]
+    );
+}
+
+#[test]
+fn growing_arguments_emit_only_the_new_suffix() {
+    let mut state = SseParseState::default();
+    let first = frame(message_frame(
+        None,
+        vec![tool_entry(
+            0,
+            "call-1",
+            "ask_user_question",
+            r#"{"question":"#,
+        )],
+    ));
+    let second = frame(message_frame(
+        None,
+        vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+    ));
+
+    assert_eq!(
+        parse(&first, &mut state),
+        vec![
+            "start:0:call-1:ask_user_question".to_string(),
+            r#"delta:0:{"question":"#.to_string(),
+        ]
+    );
+    assert_eq!(
+        parse(&second, &mut state),
+        vec![r#"delta:0:"How should local changes be handled?"}"#.to_string()]
+    );
+}
+
+#[test]
+fn repeated_cumulative_frame_emits_nothing() {
+    let mut state = SseParseState::default();
+    let block = frame(message_frame(
+        Some("Checking."),
+        vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+    ));
+
+    assert_eq!(parse(&block, &mut state).len(), 3);
+    assert!(parse(&block, &mut state).is_empty());
+    assert!(parse(&block, &mut state).is_empty());
+}
+
+#[test]
+fn multiple_new_tool_calls_in_one_frame_are_all_preserved() {
+    let mut state = SseParseState::default();
+    let block = frame(message_frame(
+        None,
+        vec![
+            tool_entry(0, "call-a", "read_file", r#"{"path":"a"}"#),
+            tool_entry(1, "call-b", "ask_user_question", ASK_ARGS),
+        ],
+    ));
+
+    assert_eq!(
+        parse(&block, &mut state),
+        vec![
+            "start:0:call-a:read_file".to_string(),
+            r#"delta:0:{"path":"a"}"#.to_string(),
+            "start:1:call-b:ask_user_question".to_string(),
+            format!("delta:1:{ASK_ARGS}"),
+        ]
+    );
+}
+
+/// Provider index is authoritative: a tool that appears at array position 0 but
+/// reports index 3 must keep routing its deltas to index 3.
+#[test]
+fn provider_index_is_not_confused_with_array_position() {
+    let mut state = SseParseState::default();
+    let first = frame(message_frame(
+        None,
+        vec![tool_entry(3, "call-x", "ask_user_question", r#"{"q"#)],
+    ));
+    let second = frame(message_frame(
+        None,
+        vec![tool_entry(
+            3,
+            "call-x",
+            "ask_user_question",
+            r#"{"question":"hi"}"#,
+        )],
+    ));
+
+    assert_eq!(
+        parse(&first, &mut state),
+        vec![
+            "start:3:call-x:ask_user_question".to_string(),
+            r#"delta:3:{"q"#.to_string(),
+        ]
+    );
+    assert_eq!(
+        parse(&second, &mut state),
+        vec![r#"delta:3:uestion":"hi"}"#.to_string()]
+    );
+}
+
+/// Providers that omit `index` fall back to the array position, and the fallback
+/// must stay stable across frames.
+#[test]
+fn missing_index_falls_back_to_array_position() {
+    let mut state = SseParseState::default();
+    let entry = |arguments: &str| {
+        serde_json::json!({
+            "id": "call-1",
+            "function": { "name": "ask_user_question", "arguments": arguments },
+        })
+    };
+    let first = frame(message_frame(None, vec![entry(r#"{"que"#)]));
+    let second = frame(message_frame(None, vec![entry(r#"{"question":"hi"}"#)]));
+
+    assert_eq!(
+        parse(&first, &mut state),
+        vec![
+            "start:0:call-1:ask_user_question".to_string(),
+            r#"delta:0:{"que"#.to_string(),
+        ]
+    );
+    assert_eq!(
+        parse(&second, &mut state),
+        vec![r#"delta:0:stion":"hi"}"#.to_string()]
+    );
+}
+
+#[test]
+fn shrinking_or_rewritten_arguments_fail_loudly() {
+    let mut state = SseParseState::default();
+    let full = frame(message_frame(
+        None,
+        vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+    ));
+    assert_eq!(parse(&full, &mut state).len(), 2);
+
+    let shrunk = frame(message_frame(
+        None,
+        vec![tool_entry(
+            0,
+            "call-1",
+            "ask_user_question",
+            r#"{"question":"#,
+        )],
+    ));
+    assert_eq!(
+        parse_err(&shrunk, &mut state),
+        SysomStreamError::ArgumentsRewritten {
+            index: 0,
+            previous_bytes: ASK_ARGS.len(),
+            new_bytes: r#"{"question":"#.len(),
+        }
+    );
+
+    let rewritten = frame(message_frame(
+        None,
+        vec![tool_entry(
+            0,
+            "call-1",
+            "ask_user_question",
+            r#"{"other":"x"}"#,
+        )],
+    ));
+    assert!(matches!(
+        parse_err(&rewritten, &mut state),
+        SysomStreamError::ArgumentsRewritten { index: 0, .. }
+    ));
+}
+
+#[test]
+fn rewritten_content_fails_loudly() {
+    let mut state = SseParseState::default();
+    assert_eq!(
+        parse(
+            &frame(message_frame(Some("hello world"), vec![])),
+            &mut state
+        ),
+        vec!["text:hello world".to_string()]
+    );
+    assert_eq!(
+        parse_err(&frame(message_frame(Some("hello"), vec![])), &mut state),
+        SysomStreamError::ContentRewritten {
+            previous_bytes: 11,
+            new_bytes: 5,
+        }
+    );
+}
+
+#[test]
+fn malformed_json_and_wrong_types_fail_loudly() {
+    let mut state = SseParseState::default();
+    assert_eq!(
+        parse_err("event: OK\ndata: {\"choices\":", &mut state),
+        SysomStreamError::MalformedJson
+    );
+
+    let mut state = SseParseState::default();
+    let object_arguments = frame(serde_json::json!({
+        "choices": [{ "message": { "tool_use": [{
+            "index": 0,
+            "id": "call-1",
+            "function": { "name": "ask_user_question", "arguments": { "question": "hi" } },
+        }] } }]
+    }));
+    assert_eq!(
+        parse_err(&object_arguments, &mut state),
+        SysomStreamError::ArgumentsWrongType { index: 0 }
+    );
+
+    let mut state = SseParseState::default();
+    let numeric_content = frame(serde_json::json!({
+        "choices": [{ "message": { "content": 7 } }]
+    }));
+    assert_eq!(
+        parse_err(&numeric_content, &mut state),
+        SysomStreamError::ContentWrongType
+    );
+
+    let mut state = SseParseState::default();
+    let scalar_entry = frame(serde_json::json!({
+        "choices": [{ "message": { "tool_use": ["ask_user_question"] } }]
+    }));
+    assert_eq!(
+        parse_err(&scalar_entry, &mut state),
+        SysomStreamError::ToolEntryWrongType { position: 0 }
+    );
+}
+
+/// A present container of the wrong shape must fail instead of degrading to
+/// "field absent": `tool_use: {…}` would otherwise drop the whole tool call
+/// while the turn still finishes with an empty assistant response.
+#[test]
+fn wrong_type_containers_fail_loudly_and_null_containers_do_not() {
+    let cases = [
+        (
+            frame(serde_json::json!({ "choices": {} })),
+            SysomStreamError::ChoicesWrongType,
+        ),
+        (
+            frame(serde_json::json!({ "choices": "done" })),
+            SysomStreamError::ChoicesWrongType,
+        ),
+        (
+            frame(serde_json::json!({ "choices": ["done"] })),
+            SysomStreamError::ChoicesWrongType,
+        ),
+        (
+            frame(serde_json::json!({ "choices": [{ "message": 7 }] })),
+            SysomStreamError::MessageWrongType,
+        ),
+        (
+            frame(serde_json::json!({ "choices": [{ "message": [] }] })),
+            SysomStreamError::MessageWrongType,
+        ),
+        (
+            frame(serde_json::json!({
+                "choices": [{ "message": { "tool_use": { "id": "call-1" } } }]
+            })),
+            SysomStreamError::ToolUseWrongType,
+        ),
+        (
+            frame(serde_json::json!({
+                "choices": [{ "message": { "tool_use": "call-1" } }]
+            })),
+            SysomStreamError::ToolUseWrongType,
+        ),
+    ];
+    for (block, expected) in cases {
+        let mut state = SseParseState::default();
+        assert_eq!(parse_err(&block, &mut state), expected, "block: {block}");
+    }
+
+    // Absent, null, and empty containers stay "nothing in this frame".
+    for data in [
+        serde_json::json!({}),
+        serde_json::json!({ "choices": null }),
+        serde_json::json!({ "choices": [] }),
+        serde_json::json!({ "choices": [null] }),
+        serde_json::json!({ "choices": [{ "message": null }] }),
+        serde_json::json!({ "choices": [{ "message": { "tool_use": null } }] }),
+    ] {
+        let mut state = SseParseState::default();
+        assert!(
+            parse(&frame(data.clone()), &mut state).is_empty(),
+            "tolerated container shape must emit nothing: {data}"
+        );
+    }
+}
+
+/// End to end, a wrong-type container must terminate the stream with a bounded
+/// error — never a clean `MessageEnd` over silently dropped content.
+#[tokio::test]
+async fn wrong_type_containers_never_end_the_message_successfully() {
+    let cases = [
+        (
+            frame(serde_json::json!({ "choices": {} })),
+            SysomStreamError::ChoicesWrongType,
+        ),
+        (
+            frame(serde_json::json!({ "choices": [{ "message": 7 }] })),
+            SysomStreamError::MessageWrongType,
+        ),
+        (
+            frame(serde_json::json!({
+                "choices": [{ "message": {
+                    "tool_use": { "id": "call-1", "function": { "name": "shell" } },
+                } }]
+            })),
+            SysomStreamError::ToolUseWrongType,
+        ),
+    ];
+    for (block, expected) in cases {
+        let events = collect_stream(vec![
+            frame(message_frame(Some("hi"), vec![])),
+            block.clone(),
+            frame(message_frame(Some("hi there"), vec![])),
+        ])
+        .await;
+        assert_eq!(
+            events,
+            vec!["text:hi".to_string(), format!("error:{expected}")],
+            "block: {block}"
+        );
+        assert!(
+            !events.iter().any(|event| event == "message_end"),
+            "dropped content must not end as success: {events:?}"
+        );
+    }
+}
+
+/// A frame root that is not a JSON object has no place for `choices` or
+/// `usage`; treating it as empty would let malformed provider output finish
+/// the turn with a clean `MessageEnd`.
+#[tokio::test]
+async fn non_object_frame_roots_never_end_the_message_successfully() {
+    for payload in ["null", "[]", "\"done\"", "7", "true"] {
+        let events = collect_stream(vec![
+            frame(message_frame(Some("hi"), vec![])),
+            format!("event: OK\ndata: {payload}\n\n"),
+            frame(message_frame(Some("hi there"), vec![])),
+        ])
+        .await;
+        assert_eq!(
+            events,
+            vec![
+                "text:hi".to_string(),
+                format!("error:{}", SysomStreamError::RootWrongType),
+            ],
+            "payload {payload} must fail the stream without message_end"
+        );
+    }
+}
+
+/// Cancellation is terminal: exactly one `Cancelled`, then the stream ends
+/// instead of repeating it on every poll or resuming queued events.
+#[tokio::test]
+async fn cancellation_yields_one_cancelled_event_then_ends() {
+    let items = vec![Ok(frame(message_frame(Some("hi"), vec![])).into_bytes())];
+    assert_eq!(
+        collect_stream_items(items, true).await,
+        vec!["cancelled".to_string()]
+    );
+}
+
+/// A transport failure is terminal: no later chunk can be trusted to extend
+/// the turn, and EOF bookkeeping must not follow it with `MessageEnd`.
+#[tokio::test]
+async fn transport_error_ends_the_stream_without_message_end() {
+    let items = vec![
+        Ok(frame(message_frame(Some("hi"), vec![])).into_bytes()),
+        Err("connection reset".to_string()),
+        Ok(frame(message_frame(Some("hi there"), vec![])).into_bytes()),
+    ];
+    assert_eq!(
+        collect_stream_items(items, false).await,
+        vec![
+            "text:hi".to_string(),
+            "error:stream error: connection reset".to_string(),
+        ]
+    );
+}
+
+/// A provider `Failed` frame is terminal end to end: later frames are not
+/// parsed and EOF must not report a successful `MessageEnd` for a failed turn.
+#[tokio::test]
+async fn provider_failure_ends_the_stream_without_message_end() {
+    let events = collect_stream(vec![
+        frame(message_frame(Some("hi"), vec![])),
+        "event: Failed\ndata: {\"code\":\"Throttling\"}\n\n".to_string(),
+        frame(message_frame(Some("hi there"), vec![])),
+    ])
+    .await;
+    assert_eq!(
+        events,
+        vec![
+            "text:hi".to_string(),
+            "error:SysOM stream failed: provider error code Throttling (21 byte payload)"
+                .to_string(),
+        ]
+    );
+}
+
+/// A `Failed` frame flushed at EOF without its blank-line terminator is just
+/// as terminal: the EOF bookkeeping that flushed it must not queue a
+/// successful `MessageEnd` right after the error.
+#[tokio::test]
+async fn trailing_unterminated_failed_frame_ends_without_message_end() {
+    let events = collect_stream(vec![
+        frame(message_frame(Some("hi"), vec![])),
+        "event: Failed\ndata: {\"code\":\"Throttling\"}".to_string(),
+    ])
+    .await;
+    assert_eq!(
+        events,
+        vec![
+            "text:hi".to_string(),
+            "error:SysOM stream failed: provider error code Throttling (21 byte payload)"
+                .to_string(),
+        ]
+    );
+}
+
+/// SSE permits one event to carry several `data:` lines joined by newlines;
+/// keeping only the last line would truncate pretty-printed JSON to its final
+/// fragment. The joined payload must survive LF and CRLF framing alike.
+#[tokio::test]
+async fn multiline_data_fields_are_joined_per_sse_semantics() {
+    let pretty = serde_json::to_string_pretty(&message_frame(
+        Some("Checking."),
+        vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+    ))
+    .expect("fixture serializes");
+    assert!(pretty.contains('\n'), "fixture must span multiple lines");
+    let data_lines: String = pretty
+        .lines()
+        .map(|line| format!("data: {line}\n"))
+        .collect();
+    let block = format!("event: OK\n{data_lines}\n");
+    let expected = vec![
+        "text:Checking.".to_string(),
+        "start:0:call-1:ask_user_question".to_string(),
+        format!("delta:0:{ASK_ARGS}"),
+        "end:0".to_string(),
+        "message_end".to_string(),
+    ];
+
+    assert_eq!(
+        collect_byte_chunks(vec![block.clone().into_bytes()]).await,
+        expected,
+        "LF-framed multiline data must reassemble"
+    );
+    assert_eq!(
+        collect_byte_chunks(vec![block.replace('\n', "\r\n").into_bytes()]).await,
+        expected,
+        "CRLF-framed multiline data must reassemble"
+    );
+}
+
+/// A multiline `Failed` payload is joined before summarizing, and the summary
+/// stays bounded: no fragment of the payload may leak.
+#[test]
+fn multiline_failed_payload_is_joined_and_stays_bounded() {
+    let mut state = SseParseState::default();
+    let block = "event: Failed\ndata: {\"message\":\ndata:  \"auth failed for sk-secret\"}\n";
+    let events =
+        parse_sysom_sse_events(block, &mut state).expect("failure frames are reported as events");
+
+    match events.as_slice() {
+        [GenerateEvent::Error(message)] => {
+            assert!(!message.contains("sk-secret"), "payload leaked: {message}");
+            // The size proves both lines were joined, not just the last kept.
+            let joined = "{\"message\":\n \"auth failed for sk-secret\"}";
+            assert!(
+                message.contains(&format!("{} byte payload", joined.len())),
+                "{message}"
+            );
+        }
+        other => panic!("expected a single error event, got {other:?}"),
+    }
+    assert!(state.message_ended);
+    assert!(state.stream_ended, "provider failure must end the stream");
+}
+
+#[tokio::test]
+async fn malformed_frame_surfaces_a_bounded_stream_error() {
+    let events = collect_stream(vec![
+        frame(message_frame(Some("hi"), vec![])),
+        "event: OK\ndata: {\"choices\":\n\n".to_string(),
+        frame(message_frame(Some("hi there"), vec![])),
+    ])
+    .await;
+
+    assert_eq!(
+        events,
+        vec![
+            "text:hi".to_string(),
+            format!("error:{}", SysomStreamError::MalformedJson),
+        ]
+    );
+}
+
+/// EOF must not swallow `MessageEnd` just because usage was reported.
+#[tokio::test]
+async fn eof_with_usage_keeps_usage_and_message_end() {
+    let mut usage_frame = message_frame(Some("done"), vec![]);
+    usage_frame["usage"] = serde_json::json!({
+        "prompt_tokens": 11,
+        "completion_tokens": 22,
+        "total_tokens": 33,
+    });
+
+    assert_eq!(
+        collect_stream(vec![frame(usage_frame)]).await,
+        vec![
+            "text:done".to_string(),
+            "usage:11:22:33".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn usage_only_final_frame_still_terminates_with_message_end() {
+    let mut final_frame = message_frame(Some("hello"), vec![]);
+    final_frame["usage"] = serde_json::json!({
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    });
+
+    assert_eq!(
+        collect_stream(vec![
+            frame(message_frame(Some("hello"), vec![])),
+            frame(final_frame),
+        ])
+        .await,
+        vec![
+            "text:hello".to_string(),
+            "usage:11:7:18".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn stream_without_usage_terminates_with_message_end() {
+    assert_eq!(
+        collect_stream(vec![frame(message_frame(Some("hi"), vec![]))]).await,
+        vec!["text:hi".to_string(), "message_end".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn unterminated_final_frame_is_flushed_before_message_end() {
+    let mut final_frame = message_frame(Some("done"), vec![]);
+    final_frame["usage"] = serde_json::json!({
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    });
+    let frame = frame(final_frame);
+
+    assert_eq!(
+        collect_stream(vec![frame.trim_end().to_string()]).await,
+        vec![
+            "text:done".to_string(),
+            "usage:3:1:4".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn tool_call_with_final_usage_reaches_message_end() {
+    let mut final_frame = message_frame(
+        None,
+        vec![tool_entry(0, "call_1", "read_file", r#"{"path":"/tmp/a"}"#)],
+    );
+    final_frame["usage"] = serde_json::json!({
+        "prompt_tokens": 20,
+        "completion_tokens": 9,
+        "total_tokens": 29,
+    });
+
+    assert_eq!(
+        collect_stream(vec![
+            frame(message_frame(
+                None,
+                vec![tool_entry(0, "call_1", "read_file", "")],
+            )),
+            frame(final_frame),
+        ])
+        .await,
+        vec![
+            "start:0:call_1:read_file".to_string(),
+            r#"delta:0:{"path":"/tmp/a"}"#.to_string(),
+            "end:0".to_string(),
+            "usage:20:9:29".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+}
+
+/// Byte stream that panics if polled again after reporting EOF.
+struct PanicOnRepoll {
+    chunks: std::vec::IntoIter<Vec<u8>>,
+    exhausted: bool,
+}
+
+impl futures::Stream for PanicOnRepoll {
+    type Item = Result<Vec<u8>, String>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        assert!(!self.exhausted, "byte stream polled after EOF");
+        match self.chunks.next() {
+            Some(chunk) => Poll::Ready(Some(Ok(chunk))),
+            None => {
+                self.exhausted = true;
+                Poll::Ready(None)
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn byte_stream_is_not_polled_after_eof() {
+    let mut usage_frame = message_frame(Some("x"), vec![]);
+    usage_frame["usage"] = serde_json::json!({
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    });
+    let source: SysomByteStream = Box::pin(PanicOnRepoll {
+        chunks: vec![frame(usage_frame).into_bytes()].into_iter(),
+        exhausted: false,
+    });
+
+    let stream = sysom_event_stream(source, Arc::new(AtomicBool::new(false)));
+    let events = summarize(&stream.collect::<Vec<_>>().await);
+
+    assert_eq!(
+        events,
+        vec![
+            "text:x".to_string(),
+            "usage:1:1:2".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn eof_closes_started_tools_before_usage_and_message_end() {
+    let mut state = SseParseState::default();
+    let block = frame(message_frame(
+        None,
+        vec![
+            tool_entry(0, "call-a", "read_file", r#"{"path":"a"}"#),
+            tool_entry(1, "call-b", "ask_user_question", ASK_ARGS),
+        ],
+    ));
+    assert_eq!(parse(&block, &mut state).len(), 4);
+    state.latest_usage = Some((1, 2, 3));
+
+    assert_eq!(
+        summarize(&sysom_eof_events(&mut state)),
+        vec![
+            "end:0".to_string(),
+            "end:1".to_string(),
+            "usage:1:2:3".to_string(),
+            "message_end".to_string(),
+        ]
+    );
+    assert!(state.stream_ended, "EOF must terminate the stream");
+    assert!(
+        summarize(&sysom_eof_events(&mut state)).eq(&["message_end".to_string()]),
+        "tool ends and usage must not be emitted twice"
+    );
+}
+
+/// The failure payload may hold credentials or the pending question, so no part of
+/// it may reach the propagated error — only size, digest, or a whitelisted code.
+#[test]
+fn failed_event_reports_no_payload_and_ends_the_message() {
+    let mut state = SseParseState::default();
+    let secret = "sk-super-secret-token";
+    let payload = format!("{{\"message\":\"auth failed for {secret}\"}}");
+    let events = parse_sysom_sse_events(&format!("event: Failed\ndata: {payload}\n\n"), &mut state)
+        .expect("failure frames are reported as events");
+
+    match events.as_slice() {
+        [GenerateEvent::Error(message)] => {
+            assert!(!message.contains(secret), "payload leaked: {message}");
+            assert!(
+                !message.contains("auth failed"),
+                "payload leaked: {message}"
+            );
+            assert!(
+                message.contains(&format!("{} byte payload", payload.len())),
+                "{message}"
+            );
+            assert!(message.contains("sha256:"), "{message}");
+        }
+        other => panic!("expected a single error event, got {other:?}"),
+    }
+    assert!(state.message_ended);
+}
+
+/// Only codes on the exact allowlist may leave the stream. A character or length
+/// filter would also pass a short secret or an IP address that happens to arrive
+/// in a `code` field, so those must degrade to size and digest.
+#[test]
+fn failed_event_forwards_only_allowlisted_provider_error_codes() {
+    let code_frame = |payload: &str| {
+        let mut state = SseParseState::default();
+        let events =
+            parse_sysom_sse_events(&format!("event: Failed\ndata: {payload}\n\n"), &mut state)
+                .expect("failure frames are reported as events");
+        match events.as_slice() {
+            [GenerateEvent::Error(message)] => message.clone(),
+            other => panic!("expected a single error event, got {other:?}"),
+        }
+    };
+
+    let known = code_frame(r#"{"code":"Throttling.User","message":"slow down user alice"}"#);
+    assert!(known.contains("Throttling.User"), "{known}");
+    assert!(!known.contains("alice"), "{known}");
+
+    let nested = code_frame(r#"{"error":{"code":"InvalidApiKey","message":"key sk-abc"}}"#);
+    assert!(nested.contains("InvalidApiKey"), "{nested}");
+    assert!(!nested.contains("sk-abc"), "{nested}");
+
+    // Values that pass any syntax rule but are not provider codes.
+    for payload in [
+        r#"{"code":"sk-super-secret-token"}"#,
+        r#"{"code":"10.0.0.7"}"#,
+        r#"{"code":"/home/alice/.cosh/config.toml"}"#,
+        r#"{"error":{"code":"AKIA1234567890ABCD"}}"#,
+        r#"{"code":"request from 10.0.0.7 rejected: bad token sk-xyz"}"#,
+    ] {
+        let summary = code_frame(payload);
+        assert!(
+            summary.contains("no recognizable provider error code"),
+            "payload {payload} must not be forwarded: {summary}"
+        );
+        for secret in [
+            "sk-super-secret-token",
+            "10.0.0.7",
+            "alice",
+            "AKIA",
+            "sk-xyz",
+        ] {
+            assert!(
+                !summary.contains(secret),
+                "payload {payload} leaked {secret}: {summary}"
+            );
+        }
+    }
+
+    // A long payload stays bounded regardless of shape.
+    let long = code_frame(&"x".repeat(4096));
+    assert!(long.len() < 200, "detail must stay bounded: {long}");
+    assert!(long.contains("4096 byte payload"), "{long}");
+}
+
+/// Core binds a tool result to the id from the first frame, so a slot must never
+/// open without an id and name, and a later frame must not rename it.
+#[test]
+fn tool_identity_must_be_present_once_and_stay_stable() {
+    let mut state = SseParseState::default();
+    let no_name = frame(serde_json::json!({
+        "choices": [{ "message": { "tool_use": [{
+            "index": 0,
+            "id": "call-1",
+            "function": { "arguments": ASK_ARGS },
+        }] } }]
+    }));
+    assert_eq!(
+        parse_err(&no_name, &mut state),
+        SysomStreamError::ToolIdentityMissing { index: 0 }
+    );
+
+    let mut state = SseParseState::default();
+    let no_id = frame(serde_json::json!({
+        "choices": [{ "message": { "tool_use": [{
+            "index": 0,
+            "function": { "name": "ask_user_question", "arguments": ASK_ARGS },
+        }] } }]
+    }));
+    assert_eq!(
+        parse_err(&no_id, &mut state),
+        SysomStreamError::ToolIdentityMissing { index: 0 }
+    );
+
+    let mut state = SseParseState::default();
+    let numeric_id = frame(serde_json::json!({
+        "choices": [{ "message": { "tool_use": [{
+            "index": 0,
+            "id": 7,
+            "function": { "name": "ask_user_question" },
+        }] } }]
+    }));
+    assert_eq!(
+        parse_err(&numeric_id, &mut state),
+        SysomStreamError::ToolIdentityWrongType { index: 0 }
+    );
+
+    let mut state = SseParseState::default();
+    assert_eq!(
+        parse(
+            &frame(message_frame(
+                None,
+                vec![tool_entry(0, "call-1", "ask_user_question", r#"{"que"#)],
+            )),
+            &mut state
+        )
+        .len(),
+        2
+    );
+    assert_eq!(
+        parse_err(
+            &frame(message_frame(
+                None,
+                vec![tool_entry(0, "call-2", "ask_user_question", ASK_ARGS)],
+            )),
+            &mut state
+        ),
+        SysomStreamError::ToolIdentityChanged { index: 0 }
+    );
+    assert_eq!(
+        parse_err(
+            &frame(message_frame(
+                None,
+                vec![tool_entry(0, "call-1", "shell", ASK_ARGS)],
+            )),
+            &mut state
+        ),
+        SysomStreamError::ToolIdentityChanged { index: 0 }
+    );
+    // Omitting the identity in a later frame is allowed: the slot keeps its own.
+    let identity_free = frame(serde_json::json!({
+        "choices": [{ "message": { "tool_use": [{
+            "index": 0,
+            "function": { "arguments": ASK_ARGS },
+        }] } }]
+    }));
+    assert_eq!(
+        parse(&identity_free, &mut state),
+        vec![r#"delta:0:stion":"How should local changes be handled?"}"#.to_string()]
+    );
+}
+
+/// Core sizes its pending-call vector from this index, so a sparse or maximal
+/// index must be refused here instead of becoming a huge allocation downstream.
+#[test]
+fn out_of_range_index_is_refused_at_the_protocol_limit() {
+    let entry_at = |index: Value| {
+        frame(serde_json::json!({
+            "choices": [{ "message": { "tool_use": [{
+                "index": index,
+                "id": "call-1",
+                "function": { "name": "ask_user_question", "arguments": ASK_ARGS },
+            }] } }]
+        }))
+    };
+
+    let mut state = SseParseState::default();
+    assert_eq!(
+        parse(
+            &entry_at(serde_json::json!(MAX_TOOL_CALL_INDEX)),
+            &mut state
+        )
+        .len(),
+        2,
+        "the limit itself is a valid index"
+    );
+
+    for out_of_range in [
+        serde_json::json!(MAX_TOOL_CALL_INDEX + 1),
+        serde_json::json!(4_294_967_295_u64),
+        serde_json::json!(u64::MAX),
+    ] {
+        let mut state = SseParseState::default();
+        assert_eq!(
+            parse_err(&entry_at(out_of_range.clone()), &mut state),
+            SysomStreamError::ToolIndexInvalid { position: 0 },
+            "index {out_of_range} must be rejected"
+        );
+    }
+
+    // An array longer than the protocol allows is out of range even without
+    // explicit indices, because the position becomes the index.
+    let mut state = SseParseState::default();
+    let long_array: Vec<Value> = (0..=MAX_TOOL_CALL_INDEX + 1)
+        .map(|_| {
+            serde_json::json!({
+                "id": "call-1",
+                "function": { "name": "ask_user_question", "arguments": ASK_ARGS },
+            })
+        })
+        .collect();
+    assert_eq!(
+        parse_err(&frame(message_frame(None, long_array)), &mut state),
+        SysomStreamError::ToolIndexInvalid {
+            position: MAX_TOOL_CALL_INDEX as usize + 1,
+        }
+    );
+}
+
+/// An unusable index must fail rather than silently fall back to the array
+/// position, which would attach the arguments to a slot the provider never named.
+#[test]
+fn unusable_index_does_not_fall_back_to_array_position() {
+    for bad_index in [
+        serde_json::json!("0"),
+        serde_json::json!(-1),
+        serde_json::json!(1.5),
+        serde_json::json!(u32::MAX as u64 + 1),
+        serde_json::json!(null),
+    ] {
+        let mut state = SseParseState::default();
+        let block = frame(serde_json::json!({
+            "choices": [{ "message": { "tool_use": [{
+                "index": bad_index,
+                "id": "call-1",
+                "function": { "name": "ask_user_question", "arguments": ASK_ARGS },
+            }] } }]
+        }));
+        assert_eq!(
+            parse_err(&block, &mut state),
+            SysomStreamError::ToolIndexInvalid { position: 0 },
+            "index {bad_index} must be rejected"
+        );
+    }
+}
+
+/// Providers may stop repeating text once they switch to tool calls. An empty
+/// snapshot carries no information, so it must not be mistaken for a rewrite.
+#[test]
+fn empty_content_or_arguments_snapshot_is_treated_as_no_change() {
+    let mut state = SseParseState::default();
+    let text_then_tool = frame(message_frame(
+        Some("Checking."),
+        vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+    ));
+    assert_eq!(parse(&text_then_tool, &mut state).len(), 3);
+
+    let dropped_snapshots = frame(message_frame(
+        Some(""),
+        vec![tool_entry(0, "call-1", "ask_user_question", "")],
+    ));
+    assert!(
+        parse(&dropped_snapshots, &mut state).is_empty(),
+        "empty snapshots must neither re-emit nor fail"
+    );
+
+    // A later real snapshot must still extend what was already seen.
+    let grown = frame(message_frame(
+        Some("Checking. Done."),
+        vec![tool_entry(0, "call-1", "ask_user_question", ASK_ARGS)],
+    ));
+    assert_eq!(parse(&grown, &mut state), vec!["text: Done.".to_string()]);
+}

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+#[test]
+fn region_id_strips_single_zone_suffix() {
+    assert_eq!(
+        region_id_from_zone_id("cn-hangzhou-j").as_deref(),
+        Some("cn-hangzhou")
+    );
+    assert_eq!(
+        region_id_from_zone_id("cn-beijing").as_deref(),
+        Some("cn-beijing")
+    );
+    assert_eq!(region_id_from_zone_id(""), None);
+}
+
+#[test]
+fn generate_console_url_uses_region_and_instance_id() {
+    assert_eq!(
+        generate_console_url("i-test123", "cn-hangzhou"),
+        "https://alinux.console.aliyun.com/cn-hangzhou/guide/cosh?instance=i-test123"
+    );
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/ask_user_question.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/ask_user_question.rs
@@ -1,0 +1,414 @@
+//! `ask_user_question` argument contract: schema declaration, strict validation,
+//! and the bounded diagnostics emitted when a call is rejected.
+//!
+//! The interactive question path is the one place where a malformed tool call
+//! used to become a valid-looking prompt, so declaration and validation live
+//! together here: a schema change that is not mirrored by a validation rule is
+//! visible in one file.
+
+use serde_json::Value;
+
+use crate::provider::ToolDeclaration;
+
+/// Tool name as declared to providers and matched in the Core tool loop.
+pub const TOOL_NAME: &str = "ask_user_question";
+
+const TOOL_DESCRIPTION: &str = "Ask the user a question. Use this when you need clarification or want the user to choose between options.";
+
+/// Validated arguments for one `ask_user_question` call.
+///
+/// Construction goes through [`inspect_arguments`] or [`validate_value`], so a
+/// value of this type is a proof that the question is answerable: `question` is
+/// non-empty after trimming, and at least one of free-text input or a non-empty
+/// option list is available.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AskUserQuestionParams {
+    /// Question text, trimmed and guaranteed non-empty.
+    pub question: String,
+    /// Selectable options; may be empty only when `allow_free_text` is true.
+    pub options: Vec<AskUserQuestionOption>,
+    /// Whether free-text answers are accepted. Defaults to true when omitted.
+    pub allow_free_text: bool,
+    /// Whether multiple options may be selected. Defaults to false when omitted.
+    pub multi_select: bool,
+}
+
+/// One selectable answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AskUserQuestionOption {
+    /// Display label, trimmed and guaranteed non-empty.
+    pub label: String,
+    /// Optional longer explanation.
+    pub description: Option<String>,
+}
+
+/// Why a set of `ask_user_question` arguments cannot be turned into a question.
+///
+/// The variants are a stable diagnostic surface: [`AskUserArgumentError::code`]
+/// strings appear in tool-result text, audit records, and tests, so rename them
+/// only together with the tests that pin them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AskUserArgumentError {
+    /// The provider produced no argument bytes at all.
+    EmptyArguments,
+    /// Argument bytes were present but not parseable as JSON.
+    InvalidJson,
+    /// Valid JSON whose root is not an object.
+    RootNotObject,
+    /// No `question` key at all.
+    MissingQuestion,
+    /// `question` present but not a JSON string, including an explicit `null`.
+    QuestionWrongType,
+    /// `question` is a string that is empty after trimming.
+    EmptyQuestion,
+    /// `options` present but not a JSON array, including an explicit `null`.
+    OptionsWrongType,
+    /// An `options` entry is not an object with a non-empty string `label`,
+    /// or carries a `description` that is present but not a string.
+    OptionInvalid,
+    /// `allow_free_text` present but not a boolean, including an explicit `null`.
+    AllowFreeTextWrongType,
+    /// `multi_select` present but not a boolean, including an explicit `null`.
+    MultiSelectWrongType,
+    /// Free text disabled with no selectable option — the user could not answer.
+    NoAnswerPath,
+    /// Claude-style nested `questions` array, which this tool does not accept.
+    UnsupportedNestedQuestions,
+}
+
+impl AskUserArgumentError {
+    /// Stable machine-readable error code.
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::EmptyArguments => "empty_arguments",
+            Self::InvalidJson => "invalid_json",
+            Self::RootNotObject => "root_not_object",
+            Self::MissingQuestion => "missing_question",
+            Self::QuestionWrongType => "question_wrong_type",
+            Self::EmptyQuestion => "empty_question",
+            Self::OptionsWrongType => "options_wrong_type",
+            Self::OptionInvalid => "option_invalid",
+            Self::AllowFreeTextWrongType => "allow_free_text_wrong_type",
+            Self::MultiSelectWrongType => "multi_select_wrong_type",
+            Self::NoAnswerPath => "no_answer_path",
+            Self::UnsupportedNestedQuestions => "unsupported_nested_questions",
+        }
+    }
+
+    /// Remediation hint describing the expected shape, never echoing the input.
+    pub fn guidance(self) -> &'static str {
+        match self {
+            Self::EmptyArguments => {
+                "the tool call carried no arguments; send a JSON object with a \"question\" string"
+            }
+            Self::InvalidJson => {
+                "arguments were not valid JSON; send one complete JSON object, not a fragment"
+            }
+            Self::RootNotObject => "arguments must be a JSON object",
+            Self::MissingQuestion => "arguments must contain a \"question\" string",
+            Self::QuestionWrongType => "\"question\" must be a string; null is not accepted",
+            Self::EmptyQuestion => "\"question\" must not be empty or whitespace only",
+            Self::OptionsWrongType => {
+                "\"options\" must be an array when present; omit the key instead of sending null"
+            }
+            Self::OptionInvalid => {
+                "each option must be an object with a non-empty string \"label\" and an optional string \"description\"; omit \"description\" instead of sending null"
+            }
+            Self::AllowFreeTextWrongType => {
+                "\"allow_free_text\" must be a boolean when present; omit the key instead of sending null"
+            }
+            Self::MultiSelectWrongType => {
+                "\"multi_select\" must be a boolean when present; omit the key instead of sending null"
+            }
+            Self::NoAnswerPath => {
+                "\"allow_free_text\": false requires at least one valid option, otherwise the user cannot answer"
+            }
+            Self::UnsupportedNestedQuestions => {
+                "nested \"questions\" arrays are not supported; ask one question per tool call using the top-level \"question\" field"
+            }
+        }
+    }
+
+    /// Tool-result text returned to the model so it can retry with valid input.
+    ///
+    /// Deliberately carries only the error code and the expected shape: the
+    /// rejected payload may contain user or session content.
+    pub fn tool_error_message(self) -> String {
+        format!(
+            "{TOOL_NAME} arguments rejected [code={}]: {}. No question was shown to the user; re-issue the call with arguments matching the declared schema.",
+            self.code(),
+            self.guidance()
+        )
+    }
+}
+
+/// Whether raw argument bytes could be parsed, used for bounded diagnostics.
+pub const JSON_PARSE_EMPTY: &str = "empty";
+/// Argument bytes were present but not valid JSON.
+pub const JSON_PARSE_INVALID: &str = "invalid";
+/// Argument bytes parsed into a JSON value.
+pub const JSON_PARSE_OK: &str = "parsed";
+
+/// Bounded facts about one argument payload, plus the validated params when the
+/// payload is acceptable.
+///
+/// Every field is safe to log: shapes, byte counts, and codes only — never the
+/// question text, option labels, or the raw arguments.
+pub struct AskUserArgumentReport {
+    /// Byte length of the raw argument string as received from the provider.
+    pub argument_bytes: usize,
+    /// One of [`JSON_PARSE_EMPTY`], [`JSON_PARSE_INVALID`], [`JSON_PARSE_OK`].
+    pub json_parse_status: &'static str,
+    /// Coarse shape of the `question` field, e.g. `missing`, `empty_string`.
+    pub question_shape: &'static str,
+    /// Parsed root value, kept only so the caller can derive audit shape/hash.
+    pub root: Option<Value>,
+    /// Validated params, or the first validation failure.
+    pub outcome: Result<AskUserQuestionParams, AskUserArgumentError>,
+}
+
+/// Parse and validate raw provider argument bytes.
+///
+/// Empty or whitespace-only input is rejected as [`AskUserArgumentError::EmptyArguments`]
+/// rather than treated as an empty object, because a question with no text is
+/// exactly the argument-loss case this validation exists to surface.
+pub fn inspect_arguments(raw: &str) -> AskUserArgumentReport {
+    let argument_bytes = raw.len();
+
+    if raw.trim().is_empty() {
+        return AskUserArgumentReport {
+            argument_bytes,
+            json_parse_status: JSON_PARSE_EMPTY,
+            question_shape: "unparsed",
+            root: None,
+            outcome: Err(AskUserArgumentError::EmptyArguments),
+        };
+    }
+
+    let root: Value = match serde_json::from_str(raw) {
+        Ok(value) => value,
+        Err(_) => {
+            return AskUserArgumentReport {
+                argument_bytes,
+                json_parse_status: JSON_PARSE_INVALID,
+                question_shape: "unparsed",
+                root: None,
+                outcome: Err(AskUserArgumentError::InvalidJson),
+            };
+        }
+    };
+
+    let question_shape = question_shape(&root);
+    let outcome = validate_value(&root);
+    AskUserArgumentReport {
+        argument_bytes,
+        json_parse_status: JSON_PARSE_OK,
+        question_shape,
+        root: Some(root),
+        outcome,
+    }
+}
+
+/// Validate an already-parsed argument object.
+///
+/// Used both by [`inspect_arguments`] and by the in-band `COSH_QUESTION:` text
+/// path, so both routes enforce identical rules.
+///
+/// # Errors
+///
+/// Returns the first violated rule as an [`AskUserArgumentError`].
+pub fn validate_value(root: &Value) -> Result<AskUserQuestionParams, AskUserArgumentError> {
+    let Some(obj) = root.as_object() else {
+        return Err(AskUserArgumentError::RootNotObject);
+    };
+
+    // Claude's native payload nests every question under `questions`. Taking the
+    // first entry would silently drop the rest, so the shape is rejected instead.
+    // `questions` is not part of the declared schema, so a null carries nothing to
+    // drop and is ignored like any other unknown key.
+    if obj.get("questions").is_some_and(|v| !v.is_null()) {
+        return Err(AskUserArgumentError::UnsupportedNestedQuestions);
+    }
+
+    // A present `null` is a schema violation, not an omission: the declared
+    // types are string/array/boolean, so defaults apply only to absent keys.
+    let question = match obj.get("question") {
+        None => return Err(AskUserArgumentError::MissingQuestion),
+        Some(Value::String(text)) => text.trim(),
+        Some(_) => return Err(AskUserArgumentError::QuestionWrongType),
+    };
+    if question.is_empty() {
+        return Err(AskUserArgumentError::EmptyQuestion);
+    }
+
+    let options = match obj.get("options") {
+        None => Vec::new(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(parse_option)
+            .collect::<Result<Vec<_>, _>>()?,
+        Some(_) => return Err(AskUserArgumentError::OptionsWrongType),
+    };
+
+    let allow_free_text = match obj.get("allow_free_text") {
+        None => true,
+        Some(Value::Bool(flag)) => *flag,
+        Some(_) => return Err(AskUserArgumentError::AllowFreeTextWrongType),
+    };
+    let multi_select = match obj.get("multi_select") {
+        None => false,
+        Some(Value::Bool(flag)) => *flag,
+        Some(_) => return Err(AskUserArgumentError::MultiSelectWrongType),
+    };
+
+    if !allow_free_text && options.is_empty() {
+        return Err(AskUserArgumentError::NoAnswerPath);
+    }
+
+    Ok(AskUserQuestionParams {
+        question: question.to_string(),
+        options,
+        allow_free_text,
+        multi_select,
+    })
+}
+
+fn parse_option(item: &Value) -> Result<AskUserQuestionOption, AskUserArgumentError> {
+    // Bare strings are not part of the declared schema; accepting them here
+    // would create an undocumented second format for the same field.
+    let Some(obj) = item.as_object() else {
+        return Err(AskUserArgumentError::OptionInvalid);
+    };
+    let label = match obj.get("label") {
+        Some(Value::String(label)) => label.trim(),
+        _ => return Err(AskUserArgumentError::OptionInvalid),
+    };
+    if label.is_empty() {
+        return Err(AskUserArgumentError::OptionInvalid);
+    }
+    let description = match obj.get("description") {
+        None => None,
+        Some(Value::String(text)) => Some(text.to_string()),
+        Some(_) => return Err(AskUserArgumentError::OptionInvalid),
+    };
+    Ok(AskUserQuestionOption {
+        label: label.to_string(),
+        description,
+    })
+}
+
+/// Coarse shape of the `question` field for diagnostics.
+fn question_shape(root: &Value) -> &'static str {
+    let Some(obj) = root.as_object() else {
+        return "root_not_object";
+    };
+    if obj.get("questions").is_some_and(|v| !v.is_null()) {
+        return "nested_questions";
+    }
+    match obj.get("question") {
+        None => "missing",
+        Some(Value::Null) => "null",
+        Some(Value::String(text)) if text.trim().is_empty() => "empty_string",
+        Some(Value::String(_)) => "nonempty_string",
+        Some(Value::Bool(_)) => "wrong_type_boolean",
+        Some(Value::Number(_)) => "wrong_type_number",
+        Some(Value::Array(_)) => "wrong_type_array",
+        Some(Value::Object(_)) => "wrong_type_object",
+    }
+}
+
+/// Bounded provider/tool metadata recorded when Core rejects a call.
+///
+/// Holds no question text, option labels, raw arguments, SSE payload, or
+/// credentials — only counts, shapes, and stable codes.
+pub struct AskUserRejectionDiagnostics<'a> {
+    /// Provider that produced the tool call, e.g. `aliyun`.
+    pub provider_type: &'a str,
+    /// Provider-assigned tool call id.
+    pub tool_call_id: &'a str,
+    /// Tool name as received; may differ from [`TOOL_NAME`] only in tests.
+    pub tool_name: &'a str,
+    /// Whether a `ToolCallStart` event was observed for this call.
+    pub start_seen: bool,
+    /// Number of `ToolCallDelta` events observed for this call.
+    pub delta_count: u32,
+    /// Whether a `ToolCallEnd` event was observed for this call.
+    pub end_seen: bool,
+    /// Accumulated argument byte count.
+    pub argument_bytes: usize,
+    /// JSON parse status from [`AskUserArgumentReport`].
+    pub json_parse_status: &'static str,
+    /// Stable code from [`AskUserArgumentError::code`].
+    pub validation_error_code: &'static str,
+    /// Coarse `question` field shape from [`AskUserArgumentReport`].
+    pub question_shape: &'static str,
+}
+
+/// Record a rejected `ask_user_question` call at `warn` level.
+pub fn log_rejection(diagnostics: &AskUserRejectionDiagnostics<'_>) {
+    tracing::warn!(
+        provider_type = diagnostics.provider_type,
+        tool_call_id = diagnostics.tool_call_id,
+        tool_name = diagnostics.tool_name,
+        start_seen = diagnostics.start_seen,
+        delta_count = diagnostics.delta_count,
+        end_seen = diagnostics.end_seen,
+        argument_bytes = diagnostics.argument_bytes,
+        json_parse_status = diagnostics.json_parse_status,
+        validation_error_code = diagnostics.validation_error_code,
+        question_shape = diagnostics.question_shape,
+        "rejected ask_user_question arguments"
+    );
+}
+
+/// Public JSON schema advertised to providers.
+///
+/// `additionalProperties` is intentionally left unset: the validator ignores
+/// unknown keys, so declaring `false` would promise a rejection Core does not
+/// perform, and the keyword's acceptance across SysOM/DashScope has not been
+/// verified against a live endpoint.
+pub fn parameters_schema() -> Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "The question to ask the user. Must be a non-empty string."
+            },
+            "options": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": { "type": "string" },
+                        "description": { "type": "string" }
+                    },
+                    "required": ["label"]
+                },
+                "description": "Options for the user to choose from"
+            },
+            "allow_free_text": {
+                "type": "boolean",
+                "description": "Whether to allow free-text input (default: true)"
+            },
+            "multi_select": {
+                "type": "boolean",
+                "description": "Whether to allow selecting multiple options (default: false)"
+            }
+        },
+        "required": ["question"]
+    })
+}
+
+/// Tool declaration sent to providers when the question tool is enabled.
+pub fn declaration() -> ToolDeclaration {
+    ToolDeclaration {
+        name: TOOL_NAME.to_string(),
+        description: TOOL_DESCRIPTION.to_string(),
+        parameters: parameters_schema(),
+    }
+}
+
+#[cfg(test)]
+#[path = "ask_user_question/tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-core/src/tool/ask_user_question/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/ask_user_question/tests.rs
@@ -1,0 +1,335 @@
+use super::*;
+
+/// Every rejection case that the provider stream can hand to Core, pinned to a
+/// stable error code so the tool-result text stays diagnosable.
+#[test]
+fn invalid_arguments_map_to_stable_error_codes() {
+    let cases: &[(&str, &str, AskUserArgumentError, &str)] = &[
+        (
+            "no argument delta at all",
+            "",
+            AskUserArgumentError::EmptyArguments,
+            "unparsed",
+        ),
+        (
+            "whitespace-only arguments",
+            "   \n",
+            AskUserArgumentError::EmptyArguments,
+            "unparsed",
+        ),
+        (
+            "truncated json",
+            r#"{"question":"Which branch"#,
+            AskUserArgumentError::InvalidJson,
+            "unparsed",
+        ),
+        (
+            "not json at all",
+            "question: which branch?",
+            AskUserArgumentError::InvalidJson,
+            "unparsed",
+        ),
+        (
+            "array root",
+            r#"[{"question":"Which branch?"}]"#,
+            AskUserArgumentError::RootNotObject,
+            "root_not_object",
+        ),
+        (
+            "string root",
+            r#""Which branch?""#,
+            AskUserArgumentError::RootNotObject,
+            "root_not_object",
+        ),
+        (
+            "empty object",
+            "{}",
+            AskUserArgumentError::MissingQuestion,
+            "missing",
+        ),
+        (
+            "question omitted but options present",
+            r#"{"options":[{"label":"Stash"}]}"#,
+            AskUserArgumentError::MissingQuestion,
+            "missing",
+        ),
+        (
+            "explicit null question",
+            r#"{"question":null}"#,
+            AskUserArgumentError::QuestionWrongType,
+            "null",
+        ),
+        (
+            "number question",
+            r#"{"question":42}"#,
+            AskUserArgumentError::QuestionWrongType,
+            "wrong_type_number",
+        ),
+        (
+            "array question",
+            r#"{"question":["one","two"]}"#,
+            AskUserArgumentError::QuestionWrongType,
+            "wrong_type_array",
+        ),
+        (
+            "object question",
+            r#"{"question":{"text":"Which branch?"}}"#,
+            AskUserArgumentError::QuestionWrongType,
+            "wrong_type_object",
+        ),
+        (
+            "boolean question",
+            r#"{"question":true}"#,
+            AskUserArgumentError::QuestionWrongType,
+            "wrong_type_boolean",
+        ),
+        (
+            "empty question",
+            r#"{"question":""}"#,
+            AskUserArgumentError::EmptyQuestion,
+            "empty_string",
+        ),
+        (
+            "whitespace question",
+            r#"{"question":"  \t \n "}"#,
+            AskUserArgumentError::EmptyQuestion,
+            "empty_string",
+        ),
+        (
+            "claude-style nested questions",
+            r#"{"questions":[{"question":"How should local changes be handled?","header":"Local changes","options":[{"label":"Stash"}],"multiSelect":false}]}"#,
+            AskUserArgumentError::UnsupportedNestedQuestions,
+            "nested_questions",
+        ),
+        (
+            "nested questions alongside a valid question",
+            r#"{"question":"Which branch?","questions":[{"question":"And then?"}]}"#,
+            AskUserArgumentError::UnsupportedNestedQuestions,
+            "nested_questions",
+        ),
+        (
+            "options wrong type",
+            r#"{"question":"Which branch?","options":"Stash"}"#,
+            AskUserArgumentError::OptionsWrongType,
+            "nonempty_string",
+        ),
+        (
+            "explicit null options",
+            r#"{"question":"Which branch?","options":null}"#,
+            AskUserArgumentError::OptionsWrongType,
+            "nonempty_string",
+        ),
+        (
+            "explicit null allow_free_text",
+            r#"{"question":"Which branch?","allow_free_text":null}"#,
+            AskUserArgumentError::AllowFreeTextWrongType,
+            "nonempty_string",
+        ),
+        (
+            "explicit null multi_select",
+            r#"{"question":"Which branch?","multi_select":null}"#,
+            AskUserArgumentError::MultiSelectWrongType,
+            "nonempty_string",
+        ),
+        (
+            "explicit null option description",
+            r#"{"question":"Which branch?","options":[{"label":"Stash","description":null}]}"#,
+            AskUserArgumentError::OptionInvalid,
+            "nonempty_string",
+        ),
+        (
+            "explicit null option label",
+            r#"{"question":"Which branch?","options":[{"label":null}]}"#,
+            AskUserArgumentError::OptionInvalid,
+            "nonempty_string",
+        ),
+        (
+            "bare string option is not a declared format",
+            r#"{"question":"Which branch?","options":["Stash"]}"#,
+            AskUserArgumentError::OptionInvalid,
+            "nonempty_string",
+        ),
+        (
+            "option missing label",
+            r#"{"question":"Which branch?","options":[{"description":"keep it"}]}"#,
+            AskUserArgumentError::OptionInvalid,
+            "nonempty_string",
+        ),
+        (
+            "option label wrong type",
+            r#"{"question":"Which branch?","options":[{"label":7}]}"#,
+            AskUserArgumentError::OptionInvalid,
+            "nonempty_string",
+        ),
+        (
+            "option label blank",
+            r#"{"question":"Which branch?","options":[{"label":"   "}]}"#,
+            AskUserArgumentError::OptionInvalid,
+            "nonempty_string",
+        ),
+        (
+            "option description wrong type",
+            r#"{"question":"Which branch?","options":[{"label":"Stash","description":3}]}"#,
+            AskUserArgumentError::OptionInvalid,
+            "nonempty_string",
+        ),
+        (
+            "allow_free_text wrong type",
+            r#"{"question":"Which branch?","allow_free_text":"yes"}"#,
+            AskUserArgumentError::AllowFreeTextWrongType,
+            "nonempty_string",
+        ),
+        (
+            "multi_select wrong type",
+            r#"{"question":"Which branch?","multi_select":1}"#,
+            AskUserArgumentError::MultiSelectWrongType,
+            "nonempty_string",
+        ),
+        (
+            "no answer path without options",
+            r#"{"question":"Which branch?","allow_free_text":false}"#,
+            AskUserArgumentError::NoAnswerPath,
+            "nonempty_string",
+        ),
+        (
+            "no answer path with empty options",
+            r#"{"question":"Which branch?","allow_free_text":false,"options":[]}"#,
+            AskUserArgumentError::NoAnswerPath,
+            "nonempty_string",
+        ),
+    ];
+
+    for (label, raw, expected_error, expected_shape) in cases {
+        let report = inspect_arguments(raw);
+        assert_eq!(
+            report.outcome.as_ref().err().copied(),
+            Some(*expected_error),
+            "case: {label}"
+        );
+        assert_eq!(report.question_shape, *expected_shape, "case: {label}");
+        assert_eq!(report.argument_bytes, raw.len(), "case: {label}");
+
+        let message = expected_error.tool_error_message();
+        assert!(
+            message.contains(expected_error.code()),
+            "case: {label} message must carry its code"
+        );
+        assert!(
+            !message.contains("Agent needs your input"),
+            "case: {label} must not fall back to a generic prompt"
+        );
+    }
+}
+
+#[test]
+fn json_parse_status_distinguishes_empty_from_malformed() {
+    assert_eq!(inspect_arguments("").json_parse_status, JSON_PARSE_EMPTY);
+    assert_eq!(
+        inspect_arguments("{\"question\":").json_parse_status,
+        JSON_PARSE_INVALID
+    );
+    assert_eq!(
+        inspect_arguments(r#"{"question":"ok"}"#).json_parse_status,
+        JSON_PARSE_OK
+    );
+}
+
+#[test]
+fn error_codes_are_unique() {
+    let all = [
+        AskUserArgumentError::EmptyArguments,
+        AskUserArgumentError::InvalidJson,
+        AskUserArgumentError::RootNotObject,
+        AskUserArgumentError::MissingQuestion,
+        AskUserArgumentError::QuestionWrongType,
+        AskUserArgumentError::EmptyQuestion,
+        AskUserArgumentError::OptionsWrongType,
+        AskUserArgumentError::OptionInvalid,
+        AskUserArgumentError::AllowFreeTextWrongType,
+        AskUserArgumentError::MultiSelectWrongType,
+        AskUserArgumentError::NoAnswerPath,
+        AskUserArgumentError::UnsupportedNestedQuestions,
+    ];
+    let mut codes: Vec<&str> = all.iter().map(|e| e.code()).collect();
+    codes.sort_unstable();
+    let total = codes.len();
+    codes.dedup();
+    assert_eq!(codes.len(), total, "error codes must be unique");
+}
+
+#[test]
+fn valid_arguments_apply_documented_defaults() {
+    let report = inspect_arguments(
+        r#"{"question":"  How should local changes be handled?  ","options":[{"label":" Stash ","description":"git stash"},{"label":"Discard"}]}"#,
+    );
+    let params = report.outcome.expect("valid arguments");
+    assert_eq!(params.question, "How should local changes be handled?");
+    assert!(params.allow_free_text, "allow_free_text defaults to true");
+    assert!(!params.multi_select, "multi_select defaults to false");
+    assert_eq!(
+        params.options,
+        vec![
+            AskUserQuestionOption {
+                label: "Stash".to_string(),
+                description: Some("git stash".to_string()),
+            },
+            AskUserQuestionOption {
+                label: "Discard".to_string(),
+                description: None,
+            },
+        ]
+    );
+    assert_eq!(report.question_shape, "nonempty_string");
+}
+
+/// Defaults belong to absent keys only: a present `null` violates the advertised
+/// string/array/boolean schema and must not be laundered into a valid question.
+#[test]
+fn omitted_optionals_use_defaults_while_explicit_nulls_are_rejected() {
+    let params = inspect_arguments(r#"{"question":"Which branch?"}"#)
+        .outcome
+        .expect("absent optionals fall back to defaults");
+    assert!(params.options.is_empty());
+    assert!(params.allow_free_text);
+    assert!(!params.multi_select);
+
+    for raw in [
+        r#"{"question":null}"#,
+        r#"{"question":"Which branch?","options":null}"#,
+        r#"{"question":"Which branch?","allow_free_text":null}"#,
+        r#"{"question":"Which branch?","multi_select":null}"#,
+        r#"{"question":"Which branch?","options":[{"label":"Stash","description":null}]}"#,
+    ] {
+        assert!(
+            inspect_arguments(raw).outcome.is_err(),
+            "explicit null must be rejected: {raw}"
+        );
+    }
+}
+
+#[test]
+fn options_only_question_may_disable_free_text() {
+    let params = inspect_arguments(
+        r#"{"question":"Which branch?","allow_free_text":false,"multi_select":true,"options":[{"label":"main"}]}"#,
+    )
+    .outcome
+    .expect("options provide an answer path");
+    assert!(!params.allow_free_text);
+    assert!(params.multi_select);
+    assert_eq!(params.options.len(), 1);
+}
+
+#[test]
+fn declaration_matches_validated_contract() {
+    let declaration = declaration();
+    assert_eq!(declaration.name, TOOL_NAME);
+    let schema = declaration.parameters;
+    assert_eq!(schema["required"], serde_json::json!(["question"]));
+    assert_eq!(schema["properties"]["question"]["type"], "string");
+    assert_eq!(
+        schema["properties"]["options"]["items"]["required"],
+        serde_json::json!(["label"])
+    );
+    // The validator ignores unknown keys; the schema must not claim otherwise.
+    assert!(schema.get("additionalProperties").is_none());
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod ask_user_question;
 pub mod edit;
 mod file_patterns;
 mod glob;
@@ -260,40 +261,7 @@ impl ToolRegistry {
             })
             .collect();
         if self.ask_user_question_enabled {
-            decls.push(ToolDeclaration {
-                name: "ask_user_question".to_string(),
-                description: "Ask the user a question. Use this when you need clarification or want the user to choose between options.".to_string(),
-                parameters: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "question": {
-                            "type": "string",
-                            "description": "The question to ask the user"
-                        },
-                        "options": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "label": { "type": "string" },
-                                    "description": { "type": "string" }
-                                },
-                                "required": ["label"]
-                            },
-                            "description": "Options for the user to choose from"
-                        },
-                        "allow_free_text": {
-                            "type": "boolean",
-                            "description": "Whether to allow free-text input (default: true)"
-                        },
-                        "multi_select": {
-                            "type": "boolean",
-                            "description": "Whether to allow selecting multiple options (default: false)"
-                        }
-                    },
-                    "required": ["question"]
-                }),
-            });
+            decls.push(ask_user_question::declaration());
         }
         decls.sort_by(|a, b| a.name.cmp(&b.name));
         decls


### PR DESCRIPTION
## Description

SysOM sends cumulative SSE snapshots, but the parser returned after the first
event and could drop complete tool arguments carried in the same frame. This
change emits every ordered observation, validates SSE framing and tool payloads
before execution, and preserves the existing empty-argument convention for
zero-parameter tools. Malformed provider data now fails with bounded,
actionable diagnostics instead of surfacing a generic user question.

## Related Issue

closes #1684

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --package cosh-core`
- `LC_ALL=C cargo test --workspace --no-fail-fast -- --test-threads=4`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `./scripts/check-test-inventory.sh`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check`

## Additional Notes

Parser tests cover cumulative frames, every UTF-8 chunk boundary, LF and CRLF
delimiters, multiline `data:` fields, frame and tool-index limits, transport
failures, provider failures, cancellation, and EOF terminal ordering. No live
SysOM credentials were used for validation.
