### PR TITLE
fix(anolisa): fail closed on stale adapter source directories

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -23,7 +23,7 @@ use anolisa_core::domain::{
 use anolisa_core::install_runner::{InstallRunner, InstalledFile, PreparedFileSet};
 use anolisa_core::lifecycle::prepare_backup;
 use anolisa_core::owned_executor::{OwnedOpError, OwnedOps, StepSuccess};
-use anolisa_core::path_safety::validate_owned_path;
+use anolisa_core::path_safety::{lexical_roots, validate_owned_path};
 use anolisa_core::planner::{HookKind, RecordWrite};
 use anolisa_core::state::{FileOwner, ObjectKind, OwnedFile, OwnedFileKind, ServiceRef};
 use anolisa_core::state_store::StateStore;
@@ -588,6 +588,7 @@ impl OwnedOps for RawTeardownOps<'_> {
     /// on the legitimate files.
     fn remove_owned_files(&mut self) -> Result<StepSuccess, OwnedOpError> {
         let mut warnings = Vec::new();
+        let mut removed_parents: Vec<PathBuf> = Vec::new();
         for file in &self.prior.files {
             if let Err(boundary) = validate_owned_path(self.layout, &file.path) {
                 warnings.push(format!(
@@ -606,7 +607,11 @@ impl OwnedOps for RawTeardownOps<'_> {
                     )));
                 }
             }
+            if let Some(parent) = file.path.parent() {
+                removed_parents.push(parent.to_path_buf());
+            }
         }
+        prune_emptied_dirs(self.layout, removed_parents);
         Ok(StepSuccess::with_warnings(warnings))
     }
 
@@ -650,6 +655,51 @@ impl OwnedOps for RawTeardownOps<'_> {
 
     fn restore_backup(&mut self) -> Vec<String> {
         Vec::new()
+    }
+}
+
+/// Best-effort removal of directories a file teardown emptied, walking
+/// each start directory upward. Without this, an uninstall leaves a bare
+/// directory skeleton behind, and a skeleton under one scope's datadir
+/// (e.g. `/usr/local/share/anolisa/extensions/<component>/`) can shadow
+/// adapter source probing for the same component in another scope.
+///
+/// Safety: `fs::remove_dir` refuses non-empty directories, and the climb
+/// stops at the *deepest* owned root containing the start path. The
+/// boundary must be per-path, not "parent is owned": owned roots can nest
+/// (user mode places `libexec_dir` inside `lib_dir`), so a parent check
+/// alone would delete the inner root itself. Errors are swallowed:
+/// pruning is cosmetic and must never fail an otherwise-successful
+/// teardown.
+fn prune_emptied_dirs(layout: &FsLayout, start_dirs: Vec<PathBuf>) {
+    let roots = lexical_roots(layout);
+    for start in start_dirs {
+        // Deepest owned root containing this path — the hard boundary
+        // that must survive the climb.
+        let Some(boundary) = roots
+            .iter()
+            .filter(|root| start.starts_with(root))
+            .max_by_key(|root| root.components().count())
+        else {
+            continue;
+        };
+        let mut dir = start;
+        while dir != **boundary {
+            if validate_owned_path(layout, &dir).is_err() {
+                break;
+            }
+            match fs::remove_dir(&dir) {
+                Ok(()) => {}
+                // Already pruned via another file's parent chain — keep
+                // climbing so shared ancestors are still considered.
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                // Non-empty or unremovable: everything above is also
+                // non-empty, stop here.
+                Err(_) => break,
+            }
+            let Some(parent) = dir.parent() else { break };
+            dir = parent.to_path_buf();
+        }
     }
 }
 
@@ -1307,4 +1357,92 @@ fn sha256_hex(bytes: &[u8]) -> String {
         let _ = write!(s, "{b:02x}");
         s
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Teardown pruning must remove the directory chain the file removal
+    /// emptied (so no skeleton is left to shadow adapter source probing in
+    /// another scope), while keeping the ANOLISA-owned roots and any
+    /// directory that still has contents.
+    #[test]
+    fn prune_emptied_dirs_removes_skeleton_but_keeps_roots_and_nonempty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let datadir = layout.datadir.clone();
+
+        // Emptied chain: datadir/extensions/tokenless/hooks (files removed).
+        let emptied = datadir.join("extensions").join("tokenless").join("hooks");
+        fs::create_dir_all(&emptied).expect("emptied chain");
+        // Sibling that must survive because it still holds a file.
+        let kept = datadir.join("extensions").join("other");
+        fs::create_dir_all(&kept).expect("kept dir");
+        fs::write(kept.join("keep.txt"), b"keep").expect("keep file");
+
+        prune_emptied_dirs(&layout, vec![emptied.clone()]);
+
+        assert!(!emptied.exists(), "emptied chain must be pruned");
+        assert!(
+            !datadir.join("extensions").join("tokenless").exists(),
+            "emptied parent must be pruned"
+        );
+        assert!(
+            datadir.join("extensions").exists(),
+            "shared ancestor with surviving content must stay"
+        );
+        assert!(
+            kept.join("keep.txt").is_file(),
+            "unrelated content must stay"
+        );
+        assert!(datadir.exists(), "the owned datadir root itself must stay");
+    }
+
+    /// The owned root itself is never pruned, even when the teardown
+    /// emptied it completely: it is the per-path climb boundary.
+    #[test]
+    fn prune_emptied_dirs_never_removes_owned_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let datadir = layout.datadir.clone();
+        let only = datadir.join("components").join("tokenless");
+        fs::create_dir_all(&only).expect("chain");
+
+        prune_emptied_dirs(&layout, vec![only]);
+
+        assert!(
+            datadir.exists(),
+            "datadir root must survive even when fully emptied"
+        );
+        assert!(!datadir.join("components").exists(), "chain below pruned");
+    }
+
+    /// Owned roots can nest: the user layout places `libexec_dir` inside
+    /// `lib_dir`. Pruning the last libexec component must stop at
+    /// `libexec_dir` itself — a parent-is-owned check alone would climb
+    /// through it because `lib_dir` is also owned.
+    #[test]
+    fn prune_emptied_dirs_keeps_nested_user_mode_roots() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).expect("home");
+        let layout = FsLayout::user(home);
+        assert!(
+            layout.libexec_dir.starts_with(&layout.lib_dir),
+            "precondition: user-mode libexec nests inside lib"
+        );
+
+        let emptied = layout.libexec_dir.join("tokenless");
+        fs::create_dir_all(&emptied).expect("chain");
+
+        prune_emptied_dirs(&layout, vec![emptied.clone()]);
+
+        assert!(!emptied.exists(), "component dir must be pruned");
+        assert!(
+            layout.libexec_dir.exists(),
+            "nested libexec root must survive the climb"
+        );
+        assert!(layout.lib_dir.exists(), "outer lib root must survive");
+    }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
@@ -85,6 +85,14 @@ impl FrameworkDriver for ClaudeCodeDriver {
         "claude-code"
     }
 
+    fn probe_bundle(&self, resource_root: &Path, _declared_entry: Option<&str>) -> bool {
+        // Mirrors read_bundle's mandatory checks: a Claude Code bundle
+        // requires both the marketplace and the plugin manifest,
+        // regardless of any contract-declared entry.
+        resource_root.join(MARKETPLACE_MANIFEST).is_file()
+            && resource_root.join(PLUGIN_MANIFEST).is_file()
+    }
+
     fn detect(&self, _env: &HostEnv) -> DetectResult {
         match find_binary_in_path(&claude_bin()) {
             Some(path) => DetectResult {

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -70,6 +70,14 @@ impl FrameworkDriver for CodexDriver {
         "codex"
     }
 
+    fn probe_bundle(&self, resource_root: &Path, declared_entry: Option<&str>) -> bool {
+        // Mirrors read_bundle's mandatory check: the codex-native plugin
+        // manifest (or the contract-declared entry) must be present.
+        resource_root
+            .join(declared_entry.unwrap_or(CODEX_PLUGIN_MANIFEST))
+            .is_file()
+    }
+
     fn detect(&self, _env: &HostEnv) -> DetectResult {
         match find_binary_in_path(&codex_bin()) {
             Some(path) => DetectResult {

--- a/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
@@ -72,6 +72,14 @@ impl FrameworkDriver for CoshDriver {
         "cosh"
     }
 
+    fn probe_bundle(&self, resource_root: &Path, declared_entry: Option<&str>) -> bool {
+        // Mirrors read_bundle's mandatory check: the native extension
+        // manifest (or the contract-declared entry) must be present.
+        resource_root
+            .join(declared_entry.unwrap_or(COSH_MANIFEST))
+            .is_file()
+    }
+
     fn detect(&self, env: &HostEnv) -> DetectResult {
         // A cosh CLI on PATH is the strong signal. Because the extension
         // model only drops files (no CLI needed to enable), an existing

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -450,6 +450,25 @@ pub trait FrameworkDriver: Send + Sync {
     /// `PATH` and the filesystem; must not spawn the framework.
     fn detect(&self, env: &HostEnv) -> DetectResult;
 
+    /// Cheap read-only check that `resource_root` plausibly holds a real
+    /// bundle for this framework. The Manager consults it when resolving
+    /// the adapter source across multiple datadir roots so a stale or
+    /// empty leftover directory in one root cannot shadow (or impersonate)
+    /// the real bundle in another.
+    ///
+    /// Must mirror [`Self::read_bundle`]'s *mandatory file* checks without
+    /// parsing or digesting, and must never be stricter than `read_bundle`
+    /// (a root this probe rejects must also fail `read_bundle`, otherwise
+    /// resolution could skip a bundle enable would accept). The default
+    /// accepts any non-empty directory, matching the frameworks whose
+    /// `read_bundle` requires no specific file (OpenClaw, Hermes).
+    fn probe_bundle(&self, resource_root: &Path, _declared_entry: Option<&str>) -> bool {
+        resource_root
+            .read_dir()
+            .map(|mut entries| entries.next().is_some())
+            .unwrap_or(false)
+    }
+
     /// External roots (outside ANOLISA-owned roots) this driver is allowed
     /// to write into. The Manager validates every
     /// [`ClaimResourceKind::ExternalPath`](super::claim::ClaimResourceKind::ExternalPath)

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -210,6 +210,10 @@ struct AdapterDecl {
     /// expansion. Used by `scan` and `enable` to resolve the
     /// contract-driven resource root.
     dest: Option<String>,
+    /// Bundle entry filename declared in the contract, if any. Scan uses
+    /// it (like enable) to tell a real bundle directory from a stale
+    /// leftover skeleton.
+    bundle_entry: Option<String>,
     /// Datadir roots from the [`VisibleRoot`] where this declaration's
     /// component contract was resolved. `dest` expansion is scoped to
     /// only these roots.
@@ -372,16 +376,24 @@ impl AdapterManager {
     pub fn scan(&self) -> Result<ScanReport, AdapterError> {
         let state = self.load_state()?;
         let mut entries: BTreeMap<(String, String), ScanEntry> = BTreeMap::new();
-        for (component, framework, resource_root) in self.discover_all() {
+        for (component, framework, _first_dir) in self.discover_all() {
             let (driver_available, framework_detected) = self.driver_scan_facts(&framework);
             let claim = state.find_adapter_claim(&component, &framework);
+            // discover_all() only supplies the (component, framework) key:
+            // its first-wins path may be a stale skeleton shadowing a real
+            // bundle in a later root. Re-select across all datadir roots so
+            // only a directory holding a real bundle is surfaced; a
+            // key with no valid bundle anywhere shows resource absent.
+            let resource_root = self
+                .discover_valid_convention_root(&component, &framework, None)
+                .map(|(path, _)| path);
             entries.insert(
                 (component.clone(), framework.clone()),
                 ScanEntry {
                     component,
                     framework,
                     declared: false,
-                    resource_root: Some(resource_root),
+                    resource_root,
                     driver_available,
                     framework_detected,
                     adapter_type: None,
@@ -408,10 +420,25 @@ impl AdapterManager {
                     entry.resource_root = declaration.dest.as_deref().and_then(|dest| {
                         self.resolve_declared_scan_root(
                             &declaration.component,
+                            &declaration.framework,
                             dest,
+                            declaration.bundle_entry.as_deref(),
                             &declaration.scoped_datadir_roots,
                         )
                     });
+                } else {
+                    // Convention adapter: always re-resolve with the
+                    // contract-declared bundle entry. The native-default
+                    // probe above may have accepted a root that lacks the
+                    // declared entry, which enable and the source probe
+                    // would reject — the declared entry is authoritative.
+                    entry.resource_root = self
+                        .discover_valid_convention_root(
+                            &declaration.component,
+                            &declaration.framework,
+                            declaration.bundle_entry.as_deref(),
+                        )
+                        .map(|(path, _)| path);
                 }
                 continue;
             }
@@ -421,7 +448,9 @@ impl AdapterManager {
             let resource_root = declaration.dest.as_deref().and_then(|dest| {
                 self.resolve_declared_scan_root(
                     &declaration.component,
+                    &declaration.framework,
                     dest,
+                    declaration.bundle_entry.as_deref(),
                     &declaration.scoped_datadir_roots,
                 )
             });
@@ -1205,11 +1234,28 @@ impl AdapterManager {
             &vr.contract_datadir_roots,
             contract_datadir_root.as_deref(),
         ) {
-            Ok((resource_root, _)) => SourceProbe {
-                status: AdapterSourceStatus::Available,
-                resource_root: Some(resource_root),
-                reason: None,
-            },
+            // resolve prefers a root with a valid bundle, so a winner that
+            // still fails the bundle check means every candidate is a stale
+            // leftover (e.g. the empty skeleton an uninstalled scope left
+            // behind). Report Missing rather than letting a hollow
+            // directory masquerade as a live source.
+            Ok((resource_root, _))
+                if self.bundle_root_valid(
+                    framework,
+                    declared_bundle_entry(&manifest, framework).as_deref(),
+                    &resource_root,
+                ) =>
+            {
+                SourceProbe {
+                    status: AdapterSourceStatus::Available,
+                    resource_root: Some(resource_root),
+                    reason: None,
+                }
+            }
+            Ok((resource_root, _)) => source_missing(format!(
+                "adapter source for '{component}/{framework}' at {} is not a valid bundle (bundle marker missing)",
+                resource_root.display()
+            )),
             Err(err) => source_missing(format!(
                 "adapter source unavailable for '{component}/{framework}': {err}"
             )),
@@ -1437,6 +1483,7 @@ impl AdapterManager {
                             .map(str::trim)
                             .filter(|d| !d.is_empty())
                             .map(str::to_string),
+                        bundle_entry: declared_bundle_entry(&manifest, framework),
                         scoped_datadir_roots: scoped_roots.clone(),
                     });
                 }
@@ -1498,6 +1545,7 @@ impl AdapterManager {
         contract_datadir_root: Option<&Path>,
     ) -> Result<(PathBuf, PathBuf), AdapterError> {
         let dest_template = declared_dest(manifest, framework);
+        let declared_entry = declared_bundle_entry(manifest, framework);
         match dest_template {
             Some(template) => {
                 let dest_uses_datadir = template.contains("{datadir}");
@@ -1506,27 +1554,51 @@ impl AdapterManager {
                 } else {
                     scoped_datadir_roots.to_vec()
                 };
+                let effective_for = |datadir: &PathBuf| -> PathBuf {
+                    if dest_uses_datadir {
+                        datadir.clone()
+                    } else {
+                        contract_datadir_root
+                            .map(Path::to_path_buf)
+                            .or_else(|| self.manifest_datadir_root(component, scoped_datadir_roots))
+                            .unwrap_or_else(|| datadir.clone())
+                    }
+                };
+                // Prefer the first root holding a real bundle. A directory
+                // that exists but fails the bundle check (e.g. the empty
+                // skeleton a raw uninstall leaves in another scope) must
+                // not shadow a valid bundle in a later root; it is kept
+                // only as a fallback so enable still reaches the driver's
+                // specific BundleInvalid error when no root has a valid
+                // bundle at all.
+                let mut existing_fallback = None;
                 let mut last_expanded = None;
                 for datadir in &ordered_roots {
                     match self.expand_dest_template(&template, component, datadir) {
-                        Ok(path) if path.is_dir() => {
-                            let effective = if dest_uses_datadir {
-                                datadir.clone()
-                            } else {
-                                contract_datadir_root
-                                    .map(Path::to_path_buf)
-                                    .or_else(|| {
-                                        self.manifest_datadir_root(component, scoped_datadir_roots)
-                                    })
-                                    .unwrap_or_else(|| datadir.clone())
-                            };
+                        Ok(path)
+                            if self.bundle_root_valid(
+                                framework,
+                                declared_entry.as_deref(),
+                                &path,
+                            ) =>
+                        {
+                            let effective = effective_for(datadir);
                             return Ok((path, effective));
+                        }
+                        Ok(path) if path.is_dir() => {
+                            if existing_fallback.is_none() {
+                                existing_fallback = Some((path, datadir.clone()));
+                            }
                         }
                         Ok(path) => {
                             last_expanded = Some((path, datadir.clone()));
                         }
                         Err(_) => continue,
                     }
+                }
+                if let Some((path, datadir)) = existing_fallback {
+                    let effective = effective_for(&datadir);
+                    return Ok((path, effective));
                 }
                 let path = match last_expanded {
                     Some((p, _)) => p,
@@ -1547,33 +1619,95 @@ impl AdapterManager {
                     path,
                 })
             }
-            None => self.discover_resource_root(component, framework).ok_or(
-                AdapterError::ResourceRootNotFound {
+            None => {
+                // Convention discovery, with the same valid-bundle
+                // preference across all datadir roots.
+                if let Some(found) = self.discover_valid_convention_root(
+                    component,
+                    framework,
+                    declared_entry.as_deref(),
+                ) {
+                    return Ok(found);
+                }
+                let mut existing_fallback = None;
+                for root in &self.all_datadir_roots {
+                    let candidate = root.join("adapters").join(component).join(framework);
+                    if existing_fallback.is_none() && candidate.is_dir() {
+                        existing_fallback = Some((candidate, root.clone()));
+                    }
+                }
+                existing_fallback.ok_or(AdapterError::ResourceRootNotFound {
                     component: component.to_string(),
                     framework: framework.to_string(),
-                },
-            ),
+                })
+            }
         }
     }
 
     /// Resolve the contract-declared resource root for a declared adapter
     /// during scan. Returns `Some(path)` only when the expanded `dest`
-    /// directory exists on disk; returns `None` when the template cannot
-    /// be expanded or the directory is absent.
+    /// directory exists on disk **and** looks like a real bundle for the
+    /// framework (see [`Self::bundle_root_valid`]); returns `None` when
+    /// the template cannot be expanded, the directory is absent, or only
+    /// a stale leftover skeleton exists.
     ///
     /// `scoped_datadir_roots` limits expansion to the visible root that
     /// owns the component's contract.
     fn resolve_declared_scan_root(
         &self,
         component: &str,
+        framework: &str,
         dest_template: &str,
+        declared_entry: Option<&str>,
         scoped_datadir_roots: &[PathBuf],
     ) -> Option<PathBuf> {
         for datadir in scoped_datadir_roots {
             if let Ok(path) = self.expand_dest_template(dest_template, component, datadir) {
-                if path.is_dir() {
+                if self.bundle_root_valid(framework, declared_entry, &path) {
                     return Some(path);
                 }
+            }
+        }
+        None
+    }
+
+    /// True when `dir` holds a plausible adapter bundle for `framework`
+    /// rather than a stale or empty leftover (e.g. the bare directory
+    /// skeleton an uninstalled scope leaves behind, which must not shadow
+    /// the real source in another datadir root).
+    ///
+    /// Validity is owned by the driver ([`FrameworkDriver::probe_bundle`]
+    /// mirrors its own `read_bundle` mandatory-file checks); a framework
+    /// without a driver falls back to "non-empty directory", the only
+    /// signal available. Fail-closed: an unreadable directory is not a
+    /// bundle.
+    fn bundle_root_valid(&self, framework: &str, declared_entry: Option<&str>, dir: &Path) -> bool {
+        if !dir.is_dir() {
+            return false;
+        }
+        match self.registry.get(framework) {
+            Some(driver) => driver.probe_bundle(dir, declared_entry),
+            None => dir
+                .read_dir()
+                .map(|mut entries| entries.next().is_some())
+                .unwrap_or(false),
+        }
+    }
+
+    /// First datadir root whose conventional
+    /// `adapters/<component>/<framework>/` directory holds a valid bundle.
+    /// Returns `(resource_root, datadir_root)` like
+    /// [`Self::discover_resource_root`], but skips stale leftovers.
+    fn discover_valid_convention_root(
+        &self,
+        component: &str,
+        framework: &str,
+        declared_entry: Option<&str>,
+    ) -> Option<(PathBuf, PathBuf)> {
+        for root in &self.all_datadir_roots {
+            let candidate = root.join("adapters").join(component).join(framework);
+            if self.bundle_root_valid(framework, declared_entry, &candidate) {
+                return Some((candidate, root.clone()));
             }
         }
         None
@@ -3868,6 +4002,443 @@ source = "adapters/openclaw"
         assert!(outcome.report.cleanup_complete);
     }
 
+    /// Contract TOML for a cosh extension adapter with a declared bundle
+    /// entry and a `{datadir}`-relative dest (the tokenless shape).
+    fn contract_toml_cosh_extension(name: &str) -> String {
+        format!(
+            r#"
+[component]
+name = "{name}"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "cosh"
+adapter_type = "extension"
+plugin_id = "{name}"
+source = "extensions/{name}"
+dest = "{{datadir}}/extensions/{{component}}/"
+
+[adapters.bundle]
+entry = "cosh-extension.json"
+"#
+        )
+    }
+
+    fn cosh_claim(component: &str, resource_root: PathBuf) -> AdapterClaim {
+        use crate::adapter::claim::{
+            CLAIM_SCHEMA_VERSION, CoshClaim, DRIVER_SCHEMA_VERSION, DriverPayload,
+        };
+
+        AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: component.to_string(),
+            framework: "cosh".to_string(),
+            plugin_id: Some(component.to_string()),
+            adapter_type: Some("extension".to_string()),
+            enabled_at: "2026-07-09T00:00:00Z".to_string(),
+            resource_root,
+            bundle_digest: None,
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            notices: Vec::new(),
+            resources: Vec::new(),
+            driver_payload: DriverPayload::Cosh(CoshClaim {
+                extension_dir_resource: "cosh_extension_dir".to_string(),
+            }),
+        }
+    }
+
+    /// A stale skeleton left in another datadir root (e.g. by an uninstall
+    /// in a different scope) must not mask a removed adapter source: with
+    /// the real bundle gone, the receipt's source must go Missing even
+    /// though the second root still has a hollow directory of the same
+    /// name (issue reproduced by AgenticOS Nightly).
+    #[test]
+    fn stale_skeleton_in_second_root_does_not_mask_missing_source() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let rpm_datadir = tmp.path().join("data-rpm");
+        let raw_datadir = tmp.path().join("data-raw");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "tokenless",
+            ObjectStatus::Installed,
+        );
+        write_contract_with_content(
+            &rpm_datadir,
+            "tokenless",
+            &contract_toml_cosh_extension("tokenless"),
+        );
+
+        // Real bundle in the first root; hollow leftover in the second.
+        let bundle_root = rpm_datadir.join("extensions").join("tokenless");
+        std::fs::create_dir_all(&bundle_root).expect("bundle dir");
+        std::fs::write(bundle_root.join("cosh-extension.json"), b"{}").expect("marker");
+        let skeleton = raw_datadir.join("extensions").join("tokenless");
+        std::fs::create_dir_all(&skeleton).expect("skeleton dir");
+
+        let state_path = state_dir.join("installed.toml");
+        let mut state = load_written_state(&state_path);
+        state.upsert_adapter_claim(cosh_claim("tokenless", bundle_root.clone()));
+        state.save(&state_path).expect("save claim");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_path;
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![rpm_datadir.clone(), raw_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![rpm_datadir, raw_datadir];
+
+        // With the real bundle present the source is available.
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "cosh")
+            .expect("cosh row");
+        assert_eq!(entry.source_status, Some(AdapterSourceStatus::Available));
+
+        // Remove the real bundle; the skeleton alone must not keep the
+        // source alive.
+        std::fs::remove_dir_all(&bundle_root).expect("remove bundle");
+        let report = manager.scan().expect("scan after removal");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "cosh")
+            .expect("cosh row after removal");
+        assert_eq!(entry.source_status, Some(AdapterSourceStatus::Missing));
+        assert!(
+            entry
+                .source_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("not a valid bundle")),
+            "reason should call out the invalid bundle, got: {:?}",
+            entry.source_reason
+        );
+        assert!(
+            entry.resource_root.is_none(),
+            "a hollow skeleton must not surface as the resource root"
+        );
+    }
+
+    /// enable's resource-root resolution must prefer the root holding a
+    /// real bundle over an earlier root that only has a stale skeleton.
+    #[test]
+    fn resolve_resource_root_prefers_valid_bundle_over_skeleton() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let first_datadir = tmp.path().join("data-first");
+        let second_datadir = tmp.path().join("data-second");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "tokenless",
+            ObjectStatus::Installed,
+        );
+        write_contract_with_content(
+            &first_datadir,
+            "tokenless",
+            &contract_toml_cosh_extension("tokenless"),
+        );
+
+        // Skeleton in the contract-origin root, real bundle in the other.
+        let skeleton = first_datadir.join("extensions").join("tokenless");
+        std::fs::create_dir_all(&skeleton).expect("skeleton dir");
+        let bundle_root = second_datadir.join("extensions").join("tokenless");
+        std::fs::create_dir_all(&bundle_root).expect("bundle dir");
+        std::fs::write(bundle_root.join("cosh-extension.json"), b"{}").expect("marker");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.clone(),
+            contract_datadir_roots: vec![first_datadir.clone(), second_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![first_datadir, second_datadir];
+
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root) = manager
+            .load_visible_component_manifest("tokenless", &state)
+            .expect("load manifest");
+        let (resolved, _) = manager
+            .resolve_resource_root(
+                "tokenless",
+                "cosh",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+            )
+            .expect("resolve");
+        assert_eq!(
+            resolved, bundle_root,
+            "resolution must skip the skeleton and pick the real bundle"
+        );
+    }
+
+    /// A root satisfying only part of a driver's mandatory file set (qoder
+    /// needs plugin manifest AND hooks.json) is not a valid bundle and must
+    /// not shadow a complete bundle in a later root.
+    #[test]
+    fn resolve_resource_root_skips_incomplete_qoder_bundle() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let first_datadir = tmp.path().join("data-first");
+        let second_datadir = tmp.path().join("data-second");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "tokenless",
+            ObjectStatus::Installed,
+        );
+        let contract = r#"
+[component]
+name = "tokenless"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "qoder"
+adapter_type = "plugin"
+plugin_id = "tokenless"
+source = "adapters/qoder"
+dest = "{datadir}/adapters/{component}/qoder/"
+
+[adapters.bundle]
+entry = ".qoder-plugin/plugin.json"
+"#;
+        write_contract_with_content(&first_datadir, "tokenless", contract);
+
+        // First root: manifest only — read_bundle would reject it for the
+        // missing hooks.json. Second root: complete bundle.
+        let incomplete = first_datadir.join("adapters/tokenless/qoder");
+        std::fs::create_dir_all(incomplete.join(".qoder-plugin")).expect("incomplete dir");
+        std::fs::write(incomplete.join(".qoder-plugin/plugin.json"), b"{}").expect("manifest");
+        let complete = second_datadir.join("adapters/tokenless/qoder");
+        std::fs::create_dir_all(complete.join(".qoder-plugin")).expect("complete dir");
+        std::fs::write(complete.join(".qoder-plugin/plugin.json"), b"{}").expect("manifest");
+        std::fs::write(complete.join("hooks.json"), b"{}").expect("hooks");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.clone(),
+            contract_datadir_roots: vec![first_datadir.clone(), second_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![first_datadir, second_datadir];
+
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root) = manager
+            .load_visible_component_manifest("tokenless", &state)
+            .expect("load manifest");
+        let (resolved, _) = manager
+            .resolve_resource_root(
+                "tokenless",
+                "qoder",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+            )
+            .expect("resolve");
+        assert_eq!(
+            resolved, complete,
+            "an incomplete qoder bundle must not shadow the complete one"
+        );
+    }
+
+    /// Convention-path scan rows (no contract dest) must not surface a
+    /// hollow directory as a present resource either.
+    #[test]
+    fn scan_convention_row_hides_skeleton_resource() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "tokenless",
+            ObjectStatus::Installed,
+        );
+        write_contract_with_content(
+            &datadir,
+            "tokenless",
+            &contract_toml_without_dest("tokenless"),
+        );
+        // Empty conventional directory — a leftover, not a bundle.
+        std::fs::create_dir_all(datadir.join("adapters/tokenless/openclaw")).expect("skeleton");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![datadir.clone()];
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "openclaw")
+            .expect("row");
+        assert!(
+            entry.resource_root.is_none(),
+            "an empty convention directory must not show as a present resource"
+        );
+
+        // A real (non-empty) bundle in the same place is surfaced again.
+        std::fs::write(
+            datadir.join("adapters/tokenless/openclaw/openclaw.plugin.json"),
+            b"{}",
+        )
+        .expect("bundle file");
+        let report = manager.scan().expect("scan with bundle");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "openclaw")
+            .expect("row with bundle");
+        assert_eq!(
+            entry.resource_root.as_deref(),
+            Some(datadir.join("adapters/tokenless/openclaw").as_path()),
+            "a real bundle must still be surfaced"
+        );
+    }
+
+    /// discover_all() dedupes on (component, framework) first-wins, so a
+    /// leading skeleton root used to swallow the key before validation
+    /// could consider later roots. Scan must re-select across all roots.
+    #[test]
+    fn scan_convention_prefers_valid_bundle_in_later_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let first_datadir = tmp.path().join("data-first");
+        let second_datadir = tmp.path().join("data-second");
+
+        // Pure directory discovery: no installed state, no contract.
+        std::fs::create_dir_all(&state_dir).expect("mkdir state");
+        InstalledState::default()
+            .save(&state_dir.join("installed.toml"))
+            .expect("save empty state");
+
+        // First root: empty skeleton. Second root: real bundle.
+        std::fs::create_dir_all(first_datadir.join("adapters/tokenless/openclaw"))
+            .expect("skeleton");
+        let bundle = second_datadir.join("adapters/tokenless/openclaw");
+        std::fs::create_dir_all(&bundle).expect("bundle dir");
+        std::fs::write(bundle.join("openclaw.plugin.json"), b"{}").expect("bundle file");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![first_datadir.clone(), second_datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![first_datadir, second_datadir];
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "openclaw")
+            .expect("row");
+        assert_eq!(
+            entry.resource_root.as_deref(),
+            Some(bundle.as_path()),
+            "a leading skeleton must not swallow the valid bundle in a later root"
+        );
+    }
+
+    /// A convention root that satisfies the driver's native marker but
+    /// lacks the contract-declared bundle entry must not be surfaced:
+    /// enable and the source probe honor the declared entry, so scan
+    /// showing that root would advertise a path they reject.
+    #[test]
+    fn scan_convention_declared_entry_overrides_native_marker() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "tokenless",
+            ObjectStatus::Installed,
+        );
+        let contract = r#"
+[component]
+name = "tokenless"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "cosh"
+adapter_type = "extension"
+source = "adapters/cosh"
+
+[adapters.bundle]
+entry = "custom-entry.json"
+"#;
+        write_contract_with_content(&datadir, "tokenless", contract);
+
+        // The native cosh manifest passes the default probe, but the
+        // contract-declared entry is missing.
+        let convention = datadir.join("adapters/tokenless/cosh");
+        std::fs::create_dir_all(&convention).expect("convention dir");
+        std::fs::write(convention.join("cosh-extension.json"), b"{}").expect("native manifest");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.path().join("home")), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![datadir.clone()];
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "cosh")
+            .expect("row");
+        assert!(
+            entry.resource_root.is_none(),
+            "a root missing the declared bundle entry must not be surfaced"
+        );
+
+        // Adding the declared entry makes the root valid again.
+        std::fs::write(convention.join("custom-entry.json"), b"{}").expect("declared entry");
+        let report = manager.scan().expect("scan with entry");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "tokenless" && e.framework == "cosh")
+            .expect("row with entry");
+        assert_eq!(
+            entry.resource_root.as_deref(),
+            Some(convention.as_path()),
+            "the root must reappear once the declared entry exists"
+        );
+    }
+
     // -- contract-driven resource root discovery --------------------------------
 
     /// Convention path still works when manifest has no dest or no manifest.
@@ -3942,6 +4513,9 @@ source = "adapters/openclaw"
 
         let convention = datadir.join("adapters").join("tokenless").join("openclaw");
         std::fs::create_dir_all(&convention).expect("mkdir convention");
+        // Discovery only surfaces real bundles; an empty directory would be
+        // treated as a stale skeleton, so give the bundle some content.
+        std::fs::write(convention.join("openclaw.plugin.json"), b"{}").expect("bundle file");
 
         let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
         let mut manager =

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
@@ -106,6 +106,16 @@ impl FrameworkDriver for QoderDriver {
         "qoder"
     }
 
+    fn probe_bundle(&self, resource_root: &Path, declared_entry: Option<&str>) -> bool {
+        // Mirrors read_bundle's mandatory checks: the plugin manifest (or
+        // the contract-declared entry) AND hooks.json must both be
+        // present — a manifest-only leftover is not a usable bundle.
+        resource_root
+            .join(declared_entry.unwrap_or(QODER_PLUGIN_MANIFEST))
+            .is_file()
+            && resource_root.join(QODER_HOOKS_FILE).is_file()
+    }
+
     fn detect(&self, env: &HostEnv) -> DetectResult {
         match resolve_qodercli(env.user_home.as_deref()) {
             Some(path) => DetectResult {

--- a/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
@@ -73,6 +73,14 @@ impl FrameworkDriver for QwenCodeDriver {
         "qwencode"
     }
 
+    fn probe_bundle(&self, resource_root: &Path, _declared_entry: Option<&str>) -> bool {
+        // Mirrors read_bundle's mandatory check: the Qwen-native root
+        // manifest must be present. The declared entry is ignored here —
+        // read_bundle rejects any entry other than the native manifest,
+        // so consulting it could only make this probe stricter.
+        resource_root.join(QWEN_MANIFEST).is_file()
+    }
+
     fn detect(&self, _env: &HostEnv) -> DetectResult {
         match find_binary_in_path(&qwen_program()) {
             Some(path) => DetectResult {


### PR DESCRIPTION
Ref: https://github.com/alibaba/anolisa/issues/1815 (bug 1 of the nightly report; analysis of the codex-receipt case is in the issue discussion)

## Root cause

`resolve_resource_root` accepted **any existing directory** as the adapter source. With multiple datadir roots visible (e.g. rpm's `/usr/share/anolisa` plus raw's `/usr/local/share/anolisa`), a hollow leftover directory in one root — such as the empty skeleton a raw uninstall leaves behind — could shadow a removed source in another root. `anolisa status` / `adapter status` then kept reporting `source_available=true` / `healthy` after the real bundle was deleted.

Reproduced on ALinux 4: install tokenless via rpm backend, enable cosh, `rm -rf /usr/share/anolisa/extensions/tokenless/` while a stale `/usr/local/share/anolisa/extensions/tokenless/` exists → `healthy` before this fix, `degraded` after.

## Changes

- **`FrameworkDriver::bundle_marker()`** (new trait method): the framework-native manifest that marks a real bundle (cosh/codex/claude-code/qoder/qwencode). OpenClaw/Hermes keep the default `None` — any non-empty directory — mirroring their `read_bundle` acceptance rule.
- **`resolve_resource_root`**: prefer the first root holding a real bundle (contract bundle entry, else driver marker). A directory that exists but fails the check no longer shadows a valid bundle in a later root; it survives only as a fallback so enable still reaches the driver's specific `BundleInvalid` error when no root has a valid bundle at all.
- **`source_probe` fails closed**: when even the winning root lacks its bundle marker, the source is reported `missing` (receipt goes `degraded`) with an explicit reason instead of `available`.
- **scan**: contract-declared resource roots are validated the same way, so a skeleton no longer surfaces as `resource_root` / `resource_present`.
- **raw uninstall prunes emptied directories** (`prune_emptied_dirs`): removes the directory chain the file removal emptied, so no skeleton is left to pollute source probing in other scopes. Bounded by `remove_dir` (refuses non-empty) and the owned-roots check (the roots themselves always survive).

## Testing

- 4 new regression tests: stale skeleton in a second root → source `missing` + not surfaced by scan; resolution prefers the valid bundle over a skeleton; pruning removes emptied chains while keeping owned roots and non-empty siblings.
- Full suite: `cargo test -p anolisa-core -p anolisa-cli` — 1754 passed, 0 failed; `cargo fmt --check`, `clippy`, `cargo doc --no-deps` clean.
- End-to-end on an ALinux 4 ECS: the nightly scenario now reports `degraded` / `source_available=false` (with a reason naming the invalid path), a healthy codex receipt on the same component stays `healthy`, and a raw install → uninstall cycle leaves zero directory skeleton.
