### PR TITLE
fix(cosh-ng): [shell,core] guarantee approval terminal state with lifecycle ledger and last-resort timeout

### DIFF
--- a/specs/cosh-ng-code-organization/decisions.md
+++ b/specs/cosh-ng-code-organization/decisions.md
@@ -106,3 +106,25 @@ Reasons:
 Removal condition: when a second cross-owner approval workflow needs the same
 lifecycle, introduce runtime domain commands and events for approval outcomes,
 move orchestration into that coordinator, and delete this exception.
+
+## D17: ApprovalLifecycleLedger lives in runtime/approval_ledger.rs (owner note)
+
+`ApprovalLifecycleLedger` (#1940) is a pure accounting index keyed by
+the #1939 identity contract (`run_id` + `request_id`): registered on
+first sight, marked on response, swept per run. It lives in `runtime/`
+because its owner is the run lifecycle, not approval policy — the
+ledger is held by `ControlState` (`runtime/state.rs`), and its two
+sweep triggers are runtime lifecycle events (`runtime/cancel.rs`,
+`runtime/evidence_delivery.rs`). It depends only on std and holds no
+policy: what a dropped request is denied *with* (message, audit
+drop-site, terminal deny) is decided by `approval/runtime.rs`, which
+consumes the ledger the same way it already consumes other
+`ControlState` accounting. Splitting the data structure from its
+`ControlState` host would recreate the cross-owner reach the note is
+about; the maintenance contract (every `control_response` exit must
+`mark_responded`) is documented in the module docs.
+
+Revisit trigger: if a second consumer beyond approval drain/sweep needs
+lifecycle bookkeeping, or the per-domain `ControlState` split lands,
+move the ledger into that extracted state module together with its
+host field.

--- a/specs/cosh-ng-code-organization/large-file-inventory.md
+++ b/specs/cosh-ng-code-organization/large-file-inventory.md
@@ -28,13 +28,13 @@ new over-threshold file appears that is not listed here.
 |------:|------|-------|---------------------|
 | 1717 | `src/ui/agent_render/health.rs` | ui | Health banner rendering; pre-existing. Split per-severity renderers. |
 | 1628 | `src/diagnostics/health/collectors.rs` | diagnostics | Per-subsystem collectors; pre-existing. Split by collector family. |
-| 850 | `src/runtime/state.rs` | runtime | Central inline state; approval state extracted. Continue per-domain splits. |
+| 861 | `src/runtime/state.rs` | runtime | Central inline state; approval state extracted to `approval_state.rs` (main baseline 850, back under the 1000-line growth bar). The #1940 approval-terminal-state fix adds the `approval_ledger` field plus two accessors, which co-locate with their `ControlState` host. Continue per-domain splits. |
 | 912 | `src/evidence/output_policy.rs` | evidence | Output excerpt policy; pre-existing. Split bounding from classification. |
 | 906 | `src/adapter/fake.rs` | adapter | Test fake adapter; pre-existing. Split scripted-scenario builders. |
 | 944 | `src/ui/agent_render/approval.rs` | ui | Approval card rendering; action-row rendering extracted to `approval_actions.rs` (turn consent, #1773). Split per-card-kind renderers next. |
 | 943 | `src/auth/runtime.rs` | auth | Auth control-protocol runtime; prompt rendering extracted to `auth/prompt.rs`, ESC back-navigation to `auth/navigation.rs` (#1760 added dispatcher glue only). Extract provider-specific flows next. |
 | 769 | `src/activity/runtime.rs` | activity | Activity runtime; pre-existing. Shell handoff row builders (tracked and untracked) extracted to `activity/shell_handoff.rs`; extract remaining lifecycle from bookkeeping. |
-| 859 | `src/agent/poll.rs` | agent | Agent run polling loop; pre-existing debt (main baseline 839). The compaction feature added the `compaction_recommended_v1` status capture; split event routing from rendering. |
+| 712 | `src/agent/poll.rs` | agent | Agent run polling loop; pre-existing debt (main baseline 839). The compaction feature added the `compaction_recommended_v1` status capture; the #1940 approval-terminal-state fix extracted the inline test module to `agent/poll/tests.rs`, pulling the file back under the 1000-line growth bar. Split event routing from rendering next. |
 | 856 | `src/parser/mod.rs` | parser | Event parser (legacy `mod.rs`); pre-existing. Split per-event-kind parsers and rename off `mod.rs`. |
 | 855 | `src/activity/runtime_render.rs` | activity | Activity rendering; pre-existing. Split per-panel renderers. |
 | 853 | `src/i18n/en.rs` | i18n | English catalog; pre-existing. Partition by message domain. |
@@ -51,3 +51,4 @@ new over-threshold file appears that is not listed here.
 | 722 | `src/i18n/message_id.rs` | i18n | `MessageId` enum; near-threshold historical file (main baseline 699, zero headroom). The compaction feature added 23 required user-facing message ids, crossing the threshold. Split plan: partition `MessageId` into domain sub-enums (or macro-generate it) as a follow-up i18n refactor. |
 | 727 | `src/shell_host/marker/bash.rs` | shell_host | Embedded bash marker script; near-threshold historical file (main baseline 697, zero headroom after the extdebug prompt-hook fix). The #1919 missing-path natural-language interception added the DEBUG-trap gate helper and two mount points, crossing the threshold. Split plan: extract the embedded script body into a standalone `.sh` asset loaded via `include_str!`, mirroring the existing `shell_host/input_intent.sh` pattern (golden byte-identity tests keep the emitted script stable). |
 | 710 | `src/slash/hooks.rs` | slash | Slash hook command; pre-existing. Split subcommands. |
+| 700 | `src/adapter/control_protocol.rs` | adapter | Control-protocol wire surface; near-threshold historical file (main baseline 690). The #1940 approval-terminal-state fix added the `ApprovalChannelMessage` envelope and the receipt-serializer re-export, crossing the threshold. Split plan: move per-provider wire DTOs into `control_protocol/` submodules alongside `serialization.rs`, leaving only channel orchestration here. |

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -405,6 +405,21 @@ impl CoshCore {
                     );
                     return Ok(AgentTurnOutcome::Completed);
                 }
+                ApprovalResult::TimedOut => {
+                    // #1940: fail closed like the transport failure above —
+                    // the turn must end rather than continue while a late
+                    // shell-side decision could still execute.
+                    self.emit(
+                        writer,
+                        &OutputMessage::assistant_text(
+                            &self.session_id,
+                            "Prompt approval timed out before reaching a decision surface. Nothing was executed; please retry.",
+                        ),
+                    );
+                    return Err(format!(
+                        "prompt approval timed out before reaching a decision surface (request_id={request_id}); nothing was executed and the turn ends here so a late decision cannot split state"
+                    ));
+                }
                 ApprovalResult::Interrupted | ApprovalResult::HostExecutedShell { .. } => {
                     return Ok(AgentTurnOutcome::Completed);
                 }
@@ -1334,6 +1349,20 @@ impl CoshCore {
                                     interrupted = true;
                                     ToolResult::error("Interrupted by user")
                                 }
+                                ApprovalResult::TimedOut => {
+                                    self.metrics.approval_deny += 1;
+                                    // #1940: fail closed. The batch still answers
+                                    // every declared call so tool-message pairing
+                                    // holds, then the fatal ends the turn before
+                                    // another provider generation — the core must
+                                    // never record "not executed" and continue a
+                                    // turn in which a late shell-side decision
+                                    // could still execute.
+                                    hold_approval_timeout_fatal(&mut fatal_turn, &request_id);
+                                    ToolResult::error(
+                                        "approval timed out: the request never reached a decision surface; the tool was not executed",
+                                    )
+                                }
                             }
                         }
                     }
@@ -1435,7 +1464,14 @@ impl CoshCore {
                     // If a hook requests sandbox bypass, present an approval
                     // panel with the original (un-sandboxed) command.
                     // ─── SLS: sandbox blocked ───
-                    if let Some(bypass) = failure_hook.sandbox_bypass_request {
+                    // #1940: when the turn is already fatal (the policy
+                    // approval above timed out), the recorded tool result is
+                    // final — never open a second approval whose Allowed arm
+                    // would still execute the tool behind that result.
+                    if let Some(bypass) = failure_hook
+                        .sandbox_bypass_request
+                        .filter(|_| fatal_turn.is_none())
+                    {
                         self.metrics.sandbox_blocked += 1;
                         self.emit(
                             writer,
@@ -1540,6 +1576,13 @@ impl CoshCore {
                                         output: llm_content,
                                         is_error,
                                     };
+                                }
+                                // #1940: same fail-closed contract as the
+                                // policy approval above — a timed-out bypass
+                                // approval ends the turn; the original sandbox
+                                // failure stays as this call's tool result.
+                                ApprovalResult::TimedOut => {
+                                    hold_approval_timeout_fatal(&mut fatal_turn, &request_id);
                                 }
                                 _ => { /* denied / interrupted: keep original error */ }
                             }
@@ -1891,7 +1934,29 @@ impl CoshCore {
         accepts_host_executed_shell: bool,
         reader: &mut tokio::io::Lines<R>,
     ) -> ApprovalResult {
-        while let Ok(Some(line)) = reader.next_line().await {
+        // #1940 residual guard: this whole-wait deadline only ends the form
+        // where the request never reached the shell's decision surface at
+        // all — without it the turn would hang forever with no visible
+        // cause. Once the shell acknowledges the request with an
+        // `approval_receipt`, the shell owns its terminal state and the
+        // guard is disarmed: a legitimate wait (a card pending on the user,
+        // a host-executed command running) can then take as long as it
+        // needs, and a dead shell still surfaces via EOF below.
+        let mut deadline = Some(tokio::time::Instant::now() + approval_response_timeout());
+        loop {
+            let line = match deadline {
+                Some(deadline) => {
+                    match tokio::time::timeout_at(deadline, reader.next_line()).await {
+                        Ok(Ok(Some(line))) => line,
+                        Ok(Ok(None)) | Ok(Err(_)) => return ApprovalResult::Interrupted,
+                        Err(_) => return ApprovalResult::TimedOut,
+                    }
+                }
+                None => match reader.next_line().await {
+                    Ok(Some(line)) => line,
+                    Ok(None) | Err(_) => return ApprovalResult::Interrupted,
+                },
+            };
             let line = line.trim().to_string();
             if line.is_empty() {
                 continue;
@@ -1903,6 +1968,15 @@ impl CoshCore {
             };
 
             match msg {
+                InputMessage::ApprovalReceipt { request_id } => {
+                    // Disarm only the request this wait owns; a receipt for a
+                    // different id (a concurrent approval observed while this
+                    // wait holds the reader) is dropped, and that request
+                    // simply keeps its residual guard.
+                    if request_id == expected_request_id {
+                        deadline = None;
+                    }
+                }
                 InputMessage::ControlResponse { response } => {
                     if response.request_id != expected_request_id {
                         continue;
@@ -1944,7 +2018,6 @@ impl CoshCore {
                 _ => {}
             }
         }
-        ApprovalResult::Interrupted
     }
 }
 
@@ -1955,6 +2028,10 @@ pub(crate) fn max_turns_error(max_turns: u32) -> String {
 /// Audit reason code for a turn ended by a dead control transport.
 const CONTROL_TRANSPORT_AUDIT_REASON: &str = "control_transport_failed";
 
+/// Audit reason code for a turn ended by an approval that never reached a
+/// decision surface before the residual deadline (#1940).
+const APPROVAL_TIMEOUT_AUDIT_REASON: &str = "approval_timeout";
+
 /// One fatal turn outcome held until every declared tool call is closed.
 struct FatalTurn {
     error: String,
@@ -1964,6 +2041,21 @@ struct FatalTurn {
 impl FatalTurn {
     fn new(error: String, reason_code: &'static str) -> Self {
         Self { error, reason_code }
+    }
+}
+
+/// #1940: holds the turn-fatal for a timed-out approval, keeping the first
+/// fatal in the batch. The batch still answers every declared call, then
+/// the turn ends before another provider generation so a late shell-side
+/// decision can never split state against a recorded "not executed".
+fn hold_approval_timeout_fatal(fatal_turn: &mut Option<FatalTurn>, request_id: &str) {
+    if fatal_turn.is_none() {
+        *fatal_turn = Some(FatalTurn::new(
+            format!(
+                "approval timed out before reaching a decision surface (request_id={request_id}); the tool was not executed and the turn ends here so a late decision cannot split state"
+            ),
+            APPROVAL_TIMEOUT_AUDIT_REASON,
+        ));
     }
 }
 
@@ -2036,6 +2128,45 @@ enum ApprovalResult {
         exit_code: Option<i32>,
     },
     Interrupted,
+    /// #1940 residual guard: the wait exceeded the last-resort deadline,
+    /// meaning the request never reached a decision surface on the shell
+    /// side. Always fails the turn closed, never ends in an execution.
+    TimedOut,
+}
+
+/// #1940 residual guard: hours-scale by design so legitimate waits (card
+/// pending, host-executed command running) effectively never hit it. A
+/// request with no receipt beyond this horizon is failed closed as
+/// "shell presumed dead": the turn ends fatally rather than recording
+/// "not executed" and continuing into a state split, and a late decision
+/// degrades through the shell's OwnerUnavailable recovery path.
+/// env override exists for tests and incident response.
+const APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS: u64 = 6 * 60 * 60;
+/// Upper bound for the env override: an absurd value would overflow
+/// `Instant + Duration` and panic at the next approval wait.
+const APPROVAL_RESPONSE_TIMEOUT_MAX_SECS: u64 = 30 * 24 * 60 * 60;
+
+fn approval_response_timeout() -> std::time::Duration {
+    let fallback = || std::time::Duration::from_secs(APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS);
+    let Ok(raw) = std::env::var("COSH_CORE_APPROVAL_TIMEOUT_SECS") else {
+        return fallback();
+    };
+    match raw.parse::<u64>() {
+        Ok(secs) if secs > 0 && secs <= APPROVAL_RESPONSE_TIMEOUT_MAX_SECS => {
+            std::time::Duration::from_secs(secs)
+        }
+        _ => {
+            // Loud fallback (PR #1968 review): an ignored override must not
+            // leave the operator wondering why their timeout did not apply.
+            tracing::warn!(
+                value = %raw,
+                "invalid COSH_CORE_APPROVAL_TIMEOUT_SECS (want 1..={} secs); \
+                 falling back to the default approval timeout",
+                APPROVAL_RESPONSE_TIMEOUT_MAX_SECS
+            );
+            fallback()
+        }
+    }
 }
 
 fn hook_decision_name(decision: &HookDecision) -> &'static str {
@@ -2061,6 +2192,7 @@ fn approval_audit_outcome(approval: &ApprovalResult) -> (AuditOutcomeStatus, &'s
             (AuditOutcomeStatus::Allowed, "allow")
         }
         ApprovalResult::Denied(_) => (AuditOutcomeStatus::Denied, "deny"),
+        ApprovalResult::TimedOut => (AuditOutcomeStatus::Denied, "timeout"),
         ApprovalResult::Interrupted => (AuditOutcomeStatus::Cancelled, "interrupted"),
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -303,6 +303,16 @@ impl CoshCore {
                     );
                     return Ok(());
                 }
+                ApprovalResult::TimedOut => {
+                    self.emit(
+                        writer,
+                        &OutputMessage::assistant_text(
+                            &self.session_id,
+                            "Prompt approval timed out before reaching a decision surface. Nothing was executed; please retry.",
+                        ),
+                    );
+                    return Ok(());
+                }
                 ApprovalResult::Interrupted | ApprovalResult::HostExecutedShell { .. } => {
                     return Ok(());
                 }
@@ -1195,6 +1205,12 @@ impl CoshCore {
                                 interrupted = true;
                                 ToolResult::error("Interrupted by user")
                             }
+                            ApprovalResult::TimedOut => {
+                                self.metrics.approval_deny += 1;
+                                ToolResult::error(
+                                    "approval timed out: the request never reached a decision surface; the tool was not executed",
+                                )
+                            }
                         }
                     }
                     Outcome::Deny => {
@@ -1695,7 +1711,19 @@ impl CoshCore {
         accepts_host_executed_shell: bool,
         reader: &mut tokio::io::Lines<R>,
     ) -> ApprovalResult {
-        while let Ok(Some(line)) = reader.next_line().await {
+        // #1940 residual guard: the shell owns the terminal state of every
+        // request it can see, so a legitimate wait (a card pending on the
+        // user, a host-executed command running) must never be timed out
+        // from here. This whole-wait deadline only ends the form where the
+        // request never reached the shell's decision surface at all —
+        // without it the turn would hang forever with no visible cause.
+        let deadline = tokio::time::Instant::now() + approval_response_timeout();
+        loop {
+            let line = match tokio::time::timeout_at(deadline, reader.next_line()).await {
+                Ok(Ok(Some(line))) => line,
+                Ok(Ok(None)) | Ok(Err(_)) => return ApprovalResult::Interrupted,
+                Err(_) => return ApprovalResult::TimedOut,
+            };
             let line = line.trim().to_string();
             if line.is_empty() {
                 continue;
@@ -1748,7 +1776,6 @@ impl CoshCore {
                 _ => {}
             }
         }
-        ApprovalResult::Interrupted
     }
 }
 
@@ -1760,6 +1787,44 @@ enum ApprovalResult {
         exit_code: Option<i32>,
     },
     Interrupted,
+    /// #1940 residual guard: the wait exceeded the last-resort deadline,
+    /// meaning the request never reached a decision surface on the shell
+    /// side. Always surfaced as an error result, never as an execution.
+    TimedOut,
+}
+
+/// #1940 residual guard: hours-scale by design so legitimate waits (card
+/// pending, host-executed command running) effectively never hit it. A
+/// card left untouched beyond this horizon is failed closed as
+/// "session presumed dead": the late decision degrades through the
+/// shell's OwnerUnavailable recovery path instead of splitting state.
+/// env override exists for tests and incident response.
+const APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS: u64 = 6 * 60 * 60;
+/// Upper bound for the env override: an absurd value would overflow
+/// `Instant + Duration` and panic at the next approval wait.
+const APPROVAL_RESPONSE_TIMEOUT_MAX_SECS: u64 = 30 * 24 * 60 * 60;
+
+fn approval_response_timeout() -> std::time::Duration {
+    let fallback = || std::time::Duration::from_secs(APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS);
+    let Ok(raw) = std::env::var("COSH_CORE_APPROVAL_TIMEOUT_SECS") else {
+        return fallback();
+    };
+    match raw.parse::<u64>() {
+        Ok(secs) if secs > 0 && secs <= APPROVAL_RESPONSE_TIMEOUT_MAX_SECS => {
+            std::time::Duration::from_secs(secs)
+        }
+        _ => {
+            // Loud fallback (PR #1968 review): an ignored override must not
+            // leave the operator wondering why their timeout did not apply.
+            tracing::warn!(
+                value = %raw,
+                "invalid COSH_CORE_APPROVAL_TIMEOUT_SECS (want 1..={} secs); \
+                 falling back to the default approval timeout",
+                APPROVAL_RESPONSE_TIMEOUT_MAX_SECS
+            );
+            fallback()
+        }
+    }
 }
 
 fn hook_decision_name(decision: &HookDecision) -> &'static str {
@@ -1785,6 +1850,7 @@ fn approval_audit_outcome(approval: &ApprovalResult) -> (AuditOutcomeStatus, &'s
             (AuditOutcomeStatus::Allowed, "allow")
         }
         ApprovalResult::Denied(_) => (AuditOutcomeStatus::Denied, "deny"),
+        ApprovalResult::TimedOut => (AuditOutcomeStatus::Denied, "timeout"),
         ApprovalResult::Interrupted => (AuditOutcomeStatus::Cancelled, "interrupted"),
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -1011,6 +1011,347 @@ async fn request_id_skips_mismatched() {
     assert!(matches!(result, ApprovalResult::Denied(_)));
 }
 
+/// Serializes the two tests that mutate the process-wide
+/// `COSH_CORE_APPROVAL_TIMEOUT_SECS`; without it a concurrent
+/// `remove_var` could send the hanging test back to the 6h default.
+static APPROVAL_TIMEOUT_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[tokio::test]
+async fn unanswered_approval_times_out_instead_of_hanging_forever() {
+    // #1940 residual guard: hours-scale by default, overridden here so the
+    // wait ends quickly. A peer that never answers and never closes the
+    // channel must not hang the turn forever.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let core = make_core(MockProvider::text_only(""));
+    let (client, _server) = tokio::io::duplex(64);
+    let mut reader = BufReader::new(client).lines();
+
+    let result = core
+        .wait_for_approval("expected-id", false, &mut reader)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+    assert!(matches!(result, ApprovalResult::TimedOut));
+}
+
+#[tokio::test]
+async fn answered_approval_beats_the_residual_timeout() {
+    // A response that arrives normally must win over the deadline: the
+    // guard only fires when nothing ever comes back.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let core = make_core(MockProvider::text_only(""));
+    let (mut client, server) = tokio::io::duplex(256);
+    tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt;
+        let mut server = server;
+        server
+            .write_all(
+                br#"{"type":"control_response","response":{"subtype":"success","request_id":"expected-id","response":{"behavior":"allow"}}}
+"#,
+            )
+            .await
+            .expect("write response");
+    });
+    let mut reader = BufReader::new(&mut client).lines();
+
+    let result = core
+        .wait_for_approval("expected-id", false, &mut reader)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+    assert!(matches!(result, ApprovalResult::Allowed));
+}
+
+#[tokio::test]
+async fn approval_receipt_disarms_the_residual_timeout_for_a_pending_card() {
+    // #1940 receipt protocol: once the shell acknowledges the request, a
+    // card waiting on the user may outlive the residual deadline — the
+    // shell owns the terminal state from that point on.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let core = make_core(MockProvider::text_only(""));
+    let (mut client, server) = tokio::io::duplex(512);
+    tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt;
+        let mut server = server;
+        server
+            .write_all(
+                br#"{"type":"approval_receipt","request_id":"expected-id"}
+"#,
+            )
+            .await
+            .expect("write receipt");
+        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+        server
+            .write_all(
+                br#"{"type":"control_response","response":{"subtype":"success","request_id":"expected-id","response":{"behavior":"allow"}}}
+"#,
+            )
+            .await
+            .expect("write response");
+    });
+    let mut reader = BufReader::new(&mut client).lines();
+
+    let result = core
+        .wait_for_approval("expected-id", false, &mut reader)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+    assert!(matches!(result, ApprovalResult::Allowed));
+}
+
+#[tokio::test]
+async fn approval_receipt_disarms_the_residual_timeout_for_a_slow_host_command() {
+    // Same disarm for a host-executed command finishing after the residual
+    // deadline: the executed result must reach the model, never a phantom
+    // "not executed" timeout.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let core = make_core(MockProvider::text_only(""));
+    let (mut client, server) = tokio::io::duplex(512);
+    tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt;
+        let mut server = server;
+        server
+            .write_all(
+                br#"{"type":"approval_receipt","request_id":"expected-id"}
+"#,
+            )
+            .await
+            .expect("write receipt");
+        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+        server
+            .write_all(
+                br#"{"type":"control_response","response":{"subtype":"success","request_id":"expected-id","response":{"behavior":"host_executed_shell","result":{"llmContent":"command output","metadata":{"exit_code":0}}}}}
+"#,
+            )
+            .await
+            .expect("write response");
+    });
+    let mut reader = BufReader::new(&mut client).lines();
+
+    let result = core
+        .wait_for_approval("expected-id", true, &mut reader)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+    assert!(matches!(
+        result,
+        ApprovalResult::HostExecutedShell {
+            exit_code: Some(0),
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn approval_receipt_for_a_different_request_keeps_the_residual_timeout() {
+    // A receipt only disarms the wait for its own request id; an unrelated
+    // receipt observed on the shared reader must not leak the disarm.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let core = make_core(MockProvider::text_only(""));
+    let (mut client, server) = tokio::io::duplex(256);
+    tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt;
+        let mut server = server;
+        server
+            .write_all(
+                br#"{"type":"approval_receipt","request_id":"other-id"}
+"#,
+            )
+            .await
+            .expect("write receipt");
+        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+    });
+    let mut reader = BufReader::new(&mut client).lines();
+
+    let result = core
+        .wait_for_approval("expected-id", false, &mut reader)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+    assert!(matches!(result, ApprovalResult::TimedOut));
+}
+
+#[tokio::test]
+async fn approval_timeout_fails_the_turn_without_a_second_generation() {
+    // #1940: a timed-out approval must end the turn. The mock peer keeps
+    // the channel open but never answers; after the residual deadline the
+    // turn fails — no second provider generation, the gated tool never
+    // runs, and a late response written afterwards is never consumed.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let shell_calls = Arc::new(AtomicUsize::new(0));
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-1".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"command":"echo must-not-run"}"#.to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("second generation must never happen".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "suggest".to_string();
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::clone(&shell_calls),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+
+    let (client, mut server) = tokio::io::duplex(256);
+    let mut reader = BufReader::new(client).lines();
+    let mut output = Vec::new();
+
+    let result = core
+        .handle_user_message("run it", &mut reader, &mut output)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+
+    // A late response written after the timeout has no waiter left: it must
+    // never turn into an execution.
+    use tokio::io::AsyncWriteExt;
+    server
+        .write_all(
+            br#"{"type":"control_response","response":{"subtype":"success","request_id":"req-0","response":{"behavior":"allow"}}}
+"#,
+        )
+        .await
+        .expect("write late response");
+
+    let error = result.expect_err("a timed-out approval must fail the turn");
+    assert!(
+        error.contains("timed out"),
+        "the failure must name the timeout: {error}"
+    );
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        !output_str.contains("second generation must never happen"),
+        "the turn must fail before another provider generation: {output_str}"
+    );
+    assert_eq!(
+        shell_calls.load(Ordering::SeqCst),
+        0,
+        "the gated tool must never execute"
+    );
+    let tool_result = core
+        .messages
+        .iter()
+        .find(|m| m.role == "tool" && m.tool_call_id.as_deref() == Some("call-1"))
+        .expect("the declared tool call keeps a paired result");
+    match &tool_result.content {
+        crate::provider::MessageContent::Text(content) => {
+            assert!(content.contains("approval timed out"), "{content}");
+        }
+        _ => panic!("expected text tool result"),
+    }
+}
+
+/// A post_tool_use_failure hook that requests a sandbox bypass and touches a
+/// marker file so the test can prove the hook actually ran.
+fn sandbox_bypass_hook(marker: &std::path::Path) -> crate::config::HookDefinition {
+    crate::config::HookDefinition {
+        command: format!(
+            "touch '{}' && printf '%s\\n' '{}'",
+            marker.display(),
+            r#"{"hookSpecificOutput":{"sandbox_bypass_request":{"original_command":"echo must-not-run","reason":"sandbox blocked"}}}"#
+        ),
+        name: Some("sandbox-bypass-hook".to_string()),
+        matcher: None,
+        timeout: Some(10_000),
+        sequential: None,
+        env: Default::default(),
+    }
+}
+
+#[tokio::test]
+async fn approval_timeout_suppresses_the_sandbox_bypass_reprompt() {
+    // #1940: once the policy approval times out the turn is fatal, so a
+    // post_tool_use_failure hook's sandbox-bypass request must not open a
+    // second approval — its Allowed arm would execute the tool behind the
+    // recorded "not executed" result.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let hook_marker = std::env::temp_dir().join(format!(
+        "cosh-bypass-hook-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_file(&hook_marker);
+    let shell_calls = Arc::new(AtomicUsize::new(0));
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-1".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"command":"echo must-not-run"}"#.to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("second generation must never happen".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "suggest".to_string();
+    config.hooks.enabled = true;
+    config.hooks.post_tool_use_failure = vec![sandbox_bypass_hook(&hook_marker)];
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::clone(&shell_calls),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+
+    let (client, _server) = tokio::io::duplex(256);
+    let mut reader = BufReader::new(client).lines();
+    let mut output = Vec::new();
+
+    let result = core
+        .handle_user_message("run it", &mut reader, &mut output)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+
+    let error = result.expect_err("a timed-out approval must fail the turn");
+    assert!(error.contains("timed out"), "{error}");
+    assert!(
+        hook_marker.exists(),
+        "the failure hook must have run, otherwise this test proves nothing"
+    );
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        !output_str.contains("second generation must never happen"),
+        "the turn must fail before another provider generation: {output_str}"
+    );
+    assert_eq!(
+        output_str.matches("can_use_tool").count(),
+        1,
+        "only the policy approval may be emitted; the bypass reprompt must be suppressed: {output_str}"
+    );
+    assert_eq!(
+        shell_calls.load(Ordering::SeqCst),
+        0,
+        "the tool must never execute, not even behind a bypass approval"
+    );
+    let _ = std::fs::remove_file(&hook_marker);
+}
+
 #[tokio::test]
 async fn approval_flow_host_executed_shell_uses_tool_result() {
     let shell_calls = Arc::new(AtomicUsize::new(0));

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -1011,6 +1011,57 @@ async fn request_id_skips_mismatched() {
     assert!(matches!(result, ApprovalResult::Denied(_)));
 }
 
+/// Serializes the two tests that mutate the process-wide
+/// `COSH_CORE_APPROVAL_TIMEOUT_SECS`; without it a concurrent
+/// `remove_var` could send the hanging test back to the 6h default.
+static APPROVAL_TIMEOUT_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[tokio::test]
+async fn unanswered_approval_times_out_instead_of_hanging_forever() {
+    // #1940 residual guard: hours-scale by default, overridden here so the
+    // wait ends quickly. A peer that never answers and never closes the
+    // channel must not hang the turn forever.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let core = make_core(MockProvider::text_only(""));
+    let (client, _server) = tokio::io::duplex(64);
+    let mut reader = BufReader::new(client).lines();
+
+    let result = core
+        .wait_for_approval("expected-id", false, &mut reader)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+    assert!(matches!(result, ApprovalResult::TimedOut));
+}
+
+#[tokio::test]
+async fn answered_approval_beats_the_residual_timeout() {
+    // A response that arrives normally must win over the deadline: the
+    // guard only fires when nothing ever comes back.
+    let _guard = APPROVAL_TIMEOUT_ENV_LOCK.lock().await;
+    std::env::set_var("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1");
+    let core = make_core(MockProvider::text_only(""));
+    let (mut client, server) = tokio::io::duplex(256);
+    tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt;
+        let mut server = server;
+        server
+            .write_all(
+                br#"{"type":"control_response","response":{"subtype":"success","request_id":"expected-id","response":{"behavior":"allow"}}}
+"#,
+            )
+            .await
+            .expect("write response");
+    });
+    let mut reader = BufReader::new(&mut client).lines();
+
+    let result = core
+        .wait_for_approval("expected-id", false, &mut reader)
+        .await;
+    std::env::remove_var("COSH_CORE_APPROVAL_TIMEOUT_SECS");
+    assert!(matches!(result, ApprovalResult::Allowed));
+}
+
 #[tokio::test]
 async fn approval_flow_host_executed_shell_uses_tool_result() {
     let shell_calls = Arc::new(AtomicUsize::new(0));

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -460,6 +460,9 @@ where
         }
 
         InputMessage::ControlResponse { .. } => {}
+        // Receipts only matter to an interactive `wait_for_approval` loop;
+        // the headless path never waits on one.
+        InputMessage::ApprovalReceipt { .. } => {}
         InputMessage::RegistryRequest {
             request_id,
             domain,

--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -75,6 +75,13 @@ pub enum InputMessage {
     #[serde(rename = "control_response")]
     ControlResponse { response: ControlResponsePayload },
 
+    /// #1940 receipt protocol: the shell emits this as soon as a control
+    /// approval request reaches its main thread, proving the request has an
+    /// owner for its terminal state. Cores that predate the receipt simply
+    /// fail to deserialize this line and keep their residual guard.
+    #[serde(rename = "approval_receipt")]
+    ApprovalReceipt { request_id: String },
+
     #[serde(rename = "registry_request")]
     RegistryRequest {
         request_id: String,
@@ -257,6 +264,11 @@ pub struct CoreControlCapabilities {
     pub can_handle_can_use_tool: bool,
     pub can_handle_host_executed_shell_tool_result: bool,
     pub can_handle_shell_evidence_tool: bool,
+    /// #1940 receipt protocol: the core consumes `approval_receipt` lines to
+    /// disarm its last-resort approval timeout. Announced so the shell only
+    /// sends receipts to a core that understands them; older or mock
+    /// providers without this capability never see receipt lines.
+    pub can_handle_approval_receipt: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
@@ -460,6 +472,7 @@ impl OutputMessage {
                         can_handle_can_use_tool: true,
                         can_handle_host_executed_shell_tool_result: true,
                         can_handle_shell_evidence_tool,
+                        can_handle_approval_receipt: true,
                     },
                 },
             },
@@ -929,6 +942,10 @@ mod tests {
         assert_eq!(
             v["response"]["response"]["capabilities"]["can_handle_shell_evidence_tool"],
             false
+        );
+        assert_eq!(
+            v["response"]["response"]["capabilities"]["can_handle_approval_receipt"],
+            true
         );
         assert!(v["response"]["response"]["capabilities"]
             .get("can_handle_shell_output_evidence_tool")

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude/driver.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude/driver.rs
@@ -9,7 +9,7 @@ use crate::types::AgentEvent;
 use super::super::{
     agent_event_is_provider_progress, commit_provider_session_if_completed, control_protocol,
     record_cancellation_pending_session, run_provider_process_loop, spawn_provider_child,
-    AdapterError, AgentRunHandle, ApprovalDecision, ApprovalResponse, ClaudeStreamParser,
+    AdapterError, AgentRunHandle, ApprovalChannelMessage, ApprovalDecision, ClaudeStreamParser,
     PreparedInvocation, ProviderCancellationArtifactStore, ProviderLineProgress,
     ProviderPromptArgMode, ProviderRunOutcome, ProviderStdinMode,
 };
@@ -175,7 +175,7 @@ pub(super) fn start_control_protocol_claude_process(
     session_state: Arc<Mutex<Option<String>>>,
 ) -> AgentRunHandle {
     let (event_tx, event_rx) = mpsc::channel();
-    let (approval_tx, approval_rx) = mpsc::channel::<ApprovalResponse>();
+    let (approval_tx, approval_rx) = mpsc::channel::<ApprovalChannelMessage>();
     let cancelled = Arc::new(AtomicBool::new(false));
     let writer_done = Arc::new(AtomicBool::new(false));
     let child_pid = Arc::new(Mutex::new(None::<u32>));
@@ -261,40 +261,43 @@ pub(super) fn start_control_protocol_claude_process(
             while !writer_done_for_thread.load(Ordering::SeqCst)
                 && !writer_cancelled.load(Ordering::SeqCst)
             {
-                let response = match approval_rx.recv_timeout(Duration::from_millis(100)) {
-                    Ok(response) => response,
+                let msg = match approval_rx.recv_timeout(Duration::from_millis(100)) {
+                    // Receipts exist only for cosh-core's residual approval
+                    // timeout; provider control protocols have no receipt
+                    // semantic, so consume them without touching the wire.
+                    Ok(ApprovalChannelMessage::Receipt { .. }) => continue,
+                    Ok(ApprovalChannelMessage::Response(response)) => match &response.decision {
+                        ApprovalDecision::Allow => match response.tool_input.as_ref() {
+                            Some(tool_input) => control_protocol::serialize_claude_allow(
+                                &response.request_id,
+                                tool_input,
+                            ),
+                            None => control_protocol::serialize_deny(
+                                &response.request_id,
+                                "Missing provider tool input",
+                            ),
+                        },
+                        ApprovalDecision::Deny { message } => {
+                            control_protocol::serialize_deny(&response.request_id, message)
+                        }
+                        ApprovalDecision::HostExecutedShell { result } => {
+                            control_protocol::serialize_host_executed_shell_result(
+                                &response.request_id,
+                                result,
+                            )
+                        }
+                        ApprovalDecision::Answer { answer } => {
+                            control_protocol::serialize_answer(&response.request_id, answer)
+                        }
+                        ApprovalDecision::ShellEvidence { result } => {
+                            control_protocol::serialize_shell_evidence_result(
+                                &response.request_id,
+                                result,
+                            )
+                        }
+                    },
                     Err(mpsc::RecvTimeoutError::Timeout) => continue,
                     Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                };
-                let msg = match &response.decision {
-                    ApprovalDecision::Allow => match response.tool_input.as_ref() {
-                        Some(tool_input) => control_protocol::serialize_claude_allow(
-                            &response.request_id,
-                            tool_input,
-                        ),
-                        None => control_protocol::serialize_deny(
-                            &response.request_id,
-                            "Missing provider tool input",
-                        ),
-                    },
-                    ApprovalDecision::Deny { message } => {
-                        control_protocol::serialize_deny(&response.request_id, message)
-                    }
-                    ApprovalDecision::HostExecutedShell { result } => {
-                        control_protocol::serialize_host_executed_shell_result(
-                            &response.request_id,
-                            result,
-                        )
-                    }
-                    ApprovalDecision::Answer { answer } => {
-                        control_protocol::serialize_answer(&response.request_id, answer)
-                    }
-                    ApprovalDecision::ShellEvidence { result } => {
-                        control_protocol::serialize_shell_evidence_result(
-                            &response.request_id,
-                            result,
-                        )
-                    }
                 };
                 if writeln!(writer, "{msg}").is_err() {
                     break;
@@ -354,7 +357,8 @@ pub(super) fn start_control_protocol_claude_process(
                                     &tool_use_id,
                                 )
                             {
-                                let _ = approval_tx_for_loop.send(response);
+                                let _ = approval_tx_for_loop
+                                    .send(ApprovalChannelMessage::Response(response));
                                 return Ok(ProviderLineProgress::AwaitingApproval);
                             }
                             send_agent_event(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
@@ -10,6 +10,7 @@ mod auth;
 mod serialization;
 
 use auth::parse_auth_provider;
+pub(crate) use serialization::serialize_approval_receipt;
 pub use serialization::{
     serialize_answer, serialize_auth_response, serialize_claude_allow, serialize_co_allow,
     serialize_deny, serialize_host_executed_shell_result, serialize_initialize,
@@ -129,12 +130,35 @@ pub struct AuthResponse {
     pub persist: bool,
 }
 
+/// Non-exhaustive: capability flags grow with the control protocol (e.g. the
+/// #1940 `can_handle_approval_receipt`), and out-of-crate code must stay
+/// source-compatible across those additions — construct via `default()` and
+/// set fields, or read them; only this crate builds it exhaustively.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ControlProtocolCapabilities {
     pub provider_initialize_seen: bool,
     pub can_handle_can_use_tool: bool,
     pub can_handle_host_executed_shell_tool_result: bool,
     pub can_handle_shell_evidence_tool: bool,
+    /// #1940 receipt protocol: only a provider that announces this capability
+    /// receives `approval_receipt` lines. Without it the receipt is skipped —
+    /// a provider that does not understand receipts would misread the line as
+    /// an ordinary response, and losing the receipt only means the core keeps
+    /// its last-resort approval guard armed (the designed degradation).
+    pub can_handle_approval_receipt: bool,
+}
+
+/// Shared writer-thread check for the #1940 receipt gate: a poisoned or
+/// unparsed capability set reads as "not capable", so the receipt is skipped
+/// rather than risking an unintelligible line on the provider's stdin.
+pub(crate) fn receipt_capable(
+    capabilities: &std::sync::Arc<std::sync::Mutex<ControlProtocolCapabilities>>,
+) -> bool {
+    capabilities
+        .lock()
+        .map(|caps| caps.can_handle_approval_receipt)
+        .unwrap_or(false)
 }
 
 #[derive(Debug, Default)]
@@ -573,6 +597,7 @@ pub fn parse_initialize_capabilities(line: &str) -> Option<ControlProtocolCapabi
             capabilities,
             "can_handle_shell_evidence_tool",
         ),
+        can_handle_approval_receipt: bool_capability(capabilities, "can_handle_approval_receipt"),
     })
 }
 
@@ -589,6 +614,16 @@ pub struct ApprovalResponse {
     pub tool_use_id: Option<String>,
     pub tool_input: Option<Value>,
     pub decision: ApprovalDecision,
+}
+
+/// #1940 receipt protocol: everything the shell can send over the approval
+/// channel. A `Response` is terminal for its request; a `Receipt` only
+/// proves the request reached the shell main thread (so the core can
+/// disarm its residual timeout) and never resolves anything.
+#[derive(Debug, Clone)]
+pub(crate) enum ApprovalChannelMessage {
+    Response(ApprovalResponse),
+    Receipt { request_id: String },
 }
 
 #[derive(Debug, Clone)]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
@@ -63,6 +63,19 @@ pub fn serialize_co_allow(request_id: &str) -> String {
     .to_string()
 }
 
+/// #1940 receipt protocol: emitted as soon as a control approval request
+/// reaches the shell main thread. A core that announced
+/// `can_handle_approval_receipt` disarms its residual timeout for this
+/// request; writers skip the line entirely for providers without the
+/// capability, whose guard then stays armed.
+pub(crate) fn serialize_approval_receipt(request_id: &str) -> String {
+    json!({
+        "type": "approval_receipt",
+        "request_id": request_id
+    })
+    .to_string()
+}
+
 pub fn serialize_claude_allow(request_id: &str, updated_input: &Value) -> String {
     json!({
         "type": "control_response",

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
@@ -304,12 +304,13 @@ fn parse_non_control_request_returns_none() {
 
 #[test]
 fn parse_initialize_capabilities_from_success_response() {
-    let line = r#"{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true,"can_handle_shell_evidence_tool":true}}}}"#;
+    let line = r#"{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true,"can_handle_shell_evidence_tool":true,"can_handle_approval_receipt":true}}}}"#;
     let capabilities = parse_initialize_capabilities(line).expect("capabilities");
     assert!(capabilities.provider_initialize_seen);
     assert!(capabilities.can_handle_can_use_tool);
     assert!(capabilities.can_handle_host_executed_shell_tool_result);
     assert!(capabilities.can_handle_shell_evidence_tool);
+    assert!(capabilities.can_handle_approval_receipt);
 }
 
 #[test]
@@ -320,6 +321,16 @@ fn parse_initialize_capabilities_defaults_missing_flags_to_false() {
     assert!(!capabilities.can_handle_can_use_tool);
     assert!(!capabilities.can_handle_host_executed_shell_tool_result);
     assert!(!capabilities.can_handle_shell_evidence_tool);
+    assert!(!capabilities.can_handle_approval_receipt);
+}
+
+#[test]
+fn receipt_capable_requires_the_announced_capability() {
+    use std::sync::{Arc, Mutex};
+    let capabilities = Arc::new(Mutex::new(ControlProtocolCapabilities::default()));
+    assert!(!receipt_capable(&capabilities));
+    capabilities.lock().unwrap().can_handle_approval_receipt = true;
+    assert!(receipt_capable(&capabilities));
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/question_writer.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/question_writer.rs
@@ -6,18 +6,19 @@ use std::thread;
 use std::time::Duration;
 
 use super::super::{
-    control_protocol, AdapterError, ApprovalDecision, ApprovalResponse, AuthResponse,
+    control_protocol, AdapterError, ApprovalChannelMessage, ApprovalDecision, AuthResponse,
 };
 use super::question_ingress::{protocol_error, CoreQuestionProtocolReason, CoshCoreQuestionGate};
 
 pub(crate) struct QuestionWriter {
     pub(crate) stdin: ChildStdin,
     pub(crate) prompt: String,
-    pub(crate) approval_rx: mpsc::Receiver<ApprovalResponse>,
+    pub(crate) approval_rx: mpsc::Receiver<ApprovalChannelMessage>,
     pub(crate) auth_rx: mpsc::Receiver<AuthResponse>,
     pub(crate) done: Arc<AtomicBool>,
     pub(crate) cancelled: Arc<AtomicBool>,
     pub(crate) gate: Arc<Mutex<CoshCoreQuestionGate>>,
+    pub(crate) capabilities: Arc<Mutex<control_protocol::ControlProtocolCapabilities>>,
     pub(crate) failure_tx: mpsc::Sender<AdapterError>,
     pub(crate) answer_confirmation_tx: mpsc::Sender<Result<String, AdapterError>>,
 }
@@ -41,7 +42,7 @@ impl QuestionWriter {
 
         while !self.done.load(Ordering::SeqCst) && !self.cancelled.load(Ordering::SeqCst) {
             let (message, answered_request_id) =
-                match Self::next_message(&self.approval_rx, &self.auth_rx) {
+                match Self::next_message(&self.approval_rx, &self.auth_rx, &self.capabilities) {
                     Ok(Some(message)) => message,
                     Ok(None) => continue,
                     Err(()) => break,
@@ -61,11 +62,24 @@ impl QuestionWriter {
     }
 
     fn next_message(
-        approval_rx: &mpsc::Receiver<ApprovalResponse>,
+        approval_rx: &mpsc::Receiver<ApprovalChannelMessage>,
         auth_rx: &mpsc::Receiver<AuthResponse>,
+        capabilities: &Arc<Mutex<control_protocol::ControlProtocolCapabilities>>,
     ) -> Result<Option<(String, Option<String>)>, ()> {
         match approval_rx.recv_timeout(Duration::from_millis(100)) {
-            Ok(response) => {
+            // #1940 receipt gate: skipped for providers that never announced
+            // `can_handle_approval_receipt` — they would misread the line, and
+            // a lost receipt only keeps the core's last-resort guard armed.
+            Ok(ApprovalChannelMessage::Receipt { request_id }) => {
+                if !control_protocol::receipt_capable(capabilities) {
+                    return Ok(None);
+                }
+                Ok(Some((
+                    control_protocol::serialize_approval_receipt(&request_id),
+                    None,
+                )))
+            }
+            Ok(ApprovalChannelMessage::Response(response)) => {
                 let answered_request_id =
                     matches!(response.decision, ApprovalDecision::Answer { .. })
                         .then(|| response.request_id.clone());

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
@@ -23,7 +23,7 @@ use super::cosh_core::{
 use super::{
     agent_event_is_provider_progress, control_protocol, record_cancellation_pending_session,
     run_provider_process_loop, spawn_provider_child, AdapterError, AgentRunHandle,
-    ApprovalResponse, AuthResponse, ClaudeStreamParser, PreparedInvocation,
+    ApprovalChannelMessage, AuthResponse, ClaudeStreamParser, PreparedInvocation,
     ProviderCancellationArtifactStore, ProviderLineProgress, ProviderPromptArgMode,
     ProviderRunOutcome, ProviderStdinMode,
 };
@@ -200,7 +200,7 @@ pub(super) fn start_control_protocol_cosh_core_process(
     resume_attempt: SessionResumeAttempt,
 ) -> AgentRunHandle {
     let (event_tx, event_rx) = mpsc::channel();
-    let (approval_tx, approval_rx) = mpsc::channel::<ApprovalResponse>();
+    let (approval_tx, approval_rx) = mpsc::channel::<ApprovalChannelMessage>();
     let (answer_confirmation_tx, answer_confirmation_rx) = mpsc::channel();
     let (auth_tx, auth_rx) = mpsc::channel::<AuthResponse>();
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -279,6 +279,7 @@ pub(super) fn start_control_protocol_cosh_core_process(
             done: Arc::clone(&writer_done),
             cancelled: Arc::clone(&cancelled),
             gate: Arc::clone(&question_gate),
+            capabilities: Arc::clone(&control_capabilities_for_thread),
             failure_tx: writer_failure_tx,
             answer_confirmation_tx,
         }
@@ -362,7 +363,8 @@ pub(super) fn start_control_protocol_cosh_core_process(
                                     &tool_use_id,
                                 )
                             {
-                                let _ = approval_tx_for_loop.send(response);
+                                let _ = approval_tx_for_loop
+                                    .send(ApprovalChannelMessage::Response(response));
                                 return Ok(ProviderLineProgress::AwaitingApproval);
                             }
                             send_agent_event(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service.rs
@@ -1,5 +1,6 @@
 //! Long-lived cosh-core JSONL process shared by Agent turns and registry requests.
 
+mod command;
 mod control;
 mod process;
 mod question;
@@ -30,7 +31,7 @@ use super::cosh_core_registry::{
 };
 use super::{
     control_protocol, record_cancellation_pending_session, AdapterError, AgentRunHandle,
-    ApprovalResponse, AuthResponse, ClaudeStreamParser, PreparedInvocation,
+    ApprovalChannelMessage, ApprovalResponse, AuthResponse, ClaudeStreamParser, PreparedInvocation,
     ProviderCancellationArtifactStore,
 };
 use process::{
@@ -274,32 +275,7 @@ enum ServiceCommand {
     Shutdown,
 }
 
-struct RunCommand {
-    run_id: String,
-    prepared: PreparedInvocation,
-    mode: CoshApprovalMode,
-    session_state: Arc<Mutex<SessionRuntimeState>>,
-    session_scope: String,
-    resume_attempt: SessionResumeAttempt,
-    event_tx: mpsc::Sender<Result<AgentEvent, AdapterError>>,
-    internal_response_tx: mpsc::Sender<ApprovalResponse>,
-    approval_rx: Option<mpsc::Receiver<ApprovalResponse>>,
-    auth_rx: Option<mpsc::Receiver<AuthResponse>>,
-    answer_confirmation_tx: mpsc::Sender<Result<String, AdapterError>>,
-    pending_session: Arc<Mutex<Option<String>>>,
-    cancellation_artifacts: ProviderCancellationArtifactStore,
-    control_capabilities: Arc<Mutex<control_protocol::ControlProtocolCapabilities>>,
-    cancelled: Arc<AtomicBool>,
-    run_done: Arc<AtomicBool>,
-}
-
-struct RegistryCommand {
-    request_id: String,
-    domain: String,
-    action: String,
-    params: Value,
-    response_tx: mpsc::Sender<Result<Value, RegistryQueryError>>,
-}
+use command::{RegistryCommand, RunCommand};
 
 fn service_loop(
     receiver: mpsc::Receiver<ServiceCommand>,
@@ -410,6 +386,13 @@ fn run_turn(
             &control_protocol::serialize_initialize("init-1"),
         )?;
         process.initialized = true;
+    } else if process.control_capabilities.provider_initialize_seen {
+        // The initialize response arrives once per process; later turns seed
+        // their per-run capability set from the process record so the #1940
+        // receipt gate keeps emitting `approval_receipt` after the first turn.
+        if let Ok(mut current) = command.control_capabilities.lock() {
+            *current = process.control_capabilities;
+        }
     }
     // Consume a reload noted while the core sat idle before the next user
     // message goes out; otherwise the coming turn would still run on the
@@ -451,6 +434,7 @@ fn run_turn(
             .take()
             .ok_or_else(|| "auth receiver is unavailable".to_string())?,
         Arc::clone(&question_gate),
+        Arc::clone(&command.control_capabilities),
         writer_failure_tx,
         command.answer_confirmation_tx.clone(),
     );
@@ -519,6 +503,10 @@ fn run_turn(
             }
         }
         if let Some(capabilities) = control_protocol::parse_initialize_capabilities(&line) {
+            // Announced once per process: keep the durable copy on the
+            // process record so later turns inherit it (mirrors
+            // `session_resumable`).
+            process.control_capabilities = capabilities;
             if let Ok(mut current) = command.control_capabilities.lock() {
                 *current = capabilities;
             }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/command.rs
@@ -1,0 +1,46 @@
+//! Command payloads carried over the persistent cosh-core service channel.
+//!
+//! Split from `cosh_core_service.rs` to keep the service module under the
+//! layout threshold; these are plain data carriers with no behavior.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::{mpsc, Arc, Mutex};
+
+use serde_json::Value;
+
+use crate::types::{AgentEvent, CoshApprovalMode};
+
+use super::super::cosh_core::{SessionResumeAttempt, SessionRuntimeState};
+use super::super::cosh_core_registry::RegistryQueryError;
+use super::super::{
+    control_protocol, AdapterError, ApprovalChannelMessage, AuthResponse,
+    ProviderCancellationArtifactStore,
+};
+use super::PreparedInvocation;
+
+pub(super) struct RunCommand {
+    pub(super) run_id: String,
+    pub(super) prepared: PreparedInvocation,
+    pub(super) mode: CoshApprovalMode,
+    pub(super) session_state: Arc<Mutex<SessionRuntimeState>>,
+    pub(super) session_scope: String,
+    pub(super) resume_attempt: SessionResumeAttempt,
+    pub(super) event_tx: mpsc::Sender<Result<AgentEvent, AdapterError>>,
+    pub(super) internal_response_tx: mpsc::Sender<ApprovalChannelMessage>,
+    pub(super) approval_rx: Option<mpsc::Receiver<ApprovalChannelMessage>>,
+    pub(super) auth_rx: Option<mpsc::Receiver<AuthResponse>>,
+    pub(super) answer_confirmation_tx: mpsc::Sender<Result<String, AdapterError>>,
+    pub(super) pending_session: Arc<Mutex<Option<String>>>,
+    pub(super) cancellation_artifacts: ProviderCancellationArtifactStore,
+    pub(super) control_capabilities: Arc<Mutex<control_protocol::ControlProtocolCapabilities>>,
+    pub(super) cancelled: Arc<AtomicBool>,
+    pub(super) run_done: Arc<AtomicBool>,
+}
+
+pub(super) struct RegistryCommand {
+    pub(super) request_id: String,
+    pub(super) domain: String,
+    pub(super) action: String,
+    pub(super) params: Value,
+    pub(super) response_tx: mpsc::Sender<Result<Value, RegistryQueryError>>,
+}

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/control.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/control.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 use crate::types::AgentEvent;
 
 use super::super::claude::send_agent_event;
-use super::super::{control_protocol, AdapterError};
+use super::super::{control_protocol, AdapterError, ApprovalChannelMessage};
 use super::RunCommand;
 
 pub(super) fn handle_control_request(
@@ -37,7 +37,9 @@ pub(super) fn handle_control_request(
                 &tool_input,
                 &tool_use_id,
             ) {
-                let _ = command.internal_response_tx.send(response);
+                let _ = command
+                    .internal_response_tx
+                    .send(ApprovalChannelMessage::Response(response));
                 return true;
             }
             send_agent_event(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
@@ -16,8 +16,8 @@ use super::super::cosh_core::question_ingress::{
     protocol_error, CoreQuestionProtocolReason, CoshCoreQuestionGate,
 };
 use super::super::{
-    control_protocol, spawn_provider_child, AdapterError, ApprovalDecision, ApprovalResponse,
-    AuthResponse, PreparedInvocation, ProviderPromptArgMode, ProviderStdinMode,
+    control_protocol, spawn_provider_child, AdapterError, ApprovalChannelMessage, ApprovalDecision,
+    ApprovalResponse, AuthResponse, PreparedInvocation, ProviderPromptArgMode, ProviderStdinMode,
 };
 use super::{
     registry_timeout, PersistentCoshCoreRuntime, RegistryCommand, RegistryQueryError,
@@ -53,15 +53,25 @@ pub(super) struct PersistentProcess {
     /// a per-turn stream parser only observes it on the first turn. Later turns
     /// read it from here instead of defaulting to "unknown".
     pub(super) session_resumable: Option<bool>,
+    /// Control-protocol capabilities announced by this process.
+    ///
+    /// Like `session_resumable`, the `initialize` response arrives once per
+    /// process, so only the first turn parses it. Later turns seed their
+    /// per-run capability set from here; otherwise the #1940 receipt gate
+    /// would fall back to "not capable" and stop emitting `approval_receipt`
+    /// from the second turn on.
+    pub(super) control_capabilities: control_protocol::ControlProtocolCapabilities,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_response_writer(
     stdin: Arc<Mutex<BufWriter<ChildStdin>>>,
     done: Arc<AtomicBool>,
     cancelled: Arc<AtomicBool>,
-    approval_rx: mpsc::Receiver<ApprovalResponse>,
+    approval_rx: mpsc::Receiver<ApprovalChannelMessage>,
     auth_rx: mpsc::Receiver<AuthResponse>,
     question_gate: Arc<Mutex<CoshCoreQuestionGate>>,
+    capabilities: Arc<Mutex<control_protocol::ControlProtocolCapabilities>>,
     failure_tx: mpsc::Sender<AdapterError>,
     answer_confirmation_tx: mpsc::Sender<Result<String, AdapterError>>,
 ) -> thread::JoinHandle<()> {
@@ -71,7 +81,26 @@ pub(super) fn spawn_response_writer(
         while !done.load(Ordering::SeqCst) && !cancelled.load(Ordering::SeqCst) {
             if approval_open {
                 match approval_rx.recv_timeout(Duration::from_millis(25)) {
-                    Ok(response) => {
+                    Ok(ApprovalChannelMessage::Receipt { request_id }) => {
+                        // #1940 receipt protocol: only providers that announce
+                        // `can_handle_approval_receipt` understand this line;
+                        // for the rest the receipt is skipped and the core-side
+                        // last-resort guard stays armed (the designed
+                        // degradation for a lost receipt).
+                        if !control_protocol::receipt_capable(&capabilities) {
+                            continue;
+                        }
+                        if send_json(
+                            &stdin,
+                            &control_protocol::serialize_approval_receipt(&request_id),
+                        )
+                        .is_err()
+                        {
+                            break;
+                        }
+                        continue;
+                    }
+                    Ok(ApprovalChannelMessage::Response(response)) => {
                         let message = approval_message(&response);
                         if matches!(&response.decision, ApprovalDecision::Answer { .. }) {
                             let write_result =
@@ -206,6 +235,7 @@ pub(super) fn spawn_process(
         session_id: None,
         workspace_scope: String::new(),
         session_resumable: None,
+        control_capabilities: control_protocol::ControlProtocolCapabilities::default(),
     })
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
@@ -2,7 +2,10 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use super::cosh_core::{CoshCoreAdapter, SessionRecoveryState, SessionRuntimeState};
-use super::{AdapterError, AgentAdapter, AgentRunHandle, AgentRunPoll, FreshSessionOutcome};
+use super::{
+    AdapterError, AgentAdapter, AgentRunHandle, AgentRunPoll, ApprovalDecision, ApprovalResponse,
+    FreshSessionOutcome,
+};
 use crate::types::{
     AgentEvent, AgentMode, AgentRequest, CommandBlock, CommandStatus, CoshApprovalMode, OutputRefs,
 };
@@ -899,6 +902,97 @@ fn cancellable_runs_and_registry_share_one_persistent_core() {
     assert_eq!(first_info["pid"], second_info["pid"]);
     assert_eq!(first_info["turns"], 1);
     assert_eq!(second_info["turns"], 2);
+    drop(adapter);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+// #1940 regression: the persistent process announces `initialize` capabilities
+// once, on the first turn. Later turns must inherit them from the process
+// record — otherwise the receipt gate reads the default "not capable" and
+// silently stops emitting `approval_receipt` from the second turn on, leaving
+// the core's residual approval timeout armed against legitimate pending cards.
+#[test]
+fn persistent_core_keeps_receipt_capability_across_turns() {
+    let (script, root) = persistent_mock_paths("receipt-capability");
+    let receipts = root.join("receipts");
+    let source = r#"#!/bin/sh
+turns=0
+while IFS= read -r line; do
+  case "$line" in
+    *'"subtype":"initialize"'*)
+      printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true,"can_handle_approval_receipt":true}}}}'
+      ;;
+    *'"type":"approval_receipt"'*)
+      printf '%s\n' "$line" >> "__RECEIPTS__"
+      ;;
+    *'"type":"user"'*)
+      turns=$((turns + 1))
+      printf '{"type":"control_request","request_id":"ctrl-%s","request":{"subtype":"can_use_tool","tool_name":"Read","input":{"path":"/tmp/receipt-capability"},"tool_use_id":"toolu-%s"}}\n' "$turns" "$turns"
+      ;;
+    *'"behavior":"allow"'*)
+      printf '{"type":"result","subtype":"success","session_id":"00000000-0000-4000-8000-000000000000","is_error":false,"result":"done"}\n'
+      ;;
+    *'"subtype":"shutdown"'*) exit 0;;
+  esac
+done
+"#
+    .replace("__RECEIPTS__", &receipts.to_string_lossy());
+    std::fs::write(&script, source).expect("write receipt capability mock");
+    let mut permissions = std::fs::metadata(&script)
+        .expect("receipt capability mock metadata")
+        .permissions();
+    use std::os::unix::fs::PermissionsExt;
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&script, permissions).expect("chmod receipt capability mock");
+    let adapter = CoshCoreAdapter::new(script.to_string_lossy(), true);
+
+    for turn in 1..=2u32 {
+        let mut request = test_request();
+        request.id = format!("test-{turn}");
+        let handle = adapter.start_cancellable(request, CoshApprovalMode::Auto);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let request_id = loop {
+            match handle
+                .poll_event_timeout(Duration::from_millis(100))
+                .expect("poll receipt capability run")
+            {
+                AgentRunPoll::Event(AgentEvent::ToolPermissionRequest { request_id, .. }) => {
+                    break request_id;
+                }
+                AgentRunPoll::Event(_) => {}
+                AgentRunPoll::Finished => {
+                    panic!("turn {turn} finished before its permission request")
+                }
+                AgentRunPoll::Timeout if Instant::now() < deadline => {}
+                AgentRunPoll::Timeout => panic!("no permission request on turn {turn}"),
+            }
+        };
+        assert_eq!(request_id, format!("ctrl-{turn}"));
+        handle
+            .send_approval_receipt(&request_id)
+            .expect("send approval receipt");
+        handle
+            .respond_approval(ApprovalResponse {
+                request_id: request_id.clone(),
+                tool_use_id: None,
+                tool_input: None,
+                decision: ApprovalDecision::Allow,
+            })
+            .expect("respond approval");
+        collect_cancellable_run(&handle);
+        let receipt_deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let logged = std::fs::read_to_string(&receipts).unwrap_or_default();
+            if logged.contains(&format!("\"request_id\":\"ctrl-{turn}\"")) {
+                break;
+            }
+            assert!(
+                Instant::now() < receipt_deadline,
+                "turn {turn} receipt never reached the provider (logged: {logged:?})"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
     drop(adapter);
     let _ = std::fs::remove_dir_all(root);
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
@@ -71,7 +71,7 @@ impl AgentAdapter for FakeAgentAdapter {
     fn run(&self, request: &AgentRequest) -> Result<Vec<AgentEvent>, AdapterError> {
         let language = crate::language_config_status().effective;
         if let Some(input) = &request.user_input {
-            let run_id = format!("fake-run-{}", request.command_block.id);
+            let run_id = request.id.clone();
             if let Some(answer) = extract_fake_pending_answer(input) {
                 return Ok(vec![
                     AgentEvent::StatusChanged {
@@ -831,7 +831,7 @@ impl AgentAdapter for FakeAgentAdapter {
             ]);
         }
 
-        let run_id = format!("fake-run-{}", request.command_block.id);
+        let run_id = request.id.clone();
         Ok(vec![
             AgentEvent::StatusChanged {
                 run_id: run_id.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake/control_protocol.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake/control_protocol.rs
@@ -14,7 +14,7 @@ pub(super) fn emit_fake_control_protocol_stream(
         return Ok(false);
     }
 
-    let run_id = format!("fake-run-{}", request.command_block.id);
+    let run_id = request.id.clone();
     if input.contains("provider native tool") {
         sink(AgentEvent::StatusChanged {
             run_id: run_id.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_markdown.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_markdown.rs
@@ -7,7 +7,7 @@ pub(super) fn emit_fake_markdown_stream(
     request: &AgentRequest,
     sink: &mut dyn FnMut(AgentEvent) -> Result<(), AdapterError>,
 ) -> Result<bool, AdapterError> {
-    let run_id = format!("fake-run-{}", request.command_block.id);
+    let run_id = request.id.clone();
     if input.contains("stream markdown table") {
         sink(AgentEvent::StatusChanged {
             run_id: run_id.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_state.rs
@@ -14,7 +14,7 @@ pub(super) fn emit_fake_stale_question_stream(
         return Ok(false);
     }
 
-    let run_id = format!("fake-run-{}", request.command_block.id);
+    let run_id = request.id.clone();
     sink(AgentEvent::StatusChanged {
         run_id: run_id.clone(),
         phase: "question".to_string(),
@@ -49,7 +49,7 @@ pub(super) fn emit_fake_late_card_or_artifact_stream(
         return Ok(false);
     }
 
-    let run_id = format!("fake-run-{}", request.command_block.id);
+    let run_id = request.id.clone();
     sink(AgentEvent::StatusChanged {
         run_id: run_id.clone(),
         phase: "thinking".to_string(),
@@ -92,7 +92,7 @@ pub(super) fn emit_fake_slow_stream(
     request: &AgentRequest,
     sink: &mut dyn FnMut(AgentEvent) -> Result<(), AdapterError>,
 ) -> Result<(), AdapterError> {
-    let run_id = format!("fake-run-{}", request.command_block.id);
+    let run_id = request.id.clone();
     if input.contains("text then wait") {
         sink(AgentEvent::StatusChanged {
             run_id: run_id.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_tool_approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_tool_approval.rs
@@ -10,7 +10,7 @@ pub(super) fn emit_fake_tool_approval_stream(
     request: &AgentRequest,
     sink: &mut dyn FnMut(AgentEvent) -> Result<(), AdapterError>,
 ) -> Result<bool, AdapterError> {
-    let run_id = format!("fake-run-{}", request.command_block.id);
+    let run_id = request.id.clone();
     if input.contains("stream batch tool approval") {
         // Multi-request turn for turn-scope batch consent (issue #1773):
         // three distinct diagnostic commands queued in one run.

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
@@ -105,7 +105,7 @@ pub trait AgentAdapter {
 pub struct AgentRunHandle {
     receiver: mpsc::Receiver<Result<AgentEvent, AdapterError>>,
     cancel: Arc<dyn Fn() + Send + Sync>,
-    pub(crate) approval_sender: Option<mpsc::Sender<ApprovalResponse>>,
+    pub(crate) approval_sender: Option<mpsc::Sender<ApprovalChannelMessage>>,
     question_answer_confirmation: Option<mpsc::Receiver<Result<String, AdapterError>>>,
     pub(crate) auth_sender: Option<std::sync::mpsc::Sender<AuthResponse>>,
     control_capabilities: Arc<Mutex<ControlProtocolCapabilities>>,
@@ -166,7 +166,7 @@ pub enum AgentRunPoll {
 impl AgentRunHandle {
     #[cfg(test)]
     pub(crate) fn test_with_approval_sender(
-        approval_sender: mpsc::Sender<ApprovalResponse>,
+        approval_sender: mpsc::Sender<ApprovalChannelMessage>,
     ) -> Self {
         let (_sender, receiver) = mpsc::channel();
         Self {
@@ -183,7 +183,7 @@ impl AgentRunHandle {
 
     #[cfg(test)]
     pub(crate) fn test_with_question_answer_confirmation(
-        approval_sender: mpsc::Sender<ApprovalResponse>,
+        approval_sender: mpsc::Sender<ApprovalChannelMessage>,
         confirmation: mpsc::Receiver<Result<String, AdapterError>>,
     ) -> Self {
         let mut handle = Self::test_with_approval_sender(approval_sender);
@@ -210,7 +210,25 @@ impl AgentRunHandle {
             .ok_or_else(|| AdapterError {
                 message: "no approval channel (not in control protocol mode)".to_string(),
             })?
-            .send(response)
+            .send(ApprovalChannelMessage::Response(response))
+            .map_err(|_| AdapterError {
+                message: "approval channel closed".to_string(),
+            })
+    }
+
+    /// #1940 receipt protocol: notifies the core that a control approval
+    /// request reached the shell main thread, so the core can disarm its
+    /// residual timeout for exactly this request. Best-effort: a lost
+    /// receipt only means the core keeps its last-resort guard.
+    pub(crate) fn send_approval_receipt(&self, request_id: &str) -> Result<(), AdapterError> {
+        self.approval_sender
+            .as_ref()
+            .ok_or_else(|| AdapterError {
+                message: "no approval channel (not in control protocol mode)".to_string(),
+            })?
+            .send(ApprovalChannelMessage::Receipt {
+                request_id: request_id.to_string(),
+            })
             .map_err(|_| AdapterError {
                 message: "approval channel closed".to_string(),
             })
@@ -536,10 +554,13 @@ mod tests {
             confirmation_receiver,
         );
         thread::spawn(move || {
-            let response = approval_receiver.recv().expect("question answer");
+            let request_id = match approval_receiver.recv().expect("question answer") {
+                ApprovalChannelMessage::Response(response) => response.request_id,
+                other => panic!("expected approval response, got {other:?}"),
+            };
             confirmation_sender
                 .send(Err(AdapterError {
-                    message: format!("failed to write {}", response.request_id),
+                    message: format!("failed to write {request_id}"),
                 }))
                 .expect("confirmation");
         });

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/qwen/driver.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/qwen/driver.rs
@@ -10,7 +10,7 @@ use super::super::qwen_stream::QwenStreamParser;
 use super::super::{
     agent_event_is_provider_progress, commit_provider_session_if_completed, control_protocol,
     record_cancellation_pending_session, run_provider_process_loop, spawn_provider_child,
-    AdapterError, AgentRunHandle, ApprovalDecision, ApprovalResponse, PreparedInvocation,
+    AdapterError, AgentRunHandle, ApprovalChannelMessage, ApprovalDecision, PreparedInvocation,
     ProviderCancellationArtifactStore, ProviderLineProgress, ProviderPromptArgMode,
     ProviderRunOutcome, ProviderStdinMode,
 };
@@ -176,7 +176,7 @@ pub(super) fn start_control_protocol_qwen_process(
     session_state: Arc<Mutex<Option<String>>>,
 ) -> AgentRunHandle {
     let (event_tx, event_rx) = mpsc::channel();
-    let (approval_tx, approval_rx) = mpsc::channel::<ApprovalResponse>();
+    let (approval_tx, approval_rx) = mpsc::channel::<ApprovalChannelMessage>();
     let cancelled = Arc::new(AtomicBool::new(false));
     let writer_done = Arc::new(AtomicBool::new(false));
     let child_pid = Arc::new(Mutex::new(None::<u32>));
@@ -262,33 +262,36 @@ pub(super) fn start_control_protocol_qwen_process(
             while !writer_done_for_thread.load(Ordering::SeqCst)
                 && !writer_cancelled.load(Ordering::SeqCst)
             {
-                let response = match approval_rx.recv_timeout(Duration::from_millis(100)) {
-                    Ok(response) => response,
+                let msg = match approval_rx.recv_timeout(Duration::from_millis(100)) {
+                    // Receipts exist only for cosh-core's residual approval
+                    // timeout; provider control protocols have no receipt
+                    // semantic, so consume them without touching the wire.
+                    Ok(ApprovalChannelMessage::Receipt { .. }) => continue,
+                    Ok(ApprovalChannelMessage::Response(response)) => match &response.decision {
+                        ApprovalDecision::Allow => {
+                            control_protocol::serialize_co_allow(&response.request_id)
+                        }
+                        ApprovalDecision::Deny { message } => {
+                            control_protocol::serialize_deny(&response.request_id, message)
+                        }
+                        ApprovalDecision::HostExecutedShell { result } => {
+                            control_protocol::serialize_host_executed_shell_result(
+                                &response.request_id,
+                                result,
+                            )
+                        }
+                        ApprovalDecision::Answer { answer } => {
+                            control_protocol::serialize_answer(&response.request_id, answer)
+                        }
+                        ApprovalDecision::ShellEvidence { result } => {
+                            control_protocol::serialize_shell_evidence_result(
+                                &response.request_id,
+                                result,
+                            )
+                        }
+                    },
                     Err(mpsc::RecvTimeoutError::Timeout) => continue,
                     Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                };
-                let msg = match &response.decision {
-                    ApprovalDecision::Allow => {
-                        control_protocol::serialize_co_allow(&response.request_id)
-                    }
-                    ApprovalDecision::Deny { message } => {
-                        control_protocol::serialize_deny(&response.request_id, message)
-                    }
-                    ApprovalDecision::HostExecutedShell { result } => {
-                        control_protocol::serialize_host_executed_shell_result(
-                            &response.request_id,
-                            result,
-                        )
-                    }
-                    ApprovalDecision::Answer { answer } => {
-                        control_protocol::serialize_answer(&response.request_id, answer)
-                    }
-                    ApprovalDecision::ShellEvidence { result } => {
-                        control_protocol::serialize_shell_evidence_result(
-                            &response.request_id,
-                            result,
-                        )
-                    }
                 };
                 if writeln!(writer, "{msg}").is_err() {
                     break;
@@ -348,7 +351,8 @@ pub(super) fn start_control_protocol_qwen_process(
                                     &tool_use_id,
                                 )
                             {
-                                let _ = approval_tx_for_loop.send(response);
+                                let _ = approval_tx_for_loop
+                                    .send(ApprovalChannelMessage::Response(response));
                                 return Ok(ProviderLineProgress::AwaitingApproval);
                             }
                             send_agent_event(

--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -65,6 +65,14 @@ pub(crate) fn finish_active_agent_run<W: Write>(
         }
         render_recovery_context_before_notice(state, &active_run, output, adapter)?;
         render_fallback_recovery_notice(state, &fallback, reason, output)?;
+        // #1940: the fallback abandons this run; sweep dropped control
+        // requests before starting its continuation so the ledger
+        // cannot grow across turns.
+        crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+            state,
+            &active_run.request.id,
+            &active_run.handle,
+        );
         // Failed provider resume escalates through the tier chain: a
         // same-session retry first, then one fresh fallback.
         start_agent_run_with_origin(
@@ -124,6 +132,16 @@ pub(crate) fn finish_active_agent_run<W: Write>(
         output,
         adapter,
     )?;
+    // #1940 run-terminal sweep: the run is detached from InlineState here,
+    // so the batch drain in render_new_agent_structured_events no longer
+    // covers it; deny every registered control request that still has no
+    // home (e.g. trailing requests parked in deferred_events by the
+    // question-rejection path) and clear the run's ledger entries.
+    crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+        state,
+        &active_run.request.id,
+        &active_run.handle,
+    );
     record_selectable_recommendations(
         state,
         &active_run.governed_events,

--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -52,6 +52,14 @@ pub(crate) fn finish_active_agent_run<W: Write>(
     if let Some((fallback, origin)) = resume_fallback {
         render_recovery_context_before_notice(state, &active_run, output, adapter)?;
         render_fresh_turn_recovery_notice(state, output)?;
+        // #1940: the fallback abandons this run; sweep dropped control
+        // requests before starting its continuation so the ledger
+        // cannot grow across turns.
+        crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+            state,
+            &active_run.request.id,
+            &active_run.handle,
+        );
         // Provider-timeout resume is an internal fallback continuation.
         start_agent_run_with_origin(
             &fallback,
@@ -110,6 +118,16 @@ pub(crate) fn finish_active_agent_run<W: Write>(
         output,
         adapter,
     )?;
+    // #1940 run-terminal sweep: the run is detached from InlineState here,
+    // so the batch drain in render_new_agent_structured_events no longer
+    // covers it; deny every registered control request that still has no
+    // home (e.g. trailing requests parked in deferred_events by the
+    // question-rejection path) and clear the run's ledger entries.
+    crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+        state,
+        &active_run.request.id,
+        &active_run.handle,
+    );
     record_selectable_recommendations(
         state,
         &active_run.governed_events,

--- a/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
@@ -340,12 +340,25 @@ fn poll_active_agent_run_with_policy<W: Write>(
                 | AgentEvent::Action { .. }
                 | AgentEvent::ToolPermissionRequest { .. }
         );
-        let deny_reentrant_shell_request = deny_shell_during_recovery;
-        deny_reentrant_shell_request_after_foreground_evidence(
+        register_control_approval_on_first_sight(
             active_run,
+            state.control.approval_ledger_mut(),
+            state.audit.as_mut(),
             &event,
-            deny_reentrant_shell_request,
         );
+        let deny_reentrant_shell_request = deny_shell_during_recovery;
+        if let Some((denied_run_id, denied_request_id)) =
+            deny_reentrant_shell_request_after_foreground_evidence(
+                active_run,
+                &event,
+                deny_reentrant_shell_request,
+            )
+        {
+            state
+                .control
+                .approval_ledger_mut()
+                .mark_responded(&denied_run_id, &denied_request_id);
+        }
         let provider_progress_observed = shell_evidence_provider_progress_observed(&event);
         let text_hold_reason = text_hold_reason_for_poll(TextHoldInputs {
             pending_interaction_before_poll,
@@ -390,6 +403,14 @@ fn poll_active_agent_run_with_policy<W: Write>(
 
     if let Some((fallback, origin, selectable_after_event_index)) = stalled_shell_recovery {
         if let Some(mut active_run) = state.agent_run.active.take() {
+            // #1940: fresh-turn recovery discards the run; sweep it first
+            // so dropped control requests still reach a terminal state
+            // and the ledger cannot grow across turns.
+            crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+                state,
+                &active_run.request.id,
+                &active_run.handle,
+            );
             active_run.handle.cancel();
             active_run.status_animation.clear(output)?;
         }
@@ -429,6 +450,56 @@ fn poll_active_agent_run_with_policy<W: Write>(
     }
 
     Ok(())
+}
+
+/// #1940: register every control approval owned by the active run on
+/// first sight so the batch drain and run-terminal sweeps can prove it
+/// reached a terminal state even if a later pipeline stage drops it, and
+/// send a receipt back to the core so its residual approval timeout
+/// disarms. A request under a foreign run id is a protocol violation the
+/// ledger could never sweep: it is denied at the door instead — no
+/// ledger entry, no receipt, exactly one terminal response.
+fn register_control_approval_on_first_sight(
+    active_run: &ActiveAgentRun,
+    ledger: &mut crate::runtime::approval_ledger::ApprovalLifecycleLedger,
+    audit: Option<&mut crate::journal::audit::ShellAuditRecorder>,
+    event: &AgentEvent,
+) {
+    let AgentEvent::ToolPermissionRequest {
+        run_id, request_id, ..
+    } = event
+    else {
+        return;
+    };
+    if run_id != &active_run.request.id {
+        // #1940 fail-closed: every drain and sweep is scoped to the owning
+        // run, so the shell can never take terminal ownership of a request
+        // registered under a foreign run id — registering or receipting it
+        // would disarm the core's last-resort guard and then wait forever.
+        // Reject at the door instead: deny so the core's wait reaches a
+        // terminal state, audit the protocol violation, and keep the
+        // request out of the ledger.
+        tracing::warn!(
+            event_run_id = %run_id,
+            active_run_id = %active_run.request.id,
+            request_id = %request_id,
+            "control approval arrived under a non-active run id; denying without registering"
+        );
+        if let Some(audit) = audit {
+            audit.record_approval_dropped(run_id, request_id, "foreign_run_rejected");
+        }
+        let _ = active_run.handle.respond_approval(
+            crate::approval::runtime::foreign_run_request_deny_response(request_id),
+        );
+        return;
+    }
+    ledger.register(run_id, request_id);
+    // #1940 receipt protocol: prove to the core that this request reached
+    // the shell main thread so it can disarm the residual approval
+    // timeout. Best-effort and idempotent: a lost receipt only means the
+    // core keeps its last-resort guard, and repeat receipts for the same
+    // request are harmless.
+    let _ = active_run.handle.send_approval_receipt(request_id);
 }
 
 fn foreground_model_from_event(event: &AgentEvent) -> Option<&str> {
@@ -534,11 +605,12 @@ fn deny_reentrant_shell_request_after_foreground_evidence(
     active_run: &ActiveAgentRun,
     event: &AgentEvent,
     deny_shell_after_foreground_evidence: bool,
-) {
+) -> Option<(String, String)> {
     if !deny_shell_after_foreground_evidence {
-        return;
+        return None;
     }
     let AgentEvent::ToolPermissionRequest {
+        run_id,
         request_id,
         tool_name,
         tool_input,
@@ -546,11 +618,20 @@ fn deny_reentrant_shell_request_after_foreground_evidence(
         ..
     } = event
     else {
-        return;
+        return None;
     };
-    if !is_shell_tool_name(tool_name) {
-        return;
+    // #1940: a foreign-run request was already denied at the registration
+    // door above; a second response here would contradict that terminal
+    // deny, and the ledger holds no entry to mark responded.
+    if run_id != &active_run.request.id {
+        return None;
     }
+    if !is_shell_tool_name(tool_name) {
+        return None;
+    }
+    // #1940: report the response either way so the ledger sweep does not
+    // double-deny this request; a failed send means the channel is gone
+    // and the sweep could not deliver a second response anyway.
     let _ = active_run.handle.respond_approval(provider_deny_response(
         ProviderResponseInput {
             request_id,
@@ -559,6 +640,7 @@ fn deny_reentrant_shell_request_after_foreground_evidence(
         },
         "The foreground shell command already completed and its output was injected. Summarize the existing shell evidence or ask the user to start a new request before running another shell command.".to_string(),
     ));
+    Some((run_id.clone(), request_id.clone()))
 }
 
 fn active_run_has_pending_provider_native_shell_result(
@@ -634,251 +716,4 @@ fn text_hold_reason_for_poll(inputs: TextHoldInputs) -> Option<TextHoldReason> {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::time::{Duration, Instant};
-
-    use super::*;
-
-    #[test]
-    fn foreground_model_tracks_initialization_and_runtime_switch() {
-        let initialized = AgentEvent::StatusChanged {
-            run_id: "run".to_string(),
-            phase: "initialized".to_string(),
-            message: "model initialized project-model".to_string(),
-        };
-        let switched = AgentEvent::StatusChanged {
-            run_id: "run".to_string(),
-            phase: "model_switched".to_string(),
-            message: "model status: model_switched:next-model".to_string(),
-        };
-
-        assert_eq!(
-            foreground_model_from_event(&initialized),
-            Some("project-model")
-        );
-        assert_eq!(foreground_model_from_event(&switched), Some("next-model"));
-    }
-
-    fn test_active_run() -> ActiveAgentRun {
-        let request = AgentRequest {
-            id: "request-1".to_string(),
-            session_id: "session-1".to_string(),
-            command_block: CommandBlock {
-                id: "cmd-1".to_string(),
-                session_id: "session-1".to_string(),
-                command: "df -h".to_string(),
-                origin: Default::default(),
-                cwd: "/tmp".to_string(),
-                end_cwd: "/tmp".to_string(),
-                started_at_ms: 1,
-                ended_at_ms: 2,
-                duration_ms: 1,
-                exit_code: 0,
-                status: CommandStatus::Completed,
-                output: OutputRefs {
-                    terminal_output_ref: None,
-                    terminal_output_bytes: 0,
-                },
-                shell_environment_generation: None,
-                audit_identity: None,
-            },
-            context_blocks: Vec::new(),
-            context_hints: Vec::new(),
-            user_input: Some("df -h".to_string()),
-            findings: Vec::new(),
-            mode: AgentMode::RecommendOnly,
-            user_confirmed: true,
-            hook_finding: None,
-            recommended_skill: None,
-        };
-        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
-        let handle = adapter.start_cancellable(request.clone(), CoshApprovalMode::Recommend);
-        let renderer = RatatuiInlineRenderer::for_terminal();
-        ActiveAgentRun {
-            request,
-            origin: AgentRunOrigin::Standard,
-            handle,
-            provider_name: "fake",
-            language: Language::EnUs,
-            renderer: renderer.clone(),
-            status_animation: renderer.status_animation(),
-            markdown_stream: renderer.stream_markdown_agent(),
-            governed_events: Vec::new(),
-            deferred_events: Vec::new(),
-            held_events: Vec::new(),
-            cosh_request_filter: crate::evidence::stream::CoshRequestStreamFilter::default(),
-            pending_cosh_requests: Vec::new(),
-            pending_cosh_request_audits: Vec::new(),
-            rendered_governed_event_count: 0,
-            selectable_after_event_index: None,
-            started_at: Instant::now(),
-            last_activity_at: Instant::now(),
-            last_heartbeat_at: Instant::now(),
-            current_phase: String::new(),
-            current_message: String::new(),
-            has_visible_text_delta: false,
-            completed: false,
-            host_completed_tool_ids: Vec::new(),
-            pending_hook_notifications: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn stalled_shell_evidence_delivery_uses_last_activity_idle_time() {
-        let mut active_run = test_active_run();
-        active_run.started_at = Instant::now() - Duration::from_secs(60);
-        active_run.last_activity_at = Instant::now();
-        active_run.has_visible_text_delta = true;
-
-        assert!(!active_run_has_stalled_shell_evidence_delivery(&active_run));
-
-        active_run.last_activity_at = Instant::now() - Duration::from_secs(16);
-
-        assert!(active_run_has_stalled_shell_evidence_delivery(&active_run));
-    }
-
-    #[test]
-    fn stalled_shell_fallback_waits_for_pending_interaction_to_close() {
-        assert!(!should_start_stalled_provider_shell_fallback(
-            StalledProviderShellFallbackInputs {
-                active_run_idle: true,
-                pending_interaction: true,
-                ..StalledProviderShellFallbackInputs::default()
-            }
-        ));
-        assert!(!should_start_stalled_provider_shell_fallback(
-            StalledProviderShellFallbackInputs {
-                active_run_idle: true,
-                unrendered_interaction: true,
-                ..StalledProviderShellFallbackInputs::default()
-            }
-        ));
-        assert!(!should_start_stalled_provider_shell_fallback(
-            StalledProviderShellFallbackInputs {
-                active_run_idle: true,
-                queued_before_held_text: true,
-                ..StalledProviderShellFallbackInputs::default()
-            }
-        ));
-    }
-
-    #[test]
-    fn stalled_shell_fallback_starts_only_when_idle_and_clear() {
-        assert!(!should_start_stalled_provider_shell_fallback(
-            StalledProviderShellFallbackInputs::default()
-        ));
-        assert!(!should_start_stalled_provider_shell_fallback(
-            StalledProviderShellFallbackInputs {
-                active_run_idle: true,
-                provider_shell_activity_pending: true,
-                ..StalledProviderShellFallbackInputs::default()
-            }
-        ));
-        assert!(should_start_stalled_provider_shell_fallback(
-            StalledProviderShellFallbackInputs {
-                active_run_idle: true,
-                ..StalledProviderShellFallbackInputs::default()
-            }
-        ));
-    }
-
-    #[test]
-    fn shell_evidence_progress_includes_tool_events() {
-        assert!(shell_evidence_provider_progress_observed(
-            &AgentEvent::ToolCall {
-                run_id: "run-1".to_string(),
-                tool_id: Some("tool-1".to_string()),
-                name: "run_shell_command".to_string(),
-                input: "df -h".to_string(),
-            }
-        ));
-        assert!(shell_evidence_provider_progress_observed(
-            &AgentEvent::ToolOutputDelta {
-                run_id: "run-1".to_string(),
-                tool_id: "tool-1".to_string(),
-                stream: "stdout".to_string(),
-                text: "output".to_string(),
-            }
-        ));
-        assert!(shell_evidence_provider_progress_observed(
-            &AgentEvent::ToolCompleted {
-                run_id: "run-1".to_string(),
-                tool_id: "tool-1".to_string(),
-                status: "success".to_string(),
-            }
-        ));
-    }
-
-    #[test]
-    fn shell_evidence_duplicate_signature_distinguishes_list_command_pages() {
-        let first =
-            shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ListCommands {
-                limit: 20,
-                cursor: None,
-            });
-        let same_first =
-            shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ListCommands {
-                limit: 20,
-                cursor: None,
-            });
-        let second_page =
-            shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ListCommands {
-                limit: 20,
-                cursor: Some("cursor-2".to_string()),
-            });
-
-        assert_eq!(first, same_first);
-        assert_ne!(first, second_page);
-    }
-
-    #[test]
-    fn shell_evidence_duplicate_signature_ignores_read_output_bypass() {
-        let normal =
-            shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ReadOutput {
-                output_id: "terminal-output://session-1/cmd-1".to_string(),
-                direction: crate::adapter::ShellOutputDirection::Tail,
-                lines: 120,
-                bypass_recent_filter: false,
-            });
-        let bypass =
-            shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ReadOutput {
-                output_id: "terminal-output://session-1/cmd-1".to_string(),
-                direction: crate::adapter::ShellOutputDirection::Tail,
-                lines: 120,
-                bypass_recent_filter: true,
-            });
-
-        assert_eq!(normal, bypass);
-    }
-
-    #[test]
-    fn text_hold_reason_none_for_plain_text_streaming() {
-        assert_eq!(text_hold_reason_for_poll(TextHoldInputs::default()), None);
-    }
-
-    #[test]
-    fn text_hold_reason_separates_interaction_and_post_tool_holds() {
-        assert_eq!(
-            text_hold_reason_for_poll(TextHoldInputs {
-                pending_interaction_before_poll: true,
-                provider_native_shell_result_pending: true,
-                ..TextHoldInputs::default()
-            }),
-            Some(TextHoldReason::InteractionPending)
-        );
-        assert_eq!(
-            text_hold_reason_for_poll(TextHoldInputs {
-                provider_native_shell_result_pending: true,
-                ..TextHoldInputs::default()
-            }),
-            Some(TextHoldReason::PostToolShellResult)
-        );
-        assert_eq!(
-            text_hold_reason_for_poll(TextHoldInputs {
-                provider_native_shell_transcript_pending: true,
-                ..TextHoldInputs::default()
-            }),
-            Some(TextHoldReason::PostToolShellTranscript)
-        );
-    }
-}
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
@@ -353,12 +353,43 @@ fn poll_active_agent_run_with_policy<W: Write>(
                 | AgentEvent::Action { .. }
                 | AgentEvent::ToolPermissionRequest { .. }
         );
+        // #1940: register every control approval on first sight so the
+        // batch drain and run-terminal sweeps can prove it reached a
+        // terminal state even if a later pipeline stage drops it.
+        if let AgentEvent::ToolPermissionRequest {
+            run_id, request_id, ..
+        } = &event
+        {
+            if run_id != &active_run.request.id {
+                // The terminal-state guarantee is keyed on the owning
+                // run; a foreign-run entry can only be drained while
+                // that run is active, so make the contract violation
+                // visible for diagnostics.
+                tracing::debug!(
+                    event_run_id = %run_id,
+                    active_run_id = %active_run.request.id,
+                    request_id = %request_id,
+                    "control approval registered under a non-active run id"
+                );
+            }
+            state
+                .control
+                .approval_ledger_mut()
+                .register(run_id, request_id);
+        }
         let deny_reentrant_shell_request = deny_shell_during_recovery;
-        deny_reentrant_shell_request_after_foreground_evidence(
-            active_run,
-            &event,
-            deny_reentrant_shell_request,
-        );
+        if let Some((denied_run_id, denied_request_id)) =
+            deny_reentrant_shell_request_after_foreground_evidence(
+                active_run,
+                &event,
+                deny_reentrant_shell_request,
+            )
+        {
+            state
+                .control
+                .approval_ledger_mut()
+                .mark_responded(&denied_run_id, &denied_request_id);
+        }
         let provider_progress_observed = shell_evidence_provider_progress_observed(&event);
         let text_hold_reason = text_hold_reason_for_poll(TextHoldInputs {
             pending_interaction_before_poll,
@@ -403,6 +434,14 @@ fn poll_active_agent_run_with_policy<W: Write>(
 
     if let Some((fallback, origin, selectable_after_event_index)) = first_text_fallback {
         if let Some(mut active_run) = state.agent_run.active.take() {
+            // #1940: fresh-turn recovery discards the run; sweep it first
+            // so dropped control requests still reach a terminal state
+            // and the ledger cannot grow across turns.
+            crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+                state,
+                &active_run.request.id,
+                &active_run.handle,
+            );
             active_run.handle.cancel();
             active_run.status_animation.clear(output)?;
         }
@@ -548,11 +587,12 @@ fn deny_reentrant_shell_request_after_foreground_evidence(
     active_run: &ActiveAgentRun,
     event: &AgentEvent,
     deny_shell_after_foreground_evidence: bool,
-) {
+) -> Option<(String, String)> {
     if !deny_shell_after_foreground_evidence {
-        return;
+        return None;
     }
     let AgentEvent::ToolPermissionRequest {
+        run_id,
         request_id,
         tool_name,
         tool_input,
@@ -560,11 +600,14 @@ fn deny_reentrant_shell_request_after_foreground_evidence(
         ..
     } = event
     else {
-        return;
+        return None;
     };
     if !is_shell_tool_name(tool_name) {
-        return;
+        return None;
     }
+    // #1940: report the response either way so the ledger sweep does not
+    // double-deny this request; a failed send means the channel is gone
+    // and the sweep could not deliver a second response anyway.
     let _ = active_run.handle.respond_approval(provider_deny_response(
         ProviderResponseInput {
             request_id,
@@ -573,6 +616,7 @@ fn deny_reentrant_shell_request_after_foreground_evidence(
         },
         "The foreground shell command already completed and its output was injected. Summarize the existing shell evidence or ask the user to start a new request before running another shell command.".to_string(),
     ));
+    Some((run_id.clone(), request_id.clone()))
 }
 
 fn active_run_has_pending_provider_native_shell_result(

--- a/src/cosh-ng/crates/cosh-shell/src/agent/poll/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/poll/tests.rs
@@ -1,0 +1,398 @@
+use std::time::{Duration, Instant};
+
+use super::*;
+
+#[test]
+fn foreground_model_tracks_initialization_and_runtime_switch() {
+    let initialized = AgentEvent::StatusChanged {
+        run_id: "run".to_string(),
+        phase: "initialized".to_string(),
+        message: "model initialized project-model".to_string(),
+    };
+    let switched = AgentEvent::StatusChanged {
+        run_id: "run".to_string(),
+        phase: "model_switched".to_string(),
+        message: "model status: model_switched:next-model".to_string(),
+    };
+
+    assert_eq!(
+        foreground_model_from_event(&initialized),
+        Some("project-model")
+    );
+    assert_eq!(foreground_model_from_event(&switched), Some("next-model"));
+}
+
+fn test_active_run() -> ActiveAgentRun {
+    let request = AgentRequest {
+        id: "request-1".to_string(),
+        session_id: "session-1".to_string(),
+        command_block: CommandBlock {
+            id: "cmd-1".to_string(),
+            session_id: "session-1".to_string(),
+            command: "df -h".to_string(),
+            origin: Default::default(),
+            cwd: "/tmp".to_string(),
+            end_cwd: "/tmp".to_string(),
+            started_at_ms: 1,
+            ended_at_ms: 2,
+            duration_ms: 1,
+            exit_code: 0,
+            status: CommandStatus::Completed,
+            output: OutputRefs {
+                terminal_output_ref: None,
+                terminal_output_bytes: 0,
+            },
+            shell_environment_generation: None,
+            audit_identity: None,
+        },
+        context_blocks: Vec::new(),
+        context_hints: Vec::new(),
+        user_input: Some("df -h".to_string()),
+        findings: Vec::new(),
+        mode: AgentMode::RecommendOnly,
+        user_confirmed: true,
+        hook_finding: None,
+        recommended_skill: None,
+    };
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let handle = adapter.start_cancellable(request.clone(), CoshApprovalMode::Recommend);
+    let renderer = RatatuiInlineRenderer::for_terminal();
+    ActiveAgentRun {
+        request,
+        origin: AgentRunOrigin::Standard,
+        handle,
+        provider_name: "fake",
+        language: Language::EnUs,
+        renderer: renderer.clone(),
+        status_animation: renderer.status_animation(),
+        markdown_stream: renderer.stream_markdown_agent(),
+        governed_events: Vec::new(),
+        deferred_events: Vec::new(),
+        held_events: Vec::new(),
+        cosh_request_filter: crate::evidence::stream::CoshRequestStreamFilter::default(),
+        pending_cosh_requests: Vec::new(),
+        pending_cosh_request_audits: Vec::new(),
+        rendered_governed_event_count: 0,
+        selectable_after_event_index: None,
+        started_at: Instant::now(),
+        last_activity_at: Instant::now(),
+        last_heartbeat_at: Instant::now(),
+        current_phase: String::new(),
+        current_message: String::new(),
+        has_visible_text_delta: false,
+        completed: false,
+        host_completed_tool_ids: Vec::new(),
+        pending_hook_notifications: Vec::new(),
+    }
+}
+
+fn control_approval_event(run_id: &str, request_id: &str) -> AgentEvent {
+    AgentEvent::ToolPermissionRequest {
+        run_id: run_id.to_string(),
+        request_id: request_id.to_string(),
+        tool_name: "run_shell_command".to_string(),
+        tool_input: serde_json::json!({ "command": "df -h" }),
+        tool_use_id: "toolu-1".to_string(),
+        hook_requires_approval: false,
+        audit_ref: None,
+    }
+}
+
+#[test]
+fn control_approval_registration_sends_receipt_and_records_ledger() {
+    let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+    let mut active_run = test_active_run();
+    active_run.handle = crate::adapter::AgentRunHandle::test_with_approval_sender(approval_tx);
+    let mut ledger = crate::runtime::approval_ledger::ApprovalLifecycleLedger::default();
+
+    register_control_approval_on_first_sight(
+        &active_run,
+        &mut ledger,
+        None,
+        &control_approval_event("request-1", "ctrl-1"),
+    );
+
+    assert_eq!(ledger.unresponded_for_run("request-1"), vec!["ctrl-1"]);
+    match approval_rx.recv_timeout(Duration::from_secs(1)) {
+        Ok(crate::adapter::ApprovalChannelMessage::Receipt { request_id }) => {
+            assert_eq!(request_id, "ctrl-1");
+        }
+        other => panic!("expected approval receipt, got {other:?}"),
+    }
+}
+
+#[test]
+fn control_approval_registration_denies_foreign_run_ids_at_the_door() {
+    // #1940 fail-closed: a request under a foreign run id can never be
+    // drained or swept, so it is rejected on sight — no ledger entry, no
+    // receipt (the shell never takes terminal ownership), exactly one
+    // terminal deny for the core's waiter.
+    let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+    let mut active_run = test_active_run();
+    active_run.handle = crate::adapter::AgentRunHandle::test_with_approval_sender(approval_tx);
+    let mut ledger = crate::runtime::approval_ledger::ApprovalLifecycleLedger::default();
+    let audit_root = std::env::temp_dir().join(format!(
+        "cosh-poll-foreign-audit-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&audit_root).expect("create audit root");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&audit_root, std::fs::Permissions::from_mode(0o700))
+            .expect("private audit root");
+    }
+    let audit_root = audit_root.canonicalize().expect("canonical audit root");
+    let mut audit = crate::journal::audit::ShellAuditRecorder::test_with_root(&audit_root);
+
+    register_control_approval_on_first_sight(
+        &active_run,
+        &mut ledger,
+        Some(&mut audit),
+        &control_approval_event("other-run", "ctrl-foreign"),
+    );
+    drop(audit);
+
+    assert!(
+        ledger.unresponded_for_run("other-run").is_empty(),
+        "a foreign request must never enter the ledger"
+    );
+    match approval_rx.recv_timeout(Duration::from_secs(1)) {
+        Ok(crate::adapter::ApprovalChannelMessage::Response(response)) => {
+            assert_eq!(response.request_id, "ctrl-foreign");
+            match response.decision {
+                crate::adapter::ApprovalDecision::Deny { ref message } => {
+                    assert_eq!(
+                        message,
+                        crate::approval::runtime::FOREIGN_RUN_REQUEST_DENY_MESSAGE
+                    );
+                }
+                other => panic!("expected a terminal deny, got {other:?}"),
+            }
+        }
+        other => panic!("expected a terminal deny, got {other:?}"),
+    }
+    assert!(
+        approval_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+        "no receipt may follow the deny"
+    );
+
+    // The door rejection is auditable under its own drop site.
+    let mut audit_text = String::new();
+    for date in std::fs::read_dir(audit_root.join("v1/segments")).expect("audit segments") {
+        for file in std::fs::read_dir(date.expect("date dir").path()).expect("segment files") {
+            audit_text.push_str(
+                &std::fs::read_to_string(file.expect("segment file").path()).expect("segment text"),
+            );
+        }
+    }
+    assert!(
+        audit_text.contains("foreign_run_rejected"),
+        "the door rejection must be auditable: {audit_text}"
+    );
+    let _ = std::fs::remove_dir_all(&audit_root);
+}
+
+#[test]
+fn reentrant_shell_deny_skips_foreign_run_ids() {
+    // #1940: the registration door already sent the terminal deny for a
+    // foreign-run request; the recovery-path reentrant deny must not send a
+    // second, contradictory response for it.
+    let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+    let mut active_run = test_active_run();
+    active_run.handle = crate::adapter::AgentRunHandle::test_with_approval_sender(approval_tx);
+
+    let denied = deny_reentrant_shell_request_after_foreground_evidence(
+        &active_run,
+        &control_approval_event("other-run", "ctrl-foreign"),
+        true,
+    );
+
+    assert!(denied.is_none());
+    assert!(
+        approval_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+        "no second response may be sent for a foreign-run request"
+    );
+}
+
+#[test]
+fn control_approval_registration_ignores_non_approval_events() {
+    let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+    let mut active_run = test_active_run();
+    active_run.handle = crate::adapter::AgentRunHandle::test_with_approval_sender(approval_tx);
+    let mut ledger = crate::runtime::approval_ledger::ApprovalLifecycleLedger::default();
+
+    register_control_approval_on_first_sight(
+        &active_run,
+        &mut ledger,
+        None,
+        &AgentEvent::StatusChanged {
+            run_id: "request-1".to_string(),
+            phase: "initialized".to_string(),
+            message: "ready".to_string(),
+        },
+    );
+
+    assert!(ledger.unresponded_for_run("request-1").is_empty());
+    assert!(approval_rx.recv_timeout(Duration::from_millis(50)).is_err());
+}
+
+#[test]
+fn stalled_shell_evidence_delivery_uses_last_activity_idle_time() {
+    let mut active_run = test_active_run();
+    active_run.started_at = Instant::now() - Duration::from_secs(60);
+    active_run.last_activity_at = Instant::now();
+    active_run.has_visible_text_delta = true;
+
+    assert!(!active_run_has_stalled_shell_evidence_delivery(&active_run));
+
+    active_run.last_activity_at = Instant::now() - Duration::from_secs(16);
+
+    assert!(active_run_has_stalled_shell_evidence_delivery(&active_run));
+}
+
+#[test]
+fn stalled_shell_fallback_waits_for_pending_interaction_to_close() {
+    assert!(!should_start_stalled_provider_shell_fallback(
+        StalledProviderShellFallbackInputs {
+            active_run_idle: true,
+            pending_interaction: true,
+            ..StalledProviderShellFallbackInputs::default()
+        }
+    ));
+    assert!(!should_start_stalled_provider_shell_fallback(
+        StalledProviderShellFallbackInputs {
+            active_run_idle: true,
+            unrendered_interaction: true,
+            ..StalledProviderShellFallbackInputs::default()
+        }
+    ));
+    assert!(!should_start_stalled_provider_shell_fallback(
+        StalledProviderShellFallbackInputs {
+            active_run_idle: true,
+            queued_before_held_text: true,
+            ..StalledProviderShellFallbackInputs::default()
+        }
+    ));
+}
+
+#[test]
+fn stalled_shell_fallback_starts_only_when_idle_and_clear() {
+    assert!(!should_start_stalled_provider_shell_fallback(
+        StalledProviderShellFallbackInputs::default()
+    ));
+    assert!(!should_start_stalled_provider_shell_fallback(
+        StalledProviderShellFallbackInputs {
+            active_run_idle: true,
+            provider_shell_activity_pending: true,
+            ..StalledProviderShellFallbackInputs::default()
+        }
+    ));
+    assert!(should_start_stalled_provider_shell_fallback(
+        StalledProviderShellFallbackInputs {
+            active_run_idle: true,
+            ..StalledProviderShellFallbackInputs::default()
+        }
+    ));
+}
+
+#[test]
+fn shell_evidence_progress_includes_tool_events() {
+    assert!(shell_evidence_provider_progress_observed(
+        &AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("tool-1".to_string()),
+            name: "run_shell_command".to_string(),
+            input: "df -h".to_string(),
+        }
+    ));
+    assert!(shell_evidence_provider_progress_observed(
+        &AgentEvent::ToolOutputDelta {
+            run_id: "run-1".to_string(),
+            tool_id: "tool-1".to_string(),
+            stream: "stdout".to_string(),
+            text: "output".to_string(),
+        }
+    ));
+    assert!(shell_evidence_provider_progress_observed(
+        &AgentEvent::ToolCompleted {
+            run_id: "run-1".to_string(),
+            tool_id: "tool-1".to_string(),
+            status: "success".to_string(),
+        }
+    ));
+}
+
+#[test]
+fn shell_evidence_duplicate_signature_distinguishes_list_command_pages() {
+    let first =
+        shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ListCommands {
+            limit: 20,
+            cursor: None,
+        });
+    let same_first =
+        shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ListCommands {
+            limit: 20,
+            cursor: None,
+        });
+    let second_page =
+        shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ListCommands {
+            limit: 20,
+            cursor: Some("cursor-2".to_string()),
+        });
+
+    assert_eq!(first, same_first);
+    assert_ne!(first, second_page);
+}
+
+#[test]
+fn shell_evidence_duplicate_signature_ignores_read_output_bypass() {
+    let normal =
+        shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ReadOutput {
+            output_id: "terminal-output://session-1/cmd-1".to_string(),
+            direction: crate::adapter::ShellOutputDirection::Tail,
+            lines: 120,
+            bypass_recent_filter: false,
+        });
+    let bypass =
+        shell_evidence_action_signature(&crate::adapter::ShellEvidenceAction::ReadOutput {
+            output_id: "terminal-output://session-1/cmd-1".to_string(),
+            direction: crate::adapter::ShellOutputDirection::Tail,
+            lines: 120,
+            bypass_recent_filter: true,
+        });
+
+    assert_eq!(normal, bypass);
+}
+
+#[test]
+fn text_hold_reason_none_for_plain_text_streaming() {
+    assert_eq!(text_hold_reason_for_poll(TextHoldInputs::default()), None);
+}
+
+#[test]
+fn text_hold_reason_separates_interaction_and_post_tool_holds() {
+    assert_eq!(
+        text_hold_reason_for_poll(TextHoldInputs {
+            pending_interaction_before_poll: true,
+            provider_native_shell_result_pending: true,
+            ..TextHoldInputs::default()
+        }),
+        Some(TextHoldReason::InteractionPending)
+    );
+    assert_eq!(
+        text_hold_reason_for_poll(TextHoldInputs {
+            provider_native_shell_result_pending: true,
+            ..TextHoldInputs::default()
+        }),
+        Some(TextHoldReason::PostToolShellResult)
+    );
+    assert_eq!(
+        text_hold_reason_for_poll(TextHoldInputs {
+            provider_native_shell_transcript_pending: true,
+            ..TextHoldInputs::default()
+        }),
+        Some(TextHoldReason::PostToolShellTranscript)
+    );
+}

--- a/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
@@ -101,6 +101,9 @@ pub(crate) struct ActiveAgentRun {
     pub(crate) host_completed_tool_ids: Vec<String>,
 }
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 impl ActiveAgentRun {
     pub(crate) fn prepare_structured_surface<W: Write>(
         &mut self,
@@ -463,6 +466,13 @@ pub(crate) fn stop_active_agent_run_without_rendering<W: Write>(
     // Turn-scope batch consent never outlives its run (issue #1773).
     state.control.trust.clear_run_batch_consent();
 
+    // #1940 run-terminal sweep before the handle is cancelled, while the
+    // response channel is still usable.
+    crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+        state,
+        &active_run.request.id,
+        &active_run.handle,
+    );
     active_run.handle.cancel();
     active_run.status_animation.clear(output)?;
     active_run.held_events.clear();

--- a/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
@@ -463,6 +463,13 @@ pub(crate) fn stop_active_agent_run_without_rendering<W: Write>(
     // Turn-scope batch consent never outlives its run (issue #1773).
     state.control.trust.clear_run_batch_consent();
 
+    // #1940 run-terminal sweep before the handle is cancelled, while the
+    // response channel is still usable.
+    crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+        state,
+        &active_run.request.id,
+        &active_run.handle,
+    );
     active_run.handle.cancel();
     active_run.status_animation.clear(output)?;
     active_run.held_events.clear();

--- a/src/cosh-ng/crates/cosh-shell/src/agent/run/test_support.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/run/test_support.rs
@@ -1,0 +1,78 @@
+//! Test-only builders for [`ActiveAgentRun`] shared across crate test
+//! modules.
+
+use super::*;
+
+/// Builds a minimal active run for tests that need an owner identity. The
+/// approval receiver is returned so the caller can keep the channel alive
+/// for the test's duration (a dropped receiver fails later responds).
+pub(crate) fn test_active_run_with_id(
+    run_id: &str,
+) -> (
+    ActiveAgentRun,
+    std::sync::mpsc::Receiver<crate::adapter::ApprovalChannelMessage>,
+) {
+    let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+    let request = AgentRequest {
+        id: run_id.to_string(),
+        session_id: "session-1".to_string(),
+        command_block: CommandBlock {
+            id: "cmd-1".to_string(),
+            session_id: "session-1".to_string(),
+            command: "approval test".to_string(),
+            origin: Default::default(),
+            cwd: "/tmp".to_string(),
+            end_cwd: "/tmp".to_string(),
+            started_at_ms: 1,
+            ended_at_ms: 2,
+            duration_ms: 1,
+            exit_code: 0,
+            status: CommandStatus::Completed,
+            output: OutputRefs {
+                terminal_output_ref: None,
+                terminal_output_bytes: 0,
+            },
+            shell_environment_generation: None,
+            audit_identity: None,
+        },
+        context_blocks: Vec::new(),
+        context_hints: Vec::new(),
+        user_input: Some("approval test".to_string()),
+        findings: Vec::new(),
+        mode: AgentMode::RecommendOnly,
+        user_confirmed: true,
+        hook_finding: None,
+        recommended_skill: None,
+    };
+    let renderer = RatatuiInlineRenderer::for_terminal();
+    (
+        ActiveAgentRun {
+            request,
+            origin: AgentRunOrigin::Standard,
+            handle: AgentRunHandle::test_with_approval_sender(approval_tx),
+            provider_name: "fake",
+            language: Language::EnUs,
+            renderer: renderer.clone(),
+            status_animation: renderer.status_animation(),
+            markdown_stream: renderer.stream_markdown_agent(),
+            governed_events: Vec::new(),
+            deferred_events: Vec::new(),
+            held_events: Vec::new(),
+            cosh_request_filter: CoshRequestStreamFilter::default(),
+            pending_cosh_requests: Vec::new(),
+            pending_cosh_request_audits: Vec::new(),
+            pending_hook_notifications: Vec::new(),
+            rendered_governed_event_count: 0,
+            selectable_after_event_index: None,
+            started_at: Instant::now(),
+            last_activity_at: Instant::now(),
+            last_heartbeat_at: Instant::now(),
+            current_phase: String::new(),
+            current_message: String::new(),
+            has_visible_text_delta: false,
+            completed: false,
+            host_completed_tool_ids: Vec::new(),
+        },
+        approval_rx,
+    )
+}

--- a/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
@@ -24,7 +24,14 @@ pub(crate) fn render_new_agent_structured_events<W: Write>(
         active_run.rendered_governed_event_count = end;
         (events, active_run.request.clone(), active_run.origin)
     };
-    render_agent_structured_events(state, &events, Some(&run_request), origin, output, adapter)
+    render_agent_structured_events(state, &events, Some(&run_request), origin, output, adapter)?;
+    // #1940 I1 batch drain assertion: whatever path the batch above took
+    // (question rejection, trust/auto early return, dedup skip), every
+    // control request registered by the poll loop must now have a home in
+    // approvals.requests or an already-sent response; leftovers were
+    // dropped mid-pipeline and are denied on the spot.
+    crate::approval::runtime::drain_unhomed_control_requests(state);
+    Ok(())
 }
 
 pub(crate) fn render_agent_structured_events<W: Write>(
@@ -158,10 +165,12 @@ mod tests {
 
     #[test]
     fn conflicting_core_question_discards_trailing_interactions_and_finishes_once() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
         let mut state = InlineState::default();
         let adapter = AdapterInstance::Fake(FakeAgentAdapter);
         let mut active_run = test_active_run();
         active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
         let run_request = active_run.request.clone();
         state.agent_run.active = Some(active_run);
         let mut output = Vec::new();
@@ -177,7 +186,7 @@ mod tests {
         .expect("render initial question");
         let trailing_tool = governed(
             AgentEvent::ToolPermissionRequest {
-                run_id: "run-1".to_string(),
+                run_id: "request-1".to_string(),
                 request_id: "approval-1".to_string(),
                 tool_name: "run_shell_command".to_string(),
                 tool_input: serde_json::json!({ "command": "rm -f /tmp/example" }),
@@ -189,7 +198,7 @@ mod tests {
         );
         let trailing_auth = governed(
             AgentEvent::AuthRequired {
-                run_id: "run-1".to_string(),
+                run_id: "request-1".to_string(),
                 request_id: "auth-1".to_string(),
                 reason: "credentials required".to_string(),
                 error_message: None,
@@ -197,6 +206,13 @@ mod tests {
             },
             GovernancePolicyDecision::DisplayOnly,
         );
+        // The poll loop registers control requests on first sight; this
+        // test drives the renderer directly, so it registers the same way
+        // to exercise the run-terminal sweep.
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-1");
         render_agent_structured_events(
             &mut state,
             &[
@@ -224,6 +240,30 @@ mod tests {
         assert!(state.activity.rows.is_empty());
         assert!(state.activity.tool_invocations.is_empty());
         assert!(!state_has_pending_interaction(&state));
+        // #1940: the discarded trailing approval still reaches a terminal
+        // state — exactly one deny response via the finish sweep.
+        // Receipts share the approval channel now; only responses are
+        // terminal for a request.
+        let responses: Vec<_> = approval_rx
+            .try_iter()
+            .filter_map(|message| match message {
+                crate::adapter::ApprovalChannelMessage::Response(response) => Some(response),
+                crate::adapter::ApprovalChannelMessage::Receipt { .. } => None,
+            })
+            .collect();
+        let terminal: Vec<_> = responses
+            .iter()
+            .filter(|response| response.request_id == "approval-1")
+            .collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "dropped request must receive exactly one terminal response: {responses:?}"
+        );
+        assert!(matches!(
+            terminal[0].decision,
+            ApprovalDecision::Deny { .. }
+        ));
         let rendered = String::from_utf8(output).expect("UTF-8");
         assert_eq!(
             rendered.matches("Agent question unavailable").count(),
@@ -236,5 +276,131 @@ mod tests {
         );
         assert!(!rendered.contains("cancelled"), "{rendered}");
         assert!(!rendered.contains("rm -f /tmp/example"), "{rendered}");
+    }
+
+    #[test]
+    fn batch_drain_denies_control_request_dropped_by_question_rejection() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+        let mut state = InlineState::default();
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut active_run = test_active_run();
+        active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
+        let run_request = active_run.request.clone();
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        // Park a pending question so the next batch's question event takes
+        // the rejection path and defers its trailing approval.
+        render_agent_structured_events(
+            &mut state,
+            &[question("question-1", "First")],
+            Some(&run_request),
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render initial question");
+        // Mirror the poll loop: governed events are appended and control
+        // requests registered before the batch is rendered.
+        {
+            let active_run = state.agent_run.active.as_mut().expect("active run");
+            active_run
+                .governed_events
+                .push(question("question-2", "Second"));
+            active_run.governed_events.push(governed(
+                AgentEvent::ToolPermissionRequest {
+                    run_id: "request-1".to_string(),
+                    request_id: "approval-1".to_string(),
+                    tool_name: "run_shell_command".to_string(),
+                    tool_input: serde_json::json!({ "command": "echo probe" }),
+                    tool_use_id: "tool-1".to_string(),
+                    hook_requires_approval: false,
+                    audit_ref: None,
+                },
+                GovernancePolicyDecision::NeedsUserApproval,
+            ));
+        }
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-1");
+
+        render_new_agent_structured_events(&mut state, &mut output, &adapter)
+            .expect("render rejected batch");
+
+        // The I1 batch drain denies the dropped request immediately, long
+        // before any run-finish sweep.
+        // Receipts share the approval channel now; only responses are
+        // terminal for a request.
+        let responses: Vec<_> = approval_rx
+            .try_iter()
+            .filter_map(|message| match message {
+                crate::adapter::ApprovalChannelMessage::Response(response) => Some(response),
+                crate::adapter::ApprovalChannelMessage::Receipt { .. } => None,
+            })
+            .collect();
+        let terminal: Vec<_> = responses
+            .iter()
+            .filter(|response| response.request_id == "approval-1")
+            .collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "dropped request must receive exactly one terminal response: {responses:?}"
+        );
+        assert!(matches!(
+            terminal[0].decision,
+            ApprovalDecision::Deny { .. }
+        ));
+        let active_run = state.agent_run.active.as_ref().expect("active run");
+        assert_eq!(active_run.deferred_events.len(), 1);
+        assert!(state.approvals.requests.is_empty());
+    }
+
+    #[test]
+    fn batch_drain_leaves_recorded_pending_card_untouched() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+        let mut state = InlineState::default();
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut active_run = test_active_run();
+        active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        state
+            .agent_run
+            .active
+            .as_mut()
+            .expect("active run")
+            .governed_events
+            .push(governed(
+                AgentEvent::ToolPermissionRequest {
+                    run_id: "request-1".to_string(),
+                    request_id: "approval-9".to_string(),
+                    tool_name: "run_shell_command".to_string(),
+                    tool_input: serde_json::json!({ "command": "echo keep" }),
+                    tool_use_id: "tool-9".to_string(),
+                    hook_requires_approval: false,
+                    audit_ref: None,
+                },
+                GovernancePolicyDecision::NeedsUserApproval,
+            ));
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-9");
+
+        render_new_agent_structured_events(&mut state, &mut output, &adapter)
+            .expect("render approval batch");
+
+        // The request found its home as a pending card, so the drain must
+        // not send any response for it.
+        assert_eq!(state.approvals.requests.len(), 1);
+        assert!(
+            approval_rx.try_iter().next().is_none(),
+            "a request with a pending card must never be drained"
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
@@ -24,7 +24,14 @@ pub(crate) fn render_new_agent_structured_events<W: Write>(
         active_run.rendered_governed_event_count = end;
         (events, active_run.request.clone(), active_run.origin)
     };
-    render_agent_structured_events(state, &events, Some(&run_request), origin, output, adapter)
+    render_agent_structured_events(state, &events, Some(&run_request), origin, output, adapter)?;
+    // #1940 I1 batch drain assertion: whatever path the batch above took
+    // (question rejection, trust/auto early return, dedup skip), every
+    // control request registered by the poll loop must now have a home in
+    // approvals.requests or an already-sent response; leftovers were
+    // dropped mid-pipeline and are denied on the spot.
+    crate::approval::runtime::drain_unhomed_control_requests(state);
+    Ok(())
 }
 
 pub(crate) fn render_agent_structured_events<W: Write>(
@@ -156,10 +163,12 @@ mod tests {
 
     #[test]
     fn conflicting_core_question_discards_trailing_interactions_and_finishes_once() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
         let mut state = InlineState::default();
         let adapter = AdapterInstance::Fake(FakeAgentAdapter);
         let mut active_run = test_active_run();
         active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
         let run_request = active_run.request.clone();
         state.agent_run.active = Some(active_run);
         let mut output = Vec::new();
@@ -175,7 +184,7 @@ mod tests {
         .expect("render initial question");
         let trailing_tool = governed(
             AgentEvent::ToolPermissionRequest {
-                run_id: "run-1".to_string(),
+                run_id: "request-1".to_string(),
                 request_id: "approval-1".to_string(),
                 tool_name: "run_shell_command".to_string(),
                 tool_input: serde_json::json!({ "command": "rm -f /tmp/example" }),
@@ -187,7 +196,7 @@ mod tests {
         );
         let trailing_auth = governed(
             AgentEvent::AuthRequired {
-                run_id: "run-1".to_string(),
+                run_id: "request-1".to_string(),
                 request_id: "auth-1".to_string(),
                 reason: "credentials required".to_string(),
                 error_message: None,
@@ -195,6 +204,13 @@ mod tests {
             },
             GovernancePolicyDecision::DisplayOnly,
         );
+        // The poll loop registers control requests on first sight; this
+        // test drives the renderer directly, so it registers the same way
+        // to exercise the run-terminal sweep.
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-1");
         render_agent_structured_events(
             &mut state,
             &[
@@ -222,6 +238,22 @@ mod tests {
         assert!(state.activity.rows.is_empty());
         assert!(state.activity.tool_invocations.is_empty());
         assert!(!state_has_pending_interaction(&state));
+        // #1940: the discarded trailing approval still reaches a terminal
+        // state — exactly one deny response via the finish sweep.
+        let responses: Vec<_> = approval_rx.try_iter().collect();
+        let terminal: Vec<_> = responses
+            .iter()
+            .filter(|response| response.request_id == "approval-1")
+            .collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "dropped request must receive exactly one terminal response: {responses:?}"
+        );
+        assert!(matches!(
+            terminal[0].decision,
+            ApprovalDecision::Deny { .. }
+        ));
         let rendered = String::from_utf8(output).expect("UTF-8");
         assert_eq!(
             rendered.matches("Agent question unavailable").count(),
@@ -234,5 +266,123 @@ mod tests {
         );
         assert!(!rendered.contains("cancelled"), "{rendered}");
         assert!(!rendered.contains("rm -f /tmp/example"), "{rendered}");
+    }
+
+    #[test]
+    fn batch_drain_denies_control_request_dropped_by_question_rejection() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+        let mut state = InlineState::default();
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut active_run = test_active_run();
+        active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
+        let run_request = active_run.request.clone();
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        // Park a pending question so the next batch's question event takes
+        // the rejection path and defers its trailing approval.
+        render_agent_structured_events(
+            &mut state,
+            &[question("question-1", "First")],
+            Some(&run_request),
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render initial question");
+        // Mirror the poll loop: governed events are appended and control
+        // requests registered before the batch is rendered.
+        {
+            let active_run = state.agent_run.active.as_mut().expect("active run");
+            active_run
+                .governed_events
+                .push(question("question-2", "Second"));
+            active_run.governed_events.push(governed(
+                AgentEvent::ToolPermissionRequest {
+                    run_id: "request-1".to_string(),
+                    request_id: "approval-1".to_string(),
+                    tool_name: "run_shell_command".to_string(),
+                    tool_input: serde_json::json!({ "command": "echo probe" }),
+                    tool_use_id: "tool-1".to_string(),
+                    hook_requires_approval: false,
+                    audit_ref: None,
+                },
+                GovernancePolicyDecision::NeedsUserApproval,
+            ));
+        }
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-1");
+
+        render_new_agent_structured_events(&mut state, &mut output, &adapter)
+            .expect("render rejected batch");
+
+        // The I1 batch drain denies the dropped request immediately, long
+        // before any run-finish sweep.
+        let responses: Vec<_> = approval_rx.try_iter().collect();
+        let terminal: Vec<_> = responses
+            .iter()
+            .filter(|response| response.request_id == "approval-1")
+            .collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "dropped request must receive exactly one terminal response: {responses:?}"
+        );
+        assert!(matches!(
+            terminal[0].decision,
+            ApprovalDecision::Deny { .. }
+        ));
+        let active_run = state.agent_run.active.as_ref().expect("active run");
+        assert_eq!(active_run.deferred_events.len(), 1);
+        assert!(state.approvals.requests.is_empty());
+    }
+
+    #[test]
+    fn batch_drain_leaves_recorded_pending_card_untouched() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+        let mut state = InlineState::default();
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut active_run = test_active_run();
+        active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        state
+            .agent_run
+            .active
+            .as_mut()
+            .expect("active run")
+            .governed_events
+            .push(governed(
+                AgentEvent::ToolPermissionRequest {
+                    run_id: "request-1".to_string(),
+                    request_id: "approval-9".to_string(),
+                    tool_name: "run_shell_command".to_string(),
+                    tool_input: serde_json::json!({ "command": "echo keep" }),
+                    tool_use_id: "tool-9".to_string(),
+                    hook_requires_approval: false,
+                    audit_ref: None,
+                },
+                GovernancePolicyDecision::NeedsUserApproval,
+            ));
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-9");
+
+        render_new_agent_structured_events(&mut state, &mut output, &adapter)
+            .expect("render approval batch");
+
+        // The request found its home as a pending card, so the drain must
+        // not send any response for it.
+        assert_eq!(state.approvals.requests.len(), 1);
+        assert!(
+            approval_rx.try_iter().next().is_none(),
+            "a request with a pending card must never be drained"
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
@@ -223,6 +223,25 @@ fn approval_request_from_event(
             hook_requires_approval,
             audit_ref,
         } => {
+            // #1940: a control approval whose run id does not match the
+            // active run was already denied at the registration door
+            // (agent/poll.rs). Never let it resurface downstream — as a
+            // pending card the user could approve, or as an auto-approval —
+            // because either path would send a second, contradictory
+            // response for a request the shell already terminated.
+            // When no run is active the ownership cannot be disproven here:
+            // a sandbox-bypass follow-up legitimately arrives after the
+            // fallback execution cleared the active run, so the request
+            // passes through and the respond path falls back to the
+            // owner-unavailable recovery if the owner is truly gone.
+            let foreign_to_active_run = state
+                .agent_run
+                .active
+                .as_ref()
+                .is_some_and(|run| &run.request.id != run_id);
+            if foreign_to_active_run {
+                return None;
+            }
             let input_str = serde_json::to_string(tool_input).unwrap_or_default();
             let presentation = presentation_for_tool(tool_name, &input_str);
             let (label, preview) = approval_tool_label_preview(&presentation);

--- a/src/cosh-ng/crates/cosh-shell/src/approval/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/runtime.rs
@@ -366,10 +366,125 @@ fn respond_provider_approval_to_owner(
         return ProviderApprovalDelivery::OwnerUnavailable;
     }
     if respond_active_run_approval(active_run, response) {
+        // #1940: settle the lifecycle ledger so the drain sweeps know this
+        // control request reached its terminal state.
+        if let Some(request_id) = request.request_id.as_deref() {
+            state
+                .control
+                .approval_ledger_mut()
+                .mark_responded(&request.run_id, request_id);
+        }
         ProviderApprovalDelivery::Responded
     } else {
         ProviderApprovalDelivery::DeliveryFailed
     }
+}
+
+/// #1940 terminal-state guarantee: deny message for a control request the
+/// rendering pipeline dropped before it reached any decision surface.
+pub(crate) const DROPPED_CONTROL_REQUEST_DENY_MESSAGE: &str = "cosh-shell could not route this approval request to a decision surface, so it was denied by the terminal-state guarantee. The request was not executed; retry it in a new turn if still needed.";
+
+fn unhomed_control_request_ids(state: &InlineState, run_id: &str) -> Vec<String> {
+    state
+        .control
+        .approval_ledger()
+        .unresponded_for_run(run_id)
+        .into_iter()
+        .filter(|request_id| {
+            !state.approvals.requests.iter().any(|request| {
+                request.run_id == run_id
+                    && request.request_id.as_deref() == Some(request_id.as_str())
+            })
+        })
+        .collect()
+}
+
+fn dropped_control_request_deny_response(request_id: &str) -> ApprovalResponse {
+    crate::approval::broker::provider_deny_response(
+        crate::approval::broker::ProviderResponseInput {
+            request_id,
+            tool_use_id: None,
+            tool_input: None,
+        },
+        DROPPED_CONTROL_REQUEST_DENY_MESSAGE.to_string(),
+    )
+}
+
+/// #1940 terminal-state guarantee: deny message for a control request that
+/// arrived under a run id other than the active run. Every sweep is scoped
+/// to the owning run, so the shell can never take terminal ownership of
+/// such a request — it is rejected at the registration door instead.
+pub(crate) const FOREIGN_RUN_REQUEST_DENY_MESSAGE: &str = "cosh-shell rejected this approval request because it arrived under a run that does not own it (protocol violation). The request was not executed.";
+
+pub(crate) fn foreign_run_request_deny_response(request_id: &str) -> ApprovalResponse {
+    crate::approval::broker::provider_deny_response(
+        crate::approval::broker::ProviderResponseInput {
+            request_id,
+            tool_use_id: None,
+            tool_input: None,
+        },
+        FOREIGN_RUN_REQUEST_DENY_MESSAGE.to_string(),
+    )
+}
+
+/// #1940 I1 batch drain: after a governed-event batch settles, every
+/// registered control request must either have a home in
+/// `approvals.requests` (card flow, auto-approve, or decision pipeline own
+/// its response) or have been responded to already. Anything else was
+/// dropped mid-pipeline and is denied on the spot instead of silently
+/// starving the provider. Requests with a home are never touched here, so
+/// a surfaced card or a running host-executed command is never timed out
+/// or overridden.
+pub(crate) fn drain_unhomed_control_requests(state: &mut InlineState) {
+    let Some(run_id) = state
+        .agent_run
+        .active
+        .as_ref()
+        .map(|run| run.request.id.clone())
+    else {
+        return;
+    };
+    for request_id in unhomed_control_request_ids(state, &run_id) {
+        // Audit the drop before responding so a user denial and a
+        // dropped-before-decision request stay distinguishable, with the
+        // drop site attached.
+        if let Some(audit) = state.audit.as_mut() {
+            audit.record_approval_dropped(&run_id, &request_id, "batch_drain");
+        }
+        if let Some(active_run) = state.agent_run.active.as_ref() {
+            let _ = active_run
+                .handle
+                .respond_approval(dropped_control_request_deny_response(&request_id));
+        }
+        state
+            .control
+            .approval_ledger_mut()
+            .mark_responded(&run_id, &request_id);
+    }
+}
+
+/// #1940 run-terminal sweep: same contract as the batch drain, for the
+/// paths where the run has already been detached from `InlineState`
+/// (finish/stop/cancel). Also clears the run's ledger entries so the
+/// accounting index cannot grow across turns. Pending requests that still
+/// have a card keep their existing late-decision recovery path
+/// (`OwnerUnavailable` -> continuation) and are not denied here.
+pub(crate) fn drain_unhomed_control_requests_with_handle(
+    state: &mut InlineState,
+    run_id: &str,
+    handle: &AgentRunHandle,
+) {
+    for request_id in unhomed_control_request_ids(state, run_id) {
+        if let Some(audit) = state.audit.as_mut() {
+            audit.record_approval_dropped(run_id, &request_id, "run_terminal_sweep");
+        }
+        let _ = handle.respond_approval(dropped_control_request_deny_response(&request_id));
+        state
+            .control
+            .approval_ledger_mut()
+            .mark_responded(run_id, &request_id);
+    }
+    state.control.approval_ledger_mut().clear_run(run_id);
 }
 
 fn active_run_owns_provider_approval(

--- a/src/cosh-ng/crates/cosh-shell/src/approval/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/runtime.rs
@@ -350,10 +350,99 @@ fn respond_provider_approval_to_owner(
         return ProviderApprovalDelivery::OwnerUnavailable;
     }
     if respond_active_run_approval(active_run, response) {
+        // #1940: settle the lifecycle ledger so the drain sweeps know this
+        // control request reached its terminal state.
+        if let Some(request_id) = request.request_id.as_deref() {
+            state
+                .control
+                .approval_ledger_mut()
+                .mark_responded(&request.run_id, request_id);
+        }
         ProviderApprovalDelivery::Responded
     } else {
         ProviderApprovalDelivery::DeliveryFailed
     }
+}
+
+/// #1940 terminal-state guarantee: deny message for a control request the
+/// rendering pipeline dropped before it reached any decision surface.
+pub(crate) const DROPPED_CONTROL_REQUEST_DENY_MESSAGE: &str = "cosh-shell could not route this approval request to a decision surface, so it was denied by the terminal-state guarantee. The request was not executed; retry it in a new turn if still needed.";
+
+fn unhomed_control_request_ids(state: &InlineState, run_id: &str) -> Vec<String> {
+    state
+        .control
+        .approval_ledger()
+        .unresponded_for_run(run_id)
+        .into_iter()
+        .filter(|request_id| {
+            !state.approvals.requests.iter().any(|request| {
+                request.run_id == run_id
+                    && request.request_id.as_deref() == Some(request_id.as_str())
+            })
+        })
+        .collect()
+}
+
+fn dropped_control_request_deny_response(request_id: &str) -> ApprovalResponse {
+    crate::approval::broker::provider_deny_response(
+        crate::approval::broker::ProviderResponseInput {
+            request_id,
+            tool_use_id: None,
+            tool_input: None,
+        },
+        DROPPED_CONTROL_REQUEST_DENY_MESSAGE.to_string(),
+    )
+}
+
+/// #1940 I1 batch drain: after a governed-event batch settles, every
+/// registered control request must either have a home in
+/// `approvals.requests` (card flow, auto-approve, or decision pipeline own
+/// its response) or have been responded to already. Anything else was
+/// dropped mid-pipeline and is denied on the spot instead of silently
+/// starving the provider. Requests with a home are never touched here, so
+/// a surfaced card or a running host-executed command is never timed out
+/// or overridden.
+pub(crate) fn drain_unhomed_control_requests(state: &mut InlineState) {
+    let Some(run_id) = state
+        .agent_run
+        .active
+        .as_ref()
+        .map(|run| run.request.id.clone())
+    else {
+        return;
+    };
+    for request_id in unhomed_control_request_ids(state, &run_id) {
+        if let Some(active_run) = state.agent_run.active.as_ref() {
+            let _ = active_run
+                .handle
+                .respond_approval(dropped_control_request_deny_response(&request_id));
+        }
+        state
+            .control
+            .approval_ledger_mut()
+            .mark_responded(&run_id, &request_id);
+    }
+}
+
+/// #1940 run-terminal sweep: same contract as the batch drain, for the
+/// paths where the run has already been detached from `InlineState`
+/// (finish/stop/cancel). Also clears the run's ledger entries so the
+/// accounting index cannot grow across turns. Pending requests that still
+/// have a card keep their existing late-decision recovery path
+/// (`OwnerUnavailable` -> continuation) and are not denied here.
+pub(crate) fn drain_unhomed_control_requests_with_handle(
+    state: &mut InlineState,
+    run_id: &str,
+    handle: &AgentRunHandle,
+) {
+    for request_id in unhomed_control_request_ids(state, run_id) {
+        let _ = handle.respond_approval(dropped_control_request_deny_response(&request_id));
+        state
+            .control
+            .approval_ledger_mut()
+            .mark_responded(run_id, &request_id);
+    }
+    state.control.approval_ledger_mut().clear_run(run_id);
 }
 
 fn active_run_owns_provider_approval(

--- a/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
@@ -631,6 +631,50 @@ fn control_shell_permission_missing_command_blocks_as_unsafe_binding() {
 }
 
 #[test]
+fn foreign_run_control_permission_never_surfaces_as_a_request() {
+    // #1940: a ToolPermissionRequest whose run id does not match the active
+    // run was already denied at the registration door (agent/poll.rs). The
+    // downstream request pipeline must never resurface it — as a pending
+    // card or an auto-approval — because either path would send a second,
+    // contradictory response for an already-terminated request.
+    let (mut state, _approval_rx) = state_with_active_control_run("run-1");
+    let mut foreign = governed_provider_tool_permission("ctrl-foreign", "toolu-foreign");
+    let AgentEvent::ToolPermissionRequest {
+        run_id: ref mut foreign_run_id,
+        ..
+    } = foreign.event
+    else {
+        panic!("expected tool permission request");
+    };
+    *foreign_run_id = "foreign-run".to_string();
+
+    assert!(
+        approval_request_from_governed_event(
+            &state,
+            &foreign,
+            None,
+            AgentRunOrigin::Standard,
+            false,
+        )
+        .is_none(),
+        "a foreign-run control approval must not become a request"
+    );
+
+    let ids = record_approval_requests(
+        &mut state,
+        &[foreign],
+        None,
+        AgentRunOrigin::Standard,
+        false,
+    );
+    assert!(ids.is_empty());
+    assert!(
+        state.approvals.requests.is_empty(),
+        "no pending card may be created for a foreign-run request"
+    );
+}
+
+#[test]
 fn non_shell_provider_permission_approval_stays_provider_owned() {
     let mut state = InlineState::default();
     state.approvals.requests.push(provider_tool_request(
@@ -1030,6 +1074,19 @@ exit 1
     panic!("mock provider did not emit tool permission");
 }
 
+fn state_with_active_control_run(
+    run_id: &str,
+) -> (
+    InlineState,
+    std::sync::mpsc::Receiver<crate::adapter::ApprovalChannelMessage>,
+) {
+    let (active_run, approval_rx) =
+        crate::agent::run::test_support::test_active_run_with_id(run_id);
+    let mut state = InlineState::default();
+    state.agent_run.active = Some(active_run);
+    (state, approval_rx)
+}
+
 fn governed_provider_tool_permission(request_id: &str, tool_use_id: &str) -> GovernedEvent {
     GovernedEvent {
         policy_decision: GovernancePolicyDecision::NeedsUserApproval,
@@ -1365,4 +1422,65 @@ fn approval_action_set_matrix() {
         approval_action_set_for(&hooked, &queued),
         ApprovalActionSet::Hook
     );
+}
+
+#[test]
+fn batch_drain_writes_drop_audit_before_responding() {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-approval-drop-audit-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).expect("create audit root");
+    #[cfg(unix)]
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700))
+        .expect("private audit root");
+    let root = root.canonicalize().expect("canonical audit root");
+
+    let (active_run, approval_rx) =
+        crate::agent::run::test_support::test_active_run_with_id("request-1");
+
+    let mut state = InlineState::default();
+    state.agent_run.active = Some(active_run);
+    state.audit = Some(crate::journal::audit::ShellAuditRecorder::test_with_root(
+        &root,
+    ));
+    state
+        .control
+        .approval_ledger_mut()
+        .register("request-1", "ctrl-drop");
+
+    crate::approval::runtime::drain_unhomed_control_requests(&mut state);
+
+    // The terminal deny still goes out on the approval channel.
+    let responses: Vec<_> = approval_rx
+        .try_iter()
+        .filter_map(|message| match message {
+            crate::adapter::ApprovalChannelMessage::Response(response) => Some(response),
+            crate::adapter::ApprovalChannelMessage::Receipt { .. } => None,
+        })
+        .collect();
+    assert_eq!(responses.len(), 1, "{responses:?}");
+    assert!(matches!(
+        responses[0].decision,
+        ApprovalDecision::Deny { .. }
+    ));
+
+    // And the drop is auditable with its drop site attached.
+    drop(state);
+    let mut content = String::new();
+    for date in std::fs::read_dir(root.join("v1/segments")).expect("segments dir") {
+        for file in std::fs::read_dir(date.expect("date dir").path()).expect("segment files") {
+            content.push_str(
+                &std::fs::read_to_string(file.expect("segment file").path()).expect("segment text"),
+            );
+        }
+    }
+    assert!(content.contains("\"approval.dropped\""), "{content}");
+    assert!(content.contains("\"batch_drain\""), "{content}");
+    assert!(content.contains("\"ctrl-drop\""), "{content}");
+    let _ = std::fs::remove_dir_all(&root);
 }

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
@@ -101,6 +101,23 @@ impl ShellAuditRecorder {
         }
     }
 
+    /// Builds a recorder rooted at a test-private directory.
+    #[cfg(test)]
+    pub(crate) fn test_with_root(root: &std::path::Path) -> Self {
+        Self {
+            writer: AuditSegmentWriter::create(root).ok(),
+            writer_root: Some(root.to_path_buf()),
+            mode: AuditMode::BestEffort,
+            shell_session_id: "audit-test-session".to_string(),
+            seen_events: 0,
+            hash_salt: "salt".to_string(),
+            degraded: false,
+            warning_emitted: false,
+            owned_approvals: std::collections::HashSet::new(),
+            command_refs: std::collections::HashMap::new(),
+        }
+    }
+
     /// Projects newly observed native command events exactly once.
     pub(crate) fn observe_shell_events(&mut self, events: &[ShellEvent]) {
         if self.seen_events > events.len() {
@@ -282,6 +299,53 @@ impl ShellAuditRecorder {
                 } else {
                     Ok(None)
                 }
+            }
+        }
+    }
+
+    /// #1940: durably records that a registered control approval was
+    /// dropped before any user decision, so production audits can
+    /// distinguish a user denial from a drain and can locate the exact
+    /// drop site. The drained request was never surfaced, so there is no
+    /// subject or preview to hash — only the ids and the drop site.
+    pub(crate) fn record_approval_dropped(
+        &mut self,
+        run_id: &str,
+        request_id: &str,
+        drop_site: &str,
+    ) -> Option<String> {
+        let event = AuditEventV1::shell(
+            "approval.dropped",
+            AuditIdentity {
+                shell_session_id: Some(self.shell_session_id.clone()),
+                run_id: Some(run_id.to_string()),
+                request_id: Some(request_id.to_string()),
+                ..AuditIdentity::default()
+            },
+            AuditEventOutcome {
+                status: AuditOutcomeStatus::Cancelled,
+                code: None,
+                retryable: false,
+            },
+            AuditSubject {
+                kind: "approval".to_string(),
+                name: None,
+            },
+            &AuditApprovalData {
+                decision: Some("dropped".to_string()),
+                reason_code: Some(drop_site.to_string()),
+                ..AuditApprovalData::default()
+            },
+            AuditRedaction::clean(),
+        );
+        match event {
+            Ok(event) => {
+                let event_id = event.event_id.clone();
+                self.append(event, false).then_some(event_id)
+            }
+            Err(error) => {
+                self.mark_degraded(&error);
+                None
             }
         }
     }

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
@@ -130,6 +130,29 @@ fn required_owned_approval_resolution_fails_before_execution_boundary() {
 }
 
 #[test]
+fn approval_drop_audit_distinguishes_drain_from_user_denial() {
+    let root = private_root();
+    let mut recorder = ShellAuditRecorder::test_with_root(&root);
+
+    let event_id = recorder.record_approval_dropped("run-1", "ctrl-9", "batch_drain");
+    assert!(event_id.is_some());
+    drop(recorder);
+
+    let content = walk_segment_text(&root);
+    let event: serde_json::Value =
+        serde_json::from_str(content.lines().next().expect("audit record")).expect("audit json");
+    assert_eq!(event["event_type"], "approval.dropped");
+    assert_eq!(event["identity"]["shell_session_id"], "audit-test-session");
+    assert_eq!(event["identity"]["run_id"], "run-1");
+    assert_eq!(event["identity"]["request_id"], "ctrl-9");
+    assert_eq!(event["outcome"]["status"], "cancelled");
+    assert_eq!(event["subject"]["kind"], "approval");
+    assert_eq!(event["data"]["decision"], "dropped");
+    assert_eq!(event["data"]["reason_code"], "batch_drain");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn required_core_host_execution_fails_before_handoff_boundary() {
     let mut recorder = ShellAuditRecorder {
         writer: None,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/approval_ledger.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/approval_ledger.rs
@@ -1,0 +1,110 @@
+//! #1940: approval lifecycle ledger.
+//!
+//! Accounting index for control-protocol approval requests: every
+//! `ToolPermissionRequest` owned by the active run is registered here,
+//! and every provider response is marked off. (A request under a
+//! foreign run id is denied at the registration door in `agent/poll.rs`
+//! and never enters the ledger — a sweep could never reach its owner.)
+//! Request facts stay in
+//! `state.approvals.requests`; the ledger only keeps lifecycle markers
+//! keyed by the #1939 identity contract (`run_id` + `request_id`), so it
+//! can never drift from the single source of truth. The batch drain
+//! assertion and the run-terminal sweep read this ledger to guarantee
+//! that a dropped request is denied instead of silently starving the
+//! provider (issue #1920's failure class).
+//!
+//! Maintenance contract: **any new code path that sends a
+//! `control_response` for an approval request must also call
+//! [`ApprovalLifecycleLedger::mark_responded`]** (directly, or via the
+//! accounting wrappers in `approval/runtime.rs`). An unmarked response
+//! lets the batch drain / run-terminal sweep re-deny an already-answered
+//! request. The existing exits — `respond_provider_approval_to_owner`,
+//! the reentrant shell deny in `agent/poll.rs`, and successful
+//! host-executed delivery in `runtime/evidence_delivery.rs` — are the
+//! reference points and are pinned by tests.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub(crate) struct ApprovalLifecycleLedger {
+    entries: HashMap<(String, String), ApprovalLifecycleMarker>,
+}
+
+#[derive(Debug, Default)]
+struct ApprovalLifecycleMarker {
+    responded: bool,
+}
+
+impl ApprovalLifecycleLedger {
+    /// Registers a control request on first sight. Idempotent: a replay
+    /// of the same `request_id` merges into the existing entry and never
+    /// resets a recorded response.
+    pub(crate) fn register(&mut self, run_id: &str, request_id: &str) {
+        self.entries
+            .entry((run_id.to_string(), request_id.to_string()))
+            .or_default();
+    }
+
+    /// Marks a provider response as sent. A no-op for unregistered ids so
+    /// non-approval control responses (questions, evidence) pass through
+    /// without creating phantom entries.
+    pub(crate) fn mark_responded(&mut self, run_id: &str, request_id: &str) {
+        if let Some(marker) = self
+            .entries
+            .get_mut(&(run_id.to_string(), request_id.to_string()))
+        {
+            marker.responded = true;
+        }
+    }
+
+    /// Request ids of the given run that never received a response.
+    pub(crate) fn unresponded_for_run(&self, run_id: &str) -> Vec<String> {
+        let mut ids: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|((run, _), marker)| run == run_id && !marker.responded)
+            .map(|((_, request_id), _)| request_id.clone())
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    /// Drops every entry of a finished run so the ledger cannot grow
+    /// across turns.
+    pub(crate) fn clear_run(&mut self, run_id: &str) {
+        self.entries.retain(|(run, _), _| run != run_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_is_idempotent_and_keeps_response_marker() {
+        let mut ledger = ApprovalLifecycleLedger::default();
+        ledger.register("run-1", "ctrl-1");
+        ledger.mark_responded("run-1", "ctrl-1");
+        ledger.register("run-1", "ctrl-1");
+        assert!(ledger.unresponded_for_run("run-1").is_empty());
+    }
+
+    #[test]
+    fn mark_responded_ignores_unregistered_ids() {
+        let mut ledger = ApprovalLifecycleLedger::default();
+        ledger.mark_responded("run-1", "question-1");
+        assert!(ledger.unresponded_for_run("run-1").is_empty());
+        ledger.register("run-1", "ctrl-1");
+        assert_eq!(ledger.unresponded_for_run("run-1"), vec!["ctrl-1"]);
+    }
+
+    #[test]
+    fn clear_run_scopes_to_one_run() {
+        let mut ledger = ApprovalLifecycleLedger::default();
+        ledger.register("run-1", "ctrl-1");
+        ledger.register("run-2", "ctrl-2");
+        ledger.clear_run("run-1");
+        assert!(ledger.unresponded_for_run("run-1").is_empty());
+        assert_eq!(ledger.unresponded_for_run("run-2"), vec!["ctrl-2"]);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/approval_ledger.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/approval_ledger.rs
@@ -1,0 +1,107 @@
+//! #1940: approval lifecycle ledger.
+//!
+//! Accounting index for control-protocol approval requests: every
+//! `ToolPermissionRequest` the main thread sees is registered here, and
+//! every provider response is marked off. Request facts stay in
+//! `state.approvals.requests`; the ledger only keeps lifecycle markers
+//! keyed by the #1939 identity contract (`run_id` + `request_id`), so it
+//! can never drift from the single source of truth. The batch drain
+//! assertion and the run-terminal sweep read this ledger to guarantee
+//! that a dropped request is denied instead of silently starving the
+//! provider (issue #1920's failure class).
+//!
+//! Maintenance contract: **any new code path that sends a
+//! `control_response` for an approval request must also call
+//! [`ApprovalLifecycleLedger::mark_responded`]** (directly, or via the
+//! accounting wrappers in `approval/runtime.rs`). An unmarked response
+//! lets the batch drain / run-terminal sweep re-deny an already-answered
+//! request. The existing exits — `respond_provider_approval_to_owner`,
+//! the reentrant shell deny in `agent/poll.rs`, and successful
+//! host-executed delivery in `runtime/evidence_delivery.rs` — are the
+//! reference points and are pinned by tests.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub(crate) struct ApprovalLifecycleLedger {
+    entries: HashMap<(String, String), ApprovalLifecycleMarker>,
+}
+
+#[derive(Debug, Default)]
+struct ApprovalLifecycleMarker {
+    responded: bool,
+}
+
+impl ApprovalLifecycleLedger {
+    /// Registers a control request on first sight. Idempotent: a replay
+    /// of the same `request_id` merges into the existing entry and never
+    /// resets a recorded response.
+    pub(crate) fn register(&mut self, run_id: &str, request_id: &str) {
+        self.entries
+            .entry((run_id.to_string(), request_id.to_string()))
+            .or_default();
+    }
+
+    /// Marks a provider response as sent. A no-op for unregistered ids so
+    /// non-approval control responses (questions, evidence) pass through
+    /// without creating phantom entries.
+    pub(crate) fn mark_responded(&mut self, run_id: &str, request_id: &str) {
+        if let Some(marker) = self
+            .entries
+            .get_mut(&(run_id.to_string(), request_id.to_string()))
+        {
+            marker.responded = true;
+        }
+    }
+
+    /// Request ids of the given run that never received a response.
+    pub(crate) fn unresponded_for_run(&self, run_id: &str) -> Vec<String> {
+        let mut ids: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|((run, _), marker)| run == run_id && !marker.responded)
+            .map(|((_, request_id), _)| request_id.clone())
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    /// Drops every entry of a finished run so the ledger cannot grow
+    /// across turns.
+    pub(crate) fn clear_run(&mut self, run_id: &str) {
+        self.entries.retain(|(run, _), _| run != run_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_is_idempotent_and_keeps_response_marker() {
+        let mut ledger = ApprovalLifecycleLedger::default();
+        ledger.register("run-1", "ctrl-1");
+        ledger.mark_responded("run-1", "ctrl-1");
+        ledger.register("run-1", "ctrl-1");
+        assert!(ledger.unresponded_for_run("run-1").is_empty());
+    }
+
+    #[test]
+    fn mark_responded_ignores_unregistered_ids() {
+        let mut ledger = ApprovalLifecycleLedger::default();
+        ledger.mark_responded("run-1", "question-1");
+        assert!(ledger.unresponded_for_run("run-1").is_empty());
+        ledger.register("run-1", "ctrl-1");
+        assert_eq!(ledger.unresponded_for_run("run-1"), vec!["ctrl-1"]);
+    }
+
+    #[test]
+    fn clear_run_scopes_to_one_run() {
+        let mut ledger = ApprovalLifecycleLedger::default();
+        ledger.register("run-1", "ctrl-1");
+        ledger.register("run-2", "ctrl-2");
+        ledger.clear_run("run-1");
+        assert!(ledger.unresponded_for_run("run-1").is_empty());
+        assert_eq!(ledger.unresponded_for_run("run-2"), vec!["ctrl-2"]);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
@@ -126,6 +126,14 @@ fn cancel_active_agent_run<W: Write>(
         active_run.handle.pending_provider_session_id(),
         active_run.handle.cancellation_artifact_store(),
     );
+    // #1940 run-terminal sweep before the handle is cancelled (G1 D2):
+    // the interrupt already unblocks cosh-core, but the sweep keeps the
+    // terminal-state invariant uniform without relying on peer behavior.
+    crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+        state,
+        &active_run.request.id,
+        &active_run.handle,
+    );
     active_run.handle.cancel();
     active_run.status_animation.clear(output)?;
     active_run.held_events.clear();

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
@@ -262,6 +262,13 @@ fn deliver_shell_result_for_request(
             .control
             .provider_tool_mut()
             .release_host_executed_shell_result(claim);
+    } else {
+        // #1940: a delivered host-executed result is the terminal response
+        // for this control request; settle the lifecycle ledger.
+        state
+            .control
+            .approval_ledger_mut()
+            .mark_responded(run_id, request_id);
     }
     if delivered {
         ShellEvidenceDelivery {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
@@ -182,6 +182,13 @@ fn deliver_host_executed_shell_result_if_supported(
             .control
             .provider_tool_mut()
             .release_host_executed_shell_result(claim);
+    } else {
+        // #1940: a delivered host-executed result is the terminal response
+        // for this control request; settle the lifecycle ledger.
+        state
+            .control
+            .approval_ledger_mut()
+            .mark_responded(&handoff.run_id, request_id);
     }
     if delivered {
         ShellEvidenceDelivery {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod approval_ledger;
 pub(crate) mod approval_state;
 pub(crate) mod cancel;
 pub(crate) mod cli_args;

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod approval_ledger;
 pub(crate) mod cancel;
 pub(crate) mod cli_args;
 pub(crate) mod continuity;

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -16,6 +16,7 @@ use crate::question::runtime::RuntimeUserQuestion;
 use crate::raw_input::PromptGhostRoute;
 use crate::recommendation::personal_feedback::FrozenPromptBinding;
 use crate::recommendation::personal_state::PersonalizationState;
+use crate::runtime::approval_ledger::ApprovalLifecycleLedger;
 use crate::runtime::approval_state::ApprovalState;
 use crate::runtime::events::ShellEventCursor;
 use crate::runtime::evidence_requests::EvidenceRequestState;
@@ -419,6 +420,7 @@ pub(crate) struct ControlState {
     handled_config_actions: HashSet<String>,
     session: SessionControlState,
     provider_tool: ProviderToolState,
+    approval_ledger: ApprovalLifecycleLedger,
     provider_shell_handoff_run_ids: HashSet<String>,
     interactive_shell_handoffs: Vec<PendingInteractiveShellHandoff>,
     shell_handoff: ShellHandoffState,
@@ -553,6 +555,12 @@ impl ControlState {
     }
     pub(crate) fn provider_tool_mut(&mut self) -> &mut ProviderToolState {
         &mut self.provider_tool
+    }
+    pub(crate) fn approval_ledger(&self) -> &ApprovalLifecycleLedger {
+        &self.approval_ledger
+    }
+    pub(crate) fn approval_ledger_mut(&mut self) -> &mut ApprovalLifecycleLedger {
+        &mut self.approval_ledger
     }
     pub(crate) fn provider_host_executed_shell_result_delivered(
         &self,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -15,6 +15,7 @@ use crate::question::runtime::RuntimeUserQuestion;
 use crate::raw_input::PromptGhostRoute;
 use crate::recommendation::personal_feedback::FrozenPromptBinding;
 use crate::recommendation::personal_state::PersonalizationState;
+use crate::runtime::approval_ledger::ApprovalLifecycleLedger;
 use crate::runtime::events::ShellEventCursor;
 use crate::runtime::evidence_requests::EvidenceRequestState;
 use crate::runtime::evidence_state::EvidenceState;
@@ -440,6 +441,7 @@ pub(crate) struct ControlState {
     handled_config_actions: HashSet<String>,
     session: SessionControlState,
     provider_tool: ProviderToolState,
+    approval_ledger: ApprovalLifecycleLedger,
     provider_shell_handoff_run_ids: HashSet<String>,
     interactive_shell_handoffs: Vec<PendingInteractiveShellHandoff>,
     shell_handoff: ShellHandoffState,
@@ -574,6 +576,12 @@ impl ControlState {
     }
     pub(crate) fn provider_tool_mut(&mut self) -> &mut ProviderToolState {
         &mut self.provider_tool
+    }
+    pub(crate) fn approval_ledger(&self) -> &ApprovalLifecycleLedger {
+        &self.approval_ledger
+    }
+    pub(crate) fn approval_ledger_mut(&mut self) -> &mut ApprovalLifecycleLedger {
+        &mut self.approval_ledger
     }
     pub(crate) fn provider_host_executed_shell_result_delivered(
         &self,

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/activity.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/activity.rs
@@ -16,7 +16,7 @@ fn raw_cli_details_for_activity_uses_structured_panel() {
 
     assert!(output.contains("Activity details out-1"), "{output}");
     assert!(output.contains("Tool output - stdout captured"), "{output}");
-    assert!(output.contains("Run: fake-run-input-"), "{output}");
+    assert!(output.contains("Run: agent-request-input-"), "{output}");
     assert!(output.contains("Detail:"), "{output}");
     assert!(output.contains("tool: tool-1"), "{output}");
     assert!(output.contains("stream: stdout"), "{output}");
@@ -50,14 +50,14 @@ fn raw_cli_activity_details_uses_zh_language_env() {
 
     assert!(output.contains("活动详情 out-1"), "{output}");
     assert!(output.contains("Tool 输出 - stdout 已捕获"), "{output}");
-    assert!(output.contains("运行: fake-run-input-"), "{output}");
+    assert!(output.contains("运行: agent-request-input-"), "{output}");
     assert!(output.contains("详情:"), "{output}");
     assert!(output.contains("tool: tool-1"), "{output}");
     assert!(output.contains("stream: stdout"), "{output}");
     assert!(output.contains("line 24: fake tool output"), "{output}");
     assert!(!output.contains("Activity details out-1"), "{output}");
     assert!(!output.contains("output - stdout captured"), "{output}");
-    assert!(!output.contains("Run: fake-run-input-"), "{output}");
+    assert!(!output.contains("Run: agent-request-input-"), "{output}");
     assert!(!output.contains("Detail:"), "{output}");
     assert!(!output.contains("bash: /details"), "{output}");
     assert_no_migrated_english_ui_labels(&output, DETAILS_ZH_FORBIDDEN_UI);

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/approval_modes.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/approval_modes.rs
@@ -154,7 +154,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-write-pass-through*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-write","request":{"subtype":"can_use_tool","tool_name":"write_file","input":{"file_path":"/tmp/cosh-core-provider-smoke.txt","content":"SHOULD_NOT_LEAK_WRITE_CONTENT"},"tool_use_id":"toolu-cosh-core-write"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"request_id":"ctrl-cosh-core-write"'*'"behavior":"allow"'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-non-shell-pass-through","message":{"content":[{"type":"text","text":"Cosh-core non-shell write permission allowed through provider control protocol."}]}}'
@@ -232,7 +239,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-write-details*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-write-details","request":{"subtype":"can_use_tool","tool_name":"write_file","input":{"file_path":"/tmp/cosh-core-provider-details.txt","content":"SHOULD_NOT_LEAK_WRITE_DETAILS_CONTENT"},"tool_use_id":"toolu-cosh-core-write-details"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"request_id":"ctrl-cosh-core-write-details"'*'"behavior":"deny"'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-write-details","message":{"content":[{"type":"text","text":"Cosh-core write details cancelled without content leak."}]}}'
@@ -309,7 +323,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-write-deny*)
     printf '%s\n' '{{"type":"control_request","request_id":"ctrl-cosh-core-write-deny","request":{{"subtype":"can_use_tool","tool_name":"write_file","input":{{"file_path":"{denied_path}","content":"denied"}},"tool_use_id":"toolu-cosh-core-write-deny"}}}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"request_id":"ctrl-cosh-core-write-deny"'*'"behavior":"deny"'*)
           printf '%s\n' '{{"type":"assistant","session_id":"sess-cosh-core-non-shell-deny","message":{{"content":[{{"type":"text","text":"Cosh-core non-shell write permission denied without host execution."}}]}}}}'

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/evidence.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/evidence.rs
@@ -196,7 +196,13 @@ printf '%s\n' '{"type":"control_response","response":{"subtype":"success","reque
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-core-duplicate-read","model":"cosh-core-test"}'
 read -r user_message
 printf '%s\n' '{"type":"control_request","request_id":"ctrl-duplicate-read","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"i=1; while [ $i -le 120 ]; do printf \"duplicate-read-line-%03d xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n\" \"$i\"; i=$((i+1)); done"},"tool_use_id":"toolu-duplicate-read"}}'
-IFS= read -r response1 || exit 2
+# #1940: skip approval receipts that now precede the decision line.
+while IFS= read -r response1; do
+  case "$response1" in
+    *'"type":"approval_receipt"'*) continue ;;
+    *) break ;;
+  esac
+done
 case "$response1" in
   *'"behavior":"host_executed_shell"'*'ShellCommandCompleted evidence'*'output_id: terminal-output://raw-session-'*) ;;
   *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-duplicate-read","is_error":true,"result":"missing host-executed output id"}'; exit 1 ;;
@@ -349,7 +355,13 @@ printf '%s\n' '{"type":"control_response","response":{"subtype":"success","reque
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-core-bypass-read","model":"cosh-core-test"}'
 read -r user_message
 printf '%s\n' '{"type":"control_request","request_id":"ctrl-bypass-read","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"printf '\''bypass-one\\nbypass-two\\nbypass-three\\n'\''"},"tool_use_id":"toolu-bypass-read"}}'
-IFS= read -r response1 || exit 2
+# #1940: skip approval receipts that now precede the decision line.
+while IFS= read -r response1; do
+  case "$response1" in
+    *'"type":"approval_receipt"'*) continue ;;
+    *) break ;;
+  esac
+done
 case "$response1" in
   *'"behavior":"host_executed_shell"'*'ShellCommandCompleted evidence'*'output_id: terminal-output://raw-session-'*) ;;
   *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-bypass-read","is_error":true,"result":"missing bypass host-executed output id"}'; exit 1 ;;

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
@@ -16,7 +16,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-host-executed-shell*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-1","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"df -h"},"tool_use_id":"toolu-cosh-core-1"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*bounded_output_summary*'df -h'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-host-executed","message":{"content":[{"type":"text","text":"Cosh-core host-executed shell result received in same provider turn."}]}}'
@@ -126,7 +133,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-auto-safe-shell*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-auto-safe","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"df -h"},"tool_use_id":"toolu-auto-safe"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'df -h'*'Filesystem'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-auto-safe","message":{"content":[{"type":"text","text":"AUTO SAFE HOSTEXEC RECEIVED"}]}}'
@@ -187,7 +201,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-sysctl-non-ascii-shell*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-sysctl-non-ascii","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"sysctl -n kernel.ostype 2>/dev/null || printf sysctl-fallback; printf '\'' 内存总计\\n'\''"},"tool_use_id":"toolu-sysctl-non-ascii"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'sysctl-fallback'*'内存总计'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-sysctl-non-ascii","message":{"content":[{"type":"text","text":"SYSCTL NON ASCII HOSTEXEC RECEIVED"}]}}'
@@ -251,7 +272,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-trust-confirm-shell*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-trust-confirm","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"printf trust-confirm-hostexec"},"tool_use_id":"toolu-trust-confirm"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'printf trust-confirm-hostexec'*'trust-confirm-hostexec'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-trust-confirm","message":{"content":[{"type":"text","text":"TRUST CONFIRM HOSTEXEC RECEIVED"}]}}'
@@ -318,13 +346,25 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-host-executed-duplicate*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-dup","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"df -h"},"tool_use_id":"toolu-cosh-core-dup"}}'
-    IFS= read -r response1 || exit 2
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response1; do
+      case "$response1" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
     case "$response1" in
       *'"behavior":"host_executed_shell"'*'df -h'*) ;;
       *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-duplicate","is_error":true,"result":"missing first host result"}'; exit 1 ;;
     esac
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-dup","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"df -h"},"tool_use_id":"toolu-cosh-core-dup"}}'
-    IFS= read -r response2 || exit 2
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response2; do
+      case "$response2" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
     case "$response2" in
       *'"behavior":"deny"'*'Duplicate shell tool request was already completed'*)
         printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-host-executed-duplicate","message":{"content":[{"type":"text","text":"Duplicate host-executed shell request denied without second execution."}]}}'
@@ -401,7 +441,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-host-executed-nonzero*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-nonzero","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"false"},"tool_use_id":"toolu-cosh-core-nonzero"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'"exit_code":1'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-host-executed-nonzero","message":{"content":[{"type":"text","text":"Cosh-core nonzero host-executed result received as normal tool result."}]}}'
@@ -475,7 +522,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-host-executed-long*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-long","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"sleep 1; echo hostexec-done"},"tool_use_id":"toolu-cosh-core-long"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'sleep 1; echo hostexec-done'*'hostexec-done'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-host-executed-long","message":{"content":[{"type":"text","text":"Cosh-core long host-executed command continued in same provider turn."}]}}'
@@ -545,7 +599,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-host-executed-large*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-large","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"printf \"%b\" \"\\110\\105\\101\\104\\137\\123\\105\\116\\124\\111\\116\\105\\114\"; printf %08000d 0; printf \"%b\" \"\\124\\101\\111\\114\\137\\123\\105\\116\\124\\111\\116\\105\\114\""},"tool_use_id":"toolu-cosh-core-large"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       response_len=${#response}
       case "$response" in
         *'"behavior":"host_executed_shell"'*'bounded_output_summary'*)
@@ -643,14 +704,26 @@ read -r user_message
 case "$user_message" in
   *cosh-core-provider-host-executed-multi-tool*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-multi-1","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"df -h"},"tool_use_id":"toolu-cosh-core-multi-1"}}'
-    IFS= read -r response1 || exit 2
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response1; do
+      case "$response1" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
     case "$response1" in
       *'"behavior":"host_executed_shell"'*'df -h'*) ;;
       *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-multi","is_error":true,"result":"missing first cosh-core host result"}'; exit 1 ;;
     esac
     printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-host-executed-multi","message":{"content":[{"type":"text","text":"FIRST COSH-CORE TOOL ANALYSIS TEXT"}]}}'
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-multi-2","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"du -sh ."},"tool_use_id":"toolu-cosh-core-multi-2"}}'
-    IFS= read -r response2 || exit 2
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response2; do
+      case "$response2" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
     case "$response2" in
       *'"behavior":"host_executed_shell"'*'du -sh .'*) ;;
       *) printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-host-executed-multi","is_error":true,"result":"missing second cosh-core host result"}'; exit 1 ;;

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/provider_native.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/provider_native.rs
@@ -16,7 +16,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-manual-host-executed-echo*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-manual-echo","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"sudo -V"},"tool_use_id":"toolu-cosh-core-manual-echo"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*bounded_output_summary*'sudo -V'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-manual-host-executed-echo","message":{"content":[{"type":"text","text":"Manual host-executed result accepted."},{"type":"tool_use","id":"toolu-cosh-core-manual-echo-provider","name":"shell","input":{"command":"sudo -V"}}]}}'
@@ -228,7 +235,13 @@ case "$user_message" in
   *cosh-core-control-snapshot-dup*)
     printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-control-snapshot","message":{"content":[{"type":"tool_use","id":"toolu-cosh-core-dup","name":"shell","input":{"command":"df -h"}}]}}'
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-cosh-core-dup","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"df -h"},"tool_use_id":"toolu-cosh-core-dup"}}'
-    IFS= read -r response || exit 2
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
     case "$response" in
       *'"behavior":"host_executed_shell"'*'df -h'*)
         printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-control-snapshot","message":{"content":[{"type":"text","text":"COSH CORE CONTROL SNAPSHOT FINAL"}]}}'

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/send_to_shell.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/send_to_shell.rs
@@ -145,7 +145,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-handoff-command-not-found*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-handoff-command-not-found","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"/help"},"tool_use_id":"toolu-handoff-command-not-found"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'/help'*'"exit_code":127'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-handoff-command-not-found","message":{"content":[{"type":"text","text":"HANDOFF COMMAND NOT FOUND HOSTEXEC RECEIVED"}]}}'
@@ -208,7 +215,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-handoff-bypass-marker*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-handoff-bypass-marker","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"?? should-run-as-shell"},"tool_use_id":"toolu-handoff-bypass-marker"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'?? should-run-as-shell'*'"exit_code":127'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-handoff-bypass-marker","message":{"content":[{"type":"text","text":"HANDOFF BYPASS MARKER HOSTEXEC RECEIVED"}]}}'
@@ -276,7 +290,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-zsh-handoff-bypass-marker*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-zsh-handoff-bypass-marker","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"?? should-run-as-zsh-shell"},"tool_use_id":"toolu-zsh-handoff-bypass-marker"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'?? should-run-as-zsh-shell'*'"exit_code":127'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-zsh-handoff-bypass-marker","message":{"content":[{"type":"text","text":"ZSH HANDOFF BYPASS MARKER HOSTEXEC RECEIVED"}]}}'
@@ -340,7 +361,14 @@ read -r user_message
 case "$user_message" in
   *cosh-core-handoff-wrapper-leak*)
     printf '%s\n' '{"type":"control_request","request_id":"ctrl-handoff-wrapper-leak","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"printf wrapper-visible"},"tool_use_id":"toolu-handoff-wrapper-leak"}}'
-    if IFS= read -r response; then
+    # #1940: skip approval receipts that now precede the decision line.
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    if [ -n "$response" ]; then
       case "$response" in
         *'"behavior":"host_executed_shell"'*'printf wrapper-visible'*'wrapper-visible'*)
           printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-handoff-wrapper-leak","message":{"content":[{"type":"text","text":"HANDOFF WRAPPER LEAK HOSTEXEC RECEIVED"}]}}'


### PR DESCRIPTION
## Summary

Closes #1940.

A control-plane approval request that reaches cosh-shell but is dropped by
a later pipeline stage (concrete repro: the question-rejection path swallows
trailing `ToolPermissionRequest`s into `deferred_events`) never receives a
`control_response`. cosh-core's `wait_for_approval` blocked forever — the
turn hangs with no user-visible failure (S2 baseline: `got 0 responses`).

Design contract, split at the visibility boundary — **"shell owns
received-and-must-answer; core owns sent-but-maybe-not-delivered"**. The
deciding predicate is whether the request_id reached the shell main loop:

- **Commit 1 (shell):** every `ToolPermissionRequest` seen by the event
  poll is guaranteed a terminal state (answered or explicitly denied),
  via a lifecycle ledger plus drain points. Legitimate waits (rendered
  card, auto-approve in flight, host-executed command, question
  interaction) are never touched: the drain only fires on requests with
  **no home** — not present in `approvals.requests` and not yet responded.
- **Commit 2 (core):** last-resort timeout for requests that never reach
  the shell at all (peer dead, channel silently broken). `wait_for_approval`
  gains an overall deadline (default **6h**, `COSH_CORE_APPROVAL_TIMEOUT_SECS`
  override, 30d hard cap) → new `ApprovalResult::TimedOut` → fail-closed
  error result + audit `approval.resolved(decision=timeout)`.

Why one PR for two crates: the core timeout is the residual counterpart of
the shell guarantee — the contract is only complete with both sides
(documented precedent for `[core,shell]` cross-crate commits on main; split
into two focused commits per review rules). False-positive analysis for the
6h default: if a card genuinely exists on the shell side when the core times
out, the late decision degrades through the existing `OwnerUnavailable` →
recovery-continuation path (no state split), and host-executed requests
degrade to a local handoff + continuation.

## Changes

**Commit 1 — `fix(cosh-ng): [shell] guarantee approval terminal state with
lifecycle ledger`**

- New `runtime/approval_ledger.rs`: `ApprovalLifecycleLedger`, a pure
  bookkeeping index keyed by `(run_id, request_id)` (the request facts stay
  in `approvals.requests`; reuses the #1939 identity contract).
- `agent/poll.rs`: register every `ToolPermissionRequest` on first sight
  (before any render decision); account the reentrant shell deny; foreign
  `run_id` registrations raise a `tracing::debug!` diagnostic.
- `approval/runtime.rs`: account `respond_provider_approval_to_owner`;
  `DROPPED_CONTROL_REQUEST_DENY_MESSAGE` + `drain_unhomed_control_requests`
  (batch) / `_with_handle` (run-terminal sweep).
- `agent/structured_events.rs`: I1 batch drain at the end of
  `render_new_agent_structured_events`.
- Run-terminal sweeps in `agent/finish.rs`, `agent/run.rs`,
  `runtime/cancel.rs` (cancel placed before `handle.cancel()`), plus the
  two bypass paths found in review (fresh-turn recovery in `poll.rs`,
  provider-timeout resume in `finish.rs`) so the ledger cannot grow across
  turns.
- `runtime/evidence_delivery.rs`: account successful host-executed delivery.

**Commit 2 — `fix(cosh-ng): [core] add last-resort timeout for unanswered
approvals`**

- `wait_for_approval`: single deadline computed at entry (not per-line) via
  `timeout_at`; `ApprovalResult::TimedOut`; EOF/IO-error semantics unchanged
  (`Interrupted`); env parsing guards non-numeric/zero/negative and caps at
  30 days to avoid `Instant + Duration` overflow.
- Three consumption points, all fail-closed: prompt path (assistant notice
  + return), tool approval (`ToolResult::error("approval timed out…")` +
  `metrics.approval_deny`), sandbox bypass (catch-all keeps original error).

## Tests

- New shell tests: `approval_ledger` ×3 (idempotent register, foreign-id
  no-op, per-run clear); `batch_drain_denies_control_request_dropped_by_
  question_rejection` (I1 denies immediately, not at finish);
  `batch_drain_leaves_recorded_pending_card_untouched` (homed request never
  drained). Re-anchored `conflicting_core_question_discards_trailing_
  interactions_and_finishes_once` to assert exactly one Deny — this is the
  S2 FAIL baseline turned green.
- New core tests: `unanswered_approval_times_out_instead_of_hanging_forever`,
  `answered_approval_beats_the_residual_timeout` (serialized via
  `tokio::sync::Mutex` around the process-wide env override).
- Gates (post-rebase `origin/main`): `cargo fmt --check`, `cargo clippy
  --workspace --all-targets` (0 warnings), `check-test-inventory.sh`,
  `check-layout.sh`, workspace tests, canonical units for both crates,
  core integration targets — all green. Focused domains: shell `agent::` +
  `approval::` 220 passed; core bin 638 passed.
- Pre-existing environment failures on this macOS host (not introduced
  here, reproduced identically on unmodified `main`): real-PTY suites are
  starved of ptys (`open pty: ENXIO`) — `protocol::session_management`
  (2), `raw_cli` (32), `shell_host` (3); all pass individually under low
  parallelism. Full-suite verdict deferred to Linux CI.

## Verification

Real-machine acceptance (cosh-lab-arm64-1940, Alibaba Cloud Linux 3 arm64;
real DashScope/qwen LLM; real PTY via `pty.fork`; trust mode; production
`sandbox-failure-handler` hook). Clean batch, 3/3 PASS:

| scenario | result |
| --- | --- |
| p1 (#1920 regression) | `审批 req-2` card surfaces, waits ~31s untouched (batch drain leaves homed requests alone), Enter approves → `bypass-probe-1920` retried successfully; audit `approval.requested(sandbox_bypass)` → `tool.completed` → `turn.completed` |
| w1 (legitimate wait) | card untouched 60s: audit shows **92.6s** card lifetime, no deny/timeout from either the shell drain or the core residual timeout; still actionable afterwards |
| c1 (control) | greeting turn completes, no approvals |

Code review (CodeReview subagent): no critical/major; 4 minors fixed and
amended (terminal-bypass sweeps ×2, test env serialization, env upper cap,
doc precision + foreign-run-id diagnostic). L3 deep security review:
**0 findings**.

## Evidence

Assets hosted on the personal fork, pinned to commit
`33485fd8c509711e64a0a9674ab9c00ba2873318` (branch `pr-1940-assets`):
asciinema casts for all three scenarios, cosh-core audit segments, the
ANSI-stripped key frames (`key-frames.txt`), and the acceptance driver.
