### PR TITLE
fix(agent-sec-core): accept SkillFS v1 notify protocol for backward compat

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/skill_ledger.py
@@ -35,6 +35,12 @@ _NOTIFY_V2_PARAM_KEYS = frozenset(
         "paths",
     }
 )
+# SkillFS v0.3.x sends v1 protocol with skillDir/skillName instead of
+# canonicalSkillDir/skillId.  Map v1 fields to v2 for backward compat.
+_NOTIFY_V1_TO_V2_FIELD_MAP = {
+    "skillDir": "canonicalSkillDir",
+    "skillName": "skillId",
+}
 
 
 def register_skill_ledger_methods(registry: MethodRegistry) -> None:
@@ -85,12 +91,22 @@ def skillfs_notify_change_handler(
 
 
 def parse_skillfs_change(params: dict[str, Any]) -> SkillFsChange:
-    """Validate daemon request params for a SkillFS change notification."""
+    """Validate daemon request params for a SkillFS change notification.
+
+    Accepts both v2 (canonicalSkillDir/skillId) and v1 (skillDir/skillName)
+    protocol fields.  SkillFS v0.3.x sends v1; v0.4+ sends v2.
+    """
+    schema_version = params.get("schemaVersion")
+
+    # Backward-compat: normalize v1 fields to v2 before strict validation.
+    if schema_version == 1 or "skillDir" in params:
+        params = _normalize_v1_params(params)
     _validate_notify_v2_param_keys(params)
 
-    schema_version = params.get("schemaVersion")
-    if schema_version != SCHEMA_VERSION:
-        raise BadRequestError("params.schemaVersion must be 2")
+    if schema_version not in (1, 2):
+        raise BadRequestError(
+            f"params.schemaVersion must be 1 or 2, got {schema_version!r}"
+        )
 
     canonical_skill_dir = _validate_canonical_skill_dir(params.get("canonicalSkillDir"))
     skill_id = _validate_skill_id(params.get("skillId"))
@@ -119,6 +135,16 @@ def _validate_notify_v2_param_keys(params: dict[str, Any]) -> None:
     if missing_fields:
         names = ", ".join(missing_fields)
         raise BadRequestError(f"params is missing required fields: {names}")
+
+
+def _normalize_v1_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Normalize SkillFS v1 notify params to v2 field names."""
+    normalized = dict(params)
+    for v1_key, v2_key in _NOTIFY_V1_TO_V2_FIELD_MAP.items():
+        if v1_key in normalized:
+            normalized[v2_key] = normalized.pop(v1_key)
+    normalized["schemaVersion"] = SCHEMA_VERSION
+    return normalized
 
 
 def _validate_canonical_skill_dir(value: Any) -> Path:


### PR DESCRIPTION
## 问题

Fixes #1969

The agent-sec-core daemon (v0.9.0) rejects SkillFS change notifications from the deployed SkillFS v0.3.2 binary because the v0.3.2 binary sends v1 protocol fields (`skillDir`/`skillName`) while the daemon's `parse_skillfs_change` handler only accepts v2 fields (`canonicalSkillDir`/`skillId`). The rejection causes SkillFS auto-notify to silently fail — skills written through the FUSE mount are never processed by the daemon, so `latestStatus` stays `unmanaged` instead of transitioning to `pass` or `deny`.

## 修复

```diff
+ _NOTIFY_V1_TO_V2_FIELD_MAP = {
+    "skillDir": "canonicalSkillDir",
+    "skillName": "skillId",
+}
 
 def parse_skillfs_change(params):
+    schema_version = params.get("schemaVersion")
+    # Backward-compat: normalize v1 fields to v2 before strict validation.
+    if schema_version == 1 or "skillDir" in params:
+        params = _normalize_v1_params(params)
+    _validate_notify_v2_param_keys(params)
+    if schema_version not in (1, 2):
+        raise BadRequestError(f"params.schemaVersion must be 1 or 2, got {schema_version!r}")
 
+def _normalize_v1_params(params):
+    normalized = dict(params)
+    for v1_key, v2_key in _NOTIFY_V1_TO_V2_FIELD_MAP.items():
+        if v1_key in normalized:
+            normalized[v2_key] = normalized.pop(v1_key)
+    normalized["schemaVersion"] = SCHEMA_VERSION
+    return normalized
```

## 验证

```shell
# Fresh clone + apply patch + rpm-build on ECS (47.239.61.17)
git clone https://github.com/alibaba/anolisa.git && cd anolisa
git apply fix.patch
bash scripts/rpm-build.sh agent-sec-core
# → exit 0, agent-sec-core-0.9.0-1.alnx4.x86_64.rpm produced

# Test: test_skillfs_auto_notify_safe_becomes_pass PASSED in 23.83s
cd /root/agentic-os-tests/agent-sec-core
pytest -xvs tests/test_skillfs_skill_ledger_journey.py::test_skillfs_auto_notify_safe_becomes_pass
# → PASSED
```

Co-Authored-By: Claude <noreply@anthropic.com>
