### PR TITLE
test(cosh-ng): add find 2>/dev/null null redirection test coverage

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -312,6 +312,13 @@ fn null_redirection_suppression_is_not_filesystem_write() {
             assessment.reasons
         );
     }
+    // GH-1752: find's reasons set must stay consistent — not just impact.
+    let find = ask("find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null");
+    assert_eq!(find.impact, RiskImpact::Medium);
+    assert!(find.reasons.contains(&"unknown-command"), "{:?}", find.reasons);
+    assert!(find.reasons.contains(&"output-suppressed"), "{:?}", find.reasons);
+    assert!(!find.reasons.contains(&"redirection-write"), "{:?}", find.reasons);
+
     // V-TOK: fd and target tokens must not leak into stages.
     let parsed = super::command_risk_parser::parse_command("ps aux 2>/dev/null");
     assert_eq!(parsed.shape, CommandShape::Simple);

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -297,6 +297,7 @@ fn null_redirection_suppression_is_not_filesystem_write() {
         "ls > /dev/null",
         "cat x 2>>/dev/null",
         "du -sh /var 2> /dev/null",
+        "find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null",  // GH-1752
     ] {
         let assessment = ask(command);
         assert_ne!(assessment.impact, RiskImpact::High, "{command}");

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -297,7 +297,7 @@ fn null_redirection_suppression_is_not_filesystem_write() {
         "ls > /dev/null",
         "cat x 2>>/dev/null",
         "du -sh /var 2> /dev/null",
-        "find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null",  // GH-1752
+        "find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null", // GH-1752
     ] {
         let assessment = ask(command);
         assert_ne!(assessment.impact, RiskImpact::High, "{command}");

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -315,9 +315,21 @@ fn null_redirection_suppression_is_not_filesystem_write() {
     // GH-1752: find's reasons set must stay consistent — not just impact.
     let find = ask("find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null");
     assert_eq!(find.impact, RiskImpact::Medium);
-    assert!(find.reasons.contains(&"unknown-command"), "{:?}", find.reasons);
-    assert!(find.reasons.contains(&"output-suppressed"), "{:?}", find.reasons);
-    assert!(!find.reasons.contains(&"redirection-write"), "{:?}", find.reasons);
+    assert!(
+        find.reasons.contains(&"unknown-command"),
+        "{:?}",
+        find.reasons
+    );
+    assert!(
+        find.reasons.contains(&"output-suppressed"),
+        "{:?}",
+        find.reasons
+    );
+    assert!(
+        !find.reasons.contains(&"redirection-write"),
+        "{:?}",
+        find.reasons
+    );
 
     // V-TOK: fd and target tokens must not leak into stages.
     let parsed = super::command_risk_parser::parse_command("ps aux 2>/dev/null");


### PR DESCRIPTION
## 概述

为 GH-1752 报告的 find ... 2>/dev/null 误判问题添加显式测试覆盖。

## 背景

GH-1752 报告了 find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null 被 readonly_rules 误判为 redirection-write high risk 的问题。经过代码审查，发现底层修复已在 commit ab88c85 (fixes #1667) 中实现：

- command_risk_parser.rs 中的 SAFE_OUTPUT_SINKS 允许列表将 /dev/null 识别为无害的输出抑制目标
- 解析器将 2>/dev/null、>/dev/null、2>>/dev/null 等 null-suppression 重定向从 RedirectionWrite 降级为非写操作
- 剩余命令按其实际形态评估（如 rm -rf x 2>/dev/null 仍保持 filesystem-delete 高风险）

## 改动

在 command_risk_tests.rs 的 null_redirection_suppression_is_not_filesystem_write 测试中添加 find 命令的显式测试用例，验证：
- find /tmp -maxdepth 3 -name '*cosh*' 2>/dev/null 不被标记为 redirection-write
- 被标记为 output-suppressed
- 整体 impact 不是 High

## 测试

全部 18 个 command_risk_tests 通过，无回归。

Related to GH-1752 (duplicate of GH-1667, fix already merged)