### PR TITLE
feat(cosh-ng): [shell] auto-execute fully readonly compound commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
@@ -5,10 +5,14 @@ use crate::approval::broker::{
     provider_deny_response, ApprovalExecutionMetadata, ApprovalOutcome, ApprovalOutcomeInput,
     ProviderApprovalStatus, ProviderResponseInput,
 };
+use crate::approval::handoff::shell_handoff_command_from_request;
 use crate::approval::journal::approval_audit_input;
 use crate::approval::provider::mark_provider_approval_resolved;
 use crate::approval::resolution::request_can_receive_host_executed_result;
+use crate::runtime::evidence_delivery::record_readonly_compound_completion;
 use crate::runtime::prelude::*;
+use crate::tools::readonly_compound::{build_readonly_compound_plan, run_readonly_compound};
+use crate::tools::{ReadonlyPipelineConfig, ReadonlyPipelineError, ReadonlyPipelineOutput};
 
 pub(crate) fn render_trusted_tool<W: Write>(
     state: &mut InlineState,
@@ -203,8 +207,20 @@ pub(crate) fn render_auto_approved_tool<W: Write>(
         ) else {
             continue;
         };
-        if auto_policy.route(&assessment) != AutoExecutionRoute::DirectReadonlyBroker {
-            continue;
+        // Issue #1882: a fully readonly compound runs through the
+        // dedicated argv executor instead of a shell handoff, so the
+        // executed argv never passes through a shell parsing layer.
+        match auto_policy.route(&assessment) {
+            AutoExecutionRoute::DirectReadonlyBroker => {}
+            AutoExecutionRoute::CompoundReadonlyExecutor => {
+                if run_auto_approved_readonly_compound(state, request, output)?
+                    == AutoApprovalFlow::Handled
+                {
+                    return Ok(true);
+                }
+                continue;
+            }
+            _ => continue,
         }
 
         if request_is_executable_bash_tool(&request)
@@ -303,7 +319,7 @@ fn approval_outcome_for_auto_request(request: &RuntimeApprovalRequest) -> Approv
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ShellRequestPolicyDecision {
+pub(super) enum ShellRequestPolicyDecision {
     Continue,
     DenyAnalysisOnly,
     DenyDuplicateHostExecuted,
@@ -327,7 +343,7 @@ fn handle_shell_request_policy(
     }
 }
 
-fn shell_request_policy_decision(
+pub(super) fn shell_request_policy_decision(
     state: &InlineState,
     run_request: Option<&AgentRequest>,
     request: &RuntimeApprovalRequest,
@@ -398,34 +414,18 @@ fn apply_auto_approved_request_outcome<W: Write>(
         )?;
         return Ok(AutoApprovalFlow::Handled);
     }
-    // DR-6: When hooks had something to say but the tool is auto-approved,
-    // render an independent hook notice panel before the tool call header
-    // so that the user is aware of the hook's intervention.
-    if !request.hook_warnings.is_empty() {
-        let mut body: Vec<String> = Vec::new();
-        for w in &request.hook_warnings {
-            let icon = hook_warning_icon(w.decision.as_deref());
-            body.push(format!("\u{2502} {icon} {}", w.hook_name));
-            for msg_line in w.message.lines() {
-                body.push(format!("\u{2502}   {msg_line}"));
-            }
-        }
-        let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
-        renderer.write_notice_panel(
-            output,
-            NoticePanelModel {
-                title: "Hook",
-                body,
-                footer: None,
-            },
-        )?;
-    }
+    render_hook_warning_notices(state, request, output)?;
     let outcome = approval_outcome_for_auto_request(request);
     if outcome == ApprovalOutcome::ForegroundShellHandoff {
         let authorized = state
             .audit
             .as_mut()
-            .map(|audit| audit.authorize_host_execution(approval_audit_input(request)))
+            .map(|audit| {
+                audit.authorize_host_execution(
+                    approval_audit_input(request),
+                    "shell_foreground_handoff",
+                )
+            })
             .transpose();
         if authorized.is_err() {
             request.status = ApprovalRequestStatus::Blocked;
@@ -462,6 +462,189 @@ fn apply_auto_approved_request_outcome<W: Write>(
             }
             Ok(AutoApprovalFlow::Handled)
         }
+    }
+}
+
+// DR-6: When hooks had something to say but the tool is auto-approved,
+// render an independent hook notice panel before the tool call header
+// so that the user is aware of the hook's intervention.
+fn render_hook_warning_notices<W: Write>(
+    state: &InlineState,
+    request: &RuntimeApprovalRequest,
+    output: &mut W,
+) -> std::io::Result<()> {
+    if request.hook_warnings.is_empty() {
+        return Ok(());
+    }
+    let mut body: Vec<String> = Vec::new();
+    for w in &request.hook_warnings {
+        let icon = hook_warning_icon(w.decision.as_deref());
+        body.push(format!("\u{2502} {icon} {}", w.hook_name));
+        for msg_line in w.message.lines() {
+            body.push(format!("\u{2502}   {msg_line}"));
+        }
+    }
+    let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+    renderer.write_notice_panel(
+        output,
+        NoticePanelModel {
+            title: "Hook",
+            body,
+            footer: None,
+        },
+    )
+}
+
+/// Issue #1882: runs an auto-approved readonly compound through the
+/// dedicated argv executor. Eligibility and the executed plan come
+/// from the same predicate (`build_readonly_compound_plan`), so the
+/// assessment above and the execution here can never disagree about
+/// what would run.
+fn run_auto_approved_readonly_compound<W: Write>(
+    state: &mut InlineState,
+    request: RuntimeApprovalRequest,
+    output: &mut W,
+) -> std::io::Result<AutoApprovalFlow> {
+    let Ok(command) = shell_handoff_command_from_request(&request) else {
+        // The command text cannot be reconstructed from the request;
+        // fall back to the manual flow rather than executing anything.
+        return Ok(AutoApprovalFlow::Continue);
+    };
+    let Some(plan) = build_readonly_compound_plan(&command) else {
+        // Route and plan are built by the same predicate, so a miss
+        // here means the request changed between assessment and
+        // execution; fall back to the manual flow rather than
+        // executing anything.
+        return Ok(AutoApprovalFlow::Continue);
+    };
+    let Some(execution_cwd) = readonly_compound_execution_cwd(state, &request) else {
+        // No verifiable working directory for this session: guessing
+        // (e.g. the process launch directory after the user has cd'd
+        // away) could auto-execute in the wrong repository, so keep
+        // the manual AskUser flow.
+        return Ok(AutoApprovalFlow::Continue);
+    };
+
+    let mut request = record_auto_approved_request(state, request);
+    // Mirror the handoff path's status gate: when the audit recorder
+    // failed closed (blocked_audit_required) the approval is not
+    // durable, and a blocked request must never reach the executor.
+    let blocked_before_authorize = request.status != ApprovalRequestStatus::Approved;
+    let authorized = if blocked_before_authorize {
+        Ok(None)
+    } else {
+        state
+            .audit
+            .as_mut()
+            .map(|audit| {
+                audit.authorize_host_execution(
+                    approval_audit_input(&request),
+                    "readonly_compound_argv_executor",
+                )
+            })
+            .transpose()
+    };
+    if blocked_before_authorize || authorized.is_err() {
+        request.status = ApprovalRequestStatus::Blocked;
+        request.execution_path = Some("blocked_audit_required");
+        render_approval_resolution(
+            state,
+            &request,
+            MessageId::ApprovalResolutionBlockedTitle,
+            output,
+        )?;
+        return Ok(AutoApprovalFlow::Handled);
+    }
+    render_hook_warning_notices(state, &request, output)?;
+    render_approval_resolution(
+        state,
+        &request,
+        MessageId::ApprovalResolutionAutoApprovedTitle,
+        output,
+    )?;
+
+    let started = std::time::Instant::now();
+    let executed = run_readonly_compound(&plan, &ReadonlyPipelineConfig::default(), &execution_cwd);
+    let duration_ms = started.elapsed().as_millis() as u64;
+    let status = readonly_compound_completion_status(&executed, &command);
+    let pipeline_output = executed.unwrap_or_else(|err| ReadonlyPipelineOutput {
+        exit_code: None,
+        stdout: String::new(),
+        stderr: format!(
+            "readonly compound executor error [{}]: {}",
+            err.reason, err.detail
+        ),
+    });
+    let evidence = record_readonly_compound_completion(
+        state,
+        &request,
+        &command,
+        &pipeline_output,
+        &execution_cwd,
+        status,
+        duration_ms,
+    );
+    mark_provider_approval_resolved(state);
+    if !evidence.provider_result_delivered
+        && !request_can_receive_host_executed_result(state, &request)
+    {
+        stop_active_agent_run_without_rendering(state, output)?;
+    }
+    Ok(AutoApprovalFlow::Handled)
+}
+
+/// Verifiable working directory for the executor route, or `None` when
+/// nothing trustworthy is available (the caller then keeps AskUser).
+/// Priority: an explicit request cwd wins when it names a real
+/// directory — and blocks when it does not (never silently replaced);
+/// a placeholder falls through to the shell's live cwd from the latest
+/// marker-tracked command block; with zero observed command activity,
+/// the shell's own latest prompt-time cwd report is used instead — a
+/// positive shell-side signal that also proves the marker channel
+/// works, and that a later line submission invalidates (dispatcher).
+/// There is no process-cwd guess: a session whose shell never
+/// reported anything stays on the manual flow (absent markers alone
+/// prove nothing about where the shell sits).
+fn readonly_compound_execution_cwd(
+    state: &InlineState,
+    request: &RuntimeApprovalRequest,
+) -> Option<std::path::PathBuf> {
+    let explicit = !request.cwd.is_empty() && request.cwd != "<unknown>";
+    if explicit {
+        let candidate = std::path::Path::new(&request.cwd);
+        return candidate.is_dir().then(|| candidate.to_path_buf());
+    }
+    if let Some(block) = state.session_blocks.last() {
+        let live = std::path::Path::new(&block.end_cwd);
+        if !block.end_cwd.is_empty() && live.is_dir() {
+            return Some(live.to_path_buf());
+        }
+        return None;
+    }
+    if state.shell_command_activity_observed {
+        return None;
+    }
+    let reported = std::path::Path::new(state.shell_prompt_cwd.as_deref()?);
+    reported.is_dir().then(|| reported.to_path_buf())
+}
+
+/// Completion status for the executor route, mirroring the handoff
+/// outcome contract (issue #1882, R6): a finished run classifies by its
+/// exit code (completed / failed / interrupted), executor timeouts
+/// report timed_out, and every other executor error reports
+/// not_executed — the provider must never mistake a failed or
+/// unfinished execution for success.
+pub(super) fn readonly_compound_completion_status(
+    executed: &Result<ReadonlyPipelineOutput, ReadonlyPipelineError>,
+    command: &str,
+) -> &'static str {
+    use crate::command::{classify_executed_command_outcome, CommandOutcome};
+    match executed {
+        Ok(output) => {
+            classify_executed_command_outcome(output.exit_code.unwrap_or(-1), command).status()
+        }
+        Err(err) if err.reason.contains("timeout") => CommandOutcome::TimedOut.status(),
+        Err(_) => CommandOutcome::NotExecuted.status(),
     }
 }
 
@@ -619,297 +802,4 @@ fn deny_duplicate_host_executed_shell_request(
     );
     let _ = active_run.handle.respond_approval(response);
     true
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn analysis_only_request() -> AgentRequest {
-        AgentRequest {
-            id: "agent-request-1".to_string(),
-            session_id: "session-1".to_string(),
-            command_block: CommandBlock {
-                id: "cmd-1".to_string(),
-                session_id: "session-1".to_string(),
-                command: "ShellCommandCompleted evidence".to_string(),
-                origin: Default::default(),
-                cwd: "/tmp".to_string(),
-                end_cwd: "/tmp".to_string(),
-                started_at_ms: 0,
-                ended_at_ms: 0,
-                duration_ms: 0,
-                exit_code: 0,
-                status: CommandStatus::Completed,
-                output: OutputRefs {
-                    terminal_output_ref: None,
-                    terminal_output_bytes: 0,
-                },
-                shell_environment_generation: None,
-                audit_identity: None,
-            },
-            context_blocks: Vec::new(),
-            context_hints: vec![
-                "analysis-only continuation after foreground shell handoff".to_string()
-            ],
-            user_input: Some("ShellCommandCompleted evidence".to_string()),
-            findings: Vec::new(),
-            mode: AgentMode::RecommendOnly,
-            user_confirmed: true,
-            hook_finding: None,
-            recommended_skill: None,
-        }
-    }
-
-    #[test]
-    fn analysis_only_continuation_blocks_streamed_shell_tool_fallback() {
-        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
-        let mut state = InlineState {
-            approval_mode: CoshApprovalMode::Auto,
-            ..InlineState::default()
-        };
-        let governed = GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-            event: AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: None,
-                name: "run_shell_command".to_string(),
-                input: r#"{"command":"df -h"}"#.to_string(),
-            },
-            reason: "visible streamed tool call".to_string(),
-            display_text: "visible streamed tool call".to_string(),
-            auto_execute: false,
-        };
-        let mut output = Vec::new();
-
-        let handled = render_auto_approved_tool(
-            &mut state,
-            &[governed],
-            Some(&analysis_only_request()),
-            AgentRunOrigin::Standard,
-            &mut output,
-            &adapter,
-        )
-        .expect("render auto approval");
-
-        assert!(handled);
-        assert!(state.approvals.requests.is_empty());
-        assert!(state.control.shell_handoff().approved_is_empty());
-    }
-
-    #[test]
-    fn trust_mode_routes_blocked_shell_request_batch_to_approval() {
-        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
-        let mut state = InlineState {
-            approval_mode: CoshApprovalMode::Trust,
-            ..InlineState::default()
-        };
-        let governed = ["run-1", "run-2"].map(|run_id| GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-            event: AgentEvent::ToolCall {
-                run_id: run_id.to_string(),
-                tool_id: None,
-                name: "Bash".to_string(),
-                input: "printf blocked\0binding".to_string(),
-            },
-            reason: "blocked shell binding".to_string(),
-            display_text: "blocked shell binding".to_string(),
-            auto_execute: false,
-        });
-        let mut output = Vec::new();
-
-        crate::agent::events::render_agent_structured_events(
-            &mut state,
-            &governed,
-            None,
-            AgentRunOrigin::Standard,
-            &mut output,
-            &adapter,
-        )
-        .expect("render trusted approval");
-
-        assert_eq!(state.approvals.requests.len(), 2);
-        assert!(state.approvals.requests.iter().all(|request| {
-            request.status == ApprovalRequestStatus::Pending
-                && request
-                    .assessment
-                    .as_ref()
-                    .is_some_and(|assessment| assessment.execution == "block")
-        }));
-        assert_eq!(state.approvals.active_panel_id.as_deref(), Some("req-1"));
-        assert!(state.approvals.active_panel_height > 0);
-    }
-
-    #[test]
-    fn trust_mode_surfaces_hook_followup_approval_after_auto_approved_tool() {
-        // #1920 regression: after the trust path auto-approves the shell
-        // tool call, the sandbox-bypass follow-up approval reuses the same
-        // tool_use_id via the control protocol with hook_requires_approval
-        // set; it must surface as a pending card instead of being dropped.
-        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
-        let mut state = InlineState {
-            approval_mode: CoshApprovalMode::Trust,
-            ..InlineState::default()
-        };
-        let tool_call = GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-            event: AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: Some("toolu-1".to_string()),
-                name: "Bash".to_string(),
-                input: r#"{"command":"echo ok"}"#.to_string(),
-            },
-            reason: "provider tool call".to_string(),
-            display_text: "provider tool call".to_string(),
-            auto_execute: false,
-        };
-        let mut output = Vec::new();
-        crate::agent::events::render_agent_structured_events(
-            &mut state,
-            &[tool_call],
-            None,
-            AgentRunOrigin::Standard,
-            &mut output,
-            &adapter,
-        )
-        .expect("render trusted tool call");
-        assert_eq!(state.approvals.requests.len(), 1);
-        assert_eq!(
-            state.approvals.requests[0].status,
-            ApprovalRequestStatus::Approved
-        );
-
-        let followup = GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
-            event: AgentEvent::ToolPermissionRequest {
-                run_id: "run-1".to_string(),
-                request_id: "ctrl-2".to_string(),
-                tool_name: "Bash".to_string(),
-                tool_input: serde_json::json!({ "command": "echo ok" }),
-                tool_use_id: "toolu-1".to_string(),
-                hook_requires_approval: true,
-                audit_ref: None,
-            },
-            reason: "sandbox bypass approval".to_string(),
-            display_text: "sandbox bypass approval".to_string(),
-            auto_execute: false,
-        };
-        crate::agent::events::render_agent_structured_events(
-            &mut state,
-            &[followup],
-            None,
-            AgentRunOrigin::Standard,
-            &mut output,
-            &adapter,
-        )
-        .expect("render hook follow-up approval");
-
-        let pending = state
-            .approvals
-            .requests
-            .iter()
-            .find(|request| request.request_id.as_deref() == Some("ctrl-2"))
-            .expect("hook follow-up approval must be recorded");
-        assert_eq!(pending.status, ApprovalRequestStatus::Pending);
-        assert!(pending.hook_requires_approval);
-        assert_eq!(pending.tool_use_id.as_deref(), Some("toolu-1"));
-        assert_eq!(
-            state.approvals.active_panel_id.as_deref(),
-            Some(pending.id.as_str())
-        );
-    }
-
-    #[test]
-    fn shell_request_policy_denies_duplicate_host_executed_request() {
-        let mut state = InlineState::default();
-        state
-            .control
-            .provider_tool_mut()
-            .claim_host_executed_shell_result("run-1", "ctrl-1", Some("toolu-1"))
-            .expect("claim host result");
-        let request = shell_request(
-            ProviderShellRequestKind::ControlPermission,
-            Some("ctrl-1"),
-            Some("toolu-1"),
-        );
-
-        assert_eq!(
-            shell_request_policy_decision(&state, None, &request),
-            ShellRequestPolicyDecision::DenyDuplicateHostExecuted
-        );
-
-        let mut next_run_request = request;
-        next_run_request.run_id = "run-2".to_string();
-        assert_eq!(
-            shell_request_policy_decision(&state, None, &next_run_request),
-            ShellRequestPolicyDecision::Continue
-        );
-    }
-
-    #[test]
-    fn shell_request_policy_denies_reentrant_fallback_after_handoff() {
-        let mut state = InlineState::default();
-        state.control.mark_provider_shell_handoff_run("run-1");
-        let request = shell_request(
-            ProviderShellRequestKind::StreamedToolCallFallback,
-            None,
-            None,
-        );
-
-        assert_eq!(
-            shell_request_policy_decision(&state, None, &request),
-            ShellRequestPolicyDecision::DenyAnalysisOnly
-        );
-    }
-
-    #[test]
-    fn shell_request_policy_allows_new_control_shell_request() {
-        let state = InlineState::default();
-        let request = shell_request(
-            ProviderShellRequestKind::ControlPermission,
-            Some("ctrl-2"),
-            Some("toolu-2"),
-        );
-
-        assert_eq!(
-            shell_request_policy_decision(&state, None, &request),
-            ShellRequestPolicyDecision::Continue
-        );
-    }
-
-    fn shell_request(
-        provider_shell_request_kind: ProviderShellRequestKind,
-        request_id: Option<&str>,
-        tool_use_id: Option<&str>,
-    ) -> RuntimeApprovalRequest {
-        RuntimeApprovalRequest {
-            id: "req-1".to_string(),
-            audit_ref: None,
-            run_id: "run-1".to_string(),
-            origin: AgentRunOrigin::Standard,
-            session_id: "sess-1".to_string(),
-            cwd: "/tmp".to_string(),
-            source: "test",
-            provider_shell_request_kind,
-            kind: ApprovalRequestKind::Tool,
-            subject: "run_shell_command".to_string(),
-            preview: "$ df -h".to_string(),
-            risk: "medium",
-            request_id: request_id.map(str::to_string),
-            tool_use_id: tool_use_id.map(str::to_string),
-            tool_input: Some(serde_json::json!({ "command": "df -h" })),
-            original_user_request: None,
-            status: ApprovalRequestStatus::Approved,
-            execution_path: None,
-            command_block_id: None,
-            redaction_status: None,
-            assessment: None,
-            hook_requires_approval: false,
-            hook_warnings: Vec::new(),
-        }
-    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
@@ -5,10 +5,14 @@ use crate::approval::broker::{
     provider_deny_response, ApprovalExecutionMetadata, ApprovalOutcome, ApprovalOutcomeInput,
     ProviderApprovalStatus, ProviderResponseInput,
 };
+use crate::approval::handoff::shell_handoff_command_from_request;
 use crate::approval::journal::approval_audit_input;
 use crate::approval::provider::mark_provider_approval_resolved;
 use crate::approval::resolution::request_can_receive_host_executed_result;
+use crate::runtime::evidence_delivery::record_readonly_compound_completion;
 use crate::runtime::prelude::*;
+use crate::tools::readonly_compound::{build_readonly_compound_plan, run_readonly_compound};
+use crate::tools::{ReadonlyPipelineConfig, ReadonlyPipelineOutput};
 
 pub(crate) fn render_trusted_tool<W: Write>(
     state: &mut InlineState,
@@ -203,8 +207,20 @@ pub(crate) fn render_auto_approved_tool<W: Write>(
         ) else {
             continue;
         };
-        if auto_policy.route(&assessment) != AutoExecutionRoute::DirectReadonlyBroker {
-            continue;
+        // Issue #1882: a fully readonly compound runs through the
+        // dedicated argv executor instead of a shell handoff, so the
+        // executed argv never passes through a shell parsing layer.
+        match auto_policy.route(&assessment) {
+            AutoExecutionRoute::DirectReadonlyBroker => {}
+            AutoExecutionRoute::CompoundReadonlyExecutor => {
+                if run_auto_approved_readonly_compound(state, request, output)?
+                    == AutoApprovalFlow::Handled
+                {
+                    return Ok(true);
+                }
+                continue;
+            }
+            _ => continue,
         }
 
         if request_is_executable_bash_tool(&request)
@@ -398,28 +414,7 @@ fn apply_auto_approved_request_outcome<W: Write>(
         )?;
         return Ok(AutoApprovalFlow::Handled);
     }
-    // DR-6: When hooks had something to say but the tool is auto-approved,
-    // render an independent hook notice panel before the tool call header
-    // so that the user is aware of the hook's intervention.
-    if !request.hook_warnings.is_empty() {
-        let mut body: Vec<String> = Vec::new();
-        for w in &request.hook_warnings {
-            let icon = hook_warning_icon(w.decision.as_deref());
-            body.push(format!("\u{2502} {icon} {}", w.hook_name));
-            for msg_line in w.message.lines() {
-                body.push(format!("\u{2502}   {msg_line}"));
-            }
-        }
-        let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
-        renderer.write_notice_panel(
-            output,
-            NoticePanelModel {
-                title: "Hook",
-                body,
-                footer: None,
-            },
-        )?;
-    }
+    render_hook_warning_notices(state, request, output)?;
     let outcome = approval_outcome_for_auto_request(request);
     if outcome == ApprovalOutcome::ForegroundShellHandoff {
         let authorized = state
@@ -463,6 +458,111 @@ fn apply_auto_approved_request_outcome<W: Write>(
             Ok(AutoApprovalFlow::Handled)
         }
     }
+}
+
+// DR-6: When hooks had something to say but the tool is auto-approved,
+// render an independent hook notice panel before the tool call header
+// so that the user is aware of the hook's intervention.
+fn render_hook_warning_notices<W: Write>(
+    state: &InlineState,
+    request: &RuntimeApprovalRequest,
+    output: &mut W,
+) -> std::io::Result<()> {
+    if request.hook_warnings.is_empty() {
+        return Ok(());
+    }
+    let mut body: Vec<String> = Vec::new();
+    for w in &request.hook_warnings {
+        let icon = hook_warning_icon(w.decision.as_deref());
+        body.push(format!("\u{2502} {icon} {}", w.hook_name));
+        for msg_line in w.message.lines() {
+            body.push(format!("\u{2502}   {msg_line}"));
+        }
+    }
+    let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+    renderer.write_notice_panel(
+        output,
+        NoticePanelModel {
+            title: "Hook",
+            body,
+            footer: None,
+        },
+    )
+}
+
+/// Issue #1882: runs an auto-approved readonly compound through the
+/// dedicated argv executor. Eligibility and the executed plan come
+/// from the same predicate (`build_readonly_compound_plan`), so the
+/// assessment above and the execution here can never disagree about
+/// what would run.
+fn run_auto_approved_readonly_compound<W: Write>(
+    state: &mut InlineState,
+    request: RuntimeApprovalRequest,
+    output: &mut W,
+) -> std::io::Result<AutoApprovalFlow> {
+    let Ok(command) = shell_handoff_command_from_request(&request) else {
+        // The command text cannot be reconstructed from the request;
+        // fall back to the manual flow rather than executing anything.
+        return Ok(AutoApprovalFlow::Continue);
+    };
+    let Some(plan) = build_readonly_compound_plan(&command) else {
+        // Route and plan are built by the same predicate, so a miss
+        // here means the request changed between assessment and
+        // execution; fall back to the manual flow rather than
+        // executing anything.
+        return Ok(AutoApprovalFlow::Continue);
+    };
+
+    let mut request = record_auto_approved_request(state, request);
+    let authorized = state
+        .audit
+        .as_mut()
+        .map(|audit| audit.authorize_host_execution(approval_audit_input(&request)))
+        .transpose();
+    if authorized.is_err() {
+        request.status = ApprovalRequestStatus::Blocked;
+        request.execution_path = Some("blocked_audit_required");
+        render_approval_resolution(
+            state,
+            &request,
+            MessageId::ApprovalResolutionBlockedTitle,
+            output,
+        )?;
+        return Ok(AutoApprovalFlow::Handled);
+    }
+    render_hook_warning_notices(state, &request, output)?;
+    render_approval_resolution(
+        state,
+        &request,
+        MessageId::ApprovalResolutionAutoApprovedTitle,
+        output,
+    )?;
+
+    let started = std::time::Instant::now();
+    let executed = run_readonly_compound(&plan, &ReadonlyPipelineConfig::default());
+    let duration_ms = started.elapsed().as_millis() as u64;
+    let pipeline_output = executed.unwrap_or_else(|err| ReadonlyPipelineOutput {
+        exit_code: None,
+        stdout: String::new(),
+        stderr: format!(
+            "readonly compound executor error [{}]: {}",
+            err.reason, err.detail
+        ),
+    });
+    let evidence = record_readonly_compound_completion(
+        state,
+        &request,
+        &command,
+        &pipeline_output,
+        duration_ms,
+    );
+    mark_provider_approval_resolved(state);
+    if !evidence.provider_result_delivered
+        && !request_can_receive_host_executed_result(state, &request)
+    {
+        stop_active_agent_run_without_rendering(state, output)?;
+    }
+    Ok(AutoApprovalFlow::Handled)
 }
 
 fn respond_provider_native_shell_fallback(
@@ -658,6 +758,146 @@ mod tests {
             user_confirmed: true,
             hook_finding: None,
             recommended_skill: None,
+        }
+    }
+
+    fn compound_tool_call_event(command: &str) -> GovernedEvent {
+        GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+            event: AgentEvent::ToolCall {
+                run_id: "run-1".to_string(),
+                tool_id: None,
+                name: "run_shell_command".to_string(),
+                input: format!(r#"{{"command":"{command}"}}"#),
+            },
+            reason: "visible streamed tool call".to_string(),
+            display_text: "visible streamed tool call".to_string(),
+            auto_execute: false,
+        }
+    }
+
+    #[test]
+    fn auto_mode_runs_fully_readonly_compound_through_executor() {
+        // Issue #1882: a compound whose every segment carries direct-
+        // readonly evidence is auto-approved and executed by the
+        // dedicated argv executor; without a provider result channel
+        // the completion falls back to shell evidence continuation,
+        // and no shell handoff is ever queued.
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        let mut state = InlineState {
+            approval_mode: CoshApprovalMode::Auto,
+            ..InlineState::default()
+        };
+        let mut output = Vec::new();
+
+        let handled = render_auto_approved_tool(
+            &mut state,
+            &[compound_tool_call_event("pwd && df -h")],
+            None,
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render auto approval");
+
+        assert!(handled);
+        assert!(state.control.shell_handoff().approved_is_empty());
+        let evidence = state
+            .evidence
+            .latest_shell_command_completed()
+            .expect("executor completion evidence");
+        assert_eq!(evidence.command, "pwd && df -h");
+        assert!(!evidence.provider_result_delivered);
+        assert_eq!(
+            evidence.provider_result_delivery_status,
+            "not_provider_tool_request"
+        );
+        assert_eq!(state.approvals.requests.len(), 1);
+        assert_eq!(
+            state.approvals.requests[0].status,
+            ApprovalRequestStatus::Approved
+        );
+    }
+
+    #[test]
+    fn auto_mode_executor_accepts_expanded_readonly_forms() {
+        // Issue #1882 executor widenings: a quoted separator is literal
+        // argv rather than a connector, and a history-style token
+        // stays literal argv, so both run through the executor. (The
+        // newline-separated form is covered at the assessment and
+        // executor levels; this ToolCall harness cannot carry a raw
+        // newline inside a JSON string.)
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        for command in ["echo 'a && b' ; pwd", "echo !-2 && pwd"] {
+            let mut state = InlineState {
+                approval_mode: CoshApprovalMode::Auto,
+                ..InlineState::default()
+            };
+            let mut output = Vec::new();
+
+            let handled = render_auto_approved_tool(
+                &mut state,
+                &[compound_tool_call_event(command)],
+                None,
+                AgentRunOrigin::Standard,
+                &mut output,
+                &adapter,
+            )
+            .expect("render auto approval");
+
+            assert!(handled, "{command}");
+            assert!(
+                state.control.shell_handoff().approved_is_empty(),
+                "{command}"
+            );
+            let evidence = state
+                .evidence
+                .latest_shell_command_completed()
+                .expect("executor completion evidence");
+            assert_eq!(evidence.command, command);
+            assert!(!evidence.provider_result_delivered, "{command}");
+        }
+    }
+
+    #[test]
+    fn auto_mode_keeps_ineligible_compound_on_the_manual_path() {
+        // Issue #1882 counter-cases: a segment without direct-readonly
+        // evidence, an expansion token in argv, and a null-redirected
+        // compound all fail plan building, so nothing is auto-approved,
+        // executed, or recorded.
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        for command in [
+            "cd /tmp && git status",
+            "echo $(pwd) && df -h",
+            "pwd && df -h >/dev/null",
+            "pwd\u{000c}&&\u{000c}df -h",
+        ] {
+            let mut state = InlineState {
+                approval_mode: CoshApprovalMode::Auto,
+                ..InlineState::default()
+            };
+            let mut output = Vec::new();
+
+            render_auto_approved_tool(
+                &mut state,
+                &[compound_tool_call_event(command)],
+                None,
+                AgentRunOrigin::Standard,
+                &mut output,
+                &adapter,
+            )
+            .expect("render auto approval");
+
+            assert!(
+                state.control.shell_handoff().approved_is_empty(),
+                "{command}"
+            );
+            assert!(
+                state.evidence.latest_shell_command_completed().is_none(),
+                "{command}"
+            );
+            assert!(state.approvals.requests.is_empty(), "{command}");
         }
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge_tests.rs
@@ -1,0 +1,907 @@
+use super::approval_bridge::*;
+use crate::runtime::evidence_delivery::record_readonly_compound_completion;
+use crate::runtime::prelude::*;
+use crate::tools::{ReadonlyPipelineError, ReadonlyPipelineOutput};
+
+fn analysis_only_request() -> AgentRequest {
+    AgentRequest {
+        id: "agent-request-1".to_string(),
+        session_id: "session-1".to_string(),
+        command_block: CommandBlock {
+            id: "cmd-1".to_string(),
+            session_id: "session-1".to_string(),
+            command: "ShellCommandCompleted evidence".to_string(),
+            origin: Default::default(),
+            cwd: "/tmp".to_string(),
+            end_cwd: "/tmp".to_string(),
+            started_at_ms: 0,
+            ended_at_ms: 0,
+            duration_ms: 0,
+            exit_code: 0,
+            status: CommandStatus::Completed,
+            output: OutputRefs {
+                terminal_output_ref: None,
+                terminal_output_bytes: 0,
+            },
+            shell_environment_generation: None,
+            audit_identity: None,
+        },
+        context_blocks: Vec::new(),
+        context_hints: vec!["analysis-only continuation after foreground shell handoff".to_string()],
+        user_input: Some("ShellCommandCompleted evidence".to_string()),
+        findings: Vec::new(),
+        mode: AgentMode::RecommendOnly,
+        user_confirmed: true,
+        hook_finding: None,
+        recommended_skill: None,
+    }
+}
+
+/// A plain provider run request (no analysis-continuation hints):
+/// executor-route tests need the request's `command_block.cwd` to
+/// reach the executor without tripping the analysis-only shell
+/// denial policy.
+fn compound_run_request() -> AgentRequest {
+    let mut request = analysis_only_request();
+    request.context_hints = Vec::new();
+    request.user_input = Some("check disk usage".to_string());
+    request
+}
+
+fn compound_tool_call_event(command: &str) -> GovernedEvent {
+    GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: None,
+            name: "run_shell_command".to_string(),
+            input: format!(r#"{{"command":"{command}"}}"#),
+        },
+        reason: "visible streamed tool call".to_string(),
+        display_text: "visible streamed tool call".to_string(),
+        auto_execute: false,
+    }
+}
+
+#[test]
+fn auto_mode_runs_fully_readonly_compound_through_executor() {
+    // Issue #1882: a compound whose every segment carries direct-
+    // readonly evidence is auto-approved and executed by the
+    // dedicated argv executor; without a provider result channel
+    // the completion falls back to shell evidence continuation,
+    // and no shell handoff is ever queued.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    let run_request = compound_run_request();
+    let mut output = Vec::new();
+
+    let handled = render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        Some(&run_request),
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(handled);
+    assert!(state.control.shell_handoff().approved_is_empty());
+    let evidence = state
+        .evidence
+        .latest_shell_command_completed()
+        .expect("executor completion evidence");
+    assert_eq!(evidence.command, "pwd && df -h");
+    assert_eq!(evidence.exit_code, 0, "compound must really execute");
+    assert_eq!(evidence.status, "completed");
+    // R5: the executor runs in — and the evidence reports — the
+    // requesting shell's directory, not this process's cwd.
+    assert_eq!(evidence.cwd, "/tmp");
+    assert_eq!(evidence.end_cwd, "/tmp");
+    assert!(!evidence.provider_result_delivered);
+    assert_eq!(
+        evidence.provider_result_delivery_status,
+        "not_provider_tool_request"
+    );
+    assert_eq!(state.approvals.requests.len(), 1);
+    assert_eq!(
+        state.approvals.requests[0].status,
+        ApprovalRequestStatus::Approved
+    );
+}
+
+#[test]
+fn audit_required_failure_blocks_compound_executor() {
+    // R5 P1 regression: when the required audit writer is
+    // unavailable, record_auto_approved_request marks the request
+    // Blocked; the executor route must honor that terminal state —
+    // nothing executes and no completion evidence is recorded.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        audit: Some(
+            crate::journal::audit::ShellAuditRecorder::test_required_unavailable("session-1"),
+        ),
+        ..InlineState::default()
+    };
+    let run_request = compound_run_request();
+    let mut output = Vec::new();
+
+    let handled = render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        Some(&run_request),
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(handled);
+    assert!(
+        state.evidence.latest_shell_command_completed().is_none(),
+        "blocked request must never reach the executor"
+    );
+    assert_eq!(state.approvals.requests.len(), 1);
+    assert_eq!(
+        state.approvals.requests[0].status,
+        ApprovalRequestStatus::Blocked
+    );
+    assert_eq!(
+        state.approvals.requests[0].execution_path,
+        Some("blocked_audit_required")
+    );
+}
+
+#[test]
+fn compound_completion_status_mirrors_handoff_outcomes() {
+    // R6 P1 regression: the executor route reports the same status
+    // vocabulary as the handoff path — never "completed" for a
+    // failed, timed out, or unstarted execution.
+    let finished = |code: i32| {
+        Ok(ReadonlyPipelineOutput {
+            exit_code: Some(code),
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    };
+    assert_eq!(
+        readonly_compound_completion_status(&finished(0), "pwd && df -h"),
+        "completed"
+    );
+    assert_eq!(
+        readonly_compound_completion_status(&finished(2), "ls missing && pwd"),
+        "failed"
+    );
+    assert_eq!(
+        readonly_compound_completion_status(&finished(127), "pwd && df -h"),
+        "failed"
+    );
+    assert_eq!(
+        readonly_compound_completion_status(&finished(130), "pwd && df -h"),
+        "interrupted"
+    );
+    assert_eq!(
+        readonly_compound_completion_status(
+            &Err(ReadonlyPipelineError {
+                reason: "stage-timeout",
+                detail: "sleep 2".to_string(),
+            }),
+            "pwd && df -h"
+        ),
+        "timed_out"
+    );
+    assert_eq!(
+        readonly_compound_completion_status(
+            &Err(ReadonlyPipelineError {
+                reason: "executor-spawn",
+                detail: "denied".to_string(),
+            }),
+            "pwd && df -h"
+        ),
+        "not_executed"
+    );
+}
+
+#[test]
+fn auto_mode_reports_failed_status_for_nonzero_compound() {
+    // R6 P1 regression, production chain: an eligible compound
+    // whose first segment exits non-zero must surface as failed —
+    // not completed — in the provider-visible evidence.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    let run_request = compound_run_request();
+    let mut output = Vec::new();
+
+    let handled = render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event(
+            "ls /cosh-1882-definitely-missing-dir && pwd",
+        )],
+        Some(&run_request),
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(handled);
+    let evidence = state
+        .evidence
+        .latest_shell_command_completed()
+        .expect("executor completion evidence");
+    assert_eq!(evidence.status, "failed");
+    assert_ne!(evidence.exit_code, 0);
+}
+
+#[test]
+fn compound_completion_scrubs_control_split_secrets() {
+    // R5 P1 regression: executor output bypasses the PTY capture
+    // pipeline, so the completion must run the canonical control-
+    // sequence cleaner BEFORE redaction — otherwise a NUL-split
+    // secret (`api_\0key=...`) never matches the redaction patterns
+    // yet renders as an ordinary assignment.
+    let mut state = InlineState::default();
+    let request = shell_request(ProviderShellRequestKind::LocalApproval, None, None);
+    let output = crate::tools::readonly_pipeline::ReadonlyPipelineOutput {
+        exit_code: Some(0),
+        stdout: "api_\u{0}key=abcdef1234567890abcdef\n".to_string(),
+        stderr: String::new(),
+    };
+    let evidence = record_readonly_compound_completion(
+        &mut state,
+        &request,
+        "pwd && df -h",
+        &output,
+        std::path::Path::new("/tmp"),
+        "completed",
+        5,
+    );
+    assert_eq!(evidence.redaction_status, "excerpt_redacted");
+}
+
+#[test]
+fn auto_mode_executes_when_request_cwd_is_unresolved() {
+    // Regression from the real-provider acceptance rerun: cosh-core
+    // control-permission requests can carry the "<unknown>" cwd
+    // placeholder (no tracked command block). With zero command
+    // activity, the shell's own prompt-time cwd report (the precmd
+    // marker at the first prompt carries `$PWD`) says where the
+    // shell sits, so the grant executes there — never in a guessed
+    // process directory.
+    let reported = std::env::temp_dir();
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        shell_prompt_cwd: Some(reported.display().to_string()),
+        ..InlineState::default()
+    };
+    let mut output = Vec::new();
+
+    let handled = render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(handled);
+    let evidence = state
+        .evidence
+        .latest_shell_command_completed()
+        .expect("executor completion evidence");
+    assert_eq!(evidence.status, "completed");
+    assert_eq!(evidence.exit_code, 0, "fallback cwd must execute");
+    assert_eq!(
+        evidence.cwd,
+        reported.display().to_string(),
+        "execution must use the shell-reported prompt cwd"
+    );
+}
+
+#[test]
+fn auto_mode_keeps_manual_flow_without_a_shell_cwd_report() {
+    // A `cd` that produced no marker at all leaves the session with
+    // zero observed activity AND no shell-side cwd report — the
+    // absence of markers proves nothing about where the shell sits,
+    // so an unknown request cwd must stay on the manual flow instead
+    // of executing in a guessed directory.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    let mut output = Vec::new();
+
+    render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(
+        state.evidence.latest_shell_command_completed().is_none(),
+        "a session without any shell cwd report must never auto-execute"
+    );
+}
+
+#[test]
+fn auto_mode_keeps_manual_flow_when_pty_input_follows_the_cwd_report() {
+    // Freshness sequence: the initial prompt reported a directory,
+    // then generic PTY input arrived — possibly a `cd` submitted
+    // through a custom `accept-line` binding the byte-stream
+    // heuristic cannot see — and its markers were lost entirely (no
+    // CommandStarted/Completed/Failed and no fresh ShellReady). The
+    // pre-input report no longer proves where the shell sits, so an
+    // unknown request cwd must stay on the manual flow instead of
+    // executing in the stale directory. Runs the real dispatch over
+    // the cumulative event stream, then the bridge.
+    let reported = std::env::temp_dir();
+    let mut ready = ShellEvent::user_input_intercepted("session-1", "");
+    ready.kind = ShellEventKind::ShellReady;
+    ready.input = None;
+    ready.cwd = Some(reported.display().to_string());
+    let mut wrote = ShellEvent::user_input_intercepted("session-1", "");
+    wrote.input = None;
+    wrote.component = Some("shell_pty_input".to_string());
+    wrote.message = Some("write".to_string());
+
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    let mut output = Vec::new();
+    crate::runtime::controller::render_inline_guidance(
+        &[ready, wrote],
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch cumulative events");
+    assert_eq!(state.shell_prompt_cwd, None);
+
+    render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(
+        state.evidence.latest_shell_command_completed().is_none(),
+        "a report invalidated by PTY input must never auto-execute"
+    );
+}
+
+#[test]
+fn auto_mode_keeps_manual_flow_when_the_shell_cwd_report_is_stale() {
+    // The shell-reported prompt cwd is still validated: a report
+    // naming a directory that no longer exists must not execute.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        shell_prompt_cwd: Some("/cosh-1882-stale-prompt-cwd".to_string()),
+        ..InlineState::default()
+    };
+    let mut output = Vec::new();
+
+    render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(
+        state.evidence.latest_shell_command_completed().is_none(),
+        "a stale shell cwd report must never auto-execute"
+    );
+}
+
+/// A marker-tracked command block whose `end_cwd` is the shell's live
+/// working directory.
+fn session_block_with_end_cwd(end_cwd: &str) -> CommandBlock {
+    CommandBlock {
+        id: "cmd-live".to_string(),
+        session_id: "session-1".to_string(),
+        command: "cd somewhere".to_string(),
+        origin: Default::default(),
+        cwd: "/".to_string(),
+        end_cwd: end_cwd.to_string(),
+        started_at_ms: 0,
+        ended_at_ms: 0,
+        duration_ms: 0,
+        exit_code: 0,
+        status: CommandStatus::Completed,
+        output: OutputRefs {
+            terminal_output_ref: None,
+            terminal_output_bytes: 0,
+        },
+        shell_environment_generation: None,
+        audit_identity: None,
+    }
+}
+
+#[test]
+fn auto_mode_prefers_the_live_shell_cwd_over_the_process_cwd() {
+    // R8: after the user cd'd away, the latest tracked command block
+    // carries the shell's live cwd — the executor must run there, not
+    // in the cosh process launch directory.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    state
+        .session_blocks
+        .push(session_block_with_end_cwd("/tmp"));
+    let mut output = Vec::new();
+
+    let handled = render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(handled);
+    let evidence = state
+        .evidence
+        .latest_shell_command_completed()
+        .expect("executor completion evidence");
+    assert_eq!(evidence.cwd, "/tmp");
+    assert_eq!(evidence.exit_code, 0);
+}
+
+#[test]
+fn auto_mode_keeps_manual_flow_when_the_live_cwd_is_unverifiable() {
+    // R8: a tracked shell cwd that no longer exists must not be
+    // silently replaced with a guess — the request stays on the
+    // manual AskUser flow and nothing executes.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    state
+        .session_blocks
+        .push(session_block_with_end_cwd("/cosh-1882-vanished-dir"));
+    let mut output = Vec::new();
+
+    render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(
+        state.evidence.latest_shell_command_completed().is_none(),
+        "unverifiable cwd must never auto-execute"
+    );
+}
+
+#[test]
+fn auto_mode_keeps_manual_flow_when_the_explicit_cwd_is_stale() {
+    // R9: an explicitly provided request cwd that no longer exists is
+    // never silently replaced by any fallback — the request stays on
+    // the manual AskUser flow.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    let mut run_request = compound_run_request();
+    run_request.command_block.cwd = "/cosh-1882-stale-explicit-cwd".to_string();
+    let mut output = Vec::new();
+
+    render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        Some(&run_request),
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(
+        state.evidence.latest_shell_command_completed().is_none(),
+        "stale explicit cwd must never auto-execute"
+    );
+}
+
+#[test]
+fn auto_mode_keeps_manual_flow_when_markers_were_incomplete() {
+    // Command activity that produced ledger errors instead of
+    // blocks (incomplete/unmatched markers) is not proof the shell
+    // never cd'd — the prompt-cwd fallback needs positive evidence of
+    // zero activity, so this session stays on the manual flow even
+    // when an earlier prompt report is available.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        shell_command_activity_observed: true,
+        shell_prompt_cwd: Some(std::env::temp_dir().display().to_string()),
+        ..InlineState::default()
+    };
+    let mut output = Vec::new();
+
+    render_auto_approved_tool(
+        &mut state,
+        &[compound_tool_call_event("pwd && df -h")],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(
+        state.evidence.latest_shell_command_completed().is_none(),
+        "unproven session cwd must never fall back to the process cwd"
+    );
+}
+
+#[test]
+fn auto_mode_executor_accepts_expanded_readonly_forms() {
+    // Issue #1882 executor widenings: a quoted separator is literal
+    // argv rather than a connector, and a history-style token
+    // stays literal argv, so both run through the executor. (The
+    // newline-separated form is covered at the assessment and
+    // executor levels; this ToolCall harness cannot carry a raw
+    // newline inside a JSON string.)
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    for command in ["echo 'a && b' ; pwd", "echo !-2 && pwd"] {
+        let mut state = InlineState {
+            approval_mode: CoshApprovalMode::Auto,
+            ..InlineState::default()
+        };
+        let run_request = compound_run_request();
+        let mut output = Vec::new();
+
+        let handled = render_auto_approved_tool(
+            &mut state,
+            &[compound_tool_call_event(command)],
+            Some(&run_request),
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render auto approval");
+
+        assert!(handled, "{command}");
+        assert!(
+            state.control.shell_handoff().approved_is_empty(),
+            "{command}"
+        );
+        let evidence = state
+            .evidence
+            .latest_shell_command_completed()
+            .expect("executor completion evidence");
+        assert_eq!(evidence.command, command);
+        assert_eq!(evidence.exit_code, 0, "{command}");
+        assert!(!evidence.provider_result_delivered, "{command}");
+    }
+}
+
+#[test]
+fn auto_mode_keeps_ineligible_compound_on_the_manual_path() {
+    // Issue #1882 counter-cases: a segment without direct-readonly
+    // evidence, an expansion token in argv, and a null-redirected
+    // compound all fail plan building, so nothing is auto-approved,
+    // executed, or recorded.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    for command in [
+        "cd /tmp && git status",
+        "echo $(pwd) && df -h",
+        "pwd && df -h >/dev/null",
+        "pwd\u{000c}&&\u{000c}df -h",
+    ] {
+        let mut state = InlineState {
+            approval_mode: CoshApprovalMode::Auto,
+            ..InlineState::default()
+        };
+        let mut output = Vec::new();
+
+        render_auto_approved_tool(
+            &mut state,
+            &[compound_tool_call_event(command)],
+            None,
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render auto approval");
+
+        assert!(
+            state.control.shell_handoff().approved_is_empty(),
+            "{command}"
+        );
+        assert!(
+            state.evidence.latest_shell_command_completed().is_none(),
+            "{command}"
+        );
+        assert!(state.approvals.requests.is_empty(), "{command}");
+    }
+}
+
+#[test]
+fn analysis_only_continuation_blocks_streamed_shell_tool_fallback() {
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Auto,
+        ..InlineState::default()
+    };
+    let governed = GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: None,
+            name: "run_shell_command".to_string(),
+            input: r#"{"command":"df -h"}"#.to_string(),
+        },
+        reason: "visible streamed tool call".to_string(),
+        display_text: "visible streamed tool call".to_string(),
+        auto_execute: false,
+    };
+    let mut output = Vec::new();
+
+    let handled = render_auto_approved_tool(
+        &mut state,
+        &[governed],
+        Some(&analysis_only_request()),
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render auto approval");
+
+    assert!(handled);
+    assert!(state.approvals.requests.is_empty());
+    assert!(state.control.shell_handoff().approved_is_empty());
+}
+
+#[test]
+fn trust_mode_routes_blocked_shell_request_batch_to_approval() {
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    let governed = ["run-1", "run-2"].map(|run_id| GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+        event: AgentEvent::ToolCall {
+            run_id: run_id.to_string(),
+            tool_id: None,
+            name: "Bash".to_string(),
+            input: "printf blocked\0binding".to_string(),
+        },
+        reason: "blocked shell binding".to_string(),
+        display_text: "blocked shell binding".to_string(),
+        auto_execute: false,
+    });
+    let mut output = Vec::new();
+
+    crate::agent::events::render_agent_structured_events(
+        &mut state,
+        &governed,
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted approval");
+
+    assert_eq!(state.approvals.requests.len(), 2);
+    assert!(state.approvals.requests.iter().all(|request| {
+        request.status == ApprovalRequestStatus::Pending
+            && request
+                .assessment
+                .as_ref()
+                .is_some_and(|assessment| assessment.execution == "block")
+    }));
+    assert_eq!(state.approvals.active_panel_id.as_deref(), Some("req-1"));
+    assert!(state.approvals.active_panel_height > 0);
+}
+
+#[test]
+fn trust_mode_surfaces_hook_followup_approval_after_auto_approved_tool() {
+    // #1920 regression: after the trust path auto-approves the shell
+    // tool call, the sandbox-bypass follow-up approval reuses the same
+    // tool_use_id via the control protocol with hook_requires_approval
+    // set; it must surface as a pending card instead of being dropped.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    let tool_call = GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("toolu-1".to_string()),
+            name: "Bash".to_string(),
+            input: r#"{"command":"echo ok"}"#.to_string(),
+        },
+        reason: "provider tool call".to_string(),
+        display_text: "provider tool call".to_string(),
+        auto_execute: false,
+    };
+    let mut output = Vec::new();
+    crate::agent::events::render_agent_structured_events(
+        &mut state,
+        &[tool_call],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool call");
+    assert_eq!(state.approvals.requests.len(), 1);
+    assert_eq!(
+        state.approvals.requests[0].status,
+        ApprovalRequestStatus::Approved
+    );
+
+    let followup = GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+        event: AgentEvent::ToolPermissionRequest {
+            run_id: "run-1".to_string(),
+            request_id: "ctrl-2".to_string(),
+            tool_name: "Bash".to_string(),
+            tool_input: serde_json::json!({ "command": "echo ok" }),
+            tool_use_id: "toolu-1".to_string(),
+            hook_requires_approval: true,
+            audit_ref: None,
+        },
+        reason: "sandbox bypass approval".to_string(),
+        display_text: "sandbox bypass approval".to_string(),
+        auto_execute: false,
+    };
+    crate::agent::events::render_agent_structured_events(
+        &mut state,
+        &[followup],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render hook follow-up approval");
+
+    let pending = state
+        .approvals
+        .requests
+        .iter()
+        .find(|request| request.request_id.as_deref() == Some("ctrl-2"))
+        .expect("hook follow-up approval must be recorded");
+    assert_eq!(pending.status, ApprovalRequestStatus::Pending);
+    assert!(pending.hook_requires_approval);
+    assert_eq!(pending.tool_use_id.as_deref(), Some("toolu-1"));
+    assert_eq!(
+        state.approvals.active_panel_id.as_deref(),
+        Some(pending.id.as_str())
+    );
+}
+
+#[test]
+fn shell_request_policy_denies_duplicate_host_executed_request() {
+    let mut state = InlineState::default();
+    state
+        .control
+        .provider_tool_mut()
+        .claim_host_executed_shell_result("run-1", "ctrl-1", Some("toolu-1"))
+        .expect("claim host result");
+    let request = shell_request(
+        ProviderShellRequestKind::ControlPermission,
+        Some("ctrl-1"),
+        Some("toolu-1"),
+    );
+
+    assert_eq!(
+        shell_request_policy_decision(&state, None, &request),
+        ShellRequestPolicyDecision::DenyDuplicateHostExecuted
+    );
+
+    let mut next_run_request = request;
+    next_run_request.run_id = "run-2".to_string();
+    assert_eq!(
+        shell_request_policy_decision(&state, None, &next_run_request),
+        ShellRequestPolicyDecision::Continue
+    );
+}
+
+#[test]
+fn shell_request_policy_denies_reentrant_fallback_after_handoff() {
+    let mut state = InlineState::default();
+    state.control.mark_provider_shell_handoff_run("run-1");
+    let request = shell_request(
+        ProviderShellRequestKind::StreamedToolCallFallback,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        shell_request_policy_decision(&state, None, &request),
+        ShellRequestPolicyDecision::DenyAnalysisOnly
+    );
+}
+
+#[test]
+fn shell_request_policy_allows_new_control_shell_request() {
+    let state = InlineState::default();
+    let request = shell_request(
+        ProviderShellRequestKind::ControlPermission,
+        Some("ctrl-2"),
+        Some("toolu-2"),
+    );
+
+    assert_eq!(
+        shell_request_policy_decision(&state, None, &request),
+        ShellRequestPolicyDecision::Continue
+    );
+}
+
+fn shell_request(
+    provider_shell_request_kind: ProviderShellRequestKind,
+    request_id: Option<&str>,
+    tool_use_id: Option<&str>,
+) -> RuntimeApprovalRequest {
+    RuntimeApprovalRequest {
+        id: "req-1".to_string(),
+        audit_ref: None,
+        run_id: "run-1".to_string(),
+        origin: AgentRunOrigin::Standard,
+        session_id: "sess-1".to_string(),
+        cwd: "/tmp".to_string(),
+        source: "test",
+        provider_shell_request_kind,
+        kind: ApprovalRequestKind::Tool,
+        subject: "run_shell_command".to_string(),
+        preview: "$ df -h".to_string(),
+        risk: "medium",
+        request_id: request_id.map(str::to_string),
+        tool_use_id: tool_use_id.map(str::to_string),
+        tool_input: Some(serde_json::json!({ "command": "df -h" })),
+        original_user_request: None,
+        status: ApprovalRequestStatus::Approved,
+        execution_path: None,
+        command_block_id: None,
+        redaction_status: None,
+        assessment: None,
+        hook_requires_approval: false,
+        hook_warnings: Vec::new(),
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/agent/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod approval_bridge;
+#[cfg(test)]
+mod approval_bridge_tests;
 pub(crate) mod continuation;
 mod display;
 pub(crate) mod events;

--- a/src/cosh-ng/crates/cosh-shell/src/approval/handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/handoff.rs
@@ -183,7 +183,7 @@ pub(crate) fn approval_shell_handoff_validation_message(i18n: &I18n, message: &s
         .unwrap_or_else(|| message.to_string())
 }
 
-pub(super) fn shell_handoff_command_from_request(
+pub(crate) fn shell_handoff_command_from_request(
     request: &RuntimeApprovalRequest,
 ) -> Result<String, String> {
     if request.request_id.is_none() {

--- a/src/cosh-ng/crates/cosh-shell/src/approval/resolution.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/resolution.rs
@@ -160,7 +160,12 @@ fn finalize_approval_decision(
         let host_audit_result = state
             .audit
             .as_mut()
-            .map(|audit| audit.authorize_host_execution(approval_audit_input(&request)))
+            .map(|audit| {
+                audit.authorize_host_execution(
+                    approval_audit_input(&request),
+                    "shell_foreground_handoff",
+                )
+            })
             .transpose();
         if host_audit_result.is_err() {
             request.status = ApprovalRequestStatus::Blocked;

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
@@ -82,6 +82,25 @@ impl ShellAuditRecorder {
         recorder
     }
 
+    /// Test-only recorder in `Required` mode with no usable writer: every
+    /// governed boundary fails closed, letting production-chain tests
+    /// assert that blocked approvals never reach an execution path.
+    #[cfg(test)]
+    pub(crate) fn test_required_unavailable(shell_session_id: impl Into<String>) -> Self {
+        Self {
+            writer: None,
+            writer_root: None,
+            mode: AuditMode::Required,
+            shell_session_id: shell_session_id.into(),
+            seen_events: 0,
+            hash_salt: "test-salt".to_string(),
+            degraded: true,
+            warning_emitted: false,
+            owned_approvals: std::collections::HashSet::new(),
+            command_refs: std::collections::HashMap::new(),
+        }
+    }
+
     /// Projects newly observed native command events exactly once.
     pub(crate) fn observe_shell_events(&mut self, events: &[ShellEvent]) {
         if self.seen_events > events.len() {

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit/host_execution.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit/host_execution.rs
@@ -8,9 +8,13 @@ use crate::types::audit::{
 
 impl ShellAuditRecorder {
     /// Durably authorizes a Core Tool whose side effect is hosted by Shell.
+    /// `execution_path` names the actual execution boundary
+    /// (`shell_foreground_handoff` or `readonly_compound_argv_executor`)
+    /// so later security investigations can tell the two routes apart.
     pub(crate) fn authorize_host_execution(
         &mut self,
         request: ShellApprovalAuditInput<'_>,
+        execution_path: &'static str,
     ) -> Result<(), String> {
         if self.owned_approvals.contains(request.id) {
             // Shell-owned approvals were made durable by record_approval_resolved.
@@ -41,7 +45,7 @@ impl ShellAuditRecorder {
             },
             &AuditToolData {
                 tool_kind: request.subject.to_string(),
-                execution_path: Some("shell_foreground_handoff".to_string()),
+                execution_path: Some(execution_path.to_string()),
                 ..AuditToolData::default()
             },
             // This boundary never receives raw Tool input, so nothing is omitted.

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
@@ -144,19 +144,22 @@ fn required_core_host_execution_fails_before_handoff_boundary() {
         command_refs: std::collections::HashMap::new(),
     };
 
-    let result = recorder.authorize_host_execution(ShellApprovalAuditInput {
-        id: "approval-1",
-        audit_ref: None,
-        session_id: "session-1",
-        run_id: "run-1",
-        request_id: Some("request-1"),
-        tool_use_id: Some("tool-1"),
-        subject: "run_shell_command",
-        risk: "medium",
-        assessment: None,
-        preview: "$ echo ok",
-        status: "approved",
-    });
+    let result = recorder.authorize_host_execution(
+        ShellApprovalAuditInput {
+            id: "approval-1",
+            audit_ref: None,
+            session_id: "session-1",
+            run_id: "run-1",
+            request_id: Some("request-1"),
+            tool_use_id: Some("tool-1"),
+            subject: "run_shell_command",
+            risk: "medium",
+            assessment: None,
+            preview: "$ echo ok",
+            status: "approved",
+        },
+        "shell_foreground_handoff",
+    );
 
     assert!(result
         .unwrap_err()
@@ -180,19 +183,22 @@ fn core_host_execution_does_not_duplicate_the_approval_resolution() {
     };
 
     recorder
-        .authorize_host_execution(ShellApprovalAuditInput {
-            id: "approval-1",
-            audit_ref: Some("core-approval-event"),
-            session_id: "session-1",
-            run_id: "run-1",
-            request_id: Some("request-1"),
-            tool_use_id: Some("tool-1"),
-            subject: "run_shell_command",
-            risk: "medium",
-            assessment: None,
-            preview: "$ echo ok",
-            status: "approved",
-        })
+        .authorize_host_execution(
+            ShellApprovalAuditInput {
+                id: "approval-1",
+                audit_ref: Some("core-approval-event"),
+                session_id: "session-1",
+                run_id: "run-1",
+                request_id: Some("request-1"),
+                tool_use_id: Some("tool-1"),
+                subject: "run_shell_command",
+                risk: "medium",
+                assessment: None,
+                preview: "$ echo ok",
+                status: "approved",
+            },
+            "shell_foreground_handoff",
+        )
         .unwrap();
 
     drop(recorder);
@@ -217,19 +223,22 @@ fn shell_owned_approval_does_not_require_a_provider_tool_identity() {
         command_refs: std::collections::HashMap::new(),
     };
 
-    let result = recorder.authorize_host_execution(ShellApprovalAuditInput {
-        id: "approval-1",
-        audit_ref: None,
-        session_id: "session-1",
-        run_id: "run-1",
-        request_id: None,
-        tool_use_id: None,
-        subject: "Bash",
-        risk: "medium",
-        assessment: None,
-        preview: "$ echo ok",
-        status: "approved",
-    });
+    let result = recorder.authorize_host_execution(
+        ShellApprovalAuditInput {
+            id: "approval-1",
+            audit_ref: None,
+            session_id: "session-1",
+            run_id: "run-1",
+            request_id: None,
+            tool_use_id: None,
+            subject: "Bash",
+            risk: "medium",
+            assessment: None,
+            preview: "$ echo ok",
+            status: "approved",
+        },
+        "shell_foreground_handoff",
+    );
 
     assert!(result.is_ok());
 }
@@ -435,19 +444,22 @@ fn host_execution_boundary_claims_clean_redaction() {
     let root = private_root();
     let mut recorder = recording_recorder(&root);
     recorder
-        .authorize_host_execution(ShellApprovalAuditInput {
-            id: "approval-1",
-            audit_ref: Some("core-approval-event"),
-            session_id: "session-1",
-            run_id: "run-1",
-            request_id: Some("request-1"),
-            tool_use_id: Some("tool-1"),
-            subject: "run_shell_command",
-            risk: "medium",
-            assessment: None,
-            preview: "$ echo ok",
-            status: "approved",
-        })
+        .authorize_host_execution(
+            ShellApprovalAuditInput {
+                id: "approval-1",
+                audit_ref: Some("core-approval-event"),
+                session_id: "session-1",
+                run_id: "run-1",
+                request_id: Some("request-1"),
+                tool_use_id: Some("tool-1"),
+                subject: "run_shell_command",
+                risk: "medium",
+                assessment: None,
+                preview: "$ echo ok",
+                status: "approved",
+            },
+            "shell_foreground_handoff",
+        )
         .unwrap();
     drop(recorder);
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -115,6 +115,49 @@ fn render_inline_guidance_from_batch<W: Write>(
     let ledger = build_command_blocks(events);
     record_completed_command_blocks(state, &ledger.blocks);
     state.session_blocks = ledger.blocks.clone();
+    // Positive evidence of command activity (R9): incomplete or
+    // unmatched markers produce ledger errors instead of blocks, so an
+    // empty `session_blocks` alone never proves the shell has not run
+    // (and cd'd inside) a command. `events` is the session's cumulative
+    // stream (the raw relay always passes the parser's full event vec,
+    // which is append-only), so once a command marker is present it is
+    // present in every later dispatch and this assignment never
+    // regresses to `false`.
+    state.shell_command_activity_observed = events.iter().any(|event| {
+        matches!(
+            event.kind,
+            ShellEventKind::CommandStarted
+                | ShellEventKind::CommandCompleted
+                | ShellEventKind::CommandFailed
+        )
+    });
+    // The shell's latest prompt-time cwd report: a `ShellReady` event
+    // is a precmd marker with no command in flight and carries the
+    // shell's `$PWD`, so it is positive evidence both that the marker
+    // channel works and of where the shell sits. Any later PTY input
+    // write invalidates the report — submit-detection in the byte
+    // stream is a documented heuristic (a custom `accept-line`
+    // binding is indistinguishable from editing keys), and the
+    // submitted line may have been a `cd` whose markers were lost
+    // entirely — so the report is only current while no user input
+    // follows it. Scanned newest first: the most recent decisive
+    // event wins, and an event-free dispatch never erases the last
+    // known state.
+    for event in events.iter().rev() {
+        if event.kind == ShellEventKind::UserInputIntercepted
+            && event.component.as_deref() == Some("shell_pty_input")
+            && event.message.as_deref() == Some("write")
+        {
+            state.shell_prompt_cwd = None;
+            break;
+        }
+        if event.kind == ShellEventKind::ShellReady {
+            if let Some(cwd) = event.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+                state.shell_prompt_cwd = Some(cwd.to_string());
+                break;
+            }
+        }
+    }
     if state.shell_exited {
         if let Some(event) = events
             .iter()
@@ -377,7 +420,7 @@ fn start_pending_shell_handoff_continuations<W: Write>(
     Ok(())
 }
 
-fn update_personal_shell_input_state(events: &[ShellEvent], state: &mut InlineState) {
+pub(super) fn update_personal_shell_input_state(events: &[ShellEvent], state: &mut InlineState) {
     for event in events {
         match event.kind {
             ShellEventKind::ShellReady
@@ -563,101 +606,3 @@ impl ActivityConsumer {
 
 #[cfg(test)]
 mod recovery_tests;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::runtime::prelude::FakeAgentAdapter;
-
-    #[test]
-    fn dispatcher_advances_cursor_to_snapshot_end() {
-        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
-        let mut state = InlineState::default();
-        let mut output = Vec::new();
-        let snapshot = ShellEventSnapshot::new(&[
-            ShellEvent::user_input_intercepted("s", "/help"),
-            ShellEvent::user_input_intercepted("s", "/help"),
-        ]);
-
-        let actions = RuntimeDispatcher::dispatch_inline_batch(
-            &snapshot,
-            &adapter,
-            "bash",
-            &mut state,
-            &mut output,
-        )
-        .expect("dispatch should render");
-        RuntimeDispatcher::apply_actions(actions, &mut state);
-
-        assert_eq!(
-            state.control.event_cursor().position(),
-            snapshot.cursor().position()
-        );
-    }
-
-    #[test]
-    fn stable_event_key_uses_marker_timestamp_when_available() {
-        let mut event = ShellEvent::user_input_intercepted("s", "/help");
-        assert_eq!(stable_event_key("slash", 7, &event), "slash:7");
-
-        event.started_at_ms = Some(123);
-        assert_eq!(stable_event_key("slash", 7, &event), "slash:123::/help");
-    }
-
-    #[test]
-    fn stable_event_key_does_not_retain_secret_card_input() {
-        let mut event = ShellEvent::user_input_intercepted("s", "auth-1:secret-value");
-        event.started_at_ms = Some(123);
-        event.component = Some("card_secret".to_string());
-
-        let key = stable_event_key("auth", 7, &event);
-
-        assert_eq!(key, "auth:123:card_secret:7");
-        assert!(!key.contains("secret-value"));
-    }
-
-    #[test]
-    fn personal_idle_tracks_whether_the_shell_input_line_is_empty() {
-        let mut state = InlineState::default();
-        let mut editing = ShellEvent::user_input_intercepted("s", "");
-        editing.component = Some("shell_input".to_string());
-        editing.message = Some("input editing".to_string());
-        update_personal_shell_input_state(&[editing], &mut state);
-        assert!(state.personalization.shell_input_active);
-
-        let mut empty = ShellEvent::user_input_intercepted("s", "");
-        empty.component = Some("shell_input".to_string());
-        empty.message = Some("input empty".to_string());
-        update_personal_shell_input_state(&[empty], &mut state);
-        assert!(!state.personalization.shell_input_active);
-    }
-
-    #[test]
-    fn busy_shell_updates_the_analyzer_foreground_gate() {
-        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
-        let cancellation =
-            crate::recommendation::personal_analysis_runtime::AnalyzerCancellation::new();
-        let mut state = InlineState {
-            personalization: crate::recommendation::personal_state::PersonalizationState {
-                analyzer_cancellation: Some(cancellation.clone()),
-                ..Default::default()
-            },
-            ..InlineState::default()
-        };
-        let mut output = Vec::new();
-        let snapshot = ShellEventSnapshot::new(&[ShellEvent::command_started(
-            "session", "command", "sleep 1", "/tmp", 1,
-        )]);
-
-        RuntimeDispatcher::dispatch_inline_batch(
-            &snapshot,
-            &adapter,
-            "bash",
-            &mut state,
-            &mut output,
-        )
-        .expect("dispatch should render");
-
-        assert!(!cancellation.foreground_idle());
-    }
-}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher_tests.rs
@@ -1,0 +1,248 @@
+use super::dispatcher::*;
+use crate::runtime::events::ShellEventSnapshot;
+use crate::runtime::prelude::{AdapterInstance, FakeAgentAdapter, InlineState, ShellEvent};
+use crate::types::ShellEventKind;
+
+#[test]
+fn dispatcher_advances_cursor_to_snapshot_end() {
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState::default();
+    let mut output = Vec::new();
+    let snapshot = ShellEventSnapshot::new(&[
+        ShellEvent::user_input_intercepted("s", "/help"),
+        ShellEvent::user_input_intercepted("s", "/help"),
+    ]);
+
+    let actions = RuntimeDispatcher::dispatch_inline_batch(
+        &snapshot,
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch should render");
+    RuntimeDispatcher::apply_actions(actions, &mut state);
+
+    assert_eq!(
+        state.control.event_cursor().position(),
+        snapshot.cursor().position()
+    );
+}
+
+#[test]
+fn command_activity_evidence_holds_across_cumulative_snapshots() {
+    // The activity flag keys the executor's cwd fallback off positive
+    // evidence of zero command activity, so it must hold once a
+    // command marker was observed. Production dispatch always scans
+    // the session's cumulative event stream (the raw relay passes the
+    // parser's append-only event vec), so a later snapshot is a
+    // superset of an earlier one and the recomputed flag can never
+    // regress to `false`.
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState::default();
+    let mut output = Vec::new();
+
+    let marker = ShellEvent::command_started("s", "cmd-1", "cd /tmp", "/", 1);
+    let with_activity = ShellEventSnapshot::new(std::slice::from_ref(&marker));
+    let actions = RuntimeDispatcher::dispatch_inline_batch(
+        &with_activity,
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch should render");
+    RuntimeDispatcher::apply_actions(actions, &mut state);
+    assert!(state.shell_command_activity_observed);
+
+    let cumulative = [marker, ShellEvent::user_input_intercepted("s", "/help")];
+    let later_snapshot = ShellEventSnapshot::new(&cumulative);
+    let actions = RuntimeDispatcher::dispatch_inline_batch(
+        &later_snapshot,
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch should render");
+    RuntimeDispatcher::apply_actions(actions, &mut state);
+    assert!(
+        state.shell_command_activity_observed,
+        "the cumulative snapshot keeps the marker, so the flag must hold"
+    );
+}
+
+/// A prompt marker with no command in flight: the shell reports its
+/// `$PWD` at every command-less prompt.
+fn shell_ready_event(cwd: &str) -> ShellEvent {
+    let mut event = ShellEvent::user_input_intercepted("s", "");
+    event.kind = ShellEventKind::ShellReady;
+    event.input = None;
+    event.cwd = Some(cwd.to_string());
+    event
+}
+
+/// A PTY input write barrier observed by the raw input relay.
+fn pty_input_event() -> ShellEvent {
+    let mut event = ShellEvent::user_input_intercepted("s", "");
+    event.input = None;
+    event.component = Some("shell_pty_input".to_string());
+    event.message = Some("write".to_string());
+    event
+}
+
+#[test]
+fn dispatcher_records_the_latest_shell_prompt_cwd_report() {
+    // The executor's cwd fallback consumes the shell's own latest
+    // prompt-time report: the most recent `ShellReady` cwd wins, and
+    // later dispatches over the cumulative stream keep it even when
+    // no new report arrived.
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState::default();
+    let mut output = Vec::new();
+
+    let reports = [shell_ready_event("/first"), shell_ready_event("/second")];
+    let snapshot = ShellEventSnapshot::new(&reports);
+    let actions = RuntimeDispatcher::dispatch_inline_batch(
+        &snapshot,
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch should render");
+    RuntimeDispatcher::apply_actions(actions, &mut state);
+    assert_eq!(state.shell_prompt_cwd.as_deref(), Some("/second"));
+
+    let cumulative = [
+        reports[0].clone(),
+        reports[1].clone(),
+        ShellEvent::user_input_intercepted("s", "/help"),
+    ];
+    let later_snapshot = ShellEventSnapshot::new(&cumulative);
+    let actions = RuntimeDispatcher::dispatch_inline_batch(
+        &later_snapshot,
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch should render");
+    RuntimeDispatcher::apply_actions(actions, &mut state);
+    assert_eq!(
+        state.shell_prompt_cwd.as_deref(),
+        Some("/second"),
+        "the last known report must survive report-free dispatches"
+    );
+}
+
+#[test]
+fn pty_input_invalidates_the_prompt_cwd_report() {
+    // Any PTY input may submit a `cd` through a binding the
+    // byte-stream heuristic cannot see, and its markers may be lost
+    // entirely (no CommandStarted/Completed/Failed and no fresh
+    // ShellReady): the pre-input report no longer proves where the
+    // shell sits, so it must be dropped until a newer cwd-bearing
+    // marker arrives — and a fresh ShellReady after the input
+    // restores the evidence with the shell's current directory.
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState::default();
+    let mut output = Vec::new();
+
+    let stale = [shell_ready_event("/repo-a"), pty_input_event()];
+    let snapshot = ShellEventSnapshot::new(&stale);
+    let actions = RuntimeDispatcher::dispatch_inline_batch(
+        &snapshot,
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch should render");
+    RuntimeDispatcher::apply_actions(actions, &mut state);
+    assert_eq!(
+        state.shell_prompt_cwd, None,
+        "a PTY input write must invalidate the earlier report"
+    );
+
+    let refreshed = [
+        shell_ready_event("/repo-a"),
+        pty_input_event(),
+        shell_ready_event("/repo-b"),
+    ];
+    let snapshot = ShellEventSnapshot::new(&refreshed);
+    let actions = RuntimeDispatcher::dispatch_inline_batch(
+        &snapshot,
+        &adapter,
+        "bash",
+        &mut state,
+        &mut output,
+    )
+    .expect("dispatch should render");
+    RuntimeDispatcher::apply_actions(actions, &mut state);
+    assert_eq!(
+        state.shell_prompt_cwd.as_deref(),
+        Some("/repo-b"),
+        "a fresh report after the input restores the evidence"
+    );
+}
+
+#[test]
+fn stable_event_key_uses_marker_timestamp_when_available() {
+    let mut event = ShellEvent::user_input_intercepted("s", "/help");
+    assert_eq!(stable_event_key("slash", 7, &event), "slash:7");
+
+    event.started_at_ms = Some(123);
+    assert_eq!(stable_event_key("slash", 7, &event), "slash:123::/help");
+}
+
+#[test]
+fn stable_event_key_does_not_retain_secret_card_input() {
+    let mut event = ShellEvent::user_input_intercepted("s", "auth-1:secret-value");
+    event.started_at_ms = Some(123);
+    event.component = Some("card_secret".to_string());
+
+    let key = stable_event_key("auth", 7, &event);
+
+    assert_eq!(key, "auth:123:card_secret:7");
+    assert!(!key.contains("secret-value"));
+}
+
+#[test]
+fn personal_idle_tracks_whether_the_shell_input_line_is_empty() {
+    let mut state = InlineState::default();
+    let mut editing = ShellEvent::user_input_intercepted("s", "");
+    editing.component = Some("shell_input".to_string());
+    editing.message = Some("input editing".to_string());
+    update_personal_shell_input_state(&[editing], &mut state);
+    assert!(state.personalization.shell_input_active);
+
+    let mut empty = ShellEvent::user_input_intercepted("s", "");
+    empty.component = Some("shell_input".to_string());
+    empty.message = Some("input empty".to_string());
+    update_personal_shell_input_state(&[empty], &mut state);
+    assert!(!state.personalization.shell_input_active);
+}
+
+#[test]
+fn busy_shell_updates_the_analyzer_foreground_gate() {
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let cancellation =
+        crate::recommendation::personal_analysis_runtime::AnalyzerCancellation::new();
+    let mut state = InlineState {
+        personalization: crate::recommendation::personal_state::PersonalizationState {
+            analyzer_cancellation: Some(cancellation.clone()),
+            ..Default::default()
+        },
+        ..InlineState::default()
+    };
+    let mut output = Vec::new();
+    let snapshot = ShellEventSnapshot::new(&[ShellEvent::command_started(
+        "session", "command", "sleep 1", "/tmp", 1,
+    )]);
+
+    RuntimeDispatcher::dispatch_inline_batch(&snapshot, &adapter, "bash", &mut state, &mut output)
+        .expect("dispatch should render");
+
+    assert!(!cancellation.foreground_idle());
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
@@ -1,3 +1,4 @@
+use crate::evidence::{clean_terminal_control_sequences, redact_sensitive_output};
 use crate::runtime::approval_state::RuntimeApprovalRequest;
 use crate::runtime::prelude::{
     redact_provider_command_text, AgentContextBinding, AgentEvent, AgentMode, AgentRequest,
@@ -5,8 +6,12 @@ use crate::runtime::prelude::{
     HostExecutedShellMetadata, HostExecutedShellResult, OutputRefs, ShellHandoffRequest,
 };
 use crate::runtime::state::InlineState;
+use crate::tools::ReadonlyPipelineOutput;
 
-use super::evidence_state::{EvidenceState, RuntimeShellCommandCompleted, ShellEvidenceDelivery};
+use super::evidence_state::{
+    EvidenceState, RuntimeShellCommandCompleted, ShellEvidenceContinuationState,
+    ShellEvidenceDelivery,
+};
 
 pub(crate) fn record_shell_handoff_completion(
     state: &mut InlineState,
@@ -118,7 +123,46 @@ fn deliver_host_executed_shell_result_if_supported(
     handoff: &ShellHandoffRequest,
     evidence: &RuntimeShellCommandCompleted,
 ) -> ShellEvidenceDelivery {
-    let Some(request_id) = handoff.request_id.as_ref() else {
+    let view = EvidenceState::provider_visible_view(evidence);
+    let untracked_notice = if evidence.status == crate::types::SHELL_HANDOFF_UNTRACKED_STATUS {
+        "\nexecution was not tracked (preexec marker missing); exit code and output are unavailable and must not be treated as a command result. Suggest rerunning the command if its outcome matters."
+    } else {
+        ""
+    };
+    let llm_content = format!(
+        "ShellCommandCompleted evidence\n\
+         {}{untracked_notice}",
+        view.provider_summary,
+    );
+    deliver_shell_result_for_request(
+        state,
+        &handoff.run_id,
+        handoff.request_id.as_deref(),
+        handoff.tool_use_id.as_deref(),
+        evidence,
+        llm_content,
+        view.redaction_status,
+        view.provider_preview_complete,
+    )
+}
+
+/// Shared delivery core for host-executed shell results: capability
+/// gating, duplicate claiming, provider response, and claim release on
+/// failure. Used by both the foreground shell handoff completion path
+/// and the readonly compound executor completion path (issue #1882),
+/// so the delivery contract can never drift between the two.
+#[allow(clippy::too_many_arguments)]
+fn deliver_shell_result_for_request(
+    state: &mut InlineState,
+    run_id: &str,
+    request_id: Option<&str>,
+    tool_use_id: Option<&str>,
+    evidence: &RuntimeShellCommandCompleted,
+    llm_content: String,
+    redaction_status: &'static str,
+    provider_preview_complete: bool,
+) -> ShellEvidenceDelivery {
+    let Some(request_id) = request_id else {
         return ShellEvidenceDelivery {
             delivered: false,
             status: "not_provider_tool_request",
@@ -136,7 +180,7 @@ fn deliver_host_executed_shell_result_if_supported(
             provider_preview_complete: false,
         };
     };
-    if active_run.request.id != handoff.run_id {
+    if active_run.request.id != run_id {
         return ShellEvidenceDelivery {
             delivered: false,
             status: "provider_run_not_owner",
@@ -161,11 +205,7 @@ fn deliver_host_executed_shell_result_if_supported(
     let Some(claim) = state
         .control
         .provider_tool_mut()
-        .claim_host_executed_shell_result(
-            &handoff.run_id,
-            request_id,
-            handoff.tool_use_id.as_deref(),
-        )
+        .claim_host_executed_shell_result(run_id, request_id, tool_use_id)
     else {
         return ShellEvidenceDelivery {
             delivered: true,
@@ -175,16 +215,35 @@ fn deliver_host_executed_shell_result_if_supported(
         };
     };
 
-    let view = EvidenceState::provider_visible_view(evidence);
-    let provider_preview_complete = view.provider_preview_complete;
-    let result = host_executed_shell_result_from_view(handoff, evidence, view);
+    let result = HostExecutedShellResult {
+        llm_content,
+        return_display: None,
+        metadata: HostExecutedShellMetadata {
+            command: redact_provider_command_text(&evidence.command),
+            status: evidence.status.to_string(),
+            exit_code: evidence.exit_code,
+            signal: None,
+            cwd: evidence.cwd.clone(),
+            end_cwd: evidence.end_cwd.clone(),
+            duration_ms: evidence.duration_ms,
+            output_ref: evidence.terminal_output_ref.as_ref().map(|_| {
+                crate::evidence::output_policy::terminal_output_id(
+                    &evidence.shell_session_id,
+                    &evidence.command_block_id,
+                )
+            }),
+            redaction_status: redaction_status.to_string(),
+            approval_id: evidence.approval_id.clone(),
+            tool_use_id: tool_use_id.map(ToString::to_string),
+        },
+    };
     let delivered = match state.agent_run.active.as_mut() {
         Some(run) => {
             let delivered = run
                 .handle
                 .respond_approval(ApprovalResponse {
-                    request_id: request_id.clone(),
-                    tool_use_id: handoff.tool_use_id.clone(),
+                    request_id: request_id.to_string(),
+                    tool_use_id: tool_use_id.map(ToString::to_string),
                     tool_input: None,
                     decision: ApprovalDecision::HostExecutedShell {
                         result: Box::new(result),
@@ -223,6 +282,97 @@ fn deliver_host_executed_shell_result_if_supported(
     }
 }
 
+/// Records completion of a readonly compound executed by the dedicated
+/// argv executor (issue #1882): no PTY handoff was involved, so the
+/// aggregated stdout/stderr captured by the executor is redacted and
+/// embedded directly as the bounded output summary, then delivered
+/// through the same host-executed result channel a handoff completion
+/// would use.
+pub(crate) fn record_readonly_compound_completion(
+    state: &mut InlineState,
+    request: &RuntimeApprovalRequest,
+    command: &str,
+    output: &ReadonlyPipelineOutput,
+    execution_cwd: &std::path::Path,
+    status: &'static str,
+    duration_ms: u64,
+) -> RuntimeShellCommandCompleted {
+    let exit_code = output.exit_code.unwrap_or(-1);
+    // The evidence names the directory the executor actually ran in
+    // (the resolved request cwd, or its fallback), never a placeholder.
+    let cwd = execution_cwd.display().to_string();
+    // Match the canonical capture pipeline: terminal control sequences
+    // (C0, OSC, zero-width) are stripped before sensitive-pattern
+    // redaction so spoofed output cannot cross the provider/durable
+    // boundary disguised by control bytes.
+    let (stdout, stdout_redacted) =
+        redact_sensitive_output(&clean_terminal_control_sequences(&output.stdout));
+    let (stderr, stderr_redacted) =
+        redact_sensitive_output(&clean_terminal_control_sequences(&output.stderr));
+    let redaction_status: &'static str = if stdout_redacted || stderr_redacted {
+        "excerpt_redacted"
+    } else {
+        "excerpt_included"
+    };
+    let mut summary = format!(
+        "command: {}\n\
+         cwd: {cwd}\n\
+         end_cwd: {cwd}\n\
+         status: {status}\n\
+         exit_code: {exit_code}\n\
+         duration_ms: {duration_ms}\n\
+         output_id: <none>\n\
+         redaction_status: {redaction_status}\n\
+         bounded_output_summary:\n{stdout}",
+        redact_provider_command_text(command),
+    );
+    if !stderr.trim().is_empty() {
+        summary.push_str("\nstderr:\n");
+        summary.push_str(&stderr);
+    }
+    let mut evidence = RuntimeShellCommandCompleted {
+        approval_id: Some(request.id.clone()),
+        origin: request.origin,
+        provider_request_id: request.request_id.clone(),
+        tool_use_id: request.tool_use_id.clone(),
+        shell_session_id: request.session_id.clone(),
+        command_block_id: format!("readonly-compound-{}", request.id),
+        command: command.to_string(),
+        cwd: cwd.clone(),
+        end_cwd: cwd,
+        status,
+        exit_code,
+        duration_ms,
+        terminal_output_ref: None,
+        redaction_status,
+        provider_result_delivered: false,
+        provider_result_delivery_status: "not_attempted",
+        recovery_reason: None,
+        continuation_state: ShellEvidenceContinuationState::PendingRecovery,
+    };
+    let provider_preview_complete =
+        !stdout.contains("<truncated>") && !stderr.contains("<truncated>");
+    let delivery = deliver_shell_result_for_request(
+        state,
+        &request.run_id,
+        request.request_id.as_deref(),
+        request.tool_use_id.as_deref(),
+        &evidence,
+        format!("ShellCommandCompleted evidence\n{summary}"),
+        redaction_status,
+        provider_preview_complete,
+    );
+    if delivery.delivered {
+        state.agent_run.native_prompt_after_run = true;
+        state.agent_run.host_executed_shell_result_delivered = true;
+    }
+    evidence.apply_provider_result_delivery(delivery);
+    state
+        .evidence
+        .record_shell_command_completed(evidence.clone());
+    evidence
+}
+
 #[cfg(test)]
 fn host_executed_shell_result(
     handoff: &ShellHandoffRequest,
@@ -232,6 +382,7 @@ fn host_executed_shell_result(
     host_executed_shell_result_from_view(handoff, evidence, view)
 }
 
+#[cfg(test)]
 fn host_executed_shell_result_from_view(
     handoff: &ShellHandoffRequest,
     evidence: &RuntimeShellCommandCompleted,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
@@ -1,11 +1,16 @@
+use crate::evidence::redact_sensitive_output;
 use crate::runtime::prelude::{
     redact_provider_command_text, AgentContextBinding, AgentMode, AgentRequest, AgentRunOrigin,
     ApprovalDecision, ApprovalResponse, CommandBlock, CommandStatus, HostExecutedShellMetadata,
     HostExecutedShellResult, OutputRefs, ShellHandoffRequest,
 };
 use crate::runtime::state::{InlineState, RuntimeApprovalRequest};
+use crate::tools::ReadonlyPipelineOutput;
 
-use super::evidence_state::{EvidenceState, RuntimeShellCommandCompleted, ShellEvidenceDelivery};
+use super::evidence_state::{
+    EvidenceState, RuntimeShellCommandCompleted, ShellEvidenceContinuationState,
+    ShellEvidenceDelivery,
+};
 
 pub(crate) fn record_shell_handoff_completion(
     state: &mut InlineState,
@@ -97,7 +102,46 @@ fn deliver_host_executed_shell_result_if_supported(
     handoff: &ShellHandoffRequest,
     evidence: &RuntimeShellCommandCompleted,
 ) -> ShellEvidenceDelivery {
-    let Some(request_id) = handoff.request_id.as_ref() else {
+    let view = EvidenceState::provider_visible_view(evidence);
+    let untracked_notice = if evidence.status == crate::types::SHELL_HANDOFF_UNTRACKED_STATUS {
+        "\nexecution was not tracked (preexec marker missing); exit code and output are unavailable and must not be treated as a command result. Suggest rerunning the command if its outcome matters."
+    } else {
+        ""
+    };
+    let llm_content = format!(
+        "ShellCommandCompleted evidence\n\
+         {}{untracked_notice}",
+        view.provider_summary,
+    );
+    deliver_shell_result_for_request(
+        state,
+        &handoff.run_id,
+        handoff.request_id.as_deref(),
+        handoff.tool_use_id.as_deref(),
+        evidence,
+        llm_content,
+        view.redaction_status,
+        view.provider_preview_complete,
+    )
+}
+
+/// Shared delivery core for host-executed shell results: capability
+/// gating, duplicate claiming, provider response, and claim release on
+/// failure. Used by both the foreground shell handoff completion path
+/// and the readonly compound executor completion path (issue #1882),
+/// so the delivery contract can never drift between the two.
+#[allow(clippy::too_many_arguments)]
+fn deliver_shell_result_for_request(
+    state: &mut InlineState,
+    run_id: &str,
+    request_id: Option<&str>,
+    tool_use_id: Option<&str>,
+    evidence: &RuntimeShellCommandCompleted,
+    llm_content: String,
+    redaction_status: &'static str,
+    provider_preview_complete: bool,
+) -> ShellEvidenceDelivery {
+    let Some(request_id) = request_id else {
         return ShellEvidenceDelivery {
             delivered: false,
             status: "not_provider_tool_request",
@@ -115,7 +159,7 @@ fn deliver_host_executed_shell_result_if_supported(
             provider_preview_complete: false,
         };
     };
-    if active_run.request.id != handoff.run_id {
+    if active_run.request.id != run_id {
         return ShellEvidenceDelivery {
             delivered: false,
             status: "provider_run_not_owner",
@@ -124,7 +168,7 @@ fn deliver_host_executed_shell_result_if_supported(
             ),
             provider_preview_complete: false,
         };
-    }
+    };
     let capabilities = active_run.handle.control_capabilities();
     if !capabilities.can_handle_host_executed_shell_tool_result {
         return ShellEvidenceDelivery {
@@ -135,16 +179,12 @@ fn deliver_host_executed_shell_result_if_supported(
             ),
             provider_preview_complete: false,
         };
-    }
+    };
 
     let Some(claim) = state
         .control
         .provider_tool_mut()
-        .claim_host_executed_shell_result(
-            &handoff.run_id,
-            request_id,
-            handoff.tool_use_id.as_deref(),
-        )
+        .claim_host_executed_shell_result(run_id, request_id, tool_use_id)
     else {
         return ShellEvidenceDelivery {
             delivered: true,
@@ -154,16 +194,35 @@ fn deliver_host_executed_shell_result_if_supported(
         };
     };
 
-    let view = EvidenceState::provider_visible_view(evidence);
-    let provider_preview_complete = view.provider_preview_complete;
-    let result = host_executed_shell_result_from_view(handoff, evidence, view);
+    let result = HostExecutedShellResult {
+        llm_content,
+        return_display: None,
+        metadata: HostExecutedShellMetadata {
+            command: redact_provider_command_text(&evidence.command),
+            status: evidence.status.to_string(),
+            exit_code: evidence.exit_code,
+            signal: None,
+            cwd: evidence.cwd.clone(),
+            end_cwd: evidence.end_cwd.clone(),
+            duration_ms: evidence.duration_ms,
+            output_ref: evidence.terminal_output_ref.as_ref().map(|_| {
+                crate::evidence::output_policy::terminal_output_id(
+                    &evidence.shell_session_id,
+                    &evidence.command_block_id,
+                )
+            }),
+            redaction_status: redaction_status.to_string(),
+            approval_id: evidence.approval_id.clone(),
+            tool_use_id: tool_use_id.map(ToString::to_string),
+        },
+    };
     let delivered = match state.agent_run.active.as_mut() {
         Some(run) => {
             let delivered = run
                 .handle
                 .respond_approval(ApprovalResponse {
-                    request_id: request_id.clone(),
-                    tool_use_id: handoff.tool_use_id.clone(),
+                    request_id: request_id.to_string(),
+                    tool_use_id: tool_use_id.map(ToString::to_string),
                     tool_input: None,
                     decision: ApprovalDecision::HostExecutedShell {
                         result: Box::new(result),
@@ -202,6 +261,89 @@ fn deliver_host_executed_shell_result_if_supported(
     }
 }
 
+/// Records completion of a readonly compound executed by the dedicated
+/// argv executor (issue #1882): no PTY handoff was involved, so the
+/// aggregated stdout/stderr captured by the executor is redacted and
+/// embedded directly as the bounded output summary, then delivered
+/// through the same host-executed result channel a handoff completion
+/// would use.
+pub(crate) fn record_readonly_compound_completion(
+    state: &mut InlineState,
+    request: &RuntimeApprovalRequest,
+    command: &str,
+    output: &ReadonlyPipelineOutput,
+    duration_ms: u64,
+) -> RuntimeShellCommandCompleted {
+    let exit_code = output.exit_code.unwrap_or(-1);
+    let cwd = std::env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default();
+    let (stdout, stdout_redacted) = redact_sensitive_output(&output.stdout);
+    let (stderr, stderr_redacted) = redact_sensitive_output(&output.stderr);
+    let redaction_status: &'static str = if stdout_redacted || stderr_redacted {
+        "excerpt_redacted"
+    } else {
+        "excerpt_included"
+    };
+    let mut summary = format!(
+        "command: {}\n\
+         cwd: {cwd}\n\
+         end_cwd: {cwd}\n\
+         status: completed\n\
+         exit_code: {exit_code}\n\
+         duration_ms: {duration_ms}\n\
+         output_id: <none>\n\
+         redaction_status: {redaction_status}\n\
+         bounded_output_summary:\n{stdout}",
+        redact_provider_command_text(command),
+    );
+    if !stderr.trim().is_empty() {
+        summary.push_str("\nstderr:\n");
+        summary.push_str(&stderr);
+    }
+    let mut evidence = RuntimeShellCommandCompleted {
+        approval_id: Some(request.id.clone()),
+        origin: request.origin,
+        provider_request_id: request.request_id.clone(),
+        tool_use_id: request.tool_use_id.clone(),
+        shell_session_id: request.session_id.clone(),
+        command_block_id: format!("readonly-compound-{}", request.id),
+        command: command.to_string(),
+        cwd: cwd.clone(),
+        end_cwd: cwd,
+        status: "completed",
+        exit_code,
+        duration_ms,
+        terminal_output_ref: None,
+        redaction_status,
+        provider_result_delivered: false,
+        provider_result_delivery_status: "not_attempted",
+        recovery_reason: None,
+        continuation_state: ShellEvidenceContinuationState::PendingRecovery,
+    };
+    let provider_preview_complete =
+        !stdout.contains("<truncated>") && !stderr.contains("<truncated>");
+    let delivery = deliver_shell_result_for_request(
+        state,
+        &request.run_id,
+        request.request_id.as_deref(),
+        request.tool_use_id.as_deref(),
+        &evidence,
+        format!("ShellCommandCompleted evidence\n{summary}"),
+        redaction_status,
+        provider_preview_complete,
+    );
+    if delivery.delivered {
+        state.agent_run.native_prompt_after_run = true;
+        state.agent_run.host_executed_shell_result_delivered = true;
+    }
+    evidence.apply_provider_result_delivery(delivery);
+    state
+        .evidence
+        .record_shell_command_completed(evidence.clone());
+    evidence
+}
+
 #[cfg(test)]
 fn host_executed_shell_result(
     handoff: &ShellHandoffRequest,
@@ -211,6 +353,8 @@ fn host_executed_shell_result(
     host_executed_shell_result_from_view(handoff, evidence, view)
 }
 
+#[cfg(test)]
+#[cfg(test)]
 fn host_executed_shell_result_from_view(
     handoff: &ShellHandoffRequest,
     evidence: &RuntimeShellCommandCompleted,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
@@ -5,6 +5,8 @@ pub(crate) mod continuity;
 pub(crate) mod controller;
 pub(crate) mod details;
 pub(crate) mod dispatcher;
+#[cfg(test)]
+mod dispatcher_tests;
 pub(crate) mod doctor;
 pub(crate) mod events;
 pub(crate) mod evidence_delivery;

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -96,6 +96,19 @@ pub(crate) struct InlineState {
     pub(crate) evidence_requests: EvidenceRequestState,
     pub(crate) shell_evidence: ShellEvidenceState,
     pub(crate) session_blocks: Vec<CommandBlock>,
+    /// Whether any shell command activity (started/completed/failed
+    /// marker events) was observed this session, including activity
+    /// that produced ledger errors instead of command blocks (R9).
+    pub(crate) shell_command_activity_observed: bool,
+    /// The shell's own latest working-directory report from a prompt
+    /// marker (a precmd with no command in flight): positive evidence
+    /// of where the shell sits, refreshed at every command-less
+    /// prompt and invalidated by any PTY input write (the input may
+    /// submit a cwd-changing line through a binding the byte-stream
+    /// heuristic cannot see, while its markers are lost). `None`
+    /// until the marker channel has proven itself — a session without
+    /// any marker traffic never gets a value here.
+    pub(crate) shell_prompt_cwd: Option<String>,
     pub(crate) shell_session_id: Option<String>,
     pub(crate) shell_exited: bool,
     pub(crate) language: Language,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -84,6 +84,10 @@ pub(super) struct OscParser {
     /// #1721 D16: shared "bash sits at PS1" gate consumed by the raw input
     /// relay; prompt_ready raises it, preexec lowers it.
     main_prompt_gate: crate::raw_input::MainPromptGate,
+    /// Collapses consecutive PTY input writes into one prompt-cwd
+    /// invalidation barrier; a fresh command-less prompt report
+    /// (`ShellReady`) re-arms it.
+    pty_input_barrier_pushed: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -133,6 +137,7 @@ impl OscParser {
             environment_observer: None,
             history_file_observer: None,
             main_prompt_gate: crate::raw_input::MainPromptGate::default(),
+            pty_input_barrier_pushed: false,
         }
     }
 
@@ -301,6 +306,10 @@ impl OscParser {
                     self.intervention_display_cuts
                         .push((self.display.len(), DisplayCutKind::PromptBoundary));
                     self.last_prompt_display_start = Some(self.display.len());
+                    // A fresh command-less prompt report re-arms the
+                    // PTY-input invalidation barrier: the cwd carried
+                    // here supersedes any earlier barrier.
+                    self.pty_input_barrier_pushed = false;
                     self.events.push(ShellEvent {
                         kind: ShellEventKind::ShellReady,
                         session_id,
@@ -725,6 +734,20 @@ impl OscParser {
             },
             None,
         );
+    }
+
+    /// User bytes were written to the shell's PTY: whatever the shell
+    /// does with them (a custom `accept-line` binding cannot be told
+    /// apart from editing keys in the byte stream), a previously
+    /// reported prompt cwd stops being provably current until a fresh
+    /// cwd-bearing marker arrives. Consecutive writes collapse into
+    /// one barrier event; a new prompt report re-arms it.
+    pub(super) fn push_shell_pty_input_event(&mut self) {
+        if self.pty_input_barrier_pushed {
+            return;
+        }
+        self.pty_input_barrier_pushed = true;
+        self.push_self_session_input_event("shell_pty_input", "write", None);
     }
 
     pub(super) fn push_card_event(&mut self, action: &str, value: &str) {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -73,7 +73,16 @@ pub(super) fn drain_raw_input_events<W: Write>(
             RawInputEvent::PtyUserWrite {
                 generation,
                 line_submits,
-            } => prompt_replay.observe_user_write(generation, line_submits),
+            } => {
+                // Any user bytes reaching the PTY invalidate the
+                // prompt-cwd report: submit-detection is a documented
+                // heuristic (CR/LF/Ctrl-O only), so a custom
+                // `accept-line` binding must not slip past the
+                // barrier. The parser collapses consecutive writes
+                // into one event per prompt.
+                parser.push_shell_pty_input_event();
+                prompt_replay.observe_user_write(generation, line_submits)
+            }
             RawInputEvent::CtrlC => parser.push_control_event("ctrl_c"),
             RawInputEvent::Esc => parser.push_control_event("esc"),
             RawInputEvent::SoftNewlineShortcutObserved => parser.push_soft_newline_shortcut_event(),

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
@@ -127,6 +127,79 @@ fn relay_write_event_expires_armed_prompt_replay() {
 }
 
 #[test]
+fn any_pty_user_write_emits_the_prompt_cwd_invalidation_barrier() {
+    // Production wiring: a PTY write with zero detected line submits
+    // (submit detection cannot see custom `accept-line` bindings)
+    // must still emit the shell_pty_input barrier event that the
+    // dispatcher consumes to invalidate the prompt-cwd report.
+    // Consecutive writes collapse into one event; a fresh
+    // command-less prompt report re-arms the barrier.
+    let mut parser = parser_for_test("pty-write-cwd-barrier");
+    let (generation, mut prompt_replay) = tracker_for_test();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let mut output = Vec::new();
+    let mut echoed = 0usize;
+
+    let barrier_count = |parser: &OscParser| {
+        parser
+            .events
+            .iter()
+            .filter(|event| {
+                event.component.as_deref() == Some("shell_pty_input")
+                    && event.message.as_deref() == Some("write")
+            })
+            .count()
+    };
+
+    for _ in 0..2 {
+        sender
+            .send(crate::raw_input::RawInputEvent::PtyUserWrite {
+                generation: generation.bump(),
+                line_submits: 0,
+            })
+            .expect("queue pty write");
+    }
+    drain_raw_input_events(
+        &receiver,
+        &mut parser,
+        &mut output,
+        "prompt> ",
+        &mut echoed,
+        &mut prompt_replay,
+    )
+    .expect("drain pty writes");
+    assert_eq!(
+        barrier_count(&parser),
+        1,
+        "consecutive writes must collapse into one barrier event"
+    );
+
+    // A fresh command-less prompt report re-arms the barrier, so the
+    // next write emits a new invalidation event.
+    feed_shell_ready(&mut parser);
+    sender
+        .send(crate::raw_input::RawInputEvent::PtyUserWrite {
+            generation: generation.bump(),
+            line_submits: 0,
+        })
+        .expect("queue post-prompt write");
+    drain_raw_input_events(
+        &receiver,
+        &mut parser,
+        &mut output,
+        "prompt> ",
+        &mut echoed,
+        &mut prompt_replay,
+    )
+    .expect("drain post-prompt write");
+    assert_eq!(
+        barrier_count(&parser),
+        2,
+        "a fresh prompt report must re-arm the barrier"
+    );
+}
+
+#[test]
 fn prompt_restore_refuses_to_arm_while_user_input_response_is_unparsed() {
     let (generation, mut prompt_replay) = tracker_for_test();
 

--- a/src/cosh-ng/crates/cosh-shell/src/tools/broker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/broker.rs
@@ -53,7 +53,7 @@ fn readonly_tokens(command: &str) -> Result<Vec<String>, String> {
     }
 }
 
-fn configured_readonly_command(tokens: &[String]) -> bool {
+pub(crate) fn configured_readonly_command(tokens: &[String]) -> bool {
     if let Some(lock) = READONLY_CONFIG.get() {
         return match lock.read() {
             Ok(config) => readonly_rules::is_readonly_command_with_config(tokens, &config),

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
@@ -405,6 +405,7 @@ fn assess_first_stage(
         stages: parsed.stages.first().cloned().into_iter().collect(),
         null_redirections: 0,
         segments: Vec::new(),
+        segment_connectors: Vec::new(),
     };
     assess_simple_command(command, simple, policy)
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
@@ -1,12 +1,14 @@
 use super::command_risk::{
     assess_pipeline, assess_simple_command, insert_structural_reason, is_high_risk_explanation,
-    AssessmentConfidence, AssessmentPolicy, CommandAssessment, CommandShape, ExecutionDecision,
-    InteractionRequirement, OutputExposure, OutputStability, RiskImpact, SideEffectClass,
+    AssessmentConfidence, AssessmentPolicy, AutoAllowEvidence, CommandAssessment, CommandShape,
+    ExecutionDecision, InteractionRequirement, OutputExposure, OutputStability, RiskImpact,
+    SideEffectClass,
 };
 use super::command_risk_build::{
     dedupe_reasons, max_output_exposure, max_output_stability, min_confidence,
 };
 use super::command_risk_parser::ParsedCommand;
+use super::readonly_compound::build_readonly_compound_plan;
 
 /// Returns the per-segment pipeline stages for all compound commands
 /// (`&&`/`||`/`;`/newline separated, issue #1785): every segment is
@@ -41,8 +43,11 @@ pub(super) fn compound_segments(parsed: &ParsedCommand) -> Option<Vec<Vec<Vec<St
 /// run`, `awk system()`, `curl | sh`) and escalated benign arguments
 /// (`echo rm>/dev/null && true`).
 ///
-/// The compound execution boundary is unchanged: always `AskUser`, never
-/// auto-allow. Only the assessment precision is improved.
+/// The compound execution boundary is relaxed in exactly one case
+/// (issue #1882): a readonly-compound execution plan exists for the
+/// whole command (see `build_readonly_compound_plan`), granting
+/// `CompoundReadonly` evidence in auto mode. Every other compound keeps
+/// `AskUser`, never auto-allow. Assessment aggregation is unchanged.
 pub(super) fn assess_stripped_compound(
     command: &str,
     shape: CommandShape,
@@ -72,6 +77,7 @@ pub(super) fn assess_stripped_compound(
             stages: segment.clone(),
             null_redirections: 0,
             segments: Vec::new(),
+            segment_connectors: Vec::new(),
         };
         let assessed = if segment.len() > 1 {
             assess_pipeline(&segment_text, parsed, policy)
@@ -103,21 +109,32 @@ pub(super) fn assess_stripped_compound(
             reasons.insert(0, primary);
         }
     }
-    insert_structural_reason(
-        &mut reasons,
-        match shape {
-            CommandShape::AndOrList => "and-or-list-not-auto-executable",
-            CommandShape::Sequence => "sequence-not-auto-executable",
-            CommandShape::RedirectionRead => "read-redirection-not-auto-executable",
-            _ => "complex-shell-not-auto-executable",
-        },
-    );
+    let auto_allow = compound_readonly_evidence(command).filter(|_| policy.auto_mode);
+    if auto_allow.is_some() {
+        // The whole compound is auto-executable; the structural
+        // "not-auto-executable" reason no longer applies.
+        reasons.insert(0, "compound-readonly");
+    } else {
+        insert_structural_reason(
+            &mut reasons,
+            match shape {
+                CommandShape::AndOrList => "and-or-list-not-auto-executable",
+                CommandShape::Sequence => "sequence-not-auto-executable",
+                CommandShape::RedirectionRead => "read-redirection-not-auto-executable",
+                _ => "complex-shell-not-auto-executable",
+            },
+        );
+    }
 
     CommandAssessment {
         source: policy.source,
         command: command.to_string(),
         shape,
-        execution: ExecutionDecision::AskUser,
+        execution: if auto_allow.is_some() {
+            ExecutionDecision::AutoAllow
+        } else {
+            ExecutionDecision::AskUser
+        },
         impact,
         confidence: min_confidence(confidence, AssessmentConfidence::Medium),
         interaction,
@@ -125,8 +142,28 @@ pub(super) fn assess_stripped_compound(
         output_exposure,
         side_effects,
         reasons,
-        auto_allow: None,
+        auto_allow,
     }
+}
+
+/// Grants `CompoundReadonly` evidence (issue #1882) exactly when an
+/// execution plan exists for the compound: eligibility is decided by
+/// `build_readonly_compound_plan`, the same function the consumer uses
+/// to build the plan it runs, so the assessment path and the execution
+/// path can never disagree about what would run. The executor spawns
+/// parser tokens directly with `std::process::Command` — no shell
+/// parsing layer ever touches the assessed text, so quote/escape/newline
+/// forms stay eligible (the parser preserves token boundaries) and no
+/// expansion mechanism (history, glob, tilde, parameter, alias) can
+/// fire: the assessed token sequence *is* the executed argv.
+///
+/// Anything without a plan falls through to the unchanged `AskUser`
+/// path, so the worst case of an unenumerated form is over-conservatism.
+/// Short-circuit semantics only decide which segments run, never their
+/// argv, and every segment carries its own evidence, so any executed
+/// subset stays within the assessed set.
+fn compound_readonly_evidence(command: &str) -> Option<AutoAllowEvidence> {
+    build_readonly_compound_plan(command).map(|_| AutoAllowEvidence::CompoundReadonly)
 }
 
 /// Applies the conservative `Complex` classification: floor the impact

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
@@ -84,6 +84,11 @@ pub enum AutoAllowEvidence {
     DirectReadonlyBroker,
     GuardedDiagnostic,
     ReadonlyPipelineExecutor,
+    /// A readonly compound execution plan exists (issue #1882): every
+    /// segment's tokens pass the direct readonly gate as-is, and the
+    /// plan is executed by the dedicated argv executor — no shell
+    /// parsing layer, no text rebuild, no handoff.
+    CompoundReadonly,
 }
 
 impl AutoAllowEvidence {
@@ -92,6 +97,7 @@ impl AutoAllowEvidence {
             Self::DirectReadonlyBroker => "bounded-readonly",
             Self::GuardedDiagnostic => "safe-diagnostic-family",
             Self::ReadonlyPipelineExecutor => "readonly-pipeline-executor",
+            Self::CompoundReadonly => "compound-readonly",
         }
     }
 }
@@ -259,6 +265,11 @@ pub enum AutoExecutionRoute {
     DirectReadonlyBroker,
     GuardedDiagnosticExecutor,
     ReadonlyPipelineExecutor,
+    /// Auto-approves a fully readonly compound command and executes it
+    /// through the dedicated readonly compound executor (issue #1882):
+    /// parser tokens are spawned directly with `std::process::Command`,
+    /// so no shell parsing layer ever touches the assessed text.
+    CompoundReadonlyExecutor,
     Block,
 }
 
@@ -286,6 +297,13 @@ impl AutoExecutionPolicy {
         match assessment.auto_allow {
             Some(AutoAllowEvidence::DirectReadonlyBroker) => {
                 AutoExecutionRoute::DirectReadonlyBroker
+            }
+            // Always live, like DirectReadonlyBroker: the executor
+            // reuses the readonly pipeline primitives, so there is no
+            // separate mechanism to gate behind a runtime flag
+            // (issue #1882).
+            Some(AutoAllowEvidence::CompoundReadonly) => {
+                AutoExecutionRoute::CompoundReadonlyExecutor
             }
             Some(AutoAllowEvidence::GuardedDiagnostic) if self.guarded_diagnostic_executor => {
                 AutoExecutionRoute::GuardedDiagnosticExecutor

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
@@ -84,6 +84,10 @@ pub enum AutoAllowEvidence {
     DirectReadonlyBroker,
     GuardedDiagnostic,
     ReadonlyPipelineExecutor,
+    /// Every compound segment individually passes the direct readonly
+    /// broker gate and the original text is lexically faithful
+    /// (issue #1882); execution reuses the approved-command handoff.
+    CompoundReadonly,
 }
 
 impl AutoAllowEvidence {
@@ -92,6 +96,7 @@ impl AutoAllowEvidence {
             Self::DirectReadonlyBroker => "bounded-readonly",
             Self::GuardedDiagnostic => "safe-diagnostic-family",
             Self::ReadonlyPipelineExecutor => "readonly-pipeline-executor",
+            Self::CompoundReadonly => "compound-readonly",
         }
     }
 }
@@ -259,6 +264,11 @@ pub enum AutoExecutionRoute {
     DirectReadonlyBroker,
     GuardedDiagnosticExecutor,
     ReadonlyPipelineExecutor,
+    /// Auto-approves a fully readonly compound command and executes it
+    /// through the dedicated readonly compound executor (issue #1882):
+    /// parser tokens are spawned directly with `std::process::Command`,
+    /// so no shell parsing layer ever touches the assessed text.
+    CompoundReadonlyExecutor,
     Block,
 }
 
@@ -286,6 +296,13 @@ impl AutoExecutionPolicy {
         match assessment.auto_allow {
             Some(AutoAllowEvidence::DirectReadonlyBroker) => {
                 AutoExecutionRoute::DirectReadonlyBroker
+            }
+            // Always live, like DirectReadonlyBroker: the executor
+            // reuses the readonly pipeline primitives, so there is no
+            // separate mechanism to gate behind a runtime flag
+            // (issue #1882).
+            Some(AutoAllowEvidence::CompoundReadonly) => {
+                AutoExecutionRoute::CompoundReadonlyExecutor
             }
             Some(AutoAllowEvidence::GuardedDiagnostic) if self.guarded_diagnostic_executor => {
                 AutoExecutionRoute::GuardedDiagnosticExecutor

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
@@ -16,6 +16,17 @@ use super::command_risk::CommandShape;
 /// `command_risk_tests.rs`.
 const SAFE_OUTPUT_SINKS: &[&str] = &["/dev/null"];
 
+/// Segment separator kind recorded at each `&&`/`||`/`;`/newline break.
+/// A single `&` also records a mark (background list separator) but the
+/// shape escalates to Complex, so its connector is never consumed by the
+/// compound path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SegmentConnector {
+    Seq,
+    And,
+    Or,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct ParsedCommand {
     pub(super) shape: CommandShape,
@@ -26,6 +37,12 @@ pub(super) struct ParsedCommand {
     /// command contains segment separators (used by the stripped-compound
     /// aggregation path).
     pub(super) segments: Vec<Vec<Vec<String>>>,
+    /// Connector kind for every recorded segment mark, in source order.
+    /// When no empty segment was swallowed, entry `i` is the connector
+    /// between `segments[i]` and `segments[i + 1]`; consumers must verify
+    /// `segment_connectors.len() == segments.len() - 1` before relying on
+    /// that pairing (a trailing separator leaves a dangling mark).
+    pub(super) segment_connectors: Vec<SegmentConnector>,
 }
 
 pub(super) fn parse_command(command: &str) -> ParsedCommand {
@@ -35,6 +52,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             stages: Vec::new(),
             null_redirections: 0,
             segments: Vec::new(),
+            segment_connectors: Vec::new(),
         };
     }
     if command.contains('\0') {
@@ -43,6 +61,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             stages: Vec::new(),
             null_redirections: 0,
             segments: Vec::new(),
+            segment_connectors: Vec::new(),
         };
     }
 
@@ -53,9 +72,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
     let mut quote: Option<char> = None;
     let mut null_redirections = 0usize;
     let mut amp_redirect_guard = false;
-    // Segment breaks recorded as (stage index, token offset) at each
-    // `&&`/`||`/`;`/newline, resolved into `segments` after parsing.
-    let mut segment_marks: Vec<(usize, usize)> = Vec::new();
+    // Segment breaks recorded as (stage index, token offset, connector)
+    // at each `&&`/`||`/`;`/newline, resolved into `segments` after
+    // parsing.
+    let mut segment_marks: Vec<(usize, usize, SegmentConnector)> = Vec::new();
     // Tracks whether the current token buffer contains quoted or escaped
     // content; such tokens are ordinary arguments and never fd prefixes.
     let mut token_quoted = false;
@@ -78,14 +98,14 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             ' ' | '\t' => push_token(&mut tokens, &mut token, &mut token_quoted),
             '\n' | ';' => {
                 push_token(&mut tokens, &mut token, &mut token_quoted);
-                segment_marks.push((stages.len(), tokens.len()));
+                segment_marks.push((stages.len(), tokens.len(), SegmentConnector::Seq));
                 shape = max_shape(shape, CommandShape::Sequence);
             }
             '|' => {
                 push_token(&mut tokens, &mut token, &mut token_quoted);
                 if chars.peek().is_some_and(|next| *next == '|') {
                     chars.next();
-                    segment_marks.push((stages.len(), tokens.len()));
+                    segment_marks.push((stages.len(), tokens.len(), SegmentConnector::Or));
                     shape = max_shape(shape, CommandShape::AndOrList);
                 } else {
                     stages.push(std::mem::take(&mut tokens));
@@ -96,7 +116,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                 push_token(&mut tokens, &mut token, &mut token_quoted);
                 if chars.peek().is_some_and(|next| *next == '&') {
                     chars.next();
-                    segment_marks.push((stages.len(), tokens.len()));
+                    segment_marks.push((stages.len(), tokens.len(), SegmentConnector::And));
                     shape = max_shape(shape, CommandShape::AndOrList);
                 } else {
                     shape = max_shape(shape, CommandShape::Complex);
@@ -109,7 +129,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                     // empty tail that the segment builder drops, so
                     // `ls &` still yields a single segment.
                     if !amp_redirect_guard {
-                        segment_marks.push((stages.len(), tokens.len()));
+                        // Shape already escalated to Complex, so this
+                        // connector is never consumed by the compound
+                        // path; the kind is irrelevant, pick Seq.
+                        segment_marks.push((stages.len(), tokens.len(), SegmentConnector::Seq));
                     }
                 }
             }
@@ -305,6 +328,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             stages: Vec::new(),
             null_redirections: 0,
             segments: Vec::new(),
+            segment_connectors: Vec::new(),
         };
     }
     push_token(&mut tokens, &mut token, &mut token_quoted);
@@ -326,6 +350,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
     ParsedCommand {
         shape,
         segments: split_segments(&stages, &segment_marks),
+        segment_connectors: segment_marks
+            .iter()
+            .map(|&(_, _, connector)| connector)
+            .collect(),
         stages,
         null_redirections,
     }
@@ -334,7 +362,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
 /// Resolves the recorded segment marks into per-segment pipeline stages.
 /// Consecutive stages between two marks belong to the same segment; a mark
 /// splits the stage it points into at the recorded token offset.
-fn split_segments(stages: &[Vec<String>], marks: &[(usize, usize)]) -> Vec<Vec<Vec<String>>> {
+fn split_segments(
+    stages: &[Vec<String>],
+    marks: &[(usize, usize, SegmentConnector)],
+) -> Vec<Vec<Vec<String>>> {
     if marks.is_empty() {
         return Vec::new();
     }
@@ -343,7 +374,7 @@ fn split_segments(stages: &[Vec<String>], marks: &[(usize, usize)]) -> Vec<Vec<V
     let mut mark_iter = marks.iter().peekable();
     for (stage_index, stage) in stages.iter().enumerate() {
         let mut start = 0usize;
-        while let Some(&&(mark_stage, mark_offset)) = mark_iter.peek() {
+        while let Some(&&(mark_stage, mark_offset, _)) = mark_iter.peek() {
             if mark_stage != stage_index {
                 break;
             }
@@ -380,7 +411,10 @@ pub(super) fn is_env_assignment(token: &str) -> bool {
 }
 
 fn push_token(tokens: &mut Vec<String>, token: &mut String, token_quoted: &mut bool) {
-    if !token.is_empty() {
+    // An explicitly quoted empty string (`''` / `""`) is a real argv entry
+    // in every shell (`ls ''` passes an empty argument and fails); dropping
+    // it would break the assessed-argv == executed-argv invariant.
+    if !token.is_empty() || *token_quoted {
         tokens.push(std::mem::take(token));
     }
     *token_quoted = false;

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
@@ -10,6 +10,17 @@ use super::command_risk::CommandShape;
 /// decision-matrix tests in `command_risk_tests.rs`.
 const SAFE_OUTPUT_SINKS: &[&str] = &["/dev/null"];
 
+/// Segment separator kind recorded at each `&&`/`||`/`;`/newline break.
+/// A single `&` also records a mark (background list separator) but the
+/// shape escalates to Complex, so its connector is never consumed by the
+/// compound path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SegmentConnector {
+    Seq,
+    And,
+    Or,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct ParsedCommand {
     pub(super) shape: CommandShape,
@@ -20,6 +31,12 @@ pub(super) struct ParsedCommand {
     /// command contains segment separators (used by the stripped-compound
     /// aggregation path).
     pub(super) segments: Vec<Vec<Vec<String>>>,
+    /// Connector kind for every recorded segment mark, in source order.
+    /// When no empty segment was swallowed, entry `i` is the connector
+    /// between `segments[i]` and `segments[i + 1]`; consumers must verify
+    /// `segment_connectors.len() == segments.len() - 1` before relying on
+    /// that pairing (a trailing separator leaves a dangling mark).
+    pub(super) segment_connectors: Vec<SegmentConnector>,
 }
 
 pub(super) fn parse_command(command: &str) -> ParsedCommand {
@@ -29,6 +46,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             stages: Vec::new(),
             null_redirections: 0,
             segments: Vec::new(),
+            segment_connectors: Vec::new(),
         };
     }
     if command.contains('\0') {
@@ -37,6 +55,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             stages: Vec::new(),
             null_redirections: 0,
             segments: Vec::new(),
+            segment_connectors: Vec::new(),
         };
     }
 
@@ -47,9 +66,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
     let mut quote: Option<char> = None;
     let mut null_redirections = 0usize;
     let mut amp_redirect_guard = false;
-    // Segment breaks recorded as (stage index, token offset) at each
-    // `&&`/`||`/`;`/newline, resolved into `segments` after parsing.
-    let mut segment_marks: Vec<(usize, usize)> = Vec::new();
+    // Segment breaks recorded as (stage index, token offset, connector)
+    // at each `&&`/`||`/`;`/newline, resolved into `segments` after
+    // parsing.
+    let mut segment_marks: Vec<(usize, usize, SegmentConnector)> = Vec::new();
     // Tracks whether the current token buffer contains quoted or escaped
     // content; such tokens are ordinary arguments and never fd prefixes.
     let mut token_quoted = false;
@@ -72,14 +92,14 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             ' ' | '\t' => push_token(&mut tokens, &mut token, &mut token_quoted),
             '\n' | ';' => {
                 push_token(&mut tokens, &mut token, &mut token_quoted);
-                segment_marks.push((stages.len(), tokens.len()));
+                segment_marks.push((stages.len(), tokens.len(), SegmentConnector::Seq));
                 shape = max_shape(shape, CommandShape::Sequence);
             }
             '|' => {
                 push_token(&mut tokens, &mut token, &mut token_quoted);
                 if chars.peek().is_some_and(|next| *next == '|') {
                     chars.next();
-                    segment_marks.push((stages.len(), tokens.len()));
+                    segment_marks.push((stages.len(), tokens.len(), SegmentConnector::Or));
                     shape = max_shape(shape, CommandShape::AndOrList);
                 } else {
                     stages.push(std::mem::take(&mut tokens));
@@ -90,7 +110,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                 push_token(&mut tokens, &mut token, &mut token_quoted);
                 if chars.peek().is_some_and(|next| *next == '&') {
                     chars.next();
-                    segment_marks.push((stages.len(), tokens.len()));
+                    segment_marks.push((stages.len(), tokens.len(), SegmentConnector::And));
                     shape = max_shape(shape, CommandShape::AndOrList);
                 } else {
                     shape = max_shape(shape, CommandShape::Complex);
@@ -103,7 +123,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                     // empty tail that the segment builder drops, so
                     // `ls &` still yields a single segment.
                     if !amp_redirect_guard {
-                        segment_marks.push((stages.len(), tokens.len()));
+                        // Shape already escalated to Complex, so this
+                        // connector is never consumed by the compound
+                        // path; the kind is irrelevant, pick Seq.
+                        segment_marks.push((stages.len(), tokens.len(), SegmentConnector::Seq));
                     }
                 }
             }
@@ -206,6 +229,7 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
             stages: Vec::new(),
             null_redirections: 0,
             segments: Vec::new(),
+            segment_connectors: Vec::new(),
         };
     }
     push_token(&mut tokens, &mut token, &mut token_quoted);
@@ -227,6 +251,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
     ParsedCommand {
         shape,
         segments: split_segments(&stages, &segment_marks),
+        segment_connectors: segment_marks
+            .iter()
+            .map(|&(_, _, connector)| connector)
+            .collect(),
         stages,
         null_redirections,
     }
@@ -235,7 +263,10 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
 /// Resolves the recorded segment marks into per-segment pipeline stages.
 /// Consecutive stages between two marks belong to the same segment; a mark
 /// splits the stage it points into at the recorded token offset.
-fn split_segments(stages: &[Vec<String>], marks: &[(usize, usize)]) -> Vec<Vec<Vec<String>>> {
+fn split_segments(
+    stages: &[Vec<String>],
+    marks: &[(usize, usize, SegmentConnector)],
+) -> Vec<Vec<Vec<String>>> {
     if marks.is_empty() {
         return Vec::new();
     }
@@ -244,7 +275,7 @@ fn split_segments(stages: &[Vec<String>], marks: &[(usize, usize)]) -> Vec<Vec<V
     let mut mark_iter = marks.iter().peekable();
     for (stage_index, stage) in stages.iter().enumerate() {
         let mut start = 0usize;
-        while let Some(&&(mark_stage, mark_offset)) = mark_iter.peek() {
+        while let Some(&&(mark_stage, mark_offset, _)) = mark_iter.peek() {
             if mark_stage != stage_index {
                 break;
             }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -942,3 +942,175 @@ fn fd_duplication_and_null_suppression_compose_independently() {
     assert!(null_only.reasons.contains(&"output-suppressed"));
     assert!(!null_only.reasons.contains(&"redirection-write"));
 }
+
+#[test]
+fn parser_preserves_explicitly_quoted_empty_arguments() {
+    // An empty quoted string (`''` / `""`) is a real argv entry in every
+    // shell: `ls ''` passes an empty path and fails. The parser must not
+    // drop it, or the assessed argv would diverge from what a shell
+    // executes (R5 review finding).
+    for command in ["ls ''", "ls \"\""] {
+        let parsed = super::command_risk_parser::parse_command(command);
+        assert_eq!(
+            parsed.stages,
+            vec![vec!["ls".to_string(), String::new()]],
+            "{command}"
+        );
+    }
+    // Interior empty quotes concatenated with text stay one token.
+    let parsed = super::command_risk_parser::parse_command("echo a''b");
+    assert_eq!(
+        parsed.stages,
+        vec![vec!["echo".to_string(), "ab".to_string()]]
+    );
+}
+
+#[test]
+fn compound_readonly_auto_executes_fully_whitelisted_compounds() {
+    // Issue #1882 FAIL→PASS anchor (S2 probe promoted): every segment
+    // carries direct-readonly evidence and the token sequence is
+    // executable as-is, so the compound auto-executes through the
+    // dedicated argv executor route in auto mode (design §3 M1-M3).
+    let policy = AutoExecutionPolicy::current_runtime();
+    for command in [
+        "pwd && df -h",
+        "pwd || df -h",
+        "pwd; df -h",
+        "pwd && df -h; git status --short",
+        // Token-rebuild fidelity extremes: the parser collapses runs of
+        // spaces/tabs at token boundaries the same way bash word
+        // splitting does, so the rebuilt text stays argv-faithful and
+        // these remain eligible.
+        "pwd   &&   df    -h",
+        "pwd\t&&\tdf -h",
+    ] {
+        let assessment = assess_shell_command(
+            command,
+            policy.assessment_policy(AssessmentSource::ProviderShellTool),
+        );
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AutoAllow,
+            "{command}"
+        );
+        assert_eq!(
+            assessment.auto_allow,
+            Some(AutoAllowEvidence::CompoundReadonly),
+            "{command}"
+        );
+        assert_eq!(
+            assessment.primary_reason(),
+            "compound-readonly",
+            "{command}"
+        );
+        assert_eq!(
+            policy.route(&assessment),
+            AutoExecutionRoute::CompoundReadonlyExecutor,
+            "{command}"
+        );
+    }
+}
+
+#[test]
+fn compound_readonly_auto_allow_covers_executor_widened_forms() {
+    // Issue #1882 design §3 widened rows (M2b/M10/M16-M18): the argv
+    // executor carries parser tokens verbatim, so newline separators,
+    // quoted tokens/separators, and history/glob/tilde/comment-shaped
+    // tokens all stay literal argv and the compound auto-executes.
+    let policy = AutoExecutionPolicy::current_runtime();
+    for command in [
+        "pwd\ndf -h",          // M2b: newline separator
+        "ls 'my dir' && pwd",  // M10: quoted token with space
+        "echo 'a && b' ; pwd", // M10: quoted separator
+        "echo !-2 && pwd",     // M16: history-shaped token stays literal
+        "ls *.log && pwd",     // M17: glob-shaped token stays literal
+        "ls ~ && pwd",         // M17: tilde-shaped token stays literal
+        "echo #x && pwd",      // M18: comment-shaped token stays literal
+    ] {
+        let assessment = assess_shell_command(
+            command,
+            policy.assessment_policy(AssessmentSource::ProviderShellTool),
+        );
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AutoAllow,
+            "{command}"
+        );
+        assert_eq!(
+            assessment.auto_allow,
+            Some(AutoAllowEvidence::CompoundReadonly),
+            "{command}"
+        );
+    }
+}
+
+#[test]
+fn compound_readonly_fails_closed_outside_the_eligible_envelope() {
+    // Issue #1882 design §3 ASK rows: every non-eligible form keeps the
+    // pre-fix AskUser boundary even in auto mode.
+    for command in [
+        "cd /tmp && git status",      // M4: segment without evidence
+        "touch /tmp/a && pwd",        // M4: mutating segment
+        "ps aux --sort=-%mem && pwd", // M5: guarded-diagnostic-only segment
+        "ps aux | head -5 && pwd",    // M6: pipeline segment
+        "pwd && df -h 2>/dev/null",   // M7: stripped null redirection
+        "wc -l < notes.txt && pwd",   // M8: read redirection shape
+        "pwd && echo $(id)",          // M9: command substitution
+        "git status \"foo\" && pwd",  // re-anchored: the quoted token
+        // parses fine, but the git readonly rule rejects the
+        // positional pathspec (condition 4 defers to the allowlist)
+        "pwd && echo $HOME",   // M11: bare expansion in a segment
+        "echo `pwd` && df -h", // M11: backtick substitution
+        "pwd && df\\ -h",      // re-anchored (design §3 M10b):
+        // the escaped space joins the token, so argv0 is the literal
+        // `df -h`, which is off the readonly allowlist
+        "pwd\u{000c}&&\u{000c}df -h", // re-anchored: form feed is not
+        // parser whitespace, so it stays inside the token and keeps
+        // argv0 off the allowlist (bash would exec `pwd\x0c` too)
+        "pwd\u{0007}&& df -h", // bell: same token-local class
+        "pwd\u{000b}&& df -h", // vertical tab: same token-local class
+        "(pwd) && df -h",      // M12: complex fail-closed (#1785)
+        "pwd & df -h",         // M12: background list separator
+        "pwd &&",              // M13: empty tail segment
+        "pwd && && df -h",     // M13: doubled separator swallows an
+                               // empty segment; the connector/segment invariant fails closed
+    ] {
+        let assessment = auto(command);
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AskUser,
+            "{command}"
+        );
+        assert!(assessment.auto_allow.is_none(), "{command}");
+    }
+}
+
+#[test]
+fn compound_readonly_grant_preserves_aggregated_assessment_fields() {
+    // Issue #1882 invariant I4: granting the evidence changes only the
+    // execution decision, the evidence, and the structural/evidence
+    // reason; every aggregated field stays identical to the ask path.
+    let allowed = auto("pwd && df -h");
+    let asked = ask("pwd && df -h");
+    // The ask-mode boundary stays explicit here in addition to the
+    // #1785 boundary-invariant loop above.
+    assert_eq!(asked.execution, ExecutionDecision::AskUser);
+    assert!(asked.auto_allow.is_none());
+    assert_eq!(allowed.impact, asked.impact);
+    assert_eq!(allowed.confidence, asked.confidence);
+    assert_eq!(allowed.interaction, asked.interaction);
+    assert_eq!(allowed.output_stability, asked.output_stability);
+    assert_eq!(allowed.output_exposure, asked.output_exposure);
+    assert_eq!(allowed.side_effects, asked.side_effects);
+    let allowed_rest: Vec<_> = allowed
+        .reasons
+        .iter()
+        .filter(|reason| **reason != "compound-readonly")
+        .collect();
+    let asked_rest: Vec<_> = asked
+        .reasons
+        .iter()
+        .filter(|reason| **reason != "and-or-list-not-auto-executable")
+        .collect();
+    assert_eq!(allowed_rest, asked_rest);
+}

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -750,3 +750,153 @@ fn adjacent_words_before_null_redirection_use_default_fd() {
         parsed.stages
     );
 }
+
+#[test]
+fn compound_readonly_auto_executes_fully_whitelisted_compounds() {
+    // Issue #1882 FAIL→PASS anchor (S2 probe promoted): every segment
+    // carries direct-readonly evidence and the token sequence is
+    // executable as-is, so the compound auto-executes through the
+    // dedicated argv executor route in auto mode (design §3 M1-M3).
+    let policy = AutoExecutionPolicy::current_runtime();
+    for command in [
+        "pwd && df -h",
+        "pwd || df -h",
+        "pwd; df -h",
+        "pwd && df -h; git status --short",
+        // Token-rebuild fidelity extremes: the parser collapses runs of
+        // spaces/tabs at token boundaries the same way bash word
+        // splitting does, so the rebuilt text stays argv-faithful and
+        // these remain eligible.
+        "pwd   &&   df    -h",
+        "pwd\t&&\tdf -h",
+    ] {
+        let assessment = assess_shell_command(
+            command,
+            policy.assessment_policy(AssessmentSource::ProviderShellTool),
+        );
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AutoAllow,
+            "{command}"
+        );
+        assert_eq!(
+            assessment.auto_allow,
+            Some(AutoAllowEvidence::CompoundReadonly),
+            "{command}"
+        );
+        assert_eq!(
+            assessment.primary_reason(),
+            "compound-readonly",
+            "{command}"
+        );
+        assert_eq!(
+            policy.route(&assessment),
+            AutoExecutionRoute::CompoundReadonlyExecutor,
+            "{command}"
+        );
+    }
+}
+
+#[test]
+fn compound_readonly_auto_allow_covers_executor_widened_forms() {
+    // Issue #1882 design §3 widened rows (M2b/M10/M16-M18): the argv
+    // executor carries parser tokens verbatim, so newline separators,
+    // quoted tokens/separators, and history/glob/tilde/comment-shaped
+    // tokens all stay literal argv and the compound auto-executes.
+    let policy = AutoExecutionPolicy::current_runtime();
+    for command in [
+        "pwd\ndf -h",          // M2b: newline separator
+        "ls 'my dir' && pwd",  // M10: quoted token with space
+        "echo 'a && b' ; pwd", // M10: quoted separator
+        "echo !-2 && pwd",     // M16: history-shaped token stays literal
+        "ls *.log && pwd",     // M17: glob-shaped token stays literal
+        "ls ~ && pwd",         // M17: tilde-shaped token stays literal
+        "echo #x && pwd",      // M18: comment-shaped token stays literal
+    ] {
+        let assessment = assess_shell_command(
+            command,
+            policy.assessment_policy(AssessmentSource::ProviderShellTool),
+        );
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AutoAllow,
+            "{command}"
+        );
+        assert_eq!(
+            assessment.auto_allow,
+            Some(AutoAllowEvidence::CompoundReadonly),
+            "{command}"
+        );
+    }
+}
+
+#[test]
+fn compound_readonly_fails_closed_outside_the_eligible_envelope() {
+    // Issue #1882 design §3 ASK rows: every non-eligible form keeps the
+    // pre-fix AskUser boundary even in auto mode.
+    for command in [
+        "cd /tmp && git status",      // M4: segment without evidence
+        "touch /tmp/a && pwd",        // M4: mutating segment
+        "ps aux --sort=-%mem && pwd", // M5: guarded-diagnostic-only segment
+        "ps aux | head -5 && pwd",    // M6: pipeline segment
+        "pwd && df -h 2>/dev/null",   // M7: stripped null redirection
+        "wc -l < notes.txt && pwd",   // M8: read redirection shape
+        "pwd && echo $(id)",          // M9: command substitution
+        "git status \"foo\" && pwd",  // re-anchored: the quoted token
+        // parses fine, but the git readonly rule rejects the
+        // positional pathspec (condition 4 defers to the allowlist)
+        "pwd && echo $HOME",   // M11: bare expansion in a segment
+        "echo `pwd` && df -h", // M11: backtick substitution
+        "pwd && df\\ -h",      // re-anchored (design §3 M10b):
+        // the escaped space joins the token, so argv0 is the literal
+        // `df -h`, which is off the readonly allowlist
+        "pwd\u{000c}&&\u{000c}df -h", // re-anchored: form feed is not
+        // parser whitespace, so it stays inside the token and keeps
+        // argv0 off the allowlist (bash would exec `pwd\x0c` too)
+        "pwd\u{0007}&& df -h", // bell: same token-local class
+        "pwd\u{000b}&& df -h", // vertical tab: same token-local class
+        "(pwd) && df -h",      // M12: complex fail-closed (#1785)
+        "pwd & df -h",         // M12: background list separator
+        "pwd &&",              // M13: empty tail segment
+        "pwd && && df -h",     // M13: doubled separator swallows an
+                               // empty segment; the connector/segment invariant fails closed
+    ] {
+        let assessment = auto(command);
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AskUser,
+            "{command}"
+        );
+        assert!(assessment.auto_allow.is_none(), "{command}");
+    }
+}
+
+#[test]
+fn compound_readonly_grant_preserves_aggregated_assessment_fields() {
+    // Issue #1882 invariant I4: granting the evidence changes only the
+    // execution decision, the evidence, and the structural/evidence
+    // reason; every aggregated field stays identical to the ask path.
+    let allowed = auto("pwd && df -h");
+    let asked = ask("pwd && df -h");
+    // The ask-mode boundary stays explicit here in addition to the
+    // #1785 boundary-invariant loop above.
+    assert_eq!(asked.execution, ExecutionDecision::AskUser);
+    assert!(asked.auto_allow.is_none());
+    assert_eq!(allowed.impact, asked.impact);
+    assert_eq!(allowed.confidence, asked.confidence);
+    assert_eq!(allowed.interaction, asked.interaction);
+    assert_eq!(allowed.output_stability, asked.output_stability);
+    assert_eq!(allowed.output_exposure, asked.output_exposure);
+    assert_eq!(allowed.side_effects, asked.side_effects);
+    let allowed_rest: Vec<_> = allowed
+        .reasons
+        .iter()
+        .filter(|reason| **reason != "compound-readonly")
+        .collect();
+    let asked_rest: Vec<_> = asked
+        .reasons
+        .iter()
+        .filter(|reason| **reason != "and-or-list-not-auto-executable")
+        .collect();
+    assert_eq!(allowed_rest, asked_rest);
+}

--- a/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
@@ -9,6 +9,9 @@ mod command_risk_parser;
 mod command_risk_tests;
 pub mod display;
 pub(crate) mod guarded_diagnostic;
+pub(crate) mod readonly_compound;
+#[cfg(test)]
+mod readonly_compound_tests;
 pub(crate) mod readonly_pipeline;
 pub(crate) mod readonly_rules;
 

--- a/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
@@ -9,6 +9,7 @@ mod command_risk_parser;
 mod command_risk_tests;
 pub mod display;
 pub(crate) mod guarded_diagnostic;
+pub(crate) mod readonly_compound;
 pub(crate) mod readonly_pipeline;
 pub(crate) mod readonly_rules;
 

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound.rs
@@ -1,0 +1,582 @@
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use super::broker;
+use super::command_risk::CommandShape;
+use super::command_risk_parser::{parse_command, SegmentConnector};
+use super::readonly_pipeline::{
+    error, limit_clean_text, wait_child_with_deadline, ReadonlyPipelineConfig,
+    ReadonlyPipelineError, ReadonlyPipelineOutput,
+};
+
+/// Execution plan for a fully-whitelisted compound command (issue #1882).
+/// The plan carries parser tokens verbatim: steps are spawned directly
+/// with `std::process::Command`, so no shell parsing layer ever touches
+/// the assessed text and every expansion mechanism (history, glob,
+/// tilde, parameter, alias, ...) is structurally inert — the assessed
+/// token sequence *is* the executed argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReadonlyCompoundPlan {
+    pub(crate) steps: Vec<ReadonlyCompoundStep>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReadonlyCompoundStep {
+    /// Connector between this step and the previous one; ignored on the
+    /// first step, which always runs.
+    pub(crate) connector: SegmentConnector,
+    /// Trusted absolute path resolved at plan-build time, so the
+    /// eligibility verdict and the executed binary can never diverge.
+    pub(crate) program: PathBuf,
+    pub(crate) argv: Vec<String>,
+}
+
+/// Builds an execution plan when — and only when — a compound command is
+/// eligible for auto-execution. Eligibility is exactly "a plan exists",
+/// so the assessment path and the execution path can never disagree
+/// about what would run. Returns `None` for every ineligible shape, in
+/// which case the caller keeps the pre-existing AskUser flow untouched.
+///
+/// Eligibility rules (design §2):
+/// 1. shape is `AndOrList` or `Sequence` (all other shapes fail closed);
+/// 2. no null-redirections were stripped by the parser (stripping loses
+///    the user's output-suppression intent);
+/// 3. at least two segments, and no empty segment was swallowed
+///    (connector count must equal the gap count);
+/// 4. every segment is exactly one stage (no pipeline segments);
+/// 5. every token is free of `$` and backtick (the executor does not
+///    expand, so expansion intent would diverge from execution);
+/// 6. every segment's token sequence passes the readonly allowlist via
+///    the same token-level predicate the broker uses (single source of
+///    truth; no text re-splitting, so quoted arguments keep their
+///    boundaries);
+/// 7. every segment's command resolves to a binary in the trusted
+///    system directories — eligibility and executability are one
+///    verdict, so a grant can never come back 127 at run time (a name
+///    only reachable through `PATH`, e.g. a rustup or Homebrew tool,
+///    stays on the AskUser path instead);
+/// 8. no segment is a context-observing command (`env`, `printenv`,
+///    `which`, `tty`): the executor runs a controlled environment
+///    with a null stdin, and reporting that context as if it were
+///    the interactive shell's live state would mislead — or, for
+///    `tty`, invert `&&`/`||` branches — so such requests stay on
+///    the AskUser path where the handoff shows the real shell state;
+/// 9. no segment would read from stdin: the executor's stdin is
+///    always null, so a bare `-` operand or a default-to-stdin
+///    filter without a file operand would report an instant
+///    empty-input result where the interactive shell reads the
+///    terminal instead.
+pub(crate) fn build_readonly_compound_plan(command: &str) -> Option<ReadonlyCompoundPlan> {
+    let parsed = parse_command(command);
+    if !matches!(
+        parsed.shape,
+        CommandShape::AndOrList | CommandShape::Sequence
+    ) {
+        return None;
+    }
+    if parsed.null_redirections > 0 {
+        return None;
+    }
+    if parsed.segments.len() < 2 {
+        return None;
+    }
+    if parsed.segment_connectors.len() != parsed.segments.len() - 1 {
+        // A doubled separator (`pwd && && df`) swallows an empty segment;
+        // bash would reject the line outright, so fail closed instead of
+        // executing a re-interpretation.
+        return None;
+    }
+
+    let mut steps = Vec::with_capacity(parsed.segments.len());
+    for (index, segment) in parsed.segments.iter().enumerate() {
+        if segment.len() != 1 {
+            return None;
+        }
+        let argv = &segment[0];
+        if argv.is_empty()
+            || argv.iter().any(|token| token.contains(['$', '`']))
+            || CONTEXT_OBSERVING_COMMANDS.contains(&argv[0].as_str())
+            || segment_reads_stdin(argv)
+            || !broker::configured_readonly_command(argv)
+        {
+            return None;
+        }
+        let program = resolve_trusted_executable(&argv[0])?;
+        steps.push(ReadonlyCompoundStep {
+            connector: if index == 0 {
+                SegmentConnector::Seq
+            } else {
+                parsed.segment_connectors[index - 1]
+            },
+            program,
+            argv: argv.clone(),
+        });
+    }
+    Some(ReadonlyCompoundPlan { steps })
+}
+
+/// Runs a compound plan with bash list semantics: `&&` runs the next
+/// step only when the previous executed step exited 0, `||` only when it
+/// exited non-zero, `;`/newline always; the overall exit code is the
+/// last executed step's code. Per-step stdout/stderr are concatenated in
+/// execution order with no annotations, matching what a terminal would
+/// have shown; each stream is bounded by the shared config budget and
+/// carries a single `<truncated>` marker once its budget is exhausted.
+/// Steps run with `cwd` as their working directory (the requesting
+/// shell's directory, not this process's). Executables resolve from
+/// the trusted system directories only — never the inherited `PATH` —
+/// and a name absent from every trusted directory reports 127 like a
+/// shell while list evaluation continues; a step ended by a signal
+/// reports 128+signum. Output is drained from pipes concurrently with
+/// a budget, so neither disk nor memory grows with the raw output
+/// size. Timeouts and executor failures fail the whole run with the
+/// same error contract as the readonly pipeline.
+pub(crate) fn run_readonly_compound(
+    plan: &ReadonlyCompoundPlan,
+    config: &ReadonlyPipelineConfig,
+    cwd: &Path,
+) -> Result<ReadonlyPipelineOutput, ReadonlyPipelineError> {
+    if plan.steps.is_empty() {
+        return Err(error(
+            "empty-plan",
+            "readonly compound requires at least one step",
+        ));
+    }
+    if !cwd.is_dir() {
+        // A missing working directory is an executor-environment
+        // failure, not a step result: reporting 127 would disguise it
+        // as command-not-found.
+        return Err(error(
+            "executor-io",
+            format!("working directory does not exist: {}", cwd.display()),
+        ));
+    }
+    let deadline = Instant::now() + config.total_timeout;
+    run_compound_steps(plan, config, cwd, deadline)
+}
+
+/// Directories a compound step's executable may resolve from: root-owned
+/// system paths only. Resolving here instead of through the inherited
+/// `PATH` closes the shadowing hole where a user-writable directory
+/// earlier in `PATH` provides a fake `pwd`/`cat` that would run without
+/// approval under an allowlisted name.
+const TRUSTED_EXECUTABLE_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+/// Environment keys passed through from the cosh process to a compound
+/// step. Everything else is cleared: the step must not observe the
+/// cosh process environment (provider credentials, transport state),
+/// and it cannot observe the requesting shell's live environment
+/// either — the executor runs a deterministic controlled environment,
+/// not an emulation of the interactive shell.
+const PASSTHROUGH_ENV_KEYS: &[&str] = &["HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ"];
+
+/// Commands whose result is a function of the execution context:
+/// under the executor's controlled environment (`env_clear` + trusted
+/// `PATH` + null stdin) they would answer differently from the
+/// interactive shell — `env`/`printenv` report variables, `which`
+/// resolves through the user's real `PATH`, and `tty` reports the
+/// terminal attached to stdin (exit 0 on the interactive PTY, exit 1
+/// on the executor's null stdin, inverting `&&`/`||` branches) — so
+/// they never receive a compound grant and stay on the AskUser path.
+const CONTEXT_OBSERVING_COMMANDS: &[&str] = &["env", "printenv", "which", "tty"];
+
+/// Allowlisted filters that read stdin when no file operand is given
+/// (`tr` always does — it never takes file operands). The executor
+/// cannot reproduce the interactive stdin, so such segments stay on
+/// the AskUser path.
+const STDIN_DEFAULT_FILTERS: &[&str] = &["sort", "uniq", "cut", "fold", "expand", "unexpand"];
+
+/// True when a segment would read from the executor's (null) stdin
+/// instead of a file: a bare `-` operand anywhere (the readonly path
+/// checks reject `-` before `--` but not after it), `tr` in any form,
+/// or a stdin-default filter without a definite file operand. Operand
+/// detection is conservative — a non-flag token directly following a
+/// flag-like token might be that flag's value, so it does not count
+/// and the segment falls back to AskUser (fails closed).
+fn segment_reads_stdin(argv: &[String]) -> bool {
+    if argv.iter().any(|token| token == "-") {
+        return true;
+    }
+    if argv[0] == "tr" {
+        return true;
+    }
+    if !STDIN_DEFAULT_FILTERS.contains(&argv[0].as_str()) {
+        return false;
+    }
+    let has_file_operand = argv
+        .iter()
+        .enumerate()
+        .skip(1)
+        .any(|(index, token)| !token.starts_with('-') && !argv[index - 1].starts_with('-'));
+    !has_file_operand
+}
+
+/// Resolves an allowlisted command name to a trusted system binary, or
+/// `None` when no trusted directory provides it. Called at plan-build
+/// time so eligibility and executability are one verdict. Plan argv
+/// never carries `/` — the readonly rules match bare names only — so a
+/// path-qualified program can never bypass this resolution.
+pub(super) fn resolve_trusted_executable(name: &str) -> Option<PathBuf> {
+    if name.contains('/') {
+        return None;
+    }
+    TRUSTED_EXECUTABLE_DIRS.iter().find_map(|dir| {
+        let candidate = Path::new(dir).join(name);
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+fn run_compound_steps(
+    plan: &ReadonlyCompoundPlan,
+    config: &ReadonlyPipelineConfig,
+    cwd: &Path,
+    deadline: Instant,
+) -> Result<ReadonlyPipelineOutput, ReadonlyPipelineError> {
+    let mut final_exit_code = None;
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut stdout_exhausted = false;
+    let mut stderr_exhausted = false;
+
+    for (index, step) in plan.steps.iter().enumerate() {
+        if index > 0 {
+            let previous_code = final_exit_code.unwrap_or(0);
+            let should_run = match step.connector {
+                SegmentConnector::Seq => true,
+                SegmentConnector::And => previous_code == 0,
+                SegmentConnector::Or => previous_code != 0,
+            };
+            if !should_run {
+                continue;
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(error("compound-timeout", "readonly compound timed out"));
+        }
+
+        let mut command = Command::new(&step.program);
+        command
+            .args(&step.argv[1..])
+            .current_dir(cwd)
+            // Deterministic controlled environment: never the cosh
+            // process env (credentials must not leak into auto-executed
+            // output) and never a fake of the interactive shell env.
+            .env_clear()
+            .env("PATH", TRUSTED_EXECUTABLE_DIRS.join(":"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for key in PASSTHROUGH_ENV_KEYS {
+            if let Some(value) = std::env::var_os(key) {
+                command.env(key, value);
+            }
+        }
+        // Each step leads its own process group so a deadline expiry
+        // can reap the whole descendant tree, not just the direct
+        // child.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                // The binary vanished between plan build and spawn:
+                // keep the shell-style 127 contract, paying the
+                // synthetic error line into the stderr budget.
+                append_bounded_text(
+                    &mut stderr,
+                    &format!("{}: command not found\n", step.argv[0]),
+                    config,
+                    &mut stderr_exhausted,
+                );
+                final_exit_code = Some(127);
+                continue;
+            }
+            Err(err) => {
+                return Err(error("executor-spawn", format!("{}: {err}", step.argv[0])));
+            }
+        };
+        // Drain both pipes concurrently with the wait loop: bytes within
+        // the remaining budget are kept, overflow is read and discarded,
+        // so the child never blocks on a full pipe and neither disk nor
+        // memory grows with the raw output size.
+        let stdout_drain = drain_capture(
+            child.stdout.take(),
+            remaining_budget(&stdout, config, stdout_exhausted),
+        );
+        let stderr_drain = drain_capture(
+            child.stderr.take(),
+            remaining_budget(&stderr, config, stderr_exhausted),
+        );
+        let stage_deadline = Instant::now()
+            + config
+                .stage_timeout
+                .min(deadline.saturating_duration_since(Instant::now()));
+        let child_pid = child.id();
+        let waited = wait_child_with_deadline(&mut child, stage_deadline, step.argv.join(" "));
+        // Terminate the step's whole process group as soon as the
+        // direct child is done — unconditionally (R9): a descendant
+        // that redirected its output away from the pipes lets both
+        // drains finish normally, so group cleanup must not be keyed
+        // off a pending drain. The drains are then joined within the
+        // deadline (write ends are gone, EOF arrives promptly).
+        kill_process_group(child_pid);
+        let (stdout_bytes, stdout_overflow) = join_capture(stdout_drain, stage_deadline);
+        let (stderr_bytes, stderr_overflow) = join_capture(stderr_drain, stage_deadline);
+        final_exit_code = waited?;
+
+        append_step_output(
+            &mut stdout,
+            &stdout_bytes,
+            stdout_overflow,
+            config,
+            &mut stdout_exhausted,
+        );
+        append_step_output(
+            &mut stderr,
+            &stderr_bytes,
+            stderr_overflow,
+            config,
+            &mut stderr_exhausted,
+        );
+    }
+
+    Ok(ReadonlyPipelineOutput {
+        exit_code: final_exit_code,
+        stdout,
+        stderr,
+    })
+}
+
+/// Remaining byte budget for one stream; zero once the stream already
+/// carries its `<truncated>` marker so later steps drain-and-discard.
+fn remaining_budget(aggregate: &str, config: &ReadonlyPipelineConfig, exhausted: bool) -> usize {
+    if exhausted {
+        0
+    } else {
+        config.output_limit_bytes.saturating_sub(aggregate.len())
+    }
+}
+
+/// Live reader-thread tally: lets tests assert that every drain
+/// reader is joined by the time a run returns, even when the pipe
+/// write end is still held open by an escaped descendant.
+#[cfg(test)]
+pub(super) static LIVE_READER_THREADS: std::sync::atomic::AtomicIsize =
+    std::sync::atomic::AtomicIsize::new(0);
+
+#[cfg(test)]
+struct ReaderThreadTally;
+
+#[cfg(test)]
+impl ReaderThreadTally {
+    fn new() -> Self {
+        LIVE_READER_THREADS.fetch_add(1, Ordering::SeqCst);
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for ReaderThreadTally {
+    fn drop(&mut self) {
+        LIVE_READER_THREADS.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// One stream's drain in progress: the reader thread appends into the
+/// shared snapshot, so a deadline-bounded join can take whatever has
+/// arrived without waiting for pipe EOF, and the cancel flag lets the
+/// join reclaim a reader whose pipe never reaches EOF (a descendant
+/// that escaped the process group can hold the write end open).
+struct DrainCapture {
+    handle: JoinHandle<()>,
+    snapshot: Arc<Mutex<(Vec<u8>, bool)>>,
+    cancel: Arc<AtomicBool>,
+}
+
+/// Reads a child pipe on a dedicated thread, keeping at most `budget`
+/// bytes in the shared snapshot and discarding the rest, and records
+/// whether the stream overflowed the budget. The read loop polls with
+/// a short interval and re-checks the cancel flag between polls, so
+/// the thread is always joinable within one poll interval plus one
+/// read — it never blocks indefinitely on a pipe whose write end is
+/// held open by an escaped descendant.
+#[cfg(unix)]
+fn drain_capture(
+    stream: Option<impl Read + std::os::unix::io::AsRawFd + Send + 'static>,
+    budget: usize,
+) -> Option<DrainCapture> {
+    let mut stream = stream?;
+    let snapshot = Arc::new(Mutex::new((Vec::new(), false)));
+    let cancel = Arc::new(AtomicBool::new(false));
+    let writer = Arc::clone(&snapshot);
+    let cancelled = Arc::clone(&cancel);
+    let handle = std::thread::spawn(move || {
+        #[cfg(test)]
+        let _tally = ReaderThreadTally::new();
+        let fd = stream.as_raw_fd();
+        let mut buffer = [0u8; 8192];
+        while !cancelled.load(Ordering::Relaxed) {
+            let mut poll_fd = nix::libc::pollfd {
+                fd,
+                events: nix::libc::POLLIN,
+                revents: 0,
+            };
+            let ready = unsafe { nix::libc::poll(&mut poll_fd, 1, 50) };
+            if ready < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                break;
+            }
+            if ready == 0 {
+                continue;
+            }
+            match stream.read(&mut buffer) {
+                Ok(0) | Err(_) => break,
+                Ok(read) => {
+                    let Ok(mut state) = writer.lock() else {
+                        break;
+                    };
+                    let room = budget.saturating_sub(state.0.len());
+                    if read > room {
+                        state.1 = true;
+                    }
+                    state.0.extend_from_slice(&buffer[..read.min(room)]);
+                }
+            }
+        }
+    });
+    Some(DrainCapture {
+        handle,
+        snapshot,
+        cancel,
+    })
+}
+
+/// Non-unix fallback without `poll`: a blocking read loop that
+/// re-checks the cancel flag after every read, so a cancelled join
+/// completes as soon as the current read returns (process teardown
+/// closes the write ends and unblocks it).
+#[cfg(not(unix))]
+fn drain_capture(
+    stream: Option<impl Read + Send + 'static>,
+    budget: usize,
+) -> Option<DrainCapture> {
+    let mut stream = stream?;
+    let snapshot = Arc::new(Mutex::new((Vec::new(), false)));
+    let cancel = Arc::new(AtomicBool::new(false));
+    let writer = Arc::clone(&snapshot);
+    let cancelled = Arc::clone(&cancel);
+    let handle = std::thread::spawn(move || {
+        let mut buffer = [0u8; 8192];
+        while !cancelled.load(Ordering::Relaxed) {
+            match stream.read(&mut buffer) {
+                Ok(0) | Err(_) => break,
+                Ok(read) => {
+                    let Ok(mut state) = writer.lock() else {
+                        break;
+                    };
+                    let room = budget.saturating_sub(state.0.len());
+                    if read > room {
+                        state.1 = true;
+                    }
+                    state.0.extend_from_slice(&buffer[..read.min(room)]);
+                }
+            }
+        }
+    });
+    Some(DrainCapture {
+        handle,
+        snapshot,
+        cancel,
+    })
+}
+
+/// Joins a drain within the stage deadline and takes the final
+/// capture. The step's process group is terminated before this join,
+/// so EOF normally arrives promptly; if the pipe never reaches EOF
+/// (an escaped descendant holds the write end open), the cancel flag
+/// stops the poll loop and the join completes within one poll
+/// interval plus one read — no reader thread is ever dropped
+/// unjoined.
+fn join_capture(capture: Option<DrainCapture>, deadline: Instant) -> (Vec<u8>, bool) {
+    let Some(capture) = capture else {
+        return Default::default();
+    };
+    while !capture.handle.is_finished() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    capture.cancel.store(true, Ordering::Relaxed);
+    let _ = capture.handle.join();
+    capture
+        .snapshot
+        .lock()
+        .map(|state| state.clone())
+        .unwrap_or_default()
+}
+
+/// Terminates a step's whole process group (the child was spawned as
+/// the group leader) so descendants cannot outlive the deadline and
+/// keep pipes, threads, or CPU alive across auto-executions. The
+/// result is checked: ESRCH just means every group member already
+/// exited, anything else is surfaced for diagnosis (the drain cancel
+/// path still bounds the join even when the kill fails).
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    let killed = unsafe { nix::libc::killpg(pid as nix::libc::pid_t, nix::libc::SIGKILL) };
+    if killed != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(nix::libc::ESRCH) {
+            tracing::warn!(pid, error = %err, "readonly compound process group kill failed");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(_pid: u32) {}
+
+/// Appends one step's captured bytes to the aggregate under the
+/// remaining budget; once a step overflows, the `<truncated>` marker
+/// terminates the aggregate and later steps are skipped for that
+/// stream.
+fn append_step_output(
+    aggregate: &mut String,
+    bytes: &[u8],
+    overflowed: bool,
+    config: &ReadonlyPipelineConfig,
+    exhausted: &mut bool,
+) {
+    if *exhausted {
+        return;
+    }
+    let remaining_bytes = config.output_limit_bytes.saturating_sub(aggregate.len());
+    let remaining_lines = config
+        .output_limit_lines
+        .saturating_sub(aggregate.lines().count());
+    let chunk = limit_clean_text(bytes, overflowed, remaining_bytes, remaining_lines);
+    if chunk.ends_with("<truncated>") {
+        *exhausted = true;
+    }
+    aggregate.push_str(&chunk);
+}
+
+/// Pays a synthetic executor-generated line (e.g. the 127 error) into
+/// the same stream budget as real step output.
+fn append_bounded_text(
+    aggregate: &mut String,
+    text: &str,
+    config: &ReadonlyPipelineConfig,
+    exhausted: &mut bool,
+) {
+    append_step_output(aggregate, text.as_bytes(), false, config, exhausted);
+}

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound.rs
@@ -1,0 +1,400 @@
+use std::fs::File;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use super::broker;
+use super::command_risk::CommandShape;
+use super::command_risk_parser::{parse_command, SegmentConnector};
+use super::readonly_pipeline::{
+    cleanup_paths, error, read_limited_clean, temp_path, wait_child_with_deadline,
+    ReadonlyPipelineConfig, ReadonlyPipelineError, ReadonlyPipelineOutput,
+};
+
+/// Execution plan for a fully-whitelisted compound command (issue #1882).
+/// The plan carries parser tokens verbatim: steps are spawned directly
+/// with `std::process::Command`, so no shell parsing layer ever touches
+/// the assessed text and every expansion mechanism (history, glob,
+/// tilde, parameter, alias, ...) is structurally inert — the assessed
+/// token sequence *is* the executed argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReadonlyCompoundPlan {
+    pub(crate) steps: Vec<ReadonlyCompoundStep>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReadonlyCompoundStep {
+    /// Connector between this step and the previous one; ignored on the
+    /// first step, which always runs.
+    pub(crate) connector: SegmentConnector,
+    pub(crate) argv: Vec<String>,
+}
+
+/// Builds an execution plan when — and only when — a compound command is
+/// eligible for auto-execution. Eligibility is exactly "a plan exists",
+/// so the assessment path and the execution path can never disagree
+/// about what would run. Returns `None` for every ineligible shape, in
+/// which case the caller keeps the pre-existing AskUser flow untouched.
+///
+/// Eligibility rules (design §2):
+/// 1. shape is `AndOrList` or `Sequence` (all other shapes fail closed);
+/// 2. no null-redirections were stripped by the parser (stripping loses
+///    the user's output-suppression intent);
+/// 3. at least two segments, and no empty segment was swallowed
+///    (connector count must equal the gap count);
+/// 4. every segment is exactly one stage (no pipeline segments);
+/// 5. every token is free of `$` and backtick (the executor does not
+///    expand, so expansion intent would diverge from execution);
+/// 6. every segment's token sequence passes the readonly allowlist via
+///    the same token-level predicate the broker uses (single source of
+///    truth; no text re-splitting, so quoted arguments keep their
+///    boundaries).
+pub(crate) fn build_readonly_compound_plan(command: &str) -> Option<ReadonlyCompoundPlan> {
+    let parsed = parse_command(command);
+    if !matches!(
+        parsed.shape,
+        CommandShape::AndOrList | CommandShape::Sequence
+    ) {
+        return None;
+    }
+    if parsed.null_redirections > 0 {
+        return None;
+    }
+    if parsed.segments.len() < 2 {
+        return None;
+    }
+    if parsed.segment_connectors.len() != parsed.segments.len() - 1 {
+        // A doubled separator (`pwd && && df`) swallows an empty segment;
+        // bash would reject the line outright, so fail closed instead of
+        // executing a re-interpretation.
+        return None;
+    }
+
+    let mut steps = Vec::with_capacity(parsed.segments.len());
+    for (index, segment) in parsed.segments.iter().enumerate() {
+        if segment.len() != 1 {
+            return None;
+        }
+        let argv = &segment[0];
+        if argv.is_empty()
+            || argv.iter().any(|token| token.contains(['$', '`']))
+            || !broker::configured_readonly_command(argv)
+        {
+            return None;
+        }
+        steps.push(ReadonlyCompoundStep {
+            connector: if index == 0 {
+                SegmentConnector::Seq
+            } else {
+                parsed.segment_connectors[index - 1]
+            },
+            argv: argv.clone(),
+        });
+    }
+    Some(ReadonlyCompoundPlan { steps })
+}
+
+/// Runs a compound plan with bash list semantics: `&&` runs the next
+/// step only when the previous executed step exited 0, `||` only when it
+/// exited non-zero, `;`/newline always; the overall exit code is the
+/// last executed step's code. Per-step stdout/stderr are concatenated in
+/// execution order with no annotations, matching what a terminal would
+/// have shown; each stream is bounded by the shared config budget and
+/// carries a single `<truncated>` marker once its budget is exhausted.
+/// Timeouts and spawn/io failures fail the whole run with the same
+/// error contract as the readonly pipeline.
+pub(crate) fn run_readonly_compound(
+    plan: &ReadonlyCompoundPlan,
+    config: &ReadonlyPipelineConfig,
+) -> Result<ReadonlyPipelineOutput, ReadonlyPipelineError> {
+    if plan.steps.is_empty() {
+        return Err(error(
+            "empty-plan",
+            "readonly compound requires at least one step",
+        ));
+    }
+    let deadline = Instant::now() + config.total_timeout;
+    let mut cleanup = Vec::new();
+    let mut final_exit_code = None;
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut stdout_exhausted = false;
+    let mut stderr_exhausted = false;
+
+    for (index, step) in plan.steps.iter().enumerate() {
+        if index > 0 {
+            let previous_code = final_exit_code.unwrap_or(0);
+            let should_run = match step.connector {
+                SegmentConnector::Seq => true,
+                SegmentConnector::And => previous_code == 0,
+                SegmentConnector::Or => previous_code != 0,
+            };
+            if !should_run {
+                continue;
+            }
+        }
+        if Instant::now() >= deadline {
+            cleanup_paths(&cleanup);
+            return Err(error("compound-timeout", "readonly compound timed out"));
+        }
+
+        let stdout_path = temp_path("stdout", index);
+        let stderr_path = temp_path("stderr", index);
+        cleanup.push(stdout_path.clone());
+        cleanup.push(stderr_path.clone());
+
+        let stdout_file = File::create(&stdout_path)
+            .map_err(|err| error("executor-io", format!("create stdout: {err}")))?;
+        let stderr_file = File::create(&stderr_path)
+            .map_err(|err| error("executor-io", format!("create stderr: {err}")))?;
+
+        let mut command = Command::new(&step.argv[0]);
+        command
+            .args(&step.argv[1..])
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout_file))
+            .stderr(Stdio::from(stderr_file));
+
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                cleanup_paths(&cleanup);
+                return Err(error("executor-spawn", format!("{}: {err}", step.argv[0])));
+            }
+        };
+        let stage_deadline = Instant::now()
+            + config
+                .stage_timeout
+                .min(deadline.saturating_duration_since(Instant::now()));
+        match wait_child_with_deadline(&mut child, stage_deadline, step.argv.join(" ")) {
+            Ok(code) => final_exit_code = code,
+            Err(err) => {
+                cleanup_paths(&cleanup);
+                return Err(err);
+            }
+        }
+
+        append_step_output(&mut stdout, &stdout_path, config, &mut stdout_exhausted)?;
+        append_step_output(&mut stderr, &stderr_path, config, &mut stderr_exhausted)?;
+    }
+
+    cleanup_paths(&cleanup);
+    Ok(ReadonlyPipelineOutput {
+        exit_code: final_exit_code,
+        stdout,
+        stderr,
+    })
+}
+
+/// Appends one step's captured stream to the aggregate under the
+/// remaining budget; once a step overflows the remaining budget the
+/// `<truncated>` marker from `read_limited_clean` terminates the
+/// aggregate and later steps are skipped for that stream.
+fn append_step_output(
+    aggregate: &mut String,
+    path: &Path,
+    config: &ReadonlyPipelineConfig,
+    exhausted: &mut bool,
+) -> Result<(), ReadonlyPipelineError> {
+    if *exhausted {
+        return Ok(());
+    }
+    let remaining_bytes = config.output_limit_bytes.saturating_sub(aggregate.len());
+    let remaining_lines = config
+        .output_limit_lines
+        .saturating_sub(aggregate.lines().count());
+    let chunk = read_limited_clean(path, remaining_bytes, remaining_lines)?;
+    if chunk.ends_with("<truncated>") {
+        *exhausted = true;
+    }
+    aggregate.push_str(&chunk);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan(command: &str) -> ReadonlyCompoundPlan {
+        build_readonly_compound_plan(command).expect("eligible compound")
+    }
+
+    /// Builds a plan directly, bypassing eligibility: executor-mechanism
+    /// tests need `true`/`false`/free-form argv that the readonly
+    /// allowlist (correctly) never grants.
+    fn raw_plan(steps: &[(&[&str], SegmentConnector)]) -> ReadonlyCompoundPlan {
+        ReadonlyCompoundPlan {
+            steps: steps
+                .iter()
+                .map(|(argv, connector)| ReadonlyCompoundStep {
+                    connector: *connector,
+                    argv: argv.iter().map(ToString::to_string).collect(),
+                })
+                .collect(),
+        }
+    }
+
+    fn run_plan(plan: &ReadonlyCompoundPlan) -> ReadonlyPipelineOutput {
+        run_readonly_compound(plan, &ReadonlyPipelineConfig::default()).expect("compound run")
+    }
+
+    use SegmentConnector::{And, Or, Seq};
+
+    #[test]
+    fn build_plan_keeps_connector_sequence() {
+        let plan = plan("pwd && df -h; git status --short || pwd");
+        assert_eq!(plan.steps.len(), 4);
+        let connectors: Vec<SegmentConnector> =
+            plan.steps.iter().map(|step| step.connector).collect();
+        assert_eq!(
+            connectors,
+            vec![
+                SegmentConnector::Seq,
+                SegmentConnector::And,
+                SegmentConnector::Seq,
+                SegmentConnector::Or,
+            ]
+        );
+        assert_eq!(plan.steps[1].argv, vec!["df", "-h"]);
+    }
+
+    #[test]
+    fn build_plan_accepts_quoted_and_newline_forms() {
+        let quoted = plan("ls 'my dir' && pwd");
+        assert_eq!(quoted.steps[0].argv, vec!["ls", "my dir"]);
+        let multiline = plan("pwd\ndf -h");
+        assert_eq!(multiline.steps.len(), 2);
+        assert_eq!(multiline.steps[1].connector, SegmentConnector::Seq);
+    }
+
+    #[test]
+    fn build_plan_fails_closed_for_ineligible_shapes() {
+        for command in [
+            // non-allowlisted segment
+            "cd /tmp && git status",
+            "touch /tmp/a && pwd",
+            // pipeline segment
+            "ps aux | head -5 && pwd",
+            // null redirection stripped by the parser
+            "pwd && df -h 2>/dev/null",
+            // read redirection
+            "wc -l < notes.txt && pwd",
+            // write redirection / command substitution (dominant shapes)
+            "pwd && echo x > f",
+            "pwd && echo $(id)",
+            "pwd && echo `id`",
+            // expansion intent the executor would not honor
+            "pwd && echo $HOME",
+            // complex shapes
+            "(pwd) && df -h",
+            "pwd & df -h",
+            // doubled separator swallows an empty segment
+            "pwd && && df -h",
+            // trailing separator leaves a single segment
+            "pwd &&",
+            // not a compound at all
+            "pwd",
+        ] {
+            assert!(
+                build_readonly_compound_plan(command).is_none(),
+                "{command} must stay ineligible"
+            );
+        }
+    }
+
+    #[test]
+    fn executor_short_circuits_like_bash() {
+        // `&&` after success runs the next step.
+        let output = run_plan(&raw_plan(&[
+            (&["echo", "first"], Seq),
+            (&["echo", "second"], And),
+        ]));
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, "first\nsecond\n");
+        // `&&` after failure skips it; the failing code is preserved.
+        let output = run_plan(&raw_plan(&[(&["false"], Seq), (&["echo", "second"], And)]));
+        assert_eq!(output.exit_code, Some(1));
+        assert_eq!(output.stdout, "");
+        // `||` after success skips the next step.
+        let output = run_plan(&raw_plan(&[(&["true"], Seq), (&["echo", "second"], Or)]));
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, "");
+        // `||` after failure runs it.
+        let output = run_plan(&raw_plan(&[(&["false"], Seq), (&["echo", "second"], Or)]));
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, "second\n");
+        // `;` always runs the next step.
+        let output = run_plan(&raw_plan(&[(&["false"], Seq), (&["echo", "second"], Seq)]));
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, "second\n");
+        // Left-associative chain: `false || false && echo ok` runs nothing
+        // after the first failure pair, exit code is the last executed step.
+        let output = run_plan(&raw_plan(&[
+            (&["false"], Seq),
+            (&["false"], Or),
+            (&["echo", "ok"], And),
+        ]));
+        assert_eq!(output.exit_code, Some(1));
+        assert_eq!(output.stdout, "");
+        // `true && false || echo x` matches bash left-associativity.
+        let output = run_plan(&raw_plan(&[
+            (&["true"], Seq),
+            (&["false"], And),
+            (&["echo", "x"], Or),
+        ]));
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, "x\n");
+    }
+
+    #[test]
+    fn executor_passes_tokens_verbatim() {
+        // Every character class that a shell would expand (history
+        // expansion trigger, glob, tilde, comment lead, spaces inside
+        // quotes) reaches the process argv untouched.
+        let output = run_plan(&raw_plan(&[(
+            &["echo", "a b", "!-2", "*.log", "~", "#x"],
+            Seq,
+        )]));
+        assert_eq!(output.exit_code, Some(0));
+        assert_eq!(output.stdout, "a b !-2 *.log ~ #x\n");
+    }
+
+    // The shell control group for the no-parsing-layer evidence lives in
+    // the integration layer (`tests/logic/tools.rs`): check-layout.sh
+    // forbids new subprocess spawns in `src` test code, and
+    // `executor_passes_tokens_verbatim` above covers the executor half.
+
+    #[test]
+    fn executor_bounds_aggregate_output() {
+        let plan = raw_plan(&[
+            (&["echo", "first"], Seq),
+            (&["echo", "second"], Seq),
+            (&["echo", "third"], Seq),
+        ]);
+        let output = run_readonly_compound(
+            &plan,
+            &ReadonlyPipelineConfig {
+                output_limit_bytes: 12,
+                ..ReadonlyPipelineConfig::default()
+            },
+        )
+        .expect("bounded run");
+        assert!(output.stdout.contains("<truncated>"), "{}", output.stdout);
+        assert!(output.stdout.len() <= 32, "{}", output.stdout);
+    }
+
+    #[test]
+    fn executor_enforces_stage_timeout() {
+        let plan = raw_plan(&[(&["sleep", "2"], Seq), (&["echo", "second"], Seq)]);
+        let err = run_readonly_compound(
+            &plan,
+            &ReadonlyPipelineConfig {
+                stage_timeout: std::time::Duration::from_millis(20),
+                total_timeout: std::time::Duration::from_secs(10),
+                ..ReadonlyPipelineConfig::default()
+            },
+        )
+        .expect_err("stage must time out");
+        assert_eq!(err.reason, "stage-timeout");
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound_tests.rs
@@ -1,0 +1,633 @@
+use super::command_risk_parser::SegmentConnector;
+use super::readonly_compound::*;
+use super::readonly_pipeline::{limit_clean_text, ReadonlyPipelineConfig, ReadonlyPipelineOutput};
+use std::path::Path;
+
+use super::*;
+
+fn plan(command: &str) -> ReadonlyCompoundPlan {
+    build_readonly_compound_plan(command).expect("eligible compound")
+}
+
+/// Builds a plan directly, bypassing eligibility: executor-mechanism
+/// tests need `true`/`false`/free-form argv that the readonly
+/// allowlist (correctly) never grants. Programs resolve through the
+/// trusted directories like a real plan; a name that does not resolve
+/// keeps its bare form so spawn reports the command-not-found path.
+fn raw_plan(steps: &[(&[&str], SegmentConnector)]) -> ReadonlyCompoundPlan {
+    ReadonlyCompoundPlan {
+        steps: steps
+            .iter()
+            .map(|(argv, connector)| ReadonlyCompoundStep {
+                connector: *connector,
+                program: resolve_trusted_executable(argv[0])
+                    .unwrap_or_else(|| std::path::PathBuf::from(argv[0])),
+                argv: argv.iter().map(ToString::to_string).collect(),
+            })
+            .collect(),
+    }
+}
+
+fn run_plan(plan: &ReadonlyCompoundPlan) -> ReadonlyPipelineOutput {
+    run_readonly_compound(plan, &ReadonlyPipelineConfig::default(), Path::new("/"))
+        .expect("compound run")
+}
+
+use SegmentConnector::{And, Or, Seq};
+
+#[test]
+fn build_plan_keeps_connector_sequence() {
+    let plan = plan("pwd && df -h; git status --short || pwd");
+    assert_eq!(plan.steps.len(), 4);
+    let connectors: Vec<SegmentConnector> = plan.steps.iter().map(|step| step.connector).collect();
+    assert_eq!(
+        connectors,
+        vec![
+            SegmentConnector::Seq,
+            SegmentConnector::And,
+            SegmentConnector::Seq,
+            SegmentConnector::Or,
+        ]
+    );
+    assert_eq!(plan.steps[1].argv, vec!["df", "-h"]);
+    // R7: eligibility and executability are one verdict — every step
+    // carries a trusted absolute program resolved at plan-build time.
+    for step in &plan.steps {
+        assert!(
+            step.program.is_absolute() && step.program.is_file(),
+            "{:?}",
+            step.program
+        );
+    }
+}
+
+#[test]
+fn build_plan_accepts_quoted_and_newline_forms() {
+    let quoted = plan("ls 'my dir' && pwd");
+    assert_eq!(quoted.steps[0].argv, vec!["ls", "my dir"]);
+    let multiline = plan("pwd\ndf -h");
+    assert_eq!(multiline.steps.len(), 2);
+    assert_eq!(multiline.steps[1].connector, SegmentConnector::Seq);
+}
+
+#[test]
+fn build_plan_fails_closed_for_ineligible_shapes() {
+    for command in [
+        // non-allowlisted segment
+        "cd /tmp && git status",
+        "touch /tmp/a && pwd",
+        // pipeline segment
+        "ps aux | head -5 && pwd",
+        // null redirection stripped by the parser
+        "pwd && df -h 2>/dev/null",
+        // read redirection
+        "wc -l < notes.txt && pwd",
+        // write redirection / command substitution (dominant shapes)
+        "pwd && echo x > f",
+        "pwd && echo $(id)",
+        "pwd && echo `id`",
+        // expansion intent the executor would not honor
+        "pwd && echo $HOME",
+        // complex shapes
+        "(pwd) && df -h",
+        "pwd & df -h",
+        // doubled separator swallows an empty segment
+        "pwd && && df -h",
+        // explicitly quoted empty argument: a real shell passes it
+        // through (`ls ''` fails on an empty path), so silently
+        // dropping it would fork assessed argv from shell behavior
+        "ls '' && pwd",
+        "ls \"\" && pwd",
+        // environment-observing commands: the executor's controlled
+        // environment is not the interactive shell's live state (R8)
+        "env && pwd",
+        "pwd && printenv",
+        "printenv HOME || pwd",
+        // `which` resolves through the user's real PATH; the executor's
+        // trusted PATH would answer differently (R9)
+        "which cargo || pwd",
+        "pwd && which git",
+        // `tty` reports the terminal attached to stdin: exit 0 on the
+        // interactive PTY, exit 1 on the executor's null stdin, so the
+        // `||` branch would invert
+        "tty || pwd",
+        "pwd && tty",
+        // stdin readers: the executor's null stdin would report an
+        // instant empty-input result where the interactive shell
+        // reads the terminal — a bare `-` operand (even behind `--`),
+        // `tr` (a pure stdin filter), and default-to-stdin filters
+        // without a file operand all stay on the AskUser path
+        "cat -- - && pwd",
+        "tr a b && pwd",
+        "sort && pwd",
+        "uniq || pwd",
+        "cut -f1 && pwd",
+        "fold -w 10 && pwd",
+        "sort -r /etc/hosts && pwd",
+        // trailing separator leaves a single segment
+        "pwd &&",
+        // not a compound at all
+        "pwd",
+    ] {
+        assert!(
+            build_readonly_compound_plan(command).is_none(),
+            "{command} must stay ineligible"
+        );
+    }
+}
+
+#[test]
+fn build_plan_keeps_stdin_filters_with_a_file_operand_eligible() {
+    // A default-to-stdin filter with a definite file operand never
+    // touches stdin, so it keeps its compound grant; the conservative
+    // operand detection only counts a non-flag token that does not
+    // directly follow a flag-like token (which might consume it as a
+    // value), so flag-adjacent forms fall back to AskUser instead.
+    let plan = plan("sort /etc/hosts && pwd");
+    assert_eq!(plan.steps[0].argv, vec!["sort", "/etc/hosts"]);
+    assert!(build_readonly_compound_plan("uniq /etc/hosts || pwd").is_some());
+}
+
+#[test]
+fn executor_short_circuits_like_bash() {
+    // `&&` after success runs the next step.
+    let output = run_plan(&raw_plan(&[
+        (&["echo", "first"], Seq),
+        (&["echo", "second"], And),
+    ]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "first\nsecond\n");
+    // `&&` after failure skips it; the failing code is preserved.
+    let output = run_plan(&raw_plan(&[(&["false"], Seq), (&["echo", "second"], And)]));
+    assert_eq!(output.exit_code, Some(1));
+    assert_eq!(output.stdout, "");
+    // `||` after success skips the next step.
+    let output = run_plan(&raw_plan(&[(&["true"], Seq), (&["echo", "second"], Or)]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "");
+    // `||` after failure runs it.
+    let output = run_plan(&raw_plan(&[(&["false"], Seq), (&["echo", "second"], Or)]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "second\n");
+    // `;` always runs the next step.
+    let output = run_plan(&raw_plan(&[(&["false"], Seq), (&["echo", "second"], Seq)]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "second\n");
+    // Left-associative chain: `false || false && echo ok` runs nothing
+    // after the first failure pair, exit code is the last executed step.
+    let output = run_plan(&raw_plan(&[
+        (&["false"], Seq),
+        (&["false"], Or),
+        (&["echo", "ok"], And),
+    ]));
+    assert_eq!(output.exit_code, Some(1));
+    assert_eq!(output.stdout, "");
+    // `true && false || echo x` matches bash left-associativity.
+    let output = run_plan(&raw_plan(&[
+        (&["true"], Seq),
+        (&["false"], And),
+        (&["echo", "x"], Or),
+    ]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "x\n");
+}
+
+#[test]
+fn executor_passes_tokens_verbatim() {
+    // Every character class that a shell would expand (history
+    // expansion trigger, glob, tilde, comment lead, spaces inside
+    // quotes) reaches the process argv untouched.
+    let output = run_plan(&raw_plan(&[(
+        &["echo", "a b", "!-2", "*.log", "~", "#x"],
+        Seq,
+    )]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "a b !-2 *.log ~ #x\n");
+}
+
+// The shell control group for the no-parsing-layer evidence lives in
+// the integration layer (`tests/logic/tools.rs`): check-layout.sh
+// forbids new subprocess spawns in `src` test code, and
+// `executor_passes_tokens_verbatim` above covers the executor half.
+
+#[test]
+fn executor_bounds_aggregate_output() {
+    let plan = raw_plan(&[
+        (&["echo", "first"], Seq),
+        (&["echo", "second"], Seq),
+        (&["echo", "third"], Seq),
+    ]);
+    let output = run_readonly_compound(
+        &plan,
+        &ReadonlyPipelineConfig {
+            output_limit_bytes: 12,
+            ..ReadonlyPipelineConfig::default()
+        },
+        Path::new("/"),
+    )
+    .expect("bounded run");
+    assert!(output.stdout.contains("<truncated>"), "{}", output.stdout);
+    assert!(output.stdout.len() <= 32, "{}", output.stdout);
+}
+
+#[test]
+fn executor_enforces_stage_timeout() {
+    let plan = raw_plan(&[(&["sleep", "2"], Seq), (&["echo", "second"], Seq)]);
+    let err = run_readonly_compound(
+        &plan,
+        &ReadonlyPipelineConfig {
+            stage_timeout: std::time::Duration::from_millis(20),
+            total_timeout: std::time::Duration::from_secs(10),
+            ..ReadonlyPipelineConfig::default()
+        },
+        Path::new("/"),
+    )
+    .expect_err("stage must time out");
+    assert_eq!(err.reason, "stage-timeout");
+}
+
+#[cfg(unix)]
+#[test]
+fn executor_ignores_path_shadowing_of_allowlisted_names() {
+    // R6 P1 regression: a user-writable directory at the front of
+    // the inherited PATH provides an executable that would create a
+    // marker file if executed. PATH-based lookup would find and run
+    // it; the executor resolves from the trusted system directories
+    // only, so the step reports 127, the marker never appears, and
+    // list evaluation continues.
+    use std::os::unix::fs::PermissionsExt;
+    let dir = std::env::temp_dir().join(format!(
+        "cosh-compound-shadow-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+    std::fs::create_dir_all(&dir).expect("create shadow dir");
+    let probe = format!("cosh-shadow-probe-{}", std::process::id());
+    let marker = dir.join("shadow-executed");
+    let fake = dir.join(&probe);
+    std::fs::write(
+        &fake,
+        format!("#!/bin/sh\ntouch {}\necho SHADOWED\n", marker.display()),
+    )
+    .expect("write fake probe");
+    std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod fake probe");
+    let original_path = std::env::var_os("PATH");
+    std::env::set_var(
+        "PATH",
+        format!(
+            "{}:{}",
+            dir.display(),
+            original_path
+                .as_deref()
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        ),
+    );
+    let output = run_readonly_compound(
+        &raw_plan(&[(&[probe.as_str()], Seq), (&["echo", "fallback"], Or)]),
+        &ReadonlyPipelineConfig::default(),
+        Path::new("/"),
+    );
+    match original_path {
+        Some(path) => std::env::set_var("PATH", path),
+        None => std::env::remove_var("PATH"),
+    }
+    let output = output.expect("compound run");
+    let marker_created = marker.exists();
+    std::fs::remove_dir_all(&dir).expect("clean shadow dir");
+    assert!(!marker_created, "PATH-resolved probe must never execute");
+    assert!(!output.stdout.contains("SHADOWED"), "{}", output.stdout);
+    assert!(
+        output.stderr.contains("command not found"),
+        "{}",
+        output.stderr
+    );
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "fallback\n");
+}
+
+#[test]
+fn executor_caps_capture_of_oversized_step_output() {
+    // R6 P1 regression: capture is pipe-drained under the budget,
+    // so a step emitting far more than the budget still yields a
+    // bounded aggregate, later steps still run, and no temp file is
+    // involved (nothing to grow with the source size).
+    let output = run_readonly_compound(
+        &raw_plan(&[
+            (&["yes", "budget-overflow-line"], Seq),
+            (&["echo", "after-large"], Seq),
+        ]),
+        &ReadonlyPipelineConfig {
+            output_limit_bytes: 4096,
+            stage_timeout: std::time::Duration::from_millis(300),
+            total_timeout: std::time::Duration::from_secs(10),
+            ..ReadonlyPipelineConfig::default()
+        },
+        Path::new("/"),
+    );
+    // `yes` never exits on its own; the stage timeout ends it, and
+    // the run reports the timeout error contract. What must hold is
+    // that the drain kept the capture bounded rather than buffering
+    // the unbounded stream.
+    let err = output.expect_err("yes must hit the stage timeout");
+    assert_eq!(err.reason, "stage-timeout");
+    // Bounded-capture happy path: a finite oversized emitter.
+    let big = "x".repeat(512 * 1024).into_bytes();
+    let chunk = limit_clean_text(&big, false, 4096, 200);
+    assert!(chunk.len() <= 4096 + "\n<truncated>".len());
+    let output = run_readonly_compound(
+        &raw_plan(&[
+            (&["head", "-c", "524288", "/dev/zero"], Seq),
+            (&["echo", "after-large"], Seq),
+        ]),
+        &ReadonlyPipelineConfig {
+            output_limit_bytes: 4096,
+            ..ReadonlyPipelineConfig::default()
+        },
+        Path::new("/"),
+    )
+    .expect("bounded oversized run");
+    assert!(output.stdout.contains("<truncated>"));
+    assert!(
+        output.stdout.len() <= 4096 + 2 * "\n<truncated>".len() + "after-large\n".len(),
+        "aggregate must stay near the budget, got {}",
+        output.stdout.len()
+    );
+    assert_eq!(output.exit_code, Some(0));
+}
+
+#[test]
+fn missing_binary_error_lines_pay_into_the_stderr_budget() {
+    // R6 P2 regression: the synthetic `command not found` lines go
+    // through the same bounded append as real step output, so a
+    // tiny budget truncates them instead of growing unbounded.
+    let output = run_readonly_compound(
+        &raw_plan(&[
+            (&["cosh-compound-missing-first"], Seq),
+            (&["cosh-compound-missing-second"], Seq),
+        ]),
+        &ReadonlyPipelineConfig {
+            output_limit_bytes: 8,
+            ..ReadonlyPipelineConfig::default()
+        },
+        Path::new("/"),
+    )
+    .expect("missing-binary run");
+    assert_eq!(output.exit_code, Some(127));
+    assert!(output.stderr.contains("<truncated>"), "{}", output.stderr);
+    assert!(
+        !output.stderr.contains("cosh-compound-missing-second"),
+        "second error must not exceed the exhausted budget: {}",
+        output.stderr
+    );
+}
+
+#[test]
+fn executor_runs_steps_in_the_requested_working_directory() {
+    let dir = std::env::temp_dir().join(format!(
+        "cosh-compound-cwd-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+    std::fs::create_dir_all(&dir).expect("create cwd fixture");
+    let output = run_readonly_compound(
+        &raw_plan(&[(&["pwd"], Seq)]),
+        &ReadonlyPipelineConfig::default(),
+        &dir,
+    )
+    .expect("compound run");
+    // macOS resolves /tmp symlinks in child processes; compare
+    // canonical forms on both sides.
+    let reported = std::fs::canonicalize(output.stdout.trim()).expect("reported cwd");
+    let expected = std::fs::canonicalize(&dir).expect("expected cwd");
+    std::fs::remove_dir_all(&dir).expect("clean cwd fixture");
+    assert_eq!(reported, expected);
+}
+
+#[test]
+fn executor_maps_missing_binary_to_127_and_continues_list() {
+    // bash semantics: command-not-found is step status 127, not a
+    // plan-level executor error, so `||` still runs the fallback
+    // (e.g. `sw_vers || uname` on a platform without `sw_vers`).
+    let output = run_plan(&raw_plan(&[
+        (&["cosh-compound-definitely-missing-binary"], Seq),
+        (&["echo", "fallback"], Or),
+    ]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "fallback\n");
+    assert!(
+        output
+            .stderr
+            .contains("cosh-compound-definitely-missing-binary: command not found"),
+        "{}",
+        output.stderr
+    );
+    // `&&` after a 127 step short-circuits, preserving the 127.
+    let output = run_plan(&raw_plan(&[
+        (&["cosh-compound-definitely-missing-binary"], Seq),
+        (&["echo", "skipped"], And),
+    ]));
+    assert_eq!(output.exit_code, Some(127));
+    assert_eq!(output.stdout, "");
+}
+
+#[cfg(unix)]
+#[test]
+fn executor_maps_signal_death_to_128_plus_signum() {
+    // A step killed by a signal must evaluate as failed for `&&`
+    // (bash reports 128+SIGTERM=143), never as success.
+    let output = run_plan(&raw_plan(&[
+        (&["sh", "-c", "kill -TERM $$"], Seq),
+        (&["echo", "skipped"], And),
+    ]));
+    assert_eq!(output.exit_code, Some(143));
+    assert_eq!(output.stdout, "");
+    // `||` treats the signal death as failure and runs the fallback.
+    let output = run_plan(&raw_plan(&[
+        (&["sh", "-c", "kill -TERM $$"], Seq),
+        (&["echo", "fallback"], Or),
+    ]));
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "fallback\n");
+}
+
+#[test]
+fn executor_runs_steps_in_a_controlled_environment() {
+    // R7 regression: steps must not observe the cosh process
+    // environment (provider credentials would leak into auto-executed
+    // output); only the pass-through keys and the trusted PATH are
+    // present. `env` is used via raw_plan as a mechanism probe — the
+    // eligibility gate itself never grants environment-observing
+    // commands (R8, covered by the fail-closed cases above).
+    let probe_key = format!("COSH_COMPOUND_ENV_PROBE_{}", std::process::id());
+    std::env::set_var(&probe_key, "leaky-secret");
+    let output = run_plan(&raw_plan(&[(&["env"], Seq)]));
+    std::env::remove_var(&probe_key);
+    assert_eq!(output.exit_code, Some(0));
+    assert!(
+        !output.stdout.contains(&probe_key),
+        "cosh process env must not reach the step: {}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains("PATH=/usr/bin:/bin:/usr/sbin:/sbin"),
+        "{}",
+        output.stdout
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn executor_join_does_not_wait_for_descendants_holding_the_pipe() {
+    // R7/R8 regression: a descendant keeping the pipe write end open
+    // (background job, fsmonitor daemon) must not stall the run past
+    // its stage deadline — and on expiry the step's whole process
+    // group is terminated, so the descendant is reaped instead of
+    // accumulating across auto-executions.
+    let started = std::time::Instant::now();
+    let output = run_readonly_compound(
+        &raw_plan(&[(&["sh", "-c", "sleep 5 & echo started $!"], Seq)]),
+        &ReadonlyPipelineConfig {
+            stage_timeout: std::time::Duration::from_millis(400),
+            total_timeout: std::time::Duration::from_secs(10),
+            ..ReadonlyPipelineConfig::default()
+        },
+        Path::new("/"),
+    )
+    .expect("compound run");
+    let elapsed = started.elapsed();
+    assert_eq!(output.exit_code, Some(0));
+    assert!(output.stdout.starts_with("started "), "{}", output.stdout);
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "join must not wait for the descendant: {elapsed:?}"
+    );
+    let descendant: i32 = output
+        .stdout
+        .trim()
+        .rsplit(' ')
+        .next()
+        .unwrap()
+        .parse()
+        .expect("descendant pid");
+    // The group kill reaps the descendant; give the signal a moment.
+    let reaped_by = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let alive = unsafe { nix::libc::kill(descendant, 0) } == 0;
+        if !alive {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < reaped_by,
+            "descendant {descendant} must not outlive the deadline"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn executor_joins_readers_when_a_setsid_descendant_escapes_the_group() {
+    // A descendant that calls `setsid` leaves the step's process
+    // group, so the group kill cannot reach it and it keeps the pipe
+    // write end open indefinitely. The drain cancellation must still
+    // reclaim both reader threads within the deadline — no reader may
+    // be dropped unjoined — and the run must return without waiting
+    // for the escaped descendant.
+    let pidfile = std::env::temp_dir().join(format!(
+        "cosh-compound-setsid-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+    let script = format!(
+        "setsid sh -c 'echo $$ > {pidfile}; exec sleep 3600' & sleep 0.2; echo leader-done",
+        pidfile = pidfile.display()
+    );
+    let baseline = LIVE_READER_THREADS.load(std::sync::atomic::Ordering::SeqCst);
+    let started = std::time::Instant::now();
+    let output = run_readonly_compound(
+        &raw_plan(&[(&["sh", "-c", script.as_str()], Seq)]),
+        &ReadonlyPipelineConfig {
+            stage_timeout: std::time::Duration::from_millis(500),
+            total_timeout: std::time::Duration::from_secs(10),
+            ..ReadonlyPipelineConfig::default()
+        },
+        Path::new("/"),
+    )
+    .expect("compound run");
+    let elapsed = started.elapsed();
+    assert_eq!(output.exit_code, Some(0));
+    assert!(output.stdout.contains("leader-done"), "{}", output.stdout);
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "run must not wait for the escaped descendant: {elapsed:?}"
+    );
+    // Both reader threads must be joined by the time the run returns;
+    // concurrent tests may transiently hold readers of their own, so
+    // poll for a sample at or below the pre-run tally.
+    let reaped_by = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if LIVE_READER_THREADS.load(std::sync::atomic::Ordering::SeqCst) <= baseline {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < reaped_by,
+            "drain readers must be joined, not dropped"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    // Clean up the escaped descendant so it cannot outlive the test.
+    if let Ok(pid_text) = std::fs::read_to_string(&pidfile) {
+        if let Ok(pid) = pid_text.trim().parse::<i32>() {
+            unsafe {
+                nix::libc::kill(pid, nix::libc::SIGKILL);
+            }
+        }
+    }
+    let _ = std::fs::remove_file(&pidfile);
+}
+
+#[cfg(unix)]
+#[test]
+fn executor_reaps_descendants_that_redirected_their_output() {
+    // R9 regression: a background descendant that redirects its output
+    // away from the pipes lets both drains complete normally, so group
+    // cleanup must not be keyed off a pending drain — the group is
+    // terminated unconditionally once the direct child is done.
+    let output = run_plan(&raw_plan(&[(
+        &["sh", "-c", "sleep 3600 >/dev/null 2>&1 & echo bg $!"],
+        Seq,
+    )]));
+    assert_eq!(output.exit_code, Some(0));
+    assert!(output.stdout.starts_with("bg "), "{}", output.stdout);
+    let descendant: i32 = output
+        .stdout
+        .trim()
+        .rsplit(' ')
+        .next()
+        .unwrap()
+        .parse()
+        .expect("descendant pid");
+    let reaped_by = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let alive = unsafe { nix::libc::kill(descendant, 0) } == 0;
+        if !alive {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < reaped_by,
+            "redirected descendant {descendant} must not survive the step"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use super::{is_sensitive_target, strip_ansi};
@@ -121,23 +122,11 @@ fn run_plan(
             + config
                 .stage_timeout
                 .min(deadline.saturating_duration_since(Instant::now()));
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    final_exit_code = status.code();
-                    break;
-                }
-                Ok(None) if Instant::now() >= stage_deadline => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    cleanup_paths(&cleanup);
-                    return Err(error("stage-timeout", stage.argv.join(" ")));
-                }
-                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
-                Err(err) => {
-                    cleanup_paths(&cleanup);
-                    return Err(error("executor-wait", err.to_string()));
-                }
+        match wait_child_with_deadline(&mut child, stage_deadline, stage.argv.join(" ")) {
+            Ok(code) => final_exit_code = code,
+            Err(err) => {
+                cleanup_paths(&cleanup);
+                return Err(err);
             }
         }
 
@@ -287,25 +276,85 @@ fn push_token(tokens: &mut Vec<String>, token: &mut String) {
     }
 }
 
-fn temp_path(kind: &str, stage: usize) -> PathBuf {
+/// Waits for a spawned child, killing it once `stage_deadline` passes.
+/// Shared by the readonly pipeline and compound executors; the caller
+/// owns any temp-file cleanup on the error path.
+pub(crate) fn wait_child_with_deadline(
+    child: &mut std::process::Child,
+    stage_deadline: Instant,
+    timeout_detail: impl Into<String>,
+) -> Result<Option<i32>, ReadonlyPipelineError> {
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(Some(exit_code_with_signal(status))),
+            Ok(None) if Instant::now() >= stage_deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error("stage-timeout", timeout_detail));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(err) => return Err(error("executor-wait", err.to_string())),
+        }
+    }
+}
+
+/// Normalizes a finished child status to the shell exit-code contract: a
+/// process ended by a signal reports `128 + signum` (e.g. SIGTERM → 143),
+/// so list connectors (`&&`/`||`) evaluate the step as failed instead of
+/// mistaking the missing code for success.
+#[cfg(unix)]
+fn exit_code_with_signal(status: std::process::ExitStatus) -> i32 {
+    use std::os::unix::process::ExitStatusExt;
+    status
+        .code()
+        .unwrap_or_else(|| 128 + status.signal().unwrap_or_default())
+}
+
+#[cfg(not(unix))]
+fn exit_code_with_signal(status: std::process::ExitStatus) -> i32 {
+    status.code().unwrap_or_default()
+}
+
+// Process-wide sequence keeping temp paths unique across concurrent
+// runs: wall-clock nanos can repeat between parallel callers (test
+// threads, sibling compounds), and a collided path lets one run's
+// cleanup delete a file another run is about to read.
+static TEMP_PATH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn temp_path(kind: &str, stage: usize) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
+    let sequence = TEMP_PATH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!(
-        "cosh-readonly-pipeline-{}-{nanos}-{stage}-{kind}",
+        "cosh-readonly-pipeline-{}-{nanos}-{sequence}-{stage}-{kind}",
         std::process::id()
     ))
 }
 
-fn read_limited_clean(
+pub(crate) fn read_limited_clean(
     path: &Path,
     byte_limit: usize,
     line_limit: usize,
 ) -> Result<String, ReadonlyPipelineError> {
     let bytes = std::fs::read(path).map_err(|err| error("executor-io", err.to_string()))?;
+    Ok(limit_clean_text(&bytes, false, byte_limit, line_limit))
+}
+
+/// Canonical bounded-text shaping shared by the file-backed pipeline
+/// capture and the pipe-backed compound capture: lossy UTF-8 within the
+/// byte budget, ANSI stripped, line budget applied, and a single
+/// `<truncated>` marker when either budget (or the caller's own
+/// overflow signal) was exceeded.
+pub(crate) fn limit_clean_text(
+    bytes: &[u8],
+    overflowed: bool,
+    byte_limit: usize,
+    line_limit: usize,
+) -> String {
     let mut text = String::from_utf8_lossy(&bytes[..bytes.len().min(byte_limit)]).to_string();
-    if bytes.len() > byte_limit {
+    if overflowed || bytes.len() > byte_limit {
         text.push_str("\n<truncated>");
     }
     let mut text = strip_ansi(&text);
@@ -314,16 +363,16 @@ fn read_limited_clean(
         text = lines.join("\n");
         text.push_str("\n<truncated>");
     }
-    Ok(text)
+    text
 }
 
-fn cleanup_paths(paths: &[PathBuf]) {
+pub(crate) fn cleanup_paths(paths: &[PathBuf]) {
     for path in paths {
         let _ = std::fs::remove_file(path);
     }
 }
 
-fn error(reason: &'static str, detail: impl Into<String>) -> ReadonlyPipelineError {
+pub(crate) fn error(reason: &'static str, detail: impl Into<String>) -> ReadonlyPipelineError {
     ReadonlyPipelineError {
         reason,
         detail: detail.into(),

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
@@ -121,23 +121,11 @@ fn run_plan(
             + config
                 .stage_timeout
                 .min(deadline.saturating_duration_since(Instant::now()));
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    final_exit_code = status.code();
-                    break;
-                }
-                Ok(None) if Instant::now() >= stage_deadline => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    cleanup_paths(&cleanup);
-                    return Err(error("stage-timeout", stage.argv.join(" ")));
-                }
-                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
-                Err(err) => {
-                    cleanup_paths(&cleanup);
-                    return Err(error("executor-wait", err.to_string()));
-                }
+        match wait_child_with_deadline(&mut child, stage_deadline, stage.argv.join(" ")) {
+            Ok(code) => final_exit_code = code,
+            Err(err) => {
+                cleanup_paths(&cleanup);
+                return Err(err);
             }
         }
 
@@ -287,7 +275,29 @@ fn push_token(tokens: &mut Vec<String>, token: &mut String) {
     }
 }
 
-fn temp_path(kind: &str, stage: usize) -> PathBuf {
+/// Waits for a spawned child, killing it once `stage_deadline` passes.
+/// Shared by the readonly pipeline and compound executors; the caller
+/// owns any temp-file cleanup on the error path.
+pub(crate) fn wait_child_with_deadline(
+    child: &mut std::process::Child,
+    stage_deadline: Instant,
+    timeout_detail: impl Into<String>,
+) -> Result<Option<i32>, ReadonlyPipelineError> {
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status.code()),
+            Ok(None) if Instant::now() >= stage_deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error("stage-timeout", timeout_detail));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(err) => return Err(error("executor-wait", err.to_string())),
+        }
+    }
+}
+
+pub(crate) fn temp_path(kind: &str, stage: usize) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
@@ -298,7 +308,7 @@ fn temp_path(kind: &str, stage: usize) -> PathBuf {
     ))
 }
 
-fn read_limited_clean(
+pub(crate) fn read_limited_clean(
     path: &Path,
     byte_limit: usize,
     line_limit: usize,
@@ -317,13 +327,13 @@ fn read_limited_clean(
     Ok(text)
 }
 
-fn cleanup_paths(paths: &[PathBuf]) {
+pub(crate) fn cleanup_paths(paths: &[PathBuf]) {
     for path in paths {
         let _ = std::fs::remove_file(path);
     }
 }
 
-fn error(reason: &'static str, detail: impl Into<String>) -> ReadonlyPipelineError {
+pub(crate) fn error(reason: &'static str, detail: impl Into<String>) -> ReadonlyPipelineError {
     ReadonlyPipelineError {
         reason,
         detail: detail.into(),

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use super::{is_sensitive_target, strip_ansi};
@@ -297,13 +298,20 @@ pub(crate) fn wait_child_with_deadline(
     }
 }
 
+// Process-wide sequence keeping temp paths unique across concurrent
+// runs: wall-clock nanos can repeat between parallel callers (test
+// threads, sibling compounds), and a collided path lets one run's
+// cleanup delete a file another run is about to read.
+static TEMP_PATH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
 pub(crate) fn temp_path(kind: &str, stage: usize) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
+    let sequence = TEMP_PATH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!(
-        "cosh-readonly-pipeline-{}-{nanos}-{stage}-{kind}",
+        "cosh-readonly-pipeline-{}-{nanos}-{sequence}-{stage}-{kind}",
         std::process::id()
     ))
 }

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/approval_reason.rs
@@ -86,6 +86,7 @@ mod tests {
             "unknown-command",
             "and-or-list-not-auto-executable",
             "pipeline-not-auto-executable",
+            "compound-readonly",
             "unsafe-binding",
             "parse-failed",
             "not-a-real-code",

--- a/src/cosh-ng/crates/cosh-shell/tests/logic/tools.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/logic/tools.rs
@@ -29,6 +29,19 @@ fn readonly_tool_does_not_interpret_shell_syntax_in_tokens() {
 }
 
 #[test]
+fn shell_expands_globs_so_verbatim_token_assertions_are_not_vacuous() {
+    // Control group for the no-parsing-layer evidence (issue #1882): a
+    // real shell in this (non-empty) working directory expands `*`, so
+    // the literal-glob assertions of the readonly executors prove the
+    // absence of a parsing layer rather than an environment that cannot
+    // expand.
+    let result = run_shell_tool("echo *", None);
+
+    assert_eq!(result.status, ToolExecutionStatus::Executed);
+    assert_ne!(result.stdout, "*\n", "control group must expand the glob");
+}
+
+#[test]
 fn user_approved_tool_runs_shell_syntax_through_bash() {
     let result = run_shell_tool("printf 'alpha\\nbeta\\n' | grep beta", None);
 

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 651
+check_overlap_ceiling cosh-shell cosh-shell 674
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 646
+check_overlap_ceiling cosh-shell cosh-shell 658
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Summary

In auto approval mode, compound commands (`&&` / `||` / `;` / newline)
always required `AskUser`, even when every segment is provably readonly
(e.g. `pwd && df -h`).

This PR grants a `CompoundReadonly` auto-allow evidence exactly when a
readonly compound **execution plan** exists —
`build_readonly_compound_plan` is the single eligibility oracle shared
by the assessment and the consumer — and executes the plan through a
new constrained **argv executor**: each segment's tokens are passed to
`execve` verbatim, with no shell parsing layer, hence no history
expansion, alias, function, glob, or tilde reinterpretation of the
assessed text.

This is the second design iteration. The first routed compounds through
the approved-command foreground shell handoff; R3 review falsified that
route with three P1 counter-examples (`histchars`-rebound history
expansion, `\u{000c}` wedging the handoff queue, alias/function
shadowing) and recommended exactly this executor. The handoff route is
fully retired.

Closes #1882

## Changes

- `tools/command_risk_parser.rs`: `SegmentConnector { Seq, And, Or }`
  and `ParsedCommand::segment_connectors`, derived from segment marks
  (`;`/newline → `Seq`, `&&` → `And`, `||` → `Or`); existing parser
  output unchanged.
- `tools/readonly_compound.rs` (new): `ReadonlyCompoundPlan` /
  `CompoundStep { program, argv, connector }` and
  `run_readonly_compound` — trusted-directory executable resolution at
  plan-build time, shell-like `&&`/`||` short-circuit, pipe-drained
  bounded capture with unconditional per-step process-group cleanup, a
  cleared deterministic environment, per-stage timeout, truncation
  markers; bounded-text shaping shared with `readonly_pipeline.rs`, whose
  behavior is unchanged except that a signal-terminated stage now
  reports `128+signum` instead of no exit code (shared shell
  exit-code contract, required by the compound short-circuit
  semantics).
- `tools/command_risk_compound.rs`: eligibility rewritten — shape
  `AndOrList`/`Sequence`, no null redirections, one stage per segment,
  segment tokens passing the readonly rules **as tokens** (no text
  rebuild), any `$`/backtick token rejects, ≥2 segments, marks
  identity guard. The v1 character blacklist (quotes, escapes, `!`,
  newline/CR) is deleted.
- `tools/command_risk_model.rs`: route renamed to
  `AutoExecutionRoute::CompoundReadonlyExecutor`; evidence name
  `CompoundReadonly` and reason code unchanged.
- `agent/approval_bridge.rs`: the executor route records the
  auto-approval, renders the existing `Auto-approved` card, and runs
  the plan, injecting aggregated output and exit code into the existing
  shell-tool result channel; `DirectReadonlyBroker` keeps the handoff
  path; deliver internals are parameterized and shared with the
  handoff.
- `scripts/check-test-inventory.sh`: cosh-shell lib/bin overlap ceiling
  646 → 669 (executor suites plus the R5–R11 review-hardening
  regressions; review fixes are folded into the feature commits per
  the fix-attribution rule).

### Scope notes

- Newline-separated compounds are now eligible and auto-execute
  (M2b) — the v1 handoff could not carry them (the wire contract
  rejects multiline commands); the argv executor has no wire at all.
- Eligibility ≡ plan existence: assessment and execution consume the
  same structured tokens, so assessed text ≡ executed argv by
  construction, regression-locked by the argv-equivalence tests.
- `cd /tmp && git status` stays `AskUser` (`cd` never passes the
  readonly rules); any token containing `$`/backticks rejects; tokens
  with embedded control characters reject (M19).

## Tests

- New executor unit tests: 3 connectors × {exit 0, non-0}
  short-circuit matrix (`/bin/echo`, `/bin/true`, `/bin/false`); argv
  equivalence incl. space / `!` / glob / tilde verbatim echo
  (`executor_passes_tokens_verbatim`); timeout and truncation;
  concurrent temp-path dedup.
- Integration control group (`tests/logic/tools.rs`): a real shell in
  the same working directory expands `*`, so the executor's
  literal-glob assertions prove the absence of a parsing layer rather
  than an environment that cannot expand (`check-layout.sh` forbids
  new subprocess spawns in `src` tests).
- Grant matrix M1–M19 rewritten (ALLOW and ASK rows); re-anchored rows
  noted inline (`git status "foo"` → ASK positional rejection, escaped
  space M10b → ASK, control character M19 → ASK).
- Approval-bridge production call chain: ALLOW executes and returns
  output; ASK never enters the executor; `DirectReadonlyBroker`
  regression; M4 still queues for manual approval.

## Verification

- Full `cargo test -p cosh-shell --bins` on macOS: 2250 passed, 0
  failed (1 ignored); integration `logic` 9/9; focused suites
  (`readonly_compound`, `readonly_pipeline`, `command_risk`,
  `approval`, `command_risk_parser`, `audit`) green; `cargo fmt
  --check` and `cargo clippy --all-targets` clean.
- `cosh-lab pr preflight` (fmt / clippy / commit-lint / check-layout /
  check-test-inventory): ok.
- CI `Test cosh-ng`: the first run on this head failed 3
  timing-sensitive raw_cli PTY tests (input echo raced by Ctrl-C, hook
  deadline, handoff intercept timing); all three pass on the same head
  in the alinux3 arm64 container and on macOS, and the CI rerun is
  green — environmental flakiness in paths this diff does not touch.

## Evidence

Real cosh-core adapter + real provider (dashscope / qwen3.7-plus,
`effective_auth_required=false`), scripted PTY (container alinux3
arm64, PTY 100x30), auto approval mode, `--gate feature-acceptance`,
canonical cases CARD-026/027/028; aggregate gate
`gate evaluate --require acceptance` → **Go**. Run ids and
environment attestation:
[v2 evidence README](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/README.md);
sha256 manifest
[v2-evidence.sha256](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-evidence.sha256).

| Scene | Screenshot |
|---|---|
| CARD-026 · `pwd && df -h` auto-approved | ![026 auto-approved](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-026-auto-approved.png) |
| CARD-026 · aggregated output returned | ![026 output](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-026-compound-output.png) |
| CARD-027 · newline compound auto-approved (card shows the two-line command) | ![027 auto-approved](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-027-auto-approved.png) |
| CARD-027 · both segments executed | ![027 output](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-027-compound-output.png) |
| CARD-028 · `histchars='@^#'`, `echo @-1 && df -h` auto-approved | ![028 auto-approved](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-028-auto-approved.png) |
| CARD-028 · `@-1` printed literally (no history expansion) | ![028 output](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-028-compound-output.png) |

Casts / replays:
[026 cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-026-transcript.cast) ·
[026 webm](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-026-auto-approved.webm) ·
[027 cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-027-transcript.cast) ·
[027 webm](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-027-auto-approved.webm) ·
[028 cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-028-transcript.cast) ·
[028 webm](https://raw.githubusercontent.com/SunnyQjm/anolisa/8492bef8ee3a7dda96d3845a90ebb133ae71582e/v2-card-028-auto-approved.webm)

Base-side (fail-closed card) evidence is unchanged from the v1 bundle
on the same branch (`fail-approval-card.png`).

### Semantic deltas (recorded as-is)

- Auto-executed compound output arrives via the tool-result channel
  (rendered inside the Agent card): it does not enter the terminal
  history and produces no direct terminal echo.
- Verbatim argv: no glob/tilde/history expansion (`echo @-1` prints
  `@-1`; `ls ~` reports "No such file or directory").
- Executables resolve from trusted system directories at plan-build
  time (never the inherited `PATH`); a name only reachable through
  `PATH` (rustup/Homebrew tools) stays on the AskUser path.
- Steps run under a cleared, deterministic environment (trusted
  `PATH` plus HOME/locale pass-through) with a null stdin: the cosh
  process env never leaks into output. Context-observing commands
  (`env`, `printenv`, `which`, `tty`) and segments that would read
  the executor's stdin (a bare `-` operand, `tr`, or a
  default-to-stdin filter without a definite file operand) never
  receive a compound grant — their result would diverge from the
  interactive shell's, so they stay on the AskUser path.
- The execution cwd is a verifiable chain: the explicit request cwd
  (blocking when stale), else the latest tracked command block's
  live cwd, else — only with zero observed command activity — the
  shell's own latest prompt-time cwd report (invalidated by a later
  PTY line submission until a fresh cwd-bearing marker arrives);
  there is no process-cwd guess, and an unverifiable cwd keeps the
  manual AskUser flow.
- Completion status follows the handoff outcome contract
  (completed / failed / interrupted / timed_out / not_executed).
- `&&`/`||` short-circuit like a shell; exit code = last executed
  segment; per-stage timeout and bounded output match the
  single-command readonly pipeline.
