### PR TITLE
fix(cosh-ng): [cli] wrap clap errors in JSON envelope (exit 1, stdout)

### DIFF
--- a/src/cosh-ng/crates/cosh-cli/src/main.rs
+++ b/src/cosh-ng/crates/cosh-cli/src/main.rs
@@ -61,9 +61,50 @@ fn main() {
         .with_target(true)
         .try_init();
 
-    let cli = Cli::parse();
-    let distro = Distro::detect();
     let start = Instant::now();
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => {
+            // --help and --version are display requests, not errors.
+            // Print to stdout and exit 0, preserving clap's default behavior.
+            if e.kind() == clap::error::ErrorKind::DisplayHelp
+                || e.kind() == clap::error::ErrorKind::DisplayVersion
+            {
+                let _ = e.print();
+                std::process::exit(0);
+            }
+            // All other clap errors (missing args, unknown subcommand, etc.)
+            // go through the JSON envelope contract: stdout + exit 1.
+            // render() yields plain text (no ANSI codes) so the JSON message
+            // stays clean even when stdout is a tty.
+            let error = cosh_types::error::CoshError::new(
+                cosh_types::error::ErrorCode::InvalidInput,
+                e.render().to_string().trim().to_string(),
+                "cli",
+            )
+            .recoverable(true)
+            .with_hint("Run with --help to see available commands and options".to_string());
+            let meta = ResponseMeta {
+                subsystem: "cli".to_string(),
+                duration_ms: start.elapsed().as_millis() as u64,
+                distro: Some(Distro::detect().id_str().to_string()),
+                dry_run: false,
+                warning: None,
+            };
+            let resp: CoshResponse<()> = CoshResponse::failure(error, meta);
+            match serde_json::to_string_pretty(&resp) {
+                Ok(json) => println!("{}", json),
+                Err(_) => {
+                    // Last-resort fallback: hand-crafted JSON so stdout is never empty.
+                    println!(
+                        r#"{{"ok":false,"error":{{"code":"InvalidInput","message":"clap error (serialization failed)","recoverable":true,"subsystem":"cli"}},"meta":{{"subsystem":"cli","duration_ms":0,"dry_run":false}}}}"#
+                    );
+                }
+            }
+            std::process::exit(1);
+        }
+    };
+    let distro = Distro::detect();
 
     let exit_code = match cli.command {
         Commands::Pkg { action } => cmd::pkg::run(action, &distro, start),

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -261,6 +261,57 @@ fn test_version_output() {
     assert!(stdout.contains("cosh-cli"));
 }
 
+// --- clap errors must produce JSON envelope (issue #1548) ---
+
+#[test]
+fn test_clap_missing_argument_returns_json_envelope() {
+    let output = cosh_bin().args(["pkg", "install"]).output().unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "clap error should exit 1, not 2"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout should be valid JSON: {e}\nstdout={stdout}"));
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "InvalidInput");
+    assert_eq!(json["error"]["subsystem"], "cli");
+    assert_eq!(json["meta"]["subsystem"], "cli");
+    assert_eq!(json["meta"]["dry_run"], false);
+}
+
+#[test]
+fn test_clap_unknown_subcommand_returns_json_envelope() {
+    let output = cosh_bin().arg("nonexistent-subcommand").output().unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "clap error should exit 1, not 2"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout should be valid JSON: {e}\nstdout={stdout}"));
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "InvalidInput");
+    assert_eq!(json["error"]["subsystem"], "cli");
+}
+
+#[test]
+fn test_clap_no_subcommand_returns_json_envelope() {
+    let output = cosh_bin().output().unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "clap error should exit 1, not 2"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout should be valid JSON: {e}\nstdout={stdout}"));
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "InvalidInput");
+}
+
 #[test]
 fn test_pkg_help() {
     let output = cosh_bin().args(["pkg", "--help"]).output().unwrap();


### PR DESCRIPTION
## Description

`cosh-cli` declares a unified JSON envelope contract for all command output, but clap-level errors (missing arguments, unknown subcommands, no subcommand) bypassed this contract entirely: stdout was empty, stderr had plain text, and exit code was 2. LLM agents consuming stdout would get empty strings and fail to parse or misinterpret command success.

**Root cause**: `main.rs` used `Cli::parse()` which internally calls `Error::exit()` on clap errors — printing plain text to stderr and exiting with code 2, never reaching the JSON envelope output path.

**Fix**: Replace `Cli::parse()` with `Cli::try_parse()` and intercept clap errors:
- `DisplayHelp` / `DisplayVersion`: preserved original behavior (stdout, exit 0)
- All other clap errors: JSON envelope on stdout with `ErrorCode::InvalidInput`, subsystem `"cli"`, exit code 1

**Before**:
```bash
$ cosh-cli pkg install
# stdout: (empty)
# stderr: error: the following required arguments were not provided...
# exit=2
```

**After**:
```bash
$ cosh-cli pkg install
{
  "ok": false,
  "error": {
    "code": "InvalidInput",
    "message": "error: the following required arguments were not provided:\n  <PACKAGE>\n...",
    "recoverable": true,
    "hint": "Run with --help to see available commands and options",
    "subsystem": "cli"
  },
  "meta": { "subsystem": "cli", "duration_ms": 0, "dry_run": false }
}
# exit=1
```

Regression tests:
- `test_clap_missing_argument_returns_json_envelope`
- `test_clap_unknown_subcommand_returns_json_envelope`
- `test_clap_no_subcommand_returns_json_envelope`

## Related Issue

closes #1548

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

```bash
# Format
cargo fmt --all -- --check    # clean

# Lint
cargo clippy -p cosh-cli --all-targets    # 0 warnings

# Regression tests (new)
cargo test -p cosh-cli --test cli_integration clap    # 3/3 passed
  - test_clap_missing_argument_returns_json_envelope
  - test_clap_unknown_subcommand_returns_json_envelope
  - test_clap_no_subcommand_returns_json_envelope

# Existing help/version tests (unchanged)
cargo test -p cosh-cli --test cli_integration help     # 6/6 passed
cargo test -p cosh-cli --test cli_integration version  # 1/1 passed
```

## Additional Notes

Changes scoped to `crates/cosh-cli/src/main.rs` (error interception, ~40 lines) and `crates/cosh-cli/tests/cli_integration.rs` (3 regression tests, ~50 lines). No i18n changes needed — clap error messages are passed through as-is in the `message` field using `e.render()` (plain text, no ANSI codes).