### PR TITLE
chore(anolisa): bump version to 0.2.12

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-07-27
+
 ### Changed
 
 - Commands that act on an installed component now report an absent target as
@@ -14,7 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing to act on" from "the invocation was wrong" without parsing the error
   message. The code reports state absence only, and does not indicate whether
   the name was valid. Affects `uninstall`, `update`, `repair`, `forget`,
-  `restart`, and `adapter`; the exit code stays 2.
+  `restart`, and `adapter`; the exit code stays 2
+  ([#1915](https://github.com/alibaba/anolisa/pull/1915)).
+
+### Fixed
+
+- Adapter status now ignores empty or incomplete stale source directories and
+  reports missing bundles as degraded; raw uninstalls prune empty directories
+  so another installation scope cannot be shadowed
+  ([#1850](https://github.com/alibaba/anolisa/pull/1850)).
+- Raw install dry-runs now validate component conflicts before execution,
+  keeping preview results aligned with real installs. Repositories without
+  lightweight sidecar metadata warn that conflict validation was skipped
+  ([#1898](https://github.com/alibaba/anolisa/pull/1898)).
 
 ## [0.2.11] - 2026-07-24
 
@@ -671,6 +685,25 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.12] - 2026-07-27
+
+### 变更
+
+- 对已安装组件执行操作的命令在目标缺失时现报告 `NOT_INSTALLED`，不再报告
+  `INVALID_ARGUMENT`，调用方无需解析错误消息即可区分“没有可操作的目标”和“调用方式错误”。
+  该错误码仅表示状态缺失，不表示组件名称是否有效；影响 `uninstall`、`update`、`repair`、
+  `forget`、`restart` 和 `adapter`，退出码仍为 2
+  ([#1915](https://github.com/alibaba/anolisa/pull/1915))。
+
+### 修复
+
+- adapter 状态检查现忽略空的或不完整的过期源目录，并将缺失 bundle 报告为 degraded；
+  raw 卸载会清理空目录，避免遮蔽其他安装 scope
+  ([#1850](https://github.com/alibaba/anolisa/pull/1850))。
+- raw 安装 dry-run 现会在执行前校验组件冲突，使预览结果与实际安装保持一致。仓库缺少
+  轻量 sidecar 元数据时会提示已跳过冲突校验
+  ([#1898](https://github.com/alibaba/anolisa/pull/1898))。
 
 ## [0.2.11] - 2026-07-24
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "chrono",
  "dirs",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,12 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Fri Jul 24 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Mon Jul 27 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Missing installed components now report `NOT_INSTALLED` in structured output.
+- Adapter status now ignores stale source directories and reports missing bundles as degraded.
+- Raw install dry-runs now validate component conflicts before execution.
+
+* Fri Jul 24 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.11-1
 - Raw `anolisa install --version` now installs the exact published component version.
 - Raw `anolisa install --version` output now reports requested and resolved versions, artifact URL, and source repository.
 - Raw `anolisa install --version` now lists published alternatives when the requested version is unavailable.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.11",
-    "@anolisa/cli-linux-arm64": "0.2.11"
+    "@anolisa/cli-linux-x64": "0.2.12",
+    "@anolisa/cli-linux-arm64": "0.2.12"
   }
 }

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

Bumps ANOLISA from 0.2.11 to 0.2.12 across Cargo, npm, and RPM release metadata. Curates matching English and Chinese changelog entries for the ANOLISA CLI changes since the 0.2.11 release: structured `NOT_INSTALLED` errors, stale adapter-source detection, and raw dry-run conflict validation. This release commit adds no further runtime behavior beyond those merged changes.

## Related Issue

no-issue: routine 0.2.12 release metadata update

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- npm JSON parsing and Cargo workspace version consistency checks

## Additional Notes

The repository does not contain a `v0.2.11` Git tag, so the changelog range uses the corresponding 0.2.11 release commit `ea5a5624` as its baseline.
