### PR TITLE
fix(anolisa): give an absent component its own error code

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Commands that act on an installed component now report an absent target as
+  `NOT_INSTALLED` instead of `INVALID_ARGUMENT`, so a caller can tell "there was
+  nothing to act on" from "the invocation was wrong" without parsing the error
+  message. The code reports state absence only, and does not indicate whether
+  the name was valid. Affects `uninstall`, `update`, `repair`, `forget`,
+  `restart`, and `adapter`; the exit code stays 2.
+
 ## [0.2.11] - 2026-07-24
 
 ### Added

--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -599,8 +599,9 @@ fn handle_status(ctx: &CliContext, component: Option<&str>) -> Result<(), CliErr
 // ---------------------------------------------------------------------------
 
 /// Map an [`AdapterError`] to the CLI error model. Input/environment
-/// problems are `INVALID_ARGUMENT` (exit 2); machine-side failures (CLI
-/// spawn, lock, state/log IO) are `EXECUTION_FAILED` (exit 1).
+/// problems are `INVALID_ARGUMENT` (exit 2), an absent component is
+/// `NOT_INSTALLED` (also exit 2); machine-side failures (CLI spawn, lock,
+/// state/log IO) are `EXECUTION_FAILED` (exit 1).
 fn map_err(command: &str, err: AdapterError) -> CliError {
     match err {
         AdapterError::UnknownPlaceholder { .. }
@@ -608,7 +609,6 @@ fn map_err(command: &str, err: AdapterError) -> CliError {
         | AdapterError::AmbiguousFramework { .. }
         | AdapterError::UnsupportedAdapterType { .. }
         | AdapterError::InvalidAdapterInput { .. }
-        | AdapterError::ComponentNotInstalled { .. }
         | AdapterError::AdapterNotDeclared { .. }
         | AdapterError::ResourceRootNotFound { .. }
         | AdapterError::ContractResourceRootNotFound { .. }
@@ -617,6 +617,13 @@ fn map_err(command: &str, err: AdapterError) -> CliError {
         | AdapterError::BundleInvalid { .. }
         | AdapterError::UnsafeInstallNotApplicable { .. }
         | AdapterError::ClaimValidation(_) => CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: err.to_string(),
+        },
+        // Same condition the lifecycle commands report as NOT_INSTALLED:
+        // the target is absent from state. Routing it anywhere else would
+        // make the code depend on which command the caller happened to run.
+        AdapterError::ComponentNotInstalled { .. } => CliError::NotInstalled {
             command: command.to_string(),
             reason: err.to_string(),
         },
@@ -714,6 +721,21 @@ mod tests {
             }
             _ => panic!("expected enable"),
         }
+    }
+
+    /// An absent component reports the same code here as it does from
+    /// `uninstall`/`update`/`repair`, so a caller never has to know which
+    /// command surfaced the condition.
+    #[test]
+    fn component_not_installed_maps_to_not_installed() {
+        let err = map_err(
+            "adapter enable",
+            AdapterError::ComponentNotInstalled {
+                component: "cosh".to_string(),
+            },
+        );
+        assert_eq!(err.code(), "NOT_INSTALLED");
+        assert_eq!(err.exit_code(), 2);
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -76,7 +76,7 @@ pub fn handle(args: ForgetArgs, ctx: &CliContext) -> Result<(), CliError> {
     // legacy state the migration refused to classify and repair cannot
     // recover.
     let provenance = record_provenance(&store, target);
-    let provenance = provenance.ok_or_else(|| CliError::InvalidArgument {
+    let provenance = provenance.ok_or_else(|| CliError::NotInstalled {
         command: command.clone(),
         reason: format!(
             "component '{target}' is not installed — nothing to forget (run `anolisa status` to see what is tracked)"
@@ -600,9 +600,9 @@ mod tests {
         );
     }
 
-    /// Forgetting an absent component routes to INVALID_ARGUMENT (exit 2).
+    /// Forgetting an absent component routes to NOT_INSTALLED (exit 2).
     #[test]
-    fn forget_unknown_component_routes_to_invalid_argument() {
+    fn forget_unknown_component_routes_to_not_installed() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         let err = handle(
@@ -612,7 +612,7 @@ mod tests {
             &c,
         )
         .expect_err("absent component must error");
-        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.code(), "NOT_INSTALLED");
         assert_eq!(err.exit_code(), 2);
         assert!(err.reason().contains("not installed"));
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -2047,7 +2047,7 @@ fn plan_action(steps: &[Step]) -> &'static str {
 fn plan_error_to_cli(err: PlanError, target: &str, command: &str) -> CliError {
     let command = command.to_string();
     match err {
-        PlanError::NotInstalled => CliError::InvalidArgument {
+        PlanError::NotInstalled => CliError::NotInstalled {
             command,
             reason: format!(
                 "component '{target}' is not installed — nothing to repair (run `anolisa status` to see what is installed)"
@@ -2657,7 +2657,7 @@ mod tests {
     // ── R7 / plan refusals ────────────────────────────────────────────
 
     #[test]
-    fn absent_component_is_invalid_argument() {
+    fn absent_component_is_not_installed() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         seed(&ctx, Vec::new());
@@ -2665,7 +2665,7 @@ mod tests {
 
         let err = repair_with_deps("cosh", &ctx, &fake, &fake, false).unwrap_err();
 
-        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.code(), "NOT_INSTALLED");
         assert!(err.reason().contains("not installed"), "got: {err}");
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -4,8 +4,8 @@
 //! unit), routing each through the [`anolisa_core::ServiceManager`] for its
 //! scope. The handler:
 //!
-//!   1. Loads `installed.toml` and locates the component. Unknown →
-//!      `INVALID_ARGUMENT`.
+//!   1. Loads `installed.toml` and locates the component. Absent →
+//!      `NOT_INSTALLED`.
 //!   2. Collects the component's restartable `.service` units, by backend:
 //!      - **raw** installs: the recorded `ServiceRef`s — ANOLISA drove the
 //!        activation, so state is the source of truth;
@@ -84,7 +84,7 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         .writable
         .state
         .find(ObjectKind::Component, &resolved)
-        .ok_or_else(|| CliError::InvalidArgument {
+        .ok_or_else(|| CliError::NotInstalled {
             command: command.clone(),
             reason: format!(
                 "component '{resolved}' is not installed — nothing to restart (run `anolisa status` to see what is installed)"
@@ -594,7 +594,7 @@ mod tests {
     }
 
     #[test]
-    fn restart_unknown_component_returns_invalid_argument() {
+    fn restart_unknown_component_returns_not_installed() {
         let tmp = tempdir().expect("tmpdir");
         let err = handle(
             RestartArgs {
@@ -603,7 +603,7 @@ mod tests {
             &ctx_with_prefix(InstallMode::System, Some(tmp.path().to_path_buf())),
         )
         .expect_err("must error");
-        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.code(), "NOT_INSTALLED");
         assert_eq!(err.exit_code(), 2);
         assert!(
             err.reason().contains("not installed"),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -989,7 +989,7 @@ fn ensure_no_adapter_claims(
 /// way out; this mapping only renders it.
 fn plan_error_to_cli(err: PlanError, target: &str, command: &str, store: &StateStore) -> CliError {
     match err {
-        PlanError::NotInstalled => CliError::InvalidArgument {
+        PlanError::NotInstalled => CliError::NotInstalled {
             command: command.to_string(),
             reason: format!(
                 "component '{target}' is not installed — nothing to uninstall (run `anolisa status` to see what is installed)",
@@ -1418,11 +1418,11 @@ mod tests {
         );
     }
 
-    /// Asking to uninstall a component that is not installed must
-    /// surface `INVALID_ARGUMENT` (exit 2), not `EXECUTION_FAILED`,
-    /// so wrapping scripts can rely on the routing.
+    /// Asking to uninstall a component that is not installed must surface
+    /// `NOT_INSTALLED` (exit 2), not `EXECUTION_FAILED` — the machine did
+    /// not fail, there was simply nothing to act on.
     #[test]
-    fn uninstall_unknown_component_routes_to_invalid_argument_exit_2() {
+    fn uninstall_unknown_component_routes_to_not_installed_exit_2() {
         let tmp = tempdir().expect("tmpdir");
         let err = handle(
             args("agentsight", false),
@@ -1434,7 +1434,7 @@ mod tests {
             ),
         )
         .expect_err("must error");
-        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.code(), "NOT_INSTALLED");
         assert_eq!(err.exit_code(), 2);
         assert!(
             err.reason().contains("not installed"),
@@ -1519,7 +1519,7 @@ mod tests {
             ),
         )
         .expect_err("dry-run must report the same refusal as a real run");
-        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.code(), "NOT_INSTALLED");
         assert!(err.reason().contains("not installed"), "{}", err.reason());
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -1012,7 +1012,7 @@ fn plan_error_to_cli(
 ) -> CliError {
     let command = command.to_string();
     match err {
-        PlanError::NotInstalled => CliError::InvalidArgument {
+        PlanError::NotInstalled => CliError::NotInstalled {
             command,
             reason: format!(
                 "component '{target}' is not installed — nothing to update (run `anolisa status` to see what is installed, or `anolisa install {target}` to install it)"
@@ -2968,16 +2968,16 @@ pub(crate) mod tests {
         );
     }
 
-    /// A component absent from state routes to INVALID_ARGUMENT (exit 2), not a
+    /// A component absent from state routes to NOT_INSTALLED (exit 2), not a
     /// runtime failure, and never runs dnf.
     #[test]
-    fn unknown_component_routes_to_invalid_argument() {
+    fn unknown_component_routes_to_not_installed() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         let rpm = FakeRpm::new("copilot-shell", None);
         let err = update_component_with_deps("copilot-shell", &c, &rpm, &rpm, true)
             .expect_err("absent component must error");
-        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.code(), "NOT_INSTALLED");
         assert_eq!(err.exit_code(), 2);
         assert!(err.reason().contains("not installed"));
         assert_eq!(rpm.update_calls.get(), 0);

--- a/src/anolisa/crates/anolisa-cli/src/response.rs
+++ b/src/anolisa/crates/anolisa-cli/src/response.rs
@@ -13,14 +13,22 @@
 //!   exact value, so we pick a non-zero reserved code and document it
 //!   here for future tightening).
 //! - `INVALID_ARGUMENT` -> 2 (POSIX convention shared with clap).
+//! - `NOT_INSTALLED` -> 2 (shares `INVALID_ARGUMENT`'s exit code only so
+//!   shell callers already branching on 2 keep working; `--json` callers
+//!   read the distinction off `error.code`). Reports one fact and only
+//!   one: the target is absent from state, so the operation had nothing
+//!   to act on. It says nothing about whether the name was valid — an
+//!   unknown name resolves to itself and lands here identically. What to
+//!   do about it is the caller's call and depends on the command: an
+//!   absent `uninstall` target is already the desired end state, an
+//!   absent `restart` target is a stale assumption.
 //! - `EXECUTION_FAILED` -> 1 (generic non-zero "the command ran but the
 //!   underlying operation failed at runtime"). Distinct from
 //!   `INVALID_ARGUMENT` so callers can tell "I gave you bad input" apart
 //!   from "you tried and something on the machine refused": download
 //!   IO, install IO, state-write IO, log-write IO, lock IO. Plan-time
-//!   refusals (e.g. blocked plan, unknown component) stay
-//!   `INVALID_ARGUMENT` — they tell the caller to fix the input or the
-//!   environment before retrying.
+//!   refusals (e.g. a blocked plan) stay `INVALID_ARGUMENT` — they tell
+//!   the caller to fix the input or the environment before retrying.
 
 use std::process::ExitCode;
 
@@ -69,6 +77,26 @@ pub enum CliError {
     /// Caller-supplied arguments violated a contract.
     #[error("invalid argument: {reason}")]
     InvalidArgument { command: String, reason: String },
+
+    /// The target is absent from ANOLISA state, so the operation had
+    /// nothing to act on.
+    ///
+    /// Kept separate from [`CliError::InvalidArgument`] so a scripted
+    /// caller can tell a state precondition from a bad invocation —
+    /// enabled adapters, a quarantined record, or
+    /// `--remove-system-package` with several targets are all things the
+    /// caller got wrong, whereas this one may be nothing to fix at all.
+    ///
+    /// **Not** a claim about the name. Resolution falls back to the literal
+    /// input when the component index has no entry for it, so an unknown
+    /// name and a known-but-absent one arrive here indistinguishably.
+    /// Callers must not read this code as "the name was valid".
+    ///
+    /// Shares exit code 2 with [`CliError::InvalidArgument`] for backward
+    /// compatibility alone — shell callers already branch on 2. It does not
+    /// imply the two call for the same response; see the module docs.
+    #[error("not installed: {reason}")]
+    NotInstalled { command: String, reason: String },
 
     /// The command was well-formed but the underlying operation failed
     /// at runtime (download IO, install IO, state-write IO, log-write
@@ -119,6 +147,7 @@ impl CliError {
         match self {
             Self::NotImplemented { .. } => "NOT_IMPLEMENTED",
             Self::InvalidArgument { .. } => "INVALID_ARGUMENT",
+            Self::NotInstalled { .. } => "NOT_INSTALLED",
             Self::Runtime { .. } => "EXECUTION_FAILED",
             Self::Degraded { .. } => "DEGRADED",
             Self::PermissionDenied { .. } => "PERMISSION_DENIED",
@@ -131,6 +160,7 @@ impl CliError {
         match self {
             Self::NotImplemented { .. } => 64,
             Self::InvalidArgument { .. } => 2,
+            Self::NotInstalled { .. } => 2,
             Self::Runtime { .. } => 1,
             Self::Degraded { .. } => 2,
             Self::PermissionDenied { .. } => 5,
@@ -143,6 +173,7 @@ impl CliError {
         match self {
             Self::NotImplemented { command, .. } => command,
             Self::InvalidArgument { command, .. } => command,
+            Self::NotInstalled { command, .. } => command,
             Self::Runtime { command, .. } => command,
             Self::Degraded { command, .. } => command,
             Self::PermissionDenied { command, .. } => command,
@@ -155,6 +186,7 @@ impl CliError {
         match self {
             Self::NotImplemented { hint, .. } => hint.as_deref(),
             Self::InvalidArgument { .. } => None,
+            Self::NotInstalled { .. } => None,
             Self::Runtime { .. } => None,
             Self::Degraded { .. } => None,
             Self::PermissionDenied { hint, .. } => hint.as_deref(),
@@ -169,6 +201,7 @@ impl CliError {
                 format!("command '{command}' is not implemented")
             }
             Self::InvalidArgument { reason, .. } => reason.clone(),
+            Self::NotInstalled { reason, .. } => reason.clone(),
             Self::Runtime { reason, .. } => reason.clone(),
             Self::Degraded { reason, .. } => reason.clone(),
             Self::PermissionDenied { reason, .. } => reason.clone(),
@@ -202,6 +235,7 @@ impl CliError {
         match &mut self {
             Self::NotImplemented { command: c, .. }
             | Self::InvalidArgument { command: c, .. }
+            | Self::NotInstalled { command: c, .. }
             | Self::Runtime { command: c, .. }
             | Self::Degraded { command: c, .. }
             | Self::PermissionDenied { command: c, .. }
@@ -367,6 +401,45 @@ mod tests {
             }
             other => panic!("expected CliError::Runtime, got {other:?}"),
         }
+    }
+
+    /// `NOT_INSTALLED` is the whole point of the variant: a caller that
+    /// wants to skip an absent target must be able to key off `code`
+    /// alone. The exit code deliberately stays 2, shared with
+    /// `INVALID_ARGUMENT`, so existing shell callers keep working.
+    #[test]
+    fn not_installed_has_its_own_code_but_keeps_exit_two() {
+        let err = CliError::NotInstalled {
+            command: "uninstall cosh".to_string(),
+            reason: "component 'cosh' is not installed — nothing to uninstall".to_string(),
+        };
+
+        assert_eq!(err.code(), "NOT_INSTALLED");
+        assert_ne!(
+            err.code(),
+            CliError::InvalidArgument {
+                command: "uninstall".to_string(),
+                reason: "bad".to_string(),
+            }
+            .code(),
+            "an absent target must not be indistinguishable from a bad argument",
+        );
+        assert_eq!(err.exit_code(), 2);
+        assert!(err.reason().contains("not installed"));
+    }
+
+    /// `with_command` re-stamps every variant; a missing arm would silently
+    /// leave the wrong command verb in the envelope.
+    #[test]
+    fn not_installed_survives_command_restamping() {
+        let err = CliError::NotInstalled {
+            command: "install".to_string(),
+            reason: "component 'cosh' is not installed".to_string(),
+        }
+        .with_command("update cosh");
+
+        assert_eq!(err.command(), "update cosh");
+        assert_eq!(err.code(), "NOT_INSTALLED");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
@@ -2,10 +2,12 @@
 //!
 //! Plain uninstall runs the planner pipeline: for an absent component the
 //! dry-run reports the same refusal as a real run would (an error envelope,
-//! exit 2), so previews never disagree with reality. `--purge` keeps the
-//! legacy plan view (#1471): a unified `data.dry_run`, plan fields flat
-//! under `data`. These tests drive the compiled binary and assert the full
-//! envelope, which in-crate unit tests cannot cover.
+//! `NOT_INSTALLED`, exit 2), so previews never disagree with reality. The
+//! code marks state absence only — it is not a statement about the name, as
+//! `not_installed_does_not_distinguish_a_known_name_from_an_unknown_one`
+//! pins. `--purge` keeps the legacy plan view: a unified `data.dry_run`,
+//! plan fields flat under `data`. These tests drive the compiled binary and
+//! assert the full envelope, which in-crate unit tests cannot cover.
 
 use std::path::Path;
 use std::process::Output;
@@ -68,11 +70,18 @@ fn absent_uninstall_args<'a>(prefix: &'a str, extra: &[&'a str]) -> Vec<&'a str>
 }
 
 fn seed_local_repo(prefix: &Path) {
+    seed_local_repo_with_index(prefix, "components = []\n");
+}
+
+/// Same layout as [`seed_local_repo`] but with a caller-supplied component
+/// index body, so a test can distinguish a name the index knows from one it
+/// has never heard of.
+fn seed_local_repo_with_index(prefix: &Path, components: &str) {
     let repo_v1 = prefix.join("repo/v1");
     std::fs::create_dir_all(&repo_v1).expect("local repo");
     std::fs::write(
         repo_v1.join("components.toml"),
-        "schema_version = 1\ncomponents = []\n",
+        format!("schema_version = 1\n{components}"),
     )
     .expect("component index");
     let etc = prefix.join("etc/anolisa");
@@ -105,7 +114,8 @@ fn uninstall_dry_run_json_absent_component_reports_not_installed() {
     let error = value.get("error").expect("envelope must carry error");
     assert_eq!(
         error.get("code").and_then(|v| v.as_str()),
-        Some("INVALID_ARGUMENT"),
+        Some("NOT_INSTALLED"),
+        "an absent target is its own code, distinct from a malformed one: {value}",
     );
     assert!(
         error
@@ -113,6 +123,58 @@ fn uninstall_dry_run_json_absent_component_reports_not_installed() {
             .and_then(|v| v.as_str())
             .is_some_and(|reason| reason.contains("not installed")),
         "the reason must say not installed: {value}",
+    );
+}
+
+/// `NOT_INSTALLED` reports state absence and nothing else. Resolution falls
+/// back to the literal input when the component index has no entry for it
+/// (`common::component_alias_from_repo_index`), so a name the index knows and
+/// a name it has never seen reach this code indistinguishably — same `code`,
+/// same exit status, differing only in the name echoed back.
+///
+/// This is pinned deliberately: callers must not read `NOT_INSTALLED` as
+/// "the name was valid, it just isn't installed". Should the CLI ever grow
+/// real identity validation, this test is the one that has to change, and
+/// its failure is the signal to revisit every doc that describes the code.
+#[test]
+fn not_installed_does_not_distinguish_a_known_name_from_an_unknown_one() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    seed_local_repo_with_index(
+        tmp.path(),
+        "components = [\n  { name = \"cosh\", package = \"copilot-shell\" },\n]\n",
+    );
+    let prefix = tmp.path().to_str().expect("utf-8 prefix");
+
+    let mut codes = Vec::new();
+    // "cosh" is in the index but not installed; "coshh" is in no index at all.
+    for component in ["cosh", "coshh"] {
+        let value = run_json(
+            &[
+                "--json",
+                "--dry-run",
+                "--install-mode",
+                "system",
+                "--prefix",
+                prefix,
+                "uninstall",
+                component,
+            ],
+            2,
+        );
+        let error = value.get("error").expect("envelope must carry error");
+        codes.push(
+            error
+                .get("code")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        );
+    }
+
+    assert_eq!(
+        codes,
+        vec!["NOT_INSTALLED".to_string(), "NOT_INSTALLED".to_string()],
+        "an index-known name and an unknown one must be reported identically",
     );
 }
 


### PR DESCRIPTION
## Description

Every command that acts on an installed component reported an absent target as
`INVALID_ARGUMENT` — the same code a bad invocation gets. A scripted caller could
not tell "there was nothing to act on" from "the invocation was wrong" without
matching on the human-readable reason string.

This adds `CliError::NotInstalled` → `NOT_INSTALLED` and routes the condition to
it from `uninstall`, `update`, `repair`, `forget`, `restart`, and `adapter`. All
six report the same underlying state, so they must report the same code; leaving
any of them behind would make the code depend on which command the caller
happened to run. Genuine invocation errors keep `INVALID_ARGUMENT`: enabled
adapter claims, a quarantined record needing `repair`, and
`--remove-system-package` with several targets all still route there.

**Scope of the code — state absence only.** It is not a statement about the name.
Resolution falls back to the literal input when the component index has no entry
for it, so an unknown name and a known-but-absent one arrive indistinguishably.
The docs say this explicitly and an integration test pins it.

**Exit code stays 2** for backward compatibility alone — shell callers already
branch on 2. Sharing it does not mean the two conditions call for the same
response, and what to do about an absent target depends on the command: an absent
`uninstall` target is already the desired end state, an absent `restart` target is
a stale assumption. The CLI reports the state and leaves that judgement to the
caller. The distinction is carried by `error.code` for `--json` consumers; reason
strings are byte-for-byte unchanged.

### Note on how this differs from what #1814 requested

#1814 asks for `uninstall <absent> --dry-run` to return `ok: true` with an empty
preview, and describes the current refusal as a regression from #1471. This PR
deliberately does not do that. The reasoning:

1. **It is not a regression from #1471.** #1471 was about *response shape* — the
   plan-view missing `data.dry_run`, `phases[0].mode = "execute"` being
   misleading, and `warnings` saying "plan is empty" while `phases[]` was
   non-empty. None of its four suggested fixes asked for dry-run to always
   succeed. Its fix landed in 0f97c779; the current behaviour came later from
   2d40b9a2, a declared breaking lifecycle-pipeline rebuild, not a silent revert.

2. **`--dry-run` is documented as "Print plan without executing"**, and the
   architecture is observe → plan → execute. `PlanError::NotInstalled` is a
   *planning* refusal, so dry-run reporting it is dry-run doing its job.

3. **A preview that succeeds where the real run fails is worse for automation.**
   The typical agent sequence is `uninstall X --dry-run` → decide → `uninstall X`.
   If the preview returns `ok: true` and the real run then returns `ok: false`
   with exit 2, the preview actively misled the caller. That also reintroduces
   the plan-view/execution-view asymmetry #1471 set out to remove — just moved
   from field shape to exit status.

4. **Fixing only `uninstall` would create a fresh inconsistency**, since
   `update.rs` and `repair.rs` map `PlanError::NotInstalled` identically.

What #1814 genuinely exposes is that `INVALID_ARGUMENT` is the wrong code for
this condition — the argument is valid, only the state precondition is unmet, and
the caller has no machine-readable way to tell the two apart. That is what this
PR fixes, without giving up the property that a preview never disagrees with the
run it previews.

## Related Issue

Relates to #1814 — deliberately **not** a closing reference; see the section above
for why this does not implement that issue's stated acceptance contract. Leaving
the issue open for maintainers to decide, per review feedback.

no-issue: this is a contract-level fix split out from the #1814 discussion rather
than an implementation of its requested behaviour.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

Flagged as breaking for honesty: a `--json` consumer that asserts
`error.code == "INVALID_ARGUMENT"` for an absent component will now see
`NOT_INSTALLED`. Exit code, `schema_version`, envelope shape, and every reason
string are unchanged, so shell callers branching on exit status are unaffected.

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

Documentation: `src/anolisa/CHANGELOG.md` `[Unreleased]` → `Changed`. The exit-code
contract lives in the `response.rs` module doc rather than `docs/`, and is updated
there. No `docs/` page enumerates CLI error codes today, so none needed a change.

## Testing

All three gate commands run on `aarch64-unknown-linux-gnu`, toolchain 1.88.0:

```
cargo fmt --all --check                          # exit 0, no diff
cargo clippy --all-targets --locked -- -D warnings   # exit 0, no warnings
cargo test --locked                              # 1885 passed, 0 failed
```

New tests:

- `not_installed_does_not_distinguish_a_known_name_from_an_unknown_one` — drives
  the real binary with a seeded component index and asserts that an index-known
  name (`cosh`) and an unknown one (`coshh`) produce the identical code. This
  pins the corrected contract rather than the wording, so if identity validation
  ever lands, this is the test that fails and flags every doc describing the code.
- `response::tests::not_installed_has_its_own_code_but_keeps_exit_two` — locks
  both halves of the contract: the code differs from `INVALID_ARGUMENT`, the exit
  code does not.
- `response::tests::not_installed_survives_command_restamping` — `with_command`
  re-stamps every variant; a missing arm would silently leave the wrong verb in
  the envelope.
- `commands::adapter::tests::component_not_installed_maps_to_not_installed` —
  cross-command consistency, so a caller never has to know which command
  surfaced the condition.

Updated to assert the new code (behaviour otherwise unchanged):
`uninstall_unknown_component_routes_to_not_installed_exit_2`,
`uninstall_dry_run_on_unknown_component_reports_not_installed`,
`update::unknown_component_routes_to_not_installed`,
`repair::absent_component_is_not_installed`,
`forget_unknown_component_routes_to_not_installed`,
`restart_unknown_component_returns_not_installed`, and the subprocess
wire-contract test `uninstall_dry_run_json_absent_component_reports_not_installed`.

Manual reproduction of the issue's command, before and after:

```
$ anolisa uninstall cosh --dry-run --json
# before: error.code = INVALID_ARGUMENT, exit 2
# after:  error.code = NOT_INSTALLED,    exit 2   (reason text identical)
```

## Additional Notes

If maintainers prefer the idempotent-`uninstall` route instead (absent target is
a no-op success, `rm -f` / `kubectl delete --ignore-not-found` semantics), that is
a defensible design — but it should change the real execution path and dry-run
together, and be applied across `update`/`repair` as well. That is a larger
breaking change than this one and is deliberately left out of scope here.

