### PR TITLE
fix(cosh): reuse compatible cosh-ng auth

### DIFF
--- a/src/copilot-shell/packages/cli/src/config/config.test.ts
+++ b/src/copilot-shell/packages/cli/src/config/config.test.ts
@@ -1557,6 +1557,78 @@ describe('loadCliConfig deprecated/unknown authType handling', () => {
   });
 });
 
+describe('loadCliConfig cosh-ng fallback precedence', () => {
+  const originalArgv = process.argv;
+
+  // Shape produced by loadCoshNgProviderFallback() and merged as the
+  // lowest-precedence settings layer.
+  const coshNgFallbackSettings = {
+    security: {
+      auth: {
+        selectedType: 'openai',
+        apiKey: 'sk-from-cosh-ng',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        openaiModel: 'model-from-cosh-ng',
+      },
+    },
+    model: { name: 'model-from-cosh-ng' },
+  } as unknown as Settings;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('lets --auth-type override the inherited auth type', async () => {
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+    process.argv = ['node', 'script.js', '--auth-type', 'gemini'];
+    const argv = await parseArguments();
+
+    const config = await loadCliConfig(coshNgFallbackSettings, argv, undefined);
+
+    expect(config.getModelsConfig().getCurrentAuthType()).toBe(
+      AuthType.USE_GEMINI,
+    );
+  });
+
+  it('lets --model override the inherited model', async () => {
+    process.argv = ['node', 'script.js', '--model', 'model-from-cli'];
+    const argv = await parseArguments();
+
+    const config = await loadCliConfig(coshNgFallbackSettings, argv, undefined);
+
+    expect(config.getModelsConfig().getModel()).toBe('model-from-cli');
+  });
+
+  it('lets OPENAI_MODEL override the inherited model', async () => {
+    vi.stubEnv('OPENAI_MODEL', 'model-from-env');
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+
+    const config = await loadCliConfig(coshNgFallbackSettings, argv, undefined);
+
+    expect(config.getModelsConfig().getModel()).toBe('model-from-env');
+  });
+
+  it('uses the inherited model when nothing overrides it', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+
+    const config = await loadCliConfig(coshNgFallbackSettings, argv, undefined);
+
+    expect(config.getModelsConfig().getCurrentAuthType()).toBe(
+      AuthType.USE_OPENAI,
+    );
+    expect(config.getModelsConfig().getModel()).toBe('model-from-cosh-ng');
+  });
+});
+
 describe('loadCliConfig folderTrust', () => {
   const originalArgv = process.argv;
 

--- a/src/copilot-shell/packages/cli/src/config/coshNgProviderFallback.test.ts
+++ b/src/copilot-shell/packages/cli/src/config/coshNgProviderFallback.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AuthType, loadCoshNgAuth } from '@copilot-shell/core';
+import { loadCoshNgProviderFallback } from './coshNgProviderFallback.js';
+
+// Reading and validating config.toml lives in core and is covered by
+// coshNgAuth.test.ts; here we only pin down the settings mapping.
+vi.mock('@copilot-shell/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@copilot-shell/core')>()),
+  loadCoshNgAuth: vi.fn(),
+}));
+
+describe('loadCoshNgProviderFallback', () => {
+  beforeEach(() => {
+    vi.mocked(loadCoshNgAuth).mockReset();
+  });
+
+  it('maps an OpenAI-compatible provider onto OpenAI auth settings', () => {
+    vi.mocked(loadCoshNgAuth).mockReturnValue({
+      kind: 'openai',
+      apiKey: 'sk-from-cosh-ng',
+      baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      model: 'qwen3-235b-a22b',
+    });
+
+    expect(loadCoshNgProviderFallback('/config/dir')).toEqual({
+      security: {
+        auth: {
+          selectedType: AuthType.USE_OPENAI,
+          apiKey: 'sk-from-cosh-ng',
+          baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+          openaiModel: 'qwen3-235b-a22b',
+        },
+      },
+      model: { name: 'qwen3-235b-a22b' },
+    });
+    expect(loadCoshNgAuth).toHaveBeenCalledWith('/config/dir');
+  });
+
+  it('maps an Aliyun provider onto Aliyun auth without copying credentials', () => {
+    vi.mocked(loadCoshNgAuth).mockReturnValue({
+      kind: 'aliyun',
+      accessKeyId: 'LTAI-test',
+      accessKeySecret: 'secret-test',
+      model: 'qwen3.7-plus',
+    });
+
+    const fallback = loadCoshNgProviderFallback();
+
+    // The AK/SK stays in config.toml; loadAliyunCredentials() reads it there.
+    expect(fallback).toEqual({
+      security: {
+        auth: {
+          selectedType: AuthType.USE_ALIYUN,
+          aliyunModel: 'qwen3.7-plus',
+        },
+      },
+      model: { name: 'qwen3.7-plus' },
+    });
+    expect(JSON.stringify(fallback)).not.toContain('secret-test');
+  });
+
+  it('leaves the model alone when cosh-ng recorded none', () => {
+    vi.mocked(loadCoshNgAuth).mockReturnValue({
+      kind: 'openai',
+      apiKey: 'sk-from-cosh-ng',
+      baseUrl: 'https://example.com/v1',
+    });
+
+    expect(loadCoshNgProviderFallback()).toEqual({
+      security: {
+        auth: {
+          selectedType: AuthType.USE_OPENAI,
+          apiKey: 'sk-from-cosh-ng',
+          baseUrl: 'https://example.com/v1',
+        },
+      },
+    });
+  });
+
+  it('returns undefined when there is nothing to inherit', () => {
+    vi.mocked(loadCoshNgAuth).mockReturnValue(undefined);
+
+    expect(loadCoshNgProviderFallback()).toBeUndefined();
+  });
+});

--- a/src/copilot-shell/packages/cli/src/config/coshNgProviderFallback.ts
+++ b/src/copilot-shell/packages/cli/src/config/coshNgProviderFallback.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthType, loadCoshNgAuth } from '@copilot-shell/core';
+import type { Settings } from './settingsSchema.js';
+
+/**
+ * Maps the authentication capability cosh-ng last used (see `loadCoshNgAuth()`
+ * in core, which owns reading and validating `config.toml`) onto this CLI's
+ * settings shape.
+ *
+ * The result is meant to be merged as the lowest-precedence settings layer, so
+ * that `settings.json`, CLI flags and environment variables all still win. It
+ * is never written back: for the OpenAI-compatible case the credential lives
+ * only in the returned in-memory settings, and for the Aliyun case the AK/SK
+ * is not copied here at all - `loadAliyunCredentials()` reads it from
+ * `config.toml` on demand.
+ *
+ * Returns `undefined` when there is nothing usable to inherit, leaving the
+ * existing `/auth` flow untouched.
+ *
+ * @param configDir Directory holding cosh-ng's `config.toml`
+ *   (normally `~/.copilot-shell`).
+ */
+export function loadCoshNgProviderFallback(
+  configDir?: string,
+): Settings | undefined {
+  const coshNgAuth = loadCoshNgAuth(configDir);
+  if (!coshNgAuth) {
+    return undefined;
+  }
+
+  // cosh-ng may not record a model; each auth type has its own default here, so
+  // leave `model.name` alone rather than inventing one.
+  const model = coshNgAuth.model;
+  const modelSettings = model ? { model: { name: model } } : {};
+
+  if (coshNgAuth.kind === 'openai') {
+    return {
+      security: {
+        auth: {
+          selectedType: AuthType.USE_OPENAI,
+          apiKey: coshNgAuth.apiKey,
+          baseUrl: coshNgAuth.baseUrl,
+          ...(model ? { openaiModel: model } : {}),
+        },
+      },
+      ...modelSettings,
+    } as Settings;
+  }
+
+  return {
+    security: {
+      auth: {
+        selectedType: AuthType.USE_ALIYUN,
+        ...(model ? { aliyunModel: model } : {}),
+      },
+    },
+    ...modelSettings,
+  } as Settings;
+}

--- a/src/copilot-shell/packages/cli/src/config/settings.test.ts
+++ b/src/copilot-shell/packages/cli/src/config/settings.test.ts
@@ -51,12 +51,14 @@ import {
 import * as fs from 'node:fs'; // fs will be mocked separately
 import stripJsonComments from 'strip-json-comments'; // Will be mocked separately
 import { isWorkspaceTrusted } from './trustedFolders.js';
+import { loadCoshNgProviderFallback } from './coshNgProviderFallback.js';
 
 // These imports will get the versions from the vi.mock('./settings.js', ...) factory.
 import {
   getSettingsWarnings,
   loadSettings,
   USER_SETTINGS_PATH, // This IS the mocked path.
+  USER_SETTINGS_DIR,
   getSystemSettingsPath,
   getSystemDefaultsPath,
   SETTINGS_DIRECTORY_NAME, // This is from the original module, but used by the mock.
@@ -102,6 +104,14 @@ vi.mock('fs', async (importOriginal) => {
 
 vi.mock('./extension.js', () => ({
   disableExtension: vi.fn(),
+}));
+
+// Parsing of cosh-ng's config.toml is covered by coshNgProviderFallback.test.ts;
+// here we only exercise how loadSettings merges whatever it returns. Mocking it
+// also keeps the blanket `existsSync -> true` mocks in this file from feeding
+// JSON to a TOML parser.
+vi.mock('./coshNgProviderFallback.js', () => ({
+  loadCoshNgProviderFallback: vi.fn(),
 }));
 
 vi.mock('strip-json-comments', () => ({
@@ -1938,6 +1948,201 @@ describe('Settings Loading and Merging', () => {
           [SETTINGS_VERSION_KEY]: SETTINGS_VERSION,
         });
       });
+    });
+  });
+
+  describe('cosh-ng config.toml auth fallback', () => {
+    const AUTH_ENV_VARS = [
+      'OPENAI_API_KEY',
+      'OPENAI_MODEL',
+      'OPENAI_BASE_URL',
+      'GEMINI_API_KEY',
+      'GEMINI_MODEL',
+      'GOOGLE_API_KEY',
+      'GOOGLE_MODEL',
+      'ANTHROPIC_API_KEY',
+      'ANTHROPIC_MODEL',
+      'ANTHROPIC_BASE_URL',
+    ];
+
+    const COSH_NG_FALLBACK: TestSettings = {
+      security: {
+        auth: {
+          selectedType: 'openai',
+          apiKey: 'sk-from-cosh-ng',
+          baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+          openaiModel: 'qwen3-235b-a22b',
+        },
+      },
+      model: { name: 'qwen3-235b-a22b' },
+    };
+
+    /** Makes only settings.json exist, with the given content. */
+    const mockUserSettings = (userSettings: TestSettings) => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) =>
+          p === USER_SETTINGS_PATH ? JSON.stringify(userSettings) : '{}',
+      );
+    };
+
+    beforeEach(() => {
+      for (const key of AUTH_ENV_VARS) {
+        vi.stubEnv(key, '');
+      }
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("adopts cosh-ng's active provider when no native auth type is set", () => {
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(COSH_NG_FALLBACK);
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(loadCoshNgProviderFallback).toHaveBeenCalledWith(
+        USER_SETTINGS_DIR,
+      );
+      expect(settings.merged.security?.auth).toEqual(
+        COSH_NG_FALLBACK.security?.auth,
+      );
+      expect(settings.merged.model?.name).toBe('qwen3-235b-a22b');
+    });
+
+    it('keeps the fallback out of originalSettings so it is never persisted', () => {
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(COSH_NG_FALLBACK);
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.systemDefaults.originalSettings).toEqual({});
+      expect(settings.systemDefaults.settings.security?.auth?.apiKey).toBe(
+        'sk-from-cosh-ng',
+      );
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('is not consulted when a native selectedType is present', () => {
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(COSH_NG_FALLBACK);
+      mockUserSettings({
+        security: { auth: { selectedType: 'anthropic' } },
+      } as TestSettings);
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(loadCoshNgProviderFallback).not.toHaveBeenCalled();
+      expect(settings.merged.security?.auth?.selectedType).toBe('anthropic');
+      expect(settings.merged.security?.auth?.apiKey).toBeUndefined();
+    });
+
+    it('fills credentials after /model persisted only auth type and model', () => {
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(COSH_NG_FALLBACK);
+      mockUserSettings({
+        security: { auth: { selectedType: 'openai' } },
+        model: { name: 'model-selected-via-dialog' },
+      } as TestSettings);
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.security?.auth).toEqual({
+        selectedType: 'openai',
+        apiKey: 'sk-from-cosh-ng',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        openaiModel: 'qwen3-235b-a22b',
+      });
+      expect(settings.merged.model?.name).toBe('model-selected-via-dialog');
+    });
+
+    it('does not override an auth type inferred from environment variables', () => {
+      vi.stubEnv('GEMINI_API_KEY', 'gemini-from-env');
+      vi.stubEnv('GEMINI_MODEL', 'gemini-model-from-env');
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(COSH_NG_FALLBACK);
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(loadCoshNgProviderFallback).not.toHaveBeenCalled();
+      expect(settings.merged.security?.auth?.selectedType).toBeUndefined();
+    });
+
+    it('ignores selectedType from an untrusted workspace', () => {
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: false,
+        source: 'file',
+      });
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(COSH_NG_FALLBACK);
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === MOCK_WORKSPACE_SETTINGS_PATH,
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) =>
+          p === MOCK_WORKSPACE_SETTINGS_PATH
+            ? JSON.stringify({
+                security: { auth: { selectedType: 'anthropic' } },
+              })
+            : '{}',
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.security?.auth).toEqual(
+        COSH_NG_FALLBACK.security?.auth,
+      );
+    });
+
+    it('lets native settings win field by field over the fallback', () => {
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(COSH_NG_FALLBACK);
+      mockUserSettings({
+        model: { name: 'model-from-settings-json' },
+      } as TestSettings);
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.security?.auth?.selectedType).toBe('openai');
+      expect(settings.merged.model?.name).toBe('model-from-settings-json');
+    });
+
+    // The cosh-ng reader has already expanded ${VAR} with cosh-ng's own
+    // semantics, so this layer must pass credentials through untouched - a
+    // second pass would also rewrite bare $VAR and corrupt a key containing a
+    // dollar sign.
+    it('does not re-resolve environment references in the fallback', () => {
+      const originalEnv = process.env['MOCK_COSH_NG_KEY'];
+      process.env['MOCK_COSH_NG_KEY'] = 'sk-from-env';
+      try {
+        vi.mocked(loadCoshNgProviderFallback).mockReturnValue({
+          security: {
+            auth: {
+              selectedType: 'openai',
+              apiKey: 'sk-literal$MOCK_COSH_NG_KEY',
+              baseUrl: 'https://example.com/v1',
+              openaiModel: 'custom-model',
+            },
+          },
+          model: { name: 'custom-model' },
+        } as TestSettings);
+
+        const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+        expect(settings.merged.security?.auth?.apiKey).toBe(
+          'sk-literal$MOCK_COSH_NG_KEY',
+        );
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env['MOCK_COSH_NG_KEY'];
+        } else {
+          process.env['MOCK_COSH_NG_KEY'] = originalEnv;
+        }
+      }
+    });
+
+    it('leaves settings untouched when there is nothing to inherit', () => {
+      vi.mocked(loadCoshNgProviderFallback).mockReturnValue(undefined);
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged).toEqual({});
     });
   });
 

--- a/src/copilot-shell/packages/cli/src/config/settings.ts
+++ b/src/copilot-shell/packages/cli/src/config/settings.ts
@@ -10,6 +10,7 @@ import { homedir, platform } from 'node:os';
 import * as dotenv from 'dotenv';
 import process from 'node:process';
 import {
+  AuthType,
   FatalConfigError,
   QWEN_DIR,
   getErrorMessage,
@@ -19,6 +20,7 @@ import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
 import { isWorkspaceTrusted } from './trustedFolders.js';
+import { loadCoshNgProviderFallback } from './coshNgProviderFallback.js';
 import {
   type Settings,
   type MemoryImportFormat,
@@ -30,6 +32,7 @@ import {
 import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
 import { customDeepMerge, type MergeableObject } from '../utils/deepMerge.js';
 import { updateSettingsFilePreservingFormat } from '../utils/commentJson.js';
+import { getAuthTypeFromEnv } from '../utils/modelConfigUtils.js';
 
 function getMergeStrategyForPath(path: string[]): MergeStrategy | undefined {
   let current: SettingDefinition | undefined = undefined;
@@ -499,6 +502,44 @@ function mergeSettings(
   ) as Settings;
 }
 
+function hasCompleteNativeOpenAiAuth(nativeSettings: Settings): boolean {
+  const nativeAuth = nativeSettings.security?.auth;
+  return !!(
+    nativeAuth?.apiKey &&
+    nativeAuth.baseUrl &&
+    (nativeAuth.openaiModel || nativeSettings.model?.name)
+  );
+}
+
+function shouldLoadCoshNgFallback(nativeSettings: Settings): boolean {
+  const nativeType = nativeSettings.security?.auth?.selectedType;
+  return (
+    !nativeType ||
+    (nativeType === AuthType.USE_OPENAI &&
+      !hasCompleteNativeOpenAiAuth(nativeSettings))
+  );
+}
+
+function shouldMergeCoshNgFallback(
+  nativeSettings: Settings,
+  fallback: Settings,
+): boolean {
+  const nativeType = nativeSettings.security?.auth?.selectedType;
+  const fallbackType = fallback.security?.auth?.selectedType;
+  if (!nativeType) {
+    return true;
+  }
+
+  // /model persists the effective auth type and model, but not credentials.
+  // Let a matching fallback fill that partial state without overriding any
+  // native values.
+  return (
+    nativeType === AuthType.USE_OPENAI &&
+    fallbackType === AuthType.USE_OPENAI &&
+    !hasCompleteNativeOpenAiAuth(nativeSettings)
+  );
+}
+
 export class LoadedSettings {
   constructor(
     system: SettingsFile,
@@ -851,6 +892,33 @@ export function loadSettings(
   // loadEnviroment depends on settings so we have to create a temp version of
   // the settings to avoid a cycle
   loadEnvironment(tempMergedSettings);
+
+  // cosh-ng compatibility: `cosh-switch` swaps the RPM but leaves the shared
+  // ~/.copilot-shell/ config untouched. After loading the environment, expose
+  // cosh-ng's active provider only when neither env-inferred auth nor a usable
+  // native selection should win. Untrusted workspace settings are absent from
+  // tempMergedSettings and therefore cannot suppress the fallback.
+  if (!getAuthTypeFromEnv() && shouldLoadCoshNgFallback(tempMergedSettings)) {
+    const coshNgFallback = loadCoshNgProviderFallback(USER_SETTINGS_DIR);
+    if (
+      coshNgFallback &&
+      shouldMergeCoshNgFallback(tempMergedSettings, coshNgFallback)
+    ) {
+      // Merged into the resolved copy only - `systemDefaultsOriginalSettings`
+      // stays untouched, so saveSettings() can never persist the fallback.
+      //
+      // Deliberately not passed through resolveEnvVarsInObject(): the cosh-ng
+      // reader already expanded `${VAR}` with cosh-ng's own semantics, and
+      // resolving again would also rewrite bare `$VAR`, corrupting a credential
+      // that legitimately contains a dollar sign.
+      systemDefaultSettings = customDeepMerge(
+        getMergeStrategyForPath,
+        {},
+        coshNgFallback,
+        systemDefaultSettings,
+      ) as Settings;
+    }
+  }
 
   // Create LoadedSettings first
 

--- a/src/copilot-shell/packages/core/src/aliyun/aliyunCredentials.test.ts
+++ b/src/copilot-shell/packages/core/src/aliyun/aliyunCredentials.test.ts
@@ -13,6 +13,7 @@ import {
   hasAliyunCredentials,
   getAliyunCredsPath,
 } from './aliyunCredentials.js';
+import { loadCoshNgAuth } from '../config/coshNgAuth.js';
 
 vi.mock('node:fs', () => ({
   promises: {
@@ -21,6 +22,12 @@ vi.mock('node:fs', () => ({
     mkdir: vi.fn(),
     unlink: vi.fn(),
   },
+}));
+
+// config.toml parsing is covered by ../config/coshNgAuth.test.ts; here we only
+// exercise how the credential loader consumes its result.
+vi.mock('../config/coshNgAuth.js', () => ({
+  loadCoshNgAuth: vi.fn(),
 }));
 
 vi.mock('../utils/credential-encryptor.js', () => ({
@@ -55,6 +62,8 @@ describe('aliyunCredentials', () => {
     vi.clearAllMocks();
     mockFs.mkdir.mockResolvedValue(undefined);
     mockFs.writeFile.mockResolvedValue(undefined);
+    // No cosh-ng config unless a test says otherwise.
+    vi.mocked(loadCoshNgAuth).mockReturnValue(undefined);
   });
 
   describe('saveAliyunCredentials', () => {
@@ -138,6 +147,93 @@ describe('aliyunCredentials', () => {
 
       const result = await loadAliyunCredentials();
       expect(result).toBeNull();
+    });
+  });
+
+  describe('loadAliyunCredentials cosh-ng fallback', () => {
+    const enoent = () =>
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' as const });
+
+    const coshNgCredentials = {
+      kind: 'aliyun' as const,
+      accessKeyId: 'LTAI-from-cosh-ng',
+      accessKeySecret: 'secret-from-cosh-ng',
+    };
+
+    it('should use cosh-ng AK/SK when aliyun_creds.json is absent', async () => {
+      mockFs.readFile.mockRejectedValue(enoent());
+      vi.mocked(loadCoshNgAuth).mockReturnValue(coshNgCredentials);
+
+      expect(await loadAliyunCredentials()).toEqual({
+        accessKeyId: 'LTAI-from-cosh-ng',
+        accessKeySecret: 'secret-from-cosh-ng',
+      });
+    });
+
+    it('should never produce STS credentials from the fallback', async () => {
+      mockFs.readFile.mockRejectedValue(enoent());
+      vi.mocked(loadCoshNgAuth).mockReturnValue(coshNgCredentials);
+
+      const credentials = await loadAliyunCredentials();
+
+      // A securityToken would make the generator treat these as STS and
+      // persist refreshed credentials on expiry, which the read-only fallback
+      // must never trigger. loadCoshNgAuth() refuses token-bearing providers.
+      expect(credentials).not.toHaveProperty('securityToken');
+      expect(credentials).not.toHaveProperty('expiration');
+    });
+
+    it('should prefer native aliyun_creds.json over cosh-ng', async () => {
+      mockFs.readFile.mockResolvedValue(
+        `enc:mock:mock:${JSON.stringify(testCredentials)}`,
+      );
+      vi.mocked(loadCoshNgAuth).mockReturnValue(coshNgCredentials);
+
+      expect(await loadAliyunCredentials()).toEqual(testCredentials);
+    });
+
+    it('should not switch identities when native credentials are corrupt', async () => {
+      mockFs.readFile.mockResolvedValue('enc:unknown:bad:data');
+      vi.mocked(loadCoshNgAuth).mockReturnValue(coshNgCredentials);
+
+      expect(await loadAliyunCredentials()).toBeNull();
+      expect(loadCoshNgAuth).not.toHaveBeenCalled();
+    });
+
+    it('should not fall back after a native credential read error', async () => {
+      mockFs.readFile.mockRejectedValue(new Error('permission denied'));
+      vi.mocked(loadCoshNgAuth).mockReturnValue(coshNgCredentials);
+
+      expect(await loadAliyunCredentials()).toBeNull();
+      expect(loadCoshNgAuth).not.toHaveBeenCalled();
+    });
+
+    it('should ignore an OpenAI-compatible cosh-ng provider', async () => {
+      mockFs.readFile.mockRejectedValue(enoent());
+      vi.mocked(loadCoshNgAuth).mockReturnValue({
+        kind: 'openai',
+        apiKey: 'sk-from-cosh-ng',
+        baseUrl: 'https://example.com/v1',
+      });
+
+      expect(await loadAliyunCredentials()).toBeNull();
+    });
+
+    it('should never write either credential store', async () => {
+      mockFs.readFile.mockRejectedValue(enoent());
+      vi.mocked(loadCoshNgAuth).mockReturnValue(coshNgCredentials);
+
+      await loadAliyunCredentials();
+
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+      expect(mockFs.mkdir).not.toHaveBeenCalled();
+    });
+
+    it('should report credentials as present via hasAliyunCredentials', async () => {
+      mockFs.readFile.mockRejectedValue(enoent());
+      vi.mocked(loadCoshNgAuth).mockReturnValue(coshNgCredentials);
+
+      expect(await hasAliyunCredentials()).toBe(true);
     });
   });
 

--- a/src/copilot-shell/packages/core/src/aliyun/aliyunCredentials.ts
+++ b/src/copilot-shell/packages/core/src/aliyun/aliyunCredentials.ts
@@ -11,6 +11,7 @@ import {
   decryptCredential,
 } from '../utils/credential-encryptor.js';
 import { Storage } from '../config/storage.js';
+import { loadCoshNgAuth } from '../config/coshNgAuth.js';
 
 const ALIYUN_CREDS_FILENAME = 'aliyun_creds.json';
 
@@ -110,8 +111,52 @@ export async function saveAliyunCredentials(
  * 从磁盘加载阿里云凭证。
  * 支持加密格式（enc: 前缀）和明文 JSON（向前兼容）。
  * 若存在 STS 凭证则返回 STS 类型，否则返回普通 AK/SK 类型。
+ *
+ * The native `aliyun_creds.json` wins. Only when it is absent is the long-lived
+ * AK/SK recorded in cosh-ng's `config.toml` reused read-only (see
+ * {@link loadCoshNgAuth}), so switching back with `cosh-switch` does not force
+ * re-authentication. A corrupt or unreadable native store keeps the prior
+ * re-authentication behavior instead of silently switching identities.
  */
 export async function loadAliyunCredentials(): Promise<AliyunCredentialsWithSTS | null> {
+  const native = await loadNativeAliyunCredentials();
+  if (native.status === 'loaded') {
+    return native.credentials;
+  }
+  if (native.status === 'invalid') {
+    return null;
+  }
+  return loadCoshNgAliyunCredentials();
+}
+
+/**
+ * Read-only fallback to cosh-ng's long-lived AK/SK.
+ *
+ * Only ever yields {@link AliyunCredentials}: both the ECS RAM role flow and
+ * temporary STS credentials are refused outright by {@link loadCoshNgAuth}.
+ * That is required rather than merely cautious - the generator treats any
+ * `securityToken` as STS, and on expiry `refreshSTSCredentials()` persists the
+ * refreshed pair to `aliyun_creds.json`, at which point the fallback would no
+ * longer be read-only.
+ */
+function loadCoshNgAliyunCredentials(): AliyunCredentials | null {
+  const coshNgAuth = loadCoshNgAuth();
+  if (coshNgAuth?.kind !== 'aliyun') {
+    return null;
+  }
+
+  return {
+    accessKeyId: coshNgAuth.accessKeyId,
+    accessKeySecret: coshNgAuth.accessKeySecret,
+  };
+}
+
+type NativeAliyunCredentialsResult =
+  | { status: 'loaded'; credentials: AliyunCredentialsWithSTS }
+  | { status: 'absent' }
+  | { status: 'invalid' };
+
+async function loadNativeAliyunCredentials(): Promise<NativeAliyunCredentialsResult> {
   const filePath = getAliyunCredsPath();
   try {
     const content = await fs.readFile(filePath, 'utf-8');
@@ -119,7 +164,7 @@ export async function loadAliyunCredentials(): Promise<AliyunCredentialsWithSTS 
     if (decrypted === undefined) {
       // Decryption failed (e.g. salt changed) — treat as corrupted
       console.warn('Failed to decrypt Aliyun credentials file');
-      return null;
+      return { status: 'invalid' };
     }
 
     const credentials = JSON.parse(decrypted) as AliyunCredentialsWithSTS;
@@ -127,17 +172,17 @@ export async function loadAliyunCredentials(): Promise<AliyunCredentialsWithSTS 
     // Validate credentials structure
     if (!credentials.accessKeyId || !credentials.accessKeySecret) {
       console.warn('Invalid Aliyun credentials format in file');
-      return null;
+      return { status: 'invalid' };
     }
 
-    return credentials;
+    return { status: 'loaded', credentials };
   } catch (error: unknown) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       // File doesn't exist
-      return null;
+      return { status: 'absent' };
     }
     console.warn('Failed to load Aliyun credentials:', error);
-    return null;
+    return { status: 'invalid' };
   }
 }
 

--- a/src/copilot-shell/packages/core/src/config/coshNgAuth.test.ts
+++ b/src/copilot-shell/packages/core/src/config/coshNgAuth.test.ts
@@ -1,0 +1,647 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  COSH_NG_CONFIG_FILE_NAME,
+  getCoshNgConfigPath,
+  loadCoshNgAuth,
+} from './coshNgAuth.js';
+
+describe('loadCoshNgAuth', () => {
+  let configDir: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  const writeConfig = (content: string) => {
+    fs.writeFileSync(
+      path.join(configDir, COSH_NG_CONFIG_FILE_NAME),
+      content,
+      'utf-8',
+    );
+  };
+
+  /** All warning text emitted so far, joined for leak assertions. */
+  const warnings = () => warnSpy.mock.calls.map((call) => String(call[0]));
+
+  /** Runs `body` with the given environment, restoring it afterwards. */
+  const withEnv = (
+    env: Record<string, string | undefined>,
+    body: () => void,
+  ) => {
+    const saved = new Map(
+      Object.keys(env).map((key) => [key, process.env[key]]),
+    );
+    try {
+      for (const [key, value] of Object.entries(env)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      body();
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  };
+
+  // cosh-ng reads several credential fields from the environment when the TOML
+  // omits them, so the ambient environment has to be pinned for these tests to
+  // mean anything.
+  const AMBIENT_CREDENTIAL_VARS = [
+    'ALIBABA_CLOUD_SECURITY_TOKEN',
+    'ALIBABA_CLOUD_ACCESS_KEY_ID',
+    'ALIBABA_CLOUD_ACCESS_KEY_SECRET',
+  ];
+  let savedAmbientEnv: Array<[string, string | undefined]> = [];
+
+  beforeEach(() => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cosh-ng-auth-'));
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    savedAmbientEnv = AMBIENT_CREDENTIAL_VARS.map((key) => [
+      key,
+      process.env[key],
+    ]);
+    for (const key of AMBIENT_CREDENTIAL_VARS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(configDir, { recursive: true, force: true });
+    warnSpy.mockRestore();
+    for (const [key, value] of savedAmbientEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  describe('OpenAI-compatible providers', () => {
+    it('reads a dashscope provider', () => {
+      writeConfig(`
+[ai]
+active_provider = "dashscope"
+active_model = "qwen3-235b-a22b"
+
+[ai.providers.dashscope]
+type = "dashscope"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "sk-dashscope"
+model = "qwen-max"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toEqual({
+        kind: 'openai',
+        apiKey: 'sk-dashscope',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        // active_model wins over the provider's own model.
+        model: 'qwen3-235b-a22b',
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['openai', 'type = "openai"'],
+      ['openai_compat', 'type = "openai_compat"'],
+      ['deepseek', 'type = "deepseek"'],
+      ['generic', 'type = "generic"'],
+      // cosh-ng defaults an omitted type to "generic".
+      ['omitted', ''],
+    ])('accepts the %s provider type', (_name, typeLine) => {
+      writeConfig(`
+[ai]
+active_provider = "p"
+
+[ai.providers.p]
+${typeLine}
+base_url = "https://example.com/v1"
+api_key = "sk-example"
+model = "some-model"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toEqual({
+        kind: 'openai',
+        apiKey: 'sk-example',
+        baseUrl: 'https://example.com/v1',
+        model: 'some-model',
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the provider model when active_model is absent', () => {
+      writeConfig(`
+[ai]
+active_provider = "custom"
+
+[ai.providers.custom]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "sk-custom"
+model = "my-model"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toMatchObject({ model: 'my-model' });
+    });
+
+    it('is usable without any model, which is not a credential', () => {
+      writeConfig(`
+[ai]
+active_provider = "custom"
+
+[ai.providers.custom]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "sk-custom"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toEqual({
+        kind: 'openai',
+        apiKey: 'sk-custom',
+        baseUrl: 'https://example.com/v1',
+        model: undefined,
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns by field name when a credential is missing', () => {
+      writeConfig(`
+[ai]
+active_provider = "partial"
+
+[ai.providers.partial]
+type = "openai_compat"
+api_key = "sk-partial-secret"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnings().join('\n')).toContain('missing base_url');
+      expect(warnings().join('\n')).not.toContain('sk-partial-secret');
+    });
+
+    it('treats blank credential values as missing', () => {
+      writeConfig(`
+[ai]
+active_provider = "blank"
+
+[ai.providers.blank]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "   "
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnings().join('\n')).toContain('missing api_key');
+    });
+  });
+
+  describe('Aliyun providers', () => {
+    it('reads AK/SK credentials', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "LTAI-test"
+access_key_secret = "secret-test"
+model = "qwen3.7-plus"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toEqual({
+        kind: 'aliyun',
+        accessKeyId: 'LTAI-test',
+        accessKeySecret: 'secret-test',
+        model: 'qwen3.7-plus',
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('refuses temporary STS credentials, which cannot stay read-only', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "STS.test"
+access_key_secret = "secret-test"
+security_token = "token-test"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      const message = warnings().join('\n');
+      expect(message).toContain('temporary STS credential');
+      expect(message).not.toContain('secret-test');
+      expect(message).not.toContain('token-test');
+    });
+
+    // cosh-ng falls back to $ALIBABA_CLOUD_SECURITY_TOKEN when the provider
+    // section omits security_token, so a temporary AK/SK can be token-bearing
+    // with nothing in the TOML to show it. Inheriting it would send every
+    // request without the token.
+    it('refuses an STS token supplied through the environment', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "STS.test"
+access_key_secret = "secret-test"
+`);
+
+      withEnv({ ALIBABA_CLOUD_SECURITY_TOKEN: 'token-from-env-secret' }, () => {
+        expect(loadCoshNgAuth(configDir)).toBeUndefined();
+        const message = warnings().join('\n');
+        expect(message).toContain('temporary STS credential');
+        expect(message).not.toContain('token-from-env-secret');
+        expect(message).not.toContain('secret-test');
+        expect(message).not.toContain('ALIBABA_CLOUD_SECURITY_TOKEN');
+      });
+    });
+
+    it('refuses a blank STS token from the environment', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "LTAI-test"
+access_key_secret = "secret-test"
+`);
+
+      withEnv({ ALIBABA_CLOUD_SECURITY_TOKEN: '' }, () => {
+        expect(loadCoshNgAuth(configDir)).toBeUndefined();
+        expect(warnings().join('\n')).toContain('temporary STS credential');
+      });
+    });
+
+    it('is unaffected by an STS token when the provider is OpenAI-compatible', () => {
+      writeConfig(`
+[ai]
+active_provider = "p"
+
+[ai.providers.p]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "sk-test"
+`);
+
+      withEnv({ ALIBABA_CLOUD_SECURITY_TOKEN: 'token-from-env' }, () => {
+        expect(loadCoshNgAuth(configDir)).toMatchObject({ kind: 'openai' });
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    it('refuses a blank security_token rather than treating it as absent', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "LTAI-test"
+access_key_secret = "secret-test"
+security_token = ""
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnings().join('\n')).toContain('temporary STS credential');
+    });
+
+    it('refuses the ECS RAM role flow, which has no equivalent here', () => {
+      writeConfig(`
+[ai]
+active_provider = "sysom-trial"
+
+[ai.providers.sysom-trial]
+type = "aliyun"
+auth_source = "ecs_ram_role"
+access_key_id = "STS.test"
+access_key_secret = "secret-test"
+security_token = "token-test"
+model = "qwen3.7-plus"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      const message = warnings().join('\n');
+      expect(message).toContain('ECS RAM role');
+      expect(message).not.toContain('secret-test');
+      expect(message).not.toContain('token-test');
+    });
+
+    it('warns by field name when AK/SK is incomplete', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "LTAI-test"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnings().join('\n')).toContain('missing access_key_secret');
+    });
+  });
+
+  // cosh-ng expands ${VAR} in credentials and base URLs, treating an undefined
+  // variable as empty. Mirroring that here keeps a config that works under
+  // cosh-ng working after cosh-switch, and turns an unresolvable reference into
+  // a refusal instead of a literal "${VAR}" reaching a provider.
+  describe('${VAR} expansion', () => {
+    it('expands defined references in OpenAI credentials', () => {
+      writeConfig(`
+[ai]
+active_provider = "envy"
+
+[ai.providers.envy]
+type = "openai_compat"
+base_url = "https://\${COSH_TEST_HOST}/v1"
+api_key = "\${COSH_TEST_KEY}"
+model = "some-model"
+`);
+
+      withEnv(
+        { COSH_TEST_KEY: 'sk-from-env', COSH_TEST_HOST: 'env.example.com' },
+        () => {
+          expect(loadCoshNgAuth(configDir)).toEqual({
+            kind: 'openai',
+            apiKey: 'sk-from-env',
+            baseUrl: 'https://env.example.com/v1',
+            model: 'some-model',
+          });
+          expect(warnSpy).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('refuses an OpenAI provider whose reference resolves to nothing', () => {
+      writeConfig(`
+[ai]
+active_provider = "envy"
+
+[ai.providers.envy]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "\${COSH_TEST_MISSING}"
+`);
+
+      withEnv({ COSH_TEST_MISSING: undefined }, () => {
+        expect(loadCoshNgAuth(configDir)).toBeUndefined();
+        const message = warnings().join('\n');
+        expect(message).toContain('missing api_key');
+        // The referenced variable name is itself user input; never echo it.
+        expect(message).not.toContain('COSH_TEST_MISSING');
+      });
+    });
+
+    it('expands defined references in Aliyun credentials', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "\${COSH_TEST_AK}"
+access_key_secret = "\${COSH_TEST_SK}"
+`);
+
+      withEnv(
+        { COSH_TEST_AK: 'LTAI-from-env', COSH_TEST_SK: 'sk-from-env' },
+        () => {
+          expect(loadCoshNgAuth(configDir)).toEqual({
+            kind: 'aliyun',
+            accessKeyId: 'LTAI-from-env',
+            accessKeySecret: 'sk-from-env',
+            model: undefined,
+          });
+          expect(warnSpy).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('refuses an Aliyun provider whose reference resolves to nothing', () => {
+      writeConfig(`
+[ai]
+active_provider = "aliyun"
+
+[ai.providers.aliyun]
+type = "aliyun"
+access_key_id = "LTAI-test"
+access_key_secret = "\${COSH_TEST_MISSING}"
+`);
+
+      withEnv({ COSH_TEST_MISSING: undefined }, () => {
+        expect(loadCoshNgAuth(configDir)).toBeUndefined();
+        expect(warnings().join('\n')).toContain('missing access_key_secret');
+      });
+    });
+
+    it('leaves the model unexpanded, as cosh-ng does', () => {
+      writeConfig(`
+[ai]
+active_provider = "envy"
+active_model = "\${COSH_TEST_MODEL}"
+
+[ai.providers.envy]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "sk-test"
+`);
+
+      withEnv({ COSH_TEST_MODEL: 'model-from-env' }, () => {
+        expect(loadCoshNgAuth(configDir)).toMatchObject({
+          model: '${COSH_TEST_MODEL}',
+        });
+      });
+    });
+
+    it('leaves an unterminated ${ alone', () => {
+      writeConfig(`
+[ai]
+active_provider = "envy"
+
+[ai.providers.envy]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "sk-\${unterminated"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toMatchObject({
+        apiKey: 'sk-${unterminated',
+      });
+    });
+
+    it('does not re-expand a substituted value', () => {
+      writeConfig(`
+[ai]
+active_provider = "envy"
+
+[ai.providers.envy]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "\${COSH_TEST_NESTED}"
+`);
+
+      withEnv(
+        { COSH_TEST_NESTED: '${COSH_TEST_INNER}', COSH_TEST_INNER: 'inner' },
+        () => {
+          expect(loadCoshNgAuth(configDir)).toMatchObject({
+            apiKey: '${COSH_TEST_INNER}',
+          });
+        },
+      );
+    });
+  });
+
+  describe('unusable configurations', () => {
+    it('returns undefined when config.toml does not exist', () => {
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns without leaking the error when config.toml is unreadable', () => {
+      const configPath = getCoshNgConfigPath(configDir);
+      fs.mkdirSync(configPath);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+
+      const message = warnings().join('\n');
+      expect(message).toContain('Could not read');
+      expect(message).toContain(configPath);
+      expect(message).not.toContain('EISDIR');
+      expect(message).not.toContain('illegal operation');
+    });
+
+    it('returns undefined without warning when there is no active provider', () => {
+      writeConfig(`
+[ai]
+active_model = "qwen-max"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns when the active provider has no section', () => {
+      writeConfig(`
+[ai]
+active_provider = "ghost"
+
+[ai.providers.other]
+type = "openai_compat"
+base_url = "https://example.com/v1"
+api_key = "sk-other-secret"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      const message = warnings().join('\n');
+      expect(message).toContain('no matching [ai.providers] section');
+      expect(message).not.toContain('ghost');
+      expect(message).not.toContain('sk-other-secret');
+    });
+
+    it('warns for provider types with no equivalent here', () => {
+      writeConfig(`
+[ai]
+active_provider = "fake"
+
+[ai.providers.fake]
+type = "mock"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnings().join('\n')).toContain('unsupported provider type');
+    });
+
+    // A pasted credential consists only of characters a provider id may
+    // legitimately contain, so identifier values must never be logged at all.
+    it('never logs the active provider id', () => {
+      writeConfig(`
+[ai]
+active_provider = "sk-live-secret-leak-check"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      const message = warnings().join('\n');
+      expect(message).toContain('The active provider');
+      expect(message).not.toContain('sk-live-secret-leak-check');
+    });
+
+    it('never logs the provider type', () => {
+      writeConfig(`
+[ai]
+active_provider = "p"
+
+[ai.providers.p]
+type = "sk-live-secret-leak-check"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      const message = warnings().join('\n');
+      expect(message).toContain('unsupported provider type');
+      expect(message).not.toContain('sk-live-secret-leak-check');
+    });
+
+    it('never leaks credentials when the TOML is malformed', () => {
+      // A truncated string literal makes the parser point straight at the
+      // api_key line, which is exactly what must not reach the log.
+      writeConfig(`
+[ai]
+active_provider = "p"
+
+[ai.providers.p]
+api_key = "sk-fake-secret
+base_url = "https://example.com/v1"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      const message = warnings().join('\n');
+      expect(message).toContain('malformed');
+      expect(message).toContain(getCoshNgConfigPath(configDir));
+      expect(message).not.toContain('sk-fake-secret');
+      expect(message).not.toContain('api_key');
+      expect(message).not.toContain('row');
+    });
+
+    it('ignores a config with no [ai] table', () => {
+      writeConfig(`
+[agent]
+approval_mode = "default"
+`);
+
+      expect(loadCoshNgAuth(configDir)).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('never writes to the cosh-ng config file', () => {
+    const configPath = getCoshNgConfigPath(configDir);
+    writeConfig(`
+[ai]
+active_provider = "dashscope"
+
+[ai.providers.dashscope]
+type = "dashscope"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "sk-dashscope"
+model = "qwen-max"
+`);
+    const before = fs.readFileSync(configPath, 'utf-8');
+    const mtimeBefore = fs.statSync(configPath).mtimeMs;
+
+    expect(loadCoshNgAuth(configDir)).toBeDefined();
+
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(before);
+    expect(fs.statSync(configPath).mtimeMs).toBe(mtimeBefore);
+    expect(fs.readdirSync(configDir)).toEqual([COSH_NG_CONFIG_FILE_NAME]);
+  });
+});

--- a/src/copilot-shell/packages/core/src/config/coshNgAuth.ts
+++ b/src/copilot-shell/packages/core/src/config/coshNgAuth.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2026 Alibaba Cloud
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import toml from '@iarna/toml';
+import { Storage } from './storage.js';
+
+/**
+ * cosh-ng keeps its configuration - including the active AI provider and its
+ * credentials - in `~/.copilot-shell/config.toml`, while this generation reads
+ * `settings.json` plus `aliyun_creds.json` from the same directory.
+ * `cosh-switch` swaps the RPM without touching either, so a user who
+ * authenticated in cosh-ng and switched back arrives with no auth type at all:
+ * the header renders "Unknown" and the auth wizard opens on every launch
+ * (issue #1938).
+ *
+ * This module is the single, provider-neutral reader for that file. It answers
+ * one question - "which authentication capability did cosh-ng last use, and
+ * with which credentials?" - and leaves the mapping onto this CLI's settings
+ * and credential stores to its callers:
+ *
+ * - the CLI settings loader turns the result into `security.auth.*`
+ * - `loadAliyunCredentials()` uses the AK/SK variant when no native
+ *   `aliyun_creds.json` exists
+ *
+ * Everything here is read-only. Nothing is copied to disk, so there is no
+ * second place a credential can go stale, no migration version to track and no
+ * half-migrated state to roll back. The scope is deliberately "capabilities
+ * both generations already share": provider types with no equivalent here are
+ * refused rather than approximated.
+ */
+export const COSH_NG_CONFIG_FILE_NAME = 'config.toml';
+
+/**
+ * cosh-ng provider types that speak the OpenAI-compatible wire protocol. These
+ * map onto a single OpenAI-compatible auth type here; cosh-ng itself only
+ * varies request details per type (see `profile_from_name()` in
+ * crates/cosh-core/src/provider/profile.rs).
+ */
+const OPENAI_COMPATIBLE_PROVIDER_TYPES: ReadonlySet<string> = new Set([
+  'openai',
+  'openai_compat',
+  'dashscope',
+  'deepseek',
+  'generic',
+]);
+
+/** cosh-ng's Aliyun AK/SK provider type. */
+const ALIYUN_PROVIDER_TYPE = 'aliyun';
+
+/**
+ * cosh-ng's ECS RAM role flow, which mints STS credentials from the instance
+ * metadata service. This generation has no equivalent, so it is never
+ * converted.
+ */
+const ECS_RAM_ROLE_AUTH_SOURCE = 'ecs_ram_role';
+
+/**
+ * cosh-ng's own default when a provider section omits `type`.
+ * See `resolve_provider()` in crates/cosh-core/src/config.rs.
+ */
+const DEFAULT_PROVIDER_TYPE = 'generic';
+
+/**
+ * An authentication capability that both generations support, as recorded by
+ * cosh-ng. `model` is optional: it is not a credential, and every caller has
+ * its own default, so a provider that omits it is still usable.
+ */
+export type CoshNgAuth =
+  | {
+      kind: 'openai';
+      apiKey: string;
+      baseUrl: string;
+      model?: string;
+    }
+  | {
+      kind: 'aliyun';
+      accessKeyId: string;
+      accessKeySecret: string;
+      model?: string;
+    };
+
+/** Absolute path of cosh-ng's config file inside the shared config directory. */
+export function getCoshNgConfigPath(configDir?: string): string {
+  return path.join(
+    configDir ?? Storage.getGlobalQwenDir(),
+    COSH_NG_CONFIG_FILE_NAME,
+  );
+}
+
+/**
+ * Emits a diagnostic about the config file.
+ *
+ * No value read out of `config.toml` is ever passed in - not credentials, not
+ * provider ids or type names, not parser output, not surrounding lines. A
+ * provider id looks like a harmless key, but it is arbitrary user input and a
+ * pasted credential is made entirely of characters an id may contain, so there
+ * is no sanitizer that makes echoing one safe. Messages therefore describe
+ * "the active provider" and name only fields, using this module's own
+ * constants.
+ */
+function warn(message: string): void {
+  console.warn(`[cosh-ng compat] ${message}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Substitutes `${VAR}` references the way cosh-ng does: an undefined variable
+ * becomes the empty string rather than staying literal, and an unterminated
+ * `${` is left alone. See `expand_env_vars()` in
+ * crates/cosh-core/src/config.rs.
+ *
+ * Substitution is single-pass - a variable whose own value contains `${` is not
+ * re-expanded - which avoids the unbounded rewrite loop the Rust
+ * implementation's repeated scan would allow.
+ */
+function expandEnvVars(value: string): string {
+  return value.replace(
+    /\$\{([^}]*)\}/g,
+    (_match, name: string) => process.env[name] ?? '',
+  );
+}
+
+/**
+ * Reads a field cosh-ng expands `${VAR}` in - credentials and base URLs.
+ *
+ * Expansion happens before the required-field check, so a reference to an
+ * undefined variable reads as absent (cosh-ng would send an empty credential)
+ * and the provider is refused rather than silently half-configured.
+ */
+function readExpandedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return readString(expandEnvVars(value));
+}
+
+/**
+ * Reads cosh-ng's active provider from `config.toml`.
+ *
+ * Returns `undefined` - leaving the existing `/auth` flow untouched - when the
+ * file is absent, unreadable, unparseable, names a provider that has no
+ * section, uses a provider type with no equivalent here, relies on the ECS RAM
+ * role flow, carries a temporary STS credential, or is missing a credential the
+ * provider cannot work without (including one whose `${VAR}` resolves to
+ * nothing).
+ *
+ * @param configDir Directory holding `config.toml`, defaulting to the shared
+ *   `~/.copilot-shell`.
+ */
+export function loadCoshNgAuth(configDir?: string): CoshNgAuth | undefined {
+  const configPath = getCoshNgConfigPath(configDir);
+
+  let content: string;
+  try {
+    if (!fs.existsSync(configPath)) {
+      return undefined;
+    }
+    content = fs.readFileSync(configPath, 'utf-8');
+  } catch (_error) {
+    // The error message can quote the path but never the contents; keep the
+    // log to the path we already know.
+    warn(
+      `Could not read ${configPath}; run /auth to configure authentication.`,
+    );
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = toml.parse(content);
+  } catch (_error) {
+    // TOML parse errors quote the offending line, which is very often the
+    // `api_key = "..."` one. Never surface it.
+    warn(
+      `Ignoring malformed ${configPath}; run /auth to configure authentication.`,
+    );
+    return undefined;
+  }
+
+  const ai = isRecord(parsed) ? parsed['ai'] : undefined;
+  if (!isRecord(ai)) {
+    return undefined;
+  }
+
+  const activeProvider = readString(ai['active_provider']);
+  if (!activeProvider) {
+    // cosh-ng was never authenticated either; there is nothing to inherit.
+    return undefined;
+  }
+
+  const providers = isRecord(ai['providers']) ? ai['providers'] : undefined;
+  const provider = providers ? providers[activeProvider] : undefined;
+  if (!isRecord(provider)) {
+    warn(
+      `The active provider has no matching [ai.providers] section in ` +
+        `${configPath}; run /auth to configure authentication.`,
+    );
+    return undefined;
+  }
+
+  const providerType = readString(provider['type']) ?? DEFAULT_PROVIDER_TYPE;
+  // cosh-ng does not expand ${VAR} in model names; keep that behaviour.
+  const model = readString(ai['active_model']) ?? readString(provider['model']);
+
+  if (OPENAI_COMPATIBLE_PROVIDER_TYPES.has(providerType)) {
+    return readOpenAiAuth(provider, configPath, model);
+  }
+  if (providerType === ALIYUN_PROVIDER_TYPE) {
+    return readAliyunAuth(provider, configPath, model);
+  }
+
+  warn(
+    `The active provider uses an unsupported provider type, which has no ` +
+      `equivalent auth method here; run /auth to configure authentication.`,
+  );
+  return undefined;
+}
+
+function readOpenAiAuth(
+  provider: Record<string, unknown>,
+  configPath: string,
+  model: string | undefined,
+): CoshNgAuth | undefined {
+  const apiKey = readExpandedString(provider['api_key']);
+  const baseUrl = readExpandedString(provider['base_url']);
+
+  const missing: string[] = [];
+  if (!apiKey) missing.push('api_key');
+  if (!baseUrl) missing.push('base_url');
+  if (!apiKey || !baseUrl) {
+    warnMissing(configPath, missing);
+    return undefined;
+  }
+
+  return { kind: 'openai', apiKey, baseUrl, model };
+}
+
+function readAliyunAuth(
+  provider: Record<string, unknown>,
+  configPath: string,
+  model: string | undefined,
+): CoshNgAuth | undefined {
+  if (readString(provider['auth_source']) === ECS_RAM_ROLE_AUTH_SOURCE) {
+    warn(
+      `The active provider authenticates through the ECS RAM role, which has ` +
+        `no equivalent here; run /auth to configure authentication.`,
+    );
+    return undefined;
+  }
+
+  // Temporary STS credentials are deliberately not inherited. This generation
+  // stores an expiry alongside the token and refreshes expired ones through the
+  // ECS RAM role - writing the result back to `aliyun_creds.json`. Inheriting a
+  // token would therefore either fake an expiry or turn a read-only fallback
+  // into a writer, so only long-lived AK/SK pairs cross the bridge.
+  //
+  // The token can arrive two ways: cosh-ng reads `security_token` from the
+  // provider section, and falls back to $ALIBABA_CLOUD_SECURITY_TOKEN when the
+  // field is absent. Both must refuse, or a temporary AK/SK would be inherited
+  // as if it were long-lived and every request would go out without its token.
+  // Presence alone disqualifies - an empty value included, since cosh-ng would
+  // read that as a token too.
+  if (
+    provider['security_token'] !== undefined ||
+    process.env['ALIBABA_CLOUD_SECURITY_TOKEN'] !== undefined
+  ) {
+    warn(
+      `The active provider uses a temporary STS credential, which is not ` +
+        `inherited; run /auth to configure authentication.`,
+    );
+    return undefined;
+  }
+
+  const accessKeyId = readExpandedString(provider['access_key_id']);
+  const accessKeySecret = readExpandedString(provider['access_key_secret']);
+
+  const missing: string[] = [];
+  if (!accessKeyId) missing.push('access_key_id');
+  if (!accessKeySecret) missing.push('access_key_secret');
+  if (!accessKeyId || !accessKeySecret) {
+    warnMissing(configPath, missing);
+    return undefined;
+  }
+
+  return { kind: 'aliyun', accessKeyId, accessKeySecret, model };
+}
+
+/**
+ * Reports absent fields by this module's own field names - never by value, and
+ * without distinguishing "absent" from "resolved to nothing", since the latter
+ * would disclose which `${VAR}` the user referenced.
+ */
+function warnMissing(configPath: string, missing: string[]): void {
+  warn(
+    `The active provider in ${configPath} is missing ` +
+      `${missing.join(', ')}; run /auth to configure authentication.`,
+  );
+}

--- a/src/copilot-shell/packages/core/src/index.ts
+++ b/src/copilot-shell/packages/core/src/index.ts
@@ -201,6 +201,8 @@ export * from './utils/browser.js';
 // OpenAI Logging Utilities
 export { OpenAILogger, openaiLogger } from './utils/openaiLogger.js';
 export { Storage } from './config/storage.js';
+// cosh-ng (config.toml) compatibility - read-only
+export { loadCoshNgAuth, type CoshNgAuth } from './config/coshNgAuth.js';
 
 // Export test utils
 export * from './test-utils/index.js';


### PR DESCRIPTION
## Description

Reuse the active cosh-ng authentication configuration when `cosh-switch` returns a user to the previous `cosh` implementation. The compatibility reader maps only authentication methods supported by both generations, keeps native and environment configuration at higher precedence, and never migrates credentials or writes fallback state automatically. Malformed, incomplete, unsupported, ECS RAM role, and temporary STS configurations fail closed with credential-safe diagnostics.

## Related Issue

closes #1938

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh` (copilot-shell)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `npm run build && make build`
- `make lint`
- `npm run typecheck`
- `make test` — 404 test files, 7412 tests passed, 9 skipped
- Review follow-up at `d4e7c3dc8a2aa138c9f621549edbb5fe86df3493` covers `/model` partial persistence, env-inferred auth precedence, untrusted workspace gating, corrupt or unreadable native Aliyun credentials, and unreadable `config.toml`.
- Manual isolated-HOME checks with fake credentials covered OpenAI-compatible routing, Aliyun AK/SK routing, `${VAR}` expansion, missing-variable refusal, STS refusal from TOML and environment, malformed TOML redaction, and no credential-store writes.
- Isolated ECS validation at `8d489237dd1d2824f03d5ff26e7e1002af77c55a`:
  - A real Token Plan OpenAI-compatible credential completed inference from both generations with the same `config.toml`.
  - A real SysOM role baseline succeeded under cosh-ng; the same unsupported role configuration was refused by cosh without invoking the model or writing settings.
  - The same static Aliyun AK/SK configuration reached the SysOM API from both generations and returned the expected fake-key `InvalidAccessKeyId.NotFound` control response.
  - The same DashScope/OpenAI-compatible configuration reached the provider from both generations and returned the expected fake-key 401 control response.
  - Neither common fallback path created `settings.json` or `aliyun_creds.json`.

## Additional Notes

The fallback intentionally excludes cosh-ng ECS RAM role authentication and temporary STS credentials because this `cosh` generation has no equivalent read-only authentication path. Native `settings.json` and `aliyun_creds.json` configuration always takes precedence. Automatic fallback paths never persist inherited credentials; if a user explicitly opens `/auth` and confirms the pre-filled values, the existing auth flow stores them encrypted in `settings.json`.