### PR TITLE
fix(anolisa): align cosh-ng RPM identity

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -813,6 +813,32 @@ build_cosh_ng() {
 
     local pkg_name
     pkg_name=$(parse_spec_name "$spec_in")
+    local component_name
+    component_name=$(awk '
+        $0 == "[component]" { in_component = 1; next }
+        in_component && /^\[/ { exit }
+        in_component && /^name = / {
+            value = $0
+            sub(/^name = "/, "", value)
+            sub(/"$/, "", value)
+            print value
+            exit
+        }
+    ' "${COSH_DIR}/component.toml")
+    if [ "$component_name" != "$pkg_name" ]; then
+        err "cosh-ng identity mismatch: RPM name '${pkg_name}', component name '${component_name}'"
+        return 1
+    fi
+    if ! grep -Fqx "Provides:       anolisa-component(${component_name})" "$spec_in"; then
+        err "cosh-ng spec must provide anolisa-component(${component_name})"
+        return 1
+    fi
+    local manifest_path="%{_datadir}/anolisa/components/${component_name}/component.toml"
+    if ! grep -Fq "install -m 0644 component.toml %{buildroot}${manifest_path}" "$spec_in" \
+        || ! grep -Fqx "$manifest_path" "$spec_in"; then
+        err "cosh-ng spec must install and own ${manifest_path}"
+        return 1
+    fi
     local tarball_name="${pkg_name}-${version}.tar.gz"
 
     local spec_file

--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -6,11 +6,13 @@
 
 use std::path::PathBuf;
 
-use anolisa_core::ObjectKind;
 use anolisa_core::adapter::manager::{AdapterManager, VisibleRoot};
-use anolisa_core::domain::InstallationScope;
+use anolisa_core::domain::{
+    Installation, InstallationScope, NativePm, PackageIdentity, ProviderBinding,
+};
 use anolisa_core::facts::{JournalEvidence, JournalInventory};
 use anolisa_core::state_store::StateStore;
+use anolisa_core::{ComponentManifest, ObjectKind};
 use anolisa_platform::fs_layout::FsLayout;
 
 use crate::color::Palette;
@@ -393,6 +395,42 @@ pub fn installed_component_manifest_path(
     )
 }
 
+/// Legacy manifest directory eligible for cleanup after a record mutation.
+pub(crate) fn legacy_component_manifest_dir_for_installation(
+    layout: &FsLayout,
+    installation: &Installation,
+    command: &str,
+) -> Result<Option<PathBuf>, CliError> {
+    Ok(legacy_cosh_ng_manifest_path(layout, installation, command)?
+        .and_then(|path| path.parent().map(PathBuf::from)))
+}
+
+fn legacy_cosh_ng_manifest_path(
+    layout: &FsLayout,
+    installation: &Installation,
+    command: &str,
+) -> Result<Option<PathBuf>, CliError> {
+    if installation.name != "cosh-ng"
+        || !matches!(
+            &installation.binding,
+            ProviderBinding::Delegated {
+                pm: NativePm::Rpm,
+                package: PackageIdentity::Resolved { name },
+                ..
+            } if name == "cosh-ng"
+        )
+    {
+        return Ok(None);
+    }
+
+    let legacy = installed_component_manifest_path(layout, "cosh", command)?;
+    let matches_legacy_identity = legacy.is_file()
+        && ComponentManifest::from_file(&legacy).is_ok_and(|manifest| {
+            manifest.component.name == "cosh" && manifest.rpm_package() == Some("cosh-ng")
+        });
+    Ok(matches_legacy_identity.then_some(legacy))
+}
+
 /// Directory for the component manifest saved as part of an installed
 /// component's local state.
 pub fn installed_component_manifest_dir(
@@ -423,7 +461,7 @@ fn validate_component_path_segment(component: &str, command: &str) -> Result<(),
 }
 
 /// Wire-friendly status label for a v5
-/// [`Installation`](anolisa_core::domain::Installation), same vocabulary as
+/// [`Installation`], same vocabulary as
 /// [`installation_status_str`] vocabulary: a delegated adopted/observed row
 /// reports its management relation (the legacy state collapsed both into one
 /// `adopted` status), any other row reports its lifecycle health.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -213,8 +213,18 @@ fn persist_forget(
             "component '{component}' disappeared from state during forget; nothing removed"
         ),
     })?;
+    let legacy_manifest_dir = store
+        .find(ObjectKind::Component, component)
+        .map(|installation| {
+            common::legacy_component_manifest_dir_for_installation(&layout, installation, command)
+        })
+        .transpose()?
+        .flatten();
     store.remove(ObjectKind::Component, component);
     remove_component_manifest_snapshot(&layout, component, command)?;
+    if let Some(dir) = legacy_manifest_dir {
+        remove_manifest_snapshot_dir(&dir, command)?;
+    }
 
     let now = now_iso8601();
     let lock_ts = Utc::now();
@@ -293,7 +303,11 @@ fn remove_component_manifest_snapshot(
     command: &str,
 ) -> Result<(), CliError> {
     let dir = common::installed_component_manifest_dir(layout, component, command)?;
-    match std::fs::remove_dir_all(&dir) {
+    remove_manifest_snapshot_dir(&dir, command)
+}
+
+fn remove_manifest_snapshot_dir(dir: &std::path::Path, command: &str) -> Result<(), CliError> {
+    match std::fs::remove_dir_all(dir) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(CliError::Runtime {
@@ -559,6 +573,49 @@ mod tests {
         assert!(
             !snapshot_dir.exists(),
             "component manifest snapshot dir must be removed",
+        );
+    }
+
+    #[test]
+    fn forget_repaired_cosh_ng_removes_the_legacy_snapshot() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        seed(
+            &c,
+            vec![rpm_observed_object("cosh", "cosh-ng", "0.13.0-1.al8")],
+            Vec::new(),
+        );
+        let layout = common::resolve_layout(&c);
+        let legacy_snapshot = common::installed_component_manifest_path(&layout, "cosh", COMMAND)
+            .expect("legacy snapshot path");
+        std::fs::create_dir_all(legacy_snapshot.parent().expect("snapshot dir"))
+            .expect("create snapshot dir");
+        std::fs::write(
+            &legacy_snapshot,
+            r#"
+            [component]
+            name = "cosh"
+            version = "0.13.0"
+
+            [backends.rpm]
+            package = "cosh-ng"
+            "#,
+        )
+        .expect("write legacy snapshot");
+
+        handle(
+            ForgetArgs {
+                component: "cosh-ng".to_string(),
+            },
+            &c,
+        )
+        .expect("forget repaired cosh-ng");
+
+        assert!(!legacy_snapshot.exists());
+        assert!(
+            load_store(&c)
+                .find(ObjectKind::Component, "cosh-ng")
+                .is_none()
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -243,6 +243,36 @@ fn delegated_install_writes_a_managed_record() {
 }
 
 #[test]
+fn delegated_cosh_ng_install_preserves_stable_identity() {
+    let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
+    let fake = FakeInstaller::new(
+        "cosh-ng",
+        pkg_info("cosh-ng", "0.13.0", Some("1.al8"), "x86_64"),
+    )
+    .with_origin("anolisa");
+    let mut install_args = args("cosh-ng");
+    install_args.backend = Some("rpm".to_string());
+
+    install_component_with_deps("cosh-ng", &install_args, &ctx, &fake, &fake, true)
+        .expect("delegated cosh-ng install");
+
+    let store = load_store(&ctx);
+    let record = store
+        .find(ObjectKind::Component, "cosh-ng")
+        .expect("cosh-ng component recorded");
+    assert!(
+        store.find(ObjectKind::Component, "cosh").is_none(),
+        "cosh-ng must not be recorded as the legacy cosh identity"
+    );
+    match &record.binding {
+        ProviderBinding::Delegated { package, .. } => {
+            assert_eq!(package.resolved_name(), Some("cosh-ng"));
+        }
+        other => panic!("expected a delegated binding, got {other:?}"),
+    }
+}
+
+#[test]
 fn delegated_install_lock_failure_precedes_dnf() {
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
     let layout = common::resolve_layout(&ctx);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -707,11 +707,10 @@ fn record_from_object(
     // installed manifest snapshot (the same per-installation copy consumed
     // by uninstall hooks, adapter discovery, and contract reconciliation).
     //
-    // Delegated rows are exempt regardless of relation: their file layout is
-    // selected by RPM macros rather than ANOLISA's raw-backend layout, so the
-    // manifest health checks (which assume that layout) would spuriously
-    // escalate a valid package. Delegated health remains adjudicated by the
-    // rpmdb drift probe after this projection.
+    // Delegated rows are exempt: their file layout is selected by RPM macros
+    // rather than ANOLISA's raw backend, so manifest checks against the raw
+    // layout can spuriously escalate a valid package. Delegated health is
+    // adjudicated by the rpmdb drift probe after this projection.
     let manifest_status = match manifest_probe {
         Some(service_backends) if !installation.binding.is_delegated() => {
             let (manifest_entries, escalated) = manifest_health_probe(
@@ -1942,6 +1941,48 @@ mod tests {
             .find(|h| h.name.starts_with("agentsight:file_exists"))
             .expect("snapshot health entry present");
         assert_eq!(entry.status, "ok");
+    }
+
+    #[test]
+    fn repaired_cosh_ng_status_skips_the_legacy_snapshot_probe() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let layout = test_layout(dir.path());
+        write_manifest_snapshot(
+            &layout,
+            "cosh",
+            r#"
+                [component]
+                name = "cosh"
+                version = "0.13.0"
+
+                [component.health_check]
+                type = "file_exists"
+                path = "{bindir}/cosh-cli"
+
+                [backends.rpm]
+                package = "cosh-ng"
+            "#,
+        );
+
+        let mut state = InstalledState::default();
+        state.upsert_object(rpm_observed_object("cosh-ng", "cosh-ng", "0.13.0-1.al8"));
+
+        let records = select_components(
+            &store_with(&state),
+            &layout,
+            "system",
+            Some("cosh-ng"),
+            None,
+        );
+
+        assert_eq!(records[0].status, "adopted");
+        assert!(
+            records[0]
+                .health
+                .iter()
+                .all(|entry| !entry.name.starts_with("cosh-ng:file_exists")),
+            "delegated RPM must not run raw-layout manifest checks"
+        );
     }
 
     /// Failing snapshot check escalates the wire status to `failed` with

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -352,6 +352,13 @@ fn uninstall_component(
         }
     })?;
     ensure_no_adapter_claims(&store, target, &command)?;
+    let legacy_manifest_dir = store
+        .find(ObjectKind::Component, target)
+        .map(|installation| {
+            common::legacy_component_manifest_dir_for_installation(&layout, installation, &command)
+        })
+        .transpose()?
+        .flatten();
     let (native_package, record_is_managed) = match store
         .find(ObjectKind::Component, target)
         .map(|record| &record.binding)
@@ -547,6 +554,11 @@ fn uninstall_component(
     // The manifest snapshot travels with the record. Best-effort: the
     // record drop is already committed.
     if let Err(err) = remove_component_manifest_snapshot(&layout, target, &command) {
+        eprintln!("warning: {err}");
+    }
+    if let Some(dir) = legacy_manifest_dir
+        && let Err(err) = remove_manifest_snapshot_dir(&dir, &command)
+    {
         eprintln!("warning: {err}");
     }
 
@@ -1144,7 +1156,11 @@ fn remove_component_manifest_snapshot(
     command: &str,
 ) -> Result<(), CliError> {
     let dir = common::installed_component_manifest_dir(layout, component, command)?;
-    match std::fs::remove_dir_all(&dir) {
+    remove_manifest_snapshot_dir(&dir, command)
+}
+
+fn remove_manifest_snapshot_dir(dir: &std::path::Path, command: &str) -> Result<(), CliError> {
+    match std::fs::remove_dir_all(dir) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(CliError::Runtime {
@@ -2127,6 +2143,50 @@ mod tests {
             scope_guard_command(&both, "system-tool"),
             "uninstall --purge --remove-system-package system-tool"
         );
+    }
+
+    #[test]
+    fn uninstall_repaired_cosh_ng_removes_the_legacy_snapshot() {
+        let tmp = tempdir().expect("tmpdir");
+        let c = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &c,
+            vec![rpm_object("cosh", "cosh-ng", Ownership::RpmObserved)],
+            Vec::new(),
+        );
+        let layout = common::resolve_layout(&c);
+        let legacy_snapshot = common::installed_component_manifest_path(&layout, "cosh", COMMAND)
+            .expect("legacy snapshot path");
+        std::fs::create_dir_all(legacy_snapshot.parent().expect("snapshot dir"))
+            .expect("create snapshot dir");
+        std::fs::write(
+            &legacy_snapshot,
+            r#"
+            [component]
+            name = "cosh"
+            version = "0.13.0"
+
+            [backends.rpm]
+            package = "cosh-ng"
+            "#,
+        )
+        .expect("write legacy snapshot");
+
+        let rpm = FakeRpm::present("cosh-ng");
+        run(args("cosh-ng", false), &c, &rpm, true).expect("record-only uninstall succeeds");
+
+        assert!(!legacy_snapshot.exists());
+        assert!(
+            load_state(&c)
+                .find(ObjectKind::Component, "cosh-ng")
+                .is_none()
+        );
+        assert_eq!(rpm.remove_calls.get(), 0);
     }
 
     fn run(

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -873,6 +873,33 @@ name = "copilot-shell"
     }
 
     #[test]
+    fn repository_component_index_maps_cosh_ng_rpm_to_cosh_ng() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let index_path = manifest_dir.join("../../manifests/components.toml");
+        let idx = ComponentIndex::load(&index_path).expect("component index template must parse");
+        let query = FakeQuery::default();
+        let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
+
+        let got = resolver
+            .resolve(
+                "cosh-ng",
+                BackendKind::Rpm,
+                ResolutionUse::Install,
+                ResolveOptions::default(),
+            )
+            .expect("resolve cosh-ng");
+
+        match got {
+            ResolutionSet::Unique(target) => {
+                assert_eq!(target.component, "cosh-ng");
+                assert_eq!(target.package, "cosh-ng");
+                assert_eq!(target.source, ResolutionSource::ComponentIndex);
+            }
+            other => panic!("expected unique, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn load_optional_component_index_uses_raw_index_for_rpm_resolution() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let layout =

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -18,6 +18,7 @@ use crate::integrity::{IntegrityStatus, check_owned_file};
 use crate::planner::{Facts, NativeProbe, RecordFacts};
 use crate::providers::{DelegatedProvider, ProviderError};
 use crate::state::{ObjectKind, OperationRecord};
+use crate::state_identity::repair_known_transaction_identity;
 use crate::state_store::StateStore;
 use crate::transaction::{Transaction, TransactionError};
 
@@ -216,7 +217,7 @@ impl JournalInventory {
         let entries = paths
             .into_iter()
             .map(|path| {
-                let transaction =
+                let mut transaction =
                     Transaction::load_journal(&path).map_err(|source| FactsError::JournalLoad {
                         path: path.clone(),
                         source,
@@ -227,6 +228,7 @@ impl JournalInventory {
                         source,
                     }
                 })?;
+                repair_known_transaction_identity(&mut transaction);
                 let effective_pending = transaction.is_pending()
                     && !legacy_rpm_install_is_committed(&transaction, evidence.operations);
                 Ok(JournalEntry {
@@ -510,6 +512,33 @@ mod tests {
         journal
     }
 
+    fn begin_legacy_cosh_ng_journal(operation: &str, root: &Path) {
+        let mut journal = Transaction::begin_with_subject(
+            operation,
+            Some("cosh"),
+            root.join("installed.toml"),
+            &root.join("journal"),
+        )
+        .expect("begin delegated journal");
+        journal
+            .record_delegated_steps(
+                DelegatedRecoveryContext {
+                    pm: NativePm::Rpm,
+                    package: Some("cosh-ng".to_string()),
+                    record_action: if operation == "install" {
+                        DelegatedRecordAction::WriteManaged
+                    } else {
+                        DelegatedRecordAction::Refresh
+                    },
+                    pinned: None,
+                },
+                [TransactionStep::planned(
+                    "native", "cosh-ng", operation, None,
+                )],
+            )
+            .expect("record delegated recovery");
+    }
+
     fn operation(operation_id: &str, status: &str) -> OperationRecord {
         OperationRecord {
             id: operation_id.to_string(),
@@ -660,6 +689,57 @@ mod tests {
             .expect("load inventory");
         assert!(inventory.blocking_for("anything").is_some());
         assert!(inventory.recoverable_for("anything").is_none());
+    }
+
+    #[test]
+    fn legacy_cosh_ng_journals_follow_the_repaired_subject() {
+        for operation in ["install", "update"] {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            begin_legacy_cosh_ng_journal(operation, tmp.path());
+
+            let inventory =
+                JournalInventory::load(JournalEvidence::new(&tmp.path().join("journal"), &[]))
+                    .expect("load inventory");
+
+            assert!(inventory.blocking_for("cosh-ng").is_some());
+            assert!(inventory.recoverable_for("cosh-ng").is_some());
+            assert!(inventory.blocking_for("cosh").is_none());
+        }
+    }
+
+    #[test]
+    fn legacy_cosh_journal_for_another_rpm_keeps_its_subject() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let mut journal = Transaction::begin_with_subject(
+            "install",
+            Some("cosh"),
+            tmp.path().join("installed.toml"),
+            &tmp.path().join("journal"),
+        )
+        .expect("begin delegated journal");
+        journal
+            .record_delegated_steps(
+                DelegatedRecoveryContext {
+                    pm: NativePm::Rpm,
+                    package: Some("copilot-shell".to_string()),
+                    record_action: DelegatedRecordAction::WriteManaged,
+                    pinned: None,
+                },
+                [TransactionStep::planned(
+                    "native",
+                    "copilot-shell",
+                    "install",
+                    None,
+                )],
+            )
+            .expect("record delegated recovery");
+
+        let inventory =
+            JournalInventory::load(JournalEvidence::new(&tmp.path().join("journal"), &[]))
+                .expect("load inventory");
+
+        assert!(inventory.recoverable_for("cosh").is_some());
+        assert!(inventory.blocking_for("cosh-ng").is_none());
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod sandbox_manifest;
 pub mod self_update;
 pub mod service;
 pub mod state;
+mod state_identity;
 pub mod state_migration;
 pub mod state_store;
 pub mod system_helper;

--- a/src/anolisa/crates/anolisa-core/src/state_identity.rs
+++ b/src/anolisa/crates/anolisa-core/src/state_identity.rs
@@ -1,0 +1,162 @@
+//! Repairs narrowly identified historical component-name mistakes.
+
+use crate::domain::{Installation, NativePm, PackageIdentity, ProviderBinding};
+use crate::state::ObjectKind;
+use crate::transaction::Transaction;
+
+const LEGACY_COSH_NAME: &str = "cosh";
+const COSH_NG_NAME: &str = "cosh-ng";
+
+/// Repairs the historical `cosh` identity emitted by the `cosh-ng` RPM.
+///
+/// The backing RPM name is the disambiguating evidence: legitimate
+/// `copilot-shell` installations remain `cosh`. A conflicting canonical
+/// record, or duplicate legacy claims in the same scope, is left untouched
+/// so loading state never guesses how to merge records.
+pub(crate) fn repair_known_installation_identities(installations: &mut [Installation]) {
+    let candidates = installations
+        .iter()
+        .enumerate()
+        .filter_map(|(index, installation)| {
+            is_legacy_cosh_ng_identity(installation).then_some((index, installation.scope))
+        })
+        .collect::<Vec<_>>();
+
+    for (index, scope) in &candidates {
+        let competing_candidate = candidates
+            .iter()
+            .any(|(other_index, other_scope)| other_index != index && other_scope == scope);
+        let canonical_exists =
+            installations
+                .iter()
+                .enumerate()
+                .any(|(other_index, installation)| {
+                    other_index != *index
+                        && installation.kind == ObjectKind::Component
+                        && installation.name == COSH_NG_NAME
+                        && installation.scope == *scope
+                });
+        if !competing_candidate && !canonical_exists {
+            installations[*index].name = COSH_NG_NAME.to_string();
+        }
+    }
+}
+
+/// Repairs pending journals written before the `cosh-ng` state rename.
+///
+/// The delegated RPM package is durable recovery evidence for the renamed
+/// subject. Journals for the unrelated `copilot-shell` package remain `cosh`.
+pub(crate) fn repair_known_transaction_identity(transaction: &mut Transaction) {
+    if transaction.subject.as_deref() == Some(LEGACY_COSH_NAME)
+        && matches!(
+            &transaction.delegated_recovery,
+            Some(context)
+                if context.pm == NativePm::Rpm
+                    && context.package.as_deref() == Some(COSH_NG_NAME)
+        )
+    {
+        transaction.subject = Some(COSH_NG_NAME.to_string());
+    }
+}
+
+fn is_legacy_cosh_ng_identity(installation: &Installation) -> bool {
+    installation.kind == ObjectKind::Component
+        && installation.name == LEGACY_COSH_NAME
+        && matches!(
+            &installation.binding,
+            ProviderBinding::Delegated {
+                pm: NativePm::Rpm,
+                package: PackageIdentity::Resolved { name },
+                ..
+            } if name == COSH_NG_NAME
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{InstallationScope, LifecycleStatus, ManagementRelation};
+
+    fn delegated_component(name: &str, package: &str, scope: InstallationScope) -> Installation {
+        Installation {
+            kind: ObjectKind::Component,
+            name: name.to_string(),
+            scope,
+            binding: ProviderBinding::Delegated {
+                pm: NativePm::Rpm,
+                package: PackageIdentity::Resolved {
+                    name: package.to_string(),
+                },
+                relation: ManagementRelation::Managed {
+                    since: "2026-07-01T00:00:00Z".to_string(),
+                },
+                last_observed: None,
+            },
+            status: LifecycleStatus::Installed,
+            installed_at: "2026-07-01T00:00:00Z".to_string(),
+            last_operation_id: None,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn repairs_cosh_record_backed_by_cosh_ng_rpm() {
+        let mut installations = vec![delegated_component(
+            LEGACY_COSH_NAME,
+            COSH_NG_NAME,
+            InstallationScope::System,
+        )];
+
+        repair_known_installation_identities(&mut installations);
+
+        assert_eq!(installations[0].name, COSH_NG_NAME);
+    }
+
+    #[test]
+    fn preserves_legitimate_copilot_shell_identity() {
+        let mut installations = vec![delegated_component(
+            LEGACY_COSH_NAME,
+            "copilot-shell",
+            InstallationScope::System,
+        )];
+
+        repair_known_installation_identities(&mut installations);
+
+        assert_eq!(installations[0].name, LEGACY_COSH_NAME);
+    }
+
+    #[test]
+    fn leaves_conflicting_canonical_record_untouched() {
+        let mut installations = vec![
+            delegated_component(LEGACY_COSH_NAME, COSH_NG_NAME, InstallationScope::System),
+            delegated_component(COSH_NG_NAME, COSH_NG_NAME, InstallationScope::System),
+        ];
+
+        repair_known_installation_identities(&mut installations);
+
+        assert_eq!(installations[0].name, LEGACY_COSH_NAME);
+        assert_eq!(installations[1].name, COSH_NG_NAME);
+    }
+
+    #[test]
+    fn repairs_each_scope_independently() {
+        let mut installations = vec![
+            delegated_component(LEGACY_COSH_NAME, COSH_NG_NAME, InstallationScope::System),
+            delegated_component(
+                LEGACY_COSH_NAME,
+                COSH_NG_NAME,
+                InstallationScope::User { uid: 1000 },
+            ),
+        ];
+
+        repair_known_installation_identities(&mut installations);
+
+        assert!(
+            installations
+                .iter()
+                .all(|installation| installation.name == COSH_NG_NAME)
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/state_store.rs
+++ b/src/anolisa/crates/anolisa-core/src/state_store.rs
@@ -26,6 +26,7 @@ use crate::state::{
     BackupRecord, InstallMode, InstalledState, ObjectKind, OperationRecord, StateError,
     now_iso8601, write_atomic,
 };
+use crate::state_identity::repair_known_installation_identities;
 use crate::state_migration::{MigrationRule, QuarantinedObject, migrate_state};
 
 /// Schema version this store reads natively and always writes.
@@ -211,10 +212,12 @@ impl StateStore {
                     path: path.to_path_buf(),
                     source,
                 })?;
+            let mut installations = file.installations;
+            repair_known_installation_identities(&mut installations);
             return Ok(Self {
                 install_mode: file.install_mode,
                 prefix: file.prefix,
-                installations: file.installations,
+                installations,
                 quarantined: file.quarantined,
                 backups: file.backups,
                 operations: file.operations,
@@ -235,10 +238,12 @@ impl StateStore {
             InstallMode::User => InstallationScope::User { uid },
         };
         let migration = migrate_state(&legacy.objects, scope);
+        let mut installations = migration.active;
+        repair_known_installation_identities(&mut installations);
         Ok(Self {
             install_mode: legacy.install_mode,
             prefix: legacy.prefix,
-            installations: migration.active,
+            installations,
             quarantined: migration.quarantined,
             backups: legacy.backups,
             operations: legacy.operations,
@@ -506,6 +511,29 @@ id = "op-1"
 command = "install"
 status = "ok"
 started_at = "2026-07-01T00:00:00Z"
+"#;
+
+    const LEGACY_COSH_NG_RPM: &str = r#"
+schema_version = 4
+updated_at = "2026-07-01T00:00:00Z"
+install_mode = "system"
+prefix = "/"
+anolisa_version = "0.2.4"
+
+[[objects]]
+kind = "component"
+name = "cosh"
+version = "0.13.0"
+status = "installed"
+install_backend = "rpm"
+ownership = "rpm_managed"
+installed_at = "2026-07-01T00:00:00Z"
+
+[objects.rpm_metadata]
+package_name = "cosh-ng"
+evr = "0.13.0-1"
+arch = "x86_64"
+source_repo = "anolisa"
 "#;
 
     fn write_file(dir: &Path, name: &str, content: &str) -> PathBuf {
@@ -782,6 +810,50 @@ started_at = "2026-07-01T00:00:00Z"
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn v5_load_repairs_cosh_ng_rpm_identity_in_memory() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = tmp.path().join("installed.toml");
+        let mut store = StateStore::empty();
+        store.upsert(Installation {
+            binding: ProviderBinding::Delegated {
+                pm: NativePm::Rpm,
+                package: PackageIdentity::Resolved {
+                    name: "cosh-ng".to_string(),
+                },
+                relation: ManagementRelation::Managed {
+                    since: "2026-07-01T00:00:00Z".to_string(),
+                },
+                last_observed: None,
+            },
+            ..owned_installation("cosh", "0.13.0")
+        });
+        store.save(&path).expect("save legacy identity as v5");
+
+        let reloaded = StateStore::load(&path, 1000).expect("reload");
+
+        assert!(
+            reloaded.find(ObjectKind::Component, "cosh").is_none(),
+            "the incorrect identity must disappear from active state"
+        );
+        assert!(
+            reloaded.find(ObjectKind::Component, "cosh-ng").is_some(),
+            "the backing package identifies the canonical component"
+        );
+    }
+
+    #[test]
+    fn legacy_load_repairs_cosh_ng_rpm_identity_after_migration() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = write_file(tmp.path(), "installed.toml", LEGACY_COSH_NG_RPM);
+
+        let store = StateStore::load(&path, 1000).expect("load legacy RPM record");
+
+        assert!(store.migrated_from_legacy());
+        assert!(store.find(ObjectKind::Component, "cosh").is_none());
+        assert!(store.find(ObjectKind::Component, "cosh-ng").is_some());
     }
 
     #[test]

--- a/src/anolisa/manifests/components.toml
+++ b/src/anolisa/manifests/components.toml
@@ -42,6 +42,12 @@ summary = "Computable Operating System Harness (cosh-ng) - a deterministic Agent
 kind = "raw"
 package = "cosh-ng"
 
+[[components.backends]]
+kind = "rpm"
+package = "cosh-ng"
+provides = "anolisa-component(cosh-ng)"
+legacy_adopt = true
+
 [[components]]
 name = "agentsight"
 display_name = "AgentSight"

--- a/src/cosh-ng/component.toml
+++ b/src/cosh-ng/component.toml
@@ -2,7 +2,7 @@ manifest_version = 2
 anolisa_min_version = "0.1.0"
 
 [component]
-name = "cosh"
+name = "cosh-ng"
 version = "0.13.0"
 layer = "runtime"
 domain = "tools"

--- a/src/cosh-ng/cosh-ng.spec.in
+++ b/src/cosh-ng/cosh-ng.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 1
+%define anolis_release 2
 %global debug_package %{nil}
 %global _libexecdir_cosh %{_libexecdir}/anolisa/cosh-ng
 
@@ -18,7 +18,7 @@ Requires(post):   lua
 Requires(postun): lua
 Requires:       openssl-libs
 Provides:       %{_bindir}/cosh-cli %{_bindir}/cosh
-Provides:       anolisa-component(cosh)
+Provides:       anolisa-component(cosh-ng)
 Conflicts:      copilot-shell
 
 %description
@@ -84,8 +84,8 @@ install -m 0644 LICENSE %{buildroot}%{_docdir}/%{name}/LICENSE
 install -m 0644 README.md %{buildroot}%{_docdir}/%{name}/README.md
 
 # Install anolisa component manifest
-install -d %{buildroot}%{_datadir}/anolisa/components/cosh
-install -m 0644 component.toml %{buildroot}%{_datadir}/anolisa/components/cosh/component.toml
+install -d %{buildroot}%{_datadir}/anolisa/components/cosh-ng
+install -m 0644 component.toml %{buildroot}%{_datadir}/anolisa/components/cosh-ng/component.toml
 
 %files
 %license %{_docdir}/%{name}/LICENSE
@@ -96,7 +96,7 @@ install -m 0644 component.toml %{buildroot}%{_datadir}/anolisa/components/cosh/c
 %dir %{_libexecdir_cosh}
 %{_libexecdir_cosh}/cosh-core
 %{_libexecdir_cosh}/cosh-shell
-%{_datadir}/anolisa/components/cosh/component.toml
+%{_datadir}/anolisa/components/cosh-ng/component.toml
 
 %post -p <lua>
 nl        = '\n'


### PR DESCRIPTION
## Description

Align the `cosh-ng` RPM with its stable ANOLISA component identity. The RPM now provides `anolisa-component(cosh-ng)`, installs a `cosh-ng` manifest under the matching data-directory path, and is resolvable through the repository component index.

The root cause was identity drift between the RPM package name, capability, packaged manifest, and component index. Existing state is repaired at the shared load boundary only when a delegated `cosh` record is backed by the resolved `cosh-ng` RPM package; legitimate `copilot-shell` records and ambiguous collisions are left untouched.

## Related Issue

closes #1930

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `bash -n scripts/rpm-build.sh`
- Verified the RPM identity build guard against the package name, capability, manifest name, install path, and `%files` ownership path

## Additional Notes

The actual RPM build was not run on this Darwin host. `build_cosh_ng` now fails before `rpmbuild` if the source identity contract drifts again.
