### PR TITLE
feat(cosh-ng): [core,shell] surface tool-argument status and cap retries

### DIFF
--- a/specs/cosh-ng-code-organization/large-file-inventory.md
+++ b/specs/cosh-ng-code-organization/large-file-inventory.md
@@ -29,7 +29,6 @@ new over-threshold file appears that is not listed here.
 | 1717 | `src/ui/agent_render/health.rs` | ui | Health banner rendering; pre-existing. Split per-severity renderers. |
 | 1628 | `src/diagnostics/health/collectors.rs` | diagnostics | Per-subsystem collectors; pre-existing. Split by collector family. |
 | 992 | `src/runtime/state.rs` | runtime | Central inline state; pre-existing. Extract per-domain state modules. |
-| 925 | `src/agent/heartbeat.rs` | agent | Heartbeat/status animation; pre-existing. Split timing from rendering. |
 | 912 | `src/evidence/output_policy.rs` | evidence | Output excerpt policy; pre-existing. Split bounding from classification. |
 | 906 | `src/adapter/fake.rs` | adapter | Test fake adapter; pre-existing. Split scripted-scenario builders. |
 | 944 | `src/ui/agent_render/approval.rs` | ui | Approval card rendering; action-row rendering extracted to `approval_actions.rs` (turn consent, #1773). Split per-card-kind renderers next. |

--- a/src/cosh-ng/crates/cosh-core/src/audit.rs
+++ b/src/cosh-ng/crates/cosh-core/src/audit.rs
@@ -522,6 +522,22 @@ impl CoreAuditRecorder {
         }
     }
 
+    /// Captured event types for one tool call, in emission order.
+    ///
+    /// Lets a test assert the per-call lifecycle rather than only that some event
+    /// of a type exists somewhere in the run.
+    #[cfg(test)]
+    pub(crate) fn captured_tool_event_types(&self, tool_use_id: &str) -> Vec<&str> {
+        match &self.sink {
+            CoreAuditSink::Capture(events) => events
+                .iter()
+                .filter(|event| event.identity.tool_use_id.as_deref() == Some(tool_use_id))
+                .map(|event| event.event_type.as_str())
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn captured_event_types(&self) -> Vec<&str> {
         match &self.sink {

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -28,8 +28,9 @@ use crate::tool::{ToolContext, ToolKind, ToolRegistry, ToolResult};
 use crate::truncator::OutputTruncator;
 
 use self::tool_execution::{
-    hash_bytes, hash_json, invalid_arguments_message, json_shape, parse_in_band_question,
-    parse_tool_arguments, InBandQuestion,
+    hash_bytes, hash_json, invalid_arguments_exhausted_error, invalid_arguments_message,
+    json_shape, parse_in_band_question, parse_tool_arguments, InBandQuestion,
+    InvalidArgumentStreak, MAX_INVALID_ARGUMENT_ATTEMPTS,
 };
 
 mod auth;
@@ -351,6 +352,10 @@ impl CoshCore {
         );
 
         let max_turns = self.config.agent.max_turns;
+        // Spans the whole message, not one turn: the model re-issues a rejected
+        // tool call on the *next* turn, so a per-turn counter would never see two
+        // attempts in a row.
+        let mut invalid_arguments = InvalidArgumentStreak::default();
 
         for _turn in 0..max_turns {
             // ─── Context preflight (every provider call, incl. tool loop) ───
@@ -843,9 +848,24 @@ impl CoshCore {
             };
 
             let mut interrupted = false;
+            // Set once a tool call ends the run. The error is returned only after
+            // this batch is fully answered.
+            let mut fatal_error: Option<String> = None;
 
             for tc in &tool_calls {
                 if tc.name.is_empty() {
+                    continue;
+                }
+
+                // Every id in the assistant message needs exactly one tool result,
+                // or the next provider request violates tool-message pairing — and
+                // headless persists and reuses the session even when a turn fails.
+                if fatal_error.is_some() {
+                    self.skip_unexecuted_tool_call(
+                        CoreAuditScope::tool(&run_id, &turn_id, &tc.id),
+                        writer,
+                        tc,
+                    );
                     continue;
                 }
 
@@ -899,11 +919,16 @@ impl CoshCore {
                     .record_tool_requested(tool_scope, &tc.name, &tool_data);
 
                 let params = match parsed_params {
-                    Ok(params) => params,
+                    Ok(params) => {
+                        invalid_arguments.clear();
+                        params
+                    }
                     Err(parse_error) => {
                         // Executing a tool with `null` parameters used to look like
                         // a call with every field absent; fail the call instead so
                         // the model can re-issue it.
+                        let attempt =
+                            invalid_arguments.record(&tc.name, parse_error.code(), &turn_id);
                         tracing::warn!(
                             provider_type = %resolved_provider.provider_type,
                             tool_call_id = %tc.id,
@@ -914,15 +939,37 @@ impl CoshCore {
                             argument_bytes = tc.arguments.len(),
                             json_parse_status = parse_error.json_parse_status(),
                             validation_error_code = parse_error.code(),
+                            attempt,
                             "rejected malformed tool arguments"
                         );
-                        self.reject_tool_arguments(
+                        let result = self.reject_tool_arguments(
                             tool_scope,
                             &tc.name,
                             &tc.id,
                             &tool_data,
-                            invalid_arguments_message(&tc.name, &parse_error),
+                            invalid_arguments_message(
+                                &tc.name,
+                                &parse_error,
+                                attempt,
+                                MAX_INVALID_ARGUMENT_ATTEMPTS,
+                            ),
                         );
+                        // Closes the pending tool in the UI before the run ends, so
+                        // the last thing on screen is the failure, not a tool that
+                        // looks like it is still generating arguments.
+                        self.emit_provider_native_tool_result(writer, &tc.id, &result);
+                        if attempt >= MAX_INVALID_ARGUMENT_ATTEMPTS {
+                            self.audit.record_turn_terminal(
+                                turn_scope,
+                                AuditOutcomeStatus::Failed,
+                                Some("invalid_tool_arguments_exhausted"),
+                            );
+                            // Recorded, not returned: the assistant message already
+                            // declared every call in this batch, and the loop must
+                            // still answer the rest before the run ends.
+                            fatal_error =
+                                Some(invalid_arguments_exhausted_error(&tc.name, &parse_error));
+                        }
                         continue;
                     }
                 };
@@ -1362,6 +1409,11 @@ impl CoshCore {
                     );
                     return Ok(());
                 }
+            }
+            // The turn was already audited as failed at the rejection; every call in
+            // the batch now has a result, so the run can end on a paired history.
+            if let Some(error) = fatal_error {
+                return Err(error);
             }
             self.audit
                 .record_turn_terminal(turn_scope, AuditOutcomeStatus::Success, None);

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -1648,6 +1648,225 @@ async fn thinking_delta_emits_stream_event() {
 }
 
 // ---------------------------------------------------------------------------
+// malformed tool arguments: visibility and retry budget
+// ---------------------------------------------------------------------------
+
+/// One turn calling `shell` with arguments that are terminated but unparseable.
+///
+/// Each turn uses a fresh id, as a real provider would: the retry budget must
+/// count the tool and the failure, not the call id.
+fn unparseable_shell_turn(call_id: &str) -> Vec<GenerateEvent> {
+    vec![
+        GenerateEvent::ToolCallStart {
+            index: 0,
+            id: call_id.to_string(),
+            name: "shell".to_string(),
+        },
+        GenerateEvent::ToolCallDelta {
+            index: 0,
+            arguments_delta: r#"{"command":"echo hello"#.to_string(),
+        },
+        GenerateEvent::ToolCallEnd { index: 0 },
+        GenerateEvent::MessageEnd,
+    ]
+}
+
+async fn run_shell_turns(turns: Vec<Vec<GenerateEvent>>) -> (Result<(), String>, String) {
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let tools = ToolRegistry::with_defaults_for_test();
+    let mut core = CoshCore::new(config, Box::new(MockProvider::new(turns)), tools);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    let result = core
+        .handle_user_message("write the file", &mut reader, &mut output)
+        .await;
+
+    (result, String::from_utf8(output).unwrap())
+}
+
+#[tokio::test]
+async fn rejected_tool_arguments_are_reported_to_the_shell_as_a_failed_tool() {
+    let (result, output) = run_shell_turns(vec![
+        unparseable_shell_turn("call-1"),
+        vec![
+            GenerateEvent::TextDelta("I will stop here.".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ])
+    .await;
+
+    result.expect("one rejection is recoverable");
+    // Without this the Shell keeps a pending tool on screen forever: the
+    // rejection only ever reached the model's context.
+    assert!(
+        output.contains(r#""type":"tool_result""#),
+        "the rejection must close the pending tool in the UI: {output}"
+    );
+    assert!(output.contains("attempt 1/3"), "{output}");
+    assert!(output.contains("code=invalid_json"), "{output}");
+    // The rejected payload can hold session content, so the result the user sees
+    // must describe the failure without quoting any of it.
+    let rejection = output
+        .lines()
+        .find(|line| line.contains(r#""type":"tool_result""#))
+        .expect("a tool result on the wire");
+    assert!(!rejection.contains("echo hello"), "{rejection}");
+}
+
+#[tokio::test]
+async fn three_consecutive_argument_rejections_stop_the_run() {
+    let (result, output) = run_shell_turns(vec![
+        unparseable_shell_turn("call-1"),
+        unparseable_shell_turn("call-2"),
+        unparseable_shell_turn("call-3"),
+        unparseable_shell_turn("call-4"),
+    ])
+    .await;
+
+    let error = result.expect_err("the run stops once the budget is spent");
+    assert!(error.contains("shell"), "{error}");
+    assert!(error.contains("code=invalid_json"), "{error}");
+    assert!(error.contains("never executed"), "{error}");
+
+    // The third rejection is still delivered, so the last thing on screen is a
+    // failed tool rather than one that looks like it is still generating.
+    assert!(output.contains("attempt 3/3"), "{output}");
+    assert_eq!(
+        output.matches(r#""type":"tool_result""#).count(),
+        3,
+        "exactly three attempts may be spent: {output}"
+    );
+    assert!(
+        !output.contains("call-4"),
+        "the fourth turn must never be requested: {output}"
+    );
+}
+
+/// The assistant message declares every call in the batch up front, so ending
+/// the run on the third rejection must not leave a later call unanswered:
+/// headless persists the session and reuses it for the next user message, and an
+/// unpaired `tool_use` id makes that request malformed.
+#[tokio::test]
+async fn stopping_on_exhaustion_still_answers_every_call_in_the_batch() {
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let tools = ToolRegistry::with_defaults_for_test();
+    let mut core = CoshCore::new(
+        config,
+        Box::new(MockProvider::new(vec![
+            unparseable_shell_turn("call-1"),
+            unparseable_shell_turn("call-2"),
+            // The fatal third rejection shares its message with a second call.
+            vec![
+                GenerateEvent::ToolCallStart {
+                    index: 0,
+                    id: "call-fatal".to_string(),
+                    name: "shell".to_string(),
+                },
+                GenerateEvent::ToolCallDelta {
+                    index: 0,
+                    arguments_delta: r#"{"command":"echo hello"#.to_string(),
+                },
+                GenerateEvent::ToolCallEnd { index: 0 },
+                GenerateEvent::ToolCallStart {
+                    index: 1,
+                    id: "call-trailing".to_string(),
+                    name: "shell".to_string(),
+                },
+                GenerateEvent::ToolCallDelta {
+                    index: 1,
+                    arguments_delta: r#"{"command":"echo trailing"}"#.to_string(),
+                },
+                GenerateEvent::ToolCallEnd { index: 1 },
+                GenerateEvent::MessageEnd,
+            ],
+        ])),
+        tools,
+    );
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("write the file", &mut reader, &mut output)
+        .await
+        .expect_err("the run stops once the budget is spent");
+
+    for call_id in ["call-1", "call-2", "call-fatal", "call-trailing"] {
+        let results = core
+            .messages
+            .iter()
+            .filter(|message| {
+                message.role == "tool" && message.tool_call_id.as_deref() == Some(call_id)
+            })
+            .count();
+        assert_eq!(results, 1, "{call_id} must have exactly one tool result");
+    }
+
+    // The trailing call was answered, not run: nothing may execute after the
+    // budget is spent.
+    let trailing = tool_result_text(&core, "call-trailing");
+    assert!(trailing.contains("was not executed"), "{trailing}");
+
+    // A skipped call is still part of the transcript, so it owes the audit trace
+    // one `tool.requested` and one terminal event like any other call — and it is
+    // counted, so the turn metrics do not under-report the failures.
+    assert_eq!(
+        core.audit.captured_tool_event_types("call-trailing"),
+        vec!["tool.requested", "tool.failed"]
+    );
+    assert_eq!(core.metrics.tool_calls_total, 4);
+    assert_eq!(core.metrics.tool_calls_fail, 4);
+    assert!(!core
+        .audit
+        .captured_tool_event_types("call-trailing")
+        .contains(&"tool.execution.started"));
+
+    // And the Shell was told, so its pending tool closes instead of hanging.
+    let output = String::from_utf8(output).unwrap();
+    let emitted = output
+        .lines()
+        .find(|line| line.contains(r#""tool_use_id":"call-trailing""#))
+        .expect("a tool result for the trailing call on the wire");
+    assert!(emitted.contains(r#""is_error":true"#), "{emitted}");
+    assert!(emitted.contains("was not executed"), "{emitted}");
+}
+
+#[tokio::test]
+async fn a_recovered_tool_call_clears_the_rejection_budget() {
+    let (result, output) = run_shell_turns(vec![
+        unparseable_shell_turn("call-1"),
+        unparseable_shell_turn("call-2"),
+        // The model recovers, which must forget the streak entirely...
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-good".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"command":"echo recovered"}"#.to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        // ...so this rejection is attempt 1 again, not the fatal third.
+        unparseable_shell_turn("call-3"),
+        vec![
+            GenerateEvent::TextDelta("Done.".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ])
+    .await;
+
+    result.expect("a recovered call in between keeps the run alive");
+    assert!(output.contains("attempt 1/3"), "{output}");
+    assert!(!output.contains("attempt 3/3"), "{output}");
+}
+
+// ---------------------------------------------------------------------------
 // ask_user_question argument validation
 // ---------------------------------------------------------------------------
 

--- a/src/cosh-ng/crates/cosh-core/src/core/tool_execution.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tool_execution.rs
@@ -161,17 +161,148 @@ pub(super) fn parse_tool_arguments(raw: &str) -> Result<serde_json::Value, Argum
     Ok(value)
 }
 
+/// How many times in a row one tool may have its arguments refused before the
+/// run is stopped.
+///
+/// Fixed rather than configurable: the budget exists to break a model that
+/// cannot produce parseable arguments, and a tunable would only let a session
+/// re-enter the loop this bound was added to end.
+pub(super) const MAX_INVALID_ARGUMENT_ATTEMPTS: u8 = 3;
+
+/// Consecutive pre-execution argument rejections within one user message.
+///
+/// Keyed by tool name and stable error code, not tool-call id: every retry is a
+/// fresh call with a fresh id, so ids would never match and the streak would
+/// never grow.
+#[derive(Debug, Default)]
+pub(super) struct InvalidArgumentStreak {
+    current: Option<(String, &'static str, String, u8)>,
+}
+
+impl InvalidArgumentStreak {
+    /// Count one rejected provider turn and return its 1-based attempt number.
+    ///
+    /// A different tool or a different error code starts a new streak at 1: the
+    /// model changing how it fails is progress, not another attempt at the same
+    /// failure. Multiple matching calls in one assistant message share an
+    /// attempt because they are a batch, not retries of one another.
+    pub(super) fn record(
+        &mut self,
+        tool_name: &str,
+        code: &'static str,
+        provider_turn_id: &str,
+    ) -> u8 {
+        match &mut self.current {
+            Some((name, current_code, counted_turn, count))
+                if name == tool_name
+                    && *current_code == code
+                    && counted_turn == provider_turn_id =>
+            {
+                *count
+            }
+            Some((name, current_code, counted_turn, count))
+                if name == tool_name && *current_code == code =>
+            {
+                *count = count.saturating_add(1);
+                *counted_turn = provider_turn_id.to_string();
+                *count
+            }
+            slot => {
+                *slot = Some((tool_name.to_string(), code, provider_turn_id.to_string(), 1));
+                1
+            }
+        }
+    }
+
+    /// Forget the streak once a tool call's arguments parsed.
+    pub(super) fn clear(&mut self) {
+        self.current = None;
+    }
+}
+
+/// Longest tool name kept in a message that reaches a terminal.
+const MAX_DISPLAY_TOOL_NAME_CHARS: usize = 64;
+
+/// A provider-supplied tool name, made safe to embed in a rendered message.
+///
+/// Mirrors cosh-shell's terminal-facing sanitizer because the Shell is a
+/// standalone crate; keep the filtering and length contract aligned in both.
+///
+/// The name is model output, not a validated identifier: an `` in the JSON
+/// arrives here as a real ESC byte and would reach the terminal as an escape
+/// sequence, and an unbounded name would flood the surface it is drawn on.
+pub(super) fn display_tool_name(tool_name: &str) -> String {
+    let mut safe: String = tool_name
+        .chars()
+        .filter(|character| {
+            !character.is_control() && !matches!(character, '\u{2028}' | '\u{2029}')
+        })
+        .take(MAX_DISPLAY_TOOL_NAME_CHARS)
+        .collect();
+    let trimmed = safe.trim();
+    if trimmed.is_empty() {
+        return "tool".to_string();
+    }
+    if trimmed.len() != safe.len() {
+        safe = trimmed.to_string();
+    }
+    if tool_name.chars().count() > MAX_DISPLAY_TOOL_NAME_CHARS {
+        safe.push('…');
+    }
+    safe
+}
+
 /// Tool-result text for a tool call whose arguments were refused.
 ///
 /// Carries no fragment of the rejected payload: malformed arguments can still
-/// contain session content.
-pub(super) fn invalid_arguments_message(tool_name: &str, error: &ArgumentError) -> String {
+/// contain session content. The attempt counter is included so the model — and
+/// the failure card the user sees — show how much budget is left.
+pub(super) fn invalid_arguments_message(
+    tool_name: &str,
+    error: &ArgumentError,
+    attempt: u8,
+    max_attempts: u8,
+) -> String {
+    let tool_name = display_tool_name(tool_name);
+    let next = if attempt >= max_attempts {
+        format!(
+            "The tool was not executed, and the run was stopped after {max_attempts} \
+             consecutive rejections."
+        )
+    } else {
+        "The tool was not executed; re-issue the call with one complete JSON object matching \
+         the declared schema."
+            .to_string()
+    };
     format!(
-        "{tool_name} arguments rejected [code={}]: {}. \
-         The tool was not executed; re-issue the call with one complete JSON object matching \
-         the declared schema.",
+        "{tool_name} arguments rejected [code={}] (attempt {attempt}/{max_attempts}): {}. {next}",
         error.code(),
         error.summary()
+    )
+}
+
+/// Run-terminating message for a tool that exhausted its rejection budget.
+///
+/// Names the tool and the stable code only, and states that nothing ran, so the
+/// user can act without seeing the payload.
+pub(super) fn invalid_arguments_exhausted_error(tool_name: &str, error: &ArgumentError) -> String {
+    format!(
+        "{} arguments were rejected {MAX_INVALID_ARGUMENT_ATTEMPTS} times in a row \
+         [code={}]; stopped this run. The tool never executed.",
+        display_tool_name(tool_name),
+        error.code()
+    )
+}
+
+/// Tool-result text for a call left unattempted because an earlier call in the
+/// same assistant message ended the run.
+///
+/// Exists so the batch stays paired: an unanswered `tool_use` id would make the
+/// next provider request malformed.
+pub(super) fn skipped_after_fatal_message(tool_name: &str) -> String {
+    format!(
+        "{} was not executed: an earlier tool call in the same message ended this run.",
+        display_tool_name(tool_name)
     )
 }
 
@@ -263,7 +394,10 @@ impl CoshCore {
                     validation_error_code: error.code(),
                     question_shape: report.question_shape,
                 });
-                self.reject_tool_arguments(
+                // The result is not emitted on the wire: the Shell never opened a
+                // pending tool for an incomplete question call, so a tool result
+                // would arrive for an id it does not know.
+                let _ = self.reject_tool_arguments(
                     scope,
                     &call.name,
                     &call.id,
@@ -304,11 +438,65 @@ impl CoshCore {
         }
     }
 
+    /// Audit data for a call refused before its arguments were ever parsed.
+    ///
+    /// Reports the payload as `unparsed` — the same shape a malformed payload
+    /// gets — because that is literally what happened: nothing inspected these
+    /// bytes. Hashing them still identifies the call in a trace without
+    /// recording session content.
+    fn unexecuted_tool_data(&self, tool_name: &str, arguments: &str) -> AuditToolData {
+        AuditToolData {
+            tool_kind: self
+                .tools
+                .get(tool_name)
+                .map(|tool| format!("{:?}", tool.kind()).to_ascii_lowercase())
+                .unwrap_or_else(|| "virtual".to_string()),
+            input_shape: Some("unparsed".to_string()),
+            input_hash: Some(hash_bytes(arguments.as_bytes())),
+            ..AuditToolData::default()
+        }
+    }
+
+    /// Fail a tool call the run never attempted, over its whole lifecycle.
+    ///
+    /// A skipped call is refused before the normal path builds any audit data, so
+    /// without this it would reach the provider history with no `tool.requested`,
+    /// no terminal event and no metrics — invisible in an audit trace even though
+    /// it is part of the transcript. The audit contract is one `tool.requested`
+    /// and one terminal event per call, including the ones that never ran.
+    pub(super) fn skip_unexecuted_tool_call<W: Write>(
+        &mut self,
+        scope: CoreAuditScope<'_>,
+        writer: &mut W,
+        call: &PendingToolCall,
+    ) -> ToolResult {
+        let tool_data = self.unexecuted_tool_data(&call.name, &call.arguments);
+        self.audit
+            .record_tool_requested(scope, &call.name, &tool_data);
+        let result = self.reject_tool_arguments(
+            scope,
+            &call.name,
+            &call.id,
+            &tool_data,
+            skipped_after_fatal_message(&call.name),
+        );
+        // The Shell never opened a pending tool for a question call, so a result
+        // for that id would be unroutable; every other tool has one to close.
+        if !(call.name == ask_user_question::TOOL_NAME && self.tools.supports_ask_user_question()) {
+            self.emit_provider_native_tool_result(writer, &call.id, &result);
+        }
+        result
+    }
+
     /// Fail a tool call whose arguments were rejected before execution.
     ///
     /// Audits the call as failed without a `tool.execution.started` record and
     /// appends an error tool result, so the model can re-issue a valid call
     /// instead of the run stalling on an unusable one.
+    ///
+    /// Returns that tool result so the caller can also emit it on the wire: the
+    /// Shell opened a pending tool for this call and only a tool result closes
+    /// it, otherwise a rejected call stays on screen as if it were still running.
     pub(super) fn reject_tool_arguments(
         &mut self,
         scope: CoreAuditScope<'_>,
@@ -316,7 +504,7 @@ impl CoshCore {
         tool_call_id: &str,
         tool_data: &AuditToolData,
         message: String,
-    ) {
+    ) -> ToolResult {
         self.note_tool_call_metrics(true, 0);
         let result = ToolResult::error(message);
         self.audit.record_tool_terminal(
@@ -332,6 +520,7 @@ impl CoshCore {
             &result.output,
             result.is_error,
         ));
+        result
     }
 
     /// Emit an interactive question and wait for the user's answer.

--- a/src/cosh-ng/crates/cosh-core/src/core/tool_execution/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tool_execution/tests.rs
@@ -110,15 +110,143 @@ fn parsed_arguments_that_are_not_an_object_are_rejected() {
 
 #[test]
 fn rejection_message_carries_a_code_and_no_payload() {
-    let malformed = invalid_arguments_message("shell", &ArgumentError::InvalidJson);
+    let malformed = invalid_arguments_message(
+        "shell",
+        &ArgumentError::InvalidJson,
+        1,
+        MAX_INVALID_ARGUMENT_ATTEMPTS,
+    );
     assert!(malformed.contains("code=invalid_json"), "{malformed}");
     assert!(malformed.contains("shell"), "{malformed}");
 
-    let wrong_root =
-        invalid_arguments_message("shell", &ArgumentError::RootNotObject { shape: "array" });
+    let wrong_root = invalid_arguments_message(
+        "shell",
+        &ArgumentError::RootNotObject { shape: "array" },
+        1,
+        MAX_INVALID_ARGUMENT_ATTEMPTS,
+    );
     assert!(
         wrong_root.contains("code=arguments_not_object"),
         "{wrong_root}"
     );
     assert!(wrong_root.contains("JSON array"), "{wrong_root}");
+}
+
+#[test]
+fn rejection_message_shows_the_attempt_and_stops_inviting_retries_at_the_limit() {
+    let retryable = invalid_arguments_message(
+        "write_file",
+        &ArgumentError::InvalidJson,
+        1,
+        MAX_INVALID_ARGUMENT_ATTEMPTS,
+    );
+    assert!(retryable.contains("attempt 1/3"), "{retryable}");
+    assert!(retryable.contains("re-issue the call"), "{retryable}");
+
+    let exhausted = invalid_arguments_message(
+        "write_file",
+        &ArgumentError::InvalidJson,
+        MAX_INVALID_ARGUMENT_ATTEMPTS,
+        MAX_INVALID_ARGUMENT_ATTEMPTS,
+    );
+    assert!(exhausted.contains("attempt 3/3"), "{exhausted}");
+    assert!(
+        !exhausted.contains("re-issue the call"),
+        "the budget is spent, so the model must not be told to try again: {exhausted}"
+    );
+    assert!(exhausted.contains("run was stopped"), "{exhausted}");
+}
+
+#[test]
+fn streak_counts_the_same_tool_and_code_and_resets_on_anything_else() {
+    let mut streak = InvalidArgumentStreak::default();
+
+    assert_eq!(streak.record("write_file", "invalid_json", "turn-1"), 1);
+    assert_eq!(streak.record("write_file", "invalid_json", "turn-2"), 2);
+
+    // A different error code from the same tool is a different failure.
+    assert_eq!(
+        streak.record("write_file", "arguments_not_object", "turn-3"),
+        1
+    );
+    // As is the same code from a different tool.
+    assert_eq!(streak.record("shell", "arguments_not_object", "turn-4"), 1);
+    assert_eq!(streak.record("shell", "arguments_not_object", "turn-5"), 2);
+
+    // A parseable call in between means the model recovered.
+    streak.clear();
+    assert_eq!(streak.record("shell", "arguments_not_object", "turn-6"), 1);
+}
+
+#[test]
+fn streak_reaches_the_limit_only_on_three_consecutive_identical_failures() {
+    let mut streak = InvalidArgumentStreak::default();
+
+    assert!(streak.record("write_file", "invalid_json", "turn-1") < MAX_INVALID_ARGUMENT_ATTEMPTS);
+    assert!(streak.record("write_file", "invalid_json", "turn-2") < MAX_INVALID_ARGUMENT_ATTEMPTS);
+    assert_eq!(
+        streak.record("write_file", "invalid_json", "turn-3"),
+        MAX_INVALID_ARGUMENT_ATTEMPTS
+    );
+}
+
+#[test]
+fn streak_counts_matching_calls_only_once_per_provider_turn() {
+    let mut streak = InvalidArgumentStreak::default();
+
+    assert_eq!(streak.record("write_file", "invalid_json", "turn-1"), 1);
+    assert_eq!(
+        streak.record("write_file", "invalid_json", "turn-1"),
+        1,
+        "parallel calls in one assistant message are not retries"
+    );
+    assert_eq!(streak.record("write_file", "invalid_json", "turn-2"), 2);
+}
+
+#[test]
+fn display_tool_name_strips_control_characters_and_bounds_length() {
+    // A provider name is model output: the escape would reach a terminal intact.
+    assert_eq!(
+        display_tool_name("write\u{1b}[2Jfile"),
+        "write[2Jfile",
+        "the ESC byte must be gone, leaving the body as inert text"
+    );
+    assert_eq!(display_tool_name("write\r\nfile"), "writefile");
+    assert_eq!(display_tool_name("a\u{2028}b"), "ab");
+    assert_eq!(display_tool_name("  spaced  "), "spaced");
+
+    // Nothing renderable left, and nothing at all, both need a stand-in.
+    assert_eq!(display_tool_name("\u{1b}\r\n"), "tool");
+    assert_eq!(display_tool_name(""), "tool");
+
+    let long = display_tool_name(&"n".repeat(200));
+    assert_eq!(long.chars().count(), 65, "{long}");
+    assert!(long.ends_with('…'), "truncation must be visible: {long}");
+}
+
+#[test]
+fn rejection_messages_use_the_safe_display_name() {
+    let message = invalid_arguments_message(
+        "write\u{1b}[2Jfile",
+        &ArgumentError::InvalidJson,
+        1,
+        MAX_INVALID_ARGUMENT_ATTEMPTS,
+    );
+    assert!(!message.contains('\u{1b}'), "{message}");
+
+    let exhausted =
+        invalid_arguments_exhausted_error("write\u{1b}[2Jfile", &ArgumentError::InvalidJson);
+    assert!(!exhausted.contains('\u{1b}'), "{exhausted}");
+
+    let skipped = skipped_after_fatal_message("write\u{1b}[2Jfile");
+    assert!(!skipped.contains('\u{1b}'), "{skipped}");
+    assert!(skipped.contains("was not executed"), "{skipped}");
+}
+
+#[test]
+fn exhausted_error_names_the_tool_and_code_without_the_payload() {
+    let error = invalid_arguments_exhausted_error("write_file", &ArgumentError::InvalidJson);
+    assert!(error.contains("write_file"), "{error}");
+    assert!(error.contains("code=invalid_json"), "{error}");
+    assert!(error.contains("never executed"), "{error}");
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use crate::types::AgentEvent;
+use crate::tools::display::display_tool_name;
+use crate::types::{AgentEvent, TOOL_ARGUMENTS_STATUS_PHASE, TOOL_ARGUMENTS_STATUS_PREFIX};
 
 use super::claude_stream_extract::{
     extract_claude_assistant_text, extract_claude_error_text, extract_claude_result_text,
@@ -91,8 +92,8 @@ impl ClaudeStreamParser {
             });
         } else if let Some(text) = extract_claude_stream_delta(&value) {
             self.push_stream_text_event(&mut events, text);
-        } else if let Some(tool_call) = self.extract_streaming_tool_call(&value) {
-            events.push(tool_call);
+        } else if let Some(streaming) = self.extract_streaming_tool_events(&value) {
+            events.extend(streaming);
         } else if self.contains_streaming_tool_snapshot(&value) {
             return events;
         } else if let Some(tool_call) = self.extract_tool_call(&value) {
@@ -203,7 +204,15 @@ impl ClaudeStreamParser {
             .any(|tool| self.is_streaming_tool_id(&tool.id))
     }
 
-    fn extract_streaming_tool_call(&mut self, value: &serde_json::Value) -> Option<AgentEvent> {
+    /// Handle one streaming tool-use block event.
+    ///
+    /// `None` means the value was not part of a tracked tool-use block, so the
+    /// caller keeps matching it against the other event shapes. `Some` — possibly
+    /// empty — means the block was consumed here.
+    fn extract_streaming_tool_events(
+        &mut self,
+        value: &serde_json::Value,
+    ) -> Option<Vec<AgentEvent>> {
         let event = value.get("event")?;
         match event.get("type").and_then(|value| value.as_str()) {
             Some("content_block_start") => {
@@ -226,6 +235,16 @@ impl ClaudeStreamParser {
                     .get("input")
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
+                // Arguments arrive as a long delta stream with no declared total
+                // length, so the only honest progress signal is the tool name.
+                // Byte counts and the partial JSON itself stay out of the status:
+                // a percentage would be invented, and the payload can hold paths
+                // and file contents.
+                let status = AgentEvent::StatusChanged {
+                    run_id: self.run_id.clone(),
+                    phase: TOOL_ARGUMENTS_STATUS_PHASE.to_string(),
+                    message: format!("{TOOL_ARGUMENTS_STATUS_PREFIX}{}", display_tool_name(&name)),
+                };
                 self.streaming_tool_uses.insert(
                     index,
                     StreamingClaudeToolUse {
@@ -235,7 +254,7 @@ impl ClaudeStreamParser {
                         input_json: String::new(),
                     },
                 );
-                None
+                Some(vec![status])
             }
             Some("content_block_delta") => {
                 let index = event.get("index").and_then(|value| value.as_u64())? as usize;
@@ -243,15 +262,20 @@ impl ClaudeStreamParser {
                     .pointer("/delta/partial_json")
                     .and_then(|value| value.as_str())
                     .unwrap_or("");
-                if let Some(tool) = self.streaming_tool_uses.get_mut(&index) {
-                    tool.input_json.push_str(partial_json);
-                }
-                None
+                // Deltas accumulate in memory only: one UI event per delta would be
+                // a refresh storm — a single call streams over a thousand of them.
+                let tool = self.streaming_tool_uses.get_mut(&index)?;
+                tool.input_json.push_str(partial_json);
+                Some(Vec::new())
             }
             Some("content_block_stop") => {
                 let index = event.get("index").and_then(|value| value.as_u64())? as usize;
                 let tool = self.streaming_tool_uses.remove(&index)?;
-                self.event_from_tool_use(tool.into_tool_use())
+                Some(
+                    self.event_from_tool_use(tool.into_tool_use())
+                        .into_iter()
+                        .collect(),
+                )
             }
             _ => None,
         }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream_tests.rs
@@ -4,6 +4,20 @@ use crate::types::{AgentEvent, QuestionSelectionMode};
 
 use super::claude_stream::ClaudeStreamParser;
 
+/// Assert that a tool-use block start produced only the argument-generation
+/// status for `tool`, so the caller can keep asserting on later events alone.
+#[track_caller]
+fn assert_tool_arguments_status(events: &[AgentEvent], tool: &str) {
+    assert!(
+        matches!(
+            events,
+            [AgentEvent::StatusChanged { phase, message, .. }]
+                if phase == "tool_arguments" && message == &format!("generating tool arguments: {tool}")
+        ),
+        "expected only an argument-generation status for {tool}, got {events:?}"
+    );
+}
+
 #[test]
 fn claude_stream_parser_extracts_partial_text_and_completion() {
     let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
@@ -185,11 +199,12 @@ fn claude_stream_parser_extracts_tool_use_and_session_id() {
 fn claude_stream_parser_extracts_streaming_bash_tool_use() {
     let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
 
-    assert!(parser
-        .parse_line(
+    assert_tool_arguments_status(
+        &parser.parse_line(
             r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_stream","name":"Bash","input":{}}}}"#
-        )
-        .is_empty());
+        ),
+        "Bash",
+    );
     assert!(parser
         .parse_line(
             r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"pwd\"}"}}}"#
@@ -202,6 +217,99 @@ fn claude_stream_parser_extracts_streaming_bash_tool_use() {
         &events[..],
         [AgentEvent::ToolCall { name, input, .. }] if name == "Bash" && input == "pwd"
     ));
+}
+
+#[test]
+fn streamed_tool_arguments_report_progress_without_leaking_the_payload() {
+    let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
+
+    let start = parser.parse_line(
+        r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_big","name":"write_file","input":{}}}}"#,
+    );
+
+    let [AgentEvent::StatusChanged { phase, message, .. }] = &start[..] else {
+        panic!("expected one status event, got {start:?}");
+    };
+    assert_eq!(phase, "tool_arguments");
+    assert_eq!(message, "generating tool arguments: write_file");
+
+    // A thousand deltas would be a refresh storm, so none of them may produce an
+    // event; and no status may carry the path or the file body they contain.
+    for chunk in [
+        r#"{"path":"/etc/secret.conf","#,
+        r#""content":"TOKEN=hunter2"#,
+        r#"UNTERMINATED"#,
+    ] {
+        let line = serde_json::json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": chunk}
+            }
+        })
+        .to_string();
+        assert!(
+            parser.parse_line(&line).is_empty(),
+            "argument delta {chunk:?} must not produce a UI event"
+        );
+    }
+
+    let rendered = format!("{start:?}");
+    assert!(!rendered.contains("/etc/secret.conf"), "{rendered}");
+    assert!(!rendered.contains("hunter2"), "{rendered}");
+}
+
+#[test]
+fn streamed_tool_argument_status_neutralizes_a_hostile_tool_name() {
+    let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
+
+    // The name is model output. A `\u001b` on the wire deserializes to a real ESC
+    // byte, and the status animation writes its label straight to the terminal.
+    let line = serde_json::json!({
+        "type": "stream_event",
+        "event": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_evil",
+                "name": "write\u{1b}[2J\r\nfile"
+            }
+        }
+    })
+    .to_string();
+    let events = parser.parse_line(&line);
+
+    let [AgentEvent::StatusChanged { message, .. }] = &events[..] else {
+        panic!("expected one status event, got {events:?}");
+    };
+    assert!(!message.contains('\u{1b}'), "{message:?}");
+    assert!(!message.contains('\r'), "{message:?}");
+    assert!(!message.contains('\n'), "{message:?}");
+    // The escape body survives as inert text; only the ESC that armed it is gone.
+    assert_eq!(message, "generating tool arguments: write[2Jfile");
+
+    let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
+    let line = serde_json::json!({
+        "type": "stream_event",
+        "event": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "tool_use", "id": "toolu_long", "name": "n".repeat(4096)}
+        }
+    })
+    .to_string();
+    let events = parser.parse_line(&line);
+
+    let [AgentEvent::StatusChanged { message, .. }] = &events[..] else {
+        panic!("expected one status event, got {events:?}");
+    };
+    assert!(
+        message.chars().count() < 120,
+        "one status line must not flood the surface: {}",
+        message.chars().count()
+    );
 }
 
 #[test]
@@ -219,11 +327,12 @@ fn claude_stream_parser_keeps_text_delta_streaming_before_streamed_tool_use() {
         &text_events[..],
         [AgentEvent::TextDelta { text, .. }] if text == "PRE TOOL TEXT"
     ));
-    assert!(parser
-        .parse_line(
+    assert_tool_arguments_status(
+        &parser.parse_line(
             r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_stream","name":"Bash","input":{}}}}"#
-        )
-        .is_empty());
+        ),
+        "Bash",
+    );
     assert!(parser
         .parse_line(
             r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"pwd\"}"}}}"#
@@ -255,11 +364,12 @@ fn claude_stream_parser_deduplicates_streamed_final_snapshot_after_tool() {
         )[..],
         [AgentEvent::TextDelta { text, .. }] if text == "PRE"
     ));
-    assert!(parser
-        .parse_line(
+    assert_tool_arguments_status(
+        &parser.parse_line(
             r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_stream","name":"Bash","input":{}}}}"#
-        )
-        .is_empty());
+        ),
+        "Bash",
+    );
     assert!(parser
         .parse_line(
             r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"pwd\"}"}}}"#
@@ -491,7 +601,7 @@ fn claude_stream_parser_waits_for_streamed_question_input_json() {
     let start_events = parser.parse_line(
         r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}}}"#,
     );
-    assert!(start_events.is_empty());
+    assert_tool_arguments_status(&start_events, "AskUserQuestion");
 
     let delta_events = parser.parse_line(
         r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"questions\":[{\"question\":\"你喜欢什么颜色？\",\"header\":\"颜色\",\"options\":[{\"label\":\"白色\"},{\"label\":\"黑色\"}],\"multiSelect\":false}]}"}}}"#,
@@ -520,11 +630,12 @@ fn claude_stream_parser_waits_for_streamed_question_input_json() {
 fn claude_stream_parser_accumulates_fragmented_question_input_json() {
     let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
 
-    assert!(parser
-        .parse_line(
-            r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}}}"#,
-        )
-        .is_empty());
+    assert_tool_arguments_status(
+        &parser.parse_line(
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}}}"#
+        ),
+        "AskUserQuestion",
+    );
 
     for partial_json in [
         r#"{"questions":[{"#,
@@ -578,11 +689,12 @@ fn claude_stream_parser_accumulates_fragmented_question_input_json() {
 fn claude_stream_parser_deduplicates_streamed_and_snapshot_tool_use() {
     let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
 
-    assert!(parser
-        .parse_line(
-            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}}}"#,
-        )
-        .is_empty());
+    assert_tool_arguments_status(
+        &parser.parse_line(
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}}}"#
+        ),
+        "AskUserQuestion",
+    );
     assert!(parser
         .parse_line(
             r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"questions\":[{\"question\":\"Pick\",\"header\":\"Pick\",\"options\":[{\"label\":\"A\"},{\"label\":\"B\"}],\"multiSelect\":false}]}"}}}"#,
@@ -615,11 +727,12 @@ fn claude_stream_parser_deduplicates_streamed_and_snapshot_tool_use() {
 fn claude_stream_parser_ignores_incomplete_snapshot_for_streaming_question() {
     let mut parser = ClaudeStreamParser::new("run-1".to_string(), None);
 
-    assert!(parser
-        .parse_line(
-            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}}}"#,
-        )
-        .is_empty());
+    assert_tool_arguments_status(
+        &parser.parse_line(
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}}}"#
+        ),
+        "AskUserQuestion",
+    );
 
     let snapshot_events = parser.parse_line(
         r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Agent needs your input"},{"type":"tool_use","id":"tool-ask","name":"AskUserQuestion","input":{}}]}}"#,

--- a/src/cosh-ng/crates/cosh-shell/src/agent/events/classification.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/events/classification.rs
@@ -1,6 +1,7 @@
 //! Classification helpers for structured Agent event rendering.
 
 use crate::runtime::prelude::*;
+use crate::types::TOOL_ARGUMENTS_STATUS_PHASE;
 
 pub(super) fn is_interaction_governed_event(event: &GovernedEvent) -> bool {
     matches!(
@@ -22,7 +23,14 @@ pub(super) fn event_may_render_structured_surface(event: &GovernedEvent) -> bool
 }
 
 pub(super) fn event_updates_pending_tool_status(event: &GovernedEvent) -> bool {
+    // Argument generation is included even though no tool call exists yet: it is
+    // the window the status was added for, and rendering it here is what ends a
+    // streamed-text surface so the status is not swallowed by it.
     matches!(event.event, AgentEvent::ToolCall { .. })
+        || matches!(
+            &event.event,
+            AgentEvent::StatusChanged { phase, .. } if phase == TOOL_ARGUMENTS_STATUS_PHASE
+        )
 }
 
 pub(super) fn should_render_governance_block(event: &GovernedEvent) -> bool {

--- a/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat.rs
@@ -2,6 +2,8 @@ use std::time::{Duration, Instant};
 
 use crate::agent::run::ActiveAgentRun;
 use crate::runtime::prelude::*;
+use crate::tools::display::display_tool_name;
+use crate::types::{TOOL_ARGUMENTS_STATUS_PHASE, TOOL_ARGUMENTS_STATUS_PREFIX};
 
 use super::display::display_agent_error;
 #[cfg(test)]
@@ -24,7 +26,7 @@ pub(crate) fn render_agent_heartbeat<W: Write>(
         return Ok(());
     }
 
-    let pending_tools = pending_tool_status_detail_for_run(active_run);
+    let pending_tools = status_detail_for_run(active_run);
     if active_run.markdown_stream.has_started() {
         return Ok(());
     }
@@ -68,7 +70,7 @@ pub(crate) fn render_agent_heartbeat<W: Write>(
 
     active_run.last_heartbeat_at = now;
     let elapsed = now.duration_since(active_run.started_at).as_secs_f32();
-    let pending_tools = pending_tool_status_detail_for_run(active_run);
+    let pending_tools = status_detail_for_run(active_run);
     let detail = if let Some(pending_tools) = pending_tools.as_deref() {
         pending_tools
     } else if active_run.current_message.is_empty() {
@@ -117,11 +119,33 @@ fn status_detail_is_generic_thinking(detail: &str, language: Language) -> bool {
     }
 }
 
+/// The status detail the heartbeat should show, if any.
+///
+/// Falls back to the tool-argument generation status: that window has no pending
+/// tool yet — the call only exists once its arguments finish — so without this it
+/// loses to streamed text and to the "no detail" path, leaving the blank Agent
+/// card this status was added to replace.
+fn status_detail_for_run(active_run: &ActiveAgentRun) -> Option<String> {
+    pending_tool_status_detail_for_run(active_run)
+        .or_else(|| tool_argument_status_detail(active_run))
+}
+
+fn tool_argument_status_detail(active_run: &ActiveAgentRun) -> Option<String> {
+    let i18n = I18n::new(active_run.language);
+    // The phase is the localized label `display_status_changed` produced for the
+    // `tool_arguments` wire phase, and every other event overwrites it — so it
+    // marks exactly the window between block start and a complete tool call.
+    if active_run.current_phase != i18n.t(MessageId::AgentStatusToolArguments) {
+        return None;
+    }
+    Some(active_run.current_message.clone()).filter(|message| !message.is_empty())
+}
+
 pub(crate) fn render_agent_pending_tool_status<W: Write>(
     active_run: &mut ActiveAgentRun,
     output: &mut W,
 ) -> std::io::Result<()> {
-    let Some(status_detail) = pending_tool_status_detail_for_run(active_run) else {
+    let Some(status_detail) = status_detail_for_run(active_run) else {
         return Ok(());
     };
     if active_run.markdown_stream.has_started() || active_run.markdown_stream.has_buffered_text() {
@@ -288,6 +312,8 @@ fn display_question_text(question: &str, i18n: &I18n) -> String {
 fn display_status_changed(phase: &str, message: &str, i18n: &I18n) -> (String, String) {
     let phase = if phase == "thinking" {
         i18n.t(MessageId::AgentStatusThinking).to_string()
+    } else if phase == TOOL_ARGUMENTS_STATUS_PHASE {
+        i18n.t(MessageId::AgentStatusToolArguments).to_string()
     } else {
         phase.to_string()
     };
@@ -308,6 +334,15 @@ fn display_status_message(message: &str, i18n: &I18n) -> String {
         return i18n
             .t(MessageId::AgentStatusStartingModelBackend)
             .to_string();
+    }
+    // Carries the tool name only — the marker is emitted before any argument
+    // byte is parsed, so there is nothing else safe to show.
+    if let Some(tool) = message.strip_prefix(TOOL_ARGUMENTS_STATUS_PREFIX) {
+        // Re-sanitized here because this is the boundary that reaches a terminal.
+        return i18n.format(
+            MessageId::AgentStatusGeneratingToolArguments,
+            &[("tool", &display_tool_name(tool))],
+        );
     }
     if let Some(model) = message.strip_prefix("model initialized ") {
         return i18n.format(MessageId::AgentStatusModelInitialized, &[("model", model)]);
@@ -341,589 +376,5 @@ fn display_agent_summary(summary: &str, i18n: &I18n) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_active_run() -> ActiveAgentRun {
-        let request = AgentRequest {
-            id: "request-1".to_string(),
-            session_id: "session-1".to_string(),
-            command_block: CommandBlock {
-                id: "cmd-1".to_string(),
-                session_id: "session-1".to_string(),
-                command: "hello".to_string(),
-                origin: Default::default(),
-                cwd: "/tmp".to_string(),
-                end_cwd: "/tmp".to_string(),
-                started_at_ms: 1,
-                ended_at_ms: 2,
-                duration_ms: 1,
-                exit_code: 0,
-                status: CommandStatus::Completed,
-                output: OutputRefs {
-                    terminal_output_ref: None,
-                    terminal_output_bytes: 0,
-                },
-                shell_environment_generation: None,
-                audit_identity: None,
-            },
-            context_blocks: Vec::new(),
-            context_hints: Vec::new(),
-            user_input: Some("hello".to_string()),
-            findings: Vec::new(),
-            mode: AgentMode::RecommendOnly,
-            user_confirmed: true,
-            hook_finding: None,
-            recommended_skill: None,
-        };
-        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
-        let handle = adapter.start_cancellable(request.clone(), CoshApprovalMode::Recommend);
-        let renderer = RatatuiInlineRenderer::for_terminal();
-        ActiveAgentRun {
-            request,
-            origin: AgentRunOrigin::Standard,
-            handle,
-            provider_name: "fake",
-            language: Language::EnUs,
-            renderer: renderer.clone(),
-            status_animation: renderer.status_animation(),
-            markdown_stream: renderer.stream_markdown_agent(),
-            governed_events: Vec::new(),
-            deferred_events: Vec::new(),
-            held_events: Vec::new(),
-            cosh_request_filter: crate::evidence::stream::CoshRequestStreamFilter::default(),
-            pending_cosh_requests: Vec::new(),
-            pending_cosh_request_audits: Vec::new(),
-            rendered_governed_event_count: 0,
-            selectable_after_event_index: None,
-            started_at: Instant::now(),
-            last_activity_at: Instant::now(),
-            last_heartbeat_at: Instant::now(),
-            current_phase: String::new(),
-            current_message: String::new(),
-            has_visible_text_delta: false,
-            completed: false,
-            host_completed_tool_ids: Vec::new(),
-            pending_hook_notifications: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn tool_call_activity_is_not_reported_as_waiting_for_approval() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        remember_agent_activity(
-            &mut active_run,
-            &[GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-                event: AgentEvent::ToolCall {
-                    run_id: "run-1".to_string(),
-                    tool_id: Some("tool-1".to_string()),
-                    name: "glob".to_string(),
-                    input: r#"{"pattern":"**/README.md"}"#.to_string(),
-                },
-                reason: "provider tool call visible".to_string(),
-                display_text: "provider tool call visible".to_string(),
-                auto_execute: false,
-            }],
-        );
-
-        assert_eq!(active_run.current_phase, "tool");
-        assert!(active_run.current_message.contains("正在查找文件 1 项"));
-        assert!(!active_run.current_message.contains("approval"));
-        assert!(!active_run.current_message.contains("README.md"));
-    }
-
-    #[test]
-    fn pending_tool_status_aggregates_by_kind_and_removes_completed_tool() {
-        let events = vec![
-            GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::ToolCall {
-                    run_id: "run-1".to_string(),
-                    tool_id: Some("read-1".to_string()),
-                    name: "Read".to_string(),
-                    input: r#"{"file_path":"/very/long/private/path/a.md"}"#.to_string(),
-                },
-                reason: "read".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            },
-            GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::ToolCall {
-                    run_id: "run-1".to_string(),
-                    tool_id: Some("read-2".to_string()),
-                    name: "Read".to_string(),
-                    input: r#"{"file_path":"/very/long/private/path/b.md"}"#.to_string(),
-                },
-                reason: "read".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            },
-            GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::ToolCall {
-                    run_id: "run-1".to_string(),
-                    tool_id: Some("grep-1".to_string()),
-                    name: "Grep".to_string(),
-                    input: r#"{"path":"src","query":"needle"}"#.to_string(),
-                },
-                reason: "grep".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            },
-        ];
-
-        let summary =
-            pending_tool_status_detail(Language::ZhCn, events.iter()).expect("pending summary");
-        assert!(summary.contains("正在读取 2 个文件"), "{summary}");
-        assert!(summary.contains("正在搜索 1 项"), "{summary}");
-        assert!(!summary.contains("private"), "{summary}");
-        assert!(!summary.contains("needle"), "{summary}");
-
-        let mut completed_events = events;
-        completed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCompleted {
-                run_id: "run-1".to_string(),
-                tool_id: "read-1".to_string(),
-                status: "success".to_string(),
-            },
-            reason: "done".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-
-        let summary = pending_tool_status_detail(Language::ZhCn, completed_events.iter())
-            .expect("pending summary");
-        assert!(summary.contains("正在读取 1 个文件"), "{summary}");
-        assert!(summary.contains("正在搜索 1 项"), "{summary}");
-
-        completed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCompleted {
-                run_id: "run-1".to_string(),
-                tool_id: "read-2".to_string(),
-                status: "success".to_string(),
-            },
-            reason: "done".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-        completed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCompleted {
-                run_id: "run-1".to_string(),
-                tool_id: "grep-1".to_string(),
-                status: "success".to_string(),
-            },
-            reason: "done".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-
-        assert!(pending_tool_status_detail(Language::ZhCn, completed_events.iter()).is_none());
-    }
-
-    #[test]
-    fn pending_tool_status_finishes_open_agent_response() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        let renderer = RatatuiInlineRenderer::with_width(100);
-        active_run.renderer = renderer.clone();
-        active_run.status_animation = renderer.status_animation();
-        active_run.markdown_stream = renderer.stream_markdown_agent();
-        let mut output = Vec::new();
-
-        active_run
-            .markdown_stream
-            .write_delta(&mut output, "Agent text before tool.\n\n")
-            .expect("write agent text");
-        active_run.has_visible_text_delta = true;
-        active_run.governed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: Some("read-1".to_string()),
-                name: "Read".to_string(),
-                input: r#"{"file_path":"Cargo.toml"}"#.to_string(),
-            },
-            reason: "read".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-
-        render_agent_pending_tool_status(&mut active_run, &mut output).expect("render status");
-        let output = String::from_utf8(output).expect("utf8 output");
-
-        assert!(!active_run.markdown_stream.has_started());
-        assert!(output.contains("正在读取 1 个文件"), "{output}");
-        assert!(output.contains('╰'), "{output}");
-    }
-
-    #[test]
-    fn pending_tool_status_flushes_buffered_agent_response() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        let renderer = RatatuiInlineRenderer::with_width(100);
-        active_run.renderer = renderer.clone();
-        active_run.status_animation = renderer.status_animation();
-        active_run.markdown_stream = renderer.stream_markdown_agent();
-        let mut output = Vec::new();
-
-        active_run
-            .markdown_stream
-            .write_delta(&mut output, "Agent text before tool")
-            .expect("write buffered agent text");
-        active_run.has_visible_text_delta = true;
-        assert!(!active_run.markdown_stream.has_started());
-        assert!(active_run.markdown_stream.has_buffered_text());
-        active_run.governed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: Some("write-1".to_string()),
-                name: "Write".to_string(),
-                input: r#"{"file_path":"snake.py"}"#.to_string(),
-            },
-            reason: "write".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-
-        render_agent_pending_tool_status(&mut active_run, &mut output).expect("render status");
-        let output = String::from_utf8(output).expect("utf8 output");
-
-        assert!(!active_run.markdown_stream.has_started());
-        assert!(!active_run.markdown_stream.has_buffered_text());
-        assert!(output.contains("Agent text before tool"), "{output}");
-        assert!(output.contains("正在写入 1 项"), "{output}");
-        assert!(output.contains('╰'), "{output}");
-    }
-
-    #[test]
-    fn shell_evidence_pending_status_finishes_open_agent_response() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        let renderer = RatatuiInlineRenderer::with_width(100).with_language(Language::ZhCn);
-        active_run.markdown_stream = renderer.stream_markdown_agent();
-        let mut output = Vec::new();
-
-        active_run
-            .markdown_stream
-            .write_delta(&mut output, "先看一下证据。\n\n")
-            .expect("write agent text");
-        active_run.has_visible_text_delta = true;
-        render_agent_shell_evidence_pending_status(&mut active_run, &mut output)
-            .expect("render shell evidence status");
-        let output = String::from_utf8(output).expect("utf8 output");
-
-        assert!(!active_run.markdown_stream.has_started());
-        assert!(output.contains("Shell 证据 1 项"), "{output}");
-        assert!(output.contains('╰'), "{output}");
-    }
-
-    #[test]
-    fn host_completed_shell_tools_are_removed_from_pending_status() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        active_run.governed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: Some("shell-1".to_string()),
-                name: "Bash".to_string(),
-                input: r#"{"command":"echo one"}"#.to_string(),
-            },
-            reason: "shell".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-        active_run.mark_host_completed_tool("shell-1");
-        active_run.governed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: Some("shell-2".to_string()),
-                name: "Bash".to_string(),
-                input: r#"{"command":"echo two"}"#.to_string(),
-            },
-            reason: "shell".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-
-        let summary = pending_tool_status_detail_for_run(&active_run).expect("pending shell");
-        assert!(summary.contains("正在执行 Shell 1 项"), "{summary}");
-        assert!(!summary.contains("2 项"), "{summary}");
-
-        active_run.mark_host_completed_tool("shell-2");
-        active_run.governed_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: Some("shell-3".to_string()),
-                name: "Bash".to_string(),
-                input: r#"{"command":"echo three"}"#.to_string(),
-            },
-            reason: "shell".to_string(),
-            display_text: String::new(),
-            auto_execute: false,
-        });
-
-        let summary = pending_tool_status_detail_for_run(&active_run).expect("pending shell");
-        assert!(summary.contains("正在执行 Shell 1 项"), "{summary}");
-        assert!(!summary.contains("3 项"), "{summary}");
-    }
-
-    #[test]
-    fn pending_tool_status_deduplicates_matching_permission_request() {
-        let events = [
-            GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::ToolCall {
-                    run_id: "run-1".to_string(),
-                    tool_id: Some("toolu-write".to_string()),
-                    name: "Write".to_string(),
-                    input: r#"{"file_path":"/tmp/report.md","content":"secret body"}"#.to_string(),
-                },
-                reason: "write".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            },
-            GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-                event: AgentEvent::ToolPermissionRequest {
-                    run_id: "run-1".to_string(),
-                    request_id: "ctrl-write".to_string(),
-                    tool_name: "Write".to_string(),
-                    tool_input: serde_json::json!({
-                        "file_path": "/tmp/report.md",
-                        "content": "secret body"
-                    }),
-                    tool_use_id: "toolu-write".to_string(),
-                    hook_requires_approval: false,
-                    audit_ref: None,
-                },
-                reason: "approval".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            },
-        ];
-
-        let summary =
-            pending_tool_status_detail(Language::ZhCn, events.iter()).expect("pending summary");
-        assert!(summary.contains("正在写入 1 项"), "{summary}");
-        assert!(!summary.contains("正在写入 2 项"), "{summary}");
-        assert!(!summary.contains("secret body"), "{summary}");
-        assert!(!summary.contains("/tmp/report.md"), "{summary}");
-    }
-
-    #[test]
-    fn pending_tool_status_uses_request_id_when_tool_use_id_is_empty() {
-        let events = [
-            GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-                event: AgentEvent::ToolPermissionRequest {
-                    run_id: "run-1".to_string(),
-                    request_id: "ctrl-read-1".to_string(),
-                    tool_name: "Read".to_string(),
-                    tool_input: serde_json::json!({ "file_path": "a.md" }),
-                    tool_use_id: String::new(),
-                    hook_requires_approval: false,
-                    audit_ref: None,
-                },
-                reason: "approval".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            },
-            GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-                event: AgentEvent::ToolPermissionRequest {
-                    run_id: "run-1".to_string(),
-                    request_id: "ctrl-read-2".to_string(),
-                    tool_name: "Read".to_string(),
-                    tool_input: serde_json::json!({ "file_path": "b.md" }),
-                    tool_use_id: String::new(),
-                    hook_requires_approval: false,
-                    audit_ref: None,
-                },
-                reason: "approval".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            },
-        ];
-
-        let summary =
-            pending_tool_status_detail(Language::ZhCn, events.iter()).expect("pending summary");
-        assert!(summary.contains("正在读取 2 个文件"), "{summary}");
-        assert!(!summary.contains("ctrl-read"), "{summary}");
-    }
-
-    #[test]
-    fn question_activity_localizes_empty_question_fallback() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        remember_agent_activity(
-            &mut active_run,
-            &[GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::UserQuestion {
-                    run_id: "run-1".to_string(),
-                    provider_request_id: None,
-                    question: String::new(),
-                    options: Vec::new(),
-                    allow_free_text: true,
-                    selection_mode: QuestionSelectionMode::Single,
-                },
-                reason: "agent question requires explicit user input".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            }],
-        );
-
-        assert_eq!(active_run.current_phase, "问题");
-        assert!(active_run.current_message.contains("Agent 需要你的输入"));
-        assert!(!active_run
-            .current_message
-            .contains("Agent needs your input"));
-    }
-
-    #[test]
-    fn provider_status_activity_localizes_neutral_tokens() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        remember_agent_activity(
-            &mut active_run,
-            &[GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::StatusChanged {
-                    run_id: "run-1".to_string(),
-                    phase: "thinking".to_string(),
-                    message: "thinking".to_string(),
-                },
-                reason: "agent status is display-only".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            }],
-        );
-
-        assert_eq!(active_run.current_phase, "正在思考");
-        assert_eq!(active_run.current_message, "正在思考");
-    }
-
-    #[test]
-    fn elapsed_heartbeat_does_not_repeat_generic_thinking_detail() {
-        let zh = I18n::new(Language::ZhCn);
-        assert_eq!(
-            elapsed_thinking_text(&zh, Language::ZhCn, 7, "正在思考"),
-            "正在思考... 7s"
-        );
-        assert_eq!(
-            elapsed_thinking_text(&zh, Language::ZhCn, 7, "正在读取 1 个文件"),
-            "正在思考... 7s · 正在读取 1 个文件"
-        );
-
-        let en = I18n::new(Language::EnUs);
-        assert_eq!(
-            elapsed_thinking_text(&en, Language::EnUs, 7, "thinking"),
-            "Thinking... 7s"
-        );
-    }
-
-    #[test]
-    fn shell_evidence_activity_uses_concise_tool_status() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        remember_agent_activity(
-            &mut active_run,
-            &[GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::ShellEvidenceRequest {
-                    run_id: "run-1".to_string(),
-                    request_id: "evidence-1".to_string(),
-                    tool_use_id: "toolu-evidence".to_string(),
-                    action: crate::adapter::ShellEvidenceAction::ListCommands {
-                        limit: 5,
-                        cursor: None,
-                    },
-                },
-                reason: "shell evidence".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            }],
-        );
-
-        assert_eq!(active_run.current_phase, "tool");
-        assert_eq!(active_run.current_message, "正在处理 Shell 证据 1 项");
-        assert!(!active_run.current_message.contains("list_commands"));
-        assert!(!active_run.current_message.contains("toolu-evidence"));
-    }
-
-    #[test]
-    fn agent_completion_activity_localizes_neutral_summary() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        remember_agent_activity(
-            &mut active_run,
-            &[GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::AgentCompleted {
-                    run_id: "run-1".to_string(),
-                    summary: "analysis completed".to_string(),
-                },
-                reason: "agent completion is display-only".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            }],
-        );
-
-        assert_eq!(active_run.current_phase, "已完成");
-        assert_eq!(active_run.current_message, "分析完成");
-    }
-
-    #[test]
-    fn provider_startup_activity_hides_adapter_name_in_zh() {
-        let mut active_run = test_active_run();
-        active_run.language = Language::ZhCn;
-        remember_agent_activity(
-            &mut active_run,
-            &[GovernedEvent {
-                decision: GovernanceDecision::Display,
-                policy_decision: GovernancePolicyDecision::DisplayOnly,
-                event: AgentEvent::StatusChanged {
-                    run_id: "run-1".to_string(),
-                    phase: "starting".to_string(),
-                    message: "starting cosh-tui headless backend".to_string(),
-                },
-                reason: "agent status is display-only".to_string(),
-                display_text: String::new(),
-                auto_execute: false,
-            }],
-        );
-
-        assert_eq!(active_run.current_message, "正在启动模型后端");
-        assert!(!active_run.current_message.contains("cosh-tui"));
-    }
-}
+#[path = "heartbeat_tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat_tests.rs
@@ -1,0 +1,703 @@
+//! Tests for the Agent heartbeat and its status surfaces.
+//!
+//! Kept beside `heartbeat.rs` rather than inline: the production module is
+//! close to the 1000-line ceiling and this crate already pairs a module with a
+//! `*_tests.rs` sibling.
+
+use super::*;
+
+fn test_active_run() -> ActiveAgentRun {
+    let request = AgentRequest {
+        id: "request-1".to_string(),
+        session_id: "session-1".to_string(),
+        command_block: CommandBlock {
+            id: "cmd-1".to_string(),
+            session_id: "session-1".to_string(),
+            command: "hello".to_string(),
+            origin: Default::default(),
+            cwd: "/tmp".to_string(),
+            end_cwd: "/tmp".to_string(),
+            started_at_ms: 1,
+            ended_at_ms: 2,
+            duration_ms: 1,
+            exit_code: 0,
+            status: CommandStatus::Completed,
+            output: OutputRefs {
+                terminal_output_ref: None,
+                terminal_output_bytes: 0,
+            },
+            shell_environment_generation: None,
+            audit_identity: None,
+        },
+        context_blocks: Vec::new(),
+        context_hints: Vec::new(),
+        user_input: Some("hello".to_string()),
+        findings: Vec::new(),
+        mode: AgentMode::RecommendOnly,
+        user_confirmed: true,
+        hook_finding: None,
+        recommended_skill: None,
+    };
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let handle = adapter.start_cancellable(request.clone(), CoshApprovalMode::Recommend);
+    let renderer = RatatuiInlineRenderer::for_terminal();
+    ActiveAgentRun {
+        request,
+        origin: AgentRunOrigin::Standard,
+        handle,
+        provider_name: "fake",
+        language: Language::EnUs,
+        renderer: renderer.clone(),
+        status_animation: renderer.status_animation(),
+        markdown_stream: renderer.stream_markdown_agent(),
+        governed_events: Vec::new(),
+        deferred_events: Vec::new(),
+        held_events: Vec::new(),
+        cosh_request_filter: crate::evidence::stream::CoshRequestStreamFilter::default(),
+        pending_cosh_requests: Vec::new(),
+        pending_cosh_request_audits: Vec::new(),
+        rendered_governed_event_count: 0,
+        selectable_after_event_index: None,
+        started_at: Instant::now(),
+        last_activity_at: Instant::now(),
+        last_heartbeat_at: Instant::now(),
+        current_phase: String::new(),
+        current_message: String::new(),
+        has_visible_text_delta: false,
+        completed: false,
+        host_completed_tool_ids: Vec::new(),
+        pending_hook_notifications: Vec::new(),
+    }
+}
+
+#[test]
+fn tool_call_activity_is_not_reported_as_waiting_for_approval() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    remember_agent_activity(
+        &mut active_run,
+        &[GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolCall {
+                run_id: "run-1".to_string(),
+                tool_id: Some("tool-1".to_string()),
+                name: "glob".to_string(),
+                input: r#"{"pattern":"**/README.md"}"#.to_string(),
+            },
+            reason: "provider tool call visible".to_string(),
+            display_text: "provider tool call visible".to_string(),
+            auto_execute: false,
+        }],
+    );
+
+    assert_eq!(active_run.current_phase, "tool");
+    assert!(active_run.current_message.contains("正在查找文件 1 项"));
+    assert!(!active_run.current_message.contains("approval"));
+    assert!(!active_run.current_message.contains("README.md"));
+}
+
+#[test]
+fn pending_tool_status_aggregates_by_kind_and_removes_completed_tool() {
+    let events = vec![
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::ToolCall {
+                run_id: "run-1".to_string(),
+                tool_id: Some("read-1".to_string()),
+                name: "Read".to_string(),
+                input: r#"{"file_path":"/very/long/private/path/a.md"}"#.to_string(),
+            },
+            reason: "read".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        },
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::ToolCall {
+                run_id: "run-1".to_string(),
+                tool_id: Some("read-2".to_string()),
+                name: "Read".to_string(),
+                input: r#"{"file_path":"/very/long/private/path/b.md"}"#.to_string(),
+            },
+            reason: "read".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        },
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::ToolCall {
+                run_id: "run-1".to_string(),
+                tool_id: Some("grep-1".to_string()),
+                name: "Grep".to_string(),
+                input: r#"{"path":"src","query":"needle"}"#.to_string(),
+            },
+            reason: "grep".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        },
+    ];
+
+    let summary =
+        pending_tool_status_detail(Language::ZhCn, events.iter()).expect("pending summary");
+    assert!(summary.contains("正在读取 2 个文件"), "{summary}");
+    assert!(summary.contains("正在搜索 1 项"), "{summary}");
+    assert!(!summary.contains("private"), "{summary}");
+    assert!(!summary.contains("needle"), "{summary}");
+
+    let mut completed_events = events;
+    completed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCompleted {
+            run_id: "run-1".to_string(),
+            tool_id: "read-1".to_string(),
+            status: "success".to_string(),
+        },
+        reason: "done".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+
+    let summary = pending_tool_status_detail(Language::ZhCn, completed_events.iter())
+        .expect("pending summary");
+    assert!(summary.contains("正在读取 1 个文件"), "{summary}");
+    assert!(summary.contains("正在搜索 1 项"), "{summary}");
+
+    completed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCompleted {
+            run_id: "run-1".to_string(),
+            tool_id: "read-2".to_string(),
+            status: "success".to_string(),
+        },
+        reason: "done".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+    completed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCompleted {
+            run_id: "run-1".to_string(),
+            tool_id: "grep-1".to_string(),
+            status: "success".to_string(),
+        },
+        reason: "done".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+
+    assert!(pending_tool_status_detail(Language::ZhCn, completed_events.iter()).is_none());
+}
+
+#[test]
+fn pending_tool_status_finishes_open_agent_response() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    let renderer = RatatuiInlineRenderer::with_width(100);
+    active_run.renderer = renderer.clone();
+    active_run.status_animation = renderer.status_animation();
+    active_run.markdown_stream = renderer.stream_markdown_agent();
+    let mut output = Vec::new();
+
+    active_run
+        .markdown_stream
+        .write_delta(&mut output, "Agent text before tool.\n\n")
+        .expect("write agent text");
+    active_run.has_visible_text_delta = true;
+    active_run.governed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("read-1".to_string()),
+            name: "Read".to_string(),
+            input: r#"{"file_path":"Cargo.toml"}"#.to_string(),
+        },
+        reason: "read".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+
+    render_agent_pending_tool_status(&mut active_run, &mut output).expect("render status");
+    let output = String::from_utf8(output).expect("utf8 output");
+
+    assert!(!active_run.markdown_stream.has_started());
+    assert!(output.contains("正在读取 1 个文件"), "{output}");
+    assert!(output.contains('╰'), "{output}");
+}
+
+#[test]
+fn pending_tool_status_flushes_buffered_agent_response() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    let renderer = RatatuiInlineRenderer::with_width(100);
+    active_run.renderer = renderer.clone();
+    active_run.status_animation = renderer.status_animation();
+    active_run.markdown_stream = renderer.stream_markdown_agent();
+    let mut output = Vec::new();
+
+    active_run
+        .markdown_stream
+        .write_delta(&mut output, "Agent text before tool")
+        .expect("write buffered agent text");
+    active_run.has_visible_text_delta = true;
+    assert!(!active_run.markdown_stream.has_started());
+    assert!(active_run.markdown_stream.has_buffered_text());
+    active_run.governed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("write-1".to_string()),
+            name: "Write".to_string(),
+            input: r#"{"file_path":"snake.py"}"#.to_string(),
+        },
+        reason: "write".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+
+    render_agent_pending_tool_status(&mut active_run, &mut output).expect("render status");
+    let output = String::from_utf8(output).expect("utf8 output");
+
+    assert!(!active_run.markdown_stream.has_started());
+    assert!(!active_run.markdown_stream.has_buffered_text());
+    assert!(output.contains("Agent text before tool"), "{output}");
+    assert!(output.contains("正在写入 1 项"), "{output}");
+    assert!(output.contains('╰'), "{output}");
+}
+
+#[test]
+fn shell_evidence_pending_status_finishes_open_agent_response() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    let renderer = RatatuiInlineRenderer::with_width(100).with_language(Language::ZhCn);
+    active_run.markdown_stream = renderer.stream_markdown_agent();
+    let mut output = Vec::new();
+
+    active_run
+        .markdown_stream
+        .write_delta(&mut output, "先看一下证据。\n\n")
+        .expect("write agent text");
+    active_run.has_visible_text_delta = true;
+    render_agent_shell_evidence_pending_status(&mut active_run, &mut output)
+        .expect("render shell evidence status");
+    let output = String::from_utf8(output).expect("utf8 output");
+
+    assert!(!active_run.markdown_stream.has_started());
+    assert!(output.contains("Shell 证据 1 项"), "{output}");
+    assert!(output.contains('╰'), "{output}");
+}
+
+#[test]
+fn host_completed_shell_tools_are_removed_from_pending_status() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    active_run.governed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("shell-1".to_string()),
+            name: "Bash".to_string(),
+            input: r#"{"command":"echo one"}"#.to_string(),
+        },
+        reason: "shell".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+    active_run.mark_host_completed_tool("shell-1");
+    active_run.governed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("shell-2".to_string()),
+            name: "Bash".to_string(),
+            input: r#"{"command":"echo two"}"#.to_string(),
+        },
+        reason: "shell".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+
+    let summary = pending_tool_status_detail_for_run(&active_run).expect("pending shell");
+    assert!(summary.contains("正在执行 Shell 1 项"), "{summary}");
+    assert!(!summary.contains("2 项"), "{summary}");
+
+    active_run.mark_host_completed_tool("shell-2");
+    active_run.governed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("shell-3".to_string()),
+            name: "Bash".to_string(),
+            input: r#"{"command":"echo three"}"#.to_string(),
+        },
+        reason: "shell".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+
+    let summary = pending_tool_status_detail_for_run(&active_run).expect("pending shell");
+    assert!(summary.contains("正在执行 Shell 1 项"), "{summary}");
+    assert!(!summary.contains("3 项"), "{summary}");
+}
+
+#[test]
+fn pending_tool_status_deduplicates_matching_permission_request() {
+    let events = [
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::ToolCall {
+                run_id: "run-1".to_string(),
+                tool_id: Some("toolu-write".to_string()),
+                name: "Write".to_string(),
+                input: r#"{"file_path":"/tmp/report.md","content":"secret body"}"#.to_string(),
+            },
+            reason: "write".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        },
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolPermissionRequest {
+                run_id: "run-1".to_string(),
+                request_id: "ctrl-write".to_string(),
+                tool_name: "Write".to_string(),
+                tool_input: serde_json::json!({
+                    "file_path": "/tmp/report.md",
+                    "content": "secret body"
+                }),
+                tool_use_id: "toolu-write".to_string(),
+                hook_requires_approval: false,
+                audit_ref: None,
+            },
+            reason: "approval".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        },
+    ];
+
+    let summary =
+        pending_tool_status_detail(Language::ZhCn, events.iter()).expect("pending summary");
+    assert!(summary.contains("正在写入 1 项"), "{summary}");
+    assert!(!summary.contains("正在写入 2 项"), "{summary}");
+    assert!(!summary.contains("secret body"), "{summary}");
+    assert!(!summary.contains("/tmp/report.md"), "{summary}");
+}
+
+#[test]
+fn pending_tool_status_uses_request_id_when_tool_use_id_is_empty() {
+    let events = [
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolPermissionRequest {
+                run_id: "run-1".to_string(),
+                request_id: "ctrl-read-1".to_string(),
+                tool_name: "Read".to_string(),
+                tool_input: serde_json::json!({ "file_path": "a.md" }),
+                tool_use_id: String::new(),
+                hook_requires_approval: false,
+                audit_ref: None,
+            },
+            reason: "approval".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        },
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolPermissionRequest {
+                run_id: "run-1".to_string(),
+                request_id: "ctrl-read-2".to_string(),
+                tool_name: "Read".to_string(),
+                tool_input: serde_json::json!({ "file_path": "b.md" }),
+                tool_use_id: String::new(),
+                hook_requires_approval: false,
+                audit_ref: None,
+            },
+            reason: "approval".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        },
+    ];
+
+    let summary =
+        pending_tool_status_detail(Language::ZhCn, events.iter()).expect("pending summary");
+    assert!(summary.contains("正在读取 2 个文件"), "{summary}");
+    assert!(!summary.contains("ctrl-read"), "{summary}");
+}
+
+#[test]
+fn question_activity_localizes_empty_question_fallback() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    remember_agent_activity(
+        &mut active_run,
+        &[GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::UserQuestion {
+                run_id: "run-1".to_string(),
+                provider_request_id: None,
+                question: String::new(),
+                options: Vec::new(),
+                allow_free_text: true,
+                selection_mode: QuestionSelectionMode::Single,
+            },
+            reason: "agent question requires explicit user input".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        }],
+    );
+
+    assert_eq!(active_run.current_phase, "问题");
+    assert!(active_run.current_message.contains("Agent 需要你的输入"));
+    assert!(!active_run
+        .current_message
+        .contains("Agent needs your input"));
+}
+
+#[test]
+fn provider_status_activity_localizes_neutral_tokens() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    remember_agent_activity(
+        &mut active_run,
+        &[GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::StatusChanged {
+                run_id: "run-1".to_string(),
+                phase: "thinking".to_string(),
+                message: "thinking".to_string(),
+            },
+            reason: "agent status is display-only".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        }],
+    );
+
+    assert_eq!(active_run.current_phase, "正在思考");
+    assert_eq!(active_run.current_message, "正在思考");
+}
+
+#[test]
+fn tool_argument_status_survives_streamed_text_and_ends_its_surface() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::EnUs;
+    let mut output = Vec::new();
+
+    // Text streamed first: without the fallback both the markdown surface and
+    // the "no pending tool" path swallow the argument-generation status.
+    active_run
+        .markdown_stream
+        .write_delta(&mut output, "Let me write that file.\n\n")
+        .expect("stream text");
+    active_run.has_visible_text_delta = true;
+    assert!(
+        active_run.markdown_stream.has_started(),
+        "the test needs a live text surface to defeat"
+    );
+
+    remember_agent_activity(
+        &mut active_run,
+        &[GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::StatusChanged {
+                run_id: "run-1".to_string(),
+                phase: "tool_arguments".to_string(),
+                message: "generating tool arguments: write_file".to_string(),
+            },
+            reason: "agent status is display-only".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        }],
+    );
+
+    assert_eq!(
+        status_detail_for_run(&active_run).as_deref(),
+        Some("generating write_file arguments...")
+    );
+
+    output.clear();
+    render_agent_pending_tool_status(&mut active_run, &mut output).expect("render status");
+    let rendered = String::from_utf8(output).expect("utf8 terminal output");
+    assert!(
+        rendered.contains("generating write_file arguments"),
+        "{rendered:?}"
+    );
+    // The text surface was closed, so the heartbeat can keep animating it.
+    assert!(!active_run.markdown_stream.has_started());
+    assert!(!active_run.has_visible_text_delta);
+}
+
+#[test]
+fn tool_argument_generation_status_is_localized_and_names_only_the_tool() {
+    for (language, expected_phase, expected_message) in [
+        (Language::ZhCn, "工具参数", "正在生成 write_file 参数..."),
+        (
+            Language::EnUs,
+            "tool arguments",
+            "generating write_file arguments...",
+        ),
+    ] {
+        let mut active_run = test_active_run();
+        active_run.language = language;
+        remember_agent_activity(
+            &mut active_run,
+            &[GovernedEvent {
+                decision: GovernanceDecision::Display,
+                policy_decision: GovernancePolicyDecision::DisplayOnly,
+                event: AgentEvent::StatusChanged {
+                    run_id: "run-1".to_string(),
+                    phase: "tool_arguments".to_string(),
+                    message: "generating tool arguments: write_file".to_string(),
+                },
+                reason: "agent status is display-only".to_string(),
+                display_text: String::new(),
+                auto_execute: false,
+            }],
+        );
+
+        assert_eq!(active_run.current_phase, expected_phase);
+        assert_eq!(active_run.current_message, expected_message);
+    }
+}
+
+#[test]
+fn pending_tool_status_takes_precedence_over_argument_generation() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::EnUs;
+    active_run.current_phase = I18n::new(Language::EnUs)
+        .t(MessageId::AgentStatusToolArguments)
+        .to_string();
+    active_run.current_message = "generating write_file arguments...".to_string();
+    active_run.governed_events.push(GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("tool-1".to_string()),
+            name: "shell".to_string(),
+            input: r#"{"command":"sleep 5"}"#.to_string(),
+        },
+        reason: "provider tool call visible".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    });
+
+    assert_eq!(
+        status_detail_for_run(&active_run).as_deref(),
+        Some("running shell command: 1"),
+        "a materialized pending tool must not be hidden by a later status token"
+    );
+}
+
+#[test]
+fn elapsed_heartbeat_does_not_repeat_generic_thinking_detail() {
+    let zh = I18n::new(Language::ZhCn);
+    assert_eq!(
+        elapsed_thinking_text(&zh, Language::ZhCn, 7, "正在思考"),
+        "正在思考... 7s"
+    );
+    assert_eq!(
+        elapsed_thinking_text(&zh, Language::ZhCn, 7, "正在读取 1 个文件"),
+        "正在思考... 7s · 正在读取 1 个文件"
+    );
+
+    let en = I18n::new(Language::EnUs);
+    assert_eq!(
+        elapsed_thinking_text(&en, Language::EnUs, 7, "thinking"),
+        "Thinking... 7s"
+    );
+}
+
+#[test]
+fn shell_evidence_activity_uses_concise_tool_status() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    remember_agent_activity(
+        &mut active_run,
+        &[GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::ShellEvidenceRequest {
+                run_id: "run-1".to_string(),
+                request_id: "evidence-1".to_string(),
+                tool_use_id: "toolu-evidence".to_string(),
+                action: crate::adapter::ShellEvidenceAction::ListCommands {
+                    limit: 5,
+                    cursor: None,
+                },
+            },
+            reason: "shell evidence".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        }],
+    );
+
+    assert_eq!(active_run.current_phase, "tool");
+    assert_eq!(active_run.current_message, "正在处理 Shell 证据 1 项");
+    assert!(!active_run.current_message.contains("list_commands"));
+    assert!(!active_run.current_message.contains("toolu-evidence"));
+}
+
+#[test]
+fn agent_completion_activity_localizes_neutral_summary() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    remember_agent_activity(
+        &mut active_run,
+        &[GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::AgentCompleted {
+                run_id: "run-1".to_string(),
+                summary: "analysis completed".to_string(),
+            },
+            reason: "agent completion is display-only".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        }],
+    );
+
+    assert_eq!(active_run.current_phase, "已完成");
+    assert_eq!(active_run.current_message, "分析完成");
+}
+
+#[test]
+fn provider_startup_activity_hides_adapter_name_in_zh() {
+    let mut active_run = test_active_run();
+    active_run.language = Language::ZhCn;
+    remember_agent_activity(
+        &mut active_run,
+        &[GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::StatusChanged {
+                run_id: "run-1".to_string(),
+                phase: "starting".to_string(),
+                message: "starting cosh-tui headless backend".to_string(),
+            },
+            reason: "agent status is display-only".to_string(),
+            display_text: String::new(),
+            auto_execute: false,
+        }],
+    );
+
+    assert_eq!(active_run.current_message, "正在启动模型后端");
+    assert!(!active_run.current_message.contains("cosh-tui"));
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
@@ -29,6 +29,8 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AgentStatusWaitingUserAnswer => "waiting for user answer: {question}",
         MessageId::AgentStatusWaitingApprovalCommand => "waiting for approval: {command}",
         MessageId::AgentStatusTool => "tool",
+        MessageId::AgentStatusToolArguments => "tool arguments",
+        MessageId::AgentStatusGeneratingToolArguments => "generating {tool} arguments...",
         MessageId::AgentStatusCapturingToolOutput => "capturing output from {tool_id}",
         MessageId::AgentStatusToolCompleted => "{tool_id} completed with status {status}",
         MessageId::AgentStatusCompleted => "completed",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -89,4 +89,5 @@ collect_message_ids!([
     approval_turn_consent_ids,
     status_query_ids,
     prompt_soft_newline_ids,
+    tool_argument_status_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
@@ -68,6 +68,19 @@ macro_rules! agent_ids {
     };
 }
 
+// Keep feature-specific additions in a trailing segment so existing public
+// MessageId discriminants remain stable.
+macro_rules! tool_argument_status_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            AgentStatusToolArguments,
+            AgentStatusGeneratingToolArguments,
+        );
+    };
+}
+
 macro_rules! agent_queue_ids {
     ($next:ident, $remaining:tt, $($ids:ident,)*) => {
         $next!(

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -120,6 +120,14 @@ mod tests {
             MessageId::ApprovalTitle as usize,
             MessageId::QuestionNoPendingBody as usize + 1
         );
+        assert_eq!(
+            MessageId::AgentStatusToolArguments as usize,
+            MessageId::ALL.len() - 2
+        );
+        assert_eq!(
+            MessageId::AgentStatusGeneratingToolArguments as usize,
+            MessageId::ALL.len() - 1
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
@@ -27,6 +27,8 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AgentStatusWaitingUserAnswer => "正在等待用户回答: {question}",
         MessageId::AgentStatusWaitingApprovalCommand => "正在等待审批: {command}",
         MessageId::AgentStatusTool => "tool",
+        MessageId::AgentStatusToolArguments => "工具参数",
+        MessageId::AgentStatusGeneratingToolArguments => "正在生成 {tool} 参数...",
         MessageId::AgentStatusCapturingToolOutput => "正在捕获 {tool_id} 的输出",
         MessageId::AgentStatusToolCompleted => "{tool_id} 已完成，状态 {status}",
         MessageId::AgentStatusCompleted => "已完成",

--- a/src/cosh-ng/crates/cosh-shell/src/tools/display.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/display.rs
@@ -2,6 +2,38 @@ use serde_json::Value;
 
 use super::classification::is_shell_tool_name;
 
+/// Longest tool name drawn on a status surface.
+const MAX_DISPLAY_TOOL_NAME_CHARS: usize = 64;
+
+/// A provider-supplied tool name, made safe to draw on a terminal.
+///
+/// Mirrors cosh-core's terminal-facing sanitizer because cosh-shell is a
+/// standalone crate; keep the filtering and length contract aligned in both.
+///
+/// Tool names are model output, not validated identifiers: `"[2J"` in the
+/// stream JSON arrives here as a real ESC byte, and the status animation writes
+/// its label straight to the terminal. Stripping the control characters leaves
+/// any escape body as inert text; the length cap keeps one status line from
+/// flooding the surface.
+pub(crate) fn display_tool_name(tool_name: &str) -> String {
+    let safe: String = tool_name
+        .chars()
+        .filter(|character| {
+            !character.is_control() && !matches!(character, '\u{2028}' | '\u{2029}')
+        })
+        .take(MAX_DISPLAY_TOOL_NAME_CHARS)
+        .collect();
+    let trimmed = safe.trim();
+    if trimmed.is_empty() {
+        return "tool".to_string();
+    }
+    let mut display = trimmed.to_string();
+    if tool_name.chars().count() > MAX_DISPLAY_TOOL_NAME_CHARS {
+        display.push('…');
+    }
+    display
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolColor {
     ReadOnly,

--- a/src/cosh-ng/crates/cosh-shell/src/types/agent_status.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/agent_status.rs
@@ -1,0 +1,10 @@
+//! Cross-owner status tokens emitted by adapters and consumed by Agent UI.
+
+/// Wire phase reported while a tool's arguments are still streaming.
+pub(crate) const TOOL_ARGUMENTS_STATUS_PHASE: &str = "tool_arguments";
+
+/// Marker prefix carrying the tool name during argument generation.
+///
+/// The status crosses the adapter boundary as a stable English string and is
+/// localized at render time, matching the other neutral status markers.
+pub(crate) const TOOL_ARGUMENTS_STATUS_PREFIX: &str = "generating tool arguments: ";

--- a/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
@@ -1,11 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+mod agent_status;
 pub mod audit;
 mod continuation;
 pub mod hooks;
 mod shell_event_metadata;
 mod shell_handoff;
 
+pub(crate) use agent_status::{TOOL_ARGUMENTS_STATUS_PHASE, TOOL_ARGUMENTS_STATUS_PREFIX};
 pub(crate) use continuation::*;
 
 pub(crate) use hooks::BuiltinFactRecord;

--- a/src/cosh-ng/crates/cosh-shell/src/types/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/public.rs
@@ -17,7 +17,7 @@ pub(crate) use implementation::{
     BuiltinFactRecord, BuiltinFindingFacts, EvaluatedHookFinding, HighMemoryProcessFacts,
     HookProvenance, MemoryPressureFacts, MetricsConfidence, ProcessMemoryFact,
     ShellEnvironmentSnapshot, SHELL_HANDOFF_CONTINUATION_HINT, SHELL_HANDOFF_UNTRACKED_STATUS,
-    USER_APPROVAL_MODE_HINT_PREFIX,
+    TOOL_ARGUMENTS_STATUS_PHASE, TOOL_ARGUMENTS_STATUS_PREFIX, USER_APPROVAL_MODE_HINT_PREFIX,
 };
 
 pub(crate) use implementation::audit;

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_tools.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_tools.rs
@@ -296,6 +296,73 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-tool-spli
     );
 }
 
+/// A model generating large arguments streams deltas for a long time before the
+/// tool call exists. Without a status for that window the Agent card sits blank
+/// and the user cannot tell generation from a hang.
+///
+/// Text is streamed first on purpose: that is the harder case, because a live
+/// markdown surface otherwise suppresses the status entirely.
+#[test]
+fn raw_cli_qwen_slow_tool_arguments_show_a_status_without_the_payload() {
+    let home = temp_shell_home("qwen-slow-tool-arguments-status");
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let co_path = bin_dir.join("co");
+    write_executable(
+        &co_path,
+        r#"#!/bin/sh
+read -r init
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true}}}}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-slow-arguments","model":"qwen-test"}'
+read -r user_message
+case "$user_message" in
+  *slow-tool-arguments-status*)
+    printf '%s\n' '{"type":"stream_event","session_id":"sess-slow-arguments","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me write that file.\n\n"}}}'
+    printf '%s\n' '{"type":"stream_event","session_id":"sess-slow-arguments","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call_write_slow","name":"write_file","input":{}}}}'
+    printf '%s\n' '{"type":"stream_event","session_id":"sess-slow-arguments","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/tmp/SECRET_ARGUMENT_PATH\",\"content\":\"SECRET_ARGUMENT_BODY"}}}'
+    sleep 8
+    printf '%s\n' '{"type":"stream_event","session_id":"sess-slow-arguments","event":{"type":"content_block_stop","index":1}}'
+    printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-slow-arguments","is_error":false,"result":"done"}'
+    exit 0
+    ;;
+esac
+printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-slow-arguments","is_error":false,"result":"ignored"}'
+"#,
+    );
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{old_path}", bin_dir.display());
+    let home_str = home.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "qwen",
+        &[],
+        &[
+            ("HOME", &home_str),
+            ("PATH", &path),
+            ("TERM", "xterm-256color"),
+            ("COSH_SHELL_ANIMATION", "always"),
+        ],
+        vec![
+            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+            (
+                b"?? slow-tool-arguments-status\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(12_000)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(output.contains("Let me write that file."), "{output}");
+    assert!(
+        output.contains("generating write_file arguments"),
+        "the argument-generation window must be visible even after streamed text: {output}"
+    );
+    // The deltas carry the destination path and the file body; neither may reach
+    // the terminal, and a byte count would only invent progress.
+    assert!(!output.contains("SECRET_ARGUMENT_PATH"), "{output}");
+    assert!(!output.contains("SECRET_ARGUMENT_BODY"), "{output}");
+}
+
 #[test]
 fn raw_cli_qwen_long_running_tool_shows_pending_status_then_result_card() {
     let home = temp_shell_home("qwen-long-running-tool-pending-status");


### PR DESCRIPTION
## Description

Surface a non-sensitive status as soon as streamed tool arguments begin, so a
large argument payload no longer leaves an apparently blank Agent card. Reject
malformed arguments through the existing tool-result path and stop after three
consecutive failures for the same tool and stable error code. When exhaustion
occurs in a multi-call assistant message, pair and audit every remaining call
without executing it. The heartbeat tests now live in a sibling test module so
the production file remains below the repository's large-file threshold.

## Related Issue

closes #1908

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional change)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p cosh-core -p cosh-shell --all-targets -- -D warnings`
- `cargo test -p cosh-core stopping_on_exhaustion_still_answers_every_call_in_the_batch`
- `cargo test -p cosh-shell --lib` — 1066 passed
- `cargo test -p cosh-shell --test protocol` — 56 passed
- `cargo test -p cosh-shell --test raw_cli raw_cli_qwen_slow_tool_arguments_show_a_status_without_the_payload`
- `cargo build -p cosh-core -p cosh-shell --release`
- `crates/cosh-shell/scripts/check-layout.sh`

## Additional Notes

The status contains only a bounded, terminal-safe tool name; argument deltas,
paths, file contents, and credentials are never rendered. The final revision
was not rerun against live SysOM on ECS; the issue contains the sanitized live
reproduction, while this PR's visible transition is covered by the PTY
regression.
