### PR TITLE
chore(cosh-ng): relax test inventory floors

### DIFF
--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -23,12 +23,12 @@ test_list() {
 
 check_source_floor() {
   local crate="$1"
-  local expected="$2"
+  local floor="$2"
   local actual
   actual="$(source_count "crates/$crate")"
-  echo "$crate source tests: $actual"
-  if [[ "$actual" -ne "$expected" ]]; then
-    fail "$crate source inventory changed from $expected to $actual; update the necessity audit"
+  echo "$crate source tests: $actual (floor $floor)"
+  if [[ "$actual" -lt "$floor" ]]; then
+    fail "$crate source inventory fell below $floor to $actual; audit removals before lowering the floor"
   fi
 }
 
@@ -50,6 +50,8 @@ check_overlap_ceiling() {
   fi
 }
 
+# These are regression floors, not exact snapshots. Feature branches must not
+# update them when adding tests; raise them periodically in a dedicated change.
 check_source_floor cosh-types 24
 check_source_floor cosh-platform 279
 check_source_floor cosh-cli 75
@@ -57,9 +59,9 @@ check_source_floor cosh-core 696
 check_source_floor cosh-shell 2571
 
 ignored_count="$(rg -n '^[[:space:]]*#\[ignore' crates -g '*.rs' | wc -l | tr -d ' ')"
-echo "ignored tests: $ignored_count"
-if [[ "$ignored_count" -ne 3 ]]; then
-  fail "ignored inventory changed from 3 to $ignored_count"
+echo "ignored tests: $ignored_count (ceiling 3)"
+if [[ "$ignored_count" -gt 3 ]]; then
+  fail "ignored test inventory increased above 3 to $ignored_count"
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4


### PR DESCRIPTION
## Description

Changes source-test inventory checks from exact snapshots to monotonic
regression floors, while retaining ignored-test and duplicate lib/bin counts
as ceilings. Exact snapshots forced every feature PR that added tests to edit
the same lines, so unrelated parallel PRs conflicted during rebase. After this
merges, adding tests no longer requires inventory updates, while genuine test
removal, new ignored tests, and excess duplication still fail. Floors can be
raised periodically in dedicated maintenance PRs.

## Related Issue

no-issue: CI maintenance to reduce recurring rebase conflicts

## Type of Change

- [x] CI/CD or build changes

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `scripts/check-test-inventory.sh`
- `scripts/run-test-gates.sh fast`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- Verified that an actual count above the floor passes and a count below the
  floor fails.

## Additional Notes

Existing feature branches that already update these baselines may see one last
rebase conflict after this merges. They should keep the new `main` version of
the inventory script and drop their feature-specific baseline update.
