### PR TITLE
chore(memory): bump version to 0.2.5

### DIFF
--- a/src/agent-memory/.anolisa/component.toml
+++ b/src/agent-memory/.anolisa/component.toml
@@ -6,7 +6,7 @@
 # Installed to: %{_datadir}/anolisa/components/agent-memory/component.toml
 [component]
 name = "agent-memory"
-version = "0.2.4"
+version = "0.2.5"
 
 [[adapters]]
 framework = "openclaw"

--- a/src/agent-memory/CHANGELOG.md
+++ b/src/agent-memory/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+[中文版](CHANGELOG_zh.md)
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.5] - 2026-07-27
+
+### Fixed
+
+- **agent-memory**: Updated to v0.2.5, derives focused recall queries from long English and CJK prompts and combines their results, agents can recall relevant memories from verbose prompts without silently dropping topics (#1574)
+
 ## 0.2.4
 
 - fix(memory): auto-recall returns empty results after observe — synchronously reindex after memory_observe so before_prompt_build hook finds new content (#1520)

--- a/src/agent-memory/CHANGELOG_zh.md
+++ b/src/agent-memory/CHANGELOG_zh.md
@@ -1,0 +1,102 @@
+# 更新日志
+
+[English](CHANGELOG.md)
+
+本项目的所有重要变更都会记录在此文件中。
+
+本文档格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
+项目遵循[语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
+
+## [0.2.5] - 2026-07-27
+
+### 修复
+
+- **agent-memory**：更新到 v0.2.5，从较长的英文和 CJK prompt 中生成聚焦的召回查询并合并结果，Agent 可从冗长 prompt 中召回相关记忆且不会静默遗漏主题（#1574）
+
+## 0.2.4
+
+- fix(memory)：修复 observe 后自动召回返回空结果的问题——`memory_observe` 后同步重建索引，使 `before_prompt_build` hook 能找到新内容（#1520）
+- fix(memory)：`install.sh` 为 hook 设置 `allowConversationAccess`（#1521）
+
+## 0.2.3
+
+- fix(memory)：在 trigger 匹配和 hash 计算前，将 OpenClaw content block 数组 `[{type:"text", text:"..."}]` 规范化为字符串，避免自动捕获因内容被转换成 `"[object Object]"` 而失效
+- fix(memory)：增加 BM25 OR fallback——当隐式 AND FTS5 查询返回 0 行且存在多个 token 时，使用 `'\"token1\" OR \"token2\" OR ...'` 重试，使部分匹配也能返回，而非静默失败
+- fix(memory)：将 `format!("{:.120}", query)` 替换为 `format!("bm25:len={}", query.len())`，清理 `audit_log`，避免用户查询内容泄漏到日志路径
+
+## 0.2.2
+
+- 修复 `memory_observe` hint 清理，使 YAML 转义的 hint 能通过不解析 YAML escape 的手写 frontmatter reader 往返读取：用 `sanitize_hint()` 替换 `yaml_escape_hint()`，仅将换行符和 ASCII 控制字符替换为空格；增加 8 个单元测试和一个真实 parser 往返测试，覆盖含反斜杠的 Windows 路径
+- 为 `MemoryConfig` 增加 `max_hint_bytes`（默认 512）和 `MEMORY_MAX_HINT_BYTES` 环境变量覆盖；将 `&MemoryConfig` 贯穿 `memory_observe`、`MemoryService` facade 和 MCP server
+- 修复 `make install INSTALL_PROFILE=user PREFIX=$HOME/.local` 在 `install-adapter-resources` 阶段因 Permission denied 失败的问题：遵循 `INSTALL_PROFILE` 并从 `$(PREFIX)` 推导 `DATADIR`/`SHARE_DIR`，使所有可写路径均服从 profile（system 模式不变）；与 tokenless/ws-ckpt 安装约定保持一致
+- 增加 `safe_fs` 安全边界单元测试（path escape、symlink traversal、sandbox root violation），并修复 `cargo fmt --all --check` 暴露的格式和 import order 问题
+
+## 0.2.1
+
+- 修复配置 embedding provider 时 vector/hybrid search panic 和索引为空的问题：index worker 在没有 tokio Handle 的 std::thread 上运行，导致无法生成 embedding，而 `memory_search mode=vector|hybrid` 从 worker thread 调用 Handle::block_on；现在 spawn 时捕获 runtime handle 并传入 worker，search path 使用 block_in_place
+- 修复 `memory_get_context` 将 `.git` 内部文件（如 `.git/logs/HEAD`）泄漏到 Agent context 的问题：通过 `safe_fs` 中共享的 `is_under_git` predicate 扩展 reserved-path filter，覆盖 `.git/`
+- 修复 `full_scan`（启动和 inotify overflow 恢复）只构建 BM25 index 而不生成 dense embedding，导致既有文件在修改前对 vector search 不可见的问题；新增 `paths_without_vec` 查询和 backfill pass，并将 embedding 逻辑集中到与 flush 共用的 `embed_sync` helper
+- 修复 `memory_search` 对短 CJK query term（少于 3 个字符，如“花名”/“小云”）返回 0 条结果的问题：trigram tokenizer 不会为少于 3 个字符的 term 生成 token，因此此类查询改用 `body LIKE '%term%'` substring scan，同时保留 recall、agent-scope filtering 以及 cold/superseded exclusion
+- 根据第一次真实 response 确定 embedding dimensions，不再硬编码 1536（DashScope text-embedding-v3 为 1024）：维度存储在以估算值初始化的 AtomicUsize 中，并在首次 embed 时覆盖
+- 通过 `.anolisa/component.toml` 增加 anolisa-cli adapter contract，使 CLI adapter manager 能通过 `[[adapters]]` TOML schema 发现 OpenClaw plugin bundle
+
+## 0.2.0
+
+- 增加 prompt injection 安全模块（`looksLikePromptInjection` + `escapeMemoryForPrompt`），Rust core 和 TS adapter 保持一致
+- 为安全模块增加 secret detection 和 PII redaction
+- 增加 auto-recall `before_prompt_build` hook，每轮注入相关 memory
+- 增加带 trigger filtering、SHA256 dedup 和 injection rejection 的 auto-capture `agent_end` hook
+- 通过可插拔 `EmbeddingProvider` 增加 dense-vector semantic search（OpenAI `/v1/embeddings`、Ollama `/api/embed`）
+- 增加 `files_vec` table（schema v2），与 FTS5 BM25 一起存储 per-file dense embedding
+- 增加通过 reciprocal rank fusion（RRF，k=60）融合 BM25 和 vector score 的 hybrid search
+- 为 `memory_search` 增加 `mode` 参数（bm25/vector/hybrid），并支持 graceful fallback 到 BM25
+- 通过 `[memory].agent_scope`（shared/isolated/filter，schema v5）增加 per-agent memory isolation
+- 增加带 `consent.toml` preference 的 memory sovereignty tool（memory_about/forget/auto_created/consent）
+- 为 `memory_observe` 增加 4 类封闭 memory classification（user/feedback/project/reference）
+- 增加 `mem_export` 和 `mem_import`，用于跨 Agent memory migration（AMA archive format）
+- 增加用于 memory overview 和 source tracking 的 `memory_summary` tool
+- 增加 `memory_session_context` tool
+- 增加 `memory_sessions` 和 `memory_timeline` session history query tool
+- 增加 `MEMORY.md` index file 和 `mem_index_refresh` tool
+- 增加 user profile synthesis（Dreaming V3 `mem_dream`）
+- 增加 memory consolidation：shutdown 时从 session audit log 自动提取 L1 atomic fact
+- 从连贯的 tool-call chain 中增加 episodic memory extraction
+- 增加 cross-session task persistence 和 incremental consolidation
+- 增加 consolidation quality filter（mutual exclusion、non-derivable、date normalization）
+- 为 BM25/vector/hybrid score 增加 time-decay ranking（exp(-λ×age_days)）
+- 使用 `mem_compact` tool 对长期从未访问的文件进行 cold archival
+- 写入新 fact 前通过 BM25 similarity 增加 conflict detection
+- 增加 category subdirectory（`facts/<category>/`）以及 `memory_search` category filter
+- 增加 token tracking（`AuditEntry` 中的 `tokens` 字段）
+- 增加手动触发 consolidation 的 `mem_consolidate` tool
+- 为 `memory_search corpus=all` 增加 corpus supplement registration
+- 增加 `EmbeddingConfig`（None/OpenAI/Ollama），支持 TOML parsing 和 env override
+- 为 `memory_search` signature 增加可选的 `mode` 和 `category` 参数
+- 将 `memory_search` query 限制为 1024 个字符，防止 FTS5 resource exhaustion
+- 将 embedding error response body 截断到 200 个字符，防止 API key 泄漏
+- 在 `ConsolidatedFact` 中区分 CJK 与 ASCII token estimation
+- 在 mutex 下持有 `FactWriter` JSONL file handle，防止 line interleaving
+- 通过 canonicalize + starts_with traversal guard，从 db path 推导 `BM25Store` mount root
+- 根据 entry timestamp 而非 chain length 计算 Episode duration
+- 将 `session_id` 传播到提取的 episodic fact
+- 从 `consolidate()` 返回 fact count，供 `mem_consolidate` reporting 使用
+- 修复 search response 中的 `effectiveMode`，使其反映实际使用的 mode
+- 修复 embedding API empty-response handling，返回维度正确的 zero vector
+
+## 0.1.0
+
+- 引入面向 AI Agent 的 filesystem memory MCP server（仅 Linux），通过 stdio JSON-RPC 2.0 提供三个 tier 的 21 个 tool（Tier A file op、Tier B BM25 search、Tier C governance）
+- 在 `~/.anolisa/memory/<ns>/` 下增加 per-namespace mount，并支持可选的 user namespace + private tmpfs isolation（auto/userland/userns strategy）
+- 对每次 Tier A file open 使用 `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` 强制执行 path sandbox
+- 增加带 transactional upsert、schema migration、trigram CJK tokenizer 和 inotify-driven debounced flush 的 SQLite FTS5 BM25 background index
+- 增加可选的 git versioning，auto-commit 在 per-handle mutex 下串行执行
+- 增加 tar.gz snapshot，使用严格的 id whitelist、restore 时的 atomic rename swap，以及 `.anolisa/trash/` 下的 rollback entry
+- 增加可选的 cgroup v2 `memory.max` self-limit，在 tokio runtime 启动前应用
+- 增加 JSONL audit log（`O_NOFOLLOW | O_CLOEXEC`、`Mutex<File>`），并支持可选的 systemd-journald fan-out
+- 在 `tools/list` 和 `tools/call` 强制执行 profile gating（basic/advanced/expert），config struct 使用 `deny_unknown_fields`
+- 在 `/run/anolisa/sessions/<sid>/` 下增加 per-session scratch 和 log（0700），并附带 tmpfiles.d snippet
+- 增加经过加固的 systemd user template `anolisa-memory@.service`（`ProtectKernelTunables/Modules/Logs`、`SystemCallFilter`、`MemoryDenyWriteExecute`、`RestrictNamespaces`、`RestrictAddressFamilies=AF_UNIX`）
+- 增加使用 offline vendor tarball 和单个 statically-linked binary（bundled SQLite + vendored libgit2）的 RPM packaging
+- 增加 OpenClaw plugin `memory-anolisa`，支持 install/detect/uninstall lifecycle，并提供 4 个通过 stdio child 路由到 MCP server 的 memory contract tool
+- 增加从 `Cargo.toml` 到 manifest/package/openclaw/mcp JSON 和 bundle 的 single-source version sync
+- 增加 `mcp-harness` example，以及覆盖 12 个 integration suite 的 140 个 automated test

--- a/src/agent-memory/Cargo.lock
+++ b/src/agent-memory/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-memory"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/agent-memory/Cargo.toml
+++ b/src/agent-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-memory"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 # edition 2024 stabilised in rustc 1.85; let-chains land in 1.88 so we
 # avoid them. Anolis ships 1.86, which is fine for build but won't take

--- a/src/agent-memory/adapters/agent-memory/manifest.json
+++ b/src/agent-memory/adapters/agent-memory/manifest.json
@@ -1,6 +1,6 @@
 {
   "component": "agent-memory",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "targets": {
     "openclaw": {
       "compatibleVersions": ">=5.0.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memory-anolisa",
   "name": "Anolisa Memory",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Persistent memory backed by the agent-memory MCP server with namespace isolation and openat2 sandbox. Provides BM25 search, file read/write, observe, and context assembly tools.",
   "activation": {
     "onStartup": false

--- a/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memory-anolisa-openclaw-plugin",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/package.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-memory/agent-memory.spec.in
+++ b/src/agent-memory/agent-memory.spec.in
@@ -198,6 +198,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Mon Jul 27 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.2.5-1
+- fix(memory): improve auto-recall for long English and CJK prompts
+
 * Fri Jul 17 2026 Lin Yan <linyan.lin@alibaba-inc.com> - 0.2.4-1
 - fix(memory): auto-recall returns empty results after observe — synchronously reindex after memory_observe so before_prompt_build hook finds new content (#1520)
 - fix(memory): install.sh sets allowConversationAccess for hooks (#1521)

--- a/src/agent-memory/config/mcp-server.json
+++ b/src/agent-memory/config/mcp-server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-memory",
   "description": "Agent memory — filesystem memory MCP server. 31 tools across three tiers: Tier A file ops (read/write/append/edit/list/grep/diff/mkdir/remove/promote + mem_session_log), Tier B structured (memory_search, memory_observe, memory_get_context, memory_task_save/resume/list/close, memory_forget, memory_consent, mem_export, mem_import), Tier C governance (mem_snapshot/mem_snapshot_list/mem_snapshot_restore/mem_log/mem_revert/mem_consolidate/mem_compact, memory_about, memory_auto_created). Optional Linux user-namespace isolation, SQLite FTS5 BM25 + vector hybrid background index, time-decay ranking, cold archival, episodic memory extraction, conflict detection, git versioning, tar.gz snapshots, cgroup v2 memory.max, and journald audit fan-out.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "command": "/usr/bin/agent-memory",
   "args": [],
   "env": {},


### PR DESCRIPTION
## Description

Bumps agent-memory to v0.2.5 after the long-prompt auto-recall fix landed in #1574.
Synchronizes Cargo, component, MCP, adapter, npm, and RPM release metadata.
Adds bilingual changelog entries describing focused English/CJK recall queries and merged results.
This release commit does not introduce additional runtime code changes.

## Related Issue

closes #1572

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [x] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 343 tests passed
- `PATH="$PWD/target/release:$PATH" npm --prefix adapters/agent-memory/openclaw test` — 88 tests passed
- `make smoke` — MCP server reported v0.2.5

## Additional Notes

`npm --prefix adapters/agent-memory/openclaw run build:check` still reports four
pre-existing OpenClaw interface/test-fixture type mismatches. The v0.2.5 release
metadata and the keyword extraction module introduce no additional type errors.
