### PR TITLE
feat(cosh-ng): [core] support hook tools and env

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/core/extensions.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/core/extensions.md
@@ -71,7 +71,8 @@ Each extension directory must contain `cosh-extension.json`:
       "name": "hook-name",
       "command": "execution command",
       "description": "description",
-      "timeout": 5000
+      "timeout": 5000,
+      "env": { "TOKENLESS_AGENT_ID": "cosh-ng" }
     }
   ]
 }
@@ -83,6 +84,26 @@ Each extension directory must contain `cosh-extension.json`:
 | `sequential` | Whether hooks in the group execute sequentially |
 | `hooks[].command` | Shell command the hook executes |
 | `hooks[].timeout` | Timeout in milliseconds |
+| `hooks[].env` | Environment variables for this hook's child process only |
+
+`env` semantics:
+
+- The child inherits the host environment; an `env` entry overrides an
+  inherited value of the same name. The host process is never modified.
+- Names must match the POSIX rule `[A-Za-z_][A-Za-z0-9_]*`. A strict
+  `schemaVersion: 1` manifest is **rejected** with
+  `extension_hook_env_name_invalid`; a legacy manifest drops the offending
+  entry and logs the name (never the value).
+- Variable substitution applies to values only — names are literal.
+- The host injects `COSH_RUNTIME=cosh-ng` and `COSH_NG_VERSION` after `env`, so
+  they take precedence over a declared entry of the same name. This is a
+  cooperative attribution signal only — a manifest also controls `command` and
+  can reassign these in its own shell.
+- `env` is executable capability and is part of the capability fingerprint:
+  declaring or changing it requires the user to re-consent. Hooks with no `env`
+  keep their existing fingerprint.
+
+See [hooks.md](hooks.md) for the full hook protocol.
 
 ## Variable Substitution
 

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/core/hooks.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/core/hooks.md
@@ -138,6 +138,39 @@ Notifications generated after hook execution are delivered to Shell via JSONL ou
 
 Shell is responsible for rendering notification cards.
 
+## Environment Variables
+
+A hook definition may declare `env`, injected into that hook's child process only:
+
+```json
+{
+  "type": "command",
+  "name": "tokenless-compress-schema",
+  "command": "python3 ${extensionPath}/hooks/compress_schema.py",
+  "env": { "TOKENLESS_AGENT_ID": "cosh-ng" }
+}
+```
+
+- The child inherits the host environment by default; an entry in `env`
+  overrides an inherited value of the same name
+- The host process itself is never modified (no `setenv` call)
+- Names must follow the POSIX rule `[A-Za-z_][A-Za-z0-9_]*`. A strict
+  `schemaVersion: 1` extension manifest is rejected outright with
+  `extension_hook_env_name_invalid`, so the problem surfaces at install time.
+  Config-file and legacy-manifest hooks are validated again at spawn time as a
+  defence in depth: the offending entry is dropped, the hook still runs, and
+  only the name is logged (values are never logged)
+- `${extensionPath}` / `${workspacePath}` are substituted in values only; names
+  are treated literally
+- The host injects `COSH_RUNTIME=cosh-ng` and `COSH_NG_VERSION` after the
+  declared map, so they take precedence over an `env` entry of the same name and
+  hooks can identify the runtime (e.g. for statistics attribution). This is a
+  cooperative signal, **not** a security boundary — the same manifest also owns
+  `command` and can reassign or unset these variables inside its own shell, so
+  nothing security-relevant may depend on them
+- `env` is executable capability and is part of the extension capability
+  fingerprint: adding or changing it triggers re-consent
+
 ## Extension Hooks
 
 Hooks registered via `cosh-extension.json` are merged with configuration file hooks and use the same execution protocol. See [extensions.md](extensions.md).

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/core/hooks.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/core/hooks.md
@@ -83,6 +83,43 @@ Hooks return decisions in JSON format:
 | `systemMessage` | Notification message (displayed to user with priority over reason) |
 | `hookSpecificOutput` | Custom JSON data (`additional_context` within it is injected into conversation context) |
 
+### BeforeModel: rewriting tool declarations
+
+`BeforeModel` input carries the full tool declarations for this request at
+`llm_request.config.tools`. A hook may return a rewritten array at the same path,
+for example to compress descriptions and JSON Schemas:
+
+```json
+{
+  "hookSpecificOutput": {
+    "llm_request": {
+      "config": {
+        "tools": [
+          { "name": "shell", "description": "compressed", "parameters": { "type": "object" } }
+        ]
+      }
+    }
+  }
+}
+```
+
+Constraints:
+
+- The rewrite applies to that single LLM request only; the tool registry and the
+  next turn's declarations are untouched
+- Tool count, order, and names must match the input exactly, and `parameters`
+  must be a JSON object; otherwise the whole array is discarded and the original
+  declarations are used (tool filtering is not part of this protocol)
+- The rewrite may only **compress**: an array whose estimated token count exceeds
+  the original is rejected even when it is otherwise structurally valid. The
+  context budget for the turn is computed from the original declarations before
+  the hook runs, so a larger array would make the runtime under-account the
+  request and risk a provider context overflow
+- With multiple hooks the last valid array in configuration order wins; an
+  invalid value never overwrites an earlier valid one
+- The tool declaration subtree is exempt from key-based redaction, so schema
+  properties named `api_key` or `token` are not corrupted
+
 ## Execution Model
 
 1. Multiple hooks can be registered for the same event point, executed sequentially in configuration order

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/core/extensions.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/core/extensions.md
@@ -71,7 +71,8 @@ cosh-core 的扩展系统通过 `cosh-extension.json` 配置文件注册技能�
       "name": "hook-name",
       "command": "执行命令",
       "description": "说明",
-      "timeout": 5000
+      "timeout": 5000,
+      "env": { "TOKENLESS_AGENT_ID": "cosh-ng" }
     }
   ]
 }
@@ -83,6 +84,22 @@ cosh-core 的扩展系统通过 `cosh-extension.json` 配置文件注册技能�
 | `sequential` | 组内钩子是否顺序执行 |
 | `hooks[].command` | 钩子执行的 shell 命令 |
 | `hooks[].timeout` | 超时时间（毫秒） |
+| `hooks[].env` | 仅注入该钩子子进程的环境变量 |
+
+`env` 语义：
+
+- 子进程继承宿主环境，`env` 中的同名条目覆盖继承值；宿主进程自身永不被修改。
+- 变量名须符合 POSIX 规则 `[A-Za-z_][A-Za-z0-9_]*`。严格 `schemaVersion: 1`
+  manifest 会以 `extension_hook_env_name_invalid` **直接拒绝**；legacy manifest
+  丢弃该条目并只记录变量名（绝不记录取值）。
+- 变量替换只作用于取值，变量名按字面量处理。
+- 宿主在 `env` 之后注入 `COSH_RUNTIME=cosh-ng` 与 `COSH_NG_VERSION`，
+  因此其优先级高于同名声明条目。这只是协作式归因信号——manifest 同时控制
+  `command`，可以在自己的 shell 中重新赋值。
+- `env` 属于可执行能力，会计入 capability 指纹：声明或修改需要用户重新确认；
+  未声明 `env` 的钩子指纹保持不变。
+
+完整钩子协议见 [hooks.md](hooks.md)。
 
 ## 变量替换
 

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/core/hooks.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/core/hooks.md
@@ -83,6 +83,36 @@ Core 以 JSON 格式将事件数据写入钩子进程的 stdin：
 | `systemMessage` | 通知消息（优先于 reason 展示给用户） |
 | `hookSpecificOutput` | 自定义 JSON 数据（其中 `additional_context` 会注入对话上下文） |
 
+### BeforeModel：改写工具声明
+
+`BeforeModel` 输入在 `llm_request.config.tools` 中携带本次请求的完整工具声明，
+钩子可以通过同一路径返回改写后的数组（例如压缩 `description` 与 JSON Schema）：
+
+```json
+{
+  "hookSpecificOutput": {
+    "llm_request": {
+      "config": {
+        "tools": [
+          { "name": "shell", "description": "压缩后的说明", "parameters": { "type": "object" } }
+        ]
+      }
+    }
+  }
+}
+```
+
+约束：
+
+- 改写只作用于当前一次 LLM 请求，工具注册表与下一轮声明不受影响
+- 数组的工具数量、顺序和名称必须与输入完全一致，`parameters` 必须是 JSON object；
+  否则整个数组被丢弃并回退原始声明（工具过滤不属于该协议）
+- 改写只允许**压缩**：估算 token 数超过原声明的数组即使结构合法也会被拒绝。
+  本轮的上下文预算在钩子执行前就按原声明计算完毕，更大的数组会让运行时低估真实
+  请求，可能导致 provider 上下文溢出
+- 多个钩子按配置顺序生效，取最后一个合法数组；非法值不会覆盖此前的合法值
+- 工具声明子树豁免基于键名的脱敏，因此名为 `api_key`、`token` 的 schema 属性不会被破坏
+
 ## 执行模型
 
 1. 同一事件点可注册多个钩子，按配置顺序依次执行

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/core/hooks.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/core/hooks.md
@@ -131,6 +131,32 @@ Core 以 JSON 格式将事件数据写入钩子进程的 stdin：
 
 Shell 端负责渲染通知卡片。
 
+## 环境变量
+
+钩子定义可声明 `env`，只注入该钩子的子进程：
+
+```json
+{
+  "type": "command",
+  "name": "tokenless-compress-schema",
+  "command": "python3 ${extensionPath}/hooks/compress_schema.py",
+  "env": { "TOKENLESS_AGENT_ID": "cosh-ng" }
+}
+```
+
+- 子进程默认继承宿主环境，`env` 中的同名变量覆盖继承值
+- 宿主进程自身永不被修改（不调用 `setenv`）
+- 变量名须符合 POSIX 规则 `[A-Za-z_][A-Za-z0-9_]*`。严格 `schemaVersion: 1`
+  扩展 manifest 会以 `extension_hook_env_name_invalid` 直接拒绝，问题在安装期暴露；
+  配置文件与 legacy manifest 的钩子在启动子进程时再校验一次作为兜底：丢弃该条目、
+  钩子照常执行，且只记录变量名（绝不记录取值）
+- `${extensionPath}` / `${workspacePath}` 只在取值中替换，变量名按字面量处理
+- 宿主在声明的 env map 之后注入 `COSH_RUNTIME=cosh-ng` 与 `COSH_NG_VERSION`，
+  因此其优先级高于同名 `env` 条目，钩子可据此识别运行时（用于统计归因等）。
+  这是协作式信号，**不是**安全边界——同一个 manifest 也控制 `command`，
+  可以在自己的 shell 里重新赋值或 unset 这些变量，因此任何安全相关逻辑都不得依赖它们
+- `env` 属于可执行能力，会计入扩展的 capability 指纹：新增或修改 `env` 会触发重新确认
+
 ## 扩展钩子
 
 通过 `cosh-extension.json` 注册的钩子与配置文件中的钩子合并，使用相同的执行协议。参见 [extensions.md](extensions.md)。

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -129,7 +129,10 @@ only in the operating-system secret store and are always displayed as
 `[redacted]`; workspace settings require an already trusted project. Extension
 context is bounded and injected after project context. Local stdio MCP tools
 use the full `<extension>/mcp/<server>/<tool>` namespace and follow normal tool
-approval. Agent definitions are validated and listed, but currently report
+approval. A hook may declare `env`, injected into that hook's own child process
+only — the host process is never modified — and because that is executable
+capability it is part of the extension capability fingerprint, so declaring or
+changing it requires fresh consent. Agent definitions are validated and listed, but currently report
 `executable=false` until the unified subagent executor is available. Registry
 mutations build a candidate generation. The shell keeps one long-lived core
 process: `/extensions reload` switches a healthy candidate immediately while

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -121,6 +121,8 @@ install、link 和能力发生变化的 update 会先生成 preflight operation�
 展示时始终为 `[redacted]`；workspace setting 只对已信任项目生效。扩展 context
 有明确大小边界，并位于 project context 之后。local stdio MCP tool 使用完整
 `<extension>/mcp/<server>/<tool>` namespace，并经过正常 tool approval。
+钩子可声明 `env`，仅注入该钩子自身的子进程——宿主进程永不被修改；由于这属于可执行
+能力，它会计入扩展 capability 指纹，因此声明或修改需要重新确认。
 Agent definition 会被严格校验和列出，但在统一 subagent executor 接入前明确报告
 `executable=false`。registry mutation 会构建 candidate generation。shell 会话复用
 同一个长生命周期 core process：空闲时 `/extensions reload` 立即切换健康 candidate；

--- a/src/cosh-ng/crates/cosh-core/src/compaction.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction.rs
@@ -20,6 +20,7 @@ pub use projection::CompactionState;
 pub use runtime::CompactionRuntime;
 
 pub(crate) use boundary::has_new_compactable_prefix;
+pub(crate) use budget::estimate_text_tokens;
 pub(crate) use engine::run_compact_cli;
 pub(crate) use preflight::run_context_preflight;
 pub(crate) use projection::sanitize_loaded_state;

--- a/src/cosh-ng/crates/cosh-core/src/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -123,7 +123,7 @@ pub struct HooksConfig {
     pub after_model: Vec<HookDefinition>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct HookDefinition {
     pub command: String,
     #[serde(default)]
@@ -134,6 +134,24 @@ pub struct HookDefinition {
     pub timeout: Option<u64>,
     #[serde(default)]
     pub sequential: Option<bool>,
+    /// Environment variables injected into this hook's child process only.
+    /// The child inherits the parent environment first, so an entry here
+    /// overrides an inherited value of the same name. The host never calls
+    /// `std::env::set_var`, so the cosh-ng process itself is unaffected.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+}
+
+/// Validates an environment variable name against POSIX rules
+/// (`[A-Za-z_][A-Za-z0-9_]*`). Only names are checked — values are opaque and
+/// must never be logged.
+pub fn is_valid_env_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -377,7 +377,13 @@ impl CoshCore {
             // ─── Hook: BeforeModel ───
             let before_model_result = self
                 .hook_system
-                .fire_before_model(&self.session_id, &cwd_str, &self.model, &provider_messages)
+                .fire_before_model(
+                    &self.session_id,
+                    &cwd_str,
+                    &self.model,
+                    &provider_messages,
+                    &tool_decls,
+                )
                 .await;
             self.emit_hook_notifications(writer, &before_model_result.notifications, None);
             self.audit.record_hook_decision(
@@ -386,6 +392,14 @@ impl CoshCore {
                 AuditOutcomeStatus::Success,
                 "observed",
             );
+
+            // A BeforeModel hook's rewritten declarations apply to this provider
+            // call only — `tool_decls` and the ToolRegistry stay authoritative
+            // for the next turn.
+            let turn_tool_decls = before_model_result
+                .updated_tools
+                .as_deref()
+                .unwrap_or(&tool_decls);
 
             let mut msgs_with_system = vec![Message::system(&system_prompt)];
             msgs_with_system.extend(provider_messages);
@@ -411,7 +425,7 @@ impl CoshCore {
 
             let stream_result = self
                 .provider
-                .generate(&msgs_with_system, &tool_decls, &generate_config)
+                .generate(&msgs_with_system, turn_tool_decls, &generate_config)
                 .await;
 
             let mut stream = match stream_result {

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -252,6 +252,7 @@ fn compress_schema_hook(command: &str) -> crate::config::HookDefinition {
         matcher: None,
         timeout: Some(10_000),
         sequential: None,
+        env: Default::default(),
     }
 }
 
@@ -1442,6 +1443,7 @@ async fn cosh_shell_evidence_bypasses_normal_tool_hooks() {
             matcher: Some("cosh_shell_evidence".to_string()),
             timeout: Some(5000),
             sequential: None,
+            env: Default::default(),
         }],
         post_tool_use: vec![config::HookDefinition {
             command: "echo '{\"decision\":\"block\",\"reason\":\"post hook should not run\"}'"
@@ -1450,6 +1452,7 @@ async fn cosh_shell_evidence_bypasses_normal_tool_hooks() {
             matcher: Some("cosh_shell_evidence".to_string()),
             timeout: Some(5000),
             sequential: None,
+            env: Default::default(),
         }],
         ..Default::default()
     };

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -25,8 +25,10 @@ struct CountingShellTool {
 
 struct ExternalTool;
 
+#[derive(Default)]
 struct RecordingProvider {
     messages: Arc<Mutex<Vec<crate::provider::Message>>>,
+    tools: Arc<Mutex<Vec<crate::provider::ToolDeclaration>>>,
 }
 
 #[async_trait]
@@ -34,10 +36,11 @@ impl crate::provider::ContentGenerator for RecordingProvider {
     async fn generate(
         &self,
         messages: &[crate::provider::Message],
-        _tools: &[crate::provider::ToolDeclaration],
+        tools: &[crate::provider::ToolDeclaration],
         _config: &crate::provider::GenerateConfig,
     ) -> Result<crate::provider::GenerateStream, String> {
         *self.messages.lock().unwrap() = messages.to_vec();
+        *self.tools.lock().unwrap() = tools.to_vec();
         Ok(Box::pin(futures::stream::iter([
             crate::provider::GenerateEvent::TextDelta("done".to_string()),
             crate::provider::GenerateEvent::MessageEnd,
@@ -203,6 +206,7 @@ async fn project_context_reaches_the_provider_boundary() {
     let captured = Arc::new(Mutex::new(Vec::new()));
     let provider = RecordingProvider {
         messages: Arc::clone(&captured),
+        ..RecordingProvider::default()
     };
     let mut config = CoreConfig::default();
     config.agent.approval_mode = "trust".to_string();
@@ -227,6 +231,116 @@ async fn project_context_reaches_the_provider_boundary() {
         .content
         .as_text()
         .contains("## Project Context\nprovider-visible marker"));
+}
+
+fn find_declaration<'a>(
+    declarations: &'a [crate::provider::ToolDeclaration],
+    name: &str,
+) -> &'a crate::provider::ToolDeclaration {
+    declarations
+        .iter()
+        .find(|tool| tool.name == name)
+        .unwrap_or_else(|| panic!("missing '{name}' declaration"))
+}
+
+/// A BeforeModel hook that rewrites every tool `description` to `compressed`
+/// and strips schema properties, mirroring tokenless schema compression.
+fn compress_schema_hook(command: &str) -> crate::config::HookDefinition {
+    crate::config::HookDefinition {
+        command: command.to_string(),
+        name: Some("compress-schema".to_string()),
+        matcher: None,
+        timeout: Some(10_000),
+        sequential: None,
+    }
+}
+
+#[tokio::test]
+async fn before_model_hook_rewrites_tool_declarations_for_one_provider_call() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        tools: Arc::clone(&captured),
+        ..RecordingProvider::default()
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    config.hooks.enabled = true;
+    config.hooks.before_model = vec![compress_schema_hook(
+        r#"python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+tools = payload["llm_request"]["config"]["tools"]
+for tool in tools:
+    tool["description"] = "compressed"
+    tool["parameters"] = {"type": "object", "properties": {"api_key": {"type": "string"}}}
+print(json.dumps({"hookSpecificOutput": {"llm_request": {"config": {"tools": tools}}}}))
+'"#,
+    )];
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::new(AtomicUsize::new(0)),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("hello", &mut reader, &mut output)
+        .await
+        .unwrap();
+
+    let recorded = captured.lock().unwrap();
+    let shell = find_declaration(&recorded, "shell");
+    assert_eq!(shell.description, "compressed");
+    // The schema property named `api_key` is a declaration, not a secret:
+    // redaction must not have collapsed it into a "<redacted>" string.
+    assert_eq!(shell.parameters["properties"]["api_key"]["type"], "string");
+
+    // The registry is the source of truth for the next turn and stays intact.
+    let declarations = core.tools.declarations();
+    let original = find_declaration(&declarations, "shell");
+    assert_eq!(original.description, "counting shell");
+    assert!(original.parameters["properties"].get("command").is_some());
+}
+
+#[tokio::test]
+async fn before_model_hook_rejecting_tool_set_changes_keeps_originals() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        tools: Arc::clone(&captured),
+        ..RecordingProvider::default()
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    config.hooks.enabled = true;
+    // Appending an undeclared tool changes tool-selection semantics, so the
+    // whole array is discarded rather than partially applied.
+    config.hooks.before_model = vec![compress_schema_hook(
+        r#"python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+tools = payload["llm_request"]["config"]["tools"]
+tools.append({"name": "smuggled", "description": "x", "parameters": {"type": "object"}})
+print(json.dumps({"hookSpecificOutput": {"llm_request": {"config": {"tools": tools}}}}))
+'"#,
+    )];
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::new(AtomicUsize::new(0)),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("hello", &mut reader, &mut output)
+        .await
+        .unwrap();
+
+    let recorded = captured.lock().unwrap();
+    assert_eq!(
+        find_declaration(&recorded, "shell").description,
+        "counting shell"
+    );
+    assert!(recorded.iter().all(|tool| tool.name != "smuggled"));
 }
 
 #[async_trait]

--- a/src/cosh-ng/crates/cosh-core/src/extension/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/config.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 
 use crate::config::HookDefinition;
@@ -83,6 +85,10 @@ pub struct CommandHookConfig {
     pub description: Option<String>,
     #[serde(default)]
     pub timeout: Option<u64>,
+    /// Environment variables for this hook's child process. Passed through to
+    /// [`HookDefinition::env`] verbatim; see there for the scoping guarantees.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
 }
 
 /// A hook group containing an optional matcher and an array of hook configs.
@@ -118,6 +124,7 @@ impl HookGroup {
                 matcher: self.matcher.clone(),
                 timeout: h.timeout,
                 sequential: self.sequential,
+                env: h.env.clone(),
             })
             .collect()
     }
@@ -275,6 +282,7 @@ mod tests {
                     name: Some("hook-a".to_string()),
                     description: None,
                     timeout: Some(3000),
+                    env: BTreeMap::from([("TOKENLESS_AGENT_ID".to_string(), "cosh".to_string())]),
                 }],
             },
             HookGroup {
@@ -286,6 +294,7 @@ mod tests {
                     name: None,
                     description: None,
                     timeout: None,
+                    env: BTreeMap::new(),
                 }],
             },
         ];
@@ -295,10 +304,15 @@ mod tests {
         assert_eq!(flat[0].command, "echo a");
         assert_eq!(flat[0].matcher.as_deref(), Some("skill"));
         assert_eq!(flat[0].timeout, Some(3000));
+        assert_eq!(
+            flat[0].env.get("TOKENLESS_AGENT_ID").map(String::as_str),
+            Some("cosh")
+        );
         // Second hook inherits sequential from group, no matcher
         assert_eq!(flat[1].command, "echo b");
         assert!(flat[1].matcher.is_none());
         assert_eq!(flat[1].sequential, Some(true));
+        assert!(flat[1].env.is_empty());
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/extension/manifest.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/manifest.rs
@@ -291,6 +291,95 @@ mod tests {
         assert_eq!(parsed.capabilities, ["example.ops/hook/guard"]);
     }
 
+    fn v1_hook_manifest(env: &str) -> String {
+        format!(
+            r#"{{
+                "schemaVersion":1,
+                "name":"example.ops",
+                "version":"1.0.0",
+                "compatibility":{{"cosh":">=0.12.0"}},
+                "hooks":{{"PreToolUse":[{{"matcher":"shell","hooks":[{{
+                    "type":"command",
+                    "name":"guard",
+                    "command":"${{extensionPath}}/hooks/guard"
+                    {env}
+                }}]}}]}}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn v1_hook_env_is_preserved_and_changes_the_capability_fingerprint() {
+        let root = package_root();
+        fs::create_dir_all(root.path().join("hooks")).unwrap();
+
+        let without_env = parse_manifest(&v1_hook_manifest(""), root.path()).unwrap();
+        let with_env = parse_manifest(
+            &v1_hook_manifest(r#","env":{"TOKENLESS_AGENT_ID":"cosh-ng"}"#),
+            root.path(),
+        )
+        .unwrap();
+
+        let hook = &with_env.config.hooks.pre_tool_use[0].hooks[0];
+        assert_eq!(
+            hook.env.get("TOKENLESS_AGENT_ID").map(String::as_str),
+            Some("cosh-ng")
+        );
+        // env is executable capability, so declaring it must force re-consent.
+        assert_ne!(
+            with_env.capability_fingerprint,
+            without_env.capability_fingerprint
+        );
+        // Extensions that never declared env keep their existing fingerprint.
+        assert_eq!(
+            without_env.capability_fingerprint,
+            "f678fe77434f8ed6a87de660a42db17c06aa29411280150fd92f2c29f8012b13"
+        );
+    }
+
+    #[test]
+    fn v1_rejects_invalid_hook_env_names() {
+        let root = package_root();
+        fs::create_dir_all(root.path().join("hooks")).unwrap();
+        for name in ["1BAD", "WITH-DASH", "WITH SPACE", "", "a=b"] {
+            let env = format!(r#","env":{{"{name}":"value"}}"#);
+            let error = parse_manifest(&v1_hook_manifest(&env), root.path()).unwrap_err();
+            assert_eq!(
+                error.code(),
+                "extension_hook_env_name_invalid",
+                "name={name}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_manifest_hook_env_changes_the_capability_fingerprint() {
+        let root = package_root();
+        let manifest = |env: &str| {
+            format!(
+                r#"{{"name":"legacy-ext","version":"1.0.0","hooks":{{"PreToolUse":[{{"hooks":[{{
+                    "type":"command","name":"guard","command":"echo guard"{env}
+                }}]}}]}}}}"#
+            )
+        };
+
+        let without_env = parse_manifest(&manifest(""), root.path()).unwrap();
+        let with_env =
+            parse_manifest(&manifest(r#","env":{"AGENT":"cosh-ng"}"#), root.path()).unwrap();
+
+        assert_eq!(
+            with_env.config.hooks.pre_tool_use[0].hooks[0]
+                .env
+                .get("AGENT")
+                .map(String::as_str),
+            Some("cosh-ng")
+        );
+        assert_ne!(
+            with_env.capability_fingerprint,
+            without_env.capability_fingerprint
+        );
+    }
+
     #[test]
     fn v1_rejects_path_escape() {
         let root = package_root();

--- a/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
@@ -324,16 +324,20 @@ pub(super) fn legacy_hook_records(config: &ExtensionConfig) -> Vec<CapabilityRec
                 let Ok(id) = CapabilityId::new(extension, CapabilityKind::Hook, local) else {
                     continue;
                 };
+                let mut projection = json!({
+                    "command": hook.command,
+                    "event": event,
+                    "id": id.canonical(),
+                    "kind": "hook",
+                    "matcher": group.matcher,
+                    "type": hook.hook_type.as_deref().unwrap_or("command")
+                });
+                if !hook.env.is_empty() {
+                    projection["env"] = json!(hook.env);
+                }
                 records.push(CapabilityRecord {
                     id: id.canonical(),
-                    projection: json!({
-                        "command": hook.command,
-                        "event": event,
-                        "id": id.canonical(),
-                        "kind": "hook",
-                        "matcher": group.matcher,
-                        "type": hook.hook_type.as_deref().unwrap_or("command")
-                    }),
+                    projection,
                 });
             }
         }
@@ -391,6 +395,14 @@ fn validate_and_convert_hooks(
                 }
                 validate_hook_command(package_root, &hook.command)?;
                 record_host_executable(&hook.command, host_executables);
+                for name in hook.env.keys() {
+                    if !crate::config::is_valid_env_name(name) {
+                        return Err(ManifestError::new(
+                            "extension_hook_env_name_invalid",
+                            format!("hook {} declares invalid env name: {name}", hook.name),
+                        ));
+                    }
+                }
                 let mut projection = json!({
                     "command": normalize_extension_command(&hook.command),
                     "event": event,
@@ -399,6 +411,13 @@ fn validate_and_convert_hooks(
                     "matcher": group.matcher,
                     "type": "command"
                 });
+                // `env` is executable capability, so declaring or changing it
+                // must move the fingerprint and force the user to re-consent.
+                // Omitted when empty so extensions that never used env keep
+                // their existing fingerprint across this upgrade.
+                if !hook.env.is_empty() {
+                    projection["env"] = json!(hook.env);
+                }
                 if group.sequential {
                     projection["sequential"] = Value::Bool(true);
                 }
@@ -415,6 +434,7 @@ fn validate_and_convert_hooks(
                     name: Some(hook.name),
                     description: hook.description,
                     timeout: hook.timeout,
+                    env: hook.env,
                 });
             }
             converted.push(HookGroup {
@@ -764,6 +784,8 @@ struct CommandHookV1 {
     description: Option<String>,
     #[serde(default)]
     timeout: Option<u64>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/cosh-ng/crates/cosh-core/src/extension/variables.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/variables.rs
@@ -40,6 +40,12 @@ fn hydrate_hook_groups(groups: &mut [super::config::HookGroup], ext_path: &str, 
     for group in groups.iter_mut() {
         for hook in group.hooks.iter_mut() {
             hook.command = hydrate_string(&hook.command, ext_path, ws_path);
+            // Values only: an env *name* is an identifier, and substituting a
+            // path into it could synthesise a name the manifest never declared
+            // and the fingerprint never covered.
+            for value in hook.env.values_mut() {
+                *value = hydrate_string(value, ext_path, ws_path);
+            }
         }
     }
 }
@@ -118,6 +124,41 @@ mod tests {
             config.hooks.pre_tool_use[0].hooks[0].command,
             "/opt/ext/hooks/pre.sh --ws=/workspace"
         );
+    }
+
+    #[test]
+    fn hydrates_hook_env_values_but_never_names() {
+        let json = r#"{
+            "name": "test",
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "run.sh",
+                                "env": {
+                                    "CACHE_DIR": "${workspacePath}/.cache",
+                                    "${extensionPath}": "literal-name"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+        let mut config: ExtensionConfig = serde_json::from_str(json).unwrap();
+        let ctx = VariableContext {
+            extension_path: &PathBuf::from("/opt/ext"),
+            workspace_path: &PathBuf::from("/workspace"),
+        };
+        hydrate_config(&mut config, &ctx);
+
+        let env = &config.hooks.pre_tool_use[0].hooks[0].env;
+        assert_eq!(env.get("CACHE_DIR").unwrap(), "/workspace/.cache");
+        // Names are identifiers: substitution there could synthesise a name the
+        // manifest never declared and the fingerprint never covered.
+        assert!(env.contains_key("${extensionPath}"));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::config::{HookDefinition, HooksConfig};
+use crate::provider::ToolDeclaration;
 
 // ─── Hook Event Names ────────────────────────────────────────────────
 
@@ -139,6 +140,11 @@ pub struct PostToolUseFailureResult {
 #[derive(Debug, Clone)]
 pub struct BeforeModelResult {
     pub notifications: Vec<HookNotification>,
+    /// Tool declarations rewritten by a BeforeModel hook, e.g. schema
+    /// compression. Only ever applies to the provider call that fired the hook:
+    /// the ToolRegistry is untouched, so the next turn starts from the original
+    /// declarations again. `None` means "use the originals".
+    pub updated_tools: Option<Vec<ToolDeclaration>>,
 }
 
 #[derive(Debug, Clone)]
@@ -647,10 +653,12 @@ impl HookSystem {
         cwd: &str,
         model: &str,
         messages: &[crate::provider::Message],
+        tools: &[ToolDeclaration],
     ) -> BeforeModelResult {
         if !self.enabled {
             return BeforeModelResult {
                 notifications: vec![],
+                updated_tools: None,
             };
         }
 
@@ -658,11 +666,13 @@ impl HookSystem {
         if defs.is_empty() {
             return BeforeModelResult {
                 notifications: vec![],
+                updated_tools: None,
             };
         }
 
-        // 对齐 copilot-shell hookTranslator.toHookLLMRequest 格式：
-        // llm_request 包含 model 和 messages 数组。
+        // Mirrors copilot-shell's hookTranslator.toHookLLMRequest shape:
+        // llm_request carries the model, the messages array, and the tool
+        // declarations at config.tools.
         let hook_messages: Vec<serde_json::Value> = messages
             .iter()
             .map(|m| {
@@ -677,17 +687,37 @@ impl HookSystem {
             "llm_request": {
                 "model": model,
                 "messages": hook_messages,
+                "config": {
+                    "tools": tools,
+                },
             },
         });
         let input = self.build_input(session_id, cwd, HookEventName::BeforeModel, event_data);
         let outputs = self.run_hooks(&defs, &input).await;
 
         let mut notifications = Vec::new();
+        let mut updated_tools = None;
         for (i, out) in outputs {
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
+            // Last valid full array in configuration order wins; a rejected
+            // array leaves an earlier hook's accepted one in place.
+            if let Some(candidate) = extract_updated_tools(&out.hook_specific_output) {
+                match validate_updated_tools(tools, candidate) {
+                    Ok(validated) => updated_tools = Some(validated),
+                    Err(reason) => {
+                        tracing::warn!(
+                            target: "cosh_hook",
+                            "Hook '{name}' tool declaration update rejected: {reason}"
+                        );
+                    }
+                }
+            }
         }
-        BeforeModelResult { notifications }
+        BeforeModelResult {
+            notifications,
+            updated_tools,
+        }
     }
 
     pub async fn fire_after_model(
@@ -788,7 +818,10 @@ impl HookSystem {
         defs: &[&HookDefinition],
         input: &HookInput,
     ) -> Vec<(usize, HookOutput)> {
-        let input_json = crate::redaction::to_redacted_json(input);
+        let input_json = crate::redaction::to_redacted_json_with_schemas(
+            input,
+            crate::redaction::TOOL_DECLARATION_PATHS,
+        );
 
         if Self::is_sequential(defs) {
             let mut results = Vec::new();
@@ -897,7 +930,10 @@ impl HookSystem {
             .system_message
             .map(|value| crate::redaction::redact_text(&value));
         if let Some(value) = &mut output.hook_specific_output {
-            crate::redaction::redact_value(value);
+            crate::redaction::redact_value_with_schemas(
+                value,
+                crate::redaction::TOOL_DECLARATION_PATHS,
+            );
         }
         output
     }
@@ -1116,6 +1152,80 @@ fn fold_additional_context(current: &mut Option<String>, specific: &Option<Value
             });
         }
     }
+}
+
+/// Read a BeforeModel hook's replacement tool array out of its
+/// `hook_specific_output`. `llm_request.config.tools` is canonical;
+/// `llm_request.tools` is accepted so hooks written against the older position
+/// keep working during migration.
+fn extract_updated_tools(specific: &Option<Value>) -> Option<&Value> {
+    let llm_request = specific.as_ref()?.get("llm_request")?;
+    llm_request
+        .get("config")
+        .and_then(|config| config.get("tools"))
+        .or_else(|| llm_request.get("tools"))
+}
+
+/// Accept a hook's tool array only if it is the *same tool set* as the host
+/// declared — same count, same names, same order. That confines hooks to
+/// rewriting `description` and `parameters` (the schema-compression use case)
+/// and keeps them from silently adding, dropping, or reordering tools, which
+/// would change tool-selection semantics. Tool filtering belongs to a separate
+/// protocol.
+fn validate_updated_tools(
+    original: &[ToolDeclaration],
+    candidate: &Value,
+) -> Result<Vec<ToolDeclaration>, String> {
+    let Some(entries) = candidate.as_array() else {
+        return Err("expected a JSON array of tool declarations".to_string());
+    };
+    if entries.len() != original.len() {
+        return Err(format!(
+            "expected {} tool declarations, got {}",
+            original.len(),
+            entries.len()
+        ));
+    }
+
+    let mut updated = Vec::with_capacity(entries.len());
+    for (entry, expected) in entries.iter().zip(original) {
+        let tool: ToolDeclaration = serde_json::from_value(entry.clone())
+            .map_err(|error| format!("invalid tool declaration: {error}"))?;
+        if tool.name != expected.name {
+            return Err(format!(
+                "tool name changed: expected '{}', got '{}'",
+                expected.name, tool.name
+            ));
+        }
+        if !tool.parameters.is_object() {
+            return Err(format!("tool '{}' parameters must be an object", tool.name));
+        }
+        updated.push(tool);
+    }
+
+    // The turn's compaction prefix estimate is computed from the original
+    // declarations before this hook runs, so a rewrite that grows them would
+    // make the runtime under-account the real request, skip an emergency
+    // compaction it needed, and overflow the provider context. The 1024-token
+    // prefix reserve cannot absorb unbounded growth. Requiring the rewrite to
+    // be no larger keeps the estimate conservative and matches the contract
+    // this protocol already advertises: compression, not expansion.
+    let original_tokens = estimate_declaration_tokens(original);
+    let updated_tokens = estimate_declaration_tokens(&updated);
+    if updated_tokens > original_tokens {
+        return Err(format!(
+            "tool declarations grew from ~{original_tokens} to ~{updated_tokens} tokens; \
+             BeforeModel may only compress declarations"
+        ));
+    }
+
+    Ok(updated)
+}
+
+/// Estimates the declarations the same way the compaction prefix estimate does,
+/// so the two cannot disagree about whether a rewrite fits.
+fn estimate_declaration_tokens(tools: &[ToolDeclaration]) -> u64 {
+    crate::compaction::estimate_text_tokens(&serde_json::to_string(tools).unwrap_or_default())
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────
@@ -1389,6 +1499,241 @@ mod tests {
     fn pick_additional_context_returns_none_when_absent() {
         let v = serde_json::json!({"other": "x"});
         assert_eq!(HookSystem::pick_additional_context(&v), None);
+    }
+
+    // ===== BeforeModel tool declaration rewriting (#1616) =====
+
+    fn shell_declaration() -> ToolDeclaration {
+        ToolDeclaration {
+            name: "shell".to_string(),
+            description: "run a shell command".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+            }),
+        }
+    }
+
+    fn updated_tools_output(tools: Value) -> Option<Value> {
+        Some(serde_json::json!({"llm_request": {"config": {"tools": tools}}}))
+    }
+
+    #[test]
+    fn extract_updated_tools_prefers_canonical_config_position() {
+        let specific = Some(serde_json::json!({
+            "llm_request": {
+                "config": {"tools": [{"name": "canonical"}]},
+                "tools": [{"name": "legacy"}],
+            }
+        }));
+        let tools = extract_updated_tools(&specific).unwrap();
+        assert_eq!(tools[0]["name"], "canonical");
+    }
+
+    #[test]
+    fn extract_updated_tools_falls_back_to_legacy_position() {
+        let specific = Some(serde_json::json!({
+            "llm_request": {"tools": [{"name": "legacy"}]}
+        }));
+        let tools = extract_updated_tools(&specific).unwrap();
+        assert_eq!(tools[0]["name"], "legacy");
+    }
+
+    #[test]
+    fn validate_updated_tools_accepts_compressed_description_and_schema() {
+        let original = vec![shell_declaration()];
+        let candidate = serde_json::json!([{
+            "name": "shell",
+            "description": "run",
+            "parameters": {"type": "object"},
+        }]);
+
+        let updated = validate_updated_tools(&original, &candidate).unwrap();
+
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].description, "run");
+    }
+
+    #[test]
+    fn validate_updated_tools_rejects_malformed_arrays() {
+        let original = vec![shell_declaration()];
+        for candidate in [
+            // not an array
+            serde_json::json!({"tools": []}),
+            // missing required field
+            serde_json::json!([{"name": "shell", "parameters": {"type": "object"}}]),
+            // parameters is not a JSON object
+            serde_json::json!([{"name": "shell", "description": "run", "parameters": "object"}]),
+            // renamed tool
+            serde_json::json!([{"name": "sh", "description": "run", "parameters": {}}]),
+            // added tool
+            serde_json::json!([
+                {"name": "shell", "description": "run", "parameters": {}},
+                {"name": "extra", "description": "x", "parameters": {}},
+            ]),
+            // dropped tool
+            serde_json::json!([]),
+        ] {
+            assert!(
+                validate_updated_tools(&original, &candidate).is_err(),
+                "should reject {candidate}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_updated_tools_rejects_expanded_declarations() {
+        let original = vec![shell_declaration()];
+
+        // Same tool set, but a description and schema far larger than the
+        // original — the compaction prefix estimate was already fixed from the
+        // originals, so accepting this would under-account the real request.
+        let candidate = serde_json::json!([{
+            "name": "shell",
+            "description": "x".repeat(4096),
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string", "description": "y".repeat(4096)}},
+            },
+        }]);
+
+        let error = validate_updated_tools(&original, &candidate).unwrap_err();
+        assert!(error.contains("may only compress"), "{error}");
+    }
+
+    #[test]
+    fn validate_updated_tools_allows_unchanged_size() {
+        let original = vec![shell_declaration()];
+        let candidate = serde_json::to_value(&original).unwrap();
+
+        assert!(validate_updated_tools(&original, &candidate).is_ok());
+    }
+
+    #[test]
+    fn validate_updated_tools_rejects_reordered_tools() {
+        let original = vec![
+            shell_declaration(),
+            ToolDeclaration {
+                name: "read_file".to_string(),
+                description: "read".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        ];
+        let candidate = serde_json::json!([
+            {"name": "read_file", "description": "read", "parameters": {"type": "object"}},
+            {"name": "shell", "description": "run", "parameters": {"type": "object"}},
+        ]);
+
+        assert!(validate_updated_tools(&original, &candidate).is_err());
+    }
+
+    #[tokio::test]
+    async fn before_model_input_carries_full_tool_declarations() {
+        let config = HooksConfig {
+            enabled: true,
+            before_model: vec![HookDefinition {
+                command: r#"python3 -c 'import sys,json; t=json.load(sys.stdin)["llm_request"]["config"]["tools"]; print(json.dumps({"systemMessage": t[0]["name"]+"|"+t[0]["description"]+"|"+t[0]["parameters"]["properties"]["command"]["type"]}))'"#.to_string(),
+                name: Some("inspect".to_string()),
+                matcher: None,
+                timeout: Some(10_000),
+                sequential: None,
+            }],
+            ..Default::default()
+        };
+        let sys = HookSystem::from_config(&config);
+
+        let result = sys
+            .fire_before_model("s1", "/tmp", "m", &[], &[shell_declaration()])
+            .await;
+
+        assert_eq!(
+            result.notifications[0].message,
+            "shell|run a shell command|string"
+        );
+        assert!(result.updated_tools.is_none());
+    }
+
+    #[tokio::test]
+    async fn before_model_last_valid_tool_array_wins_over_later_invalid_one() {
+        let config = HooksConfig {
+            enabled: true,
+            before_model: vec![
+                HookDefinition {
+                    command: r#"python3 -c 'print("""{"hookSpecificOutput":{"llm_request":{"config":{"tools":[{"name":"shell","description":"first","parameters":{"type":"object"}}]}}}}""")'"#.to_string(),
+                    name: Some("first".to_string()),
+                    matcher: None,
+                    timeout: Some(10_000),
+                    sequential: None,
+                },
+                HookDefinition {
+                    command: r#"python3 -c 'print("""{"hookSpecificOutput":{"llm_request":{"config":{"tools":[{"name":"renamed","description":"second","parameters":{"type":"object"}}]}}}}""")'"#.to_string(),
+                    name: Some("second".to_string()),
+                    matcher: None,
+                    timeout: Some(10_000),
+                    sequential: None,
+                },
+            ],
+            ..Default::default()
+        };
+        let sys = HookSystem::from_config(&config);
+
+        let result = sys
+            .fire_before_model("s1", "/tmp", "m", &[], &[shell_declaration()])
+            .await;
+
+        let updated = result.updated_tools.expect("first hook's array applies");
+        assert_eq!(updated[0].description, "first");
+    }
+
+    #[test]
+    fn hook_output_tool_schemas_survive_redaction() {
+        let output = HookOutput {
+            decision: None,
+            reason: None,
+            system_message: None,
+            hook_specific_output: updated_tools_output(serde_json::json!([{
+                "name": "shell",
+                "description": "pass --token secret-in-description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "api_key": {"type": "string"},
+                        "token": {"type": "string"},
+                    },
+                },
+            }])),
+        };
+
+        let output = HookSystem::redact_hook_output(output);
+        let tools = extract_updated_tools(&output.hook_specific_output).unwrap();
+
+        assert_eq!(
+            tools[0]["parameters"]["properties"]["api_key"]["type"],
+            "string"
+        );
+        assert_eq!(
+            tools[0]["parameters"]["properties"]["token"]["type"],
+            "string"
+        );
+        // String leaves inside the exempt subtree still lose secret shapes.
+        assert_eq!(tools[0]["description"], "pass --token <redacted>");
+    }
+
+    #[test]
+    fn hook_output_outside_tool_schemas_is_still_redacted() {
+        let output = HookOutput {
+            decision: None,
+            reason: None,
+            system_message: None,
+            hook_specific_output: Some(serde_json::json!({
+                "api_key": "leaked-value",
+            })),
+        };
+
+        let output = HookSystem::redact_hook_output(output);
+        let specific = output.hook_specific_output.unwrap();
+
+        assert_eq!(specific["api_key"], "<redacted>");
     }
 
     // ===== Task 3: tool_response 包装 =====

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 
 use regex::Regex;
@@ -837,9 +837,10 @@ impl HookSystem {
                 .map(|(i, def)| {
                     let json = input_json.clone();
                     let cmd = def.command.clone();
+                    let env = def.env.clone();
                     let timeout = Self::timeout_for(def);
                     async move {
-                        let output = Self::run_hook_cmd(&cmd, &json, timeout).await;
+                        let output = Self::run_hook_cmd(&cmd, &env, &json, timeout).await;
                         (i, output)
                     }
                 })
@@ -849,10 +850,15 @@ impl HookSystem {
     }
 
     async fn run_single_hook(def: &HookDefinition, input_json: &str) -> HookOutput {
-        Self::run_hook_cmd(&def.command, input_json, Self::timeout_for(def)).await
+        Self::run_hook_cmd(&def.command, &def.env, input_json, Self::timeout_for(def)).await
     }
 
-    async fn run_hook_cmd(command: &str, input_json: &str, timeout: Duration) -> HookOutput {
+    async fn run_hook_cmd(
+        command: &str,
+        env: &BTreeMap<String, String>,
+        input_json: &str,
+        timeout: Duration,
+    ) -> HookOutput {
         use tokio::process::Command;
 
         use crate::process::{output_with_timeout, OutputError};
@@ -860,6 +866,31 @@ impl HookSystem {
         let safe_command = crate::redaction::redact_text(command);
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg(command);
+
+        // `Command` inherits the parent environment by default, so declared
+        // entries override inherited values of the same name for this child
+        // only. Invalid names are dropped with the name (never the value) in
+        // the log.
+        let (valid, invalid): (Vec<_>, Vec<_>) = env
+            .iter()
+            .partition(|(name, _)| crate::config::is_valid_env_name(name));
+        if !invalid.is_empty() {
+            let names: Vec<&str> = invalid.iter().map(|(name, _)| name.as_str()).collect();
+            tracing::warn!(
+                target: "cosh_hook",
+                "Hook '{safe_command}' declares invalid env names, skipped: {}",
+                names.join(", ")
+            );
+        }
+        cmd.envs(valid);
+
+        // Host attribution, applied after the declared map so it takes
+        // precedence over an `env` entry of the same name. This is a
+        // cooperative signal, not a security boundary: the same manifest also
+        // owns `command`, so it can reassign or unset these inside the shell it
+        // asked for. Nothing security-relevant may depend on them.
+        cmd.env("COSH_RUNTIME", "cosh-ng");
+        cmd.env("COSH_NG_VERSION", env!("CARGO_PKG_VERSION"));
 
         // The deadline covers the stdin write as well: a hook that never
         // reads stdin must not stall the session, and on timeout the whole
@@ -1318,6 +1349,7 @@ mod tests {
             matcher: Some("run_shell.*".to_string()),
             timeout: None,
             sequential: None,
+            env: Default::default(),
         };
         assert!(HookSystem::matches_tool(&def, "run_shell_command"));
         assert!(!HookSystem::matches_tool(&def, "read_file"));
@@ -1331,6 +1363,7 @@ mod tests {
             matcher: None,
             timeout: None,
             sequential: None,
+            env: Default::default(),
         };
         assert!(HookSystem::matches_tool(&def, "any_tool"));
     }
@@ -1346,6 +1379,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                env: Default::default(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1384,6 +1418,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: None,
                 sequential: None,
+                env: Default::default(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1418,6 +1453,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                env: Default::default(),
             }],
             post_tool_use: vec![],
             post_tool_use_failure: vec![],
@@ -1443,6 +1479,7 @@ mod tests {
             matcher: Some(matcher.to_string()),
             timeout: None,
             sequential: None,
+            env: Default::default(),
         }
     }
 
@@ -1637,6 +1674,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(10_000),
                 sequential: None,
+                env: Default::default(),
             }],
             ..Default::default()
         };
@@ -1664,6 +1702,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(10_000),
                     sequential: None,
+                    env: Default::default(),
                 },
                 HookDefinition {
                     command: r#"python3 -c 'print("""{"hookSpecificOutput":{"llm_request":{"config":{"tools":[{"name":"renamed","description":"second","parameters":{"type":"object"}}]}}}}""")'"#.to_string(),
@@ -1671,6 +1710,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(10_000),
                     sequential: None,
+                    env: Default::default(),
                 },
             ],
             ..Default::default()
@@ -1801,6 +1841,7 @@ mod tests {
                 matcher: Some("^run_shell_command$".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                env: Default::default(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1842,6 +1883,7 @@ mod tests {
                 matcher: Some("skill".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                env: Default::default(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -1883,7 +1925,9 @@ mod tests {
         let pid_file = dir.path().join("pids");
         let script = leak_script(&marker, &pid_file);
 
-        let out = HookSystem::run_hook_cmd(&script, "{}", Duration::from_millis(300)).await;
+        let out =
+            HookSystem::run_hook_cmd(&script, &BTreeMap::new(), "{}", Duration::from_millis(300))
+                .await;
         assert!(
             out.decision.is_none(),
             "timed-out hook must fall back to the default output"
@@ -1905,12 +1949,116 @@ mod tests {
         // blocked in the stdin write before the timeout even started.
         let payload = "x".repeat(1 << 20);
         let started = std::time::Instant::now();
-        let out = HookSystem::run_hook_cmd("sleep 30", &payload, Duration::from_millis(300)).await;
+        let out = HookSystem::run_hook_cmd(
+            "sleep 30",
+            &BTreeMap::new(),
+            &payload,
+            Duration::from_millis(300),
+        )
+        .await;
         assert!(out.decision.is_none());
         assert!(
             started.elapsed() < Duration::from_secs(5),
             "stdin write must be bounded by the hook deadline"
         );
+    }
+
+    // ─── #1617: hook env tests ───────────────────────────────────────
+
+    // Runs a hook that reports `$probe`, `$COSH_RUNTIME` and
+    // `$COSH_NG_VERSION` as seen by the child, joined with `|`.
+    async fn probe_env(probe: &str, env: BTreeMap<String, String>) -> Vec<String> {
+        let config = HooksConfig {
+            enabled: true,
+            session_start: vec![HookDefinition {
+                command: format!(
+                    r#"python3 -c 'import json,os; print(json.dumps({{"systemMessage": "|".join(os.environ.get(name,"<unset>") for name in ["{probe}","COSH_RUNTIME","COSH_NG_VERSION"])}}))'"#
+                ),
+                name: Some("probe".to_string()),
+                timeout: Some(10_000),
+                env,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let sys = HookSystem::from_config(&config);
+        let result = sys.fire_session_start("s1", "/tmp").await;
+        result
+            .notifications
+            .first()
+            .expect("hook system message")
+            .message
+            .split('|')
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn hook_env_overrides_inherited_value_without_touching_the_parent() {
+        // HOME is inherited from the parent; the hook shadows it for its own
+        // child process only.
+        let inherited = std::env::var("HOME").expect("HOME is set in the test environment");
+        assert_ne!(inherited, "from-hook");
+
+        let baseline = probe_env("HOME", BTreeMap::new()).await;
+        assert_eq!(baseline[0], inherited, "child must inherit the parent env");
+
+        let fields = probe_env(
+            "HOME",
+            BTreeMap::from([("HOME".to_string(), "from-hook".to_string())]),
+        )
+        .await;
+
+        assert_eq!(fields[0], "from-hook");
+        // Host-owned attribution reaches the child.
+        assert_eq!(fields[1], "cosh-ng");
+        assert_eq!(fields[2], env!("CARGO_PKG_VERSION"));
+        // The host process itself is never mutated — no std::env::set_var.
+        assert_eq!(std::env::var("HOME").unwrap(), inherited);
+    }
+
+    // Covers precedence only. The host values are a cooperative signal, not a
+    // security boundary — the manifest also owns `command` and can reassign
+    // them inside its own shell — so this proves nothing stronger than that a
+    // declared `env` entry loses to the host's.
+    #[tokio::test]
+    async fn host_attribution_overrides_declared_hook_env() {
+        let fields = probe_env(
+            "COSH_RUNTIME",
+            BTreeMap::from([
+                ("COSH_RUNTIME".to_string(), "copilot-shell".to_string()),
+                ("COSH_NG_VERSION".to_string(), "99.99.99".to_string()),
+            ]),
+        )
+        .await;
+
+        assert_eq!(fields[1], "cosh-ng");
+        assert_eq!(fields[2], env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn hook_env_with_invalid_name_is_dropped_and_hook_still_runs() {
+        let fields = probe_env(
+            "HOME",
+            BTreeMap::from([
+                ("HOME".to_string(), "kept".to_string()),
+                ("1INVALID".to_string(), "dropped".to_string()),
+                ("WITH-DASH".to_string(), "dropped".to_string()),
+            ]),
+        )
+        .await;
+
+        assert_eq!(fields[0], "kept");
+    }
+
+    #[test]
+    fn env_name_validation_follows_posix_rules() {
+        for name in ["PATH", "_UNDERSCORE", "A1", "_"] {
+            assert!(crate::config::is_valid_env_name(name), "{name}");
+        }
+        for name in ["", "1LEADING", "WITH-DASH", "WITH SPACE", "a=b", "ä"] {
+            assert!(!crate::config::is_valid_env_name(name), "{name}");
+        }
     }
 
     // ─── #1614: updated_tool_response tests ──────────────────────────
@@ -1985,6 +2133,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                env: Default::default(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],
@@ -2030,6 +2179,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(5000),
                     sequential: None,
+                    env: Default::default(),
                 },
                 HookDefinition {
                     command: r#"python3 -c 'import sys,json; print(json.dumps({"hook_specific_output": {"updatedToolResponse": "second"}}))'"#.to_string(),
@@ -2037,6 +2187,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(5000),
                     sequential: None,
+                    env: Default::default(),
                 },
             ],
             post_tool_use_failure: vec![],
@@ -2076,6 +2227,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                env: Default::default(),
             }],
             post_tool_use_failure: vec![],
             user_prompt_submit: vec![],

--- a/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
@@ -134,7 +134,7 @@ impl Message {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDeclaration {
     pub name: String,
     pub description: String,

--- a/src/cosh-ng/crates/cosh-core/src/redaction.rs
+++ b/src/cosh-ng/crates/cosh-core/src/redaction.rs
@@ -57,6 +57,87 @@ pub(crate) fn to_redacted_json<T: Serialize>(value: &T) -> String {
     serde_json::to_string(&value).unwrap_or_default()
 }
 
+/// Hook payload subtrees holding tool declarations. These are JSON Schema —
+/// a property named `api_key` is a *declaration*, not a secret, so key-based
+/// redaction would replace the property object with `"<redacted>"` and hand
+/// the model (or the hook) a corrupt schema. Both the canonical
+/// `llm_request.config.tools` and the legacy `llm_request.tools` positions are
+/// listed so hook output written against either survives intact.
+pub(crate) const TOOL_DECLARATION_PATHS: &[&[&str]] = &[
+    &["llm_request", "config", "tools"],
+    &["llm_request", "tools"],
+];
+
+/// Like [`to_redacted_json`], but applies structure-preserving redaction to the
+/// subtrees at `schema_paths` instead of key-based redaction. Paths that are
+/// absent are ignored, so this is safe to use for every hook event.
+pub(crate) fn to_redacted_json_with_schemas<T: Serialize>(
+    value: &T,
+    schema_paths: &[&[&str]],
+) -> String {
+    let Ok(mut value) = serde_json::to_value(value) else {
+        return String::new();
+    };
+    redact_value_with_schemas(&mut value, schema_paths);
+    serde_json::to_string(&value).unwrap_or_default()
+}
+
+pub(crate) fn redact_value_with_schemas(value: &mut Value, schema_paths: &[&[&str]]) {
+    let detached: Vec<Option<Value>> = schema_paths
+        .iter()
+        .map(|path| detach_path(value, path))
+        .collect();
+
+    redact_value(value);
+
+    for (path, subtree) in schema_paths.iter().zip(detached) {
+        if let Some(mut subtree) = subtree {
+            redact_schema_value(&mut subtree);
+            reattach_path(value, path, subtree);
+        }
+    }
+}
+
+/// Structure-preserving redaction: scrubs secret *shapes* out of string leaves
+/// but never replaces a value because its key name looks sensitive.
+fn redact_schema_value(value: &mut Value) {
+    match value {
+        Value::Object(values) => {
+            for value in values.values_mut() {
+                redact_schema_value(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_schema_value(value);
+            }
+        }
+        Value::String(text) => *text = redact_text(text),
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+/// Removes the subtree at `path`, leaving `Null` behind so [`reattach_path`]
+/// can find the slot again after the surrounding value has been redacted.
+fn detach_path(value: &mut Value, path: &[&str]) -> Option<Value> {
+    let mut cursor = value;
+    for key in path {
+        cursor = cursor.as_object_mut()?.get_mut(*key)?;
+    }
+    (!cursor.is_null()).then(|| cursor.take())
+}
+
+fn reattach_path(value: &mut Value, path: &[&str], subtree: Value) {
+    let mut cursor = value;
+    for key in path {
+        let Some(next) = cursor.as_object_mut().and_then(|map| map.get_mut(*key)) else {
+            return;
+        };
+        cursor = next;
+    }
+    *cursor = subtree;
+}
+
 pub(crate) fn redact_messages(messages: &mut [Message]) {
     for message in messages {
         redact_message(message);

--- a/src/cosh-ng/crates/cosh-core/src/tool/mcp.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mcp.rs
@@ -823,18 +823,12 @@ fn configure_child_environment(
         }
     }
     for (name, value) in configured_env {
-        if !is_valid_env_name(name) {
+        if !crate::config::is_valid_env_name(name) {
             return Err(format!("invalid MCP environment variable name: {name}"));
         }
         command.env(name, expand_env_vars(value));
     }
     Ok(())
-}
-
-fn is_valid_env_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    matches!(chars.next(), Some('A'..='Z' | 'a'..='z' | '_'))
-        && chars.all(|c| matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_'))
 }
 
 fn expand_env_vars(value: &str) -> String {

--- a/src/cosh-ng/docs/design/hook-protocol.md
+++ b/src/cosh-ng/docs/design/hook-protocol.md
@@ -1,0 +1,94 @@
+# cosh-ng Hook Wire Contract Design
+
+Date: 2026-07-27
+
+Related documents: [user guide](../../../../docs/user-guide/en/user-entrypoint/cosh-ng/core/hooks.md),
+[extension guide](../../../../docs/user-guide/en/user-entrypoint/cosh-ng/core/extensions.md)
+
+## Summary
+
+Hooks are external processes. cosh-ng writes one JSON object to the child's stdin and reads one
+JSON object from its stdout, so the wire shape — not any in-process type — is the compatibility
+surface. This document fixes the part of that surface that lets a hook *change* what the runtime does,
+rather than merely observe it: `BeforeModel` tool declaration rewriting. It is deliberately
+narrower than "let the hook patch the request".
+
+The shape follows copilot-shell's Hook Translator (`llm_request.model`, `llm_request.messages`,
+`llm_request.config.tools`), so one hook binary can read either host's input. Field positions are
+therefore a cross-component contract and must not move unilaterally.
+
+Input compatibility only. copilot-shell's `fromHookLLMRequest` does not currently copy
+`config.tools` back into the SDK request, so a returned tool rewrite is applied by cosh-ng and
+silently ignored there. That output gap is a known copilot-shell limitation, not something this
+contract papers over; a hook that depends on the rewrite taking effect must detect the runtime.
+
+## BeforeModel: tool declaration rewriting
+
+### Wire shape
+
+Input carries the declarations for the request that is about to be sent:
+
+```json
+{
+  "hook_event_name": "BeforeModel",
+  "llm_request": {
+    "model": "...",
+    "messages": [{ "role": "user", "content": "..." }],
+    "config": { "tools": [{ "name": "shell", "description": "...", "parameters": {} }] }
+  }
+}
+```
+
+A hook returns a replacement array at the same path. The tool set is unchanged — only
+`description` and `parameters` are compressed:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "BeforeModel",
+    "llm_request": {
+      "config": {
+        "tools": [{ "name": "shell", "description": "run cmd", "parameters": {} }]
+      }
+    }
+  }
+}
+```
+
+`llm_request.config.tools` is canonical. `llm_request.tools` is accepted on read for migration
+only; presence of the canonical key decides, so a host declaring an empty tool set is never served
+a stale legacy field. Writers must emit the canonical position.
+
+### Invariants
+
+| Invariant | Rationale |
+|---|---|
+| Applies to one `provider.generate()` call | The ToolRegistry and `tool_decls` stay authoritative for the next turn, so a hook cannot accumulate drift across a run. |
+| Identical tool count, order, and names | Adding, dropping, or reordering tools silently changes tool-selection semantics. Filtering is a separate concern and needs its own protocol. |
+| `parameters` must be a JSON object | A non-object schema is rejected by providers; failing here keeps the error local to the hook. |
+| Rewrite may not grow the estimated token count | The turn's compaction prefix estimate is computed from the original declarations *before* the hook runs. Accepting growth would under-account the request, skip an emergency compaction, and overflow the provider context; the 1024-token prefix reserve cannot absorb unbounded growth. |
+| Last valid array in configuration order wins | Deep-merging two independent rewrites has no well-defined result. An invalid array is discarded whole and never partially overwrites an accepted one. |
+| Messages are not rewritable | Editing history would break tool-call/tool-result pairing and compaction projections. |
+
+Any violation discards that whole candidate array — never part of it. The originals are used only
+when no valid candidate exists; a rejected candidate does not undo an earlier hook's accepted
+rewrite. A rejected candidate is a logged warning, never a turn failure — a broken hook must not be
+able to stop the session.
+
+### Redaction
+
+The declaration subtree is exempt from key-based redaction in **both** directions. A JSON Schema
+property named `api_key` is a declaration, not a secret; replacing it with `"<redacted>"` would hand
+the hook — or the provider — a corrupt schema. The subtree still gets pattern-based scrubbing of its
+string leaves, so a real secret *shape* is removed. Messages keep the stricter key-based redaction.
+
+## Trade-offs
+
+- **No general request-patch framework.** Each mutable field is added explicitly with its own
+  invariants. This is more code per field but keeps the blast radius of a misbehaving hook bounded
+  and reviewable.
+- **Compression-only declarations.** Supporting growth means recomputing the effective prefix after
+  the hook and re-running preflight without invalidating the message view the hook already saw.
+  That reordering is deferred until a use case requires it.
+- **Two accepted read positions for tools.** A migration cost carried on the read path only, so
+  writers converge on one position.

--- a/src/cosh-ng/docs/design/hook-protocol.md
+++ b/src/cosh-ng/docs/design/hook-protocol.md
@@ -9,9 +9,9 @@ Related documents: [user guide](../../../../docs/user-guide/en/user-entrypoint/c
 
 Hooks are external processes. cosh-ng writes one JSON object to the child's stdin and reads one
 JSON object from its stdout, so the wire shape — not any in-process type — is the compatibility
-surface. This document fixes the part of that surface that lets a hook *change* what the runtime does,
-rather than merely observe it: `BeforeModel` tool declaration rewriting. It is deliberately
-narrower than "let the hook patch the request".
+surface. This document fixes the two parts of that surface that let a hook *change* what the
+runtime does, rather than merely observe it: `BeforeModel` tool declaration rewriting and hook
+`env`. Both are deliberately narrower than "let the hook patch the request".
 
 The shape follows copilot-shell's Hook Translator (`llm_request.model`, `llm_request.messages`,
 `llm_request.config.tools`), so one hook binary can read either host's input. Field positions are
@@ -81,6 +81,42 @@ The declaration subtree is exempt from key-based redaction in **both** direction
 property named `api_key` is a declaration, not a secret; replacing it with `"<redacted>"` would hand
 the hook — or the provider — a corrupt schema. The subtree still gets pattern-based scrubbing of its
 string leaves, so a real secret *shape* is removed. Messages keep the stricter key-based redaction.
+
+## Hook env
+
+A hook definition may declare `env`, applied to that hook's child process only.
+
+Precedence, lowest to highest:
+
+1. inherited parent environment
+2. hook manifest `env`
+3. host attribution: `COSH_RUNTIME=cosh-ng`, `COSH_NG_VERSION`
+
+`std::env::set_var` is never called, so the host process is unaffected and concurrently running
+hooks cannot observe each other's values.
+
+Names must match the POSIX rule `[A-Za-z_][A-Za-z0-9_]*`. A strict `schemaVersion: 1` manifest is
+rejected at install time with `extension_hook_env_name_invalid`; config-file and legacy-manifest
+hooks are re-validated at spawn time as defence in depth, dropping the entry and logging only the
+name. Values are opaque and never logged or formatted.
+
+`env` is part of the capability fingerprint: a previously inert field became executable capability,
+so declaring or changing it must force re-consent. The key is omitted from the projection when
+empty, so extensions that never used `env` keep their existing fingerprint.
+
+### Security boundary
+
+The host variables are applied after the declared map, so they take precedence over an `env` entry
+of the same name. **They are a cooperative attribution signal, not a security boundary.** The same
+manifest owns `command`, and the hook runs under `sh -c`, so it can trivially reassign or unset them:
+
+```sh
+COSH_RUNTIME=fake python3 hook.py
+```
+
+Nothing security-relevant may depend on these variables. They exist so a cooperating hook can
+report which runtime it ran under (statistics attribution), which a shared extension manifest
+cannot express on its own.
 
 ## Trade-offs
 

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -196,6 +196,7 @@ test-hooks:
 test-integration:
 	@echo "==> Testing hook integration (Python)..."
 	python3 tests/test_compress_response_hook.py
+	python3 tests/test_compress_schema_hook.py
 
 # Lint (rtk excluded — vendored third-party source)
 lint:

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -57,6 +57,7 @@ from hook_utils import (
     get_thresholds,
     is_skill_file,
     parse_version,
+    resolve_agent_id,
     resolve_binary,
     resolve_tool_call_id,
     secure_write_text,
@@ -85,14 +86,6 @@ _CLAUDE_VERSION_CACHE = os.path.join(
 
 
 # -- helpers -------------------------------------------------------------------
-
-
-def _resolve_agent_id(cosh_ng_detected: bool) -> str:
-    """Resolve the agent ID, using cosh-ng when detected under that runtime."""
-    env_id = os.environ.get("TOKENLESS_AGENT_ID", "")
-    if cosh_ng_detected:
-        return env_id or "cosh-ng"
-    return env_id or "tokenless"
 
 
 def _build_additional_context(
@@ -223,7 +216,7 @@ def main() -> None:
         skip()
 
     # 2. Resolve agent ID based on runtime
-    agent_id = _resolve_agent_id(cosh_ng_detected)
+    agent_id = resolve_agent_id()
 
     # 3. Resolve binaries
     tokenless_bin = resolve_binary(

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
@@ -22,6 +22,7 @@ from hook_utils import (
     _TOKENLESS_FALLBACK,
     _TOKENLESS_LOCAL_LIB,
     _TOKENLESS_LOCAL_SHARE,
+    resolve_agent_id,
     resolve_binary,
     resolve_tool_call_id,
     skip,
@@ -30,7 +31,7 @@ from hook_utils import (
 
 # -- constants ---------------------------------------------------------------
 
-_AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
+_AGENT_ID = resolve_agent_id()
 
 
 # -- helpers -----------------------------------------------------------------
@@ -68,9 +69,19 @@ def main() -> None:
         warn("failed to read BeforeModel payload. Passing through unchanged.")
         skip()
 
-    # 3. Extract tools array
+    # 3. Extract tools array. `config.tools` is the canonical position (both
+    # copilot-shell's Hook Translator and Cosh-NG put it there); the top-level
+    # `tools` is the older position, kept for hosts that still emit it.
+    # Presence of the canonical key decides, not its truthiness: a host that
+    # declares no tools sends an empty canonical array, and falling through to
+    # a stale legacy field there would compress declarations this request never
+    # carried. This mirrors the host-side precedence.
     llm_request = input_data.get("llm_request", {})
-    tools = llm_request.get("tools")
+    config = llm_request.get("config")
+    if isinstance(config, dict) and "tools" in config:
+        tools = config["tools"]
+    else:
+        tools = llm_request.get("tools")
     if not tools:
         skip()
 
@@ -115,12 +126,14 @@ def main() -> None:
         )
         skip()
 
-    # 6. Build response
+    # 6. Build response at the canonical position.
     output = {
         "hookSpecificOutput": {
             "hookEventName": "BeforeModel",
             "llm_request": {
-                "tools": json.loads(compressed),
+                "config": {
+                    "tools": json.loads(compressed),
+                },
             },
         },
     }

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
@@ -28,6 +28,7 @@ from hook_utils import (
     _TOKENLESS_LOCAL_SHARE,
     CONTENT_RETRIEVAL_TOOLS,
     is_skill_file,
+    resolve_agent_id,
     resolve_binary,
     skip,
     try_parse_json,
@@ -37,7 +38,7 @@ from hook_utils import (
 
 # -- constants ---------------------------------------------------------------
 
-_AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
+_AGENT_ID = resolve_agent_id()
 _MIN_RESPONSE_CHARS = 200
 
 

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -431,6 +431,25 @@ def detect_cosh_ng_runtime() -> tuple | None:
     return None
 
 
+def resolve_agent_id(default: str = "tokenless") -> str:
+    """Resolve the agent ID used for stats attribution.
+
+    Runtime detection wins over ``TOKENLESS_AGENT_ID``. The shared extension
+    manifest sets that variable to ``copilot-shell``, and now that Cosh-NG
+    honours hook ``env`` (#1617) an unconditional read would attribute Cosh-NG
+    sessions to copilot-shell. ``COSH_RUNTIME`` / ``COSH_NG_VERSION`` are
+    injected by the host after the manifest env, so they take precedence over
+    the declared env map.
+
+    This is attribution only. The signal is cooperative — a manifest controls
+    its own ``command`` and could reassign these — so it must never gate
+    anything security-relevant.
+    """
+    if detect_cosh_ng_runtime() is not None:
+        return "cosh-ng"
+    return os.environ.get("TOKENLESS_AGENT_ID") or default
+
+
 def parse_version(version_str: str) -> tuple | None:
     """Parse a version string like '0.35.0' into a (major, minor, patch) tuple."""
     m = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -28,6 +28,7 @@ from hook_utils import (
     _TOKENLESS_LOCAL_SHARE,
     forward_stderr,
     parse_version,
+    resolve_agent_id,
     resolve_binary,
     resolve_tool_call_id,
     skip,
@@ -38,12 +39,7 @@ from hook_utils import (
 # -- constants ---------------------------------------------------------------
 
 _MIN_RTK_VERSION = (0, 35, 0)
-_AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "tokenless")
-
-# Import Cosh-NG detection for stats attribution
-from hook_utils import detect_cosh_ng_runtime as _detect_cosh_ng
-if _detect_cosh_ng() is not None and _AGENT_ID == "tokenless":
-    _AGENT_ID = "cosh-ng"
+_AGENT_ID = resolve_agent_id()
 
 
 # -- main --------------------------------------------------------------------

--- a/src/tokenless/tests/test_compress_schema_hook.py
+++ b/src/tokenless/tests/test_compress_schema_hook.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Integration tests for compress_schema_hook.py.
+
+Validates the BeforeModel hook contract:
+- Tool declarations are read from the canonical ``llm_request.config.tools``
+  position, with the older top-level ``llm_request.tools`` still accepted.
+- Compressed declarations are written back to the canonical position.
+- Stats attribution: when the host announces itself via ``COSH_RUNTIME`` /
+  ``COSH_NG_VERSION``, the agent ID is ``cosh-ng`` even though the shared
+  extension manifest sets ``TOKENLESS_AGENT_ID=copilot-shell``.
+
+Uses subprocess to invoke the hook with a mock tokenless binary,
+avoiding Python version issues with the hook_utils module.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import shutil
+import tempfile
+import textwrap
+import unittest
+
+_TOOLS = [
+    {
+        "name": "shell",
+        "description": "Run a shell command. " * 20,
+        "parameters": {
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+        },
+    }
+]
+
+
+def _create_mock_tokenless(tmpdir: str, argv_log: str) -> str:
+    """Mock `tokenless compress-schema` that truncates descriptions.
+
+    Records its own argv to ``argv_log`` so tests can assert the agent ID the
+    hook attributed the invocation to.
+    """
+    mock_script = os.path.join(tmpdir, "tokenless")
+    script = textwrap.dedent(f"""\
+        #!/usr/bin/env python3
+        import json, sys
+        with open({argv_log!r}, "w") as log:
+            log.write(json.dumps(sys.argv[1:]))
+        tools = json.loads(sys.stdin.read())
+        for tool in tools:
+            tool["description"] = "compressed"
+        print(json.dumps(tools))
+    """)
+    with open(mock_script, "w") as handle:
+        handle.write(script)
+    os.chmod(
+        mock_script,
+        os.stat(mock_script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH,
+    )
+    return mock_script
+
+
+def _run_hook(stdin_data: dict, mock_tokenless_path: str, extra_env: dict) -> dict:
+    """Run the hook as a subprocess with a mocked tokenless binary."""
+    hooks_dir = os.path.normpath(os.path.join(
+        os.path.dirname(__file__),
+        os.pardir, "adapters", "tokenless", "common", "hooks",
+    ))
+    hook_path = os.path.join(hooks_dir, "compress_schema_hook.py")
+
+    env = os.environ.copy()
+    # The host-owned variables must not leak in from the caller's environment.
+    env.pop("COSH_RUNTIME", None)
+    env.pop("COSH_NG_VERSION", None)
+    env["PATH"] = os.path.dirname(mock_tokenless_path) + ":" + env.get("PATH", "")
+    env.update(extra_env)
+
+    proc = subprocess.run(
+        [sys.executable, hook_path],
+        input=json.dumps(stdin_data),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+    if proc.returncode != 0:
+        return {
+            "_subprocess_error": True,
+            "_returncode": proc.returncode,
+            "_stderr": proc.stderr,
+        }
+
+    stdout = proc.stdout.strip()
+    if not stdout or stdout == "{}":
+        return {}
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return {"_raw_stdout": stdout, "_stderr": proc.stderr}
+
+
+_needs_py39 = sys.version_info < (3, 9)
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestSchemaCompressionProtocol(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.argv_log = os.path.join(self.tmpdir, "argv.json")
+        self.mock_bin = _create_mock_tokenless(self.tmpdir, self.argv_log)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _recorded_agent_id(self) -> str:
+        with open(self.argv_log) as handle:
+            argv = json.load(handle)
+        return argv[argv.index("--agent-id") + 1]
+
+    def test_reads_and_writes_canonical_config_tools(self):
+        result = _run_hook(
+            {"session_id": "s1", "llm_request": {"config": {"tools": _TOOLS}}},
+            self.mock_bin,
+            {"TOKENLESS_AGENT_ID": "copilot-shell"},
+        )
+
+        tools = result["hookSpecificOutput"]["llm_request"]["config"]["tools"]
+        self.assertEqual(tools[0]["name"], "shell")
+        self.assertEqual(tools[0]["description"], "compressed")
+
+    def test_accepts_legacy_top_level_tools(self):
+        result = _run_hook(
+            {"session_id": "s1", "llm_request": {"tools": _TOOLS}},
+            self.mock_bin,
+            {"TOKENLESS_AGENT_ID": "copilot-shell"},
+        )
+
+        # Read from the legacy position, but always written back to the
+        # canonical one.
+        tools = result["hookSpecificOutput"]["llm_request"]["config"]["tools"]
+        self.assertEqual(tools[0]["description"], "compressed")
+
+    def test_canonical_position_wins_over_legacy_when_both_present(self):
+        result = _run_hook(
+            {
+                "session_id": "s1",
+                "llm_request": {
+                    "config": {"tools": _TOOLS},
+                    "tools": [{
+                        "name": "legacy-only",
+                        "description": "stale",
+                        "parameters": {"type": "object"},
+                    }],
+                },
+            },
+            self.mock_bin,
+            {"TOKENLESS_AGENT_ID": "copilot-shell"},
+        )
+
+        tools = result["hookSpecificOutput"]["llm_request"]["config"]["tools"]
+        self.assertEqual([tool["name"] for tool in tools], ["shell"])
+
+    def test_empty_canonical_tools_does_not_fall_back_to_legacy(self):
+        """An explicitly empty canonical array means "no tools this request"."""
+        result = _run_hook(
+            {
+                "session_id": "s1",
+                "llm_request": {
+                    "config": {"tools": []},
+                    "tools": _TOOLS,
+                },
+            },
+            self.mock_bin,
+            {"TOKENLESS_AGENT_ID": "copilot-shell"},
+        )
+
+        self.assertEqual(result, {})
+
+    def test_skips_when_no_tools_present(self):
+        result = _run_hook(
+            {"session_id": "s1", "llm_request": {"model": "m", "messages": []}},
+            self.mock_bin,
+            {"TOKENLESS_AGENT_ID": "copilot-shell"},
+        )
+
+        self.assertEqual(result, {})
+
+    def test_cosh_ng_runtime_wins_over_manifest_agent_id(self):
+        _run_hook(
+            {"session_id": "s1", "llm_request": {"config": {"tools": _TOOLS}}},
+            self.mock_bin,
+            {
+                "TOKENLESS_AGENT_ID": "copilot-shell",
+                "COSH_RUNTIME": "cosh-ng",
+                "COSH_NG_VERSION": "0.13.0",
+            },
+        )
+
+        self.assertEqual(self._recorded_agent_id(), "cosh-ng")
+
+    def test_manifest_agent_id_still_serves_copilot_shell(self):
+        _run_hook(
+            {"session_id": "s1", "llm_request": {"config": {"tools": _TOOLS}}},
+            self.mock_bin,
+            {"TOKENLESS_AGENT_ID": "copilot-shell"},
+        )
+
+        self.assertEqual(self._recorded_agent_id(), "copilot-shell")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds validated `BeforeModel` tool-declaration rewrites so schema-compression hooks can affect the following provider request without mutating the registry. Preserves compaction accounting by rejecting declaration growth and keeps JSON Schema structure intact during redaction. Hook-level `env` is now validated, fingerprinted, hydrated by value, and injected only into the child process. Tokenless now uses the canonical `llm_request.config.tools` path and attributes Cosh-NG sessions correctly.

## Related Issue

closes #1616
closes #1617

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Scope

- [x] `cosh-ng` (cosh-ng)
- [x] `tokenless` (tokenless)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p cosh-core --all-targets --locked -- -D warnings`
- `cargo test -p cosh-core --locked`
- `cargo doc -p cosh-core --no-deps --locked`
- `python3 tests/test_compress_schema_hook.py`
- `python3 tests/test_compress_response_hook.py`
- Full Cosh-NG workspace tests were also exercised. The two environment-specific failures reproduced unchanged on the clean base: the apt dry-run assertion depends on English locale output, and the shell-host marker test depends on PTY behavior.

## Additional Notes

Cosh-NG applies returned `config.tools` rewrites. copilot-shell currently exposes the same input path but does not copy returned tools back into its SDK request; the protocol design document records this existing limitation explicitly.