### PR TITLE
chore(tokenless): bump version to 0.7.2

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.0"
+version = "0.7.2"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -6,7 +6,7 @@
 # Installed to: %{_datadir}/anolisa/components/tokenless/component.toml
 [component]
 name = "tokenless"
-version = "0.7.1"
+version = "0.7.2"
 
 [[adapters]]
 framework = "openclaw"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -1,8 +1,36 @@
 # Changelog
 
-## Unreleased
+All notable changes to Tokenless will be documented in this file.
 
-- fix Claude Code PostToolUse hook to *replace* the model-visible tool result via `hookSpecificOutput.updatedToolOutput` (Claude Code >= 2.1.121) instead of appending the compressed payload through the additive `additionalContext`, which duplicated the original output — `additionalContext` now carries only additive env-attribution diagnostics, empty schema fields (e.g. Bash `stderr`/`interrupted`/`isImage`) are restored on the replacement, older or undetectable Claude Code versions fail open by disabling compression, and non-beneficial compressions now pass through unchanged for every agent; adds `tests/test-posttooluse-replacement.sh` covering replacement semantics (closes #1645)
+Releases from 0.7.2 onward follow
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [0.7.2] - 2026-07-27
+
+### Added
+
+- Tokenless now compresses Cosh-NG tool responses by replacing the original model-visible content ([#1669](https://github.com/alibaba/anolisa/pull/1669)).
+- Tokenless now rewrites supported Cosh-NG shell commands for more compact output ([#1669](https://github.com/alibaba/anolisa/pull/1669)).
+
+### Changed
+
+- Shell environment checks now report only recommended tools referenced by the current command ([#1598](https://github.com/alibaba/anolisa/pull/1598)).
+- `tokenless env-check --fix` now installs required dependencies only, leaving optional recommendations untouched ([#1598](https://github.com/alibaba/anolisa/pull/1598)).
+- Automatic dependency fixes now fail quickly with actionable authentication, network, or permission messages instead of prompting for sudo ([#1598](https://github.com/alibaba/anolisa/pull/1598)).
+- Cosh-NG compression statistics are now recorded under the `cosh-ng` agent ([#1669](https://github.com/alibaba/anolisa/pull/1669)).
+- Cosh-NG compression now excludes display-only content from model context ([#1669](https://github.com/alibaba/anolisa/pull/1669)).
+- Cosh-NG runs with undetectable versions now keep original tool responses unchanged ([#1669](https://github.com/alibaba/anolisa/pull/1669)).
+- Compression now leaves tool results unchanged when the compressed output is not smaller ([#1674](https://github.com/alibaba/anolisa/pull/1674)).
+- Tokenless user manuals now live in the central ANOLISA guide instead of the RPM package ([#1586](https://github.com/alibaba/anolisa/pull/1586)).
+
+### Fixed
+
+- Claude Code 2.1.121+ now replaces original tool results with compressed versions, preventing duplicate context ([#1674](https://github.com/alibaba/anolisa/pull/1674), [#1686](https://github.com/alibaba/anolisa/pull/1686)).
+- Older or undetectable Claude Code versions now pass tool results through unchanged instead of duplicating compressed context ([#1674](https://github.com/alibaba/anolisa/pull/1674), [#1686](https://github.com/alibaba/anolisa/pull/1686)).
+- Claude Code replacements now preserve built-in tool result formats, including empty fields ([#1674](https://github.com/alibaba/anolisa/pull/1674), [#1686](https://github.com/alibaba/anolisa/pull/1686)).
+- ANOLISA now recognizes the packaged Tokenless version correctly ([#1587](https://github.com/alibaba/anolisa/pull/1587)).
 
 ## 0.7.1
 
@@ -156,3 +184,6 @@
 ## 0.1.0
 
 - introduce tokenless into ANOLISA (#199)
+
+[Unreleased]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.2...HEAD
+[0.7.2]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.1...tokenless/v0.7.2

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "clap",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "regex",
  "serde_json",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "MIT"
 

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -33,6 +33,7 @@ ADAPTER_TEMPLATES := \
 # adapter payload tree so the contract is not mixed with adapter resources.
 # Shipped to %{_datadir}/anolisa/components/tokenless/component.toml.
 COMPONENT_CONTRACT := .anolisa/component.toml
+ANOLISA_COMPONENT_MANIFEST := ../anolisa/manifests/components/tokenless/component.toml
 TOON_VER := 0.5.0
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
@@ -85,6 +86,12 @@ check-component-contract:
 		$(MAKE) -B "$(COMPONENT_CONTRACT)"; \
 		cmp -s "$$tmp" "$(COMPONENT_CONTRACT)" || { \
 			diff -u "$$tmp" "$(COMPONENT_CONTRACT)"; \
+			exit 1; \
+		}
+	@catalog_version=$$(sed -n 's/^version = "\([^"]*\)"/\1/p' \
+		"$(ANOLISA_COMPONENT_MANIFEST)" | head -1); \
+		[ "$$catalog_version" = "$(VERSION)" ] || { \
+			echo "ANOLISA tokenless manifest version '$$catalog_version' does not match $(VERSION)"; \
 			exit 1; \
 		}
 


### PR DESCRIPTION
## Description

Prepare Tokenless 0.7.2 by aligning Cargo package versions, component contracts, and ANOLISA catalog metadata. Curate all user-visible changes since `tokenless/v0.7.1` into Added, Changed, and Fixed entries while excluding refactors, tests, and CI-only changes. This makes every release surface report one version and gives users concise release notes.

## Related Issue

no-issue: release-only version bump and changelog aggregation

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 431 passed, 2 ignored
- `make check-component-contract`
- `target/debug/tokenless --version` — reports `tokenless 0.7.2`

## Additional Notes

The runtime changes summarized in the changelog are already present on `main`; this PR contains only release metadata and documentation updates.