### PR TITLE
test(cosh-ng): [shell] stabilize PTY marker gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -993,10 +993,9 @@ jobs:
 
       - name: Run process and PTY integration tests
         env:
-          # Raw CLI PTY tests are wait-bound, not CPU-bound; probe a wider
-          # shared gate on CI runners. Revert this env to fall back to the
-          # in-tree default (8) if timing flakes regress.
-          COSH_RAW_CLI_TEST_PARALLELISM: '16'
+          # Libtest still schedules 16 workers, while the harness gate bounds
+          # live PTY sessions to avoid oversubscribing loaded CI runners.
+          COSH_RAW_CLI_TEST_PARALLELISM: '8'
         run: |
           cd src/cosh-ng
           scripts/run-test-gates.sh integration

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -23,11 +23,13 @@ use super::prompt_replay::{
 };
 
 mod input_events;
+mod input_readiness;
 mod pty_emit;
 mod terminal_recovery;
 mod terminal_size;
 
 use input_events::drain_raw_input_events;
+use input_readiness::RawInputReadinessProbe;
 use pty_emit::resolve_pty_emit;
 #[cfg(test)]
 use pty_emit::restore_prompt_display_before_handoff;
@@ -80,6 +82,7 @@ where
     let mut last_pty_output: Option<Instant> = None;
     let mut pending_terminal_restore = PendingTerminalRecovery::default();
     let mut pending_prompt_restore = None;
+    let mut input_readiness = RawInputReadinessProbe::from_env();
     loop {
         sync_outer_terminal_winsize(master.as_raw_fd(), child.id(), last_winsize)?;
         if restore_terminal_after_interrupted_command(
@@ -337,6 +340,7 @@ where
             )?;
             output.flush()?;
         }
+        input_readiness.acknowledge_if_ready(output, input_mode)?;
         // The PTY is drained (WouldBlock) at this point: write off
         // submissions a foreground program consumed once the shell has
         // painted a prompt after the last boundary and idles at it. A bare

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_readiness.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_readiness.rs
@@ -1,0 +1,138 @@
+//! Test-only handshake for marker-gated raw CLI input.
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::raw_input::RawInputMode;
+
+const REQUEST_PATH_ENV: &str = "COSH_RAW_CLI_TEST_INPUT_READY_REQUEST";
+const TOKEN_ENV: &str = "COSH_RAW_CLI_TEST_INPUT_READY_TOKEN";
+
+pub(super) struct RawInputReadinessProbe {
+    request_path: Option<PathBuf>,
+    token: String,
+    acknowledged: u64,
+}
+
+impl RawInputReadinessProbe {
+    pub(super) fn from_env() -> Self {
+        let request_path = std::env::var_os(REQUEST_PATH_ENV).map(PathBuf::from);
+        let token = std::env::var(TOKEN_ENV)
+            .ok()
+            .filter(|token| valid_token(token))
+            .unwrap_or_default();
+        Self {
+            request_path: request_path.filter(|_| !token.is_empty()),
+            token,
+            acknowledged: 0,
+        }
+    }
+
+    pub(super) fn acknowledge_if_ready<W: Write>(
+        &mut self,
+        output: &mut W,
+        input_mode: &Arc<Mutex<RawInputMode>>,
+    ) -> io::Result<()> {
+        let Some(request_path) = self.request_path.as_ref() else {
+            return Ok(());
+        };
+        let request = match fs::read_to_string(request_path) {
+            Ok(request) => request,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        let Ok(request) = request.trim().parse::<u64>() else {
+            return Ok(());
+        };
+        if request <= self.acknowledged {
+            return Ok(());
+        }
+
+        let mode = input_mode
+            .lock()
+            .map_err(|_| io::Error::other("raw input mode lock poisoned"))?;
+        let Some(readiness) = ready_mode(&mode) else {
+            return Ok(());
+        };
+        write!(output, "\x1e{}:{request}:{readiness}\x1f", self.token)?;
+        output.flush()?;
+        self.acknowledged = request;
+        Ok(())
+    }
+}
+
+fn valid_token(token: &str) -> bool {
+    !token.is_empty()
+        && token.len() <= 96
+        && token
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+fn ready_mode(mode: &RawInputMode) -> Option<String> {
+    match mode {
+        RawInputMode::Passthrough => Some("passthrough".to_string()),
+        RawInputMode::RawPassthrough => Some("raw-passthrough".to_string()),
+        RawInputMode::Hold => Some("hold".to_string()),
+        RawInputMode::Delay { generation } => Some(format!("delay={generation}")),
+        RawInputMode::PromptGhost { .. } => Some("prompt-ghost".to_string()),
+        RawInputMode::Capture { generation, .. } => Some(format!("capture={generation}")),
+        RawInputMode::Submitted { .. }
+        | RawInputMode::Draining { .. }
+        | RawInputMode::Terminal { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::raw_input::RawInputCapture;
+
+    use super::*;
+
+    #[test]
+    fn acknowledges_only_after_the_next_capture_is_installed() {
+        let request_path = std::env::temp_dir().join(format!(
+            "cosh-input-ready-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::write(&request_path, "1").expect("readiness request");
+        let capture = RawInputCapture::Consultation {
+            id: "consult-1".to_string(),
+        };
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Submitted {
+            capture: capture.clone(),
+            generation: 7,
+        }));
+        let mut probe = RawInputReadinessProbe {
+            request_path: Some(request_path.clone()),
+            token: "test-token".to_string(),
+            acknowledged: 0,
+        };
+        let mut output = Vec::new();
+
+        probe
+            .acknowledge_if_ready(&mut output, &input_mode)
+            .expect("transitional mode");
+        assert!(output.is_empty());
+
+        *input_mode.lock().expect("input mode") = RawInputMode::Capture {
+            capture,
+            generation: 8,
+            installed_at: std::time::Instant::now(),
+        };
+        probe
+            .acknowledge_if_ready(&mut output, &input_mode)
+            .expect("ready capture");
+
+        assert_eq!(output, b"\x1etest-token:1:capture=8\x1f");
+        let _ = fs::remove_file(request_path);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -325,6 +325,45 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|w| w == needle)
 }
 
+fn wait_for_raw_cli_input_ready(
+    receiver: &std::sync::mpsc::Receiver<Vec<u8>>,
+    observed: &mut Vec<u8>,
+    cursor: usize,
+    token: &str,
+    request: u64,
+) -> Result<(), String> {
+    let prefix = format!("\x1e{token}:{request}:");
+    let deadline = std::time::Instant::now() + RAW_CLI_TIMEOUT;
+    loop {
+        let window = &observed[cursor.min(observed.len())..];
+        if let Some(found) = find_subslice(window, prefix.as_bytes()) {
+            let frame = cursor + found + prefix.len();
+            if observed[frame..].contains(&b'\x1f') {
+                return Ok(());
+            }
+        }
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(format!(
+                "raw CLI did not acknowledge input readiness request {request}"
+            ));
+        }
+        match receiver.recv_timeout(remaining) {
+            Ok(chunk) => observed.extend(chunk),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                return Err(format!(
+                    "raw CLI timed out before input readiness request {request}"
+                ));
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(format!(
+                    "raw CLI closed before input readiness request {request}"
+                ));
+            }
+        }
+    }
+}
+
 fn wait_for_raw_cli_marker_or_retry(
     receiver: &std::sync::mpsc::Receiver<Vec<u8>>,
     observed: &mut Vec<u8>,
@@ -520,6 +559,7 @@ fn run_raw_cli_marker_input_inner(
     run_mode: RawCliRunMode,
 ) -> String {
     let _run_guard = raw_cli_run_guard(run_mode);
+    let mut input_readiness = RawCliInputReadiness::new();
     let binary = env!("CARGO_BIN_EXE_cosh-shell");
     let mut command = Command::new(binary);
     command
@@ -531,6 +571,7 @@ fn run_raw_cli_marker_input_inner(
         .stderr(Stdio::piped());
     configure_raw_cli_command(&mut command);
     apply_raw_cli_envs(&mut command, envs);
+    input_readiness.configure(&mut command);
     command.process_group(0);
     let mut child = RawCliChildGuard::new(command.spawn().expect("spawn cosh-shell raw"));
     let mut stdin = child.child_mut().stdin.take().expect("child stdin");
@@ -548,6 +589,19 @@ fn run_raw_cli_marker_input_inner(
                 abort_raw_cli_with_output(&mut child, stdout_reader, stderr_reader, &error)
             }
         }
+        if !input.is_empty() {
+            let request = input_readiness.request();
+            if let Err(error) = wait_for_raw_cli_input_ready(
+                &output_receiver,
+                &mut observed,
+                cursor,
+                input_readiness.token(),
+                request,
+            ) {
+                abort_raw_cli_with_output(&mut child, stdout_reader, stderr_reader, &error);
+            }
+            cursor = observed.len();
+        }
         stdin.write_all(input).expect("write marker-gated input");
         stdin.flush().expect("flush marker-gated input");
     }
@@ -562,7 +616,7 @@ fn run_raw_cli_marker_input_inner(
             "raw CLI timed out after marker-gated input",
         ),
     };
-    let stdout = join_reader(stdout_reader, "stdout");
+    let stdout = input_readiness.strip_frames(&join_reader(stdout_reader, "stdout"));
     let stderr = join_reader(stderr_reader, "stderr");
     assert!(
         status.success(),
@@ -573,6 +627,79 @@ fn run_raw_cli_marker_input_inner(
     let mut text = String::from_utf8_lossy(&stdout).to_string();
     text.push_str(&String::from_utf8_lossy(&stderr));
     text
+}
+
+struct RawCliInputReadiness {
+    directory: PathBuf,
+    request_path: PathBuf,
+    token: String,
+    next_request: u64,
+}
+
+impl RawCliInputReadiness {
+    fn new() -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "cosh-raw-cli-input-ready-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&directory).expect("create raw CLI input readiness directory");
+        let request_path = directory.join("request");
+        let token = format!("cosh-input-ready-{}-{nanos}", std::process::id());
+        Self {
+            directory,
+            request_path,
+            token,
+            next_request: 0,
+        }
+    }
+
+    fn configure(&self, command: &mut Command) {
+        command
+            .env("COSH_RAW_CLI_TEST_INPUT_READY_REQUEST", &self.request_path)
+            .env("COSH_RAW_CLI_TEST_INPUT_READY_TOKEN", &self.token);
+    }
+
+    fn request(&mut self) -> u64 {
+        self.next_request = self.next_request.saturating_add(1);
+        fs::write(&self.request_path, self.next_request.to_string())
+            .expect("write raw CLI input readiness request");
+        self.next_request
+    }
+
+    fn token(&self) -> &str {
+        &self.token
+    }
+
+    fn strip_frames(&self, output: &[u8]) -> Vec<u8> {
+        let prefix = format!("\x1e{}:", self.token);
+        let mut stripped = Vec::with_capacity(output.len());
+        let mut cursor = 0;
+        while let Some(found) = find_subslice(&output[cursor..], prefix.as_bytes()) {
+            let frame_start = cursor + found;
+            stripped.extend_from_slice(&output[cursor..frame_start]);
+            let payload_start = frame_start + prefix.len();
+            let Some(frame_end) = output[payload_start..]
+                .iter()
+                .position(|byte| *byte == b'\x1f')
+            else {
+                stripped.extend_from_slice(&output[frame_start..]);
+                return stripped;
+            };
+            cursor = payload_start + frame_end + 1;
+        }
+        stripped.extend_from_slice(&output[cursor..]);
+        stripped
+    }
+}
+
+impl Drop for RawCliInputReadiness {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.directory);
+    }
 }
 
 fn run_raw_cli_with_args_env_current_dir_and_delayed_input_inner(


### PR DESCRIPTION
## Description

Marker-gated raw CLI tests could send input as soon as a card title became visible, before the next input-capture generation was active. Under load, that input was quarantined as late input from the previous capture, leaving the test waiting until its marker timeout. This change adds a test-only request/acknowledgement handshake: after observing a marker, the harness requests readiness, and the raw relay acknowledges on the same output stream only after input ownership leaves transitional states. Capture acknowledgements include the installed generation, and consuming through the acknowledgement also prevents repeated repaint text from satisfying the next step.

The CI runner also showed unrelated delayed-input flakes at 16 live PTY sessions, including recovery commands losing the first byte (`echo` becoming `cho`). The integration job keeps libtest at 16 workers but caps live raw CLI sessions at the in-tree default of 8, avoiding runner oversubscription without weakening assertions or extending per-test sleeps.

## Related Issue

closes #1912

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD or build changes

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p cosh-shell --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`
- `cargo test --locked -p cosh-shell input_readiness` — readiness unit test passed in both library and binary targets
- `COSH_RAW_CLI_TEST_PARALLELISM=8 cargo test --locked -p cosh-shell --test raw_cli auth:: -- --test-threads=8` — 13 passed
- `COSH_RAW_CLI_TEST_PARALLELISM=8 cargo test --locked -p cosh-shell --test raw_cli -- --test-threads=16` — 404 passed, 1 ignored in 224.50s
- `cargo test --locked -p cosh-shell --lib` — 1069 passed
- `cargo build --locked -p cosh-shell --release`

## Additional Notes

The readiness hook is dormant unless the marker harness supplies its private request path and token. Production authentication and terminal behavior are unchanged; the remaining CI adjustment only limits concurrent test PTY sessions.