### PR TITLE
fix(anolisa): validate dry-run conflicts

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -10,7 +10,7 @@
 //! Everything that is not a fresh delegated install keeps the per-item
 //! pipeline unchanged.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Serialize;
 
@@ -49,8 +49,9 @@ use super::{COMMAND, InstallArgs};
 // shared guards it mirrors.
 use super::io_util::now_iso8601;
 use super::{
-    PlannedComponent, PlannedRoute, handle_one, host_backends, plan_component, quarantined,
-    require_configured_rpm_backend, revalidate_native_absence, step_label,
+    PlannedComponent, PlannedRoute, handle_one, handle_one_with_planned_components, host_backends,
+    plan_component, quarantined, require_configured_rpm_backend, revalidate_native_absence,
+    step_label,
 };
 // ── --all support ───────────────────────────────────────────────────
 
@@ -157,6 +158,10 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
         (!merged.is_empty()).then(|| merged.iter().map(|item| item.package.clone()).collect());
 
     let mut results: HashMap<String, AllSummaryItem> = HashMap::with_capacity(names.len());
+    // Dry-run does not persist each successful member, so carry the batch's
+    // simulated state forward to keep later raw conflict checks aligned with
+    // the sequential real execution order.
+    let mut planned_components: HashSet<String> = HashSet::new();
     let mut fail_fast_tripped = false;
 
     if !merged.is_empty() {
@@ -191,6 +196,7 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
                         plan: Some(labels),
                     },
                 );
+                planned_components.insert(item.name.clone());
             }
         } else {
             let statuses = execute_merged_group(merged, &args, ctx);
@@ -213,10 +219,18 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
             println!("{} {name}", color.label("==>"));
         }
         let per_args = per_component_args(name, &args);
-        match handle_one(name.clone(), per_args, &suppressed_ctx) {
+        match handle_one_with_planned_components(
+            name.clone(),
+            per_args,
+            &suppressed_ctx,
+            &planned_components,
+        ) {
             // Map (outcome, dry-run) to a batch status string (§7.5).
             // Dry-run successes are "planned": nothing was written.
             Ok(outcome) => {
+                if ctx.dry_run && outcome == InstallOutcome::Installed {
+                    planned_components.insert(name.clone());
+                }
                 results.insert(
                     name.clone(),
                     AllSummaryItem {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -7,6 +7,7 @@
 //! through [`RawInstallOps`], a delegated plan re-uses the native-transaction
 //! executor with a [`StoreRecordSink`]. No lifecycle policy lives here.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use anolisa_core::executor::{DelegatedExecutionTarget, execute_delegated_steps};
@@ -49,9 +50,10 @@ use crate::resolution::{
 use crate::response::{CliError, render_json};
 
 use super::owned_ops::{
-    RawInstallOps, ValidatedInstall, installed_version_label, validate_owned_install,
+    RawInstallOps, ValidatedInstall, installed_version_label, validate_component_conflict,
+    validate_owned_install,
 };
-use super::raw::resolve_raw;
+use super::raw::{load_dry_run_install_contract, resolve_raw};
 use super::render::repo_config_err;
 use super::rpm::{
     PinError, RpmTarget, resolve_pinned_candidate, rpm_package_candidates_with_index,
@@ -67,6 +69,26 @@ pub(crate) fn handle_one(
 ) -> Result<InstallOutcome, CliError> {
     let (query, txn) = host_backends(&component, &args, ctx)?;
     install_component_with_deps(&component, &args, ctx, &query, &txn, privilege::is_root())
+}
+
+/// Dispatch one batch member while treating earlier successful dry-run
+/// members as installed for directional manifest-conflict validation.
+pub(crate) fn handle_one_with_planned_components(
+    component: String,
+    args: InstallArgs,
+    ctx: &CliContext,
+    planned_components: &HashSet<String>,
+) -> Result<InstallOutcome, CliError> {
+    let (query, txn) = host_backends(&component, &args, ctx)?;
+    install_component_with_deps_and_planned(
+        &component,
+        &args,
+        ctx,
+        &query,
+        &txn,
+        privilege::is_root(),
+        planned_components,
+    )
 }
 
 /// Real host backends for one component invocation.
@@ -248,8 +270,20 @@ pub(crate) fn install_component_with_deps(
     txn: &dyn PackageTransaction,
     is_root: bool,
 ) -> Result<InstallOutcome, CliError> {
+    install_component_with_deps_and_planned(input, args, ctx, query, txn, is_root, &HashSet::new())
+}
+
+fn install_component_with_deps_and_planned(
+    input: &str,
+    args: &InstallArgs,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    planned_components: &HashSet<String>,
+) -> Result<InstallOutcome, CliError> {
     let planned = plan_component(input, args, ctx, query, txn)?;
-    execute_planned(planned, args, ctx, query, txn, is_root)
+    execute_planned(planned, args, ctx, query, txn, is_root, planned_components)
 }
 
 /// Planning prefix of an install: resolve the component and its provider
@@ -496,6 +530,7 @@ fn execute_planned(
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
+    planned_components: &HashSet<String>,
 ) -> Result<InstallOutcome, CliError> {
     let PlannedComponent {
         command,
@@ -569,6 +604,22 @@ fn execute_planned(
     if ctx.dry_run {
         for warning in resolution.iter().flat_map(|r| r.warnings.iter()) {
             eprintln!("warning: {warning}");
+        }
+        if let Some(resolution) = resolution.as_ref() {
+            match load_dry_run_install_contract(ctx, &layout, resolution)? {
+                Some(contract) => {
+                    validate_component_conflict(
+                        &contract.manifest,
+                        &store,
+                        planned_components,
+                        &command,
+                    )?;
+                }
+                None => eprintln!(
+                    "warning: dry-run could not validate component conflicts for '{}' because the repository has no lightweight meta.toml; the full artifact was not downloaded",
+                    resolution.component
+                ),
+            }
         }
         // A pinned dry-run reports the version it resolved against the
         // repository, not the raw `--version` echo — the pin fields carry

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -13,6 +13,7 @@
 //! reaches them fails loudly at the exact step rather than committing a
 //! record that lies.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -874,12 +875,7 @@ pub(crate) fn validate_owned_install(
             command: command.to_string(),
             reason: format!("failed to parse component manifest: {err}"),
         })?;
-    if let Some(reason) = component_conflict(&manifest, store) {
-        return Err(CliError::InvalidArgument {
-            command: command.to_string(),
-            reason,
-        });
-    }
+    validate_component_conflict(&manifest, store, &HashSet::new(), command)?;
     let hooks = resolve_install_hooks(&manifest, layout, &component)?;
     let prepared_files = InstallRunner::new(layout)
         .prepare_files(
@@ -897,6 +893,34 @@ pub(crate) fn validate_owned_install(
         manifest,
         hooks,
     })
+}
+
+/// Reject an incoming component whose manifest conflicts with active state
+/// or an earlier successful member of the same dry-run batch.
+pub(crate) fn validate_component_conflict(
+    manifest: &anolisa_core::ComponentManifest,
+    store: &StateStore,
+    planned_components: &HashSet<String>,
+    command: &str,
+) -> Result<(), CliError> {
+    if let Some(reason) = component_conflict(manifest, store) {
+        return Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason,
+        });
+    }
+    for conflict in &manifest.component.conflicts {
+        if planned_components.contains(conflict) {
+            return Err(CliError::InvalidArgument {
+                command: command.to_string(),
+                reason: format!(
+                    "component '{}' conflicts with component '{}' planned earlier in this batch — remove one component from the batch, then retry",
+                    manifest.component.name, conflict
+                ),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Component-level mutual exclusion (the raw equivalent of RPM's

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use anolisa_core::download::DownloadCache;
+use anolisa_core::download::{DownloadCache, DownloadError};
 use anolisa_core::install_runner::{
     ResolvedInstallFile, SUPPORTED_ARTIFACT_TYPES, read_embedded_component_manifest_text,
 };
@@ -15,6 +15,7 @@ use anolisa_core::{
     resolve_manifest_hooks,
 };
 use anolisa_platform::fs_layout::FsLayout;
+use sha2::{Digest, Sha256};
 
 use crate::context::CliContext;
 use crate::repo_config::{
@@ -246,8 +247,109 @@ impl InstallContractSource {
     fn label(self) -> &'static str {
         match self {
             Self::EmbeddedArtifact => "embedded artifact manifest",
+            Self::SidecarMeta => "sidecar meta.toml",
         }
     }
+}
+
+/// Load the published lightweight install contract without fetching the full
+/// artifact, so dry-run can enforce manifest-backed refusals such as component
+/// conflicts.
+pub(crate) fn load_dry_run_install_contract(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    resolution: &RawResolution,
+) -> Result<Option<LoadedInstallContract>, CliError> {
+    let Some(meta_url) = sidecar_meta_url(
+        &resolution.artifact_url,
+        &resolution.entry.component,
+        &resolution.entry.version,
+    ) else {
+        return Ok(None);
+    };
+    let expected_sha = manifest_digest_sha256(resolution.entry.manifest_digest.as_deref())?;
+    let cache = DownloadCache::new(layout.cache_dir.clone());
+    let downloaded = match cache.fetch(&meta_url, expected_sha) {
+        Ok(downloaded) => downloaded,
+        Err(DownloadError::HttpStatus { status: 404, .. }) => return Ok(None),
+        Err(DownloadError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(err) => {
+            return Err(CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!("failed to fetch sidecar metadata {meta_url}: {err}"),
+            });
+        }
+    };
+    let toml =
+        std::fs::read_to_string(&downloaded.cached_path).map_err(|err| CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "failed to read sidecar metadata {} from cache: {err}",
+                downloaded.cached_path.display()
+            ),
+        })?;
+    let manifest = ComponentManifest::from_toml_str(&toml).map_err(|err| CliError::Runtime {
+        command: COMMAND.to_string(),
+        reason: format!("failed to parse sidecar metadata {meta_url}: {err}"),
+    })?;
+    validate_manifest_contract_header(
+        &manifest,
+        resolution,
+        ctx.install_mode.as_str(),
+        InstallContractSource::SidecarMeta,
+    )?;
+    Ok(Some(LoadedInstallContract {
+        manifest,
+        source: InstallContractSource::SidecarMeta,
+        toml,
+    }))
+}
+
+fn sidecar_meta_url(artifact_url: &str, component: &str, version: &str) -> Option<String> {
+    let version_marker = format!("/{component}/{version}/");
+    if let Some(index) = artifact_url.rfind(&version_marker) {
+        return Some(format!(
+            "{}meta.toml",
+            &artifact_url[..index + version_marker.len()]
+        ));
+    }
+
+    artifact_url
+        .rfind('/')
+        .map(|index| format!("{}/meta.toml", &artifact_url[..index]))
+}
+
+fn manifest_digest_sha256(digest: Option<&str>) -> Result<Option<&str>, CliError> {
+    match digest {
+        None => Ok(None),
+        Some(value) => value
+            .strip_prefix("sha256:")
+            .map(Some)
+            .ok_or_else(|| CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!("unsupported manifest_digest '{value}' in the distribution index"),
+            }),
+    }
+}
+
+fn validate_manifest_digest(toml: &str, resolution: &RawResolution) -> Result<(), CliError> {
+    let Some(expected) = manifest_digest_sha256(resolution.entry.manifest_digest.as_deref())?
+    else {
+        return Ok(());
+    };
+    let actual = format!("{:x}", Sha256::digest(toml.as_bytes()));
+    if expected.eq_ignore_ascii_case(&actual) {
+        return Ok(());
+    }
+    Err(CliError::Runtime {
+        command: COMMAND.to_string(),
+        reason: format!(
+            "embedded component manifest digest for '{}' {} does not match the distribution index: expected {expected}, got {actual}",
+            resolution.component, resolution.entry.version
+        ),
+    })
 }
 
 pub(crate) fn prepare_raw_execution(
@@ -324,6 +426,7 @@ fn load_execution_install_contract(
                         resolution.artifact_url
                     ),
                 })?;
+            validate_manifest_digest(&toml, resolution)?;
             Ok(LoadedInstallContract {
                 manifest,
                 source: InstallContractSource::EmbeddedArtifact,
@@ -356,6 +459,40 @@ fn resolve_manifest_contract(
     mode: &str,
     source: InstallContractSource,
 ) -> Result<ResolvedContract, CliError> {
+    validate_manifest_contract_header(manifest, resolution, mode, source)?;
+
+    let mut files = resolve_manifest_files(manifest, layout, &resolution.component)?;
+    if files.is_empty() {
+        return Err(CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "component '{}' declares no [install.files] — nothing to install",
+                resolution.component
+            ),
+        });
+    }
+    // Adapter resources are laid alongside the component's own files, from
+    // the same artifact. Install only *places* them under the standard
+    // `{datadir}/adapters/<component>/<framework>/` tree — enabling them
+    // against a framework is the separate `anolisa adapter enable` step.
+    files.extend(resolve_adapter_files(
+        manifest,
+        layout,
+        &resolution.component,
+    )?);
+
+    let services = resolve_manifest_services(manifest, &resolution.component, mode)?;
+    let capabilities = resolve_manifest_capabilities(manifest, layout, &resolution.component)?;
+
+    Ok((files, services, capabilities))
+}
+
+fn validate_manifest_contract_header(
+    manifest: &ComponentManifest,
+    resolution: &RawResolution,
+    mode: &str,
+    source: InstallContractSource,
+) -> Result<(), CliError> {
     if manifest.component.name.as_str() != resolution.component {
         return Err(CliError::Runtime {
             command: COMMAND.to_string(),
@@ -392,31 +529,7 @@ fn resolve_manifest_contract(
             ),
         });
     }
-
-    let mut files = resolve_manifest_files(manifest, layout, &resolution.component)?;
-    if files.is_empty() {
-        return Err(CliError::Runtime {
-            command: COMMAND.to_string(),
-            reason: format!(
-                "component '{}' declares no [install.files] — nothing to install",
-                resolution.component
-            ),
-        });
-    }
-    // Adapter resources are laid alongside the component's own files, from
-    // the same artifact. Install only *places* them under the standard
-    // `{datadir}/adapters/<component>/<framework>/` tree — enabling them
-    // against a framework is the separate `anolisa adapter enable` step.
-    files.extend(resolve_adapter_files(
-        manifest,
-        layout,
-        &resolution.component,
-    )?);
-
-    let services = resolve_manifest_services(manifest, &resolution.component, mode)?;
-    let capabilities = resolve_manifest_capabilities(manifest, layout, &resolution.component)?;
-
-    Ok((files, services, capabilities))
+    Ok(())
 }
 
 /// Render the manifest's `[[component.services]]` into activation requests:

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -11,6 +11,8 @@ use anolisa_core::state_store::StateStore;
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::commands::common;
+use crate::context::InstallMode;
+use crate::test_support::{TestContextOptions, TestSandbox};
 use tempfile::tempdir;
 
 /// v5 store as the pipeline persisted it for a system-prefix layout.
@@ -99,6 +101,10 @@ fn install_dry_run_does_not_download_the_artifact() {
             .iter()
             .all(|name| !name.ends_with("remote-only-1.0.0-linux-x86_64.tar.gz")),
         "dry-run must not download the install artifact; cache entries: {cached_names:?}"
+    );
+    assert!(
+        cached_names.iter().any(|name| name.ends_with("meta.toml")),
+        "dry-run must fetch the lightweight contract; cache entries: {cached_names:?}"
     );
 }
 
@@ -942,6 +948,8 @@ fn write_local_repo_with_conflicts(
     std::fs::create_dir_all(&v1).expect("create repo dirs");
 
     let manifest = component_manifest_toml_with_conflicts(component, version, modes, conflicts);
+    let manifest_sha = format!("{:x}", Sha256::digest(manifest.as_bytes()));
+    std::fs::write(v1.join("meta.toml"), &manifest).expect("write sidecar manifest");
     let bin_path = format!("bin/{component}");
     let payload = format!("#!/bin/sh\necho {component}\n");
     let artifact = build_tar_gz(&[
@@ -970,6 +978,7 @@ os = "{os}"
 arch = "{arch}"
 install_modes = {modes_str}
 sha256 = "{sha}"
+manifest_digest = "sha256:{manifest_sha}"
 "#,
         os = env.os,
         arch = env.arch,
@@ -978,13 +987,85 @@ sha256 = "{sha}"
     format!("file://{}", v1.display())
 }
 
-#[test]
-fn install_conflict_blocks_when_conflicting_component_is_installed() {
-    let tmp = tempdir().expect("tmpdir");
-    let prefix = tmp.path().join("sys");
-    let layout = FsLayout::system(Some(prefix.clone()));
+fn write_published_batch_conflict_repo(root: &Path) -> String {
+    let v1 = root.join("v1");
+    std::fs::create_dir_all(&v1).expect("create repo dirs");
+    let env = anolisa_env::EnvService::detect();
+    let mut index =
+        String::from("schema_version = 1\nchannel = \"stable\"\npublisher = \"test\"\n");
 
-    // Pre-seed state: cosh v2.6.0 is already installed.
+    for (component, conflicts) in [("cosh", &[][..]), ("cosh-ng", &["cosh"][..])] {
+        let version = "1.0.0";
+        let version_dir = v1.join(component).join(version);
+        let artifact_dir = version_dir.join(&env.os).join(&env.arch);
+        std::fs::create_dir_all(&artifact_dir).expect("create artifact dirs");
+
+        let manifest =
+            component_manifest_toml_with_conflicts(component, version, &["user"], conflicts);
+        std::fs::write(version_dir.join("meta.toml"), &manifest).expect("write sidecar manifest");
+        let manifest_sha = format!("{:x}", Sha256::digest(manifest.as_bytes()));
+        let bin_path = format!("bin/{component}");
+        let payload = format!("#!/bin/sh\necho {component}\n");
+        let artifact = build_tar_gz(&[
+            (".anolisa/component.toml", manifest.as_bytes()),
+            (bin_path.as_str(), payload.as_bytes()),
+        ]);
+        let artifact_name = format!(
+            "{component}-{version}-{os}-{arch}.tar.gz",
+            os = env.os,
+            arch = env.arch
+        );
+        std::fs::write(artifact_dir.join(&artifact_name), &artifact).expect("write artifact");
+        let artifact_sha = format!("{:x}", Sha256::digest(&artifact));
+        let url = format!(
+            "{component}/{version}/{os}/{arch}/{artifact_name}",
+            os = env.os,
+            arch = env.arch
+        );
+        index.push_str(&format!(
+            r#"
+[[entries]]
+component = "{component}"
+version = "{version}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "{url}"
+os = "{os}"
+arch = "{arch}"
+install_modes = ["user"]
+sha256 = "{artifact_sha}"
+manifest_digest = "sha256:{manifest_sha}"
+"#,
+            os = env.os,
+            arch = env.arch,
+        ));
+    }
+    std::fs::write(v1.join("index.toml"), index).expect("write distribution index");
+    std::fs::write(
+        v1.join("components.toml"),
+        r#"schema_version = 1
+
+[[components]]
+name = "cosh"
+
+[[components.backends]]
+kind = "raw"
+package = "cosh"
+
+[[components]]
+name = "cosh-ng"
+
+[[components.backends]]
+kind = "raw"
+package = "cosh-ng"
+"#,
+    )
+    .expect("write component index");
+    format!("file://{}", v1.display())
+}
+
+fn seed_installed_component(layout: &FsLayout, component: &str, version: &str) {
     std::fs::create_dir_all(&layout.state_dir).expect("create state dir");
     let mut state = anolisa_core::InstalledState {
         install_mode: StateInstallMode::System,
@@ -993,12 +1074,12 @@ fn install_conflict_blocks_when_conflicting_component_is_installed() {
     };
     state.upsert_object(InstalledObject {
         kind: ObjectKind::Component,
-        name: "cosh".to_string(),
-        version: "2.6.0".to_string(),
+        name: component.to_string(),
+        version: version.to_string(),
         status: ObjectStatus::Installed,
         manifest_digest: None,
-        distribution_source: Some("file:///repo/v1/cosh.tar.gz".to_string()),
-        raw_package: Some("cosh".to_string()),
+        distribution_source: Some(format!("file:///repo/v1/{component}.tar.gz")),
+        raw_package: Some(component.to_string()),
         install_backend: Some("raw".to_string()),
         ownership: None,
         rpm_metadata: None,
@@ -1018,6 +1099,15 @@ fn install_conflict_blocks_when_conflicting_component_is_installed() {
     state
         .save(&layout.state_dir.join("installed.toml"))
         .expect("save state");
+}
+
+#[test]
+fn install_conflict_blocks_when_conflicting_component_is_installed() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let layout = FsLayout::system(Some(prefix.clone()));
+
+    seed_installed_component(&layout, "cosh", "2.6.0");
 
     // Write a repo with cosh-ng that declares conflicts = ["cosh"].
     let repo_url = write_local_repo_with_conflicts(
@@ -1049,6 +1139,157 @@ fn install_conflict_blocks_when_conflicting_component_is_installed() {
         err.reason().contains("uninstall 'cosh' first"),
         "error must provide remediation: {}",
         err.reason()
+    );
+}
+
+#[test]
+fn install_dry_run_reports_conflict_without_downloading_artifact() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let layout = FsLayout::system(Some(prefix.clone()));
+    seed_installed_component(&layout, "cosh", "2.6.0");
+    let repo_url = write_local_repo_with_conflicts(
+        &tmp.path().join("repo"),
+        "cosh-ng",
+        "0.11.0",
+        &["system"],
+        &["cosh"],
+    );
+
+    let mut a = args("cosh-ng");
+    a.repo = Some(repo_url);
+    let mut ctx = ctx_with_prefix(false, Some(prefix));
+    ctx.dry_run = true;
+    let err = handle_with_fake_rpm(a, &ctx).expect_err("dry-run must report the conflict");
+
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(
+        err.reason()
+            .contains("conflicts with installed component 'cosh'"),
+        "got: {}",
+        err.reason()
+    );
+    let cached_names: Vec<String> = std::fs::read_dir(layout.cache_dir.join("downloads"))
+        .expect("downloads cache exists")
+        .map(|entry| {
+            entry
+                .expect("cache entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert!(
+        cached_names.iter().any(|name| name.ends_with("meta.toml")),
+        "dry-run must fetch the lightweight contract; cache entries: {cached_names:?}"
+    );
+    assert!(
+        cached_names
+            .iter()
+            .all(|name| !name.ends_with("cosh-ng.tar.gz")),
+        "dry-run must not fetch the install artifact; cache entries: {cached_names:?}"
+    );
+}
+
+#[test]
+fn install_all_dry_run_rejects_conflicts_between_planned_components() {
+    let sandbox = TestSandbox::new();
+    let repo_url = write_published_batch_conflict_repo(sandbox.repo_root());
+    let ctx = sandbox.context_with(
+        InstallMode::User,
+        TestContextOptions {
+            dry_run: true,
+            ..Default::default()
+        },
+    );
+    let layout = common::resolve_layout(&ctx);
+    std::fs::create_dir_all(&layout.etc_dir).expect("create config dir");
+    std::fs::write(
+        layout.etc_dir.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"{repo_url}\"\n"
+        ),
+    )
+    .expect("write repo config");
+    let batch_args = InstallArgs {
+        component: None,
+        all: true,
+        fail_fast: false,
+        version: None,
+        backend: Some("raw".to_string()),
+        repo: None,
+        package: None,
+    };
+
+    let err = handle_all(batch_args, &ctx)
+        .expect_err("the second component must conflict with the first planned component");
+
+    assert!(matches!(err, CliError::BatchPartial { .. }), "got: {err}");
+    assert!(
+        !layout.state_dir.join("installed.toml").exists(),
+        "dry-run must not persist simulated batch state"
+    );
+    let cached_names: Vec<String> = std::fs::read_dir(layout.cache_dir.join("downloads"))
+        .expect("downloads cache exists")
+        .map(|entry| {
+            entry
+                .expect("cache entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert_eq!(
+        cached_names
+            .iter()
+            .filter(|name| name.ends_with("meta.toml"))
+            .count(),
+        2,
+        "both batch contracts must be checked; cache entries: {cached_names:?}"
+    );
+    assert!(
+        cached_names.iter().all(|name| !name.ends_with(".tar.gz")),
+        "dry-run must not fetch batch artifacts; cache entries: {cached_names:?}"
+    );
+}
+
+#[test]
+fn install_dry_run_rejects_mismatched_sidecar_digest() {
+    let tmp = tempdir().expect("tmpdir");
+    let repo_root = tmp.path().join("repo");
+    let repo_url =
+        write_local_repo_with_conflicts(&repo_root, "cosh-ng", "0.11.0", &["system"], &["cosh"]);
+    std::fs::write(
+        repo_root.join("v1/meta.toml"),
+        component_manifest_toml("cosh-ng", "0.11.0", &["system"]),
+    )
+    .expect("replace sidecar manifest");
+
+    let mut a = args("cosh-ng");
+    a.repo = Some(repo_url);
+    let prefix = tmp.path().join("sys");
+    let layout = FsLayout::system(Some(prefix.clone()));
+    let mut ctx = ctx_with_prefix(false, Some(prefix));
+    ctx.dry_run = true;
+    let err = handle_with_fake_rpm(a, &ctx).expect_err("digest mismatch must fail dry-run");
+
+    assert_eq!(err.code(), "EXECUTION_FAILED");
+    assert!(err.reason().contains("sha256 mismatch"), "got: {err}");
+    let cached_names: Vec<String> = std::fs::read_dir(layout.cache_dir.join("downloads"))
+        .expect("downloads cache exists")
+        .map(|entry| {
+            entry
+                .expect("cache entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert!(
+        cached_names
+            .iter()
+            .all(|name| !name.ends_with("cosh-ng.tar.gz")),
+        "digest failure must not fetch the install artifact; cache entries: {cached_names:?}"
     );
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/types.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/types.rs
@@ -51,6 +51,7 @@ pub(crate) struct LoadedInstallContract {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InstallContractSource {
     EmbeddedArtifact,
+    SidecarMeta,
 }
 
 /// What `handle_one` did, so `--all` can distinguish outcomes in its batch


### PR DESCRIPTION
## Description

Raw install dry-runs returned before the artifact-backed contract validation, so component conflicts declared in the manifest were not evaluated. This change loads the published lightweight `meta.toml` sidecar and reuses the execution conflict validator without downloading the full artifact. It also verifies the manifest digest when the index provides one, while repositories without sidecar metadata retain the existing degraded preview behavior with an explicit warning.

## Related Issue

closes #1734

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`

Added regression coverage proving that raw dry-run reports the same component conflict as a real install, fetches only the lightweight sidecar, and rejects a sidecar whose digest disagrees with the distribution index.

## Additional Notes

This PR addresses the raw-backend conflict regression. RPM conflict preflight uses a different native-solver path and is intentionally out of scope.