### PR TITLE
fix(cosh-ng): [shell] let Up recall slash commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
@@ -53,6 +53,14 @@ impl InputClassifier {
         self.is_slash_control_input(token)
     }
 
+    /// Exact registry hits only, excluding hint prefixes such as `/sk`. The
+    /// shell marker's case lists carry the same exact tokens, so only these
+    /// submissions can be routed through the shell for history recording
+    /// (issue #1718) with a guaranteed shell-side intercept.
+    pub(crate) fn is_exact_slash_control_command(&self, token: &str) -> bool {
+        self.slash_commands.iter().any(|command| token == command)
+    }
+
     pub fn classify(&self, input: &str) -> InputDecision {
         let trimmed = input.trim();
         if trimmed.is_empty() {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -32,6 +32,12 @@ pub(super) struct InputRelayContext<'a> {
     pub(super) native_line_state: &'a mut NativeLineState,
     pub(super) exit_tracker: &'a mut ExplicitExitTracker,
     pub(super) main_prompt_gate: &'a MainPromptGate,
+    /// Routes exact slash-control submissions through bash so they enter
+    /// native history (issue #1718); admission additionally requires the
+    /// main prompt gate, so any submission (slash or shell) lowers the gate
+    /// until the next prompt_ready marker and later bytes fall back to the
+    /// Rust intercept path instead of leaking into a foreground process.
+    pub(super) slash_route_enabled: bool,
 }
 
 /// Writes real user bytes to the PTY, bumping the shared input generation
@@ -488,6 +494,24 @@ fn relay_candidate_line(
             }
             match relay.input_classifier.classify(&line) {
                 InputDecision::Intercept { input, reason } => {
+                    if reason == InterceptReason::Slash
+                        && relay.slash_route_enabled
+                        && relay.main_prompt_gate.is_at_prompt()
+                        && relay.input_classifier.is_exact_slash_control_command(
+                            line.split_whitespace().next().unwrap_or_default(),
+                        )
+                    {
+                        // Submit the exact slash line through bash so
+                        // readline records it in native history (issue
+                        // #1718). The shell marker's DEBUG trap intercepts
+                        // it at the prompt boundary (#1724) and emits the
+                        // same UserInputIntercepted event as the Rust path
+                        // below. write_user_bytes_to_pty lowers the prompt
+                        // gate for this and every other line submission, so
+                        // follow-up slash bytes can never route into a
+                        // foreground process before the next prompt_ready.
+                        return submit_line_bytes_to_shell(relay, bytes, remainder, emit_activity);
+                    }
                     let _ = relay.input_events.send(RawInputEvent::CandidateCommit(
                         redact_extension_setting_value(line.as_bytes()),
                     ));
@@ -518,28 +542,7 @@ fn relay_candidate_line(
                         wrapped.extend_from_slice(b"\x1b[201~");
                         bytes = wrapped;
                     }
-                    let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
-                    send_raw_input_events(&bytes, relay.input_events);
-                    relay.native_line_state.observe_shell_bytes(&bytes);
-                    if emit_activity && !bytes.is_empty() {
-                        send_shell_input_state(
-                            relay.native_line_state.is_empty(),
-                            relay.input_events,
-                        );
-                    }
-                    relay.exit_tracker.observe_shell_bytes(&bytes);
-                    write_user_bytes_to_pty(
-                        relay.master,
-                        relay.input_generation,
-                        relay.line_submits,
-                        relay.input_events,
-                        relay.main_prompt_gate,
-                        &bytes,
-                    )?;
-                    if !remainder.is_empty() {
-                        relay_passthrough_input_with_activity(&remainder, relay, emit_activity)?;
-                    }
-                    Ok(false)
+                    submit_line_bytes_to_shell(relay, bytes, remainder, emit_activity)
                 }
                 InputDecision::Consume => {
                     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
@@ -570,6 +573,18 @@ fn flush_candidate_line_to_shell(
         wrapped.extend_from_slice(b"\x1b[201~");
         bytes = wrapped;
     }
+    submit_line_bytes_to_shell(relay, bytes, Vec::new(), emit_activity)
+}
+
+/// Clears the cosh-echoed candidate line and writes the taken bytes to the
+/// PTY, then relays any remainder. Shared by SendToShell submissions, unsafe
+/// candidate flushes, and shell-routed slash submissions (issue #1718).
+fn submit_line_bytes_to_shell(
+    relay: &mut InputRelayContext<'_>,
+    bytes: Vec<u8>,
+    remainder: Vec<u8>,
+    emit_activity: bool,
+) -> io::Result<bool> {
     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
     send_raw_input_events(&bytes, relay.input_events);
     relay.native_line_state.observe_shell_bytes(&bytes);
@@ -585,6 +600,9 @@ fn flush_candidate_line_to_shell(
         relay.main_prompt_gate,
         &bytes,
     )?;
+    if !remainder.is_empty() {
+        relay_passthrough_input_with_activity(&remainder, relay, emit_activity)?;
+    }
     Ok(false)
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -158,6 +158,7 @@ impl SelectionRelay {
             input_mode.clone(),
             UserPtyInputGeneration::default(),
             super::super::MainPromptGate::default(),
+            false,
         );
         Self {
             path,
@@ -217,6 +218,7 @@ impl DelayRelay {
             input_mode.clone(),
             UserPtyInputGeneration::default(),
             super::super::MainPromptGate::default(),
+            false,
         );
         Self {
             path,
@@ -353,6 +355,7 @@ fn submitted_capture_discards_a_later_owned_read_when_the_chain_ends() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"first\n".to_vec()).expect("first answer");
@@ -452,6 +455,7 @@ fn input_obtained_before_capture_replacement_does_not_enter_the_new_capture() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"first\n".to_vec()).expect("first answer");
@@ -541,6 +545,7 @@ fn input_obtained_after_capture_install_enters_the_new_capture() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     read_started_rx
@@ -601,6 +606,7 @@ fn passthrough_owned_input_does_not_enter_a_later_capture() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"stale".to_vec()).expect("passthrough input");
@@ -665,6 +671,7 @@ fn delay_owned_escape_does_not_reach_a_later_capture_or_shell() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(vec![0x1b]).expect("delay escape");
@@ -731,6 +738,7 @@ fn capture_owned_input_does_not_enter_later_passthrough() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx
@@ -780,6 +788,7 @@ fn prompt_ghost_candidate_cycle_during_read_does_not_drop_input() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"x".to_vec()).expect("typed input");
@@ -842,6 +851,7 @@ fn tab_read_under_selection_is_not_reinterpreted_by_native_route() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"\t".to_vec()).expect("tab input");
@@ -900,6 +910,7 @@ fn tab_read_under_native_route_is_not_reinterpreted_by_agent_intercept() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"\t".to_vec()).expect("tab input");
@@ -961,6 +972,7 @@ fn enter_read_under_intercept_is_not_reinterpreted_by_selection() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"\r".to_vec()).expect("enter input");
@@ -1013,6 +1025,7 @@ fn tab_after_route_cutover_is_relayed_under_the_new_route() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"\t".to_vec()).expect("in-flight tab");
@@ -1136,6 +1149,7 @@ fn active_capture_eof_drains_the_generation_without_input() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     drop(input_tx);
@@ -1186,6 +1200,7 @@ fn selection_bare_escape_times_out_without_waiting_for_another_key() {
         input_mode.clone(),
         UserPtyInputGeneration::default(),
         super::super::MainPromptGate::default(),
+        false,
     );
 
     input_tx.send(b"\x1b".to_vec()).expect("send escape");
@@ -1227,6 +1242,8 @@ fn selection_action_wait_flushes_escape_at_the_deadline() {
         InputClassifier::default(),
         input_mode.clone(),
         UserPtyInputGeneration::default(),
+        super::super::MainPromptGate::default(),
+        false,
     );
 
     expect_prompt_ghost_dismissal(&rx);
@@ -1811,6 +1828,7 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     assert!(relay_prompt_ghost_input(
@@ -1874,6 +1892,7 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     relay_passthrough_input(b"/ho", &mut relay).expect("buffer slash prefix");
@@ -1918,6 +1937,7 @@ fn native_shell_input_reports_editing_then_empty_without_content() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     relay_passthrough_input(b"partial", &mut relay).expect("type partial line");
@@ -1970,6 +1990,7 @@ fn agent_prompt_tab_stays_local_until_enter_and_keeps_suggestion_id() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2043,6 +2064,7 @@ fn selection_enter_submits_the_active_prompt_without_shell_execution() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     relay_prompt_ghost_input(b"\r", "inspect disk pressure", &route, &mut relay)
@@ -2095,6 +2117,7 @@ fn clearing_accepted_agent_prompt_emits_binding_dismissal() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2137,6 +2160,7 @@ fn unsupported_arrow_after_agent_prompt_tab_cancels_without_writing_to_shell() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2190,6 +2214,7 @@ fn split_cursor_sequences_after_agent_prompt_tab_never_reach_shell() {
             native_line_state: &mut native_line_state,
             exit_tracker: &mut exit_tracker,
             main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: false,
         };
 
         relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2239,6 +2264,7 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
         native_line_state: &mut native_line_state,
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2279,6 +2305,7 @@ fn passthrough_relay_fixture<'a>(
         native_line_state,
         exit_tracker,
         main_prompt_gate,
+        slash_route_enabled: false,
     }
 }
 
@@ -3391,5 +3418,202 @@ fn native_delete_at_line_end_keeps_the_mirror() {
         )),
         "EOL Delete must not eat a mirrored char: {events:?}"
     );
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn native_exact_slash_routes_to_shell_when_at_prompt() {
+    // Covers both relay classifier flavors (issue #1718 G4): conservative is
+    // the production default, non-conservative the explicit opt-out.
+    for conservative in [true, false] {
+        let label = format!("slash-route-exact-{conservative}");
+        let (path, mut master) = output_file(&label);
+        let (tx, rx) = mpsc::channel();
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+        let main_prompt_gate = super::super::MainPromptGate::default();
+        main_prompt_gate.set_at_prompt(true);
+        let mut line_buffer = CandidateLineBuffer::default();
+        let mut native_line_state = NativeLineState::default();
+        let mut exit_tracker = ExplicitExitTracker::default();
+        let classifier = if conservative {
+            InputClassifier::conservative()
+        } else {
+            InputClassifier::default()
+        };
+        let input_generation = UserPtyInputGeneration::default();
+        let mut line_submits = LineSubmitCounter::default();
+        let mut relay = InputRelayContext {
+            master: &mut master,
+            input_classifier: &classifier,
+            input_events: &tx,
+            input_mode: &input_mode,
+            input_generation: &input_generation,
+            line_submits: &mut line_submits,
+            line_buffer: &mut line_buffer,
+            native_line_state: &mut native_line_state,
+            exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: true,
+        };
+
+        relay_passthrough_input(b"/mode approval\n", &mut relay).expect("route exact slash");
+        master.sync_all().expect("sync test output");
+
+        let events = rx.try_iter().collect::<Vec<_>>();
+        // Routed submissions leave interception to the shell marker: no
+        // Rust-side intercept or commit events, bytes written to the PTY.
+        assert!(events
+            .iter()
+            .all(|event| !matches!(event, RawInputEvent::UserIntercept(..))));
+        assert!(events
+            .iter()
+            .all(|event| !matches!(event, RawInputEvent::CandidateCommit(..))));
+        assert!(events.contains(&RawInputEvent::CandidateClearLine));
+        assert_eq!(
+            fs::read(&path).expect("read test output"),
+            b"/mode approval\n"
+        );
+        // The submission lowers the prompt gate until the next prompt_ready
+        // marker (#1721 D16), so racing follow-up slash bytes fall back to
+        // the Rust intercept path.
+        assert!(!main_prompt_gate.is_at_prompt());
+        assert!(matches!(
+            *input_mode.lock().expect("input mode"),
+            RawInputMode::Passthrough
+        ));
+        fs::remove_file(path).ok();
+    }
+}
+
+#[test]
+fn native_exact_slash_falls_back_to_rust_intercept_when_not_at_prompt() {
+    let (path, mut master) = output_file("slash-route-not-at-prompt");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: true,
+    };
+
+    relay_passthrough_input(b"/mode approval\n", &mut relay).expect("fall back to intercept");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    // Without a proven prompt the routing must not leak bytes into the PTY
+    // (a foreground REPL could own it): the Rust intercept path stays.
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::UserIntercept(input, InterceptReason::Slash) if input == "/mode approval"
+    )));
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn native_shell_submission_lowers_gate_before_follow_up_slash() {
+    // Regression for the review P1 (#1922): a plain shell submission (e.g.
+    // one that starts a REPL) must lower the prompt gate synchronously, so a
+    // slash typed before the parser observes preexec still takes the Rust
+    // intercept path instead of leaking into the foreground process.
+    let (path, mut master) = output_file("slash-route-after-shell-submit");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: true,
+    };
+
+    relay_passthrough_input(b"python\n", &mut relay).expect("submit shell command");
+    assert!(
+        !main_prompt_gate.is_at_prompt(),
+        "plain submission must lower the gate synchronously"
+    );
+    relay_passthrough_input(b"/mode approval\n", &mut relay).expect("slash after submit");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::UserIntercept(input, InterceptReason::Slash) if input == "/mode approval"
+    )));
+    // Only the shell command reaches the PTY; the slash stays Rust-side.
+    assert_eq!(fs::read(&path).expect("read test output"), b"python\n");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn native_hint_prefix_slash_keeps_rust_intercept_when_routed() {
+    let (path, mut master) = output_file("slash-route-hint-prefix");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::conservative();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: true,
+    };
+
+    relay_passthrough_input(b"/sk\n", &mut relay).expect("hint prefix intercept");
+    master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    // Hint prefixes are not in the shell marker's exact case lists, so
+    // routing them would make bash execute the line; they keep the Rust
+    // intercept path and never enter history.
+    assert!(events.iter().any(|event| matches!(
+        event,
+        RawInputEvent::UserIntercept(input, InterceptReason::Slash) if input == "/sk"
+    )));
+    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    // A non-routed submission does not touch the prompt gate.
+    assert!(main_prompt_gate.is_at_prompt());
     fs::remove_file(path).ok();
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -76,6 +76,7 @@ pub(crate) fn spawn_raw_input_relay<R>(
     input_mode: Arc<Mutex<RawInputMode>>,
     input_generation: UserPtyInputGeneration,
     main_prompt_gate: MainPromptGate,
+    slash_route_enabled: bool,
 ) -> JoinHandle<io::Result<()>>
 where
     R: Read + Send + 'static,
@@ -86,8 +87,11 @@ where
         let reader_input_mode = input_mode.clone();
         thread::spawn(move || read_input_chunks(input, read_tx, reader_input_mode));
 
-        let mut state =
-            RawInputRelayState::with_generation_and_gate(input_generation, main_prompt_gate);
+        let mut state = RawInputRelayState::with_generation_and_gate(
+            input_generation,
+            main_prompt_gate,
+            slash_route_enabled,
+        );
         loop {
             sync_pending_draft_escape(&mut state);
             let input = match receive_input(&read_rx, &mut state) {
@@ -595,6 +599,7 @@ fn relay_input_for_mode(
         input_generation,
         line_submits,
         main_prompt_gate,
+        slash_route_enabled,
         ..
     } = state;
     let mut relay = InputRelayContext {
@@ -608,6 +613,7 @@ fn relay_input_for_mode(
         native_line_state,
         exit_tracker,
         main_prompt_gate,
+        slash_route_enabled: *slash_route_enabled,
     };
     relay_input_chunk(
         bytes,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/action.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/action.rs
@@ -13,7 +13,7 @@ use crate::input::InputClassifier;
 use super::super::generation::UserPtyInputGeneration;
 use super::super::mode::RawInputMode;
 use super::super::pty::{set_pty_winsize, signal_process_group};
-use super::super::{RawInputEvent, RawRelayAction};
+use super::super::{MainPromptGate, RawInputEvent, RawRelayAction};
 use super::{
     finish_input_relay, flush_pending_prompt_ghost_escape,
     flush_pending_replaced_prompt_ghost_suffix, next_pending_deadline, relay_input_bytes,
@@ -177,6 +177,7 @@ fn wait_for_raw_action(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_raw_action_relay(
     actions: Vec<RawRelayAction>,
     mut master: File,
@@ -185,9 +186,15 @@ pub(crate) fn spawn_raw_action_relay(
     input_classifier: InputClassifier,
     input_mode: Arc<Mutex<RawInputMode>>,
     input_generation: UserPtyInputGeneration,
+    main_prompt_gate: MainPromptGate,
+    slash_route_enabled: bool,
 ) -> JoinHandle<io::Result<()>> {
     thread::spawn(move || {
-        let mut state = RawInputRelayState::with_generation(input_generation);
+        let mut state = RawInputRelayState::with_generation_and_gate(
+            input_generation,
+            main_prompt_gate,
+            slash_route_enabled,
+        );
         for action in actions {
             flush_pending_prompt_ghost_escape(
                 false,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -284,6 +284,7 @@ pub(in super::super) fn relay_late_capture_input(
         input_generation,
         line_submits,
         main_prompt_gate,
+        slash_route_enabled,
         ..
     } = state;
     let mut relay = InputRelayContext {
@@ -297,6 +298,7 @@ pub(in super::super) fn relay_late_capture_input(
         native_line_state,
         exit_tracker,
         main_prompt_gate,
+        slash_route_enabled: *slash_route_enabled,
     };
     relay_late_capture_bytes(bytes, generation, capture_owned_input, &mut relay)
 }
@@ -463,6 +465,7 @@ pub(in super::super) fn finish_input_relay(
             native_line_state,
             exit_tracker,
             main_prompt_gate,
+            slash_route_enabled: false,
         };
         drain_abandoned_capture(capture_owned_input, &mut relay)?;
     }
@@ -561,6 +564,7 @@ mod tests {
             native_line_state: &mut native_line_state,
             exit_tracker: &mut exit_tracker,
             main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: false,
         };
 
         relay_input_chunk(
@@ -613,6 +617,7 @@ mod tests {
             native_line_state: &mut native_line_state,
             exit_tracker: &mut exit_tracker,
             main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: false,
         };
         relay_input_chunk(
             b"later",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
@@ -30,6 +30,10 @@ pub(in super::super) struct RawInputRelayState {
     pub(super) input_generation: UserPtyInputGeneration,
     pub(super) line_submits: LineSubmitCounter,
     pub(super) main_prompt_gate: MainPromptGate,
+    /// Routes exact slash submissions through bash for native history
+    /// recall (issue #1718); gated further by `main_prompt_gate` at
+    /// submission time.
+    pub(super) slash_route_enabled: bool,
     pub(super) pending_prompt_ghost_escape: Option<PendingPromptGhostEscape>,
     pub(super) pending_delay_escape: Option<PendingDelayEscape>,
     pub(super) pending_replaced_prompt_ghost_suffix: Option<PendingReplacedPromptGhostSuffix>,
@@ -41,20 +45,15 @@ pub(in super::super) struct RawInputRelayState {
 }
 
 impl RawInputRelayState {
-    pub(super) fn with_generation(input_generation: UserPtyInputGeneration) -> Self {
-        Self {
-            input_generation,
-            ..Self::default()
-        }
-    }
-
     pub(super) fn with_generation_and_gate(
         input_generation: UserPtyInputGeneration,
         main_prompt_gate: MainPromptGate,
+        slash_route_enabled: bool,
     ) -> Self {
         Self {
             input_generation,
             main_prompt_gate,
+            slash_route_enabled,
             ..Self::default()
         }
     }
@@ -77,6 +76,7 @@ pub(super) fn input_relay_context<'a>(
         native_line_state: &mut state.native_line_state,
         exit_tracker: &mut state.exit_tracker,
         main_prompt_gate: &state.main_prompt_gate,
+        slash_route_enabled: state.slash_route_enabled,
     }
 }
 
@@ -143,6 +143,7 @@ pub(super) fn flush_pending_draft_escape(
                 input_generation,
                 line_submits,
                 main_prompt_gate,
+                slash_route_enabled,
                 ..
             } = state;
             let mut relay = InputRelayContext {
@@ -156,6 +157,7 @@ pub(super) fn flush_pending_draft_escape(
                 native_line_state,
                 exit_tracker,
                 main_prompt_gate,
+                slash_route_enabled: *slash_route_enabled,
             };
             relay.line_buffer.clear();
             relay.native_line_state.clear();

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -583,6 +583,13 @@ _cosh_preexec_marker() {
         fi
         local reason
         if reason="$(_cosh_should_intercept_unknown "$first_word" "$command" "$argc")"; then
+          # Intercepted lines return 1 before the secret redaction below
+          # ever runs, so scrub credential-bearing entries here or the raw
+          # text would persist in native history (routed slash submissions
+          # enter history via readline before the trap fires).
+          if _cosh_command_has_secret "$command"; then
+            builtin history -d "$history_no" 2>/dev/null || true
+          fi
           _cosh_emit_intercept_marker "$command" "$reason"
           _COSH_AT_PROMPT=0
           eval "$active_debug_trap" 2>/dev/null || true

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
@@ -65,6 +65,12 @@ pub struct ShellHostConfig {
     pub input_classifier: InputClassifier,
     pub native_mode: bool,
     pub login_shell: bool,
+    /// Routes exact slash-control submissions through bash so they enter
+    /// native history (issue #1718). Defaults from `COSH_SLASH_VIA_SHELL`
+    /// (on unless "0"); disabling restores the pre-#1718 Rust intercept
+    /// path end to end. Only bash runners consult it; zsh has no extdebug
+    /// return-suppression equivalent and always keeps the Rust path.
+    pub slash_via_shell: bool,
     pub env_overrides: Vec<(String, String)>,
     pub raw_action_watchdog: Duration,
     pub(super) shell_environment_observer: Option<ShellEnvironmentObserver>,
@@ -84,6 +90,7 @@ impl ShellHostConfig {
             input_classifier: InputClassifier::default(),
             native_mode: true,
             login_shell: false,
+            slash_via_shell: slash_via_shell_default(),
             env_overrides: Vec::new(),
             raw_action_watchdog: Duration::from_secs(120),
             shell_environment_observer: None,
@@ -122,6 +129,14 @@ impl ShellHostConfig {
     pub(crate) fn clear_shell_history_file_observer(&mut self) {
         self.shell_history_file_observer = None;
     }
+}
+
+/// `COSH_SLASH_VIA_SHELL` gates the shell routing of exact slash
+/// submissions; any value other than "0" (including unset) keeps it on.
+fn slash_via_shell_default() -> bool {
+    std::env::var("COSH_SLASH_VIA_SHELL")
+        .map(|value| value != "0")
+        .unwrap_or(true)
 }
 
 fn default_winsize() -> Winsize {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -69,7 +69,8 @@ where
         event_observer,
         config.input_classifier.clone(),
         None,
-        |master, _, input_events, input_classifier, input_mode, input_generation, gate| {
+        config.slash_via_shell,
+        |master, _, input_events, input_classifier, input_mode, input_generation, gate, routed| {
             spawn_raw_input_relay(
                 input,
                 master,
@@ -78,6 +79,7 @@ where
                 input_mode,
                 input_generation,
                 gate,
+                routed,
             )
         },
     )
@@ -101,7 +103,8 @@ where
         event_observer,
         config.input_classifier.clone(),
         None,
-        |master, _, input_events, input_classifier, input_mode, input_generation, gate| {
+        false,
+        |master, _, input_events, input_classifier, input_mode, input_generation, gate, routed| {
             spawn_raw_input_relay(
                 input,
                 master,
@@ -110,6 +113,7 @@ where
                 input_mode,
                 input_generation,
                 gate,
+                routed,
             )
         },
     )
@@ -141,7 +145,15 @@ where
         |_, _| Ok(RawObserverAction::Continue),
         config.input_classifier.clone(),
         Some(config.raw_action_watchdog),
-        |master, child_pid, input_events, input_classifier, input_mode, input_generation, _gate| {
+        false,
+        |master,
+         child_pid,
+         input_events,
+         input_classifier,
+         input_mode,
+         input_generation,
+         gate,
+         routed| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -150,6 +162,8 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
+                gate,
+                routed,
             )
         },
     )
@@ -176,7 +190,15 @@ where
         },
         config.input_classifier.clone(),
         Some(config.raw_action_watchdog),
-        |master, child_pid, input_events, input_classifier, input_mode, input_generation, _gate| {
+        config.slash_via_shell,
+        |master,
+         child_pid,
+         input_events,
+         input_classifier,
+         input_mode,
+         input_generation,
+         gate,
+         routed| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -185,6 +207,8 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
+                gate,
+                routed,
             )
         },
     )
@@ -207,7 +231,15 @@ where
         event_observer,
         config.input_classifier.clone(),
         Some(config.raw_action_watchdog),
-        |master, child_pid, input_events, input_classifier, input_mode, input_generation, _gate| {
+        config.slash_via_shell,
+        |master,
+         child_pid,
+         input_events,
+         input_classifier,
+         input_mode,
+         input_generation,
+         gate,
+         routed| {
             spawn_raw_action_relay(
                 actions,
                 master,
@@ -216,6 +248,8 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
+                gate,
+                routed,
             )
         },
     )
@@ -228,6 +262,7 @@ fn run_raw_relay_with_driver<W, F, D>(
     mut event_observer: F,
     input_classifier: InputClassifier,
     action_watchdog: Option<Duration>,
+    slash_via_shell: bool,
     spawn_driver: D,
 ) -> io::Result<ShellHostOutput>
 where
@@ -241,6 +276,7 @@ where
         Arc<Mutex<RawInputMode>>,
         UserPtyInputGeneration,
         MainPromptGate,
+        bool,
     ) -> JoinHandle<io::Result<()>>,
 {
     let mut session = start_session(config)?;
@@ -270,6 +306,10 @@ where
     session
         .parser
         .set_main_prompt_gate(main_prompt_gate.clone());
+    // Slash-via-shell routing (issue #1718) needs a markered native session
+    // so the prompt gate can prove bash is at its prompt; everything else
+    // keeps the Rust intercept path.
+    let slash_route_enabled = slash_via_shell && config.native_mode;
     let driver_thread = spawn_driver(
         input_master,
         session.child.id(),
@@ -278,6 +318,7 @@ where
         Arc::clone(&input_mode),
         input_generation.clone(),
         main_prompt_gate,
+        slash_route_enabled,
     );
     let watchdog = action_watchdog.map(|grace| {
         let driver_done = Arc::new(Mutex::new(None));

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -507,5 +507,38 @@ mod tests {
                 "shell marker has unregistered slash token {token}"
             );
         }
+
+        // Shell routing of exact slash submissions (issue #1718) is only
+        // safe when the shell side can intercept every routed token, so
+        // both bash case lists (_cosh_should_intercept_unknown and
+        // _cosh_is_slash_control_candidate) must each carry the full
+        // registry set, not merely the bash+zsh union checked above.
+        // Case-arm lines end with `)` and every alternative starts with
+        // `/`, which keeps slash-leading comment lines out of the match.
+        let bash_case_lines = include_str!("../shell_host/marker/bash.rs")
+            .lines()
+            .map(str::trim)
+            .filter(|line| {
+                line.ends_with(')')
+                    && line
+                        .trim_end_matches(')')
+                        .split('|')
+                        .all(|token| token.trim().starts_with('/'))
+            })
+            .filter(|line| line.contains('|'))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bash_case_lines.len(),
+            2,
+            "expected exactly the two bash slash case lists"
+        );
+        for line in bash_case_lines {
+            let tokens = line
+                .trim_end_matches(')')
+                .split('|')
+                .map(str::trim)
+                .collect::<BTreeSet<_>>();
+            assert_eq!(tokens, registry, "bash case list diverged from registry");
+        }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -211,6 +211,229 @@ fn raw_relay_bash_intercepts_fragmented_slash_while_typing() {
 }
 
 #[test]
+fn raw_relay_bash_up_recalls_intercepted_slash_command() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-1718-recall-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(
+        home.join(".bashrc"),
+        "export HISTFILE=\"$HOME/.bash_history\"\n\
+         export HISTSIZE=1000\n\
+         shopt -s histappend\n",
+    )
+    .expect("bashrc");
+    std::fs::write(home.join(".bash_history"), "echo prior-shell-cmd\n").expect("history");
+
+    let mut config = ShellHostConfig::new("bash-1718-recall", &work_dir)
+        .with_env("HOME", home.display().to_string());
+    config.slash_via_shell = true;
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/skills detail xlsx"),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::write(b"\x1b[A".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::write(b"\n".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("1718 recall relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    let intercept_count = output
+        .events
+        .iter()
+        .filter(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some("/skills detail xlsx")
+                && event.component.as_deref() == Some("slash")
+        })
+        .count();
+    let recalled_prior_shell_cmd = output.events.iter().any(|event| {
+        event.kind == ShellEventKind::CommandStarted
+            && event.command.as_deref() == Some("echo prior-shell-cmd")
+    });
+    // Issue #1718: Up right after a slash intercept recalls the slash
+    // command (intercepted again through the shell marker), not the older
+    // shell command from bash history.
+    assert_eq!(intercept_count, 2, "{rendered_text}");
+    assert!(!recalled_prior_shell_cmd, "{rendered_text}");
+    // The routed line must never execute as a shell command.
+    assert!(!rendered_text.contains("bash: /skills"), "{rendered_text}");
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn raw_relay_bash_routed_slash_enters_native_history_file() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-1718-histfile-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(
+        home.join(".bashrc"),
+        "export HISTFILE=\"$HOME/.bash_history\"\n\
+         export HISTSIZE=1000\n\
+         shopt -s histappend\n",
+    )
+    .expect("bashrc");
+
+    let mut config = ShellHostConfig::new("bash-1718-histfile", &work_dir)
+        .with_env("HOME", home.display().to_string());
+    config.slash_via_shell = true;
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/skills detail xlsx"),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("1718 histfile relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    let intercepted = output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some("/skills detail xlsx")
+            && event.component.as_deref() == Some("slash")
+    });
+    assert!(intercepted, "{rendered_text}");
+    // bash owns persistence: the routed slash reaches HISTFILE through the
+    // user's native histappend semantics, with no cosh-side writes.
+    let history = std::fs::read_to_string(home.join(".bash_history")).expect("histfile");
+    assert!(history.contains("/skills detail xlsx"), "{history}");
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn raw_relay_bash_slash_route_switch_off_keeps_rust_intercept() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-1718-switch-off-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(
+        home.join(".bashrc"),
+        "export HISTFILE=\"$HOME/.bash_history\"\n\
+         export HISTSIZE=1000\n\
+         shopt -s histappend\n",
+    )
+    .expect("bashrc");
+    std::fs::write(home.join(".bash_history"), "echo prior-shell-cmd\n").expect("history");
+
+    let mut config = ShellHostConfig::new("bash-1718-switch-off", &work_dir)
+        .with_env("HOME", home.display().to_string());
+    config.slash_via_shell = false;
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/skills detail xlsx"),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::write(b"\x1b[A".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::write(b"\n".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("1718 switch-off relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    let intercept_count = output
+        .events
+        .iter()
+        .filter(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some("/skills detail xlsx")
+                && event.component.as_deref() == Some("slash")
+        })
+        .count();
+    let recalled_prior_shell_cmd = output.events.iter().any(|event| {
+        event.kind == ShellEventKind::CommandStarted
+            && event.command.as_deref() == Some("echo prior-shell-cmd")
+    });
+    // COSH_SLASH_VIA_SHELL=0 restores the pre-#1718 chain end to end: the
+    // slash is intercepted in the Rust relay, never enters history, and Up
+    // recalls the older shell command.
+    assert_eq!(intercept_count, 1, "{rendered_text}");
+    assert!(recalled_prior_shell_cmd, "{rendered_text}");
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn raw_relay_bash_routed_slash_with_secret_never_persists_in_history() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-1718-secret-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(
+        home.join(".bashrc"),
+        "export HISTFILE=\"$HOME/.bash_history\"\n\
+         export HISTSIZE=1000\n\
+         shopt -s histappend\n",
+    )
+    .expect("bashrc");
+
+    let mut config = ShellHostConfig::new("bash-1718-secret", &work_dir)
+        .with_env("HOME", home.display().to_string());
+    config.slash_via_shell = true;
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/config set api_key=sk-test-secret"),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("1718 secret relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    let intercepted = output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.component.as_deref() == Some("slash")
+    });
+    assert!(intercepted, "{rendered_text}");
+    // The intercept branch scrubs credential-bearing entries before its
+    // return 1, so the routed line must never reach the history file.
+    let history = std::fs::read_to_string(home.join(".bash_history")).unwrap_or_default();
+    assert!(!history.contains("api_key"), "{history}");
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
 fn raw_relay_bash_intercepts_recalled_duplicate_slash_each_time() {
     let root = std::env::temp_dir().join(format!(
         "cosh-shell-bash-recalled-slash-test-{}-{}",


### PR DESCRIPTION
# Summary

Fixes #1718. Hand-typed slash commands were intercepted in the Rust relay before any byte reached the PTY, so bash never recorded them in history and an empty-prompt `Up` recalled the previous shell command instead. A failed slash (e.g. `/mode analysis off`) could not be recalled and edited for retry.

This PR routes exact slash-control submissions through the shell: on Enter the relay clears the cosh echo and writes the full line to the PTY, bash records it in native history, and the shell marker's DEBUG trap intercepts it at the prompt boundary — the same #1724-hardened path that already covers recalled slash lines. `Up` / `Ctrl-R` / line editing stay fully native; recall → edit → resubmit now works end to end.

# Changes

- **Routing admission (conservative, fail-back to the pre-#1718 Rust intercept path)** — all four conditions must hold, otherwise behavior is unchanged:
  1. first token is an exact hit in `slash::registry::exact_slash_control_commands()` (hint prefixes such as `/sk` stay Rust-side; the shell case lists carry only exact tokens, so routing a prefix would make bash execute it);
  2. `COSH_SLASH_VIA_SHELL` is not `"0"` (`ShellHostConfig::slash_via_shell`, runtime kill switch);
  3. bash native (markered) sessions only — zsh has no extdebug return-suppression equivalent and keeps the Rust path;
  4. an at-prompt gate is set: `OscParser` owns an `AtomicBool` set on `prompt_ready` markers and cleared on `preexec` / `intercept` / routed submission, so bytes are never routed while a foreground command or REPL owns the PTY (`exec bash` marker loss also degrades safely to the Rust path).
- `raw_input/relay.rs`: the `Intercept{Slash}` branch routes admitted lines through the same submit sequence as `SendToShell` (extracted as `submit_line_bytes_to_shell`, incl. remainder handling); non-admitted lines keep the existing intercept events.
- `shell_host/marker/bash.rs`: the trap intercept branch returns 1 before the existing secret redaction ever runs, so it now scrubs credential-bearing lines from history (`_cosh_command_has_secret` → `history -d`) before emitting the intercept marker. The stale-history fallback branch is deliberately left alone: its `history_no` points at an unrelated entry and deleting it would drop user history.
- `raw_input/spawn.rs` relay state types moved to `spawn/state.rs` (layout gate: the file had crossed the 700-line threshold; structural split instead of a waiver).
- `slash/registry.rs` parity test now asserts **each** bash case list (`_cosh_should_intercept_unknown`, `_cosh_is_slash_control_candidate`) carries the full exact-command registry set, not just the bash+zsh union — the routing admission's correctness precondition.

# Tests

New coverage (all green in container, Linux arm64, bash 5.2):

- PTY regression (`tests/shell_host/relay.rs`):
  - `raw_relay_bash_up_recalls_intercepted_slash_command` — the issue's literal FAIL→PASS anchor: intercept count 2, prior shell command not executed;
  - `raw_relay_bash_routed_slash_enters_native_history_file` — HISTFILE persistence via native histappend, no cosh-side writes;
  - `raw_relay_bash_slash_route_switch_off_keeps_rust_intercept` — `COSH_SLASH_VIA_SHELL=0` restores pre-#1718 behavior end to end;
  - `raw_relay_bash_routed_slash_with_secret_never_persists_in_history` — credential-bearing slash never reaches `.bash_history`.
- Relay unit tests (`raw_input/relay_tests.rs`): exact-hit routing under both classifier flavors (conservative/non-conservative), at-prompt-false fallback with zero PTY leakage, hint-prefix fallback without consuming the prompt gate.
- `#1724` regression `raw_relay_bash_intercepts_recalled_duplicate_slash_each_time` stays green (recall-side invariant).

# Verification

- FAIL→PASS: the S2 probe (seed `echo prior-shell-cmd` → submit `/skills detail xlsx` → `Up`+Enter) failed deterministically on `origin/main` (intercept 1, stale command executed) and passes with this PR (intercept 2, no stale execution); promoted to the first regression test above.
- Container (Alinux3 arm64, bash 5.2): cosh-shell lib 1067 + bin 2050 + logic/protocol green; shell_host 86/89 green — the 3 failures (`heavy` sudo prompt, `termios` ×2) and 8 raw_cli failures (passthrough/heavy/cosh_core/auth) fail identically on `origin/main` in the same container (serial reruns + A/B checkout), i.e. pre-existing environment-sensitive tests, not introduced here.
- Host (macOS, bash 3.2): focused scopes green (`relay` 70, `registry` 19, shell_host `slash` filter 7/7); marker protocol byte-diff between main and this PR under a bare bash 3.2 driver shows no divergence.
- Preflight: fmt / clippy `-D warnings` / commit lint / `check-layout.sh` / `check-test-inventory.sh` all green; L3 security review: 0 findings.
- Excluded scope (not run here): full workspace tests beyond cosh-shell; x86_64; zsh behavior is intentionally unchanged (guard test only); real-machine ECS acceptance.

# Evidence

Real-PTY acceptance on the PR binary (container, Alinux3 arm64, bash 4.4 native marker mode; issue-literal scenario `/mode analysis off` → `Up` → edit `off`→`manual` → Enter). Assets are SHA-pinned on the fork assets branch `pr-1922-assets` (`21aa6992`).

| Point | Screenshot |
| --- | --- |
| Failed slash panel (`Unknown analysis mode: off`) | ![failed slash](https://raw.githubusercontent.com/SunnyQjm/anolisa/21aa69924500d565acdb04cdc292ef62ab63391e/01-failed-slash-panel.png) |
| Empty-prompt `Up` recalls the slash line (was: recalled the older shell command) | ![up recalls slash](https://raw.githubusercontent.com/SunnyQjm/anolisa/21aa69924500d565acdb04cdc292ef62ab63391e/02-up-recalls-slash.png) |
| Native line editing: `off` → `manual` | ![edited](https://raw.githubusercontent.com/SunnyQjm/anolisa/21aa69924500d565acdb04cdc292ef62ab63391e/03-edited-to-manual.png) |
| Retry succeeds (`Mode set to manual.`) | ![retry ok](https://raw.githubusercontent.com/SunnyQjm/anolisa/21aa69924500d565acdb04cdc292ef62ab63391e/04-retry-succeeded.png) |
| `history 4`: both slash lines recorded natively, no execution leak | ![history](https://raw.githubusercontent.com/SunnyQjm/anolisa/21aa69924500d565acdb04cdc292ef62ab63391e/05-native-history.png) |

Full session replay: [issue-1718-recall.gif](https://raw.githubusercontent.com/SunnyQjm/anolisa/21aa69924500d565acdb04cdc292ef62ab63391e/issue-1718-recall.gif) · [issue-1718-recall.cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/21aa69924500d565acdb04cdc292ef62ab63391e/issue-1718-recall.cast)

Note: isolated sessions (`COSH_SHELL_ISOLATED=1`, non-native) intentionally keep the Rust intercept path — routing admission requires a markered native session, so behavior there is unchanged by design.
