### PR TITLE
fix(tokenless): discover all install layouts

### DIFF
--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -108,7 +108,8 @@ fi
 # Shared hook scripts live under FHS; warn when missing so user knows to run
 # `make install` (or install the RPM) before adapter actually fires.
 SHARED_HOOKS_DIR=""
-for d in /usr/share/anolisa/adapters/tokenless/common/hooks \
+for d in /usr/local/share/anolisa/adapters/tokenless/common/hooks \
+         /usr/share/anolisa/adapters/tokenless/common/hooks \
          "$HOME/.local/share/anolisa/adapters/tokenless/common/hooks"; do
     if [ -d "$d" ]; then SHARED_HOOKS_DIR="$d"; break; fi
 done

--- a/src/tokenless/adapters/tokenless/codex/scripts/check-tokenless
+++ b/src/tokenless/adapters/tokenless/codex/scripts/check-tokenless
@@ -11,23 +11,61 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Optional, Tuple
+
+try:
+    import pwd as _pwd
+
+    _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
+except (ImportError, KeyError):
+    _REAL_HOME = ""
+if not os.path.isabs(_REAL_HOME):
+    _REAL_HOME = ""
 
 
 def _warn(msg: str) -> None:
     print(f"[tokenless] {msg}", file=sys.stderr)
 
 
+def _known_tokenless_paths(home: Optional[str] = None) -> Tuple[str, ...]:
+    """Return standalone fallbacks for the supported installation layouts."""
+    # Codex can cache this script without common/hooks. Keep this standalone
+    # copy aligned with hook_utils.py::_known_binary_paths.
+    user_home = _REAL_HOME if home is None else home
+    user_home = user_home if user_home and os.path.isabs(user_home) else ""
+    paths = []
+    if user_home:
+        paths.append(os.path.join(user_home, ".local", "bin", "tokenless"))
+    paths.extend(("/usr/local/bin/tokenless", "/usr/bin/tokenless"))
+    if user_home:
+        paths.extend(
+            (
+                os.path.join(
+                    user_home,
+                    ".local",
+                    "share",
+                    "anolisa",
+                    "tokenless",
+                    "tokenless",
+                ),
+                os.path.join(
+                    user_home,
+                    ".local",
+                    "lib",
+                    "anolisa",
+                    "tokenless",
+                    "tokenless",
+                ),
+            )
+        )
+    return tuple(paths)
+
+
 def main() -> None:
     # Find tokenless
     tokenless_bin = shutil.which("tokenless")
     if not tokenless_bin:
-        for fp in (
-            "/usr/bin/tokenless",
-            os.path.join(os.path.expanduser("~"),
-                         ".local/share/anolisa/tokenless/tokenless"),
-            os.path.join(os.path.expanduser("~"),
-                         ".local/lib/anolisa/tokenless/tokenless"),
-        ):
+        for fp in _known_tokenless_paths():
             if os.path.isfile(fp) and os.access(fp, os.X_OK):
                 tokenless_bin = fp
                 break

--- a/src/tokenless/adapters/tokenless/codex/scripts/compress-response
+++ b/src/tokenless/adapters/tokenless/codex/scripts/compress-response
@@ -95,6 +95,13 @@ try:
     _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
 except (ImportError, KeyError):
     _REAL_HOME = ""
+if not os.path.isabs(_REAL_HOME):
+    _REAL_HOME = ""
+
+
+def _user_path(*parts: str) -> str:
+    return os.path.join(_REAL_HOME, *parts) if _REAL_HOME else ""
+
 
 _HOOK_UTILS_CANDIDATES = [
     os.path.join(_HERE, "..", "..", "common", "hooks"),                   # source-tree / FHS
@@ -176,13 +183,17 @@ SKIP_TOOLS: set[str] = _SKIP_TOOLS_SHARED | {
 COMPRESSED_CONTENT_CAP: int = 32_768
 
 # -- tokenless binary search paths (ANOLISA FHS spec) ------------------------
+# Codex can cache this script without common/hooks. Keep this standalone list
+# aligned with hook_utils.py::_known_binary_paths.
 
 _TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOKENLESS_LOCAL_SHARE = os.path.join(
-    os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless"
+_TOKENLESS_SYSTEM_FALLBACK = "/usr/local/bin/tokenless"
+_TOKENLESS_LOCAL_BIN = _user_path(".local", "bin", "tokenless")
+_TOKENLESS_LOCAL_SHARE = _user_path(
+    ".local", "share", "anolisa", "tokenless", "tokenless"
 )
-_TOKENLESS_LOCAL_LIB = os.path.join(
-    os.path.expanduser("~"), ".local", "lib", "anolisa", "tokenless", "tokenless"
+_TOKENLESS_LOCAL_LIB = _user_path(
+    ".local", "lib", "anolisa", "tokenless", "tokenless"
 )
 
 # ---------------------------------------------------------------------------
@@ -200,7 +211,13 @@ def _find_tokenless() -> Optional[str]:
     if path:
         return path
 
-    for fp in (_TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
+    for fp in (
+        _TOKENLESS_LOCAL_BIN,
+        _TOKENLESS_SYSTEM_FALLBACK,
+        _TOKENLESS_FALLBACK,
+        _TOKENLESS_LOCAL_SHARE,
+        _TOKENLESS_LOCAL_LIB,
+    ):
         if os.path.isfile(fp) and os.access(fp, os.X_OK):
             return fp
     return None

--- a/src/tokenless/adapters/tokenless/codex/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/codex/scripts/detect.sh
@@ -19,6 +19,7 @@ fi
 if [[ -z "$TOKENLESS_BIN" ]]; then
     for fp in \
         "$HOME/.local/bin/tokenless" \
+        "/usr/local/bin/tokenless" \
         "/usr/bin/tokenless" \
         "$HOME/.local/share/anolisa/tokenless/tokenless" \
         "$HOME/.local/lib/anolisa/tokenless/tokenless"; do

--- a/src/tokenless/adapters/tokenless/codex/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/codex/scripts/install.sh
@@ -54,6 +54,8 @@ if command -v tokenless >/dev/null 2>&1; then
     TOKENLESS_BIN="$(command -v tokenless)"
 elif [[ -x "$BINDIR/tokenless" ]]; then
     TOKENLESS_BIN="$BINDIR/tokenless"
+elif [[ -x /usr/local/bin/tokenless ]]; then
+    TOKENLESS_BIN="/usr/local/bin/tokenless"
 elif [[ -x /usr/bin/tokenless ]]; then
     TOKENLESS_BIN="/usr/bin/tokenless"
 fi

--- a/src/tokenless/adapters/tokenless/codex/scripts/rewrite-hook
+++ b/src/tokenless/adapters/tokenless/codex/scripts/rewrite-hook
@@ -90,6 +90,13 @@ try:
     _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
 except (ImportError, KeyError):
     _REAL_HOME = ""
+if not os.path.isabs(_REAL_HOME):
+    _REAL_HOME = ""
+
+
+def _user_path(*parts: str) -> str:
+    return os.path.join(_REAL_HOME, *parts) if _REAL_HOME else ""
+
 
 _HOOK_UTILS_CANDIDATES = [
     os.path.join(_HERE, "..", "..", "common", "hooks"),                   # source-tree / FHS
@@ -136,15 +143,25 @@ else:
 AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "codex")
 _MIN_RTK_VERSION = (0, 35, 0)
 
-# RTK binary search paths
+# RTK binary search paths. Codex can cache this script without common/hooks;
+# keep this standalone list aligned with hook_utils.py::_known_binary_paths.
 _RTK_FALLBACK = "/usr/libexec/anolisa/tokenless/rtk"
 _RTK_FALLBACK_DEBIAN = "/usr/lib/anolisa/tokenless/rtk"
-_RTK_LOCAL_SHARE = os.path.join(
-    os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "rtk"
+_RTK_SYSTEM_BIN = "/usr/local/bin/rtk"
+_RTK_SYSTEM_LIBEXEC = "/usr/local/libexec/anolisa/tokenless/rtk"
+_RTK_RPM_BIN = "/usr/bin/rtk"
+_RTK_LOCAL_BIN = _user_path(".local", "bin", "rtk")
+_RTK_ANOLISA_USER = _user_path(
+    ".local",
+    "lib",
+    "anolisa",
+    "libexec",
+    "tokenless",
+    "rtk",
 )
-_RTK_LOCAL_LIB = os.path.join(
-    os.path.expanduser("~"), ".local", "lib", "anolisa", "tokenless", "rtk"
-)
+_RTK_MAKE_USER = _user_path(".local", "libexec", "anolisa", "tokenless", "rtk")
+_RTK_LOCAL_SHARE = _user_path(".local", "share", "anolisa", "tokenless", "rtk")
+_RTK_LOCAL_LIB = _user_path(".local", "lib", "anolisa", "tokenless", "rtk")
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -156,7 +173,18 @@ def _find_rtk() -> Optional[str]:
     path = shutil.which("rtk")
     if path:
         return path
-    for fp in (_RTK_FALLBACK, _RTK_FALLBACK_DEBIAN, _RTK_LOCAL_SHARE, _RTK_LOCAL_LIB):
+    for fp in (
+        _RTK_LOCAL_BIN,
+        _RTK_ANOLISA_USER,
+        _RTK_MAKE_USER,
+        _RTK_SYSTEM_BIN,
+        _RTK_SYSTEM_LIBEXEC,
+        _RTK_RPM_BIN,
+        _RTK_FALLBACK,
+        _RTK_FALLBACK_DEBIAN,
+        _RTK_LOCAL_SHARE,
+        _RTK_LOCAL_LIB,
+    ):
         if os.path.isfile(fp) and os.access(fp, os.X_OK):
             return fp
     return None

--- a/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
+++ b/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
@@ -95,6 +95,13 @@ try:
     _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
 except (ImportError, KeyError):
     _REAL_HOME = ""
+if not os.path.isabs(_REAL_HOME):
+    _REAL_HOME = ""
+
+
+def _user_path(*parts: str) -> str:
+    return os.path.join(_REAL_HOME, *parts) if _REAL_HOME else ""
+
 
 _HOOK_UTILS_CANDIDATES = [
     os.path.join(_HERE, "..", "..", "common", "hooks"),                   # source-tree / FHS
@@ -126,13 +133,17 @@ AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "codex")
 FIX_TIMEOUT = 60  # auto-fix may involve package installs (dnf/pip)
 
 # -- tokenless binary search paths (ANOLISA FHS spec) ------------------------
+# Codex can cache this script without common/hooks. Keep this standalone list
+# aligned with hook_utils.py::_known_binary_paths.
 
 _TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOKENLESS_LOCAL_SHARE = os.path.join(
-    os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless"
+_TOKENLESS_SYSTEM_FALLBACK = "/usr/local/bin/tokenless"
+_TOKENLESS_LOCAL_BIN = _user_path(".local", "bin", "tokenless")
+_TOKENLESS_LOCAL_SHARE = _user_path(
+    ".local", "share", "anolisa", "tokenless", "tokenless"
 )
-_TOKENLESS_LOCAL_LIB = os.path.join(
-    os.path.expanduser("~"), ".local", "lib", "anolisa", "tokenless", "tokenless"
+_TOKENLESS_LOCAL_LIB = _user_path(
+    ".local", "lib", "anolisa", "tokenless", "tokenless"
 )
 
 # ---------------------------------------------------------------------------
@@ -151,7 +162,13 @@ def _find_tokenless() -> Optional[str]:
     path = shutil.which("tokenless")
     if path:
         return path
-    for fp in (_TOKENLESS_FALLBACK, _TOKENLESS_LOCAL_SHARE, _TOKENLESS_LOCAL_LIB):
+    for fp in (
+        _TOKENLESS_LOCAL_BIN,
+        _TOKENLESS_SYSTEM_FALLBACK,
+        _TOKENLESS_FALLBACK,
+        _TOKENLESS_LOCAL_SHARE,
+        _TOKENLESS_LOCAL_LIB,
+    ):
         if os.path.isfile(fp) and os.access(fp, os.X_OK):
             return fp
     return None

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -1,5 +1,7 @@
 """Shared utilities for tokenless Python hooks."""
 
+from __future__ import annotations
+
 import json
 import os
 import re
@@ -7,22 +9,109 @@ import shutil
 import subprocess
 import sys
 
-# -- FHS fallback paths (ANOLISA spec) ----------------------------------------
+# -- Binary fallback paths ----------------------------------------------------
+#
+# Tokenless has three supported installers whose layouts differ:
+#
+# - Makefile:     ~/.local/{bin,libexec} or /usr/{bin,libexec}
+# - Anolisa CLI:  ~/.local/{bin,lib/anolisa/libexec} or /usr/local/{bin,libexec}
+# - RPM:          /usr/{bin,libexec}
+#
+# Keep the legacy lib/share paths until installations made by older releases
+# have aged out.
+#
+# KEEP IN SYNC with tool_ready_hook.sh::resolve_binary,
+# env_check.rs::binary_fallback_paths, OpenClaw's fallback constants, and the
+# Codex standalone scripts. Makefile and the Anolisa component manifest define
+# the supported layouts; the canonical order is user, /usr/local, /usr, legacy.
+
+_USER_HOME = os.path.expanduser("~")
+if not _USER_HOME or not os.path.isabs(_USER_HOME):
+    _USER_HOME = ""
+
+
+def _user_path(*parts: str) -> str:
+    return os.path.join(_USER_HOME, *parts) if _USER_HOME else ""
+
 
 _TOKENLESS_FALLBACK = "/usr/bin/tokenless"
-_TOKENLESS_LOCAL_SHARE = os.path.join(
-    os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "tokenless"
+_TOKENLESS_LOCAL_SHARE = _user_path(
+    ".local", "share", "anolisa", "tokenless", "tokenless"
 )
-_TOKENLESS_LOCAL_LIB = os.path.join(
-    os.path.expanduser("~"), ".local", "lib", "anolisa", "tokenless", "tokenless"
+_TOKENLESS_LOCAL_LIB = _user_path(
+    ".local", "lib", "anolisa", "tokenless", "tokenless"
 )
 _RTK_FALLBACK = "/usr/libexec/anolisa/tokenless/rtk"
-_RTK_LOCAL_SHARE = os.path.join(
-    os.path.expanduser("~"), ".local", "share", "anolisa", "tokenless", "rtk"
+_RTK_LOCAL_SHARE = _user_path(
+    ".local", "share", "anolisa", "tokenless", "rtk"
 )
-_RTK_LOCAL_LIB = os.path.join(
-    os.path.expanduser("~"), ".local", "lib", "anolisa", "tokenless", "rtk"
-)
+_RTK_LOCAL_LIB = _user_path(".local", "lib", "anolisa", "tokenless", "rtk")
+
+_TOKENLESS_HELPER_BINARIES = frozenset({"rtk", "toon"})
+
+
+def _known_binary_paths(name: str, home: str | None = None) -> tuple[str, ...]:
+    """Return install-layout fallbacks for a binary outside ``PATH``."""
+    if not name or os.path.basename(name) != name or name in {".", ".."}:
+        return ()
+    home = os.path.expanduser("~") if home is None else home
+    user_home = home if home and os.path.isabs(home) else None
+    paths = []
+    if user_home:
+        paths.append(os.path.join(user_home, ".local", "bin", name))
+    if name in _TOKENLESS_HELPER_BINARIES:
+        if user_home:
+            paths.extend(
+                [
+                    # Anolisa CLI user mode.
+                    os.path.join(
+                        user_home,
+                        ".local",
+                        "lib",
+                        "anolisa",
+                        "libexec",
+                        "tokenless",
+                        name,
+                    ),
+                    # Makefile user mode.
+                    os.path.join(
+                        user_home,
+                        ".local",
+                        "libexec",
+                        "anolisa",
+                        "tokenless",
+                        name,
+                    ),
+                ]
+            )
+    paths.append(os.path.join("/usr/local/bin", name))
+    if name in _TOKENLESS_HELPER_BINARIES:
+        # Anolisa CLI system mode.
+        paths.append(
+            os.path.join("/usr/local/libexec/anolisa/tokenless", name)
+        )
+    paths.append(os.path.join("/usr/bin", name))
+    if name in _TOKENLESS_HELPER_BINARIES:
+        paths.extend(
+            [
+                # Makefile system mode and RPM.
+                os.path.join("/usr/libexec/anolisa/tokenless", name),
+                # Debian and pre-layout-migration compatibility.
+                os.path.join("/usr/lib/anolisa/tokenless", name),
+            ]
+        )
+        if user_home:
+            paths.extend(
+                [
+                    os.path.join(
+                        user_home, ".local", "share", "anolisa", "tokenless", name
+                    ),
+                    os.path.join(
+                        user_home, ".local", "lib", "anolisa", "tokenless", name
+                    ),
+                ]
+            )
+    return tuple(paths)
 
 # -- Unified tool categorization ----------------------------------------------
 
@@ -263,12 +352,13 @@ _resolved_cache: dict[tuple, str | None] = {}
 
 
 def resolve_binary(name: str, *fallback_paths: str) -> str | None:
-    """Locate a binary by PATH search, then optional fallback paths.
+    """Locate a binary by PATH search, install layouts, then explicit paths.
 
-    Results are cached per (name, fallback_paths) — different callers passing
-    distinct fallback paths for the same name get independent cache entries.
+    Results are cached per name, explicit fallbacks, and home directory so
+    callers with distinct install contexts get independent entries.
     """
-    cache_key = (name, fallback_paths)
+    home = os.path.expanduser("~")
+    cache_key = (name, fallback_paths, home)
     if cache_key in _resolved_cache:
         return _resolved_cache[cache_key]
 
@@ -277,7 +367,8 @@ def resolve_binary(name: str, *fallback_paths: str) -> str | None:
     if path:
         result = path
     else:
-        for fp in fallback_paths:
+        candidates = dict.fromkeys((*_known_binary_paths(name, home), *fallback_paths))
+        for fp in candidates:
             if fp and os.path.isfile(fp) and os.access(fp, os.X_OK):
                 result = fp
                 break

--- a/src/tokenless/adapters/tokenless/common/hooks/run-hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/run-hook.sh
@@ -37,6 +37,7 @@ case "$SCRIPT" in
 esac
 
 CANDIDATES=(
+    "/usr/local/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"
     "/usr/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"
     "${HOME}/.local/share/anolisa/adapters/tokenless/common/hooks/${SCRIPT}"
 )

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -18,6 +18,12 @@ set -euo pipefail
 VERBOSE="${TOKENLESS_VERBOSE:-}"
 log_v() { [ -n "$VERBOSE" ] && echo "[tokenless:ready] $1" >&2 || true; }
 
+USER_HOME="${HOME:-}"
+case "$USER_HOME" in
+  /*) ;;
+  *) USER_HOME="" ;;
+esac
+
 # --- Dependency check (fail-open) ---
 if ! command -v jq &>/dev/null; then log_v "jq not found, skipping"; exit 0; fi
 
@@ -99,9 +105,10 @@ SPEC_FILE=""
 for candidate in \
     "${TOKENLESS_TOOL_READY_SPEC:-}" \
     "${ANOLISA_ADAPTER_DIR:+$ANOLISA_ADAPTER_DIR/common/tool-ready-spec.json}" \
-    "$HOME/.local/share/anolisa/adapters/tokenless/common/tool-ready-spec.json" \
+    "${USER_HOME:+$USER_HOME/.local/share/anolisa/adapters/tokenless/common/tool-ready-spec.json}" \
+    "/usr/local/share/anolisa/adapters/tokenless/common/tool-ready-spec.json" \
     "/usr/share/anolisa/adapters/tokenless/common/tool-ready-spec.json" \
-    "$HOME/.tokenless/tool-ready-spec.json" \
+    "${USER_HOME:+$USER_HOME/.tokenless/tool-ready-spec.json}" \
     "${SCRIPT_DIR}/../tool-ready-spec.json"; do
     if [ -n "$candidate" ] && is_trusted_file "$candidate"; then
         SPEC_FILE="$candidate"
@@ -113,9 +120,10 @@ FIX_SCRIPT=""
 for candidate in \
     "${TOKENLESS_ENV_FIX_SCRIPT:-}" \
     "${ANOLISA_ADAPTER_DIR:+$ANOLISA_ADAPTER_DIR/common/tokenless-env-fix.sh}" \
-    "$HOME/.local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
+    "${USER_HOME:+$USER_HOME/.local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh}" \
+    "/usr/local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
     "/usr/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
-    "$HOME/.tokenless/tokenless-env-fix.sh" \
+    "${USER_HOME:+$USER_HOME/.tokenless/tokenless-env-fix.sh}" \
     "${SCRIPT_DIR}/../tokenless-env-fix.sh"; do
     if [ -n "$candidate" ] && [ -x "$candidate" ] && is_trusted_file "$candidate"; then
         FIX_SCRIPT="$candidate"
@@ -259,13 +267,61 @@ version_ge() {
 
 # --- Resolve binary path ---
 # Tries command -v first, then known install paths.
+# KEEP IN SYNC with hook_utils.py::_known_binary_paths,
+# env_check.rs::binary_fallback_paths, OpenClaw's fallback constants, and the
+# Codex standalone scripts. Makefile and the Anolisa component manifest define
+# the supported layouts; the canonical order is user, /usr/local, /usr, legacy.
 resolve_binary() {
   local name="$1"
+  case "$name" in
+    ""|*/*|"."|"..") return 1 ;;
+  esac
   local found
   found=$(command -v "$name" 2>/dev/null || true)
   if [ -n "$found" ]; then echo "$found"; return 0; fi
-  for candidate in "$HOME/.local/bin/$name" "$HOME/.local/lib/anolisa/tokenless/$name"; do
-    if [ -x "$candidate" ]; then echo "$candidate"; return 0; fi
+
+  local candidates=()
+  if [ -n "$USER_HOME" ]; then
+    candidates+=("$USER_HOME/.local/bin/$name")
+  fi
+  case "$name" in
+    rtk|toon)
+      if [ -n "$USER_HOME" ]; then
+        candidates+=(
+          "$USER_HOME/.local/lib/anolisa/libexec/tokenless/$name"
+          "$USER_HOME/.local/libexec/anolisa/tokenless/$name"
+        )
+      fi
+      ;;
+  esac
+  candidates+=("/usr/local/bin/$name")
+  case "$name" in
+    rtk|toon)
+      candidates+=("/usr/local/libexec/anolisa/tokenless/$name")
+      ;;
+  esac
+  candidates+=("/usr/bin/$name")
+  case "$name" in
+    rtk|toon)
+      candidates+=(
+        "/usr/libexec/anolisa/tokenless/$name"
+        "/usr/lib/anolisa/tokenless/$name"
+      )
+      if [ -n "$USER_HOME" ]; then
+        candidates+=(
+          "$USER_HOME/.local/share/anolisa/tokenless/$name"
+          "$USER_HOME/.local/lib/anolisa/tokenless/$name"
+        )
+      fi
+      ;;
+  esac
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [ -f "$candidate" ] && [ -x "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
   done
   return 1
 }
@@ -307,7 +363,7 @@ check_permissions() {
     case "$perm" in
       file_read)   [ ! -r / ] && perm_missing="${perm_missing} file_read" ;;
       file_write)  touch "${TMPDIR:-/tmp}/.tokenless-ready-test" 2>/dev/null; rc=$?; rm -f "${TMPDIR:-/tmp}/.tokenless-ready-test" 2>/dev/null; [ $rc -ne 0 ] && perm_missing="${perm_missing} file_write" ;;
-      exec_shell)  ! command -v bash &>/dev/null && perm_missing="${perm_missing} exec_shell" ;;
+      exec_shell)  ! resolve_binary bash >/dev/null 2>&1 && perm_missing="${perm_missing} exec_shell" ;;
       docker_socket) [ ! -S /var/run/docker.sock ] && [ ! -S /run/docker.sock ] && perm_missing="${perm_missing} docker_socket" ;;
     esac
   done

--- a/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
+++ b/src/tokenless/adapters/tokenless/common/tokenless-env-fix.sh
@@ -559,7 +559,8 @@ fix_dep() {
       local fb_method fb_package fb_binary fb_source fb_manifest fb_features fb_url fb_args
       fb_method=$(echo "$fallbacks" | jq -r ".[$i].method // empty")
       fb_package=$(echo "$fallbacks" | jq -r ".[$i].package // empty")
-      fb_binary=$(echo "$fallbacks" | jq -r --arg def "$binary" ".[$i].binary // \$def")
+      fb_binary=$(echo "$fallbacks" | jq -r \
+        --arg default_binary "$binary" ".[$i].binary // \$default_binary")
       fb_source=$(echo "$fallbacks" | jq -r ".[$i].source // empty")
       fb_manifest=$(echo "$fallbacks" | jq -r ".[$i].manifest // empty")
       fb_features=$(echo "$fallbacks" | jq -r ".[$i].features // empty")

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -22,7 +22,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, statSync, readFileSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 
 // ---- Session ID mapping --------------------------------------------------------
 // OpenClaw's tool_result_persist ctx provides sessionKey ("agent:main:main")
@@ -56,18 +56,38 @@ let tokenlessAvailable: boolean | null = null;
 let tokenlessCheckedAt: number | null = null;
 
 // Resolved absolute paths — set by check*() functions so subprocess calls
-// use the correct path even when the binary is not on PATH (e.g. RPM installs
-// that place rtk/toon in /usr/libexec/anolisa/tokenless/ or Debian installs
-// that use /usr/lib/anolisa/tokenless/).
+// use the correct path even when the binary is not on PATH.
 let rtkPath: string = "rtk";
 let tokenlessPath: string = "tokenless";
 
+// KEEP IN SYNC with common/hooks/hook_utils.py, tool_ready_hook.sh,
+// env_check.rs::binary_fallback_paths, and the Codex standalone scripts.
+// Makefile and the Anolisa component manifest define the supported layouts;
+// the canonical order is user, /usr/local, /usr, then legacy.
 const LIBEXEC_FALLBACK = "/usr/libexec/anolisa/tokenless";
 const LIB_FALLBACK = "/usr/lib/anolisa/tokenless";
 const TOKENLESS_FALLBACK = "/usr/bin/tokenless";
-const LOCAL_BIN = `${process.env.HOME || ""}/.local/bin`;
-const LOCAL_LIB = `${process.env.HOME || ""}/.local/lib/anolisa/tokenless`;
-const LOCAL_FALLBACK = `${process.env.HOME || ""}/.local/share/anolisa/tokenless`;
+const SYSTEM_BIN = "/usr/local/bin";
+const SYSTEM_LIBEXEC = "/usr/local/libexec/anolisa/tokenless";
+const RPM_BIN = "/usr/bin";
+const USER_HOME = process.env.HOME && isAbsolute(process.env.HOME) ? process.env.HOME : null;
+const LOCAL_BIN = USER_HOME ? join(USER_HOME, ".local", "bin") : null;
+const LOCAL_ANOLISA_LIBEXEC = USER_HOME
+  ? join(USER_HOME, ".local", "lib", "anolisa", "libexec", "tokenless")
+  : null;
+const LOCAL_MAKE_LIBEXEC = USER_HOME
+  ? join(USER_HOME, ".local", "libexec", "anolisa", "tokenless")
+  : null;
+const LOCAL_LIB = USER_HOME
+  ? join(USER_HOME, ".local", "lib", "anolisa", "tokenless")
+  : null;
+const LOCAL_FALLBACK = USER_HOME
+  ? join(USER_HOME, ".local", "share", "anolisa", "tokenless")
+  : null;
+
+function binaryIn(directory: string | null, name: string): string {
+  return directory ? join(directory, name) : "";
+}
 
 // Check both existence and execute permission (mirrors shell `-x` test).
 function isExecutable(path: string): boolean {
@@ -108,7 +128,19 @@ function checkRtk(): boolean {
     rtkAvailable = null;
   }
   if (rtkAvailable !== null) return rtkAvailable;
-  const resolved = resolveBinaryPath("rtk", `${LIBEXEC_FALLBACK}/rtk`, `${LIB_FALLBACK}/rtk`, `${LOCAL_FALLBACK}/rtk`, `${LOCAL_LIB}/rtk`, `${LOCAL_BIN}/rtk`);
+  const resolved = resolveBinaryPath(
+    "rtk",
+    binaryIn(LOCAL_BIN, "rtk"),
+    binaryIn(LOCAL_ANOLISA_LIBEXEC, "rtk"),
+    binaryIn(LOCAL_MAKE_LIBEXEC, "rtk"),
+    join(SYSTEM_BIN, "rtk"),
+    join(SYSTEM_LIBEXEC, "rtk"),
+    join(RPM_BIN, "rtk"),
+    join(LIBEXEC_FALLBACK, "rtk"),
+    join(LIB_FALLBACK, "rtk"),
+    binaryIn(LOCAL_FALLBACK, "rtk"),
+    binaryIn(LOCAL_LIB, "rtk"),
+  );
   if (resolved) { rtkPath = resolved; rtkAvailable = true; }
   else { rtkAvailable = false; }
   rtkCheckedAt = Date.now();
@@ -132,7 +164,14 @@ function checkTokenless(): boolean {
     tokenlessAvailable = null;
   }
   if (tokenlessAvailable !== null) return tokenlessAvailable;
-  const resolved = resolveBinaryPath("tokenless", TOKENLESS_FALLBACK, `${LOCAL_FALLBACK}/tokenless`, `${LOCAL_LIB}/tokenless`, `${LOCAL_BIN}/tokenless`);
+  const resolved = resolveBinaryPath(
+    "tokenless",
+    binaryIn(LOCAL_BIN, "tokenless"),
+    join(SYSTEM_BIN, "tokenless"),
+    TOKENLESS_FALLBACK,
+    binaryIn(LOCAL_FALLBACK, "tokenless"),
+    binaryIn(LOCAL_LIB, "tokenless"),
+  );
   if (resolved) { tokenlessPath = resolved; tokenlessAvailable = true; }
   else { tokenlessAvailable = false; }
   tokenlessCheckedAt = Date.now();

--- a/src/tokenless/adapters/tokenless/qwencode/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/qwencode/scripts/detect.sh
@@ -94,7 +94,8 @@ fi
 # Shared hook scripts live under FHS; warn when missing so user knows to run
 # `make install` (or install the RPM) before adapter actually fires.
 SHARED_HOOKS_DIR=""
-for d in /usr/share/anolisa/adapters/tokenless/common/hooks \
+for d in /usr/local/share/anolisa/adapters/tokenless/common/hooks \
+         /usr/share/anolisa/adapters/tokenless/common/hooks \
          "$HOME/.local/share/anolisa/adapters/tokenless/common/hooks"; do
     if [ -d "$d" ]; then SHARED_HOOKS_DIR="$d"; break; fi
 done

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -500,57 +500,103 @@ fn version_ge(installed: &str, required: &str) -> bool {
     true
 }
 
-/// Check if a binary is available and meets version constraints.
-fn check_dep(dep: &DepEntry) -> DepStatus {
+// KEEP IN SYNC with common/hooks/hook_utils.py, tool_ready_hook.sh, OpenClaw's
+// fallback constants, and the Codex standalone scripts. Makefile and the
+// Anolisa component manifest define the supported layouts; the canonical
+// order is user, /usr/local, /usr, then legacy.
+fn binary_fallback_paths(binary: &str, home: &str) -> Vec<PathBuf> {
+    let mut components = std::path::Path::new(binary).components();
+    if !matches!(
+        (components.next(), components.next()),
+        (Some(std::path::Component::Normal(_)), None)
+    ) {
+        return Vec::new();
+    }
+
+    let home = std::path::Path::new(home);
+    let user_home = (!home.as_os_str().is_empty() && home.is_absolute()).then_some(home);
+    let mut paths = Vec::new();
+    if let Some(home) = user_home {
+        paths.push(home.join(".local/bin").join(binary));
+        if matches!(binary, "rtk" | "toon") {
+            paths.extend([
+                // Anolisa CLI user mode.
+                home.join(".local/lib/anolisa/libexec/tokenless")
+                    .join(binary),
+                // Makefile user mode.
+                home.join(".local/libexec/anolisa/tokenless").join(binary),
+            ]);
+        }
+    }
+    paths.push(PathBuf::from("/usr/local/bin").join(binary));
+    if matches!(binary, "rtk" | "toon") {
+        // Anolisa CLI system mode.
+        paths.push(PathBuf::from("/usr/local/libexec/anolisa/tokenless").join(binary));
+    }
+    paths.push(PathBuf::from("/usr/bin").join(binary));
+    if matches!(binary, "rtk" | "toon") {
+        paths.extend([
+            // Makefile system mode and RPM.
+            PathBuf::from("/usr/libexec/anolisa/tokenless").join(binary),
+            // Debian and pre-layout-migration compatibility.
+            PathBuf::from("/usr/lib/anolisa/tokenless").join(binary),
+        ]);
+        if let Some(home) = user_home {
+            paths.extend([
+                home.join(".local/share/anolisa/tokenless").join(binary),
+                home.join(".local/lib/anolisa/tokenless").join(binary),
+            ]);
+        }
+    }
+
+    paths
+}
+
+fn is_executable_file(path: &std::path::Path) -> bool {
+    if !path.is_file() || !is_trusted_path(path) {
+        return false;
+    }
+    std::fs::metadata(path)
+        .map(|metadata| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                metadata.permissions().mode() & 0o111 != 0
+            }
+            #[cfg(not(unix))]
+            true
+        })
+        .unwrap_or(false)
+}
+
+fn resolve_binary_path(binary: &str) -> Option<String> {
     let which_result = Command::new("sh")
-        .args(["-c", "command -v \"$1\"", "--", &dep.binary])
+        .args(["-c", "command -v \"$1\"", "--", binary])
         .output();
 
-    let binary_path: Option<String> = match which_result {
+    match which_result {
         Ok(output) if output.status.success() => {
-            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            (!path.is_empty()).then_some(path)
         }
         _ => {
-            // PATH lookup failed — try known install paths. Each candidate
-            // must clear is_trusted_path() before we report it as available:
-            // otherwise a spoofed $HOME / world-writable directory could let
-            // an attacker drop a malicious binary that we'd then exec when
-            // we run `--version` or any later invocation.
+            // PATH lookup failed — cover Makefile, Anolisa user/system, and
+            // package-manager layouts. Trust validation prevents a spoofed
+            // user path from supplying the executable used below.
             let home = crate::get_home_dir();
-            let candidates = [
-                format!("/usr/libexec/anolisa/tokenless/{}", dep.binary),
-                format!("/usr/lib/anolisa/tokenless/{}", dep.binary),
-                format!("{}/.local/bin/{}", home, dep.binary),
-                format!("{}/.local/lib/anolisa/tokenless/{}", home, dep.binary),
-            ];
-            candidates
-                .iter()
-                .find(|p| {
-                    let path = std::path::Path::new(p);
-                    if !path.exists() {
-                        return false;
-                    }
-                    if !is_trusted_path(path) {
-                        return false;
-                    }
-                    std::fs::metadata(path)
-                        .map(|m| {
-                            #[cfg(unix)]
-                            {
-                                use std::os::unix::fs::PermissionsExt;
-                                m.permissions().mode() & 0o111 != 0
-                            }
-                            #[cfg(not(unix))]
-                            true
-                        })
-                        .unwrap_or(false)
-                })
-                .cloned()
+            binary_fallback_paths(binary, &home)
+                .into_iter()
+                .find(|path| is_executable_file(path))
+                .map(|path| path.to_string_lossy().into_owned())
         }
-    };
+    }
+}
 
+/// Check if a binary is available and meets version constraints.
+fn check_dep(dep: &DepEntry) -> DepStatus {
+    let binary_path = resolve_binary_path(&dep.binary);
     match binary_path {
-        Some(path) if !path.is_empty() => {
+        Some(path) => {
             if let Some(ref version) = dep.version {
                 let required_version = extract_required_version(version);
                 let version_output = Command::new(&path).arg("--version").output();
@@ -627,11 +673,7 @@ fn check_permission(perm: &str) -> bool {
             }
             can_write
         }
-        "exec_shell" => Command::new("sh")
-            .args(["-c", "command -v bash"])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false),
+        "exec_shell" => resolve_binary_path("bash").is_some(),
         _ => true,
     }
 }
@@ -906,6 +948,7 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
             "{}/.local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh",
             home
         )),
+        Some("/usr/local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh".to_string()),
         Some("/usr/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh".to_string()),
         // Legacy paths (pre-FHS refactor, flat layout without common/ subdir)
         Some(format!(
@@ -1069,6 +1112,9 @@ fn find_spec_path() -> Result<PathBuf, String> {
             "{}/.local/share/anolisa/adapters/tokenless/common/tool-ready-spec.json",
             home
         ))),
+        Some(PathBuf::from(
+            "/usr/local/share/anolisa/adapters/tokenless/common/tool-ready-spec.json",
+        )),
         Some(PathBuf::from(
             "/usr/share/anolisa/adapters/tokenless/common/tool-ready-spec.json",
         )),

--- a/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
@@ -168,6 +168,51 @@ fn version_ge_patch_comparison() {
 }
 
 #[test]
+fn binary_fallback_paths_cover_supported_installers() {
+    let paths = binary_fallback_paths("rtk", "/home/alice");
+    let expected = [
+        "/home/alice/.local/bin/rtk",
+        "/home/alice/.local/lib/anolisa/libexec/tokenless/rtk",
+        "/home/alice/.local/libexec/anolisa/tokenless/rtk",
+        "/usr/local/bin/rtk",
+        "/usr/local/libexec/anolisa/tokenless/rtk",
+        "/usr/bin/rtk",
+        "/usr/libexec/anolisa/tokenless/rtk",
+        "/usr/lib/anolisa/tokenless/rtk",
+        "/home/alice/.local/share/anolisa/tokenless/rtk",
+        "/home/alice/.local/lib/anolisa/tokenless/rtk",
+    ]
+    .map(PathBuf::from);
+    assert_eq!(paths, expected);
+}
+
+#[test]
+fn generic_binary_fallbacks_do_not_probe_component_helpers() {
+    let paths = binary_fallback_paths("docker", "/home/alice");
+    assert!(paths.contains(&PathBuf::from("/home/alice/.local/bin/docker")));
+    assert!(paths.contains(&PathBuf::from("/usr/local/bin/docker")));
+    assert!(paths.contains(&PathBuf::from("/usr/bin/docker")));
+    assert!(
+        !paths
+            .iter()
+            .any(|path| path.to_string_lossy().contains("tokenless"))
+    );
+}
+
+#[test]
+fn binary_fallback_paths_skip_user_layout_without_absolute_home() {
+    for home in ["", "relative/home"] {
+        let paths = binary_fallback_paths("rtk", home);
+        assert!(paths.iter().all(|path| path.is_absolute()));
+        assert!(
+            !paths
+                .iter()
+                .any(|path| path.to_string_lossy().contains(".local"))
+        );
+    }
+}
+
+#[test]
 fn build_json_result_ready() {
     let result = build_json_result("Shell", &ReadyStatus::Ready, &[], &[]);
     assert_eq!(result["tool"], "Shell");

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -9,6 +9,9 @@
 
 set -uo pipefail
 
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOKENLESS_SOURCE_DIR="$(cd "$TEST_SCRIPT_DIR/.." && pwd)"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -309,7 +312,9 @@ test_tool_ready() {
     local SPEC_FILE=""
     for p in \
         "${ANOLISA_ADAPTER_DIR:+$ANOLISA_ADAPTER_DIR/common/tool-ready-spec.json}" \
+        "$TOKENLESS_SOURCE_DIR/adapters/tokenless/common/tool-ready-spec.json" \
         "$HOME/.local/share/anolisa/adapters/tokenless/common/tool-ready-spec.json" \
+        "/usr/local/share/anolisa/adapters/tokenless/common/tool-ready-spec.json" \
         "/usr/share/anolisa/adapters/tokenless/common/tool-ready-spec.json" \
         "$HOME/.tokenless/tool-ready-spec.json"; do
         if [ -f "$p" ]; then SPEC_FILE="$p"; break; fi
@@ -317,12 +322,29 @@ test_tool_ready() {
     local FIX_SCRIPT=""
     for p in \
         "${ANOLISA_ADAPTER_DIR:+$ANOLISA_ADAPTER_DIR/common/tokenless-env-fix.sh}" \
+        "$TOKENLESS_SOURCE_DIR/adapters/tokenless/common/tokenless-env-fix.sh" \
         "$HOME/.local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
+        "/usr/local/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
         "/usr/share/anolisa/adapters/tokenless/common/tokenless-env-fix.sh" \
         "$HOME/.tokenless/tokenless-env-fix.sh"; do
         if [ -f "$p" ] && [ -x "$p" ]; then FIX_SCRIPT="$p"; break; fi
     done
-    HOOK_DIR="/usr/share/anolisa/adapters/tokenless/common/hooks"
+    local HOOK_DIR=""
+    for d in \
+        "${ANOLISA_ADAPTER_DIR:+$ANOLISA_ADAPTER_DIR/common/hooks}" \
+        "$TOKENLESS_SOURCE_DIR/adapters/tokenless/common/hooks" \
+        "$HOME/.local/share/anolisa/adapters/tokenless/common/hooks" \
+        "/usr/local/share/anolisa/adapters/tokenless/common/hooks" \
+        "/usr/share/anolisa/adapters/tokenless/common/hooks"; do
+        if [ -f "$d/tool_ready_hook.sh" ] && [ -f "$d/compress_response_hook.py" ]; then
+            HOOK_DIR="$d"
+            break
+        fi
+    done
+    if [ -z "$HOOK_DIR" ]; then
+        log_fail "tokenless common hooks not found"
+        return
+    fi
     READY_SCRIPT="$HOOK_DIR/tool_ready_hook.sh"
     COMPRESS_SCRIPT="$HOOK_DIR/compress_response_hook.py"
 
@@ -517,7 +539,14 @@ test_tool_ready() {
     # 6.22 tool-ready hook: NOT_READY + Skip retry
     # ==========================================
     log_info "Test 6.22: tool-ready hook — NOT_READY"
-    local tmp_spec=$(mktemp)
+    local tmp_dir
+    local tmp_spec
+    if ! tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/tokenless-tool-ready.XXXXXX"); then
+        log_fail "unable to create private temporary directory"
+        return
+    fi
+    chmod 0700 "$tmp_dir"
+    tmp_spec="$tmp_dir/tool-ready-spec.json"
     cat > "$tmp_spec" << 'EOF'
 {"TestMissing":{"required":[{"binary":"fakebin99","package":"fakebin99","manager":"rpm"}],"recommended":[],"permissions":[],"network":[]}}
 EOF
@@ -525,6 +554,7 @@ EOF
     assert_contains "$not_ready_out" "NOT_READY" "hook outputs NOT_READY"
     assert_contains "$not_ready_out" "Skip retry" "hook includes Skip retry guidance"
     rm -f "$tmp_spec"
+    rmdir "$tmp_dir"
 
     # ==========================================
     # 6.23 Attribution: ENV_DEPENDENCY_MISSING

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -12,6 +12,8 @@ Uses subprocess to invoke the hook with a mock tokenless binary,
 avoiding Python version issues with the hook_utils module.
 """
 
+import importlib.machinery
+import importlib.util
 import json
 import os
 import stat
@@ -20,7 +22,9 @@ import sys
 import shutil
 import tempfile
 import textwrap
+import types
 import unittest
+from unittest import mock
 
 
 def _make_large_json_payload(char_target: int = 500) -> dict:
@@ -153,6 +157,143 @@ def _run_hook(stdin_data: dict, agent_id: str, mock_tokenless_path: str,
 
 
 _needs_py39 = sys.version_info < (3, 9)
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestBinaryFallbackPaths(unittest.TestCase):
+    @staticmethod
+    def _hook_utils() -> types.ModuleType:
+        hooks_dir = os.path.normpath(os.path.join(
+            os.path.dirname(__file__),
+            os.pardir, "adapters", "tokenless", "common", "hooks",
+        ))
+        sys.path.insert(0, hooks_dir)
+        try:
+            import hook_utils
+        finally:
+            sys.path.pop(0)
+        return hook_utils
+
+    @staticmethod
+    def _codex_check_tokenless() -> types.ModuleType:
+        script_path = os.path.normpath(
+            os.path.join(
+                os.path.dirname(__file__),
+                os.pardir,
+                "adapters",
+                "tokenless",
+                "codex",
+                "scripts",
+                "check-tokenless",
+            )
+        )
+        loader = importlib.machinery.SourceFileLoader(
+            "codex_check_tokenless", script_path
+        )
+        spec = importlib.util.spec_from_loader("codex_check_tokenless", loader)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("unable to load codex check-tokenless")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_supported_install_layouts_are_covered(self) -> None:
+        paths = self._hook_utils()._known_binary_paths("rtk", "/home/alice")
+        expected = (
+            "/home/alice/.local/bin/rtk",
+            "/home/alice/.local/lib/anolisa/libexec/tokenless/rtk",
+            "/home/alice/.local/libexec/anolisa/tokenless/rtk",
+            "/usr/local/bin/rtk",
+            "/usr/local/libexec/anolisa/tokenless/rtk",
+            "/usr/bin/rtk",
+            "/usr/libexec/anolisa/tokenless/rtk",
+            "/usr/lib/anolisa/tokenless/rtk",
+            "/home/alice/.local/share/anolisa/tokenless/rtk",
+            "/home/alice/.local/lib/anolisa/tokenless/rtk",
+        )
+        self.assertEqual(paths, expected)
+
+    def test_generic_binaries_skip_tokenless_helper_dirs(self) -> None:
+        paths = self._hook_utils()._known_binary_paths("docker", "/home/alice")
+        self.assertIn("/home/alice/.local/bin/docker", paths)
+        self.assertIn("/usr/local/bin/docker", paths)
+        self.assertIn("/usr/bin/docker", paths)
+        self.assertFalse(any("tokenless" in path for path in paths))
+
+    def test_user_layouts_require_an_absolute_home(self) -> None:
+        hook_utils = self._hook_utils()
+        for home in ("", "relative/home"):
+            with self.subTest(home=home):
+                paths = hook_utils._known_binary_paths("rtk", home)
+                self.assertTrue(all(os.path.isabs(path) for path in paths))
+                self.assertFalse(any(".local" in path for path in paths))
+
+    def test_codex_check_tokenless_uses_canonical_order(self) -> None:
+        paths = self._codex_check_tokenless()._known_tokenless_paths("/home/alice")
+        self.assertEqual(
+            paths,
+            (
+                "/home/alice/.local/bin/tokenless",
+                "/usr/local/bin/tokenless",
+                "/usr/bin/tokenless",
+                "/home/alice/.local/share/anolisa/tokenless/tokenless",
+                "/home/alice/.local/lib/anolisa/tokenless/tokenless",
+            ),
+        )
+
+    def test_codex_check_tokenless_rejects_invalid_home(self) -> None:
+        check_tokenless = self._codex_check_tokenless()
+        for home in ("", "relative/home"):
+            with self.subTest(home=home):
+                paths = check_tokenless._known_tokenless_paths(home)
+                self.assertEqual(
+                    paths,
+                    ("/usr/local/bin/tokenless", "/usr/bin/tokenless"),
+                )
+
+    def test_resolver_finds_makefile_user_helper_without_path(self) -> None:
+        hook_utils = self._hook_utils()
+        with tempfile.TemporaryDirectory() as home:
+            helper_dir = os.path.join(
+                home, ".local", "libexec", "anolisa", "tokenless"
+            )
+            os.makedirs(helper_dir)
+            rtk_path = os.path.join(helper_dir, "rtk")
+            with open(rtk_path, "w", encoding="utf-8") as handle:
+                handle.write("#!/bin/sh\n")
+            os.chmod(rtk_path, 0o755)
+
+            hook_utils._resolved_cache.clear()
+            with (
+                mock.patch.dict(os.environ, {"HOME": home}),
+                mock.patch.object(hook_utils.shutil, "which", return_value=None),
+            ):
+                self.assertEqual(hook_utils.resolve_binary("rtk"), rtk_path)
+            hook_utils._resolved_cache.clear()
+
+    def test_resolver_prefers_user_layout_to_explicit_legacy_fallback(self) -> None:
+        hook_utils = self._hook_utils()
+        with tempfile.TemporaryDirectory() as home:
+            local_bin = os.path.join(home, ".local", "bin")
+            legacy_bin = os.path.join(home, "legacy")
+            os.makedirs(local_bin)
+            os.makedirs(legacy_bin)
+            user_rtk = os.path.join(local_bin, "rtk")
+            legacy_rtk = os.path.join(legacy_bin, "rtk")
+            for path in (user_rtk, legacy_rtk):
+                with open(path, "w", encoding="utf-8") as handle:
+                    handle.write("#!/bin/sh\n")
+                os.chmod(path, 0o755)
+
+            hook_utils._resolved_cache.clear()
+            with (
+                mock.patch.dict(os.environ, {"HOME": home}),
+                mock.patch.object(hook_utils.shutil, "which", return_value=None),
+            ):
+                self.assertEqual(
+                    hook_utils.resolve_binary("rtk", legacy_rtk), user_rtk
+                )
+            hook_utils._resolved_cache.clear()
 
 
 @unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")


### PR DESCRIPTION
## Description

Tokenless hooks, Codex/OpenClaw adapters, and `env-check` now resolve binaries installed through Makefile, Anolisa CLI user/system mode, or RPM even when the host provides a sanitized `PATH`. The root cause was a set of fragmented fallback lists that omitted Anolisa user libexec and `/usr/local` layouts, while some paths preferred stale RPM binaries over newer user installs. The new lookup order keeps `PATH` first, prefers supported user and `/usr/local` layouts, retains legacy compatibility, and rejects empty or relative home roots in the Rust resolver. Shared hook resource lookup now follows the same precedence, and integration tests use a trusted private temporary directory so read-only source trees remain supported.

## Related Issue

no-issue: installation-layout discovery regression reported outside GitHub

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1` — 434 passed, 2 network tests ignored
- `python3 tests/test_compress_response_hook.py` — 11 passed
- `python3 tests/test_compress_schema_hook.py` — 7 passed
- `npm run build` in `adapters/tokenless/openclaw`
- `bash tests/run-all-tests.sh` — 106/106 passed
- `bash -n` on the changed shell entry points

## Additional Notes

No user-facing documentation changes are required; this restores discovery for already-supported installation modes and keeps legacy paths compatible.