### PR TITLE
fix(anolisa): restore file modes and capabilities on rollback

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -44,7 +44,9 @@ use super::io_util::{
     service_cleanup_suffix, write_installed_component_manifest,
 };
 use super::provision::{retained_packages_note, run_provision};
-use super::raw::{InstallHooks, prepare_raw_execution, resolve_install_hooks};
+use super::raw::{
+    InstallHooks, prepare_raw_execution, resolve_install_hooks, resolve_manifest_capabilities,
+};
 use super::render::artifact_type_wire;
 use super::types::{PreparedInstall, RawResolution};
 
@@ -52,6 +54,9 @@ struct ReplayBackup {
     source: PathBuf,
     dest: PathBuf,
     sha256: Option<String>,
+    /// Permission bits `dest` carried before the replay, so restore puts
+    /// the file back executable if it was executable.
+    mode: Option<u32>,
 }
 
 /// Raw-backend [`OwnedOps`] for one replay operation.
@@ -171,6 +176,100 @@ impl<'a> RawReplayOps<'a> {
             .collect()
     }
 
+    /// Re-apply the file capabilities the *prior* contract declared, after
+    /// the backup has been put back.
+    ///
+    /// Restoring a file writes a new inode, and a new inode carries no
+    /// `security.capability` xattr — so a rollback silently strips the
+    /// capabilities the installed version was running with, the same way it
+    /// used to strip the executable bit. Ownership of that repair belongs
+    /// here rather than in a compensation of its own: capabilities attach to
+    /// the file, so they can only be re-applied once the file is back, and
+    /// `restore_backup` is the last compensation the executor replays.
+    ///
+    /// The prior contract is read from the restored manifest snapshot, not
+    /// from `self.prepared` — the new version's capability set is exactly
+    /// what rollback must *not* leave behind.
+    fn reapply_prior_capabilities(&self) -> Vec<String> {
+        let manifest_path = match crate::commands::common::installed_component_manifest_path(
+            self.layout,
+            &self.component,
+            super::COMMAND,
+        ) {
+            Ok(path) => path,
+            Err(err) => return vec![format!("cannot locate the restored manifest: {err}")],
+        };
+        if !manifest_path.exists() {
+            // Two very different situations reach here. If the record owned
+            // the snapshot, restore was supposed to put it back and did not,
+            // so the prior contract is unreadable and any capabilities it
+            // declared are silently gone — say so. If the record never owned
+            // one, this predates manifest snapshots: nothing was knowable to
+            // begin with, and warning on every such rollback would be noise.
+            if self.prior.files.iter().any(|f| f.path == manifest_path) {
+                return vec![format!(
+                    "restored files but {} is missing, so any file capabilities the previous \
+                     version declared could not be re-applied",
+                    manifest_path.display()
+                )];
+            }
+            return Vec::new();
+        }
+        let toml = match fs::read_to_string(&manifest_path) {
+            Ok(toml) => toml,
+            Err(err) => {
+                return vec![format!(
+                    "restored files but could not read {} to re-apply file capabilities: {err}",
+                    manifest_path.display()
+                )];
+            }
+        };
+        let manifest = match anolisa_core::ComponentManifest::from_toml_str(&toml) {
+            Ok(manifest) => manifest,
+            Err(err) => {
+                return vec![format!(
+                    "restored files but could not parse {} to re-apply file capabilities: {err}",
+                    manifest_path.display()
+                )];
+            }
+        };
+        let requests = match resolve_manifest_capabilities(&manifest, self.layout, &self.component)
+        {
+            Ok(requests) => requests,
+            Err(err) => {
+                return vec![format!(
+                    "restored files but could not resolve the file capabilities {} declares: {}",
+                    manifest_path.display(),
+                    err.reason()
+                )];
+            }
+        };
+        if requests.is_empty() {
+            return Vec::new();
+        }
+
+        let manager = capability_for_install_mode(self.ctx.install_mode.as_str(), &self.env);
+        let outcome = apply_capabilities(
+            manager.as_ref(),
+            &requests,
+            Some(&self.log),
+            &self.component,
+            &self.operation_id,
+            "cli",
+            self.ctx.install_mode.as_str(),
+        );
+        let mut warnings = outcome.warnings;
+        // A required capability that would not apply aborts the *install*
+        // path; during rollback there is nothing left to abort, so it
+        // downgrades to a warning naming what the restored file lost.
+        if let Some(reason) = outcome.aborted {
+            warnings.push(format!(
+                "restored files but could not re-apply their file capabilities: {reason}"
+            ));
+        }
+        warnings
+    }
+
     fn not_wired(what: &str) -> Result<StepSuccess, OwnedOpError> {
         Err(OwnedOpError(format!(
             "{what} is not wired for owned replay yet"
@@ -229,6 +328,7 @@ impl OwnedOps for RawReplayOps<'_> {
                 Ok(Some(artifact)) => self.backups.push(ReplayBackup {
                     source: backup_path,
                     dest: file.path.clone(),
+                    mode: artifact.mode(),
                     sha256: artifact.into_sha256(),
                 }),
                 // Already gone from disk — nothing to preserve; placement
@@ -421,14 +521,23 @@ impl OwnedOps for RawReplayOps<'_> {
     fn restore_backup(&mut self) -> Vec<String> {
         let mut warnings = Vec::new();
         for backup in &self.backups {
-            if let Err(err) =
-                restore_backup_file(&backup.source, &backup.dest, backup.sha256.as_deref())
-            {
-                warnings.push(format!(
+            match restore_backup_file(
+                &backup.source,
+                &backup.dest,
+                backup.sha256.as_deref(),
+                backup.mode,
+            ) {
+                Ok(restore_warnings) => warnings.extend(restore_warnings),
+                Err(err) => warnings.push(format!(
                     "failed to restore {} from its backup: {err}",
                     backup.dest.display()
-                ));
+                )),
             }
+        }
+        // The restored inodes carry no capability xattrs; put the prior
+        // contract's back before the executor calls the rollback done.
+        if !self.backups.is_empty() {
+            warnings.extend(self.reapply_prior_capabilities());
         }
         warnings
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -3594,16 +3594,27 @@ sha256 = "{sha}"
     }
 
     /// A failure while installing the new version compensates back: the old
-    /// files are restored from backup and the recorded version is unchanged.
+    /// files are restored from backup — bytes *and* mode — and the recorded
+    /// version is unchanged. Restoring an owned binary without its
+    /// executable bit leaves the component unusable after a rollback the
+    /// CLI called clean, so the mode is part of what "restored" means.
     #[test]
     fn raw_update_rolls_back_on_install_failure() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().join("sys"), InstallMode::System, false);
         let body: &[u8] = b"original v1 binary\n";
         seed_installed_raw(&c, "foo", "0.1.0", body);
+        let layout = common::resolve_layout(&c);
+        let bin = layout.bin_dir.join("foo");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+                .expect("seed the binary executable, as an install would");
+        }
         publish_raw_repo(
             &tmp.path().join("repo"),
-            &common::resolve_layout(&c),
+            &layout,
             "foo",
             "0.2.0",
             &raw_artifact_missing_binary("foo", "0.2.0"),
@@ -3619,16 +3630,133 @@ sha256 = "{sha}"
             err.reason()
         );
 
-        let layout = common::resolve_layout(&c);
         assert_eq!(
-            std::fs::read(layout.bin_dir.join("foo")).expect("read bin"),
+            std::fs::read(&bin).expect("read bin"),
             body,
             "old binary must be restored from backup"
         );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&bin)
+                    .expect("stat bin")
+                    .permissions()
+                    .mode()
+                    & 0o7777,
+                0o755,
+                "restored binary must keep the executable bit it had before the update"
+            );
+        }
         assert_eq!(
             owned_artifact(&find_component(&c, "foo")).version,
             "0.1.0",
             "failed update must not change the recorded version"
+        );
+    }
+
+    /// Restoring a file writes a new inode, which carries no capability
+    /// xattr — so the rollback has to re-apply the capabilities the *prior*
+    /// contract declared, or the restored binary comes back stripped of them
+    /// exactly like it used to come back stripped of its executable bit.
+    ///
+    /// User mode is deliberate: `capability_for_install_mode` always answers
+    /// with the unsupported manager there, so the assertion is about which
+    /// capabilities the rollback resolved and attempted, not about whether
+    /// this machine happens to have `setcap`.
+    #[test]
+    fn raw_update_rollback_reapplies_prior_capabilities() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().join("home"), InstallMode::User, false);
+        seed_installed_raw(&c, "foo", "0.1.0", b"original v1 binary\n");
+        let layout = common::resolve_layout(&c);
+        let bin = layout.bin_dir.join("foo");
+
+        // Re-state the installed contract with a capability row. The record
+        // keeps no digest for the manifest, so rewriting it in place is what
+        // an installation of a cap-declaring component would have left.
+        let manifest_path = common::installed_component_manifest_path(&layout, "foo", "update")
+            .expect("manifest path");
+        let with_caps = format!(
+            "{}\n[[component.capabilities]]\npath = \"{{bindir}}/foo\"\ncaps = [\"cap_net_bind_service\"]\n",
+            raw_manifest("foo", "0.1.0")
+        );
+        std::fs::write(&manifest_path, &with_caps).expect("rewrite installed manifest");
+
+        publish_raw_repo(
+            &tmp.path().join("repo"),
+            &layout,
+            "foo",
+            "0.2.0",
+            &raw_artifact_missing_binary("foo", "0.2.0"),
+        );
+        let rpm = FakeRpm::new("unused", None);
+
+        let err = update_component_with_deps("foo", &c, &rpm, &rpm, false)
+            .expect_err("install of the new version must fail");
+        assert!(
+            err.reason().contains("the previous files were restored"),
+            "the failure must report the compensation honestly: {}",
+            err.reason()
+        );
+
+        // The forward path never reached SetCapabilities, so any capability
+        // record in the log was written by the rollback.
+        let log = std::fs::read_to_string(&layout.central_log).expect("read central log");
+        let applied: Vec<serde_json::Value> = log
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|record| record["command"] == "capability:apply")
+            .collect();
+        assert_eq!(
+            applied.len(),
+            1,
+            "rollback must re-apply the prior contract's capabilities exactly once: {log}"
+        );
+        assert_eq!(applied[0]["details"]["path"], bin.display().to_string());
+        assert_eq!(applied[0]["details"]["caps"][0], "cap_net_bind_service");
+    }
+
+    /// A contract the rollback cannot read is the one case where capabilities
+    /// go missing without anyone applying them, so it must not degrade to a
+    /// silent skip: the operator has to learn from the failure itself that the
+    /// restored files may be short their capabilities.
+    #[test]
+    fn raw_update_rollback_reports_an_unreadable_prior_contract() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().join("home"), InstallMode::User, false);
+        seed_installed_raw(&c, "foo", "0.1.0", b"original v1 binary\n");
+        let layout = common::resolve_layout(&c);
+
+        let manifest_path = common::installed_component_manifest_path(&layout, "foo", "update")
+            .expect("manifest path");
+        std::fs::write(&manifest_path, "this is not = valid toml [[[").expect("corrupt manifest");
+
+        publish_raw_repo(
+            &tmp.path().join("repo"),
+            &layout,
+            "foo",
+            "0.2.0",
+            &raw_artifact_missing_binary("foo", "0.2.0"),
+        );
+        let rpm = FakeRpm::new("unused", None);
+
+        let err = update_component_with_deps("foo", &c, &rpm, &rpm, false)
+            .expect_err("install of the new version must fail");
+        let reason = err.reason();
+        assert!(
+            reason.contains("restoring the previous files reported problems"),
+            "an unreadable contract must downgrade the honest-rollback claim: {reason}"
+        );
+        assert!(
+            reason.contains(&manifest_path.display().to_string())
+                && reason.contains("file capabilities"),
+            "the warning must name the snapshot it could not use: {reason}"
+        );
+        assert_eq!(
+            std::fs::read(layout.bin_dir.join("foo")).expect("read bin"),
+            b"original v1 binary\n",
+            "an unreadable contract must not stop the files themselves coming back"
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/src/lifecycle.rs
+++ b/src/anolisa/crates/anolisa-core/src/lifecycle.rs
@@ -636,8 +636,13 @@ pub struct ResolvedLifecycleHooks {
 pub enum BackupArtifact {
     /// Regular file copied byte-for-byte; sha256 of those bytes.
     File {
-        /// Content hash recorded on the `RestoreFile` rollback action.
+        /// Content hash recorded on the rollback action.
         sha256: String,
+        /// Permission bits observed on the source, so rollback can put the
+        /// file back executable if it was executable. The full word
+        /// including setuid/setgid/sticky is reported; what a restore may
+        /// safely reproduce is the restore's decision, not the backup's.
+        mode: Option<u32>,
     },
     /// Symlink reproduced as an identical link. The referent is never
     /// read through, so there is no byte hash to verify on restore.
@@ -648,7 +653,16 @@ impl BackupArtifact {
     /// Hash to record on the rollback action; `None` for symlinks.
     pub fn into_sha256(self) -> Option<String> {
         match self {
-            Self::File { sha256 } => Some(sha256),
+            Self::File { sha256, .. } => Some(sha256),
+            Self::Symlink => None,
+        }
+    }
+
+    /// Permission bits observed on the source; `None` for symlinks (a
+    /// link's own mode is not meaningful on Linux).
+    pub fn mode(&self) -> Option<u32> {
+        match self {
+            Self::File { mode, .. } => *mode,
             Self::Symlink => None,
         }
     }
@@ -670,6 +684,15 @@ impl BackupArtifact {
 ///     a pre-placed symlink or stale file at the backup path fails the
 ///     open instead of being followed or overwritten (`symlink(2)` gives
 ///     the same EEXIST guarantee on the link branch).
+///   * The source's permission bits are *reported*, so rollback can put
+///     the file back with the mode it had instead of whatever the umask
+///     gives a fresh file. They are deliberately not reproduced on the
+///     copy: the backup tree is operation scratch that a failed plan
+///     leaves on disk for forensics, so a copy of a `4755` helper must not
+///     itself be a setuid binary sitting under the backup root, and a copy
+///     of a `0111` run-only file must stay readable to the process that
+///     has to read it back. The copy is owner-only instead — strictly
+///     tighter than the `0666 & ~umask` it used to get.
 ///   * Streaming read+hash so a multi-GB owned file does not have to fit
 ///     in RAM, and so the on-disk bytes match the recorded sha exactly.
 ///
@@ -739,12 +762,29 @@ pub fn prepare_backup(src: &Path, backup: &Path) -> Result<Option<BackupArtifact
         });
     }
 
+    // Read the mode off the open descriptor, not the path: the O_NOFOLLOW
+    // open above already pinned the inode, so this cannot be raced onto a
+    // different file between the check and the copy.
+    let src_mode = {
+        use std::os::unix::fs::PermissionsExt;
+        let meta = src_f
+            .metadata()
+            .map_err(|source| LifecycleError::Filesystem {
+                path: src.to_path_buf(),
+                source,
+            })?;
+        Some(meta.permissions().mode() & 0o7777)
+    };
+
     let mut backup_opts = fs::OpenOptions::new();
     backup_opts.write(true).create_new(true);
-    #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         backup_opts.custom_flags(nix::libc::O_NOFOLLOW);
+        // Owner-only: the copy is scratch, not a mirror. It never needs to
+        // be executable, and a private source must not become readable to
+        // anyone else just because it passed through the backup tree.
+        backup_opts.mode(0o600);
     }
     let mut backup_f = match backup_opts.open(backup) {
         Ok(f) => f,
@@ -755,6 +795,49 @@ pub fn prepare_backup(src: &Path, backup: &Path) -> Result<Option<BackupArtifact
             });
         }
     };
+    {
+        // `mode` above is only the `open(2)` creation mask, which the umask
+        // subtracts from: under `umask 0400` the copy would land `0200` and
+        // rollback could not read back the very backup it just wrote.
+        // `fchmod` is not umask-filtered, so it pins the mode exactly.
+        use std::os::unix::fs::PermissionsExt;
+        let chmod_error = backup_f
+            .set_permissions(fs::Permissions::from_mode(0o600))
+            .err();
+
+        // Fail closed, unlike the restore path. This runs *before* the
+        // destructive steps, so nothing has been overwritten yet and a
+        // backup the rollback could not read back is worth refusing the
+        // operation over — registering it as compensatable would let the
+        // executor destroy the original against a promise it cannot keep.
+        // Restore is the mirror case: the damage is already done there, so
+        // the mode is best-effort and a warning.
+        //
+        // The gate is the resulting mode rather than whether `fchmod`
+        // reported success: a filesystem that cannot chmod but creates
+        // readable files is perfectly usable, and only an unreadable copy
+        // disqualifies the backup.
+        match backup_f
+            .metadata()
+            .map(|meta| meta.permissions().mode() & 0o400 != 0)
+        {
+            Ok(true) => {}
+            other => {
+                let _ = fs::remove_file(backup);
+                let source = chmod_error.or_else(|| other.err()).unwrap_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "backup copy is not readable by its owner, so a rollback could not \
+                             restore from it",
+                    )
+                });
+                return Err(LifecycleError::Filesystem {
+                    path: backup.to_path_buf(),
+                    source,
+                });
+            }
+        }
+    }
 
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 64 * 1024];
@@ -792,7 +875,10 @@ pub fn prepare_backup(src: &Path, backup: &Path) -> Result<Option<BackupArtifact
     for b in out {
         sha.push_str(&format!("{b:02x}"));
     }
-    Ok(Some(BackupArtifact::File { sha256: sha }))
+    Ok(Some(BackupArtifact::File {
+        sha256: sha,
+        mode: src_mode,
+    }))
 }
 
 #[cfg(test)]
@@ -1082,6 +1168,173 @@ mod tests {
         let meta = std_fs::symlink_metadata(&backup).expect("backup exists");
         assert!(meta.file_type().is_symlink(), "backup must be a link");
         assert_eq!(std_fs::read_link(&backup).expect("read_link"), target);
+    }
+
+    /// The source's permission bits are reported so rollback can put the
+    /// file back executable; a backup that only carried bytes is the whole
+    /// of the restore-drops-the-executable-bit bug.
+    #[test]
+    #[cfg(unix)]
+    fn prepare_backup_reports_the_source_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let src = tmp.path().join("bin/tool");
+        std_fs::create_dir_all(src.parent().expect("parent")).expect("mkdir");
+        std_fs::write(&src, b"tool bytes").expect("write src");
+        std_fs::set_permissions(&src, std_fs::Permissions::from_mode(0o755)).expect("chmod src");
+        let backup = tmp.path().join("backup/0.bak");
+
+        let artifact = prepare_backup(&src, &backup)
+            .expect("backup ok")
+            .expect("src exists");
+
+        assert_eq!(artifact.mode(), Some(0o755));
+    }
+
+    /// The setuid bit is reported verbatim — deciding what may safely be
+    /// replayed belongs to the restore, which knows it cannot reproduce the
+    /// original owner. The copy itself must never become that setuid binary:
+    /// it sits in the backup tree, which a failed plan leaves on disk.
+    #[test]
+    #[cfg(unix)]
+    fn prepare_backup_reports_setuid_without_reproducing_it() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let src = tmp.path().join("libexec/helper");
+        std_fs::create_dir_all(src.parent().expect("parent")).expect("mkdir");
+        std_fs::write(&src, b"helper bytes").expect("write src");
+        std_fs::set_permissions(&src, std_fs::Permissions::from_mode(0o4755)).expect("chmod src");
+        let backup = tmp.path().join("backup/0.bak");
+
+        let artifact = prepare_backup(&src, &backup)
+            .expect("backup ok")
+            .expect("src exists");
+
+        assert_eq!(artifact.mode(), Some(0o4755));
+        let copy_mode = std_fs::metadata(&backup)
+            .expect("stat backup")
+            .permissions()
+            .mode()
+            & 0o7777;
+        assert_eq!(
+            copy_mode & 0o7000,
+            0,
+            "a backup copy must never be setuid/setgid: {copy_mode:04o}"
+        );
+        assert_eq!(
+            copy_mode & 0o111,
+            0,
+            "a backup copy is inert data, not an executable: {copy_mode:04o}"
+        );
+    }
+
+    /// Whatever the source mode and whatever the umask, the copy is
+    /// owner-only: backing up a `0600` secret must not widen it, and
+    /// backing up a `0644` config must not leave a second readable copy
+    /// under the backup root.
+    #[test]
+    #[cfg(unix)]
+    fn prepare_backup_copies_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        for (name, mode) in [("secret.toml", 0o600), ("config.toml", 0o644)] {
+            let src = tmp.path().join("etc").join(name);
+            std_fs::create_dir_all(src.parent().expect("parent")).expect("mkdir");
+            std_fs::write(&src, b"token = \"s3cr3t\"").expect("write src");
+            std_fs::set_permissions(&src, std_fs::Permissions::from_mode(mode)).expect("chmod src");
+            let backup = tmp.path().join("backup").join(name);
+
+            prepare_backup(&src, &backup)
+                .expect("backup ok")
+                .expect("src exists");
+
+            assert_eq!(
+                std_fs::metadata(&backup)
+                    .expect("stat backup")
+                    .permissions()
+                    .mode()
+                    & 0o7777,
+                0o600,
+                "the copy of a {mode:o} source must be owner-only"
+            );
+        }
+    }
+
+    /// The backup copy must stay owner-*readable* whatever umask the caller
+    /// runs under. `OpenOptions::mode` is only the `open(2)` creation mask,
+    /// which the umask subtracts from, so `umask 0400` turns a `0600` request
+    /// into a write-only `0200` copy — and then `restore_backup_file` cannot
+    /// read back the backup it just wrote, turning the compensation this
+    /// module exists to make whole into a partial one.
+    ///
+    /// umask is process-global, so the hostile value is set in a child
+    /// process running only this test; mutating it in-process would leak
+    /// into whatever tests happen to run beside it.
+    #[test]
+    #[cfg(unix)]
+    fn prepare_backup_copies_stay_readable_under_a_hostile_umask() {
+        const CHILD: &str = "ANOLISA_PREPARE_BACKUP_UMASK_CHILD";
+        const TEST: &str =
+            "lifecycle::tests::prepare_backup_copies_stay_readable_under_a_hostile_umask";
+
+        if std::env::var_os(CHILD).is_none() {
+            let out = std::process::Command::new(
+                std::env::current_exe().expect("locate the test binary"),
+            )
+            .args(["--exact", TEST, "--nocapture"])
+            .env(CHILD, "1")
+            .output()
+            .expect("re-exec the test binary");
+            let report = format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            // A filter that matches nothing also exits 0, which would make
+            // this test vacuous; require the child to say it ran one test.
+            assert!(
+                report.contains("1 passed"),
+                "the child must actually run {TEST}: {report}"
+            );
+            assert!(out.status.success(), "child failed: {report}");
+            return;
+        }
+
+        use std::os::unix::fs::PermissionsExt;
+
+        // Lay the fixture down first: the source is what an earlier install
+        // left behind under a normal umask, so only the backup itself should
+        // meet the hostile one.
+        let tmp = tempdir().expect("tempdir");
+        let src = tmp.path().join("etc/secret.toml");
+        std_fs::create_dir_all(src.parent().expect("parent")).expect("mkdir");
+        std_fs::write(&src, b"token = \"s3cr3t\"").expect("write src");
+        std_fs::set_permissions(&src, std_fs::Permissions::from_mode(0o600)).expect("chmod src");
+        let backup = tmp.path().join("backup/0.bak");
+
+        // Only this test runs in the child, so the global umask is ours.
+        unsafe { nix::libc::umask(0o400) };
+
+        prepare_backup(&src, &backup)
+            .expect("backup ok")
+            .expect("src exists");
+
+        let mode = std_fs::metadata(&backup)
+            .expect("stat backup")
+            .permissions()
+            .mode()
+            & 0o7777;
+        assert_eq!(
+            mode, 0o600,
+            "umask must not narrow the copy out of the owner's reach: {mode:04o}"
+        );
+        assert_eq!(
+            std_fs::read(&backup).expect("the rollback has to be able to read its own backup"),
+            b"token = \"s3cr3t\""
+        );
     }
 
     /// A pre-placed file at the backup leaf must fail the symlink backup

--- a/src/anolisa/crates/anolisa-core/src/transaction.rs
+++ b/src/anolisa/crates/anolisa-core/src/transaction.rs
@@ -762,6 +762,10 @@ impl Transaction {
     /// entry backed up as a link) is restored by recreating an identical
     /// link at `dest` — its bytes are never read through, so `sha256` is
     /// not applicable and is ignored.
+    ///
+    /// A journaled action carries no mode, so the restored file takes the
+    /// umask default. In-process compensation restores the observed mode
+    /// by calling [`restore_backup_file`] directly.
     pub fn restore_file(&self, rollback: &RollbackAction) -> Result<(), TransactionError> {
         if rollback.kind != RollbackActionKind::RestoreFile {
             return Err(TransactionError::Rollback(format!(
@@ -777,7 +781,7 @@ impl Transaction {
             .as_ref()
             .ok_or_else(|| TransactionError::Rollback("restore_file: missing dest".to_string()))?;
 
-        restore_backup_file(source, dest, rollback.sha256.as_deref())
+        restore_backup_file(source, dest, rollback.sha256.as_deref(), None).map(|_| ())
     }
 
     /// Load a previously-written journal. Returns
@@ -916,6 +920,24 @@ impl Transaction {
 /// sibling rename. A symlink backup is recreated as the same link. This is
 /// the shared rollback primitive for journaled and in-process compensation.
 ///
+/// Rollback must return the destination to its pre-operation state *mode
+/// for mode*, not just byte for byte: the atomic sibling would otherwise
+/// land at `0666 & ~umask`, silently stripping the executable bit off a
+/// restored binary and leaving the component unusable after a rollback the
+/// CLI reported as clean. `mode` is what [`crate::lifecycle::prepare_backup`]
+/// observed on the source; `None` restores the bytes and leaves the mode to
+/// the umask, as it always did.
+///
+/// Only the permission bits (`0o777`) are reproduced. Restore writes a new
+/// inode owned by the *restoring* process and cannot put back the original
+/// uid/gid, so replaying setuid/setgid onto it would mint a setuid binary
+/// owned by root that the pre-operation state never had. Those bits are
+/// dropped and reported in the returned warnings instead.
+///
+/// Applying the mode is best-effort: on a filesystem that cannot chmod, the
+/// bytes still land and the trouble is returned as a warning. Losing the
+/// file to protect its metadata inverts what a rollback is for.
+///
 /// # Errors
 ///
 /// Returns an IO error when the backup cannot be read or the destination
@@ -925,7 +947,8 @@ pub fn restore_backup_file(
     source: &Path,
     dest: &Path,
     expected_sha256: Option<&str>,
-) -> Result<(), TransactionError> {
+    mode: Option<u32>,
+) -> Result<Vec<String>, TransactionError> {
     let meta = fs::symlink_metadata(source)
         .map_err(|err| TransactionError::Io(source.to_path_buf(), err))?;
     if meta.file_type().is_symlink() {
@@ -944,7 +967,7 @@ pub fn restore_backup_file(
         }
         std::os::unix::fs::symlink(&referent, dest)
             .map_err(|err| TransactionError::Io(dest.to_path_buf(), err))?;
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let bytes = fs::read(source).map_err(|err| TransactionError::Io(source.to_path_buf(), err))?;
@@ -957,7 +980,32 @@ pub fn restore_backup_file(
             )));
         }
     }
-    write_atomic(dest, &bytes).map_err(|err| TransactionError::Rollback(err.to_string()))
+
+    let mut warnings = Vec::new();
+    let mode = mode.map(|mode| {
+        if mode & 0o7000 != 0 {
+            warnings.push(format!(
+                "{} was {:04o} before the operation; restoring it as {:03o} \
+                 because rollback cannot reproduce its original owner and a \
+                 setuid or setgid file owned by the restoring user would grant \
+                 more than the original did",
+                dest.display(),
+                mode,
+                mode & 0o777
+            ));
+        }
+        mode & 0o777
+    });
+    if let Some(err) = write_atomic_with_mode(dest, &bytes, mode)
+        .map_err(|err| TransactionError::Rollback(err.to_string()))?
+    {
+        warnings.push(format!(
+            "restored {} but could not set its mode to {:03o}: {err}",
+            dest.display(),
+            mode.unwrap_or_default()
+        ));
+    }
+    Ok(warnings)
 }
 
 /// Mint a fresh operation id outside a journal, in the same format
@@ -1007,13 +1055,39 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// same operation_id (or a stale tmp left behind by an earlier process)
 /// cannot collide on the same path.
 fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    // Journal and state writes take whatever the umask gives them; only
+    // the rollback path has a mode it must reproduce.
+    write_atomic_with_mode(path, bytes, None).map(|_| ())
+}
+
+/// [`write_atomic`] that lands the destination on `mode`.
+///
+/// The tmp sibling is created owner-only rather than at the umask default,
+/// because it holds the same bytes as the destination for the whole write:
+/// restoring a `0600` secret through a tmp that a crash could strand at
+/// `0644` would leak it. `fchmod` widens the tmp to `mode` only once the
+/// bytes are down, so the file is never more permissive than its final
+/// mode at any point. Mirrors `install_runner::write_dest_atomic`, which
+/// applies the manifest layout mode the same way on the install path —
+/// restore has to match it or a rollback downgrades the file.
+///
+/// Returns the `fchmod` error instead of propagating it: on a filesystem
+/// that cannot chmod, a restore that lands the bytes with the wrong mode
+/// still beats one that deletes the staged content and leaves nothing.
+fn write_atomic_with_mode(
+    path: &Path,
+    bytes: &[u8],
+    mode: Option<u32>,
+) -> io::Result<Option<io::Error>> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
         fs::create_dir_all(parent)?;
     }
     let tmp = tmp_path_for(path);
-    let mut f = open_excl_nofollow(&tmp)?;
+    // Owner-only while the bytes are in flight when we know the target
+    // mode; `None` keeps the historical umask default for journal writes.
+    let mut f = open_excl_nofollow(&tmp, mode.map(|_| 0o600))?;
     if let Err(err) = f.write_all(bytes) {
         // Drop the half-written tmp so we don't leak it.
         let _ = fs::remove_file(&tmp);
@@ -1023,6 +1097,15 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     // install_runner.rs — a sync_all failure here is not fatal because
     // the rename below is the actual atomicity guarantee.
     let _ = f.sync_all();
+    let mut mode_error = None;
+    if let Some(mode) = mode {
+        use std::os::unix::fs::PermissionsExt;
+        // `fchmod` on the descriptor, not the tmp path: nothing can be
+        // swapped in underneath between the write and the mode change.
+        if let Err(err) = f.set_permissions(fs::Permissions::from_mode(mode)) {
+            mode_error = Some(err);
+        }
+    }
     // Close before rename so the bytes are fully flushed to the
     // descriptor before another process can observe the renamed file.
     drop(f);
@@ -1030,25 +1113,43 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
         let _ = fs::remove_file(&tmp);
         return Err(err);
     }
-    Ok(())
+    Ok(mode_error)
 }
 
-/// Open `tmp` for writing with `O_CREAT|O_EXCL` (+ `O_NOFOLLOW` on Unix).
+/// Open `tmp` for writing with `O_CREAT|O_EXCL` (+ `O_NOFOLLOW` on Unix),
+/// at `create_mode` when the caller wants something tighter than the umask
+/// default.
 ///
 /// Extracted as a named helper so the symlink/TOCTOU hardening can be
 /// exercised directly from tests without having to race the random tmp
 /// suffix produced by [`tmp_path_for`]. Mirrors the pattern used by
 /// `download::stream_reader_and_hash` and
 /// `install_runner::stream_write_and_hash`.
-fn open_excl_nofollow(tmp: &Path) -> io::Result<File> {
+fn open_excl_nofollow(tmp: &Path, create_mode: Option<u32>) -> io::Result<File> {
     let mut opts = OpenOptions::new();
     opts.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         opts.custom_flags(nix::libc::O_NOFOLLOW);
+        if let Some(mode) = create_mode {
+            opts.mode(mode);
+        }
     }
-    opts.open(tmp)
+    let file = opts.open(tmp)?;
+    #[cfg(unix)]
+    if let Some(mode) = create_mode {
+        // The `open(2)` creation mask is umask-filtered, so it can only be
+        // narrowed — under `umask 0400` a `0600` request lands `0200`. That
+        // is harmless for the staging window itself, but it would make the
+        // helper's "created at exactly `create_mode`" contract a lie for
+        // anyone reading back through this descriptor. `fchmod` is not
+        // umask-filtered. Best-effort: callers that need the final mode
+        // enforced apply and report it themselves.
+        use std::os::unix::fs::PermissionsExt;
+        let _ = file.set_permissions(fs::Permissions::from_mode(mode));
+    }
+    Ok(file)
 }
 
 /// Monotonic, process-wide counter mixed into [`tmp_path_for`] so that
@@ -1796,7 +1897,7 @@ journal_path = "/tmp/x.journal.toml"
         std_fs::write(&outside, b"outside bytes").expect("seed outside target");
         std::os::unix::fs::symlink(&outside, &dest).expect("plant destination symlink");
 
-        restore_backup_file(&backup, &dest, Some(&sha256_hex(b"owned bytes")))
+        restore_backup_file(&backup, &dest, Some(&sha256_hex(b"owned bytes")), None)
             .expect("restore backup");
 
         assert_eq!(
@@ -1813,6 +1914,125 @@ journal_path = "/tmp/x.journal.toml"
         assert_eq!(
             std_fs::read(&dest).expect("read restored file"),
             b"owned bytes"
+        );
+    }
+
+    /// Rollback restores mode for mode, not only byte for byte: the atomic
+    /// sibling lands at `0666 & ~umask`, so without an explicit chmod a
+    /// restored `0755` binary comes back non-executable.
+    #[test]
+    #[cfg(unix)]
+    fn restore_backup_file_reapplies_the_recorded_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let backup = tmp.path().join("backup/0.bak");
+        let dest = tmp.path().join("bin/tool");
+        std_fs::create_dir_all(backup.parent().expect("backup parent")).expect("mkdir backup");
+        std_fs::create_dir_all(dest.parent().expect("dest parent")).expect("mkdir dest");
+        std_fs::write(&backup, b"owned bytes").expect("seed backup");
+        std_fs::write(&dest, b"replaced bytes").expect("seed dest");
+
+        let warnings = restore_backup_file(
+            &backup,
+            &dest,
+            Some(&sha256_hex(b"owned bytes")),
+            Some(0o755),
+        )
+        .expect("restore backup");
+
+        assert!(warnings.is_empty(), "clean restore must not warn");
+        assert_eq!(
+            std_fs::read(&dest).expect("read restored file"),
+            b"owned bytes"
+        );
+        assert_eq!(
+            std_fs::metadata(&dest)
+                .expect("stat restored file")
+                .permissions()
+                .mode()
+                & 0o7777,
+            0o755,
+            "the recorded mode must survive the tmp+rename"
+        );
+    }
+
+    /// Restore writes a new inode owned by the restoring process, so
+    /// replaying setuid/setgid would hand out privileges the pre-operation
+    /// file never granted. Those bits are dropped, and the operator is told
+    /// rather than left to discover it from `ls`.
+    #[test]
+    #[cfg(unix)]
+    fn restore_backup_file_drops_setuid_and_says_so() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let backup = tmp.path().join("backup/0.bak");
+        let dest = tmp.path().join("libexec/helper");
+        std_fs::create_dir_all(backup.parent().expect("backup parent")).expect("mkdir backup");
+        std_fs::create_dir_all(dest.parent().expect("dest parent")).expect("mkdir dest");
+        std_fs::write(&backup, b"helper bytes").expect("seed backup");
+
+        let warnings =
+            restore_backup_file(&backup, &dest, None, Some(0o4755)).expect("restore backup");
+
+        let mode = std_fs::metadata(&dest)
+            .expect("stat restored file")
+            .permissions()
+            .mode()
+            & 0o7777;
+        assert_eq!(
+            mode, 0o755,
+            "the executable bits come back, the setuid bit does not: {mode:04o}"
+        );
+        assert_eq!(warnings.len(), 1, "the dropped bit must be reported");
+        assert!(
+            warnings[0].contains("4755") && warnings[0].contains("755"),
+            "the warning must name both modes: {}",
+            warnings[0]
+        );
+    }
+
+    /// With no recorded mode the bytes still land; the destination simply
+    /// takes the umask default, exactly as it did before modes were carried.
+    #[test]
+    #[cfg(unix)]
+    fn restore_backup_file_without_a_mode_restores_bytes_only() {
+        let tmp = tempdir().expect("tempdir");
+        let backup = tmp.path().join("backup/0.bak");
+        let dest = tmp.path().join("bin/tool");
+        std_fs::create_dir_all(backup.parent().expect("backup parent")).expect("mkdir backup");
+        std_fs::create_dir_all(dest.parent().expect("dest parent")).expect("mkdir dest");
+        std_fs::write(&backup, b"owned bytes").expect("seed backup");
+
+        let warnings = restore_backup_file(&backup, &dest, None, None).expect("restore backup");
+
+        assert!(warnings.is_empty());
+        assert_eq!(
+            std_fs::read(&dest).expect("read restored file"),
+            b"owned bytes"
+        );
+    }
+
+    /// The tmp sibling holds the same bytes as the destination for the whole
+    /// write, so it must never be created at the umask default when the
+    /// caller knows the target mode — a crash between write and rename would
+    /// otherwise strand a world-readable copy of a private file.
+    #[test]
+    #[cfg(unix)]
+    fn write_atomic_with_mode_stages_the_tmp_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let target = tmp.path().join("etc/secret.toml");
+        std_fs::create_dir_all(target.parent().expect("parent")).expect("mkdir");
+
+        let staged = open_excl_nofollow(&tmp_path_for(&target), Some(0o600)).expect("open tmp");
+        let mode = staged.metadata().expect("stat tmp").permissions().mode() & 0o7777;
+
+        assert_eq!(
+            mode, 0o600,
+            "the staged tmp must be owner-only regardless of umask: {mode:04o}"
         );
     }
 
@@ -1902,7 +2122,7 @@ journal_path = "/tmp/x.journal.toml"
         let tmp_plant = dir.path().join(".target.tmp");
         std::os::unix::fs::symlink(&victim, &tmp_plant).expect("plant symlink");
 
-        let err = open_excl_nofollow(&tmp_plant).expect_err("must refuse symlink");
+        let err = open_excl_nofollow(&tmp_plant, None).expect_err("must refuse symlink");
         // Either ELOOP (NOFOLLOW kicked in) or EEXIST (EXCL kicked in) is
         // acceptable; both mean the bytes never touched the victim.
         let kind = err.kind();
@@ -1926,7 +2146,7 @@ journal_path = "/tmp/x.journal.toml"
         let tmp_plant = dir.path().join(".already-here.tmp");
         std_fs::write(&tmp_plant, b"stale").expect("seed stale tmp");
 
-        let err = open_excl_nofollow(&tmp_plant).expect_err("must refuse existing file");
+        let err = open_excl_nofollow(&tmp_plant, None).expect_err("must refuse existing file");
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
     }
 


### PR DESCRIPTION
## Description

A failed `anolisa update` or `anolisa repair` restored the previous files byte for byte and nothing else, so a rollback the CLI reported as clean left the component broken. Backup and restore both created their files with bare `create_new`, which means the mode was already gone by the time restore ran and the destination landed at `0666 & ~umask` — an owned binary came back as 644 and `Permission denied`. File capabilities were lost the same way: restore writes a new inode, and a new inode carries no `security.capability` xattr.

`prepare_backup` now reports the mode it observed on the source, and the replay port applies it to the tmp sibling before the rename — the way the install path already applies the manifest layout mode. Once the files are back, the port re-applies the capabilities the *prior* contract declared, read from the restored manifest snapshot rather than from the version that failed to install; this lives at the end of `restore_backup` because capabilities attach to the file and that is the last compensation the executor replays.

Key decision: only the permission bits are replayed. Restore writes an inode owned by the restoring process and cannot put back the original uid/gid, so reproducing setuid/setgid would mint a setuid-root binary the pre-operation state never had. Those bits are dropped with a warning rather than silently. Applying mode and capabilities is best-effort on both sides — losing a file to protect its metadata inverts what a rollback is for.

Note that the damage did not require the files to have been touched: `BackupFiles` runs before `DownloadVerify` and registers its compensation unconditionally, so the reported failure at the download step still rewrote an untouched binary. Both `update` (U3) and `repair` (R2 owned replay) go through `RawReplayOps` and are fixed together.

## Related Issue

closes #1883

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly <!-- no README/user-guide change needed; per specs/documentation-standard.md CHANGELOG belongs to the release bump PR -->
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

`cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked --workspace` all pass from `src/anolisa`.

Every new test was verified to fail with the fix disabled, not just to pass with it:

- **End-to-end (`raw_update_rolls_back_on_install_failure`)** — the existing rollback test now seeds the binary `0755` and asserts the restored mode. With the mode dropped on the restore call it fails `436 != 493` (0664 vs 0755 under this box's umask; 0644 under a stock root umask, matching the issue report). Kept in the existing test rather than added as a second one so the two copies cannot drift.
- **End-to-end (`raw_update_rollback_reapplies_prior_capabilities`)** — a rolled-back update whose prior manifest declares `cap_net_bind_service` must produce exactly one `capability:apply` record naming the restored binary. Runs in user mode on purpose: `capability_for_install_mode` always answers with the unsupported manager there, so the assertion is about which capabilities the rollback resolved and attempted, not about whether the test machine has `setcap`. The forward path never reaches `SetCapabilities` in this scenario, so any such record can only have come from the rollback.
- **End-to-end (`raw_update_rollback_reports_an_unreadable_prior_contract`)** — a manifest snapshot the rollback cannot parse must not degrade to a silent skip: the CLI error drops from `the previous files were restored` to `restoring the previous files reported problems (...)`, names the unusable snapshot, and the files still come back. Fails if the parse branch returns silently.
- **Unit (`prepare_backup_copies_stay_readable_under_a_hostile_umask`)** — `OpenOptions::mode` is only the `open(2)` creation mask, so `umask 0400` would land a `0600` backup at `0200` and rollback could not read back its own backup. The mode is pinned with `fchmod` instead; the test re-execs itself in a child process to set the hostile umask, since umask is process-global and would otherwise leak into tests running in parallel. The parent asserts the child reported `1 passed`, because an `--exact` filter that matches nothing also exits 0.
- **Unit** — the source mode is reported; setuid is reported but never reproduced on the backup copy or the restored file; the restored file's warning names both the original and the applied mode; backup copies of both `0600` and `0644` sources come out owner-only; the staged tmp is owner-only; a restore with no recorded mode still lands the bytes.

Edge cases verified: symlink entries were already restored correctly and are untouched (a link's own mode is not meaningful on Linux); a chmod failure now warns and keeps the file instead of unlinking the staged content; a missing or unparseable manifest snapshot warns instead of silently skipping the capability replay.

## Additional Notes

Two deliberate non-changes:

- The mode is **not** threaded through `RollbackAction`. Journaled rollback actions have had no producer since `2d40b9a2` moved compensation in-process — `journal_step` passes `None` for every step — and a `repair` test asserts owned journals are "terminated, not replayed". A journal field would have no writer, so adding one would mean a breaking public signature change and a wire field for a path that never runs. Cleaning up the orphaned `RollbackAction` machinery is a separate concern and is not attempted here.
- No CHANGELOG entry: `specs/documentation-standard.md` reserves CHANGELOG writes for release version bump PRs. The user-perceivable effect for that PR to aggregate is "a rolled-back update now restores executable bits and file capabilities; setuid/setgid are not restored and the rollback warns".

This PR was reviewed by a multi-agent code review before submission; the findings it raised — setuid replay without ownership restoration, the tmp sibling's write window, chmod failures being fatal, and the capability gap — are all addressed above.