### PR TITLE
fix(cosh-ng): vendor ws-ckpt-common into RPM source tarball

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -860,7 +860,47 @@ build_cosh_ng() {
         --exclude='node_modules' \
         . | tar -xf - -C "$pkg_dir"
 
-    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
+    # Vendor ws-ckpt-common source into the tarball as a sibling top-level dir.
+    # cosh-types/Cargo.toml has a dev-dependency path
+    # `../../../ws-ckpt/src/crates/common` that escapes the cosh-ng workspace
+    # root. During `cargo build --workspace --release` rpmbuild resolves the
+    # path (cargo loads manifests for ALL workspace dev-dependencies when
+    # computing the lockfile) and fails because the path points outside the
+    # extracted tarball. Vendoring the source lets the path resolve inside
+    # the tarball without changing Cargo.toml. The dev-dep is only used by
+    # `tests/checkpoint_wire_conformance.rs` and is not compiled into the
+    # release binaries, but cargo still needs to load its manifest.
+    #
+    # ws-ckpt-common's Cargo.toml inherits version/edition/etc. from its
+    # workspace root at ws-ckpt/src/Cargo.toml — vendor the workspace root
+    # too so cargo can resolve the inheritance. Use original workspace
+    # Cargo.toml with members filtered to only `crates/common` (avoid pulling
+    # daemon/cli member manifests which would trigger further deps).
+    local wsckpt_src_root="${ROOT_DIR}/src/ws-ckpt/src"
+    if [ -d "${wsckpt_src_root}/crates/common" ]; then
+        mkdir -p "${tmp_dir}/ws-ckpt/src/crates/common"
+        tar -cf - -C "${wsckpt_src_root}/crates/common" \
+            --exclude='target' \
+            --exclude='.git' \
+            . | tar -xf - -C "${tmp_dir}/ws-ckpt/src/crates/common"
+        # Copy original workspace Cargo.toml, replace `members = [...]` line
+        # with only `crates/common` (avoid pulling daemon/cli member manifests
+        # which would trigger further deps). This preserves all [workspace.package]
+        # keys (version/edition/license/authors/repository/...) so if ws-ckpt-common
+        # later adds `.workspace = true` inheritance for new fields, cargo still
+        # resolves (a hand-written trimmed manifest would silently break — Issue 4
+        # from code-review).
+        if [ -f "${wsckpt_src_root}/Cargo.toml" ]; then
+            sed -E 's|^members[[:space:]]*=.*|members = ["crates/common"]|' \
+                "${wsckpt_src_root}/Cargo.toml" > "${tmp_dir}/ws-ckpt/src/Cargo.toml"
+        else
+            warn "ws-ckpt workspace Cargo.toml not found at ${wsckpt_src_root}/Cargo.toml"
+        fi
+    else
+        warn "ws-ckpt-common source not found at ${wsckpt_src_root}/crates/common; cosh-types wire-conformance dev-dependency path will not resolve during rpmbuild"
+    fi
+
+    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}" ws-ckpt
     rm -rf "$tmp_dir"
 
     log "Step 2/2: Running rpmbuild..."


### PR DESCRIPTION
Fixes #1973

## 问题

nightly-20260729-020133 cosh-ng worker BUILD_FAILED。错误:
```
error: failed to load manifest for workspace member cosh-types
Caused by: failed to read /root/anolisa/scripts/rpmbuild/BUILD/ws-ckpt/src/crates/common/Cargo.toml (No such file or directory, os error 2)
```

## 根因

`crates/cosh-types/Cargo.toml` 在 b3e6f8f9 引入 dev-dependency path:
```toml
[dev-dependencies]
ws-ckpt-common = { path = "../../../ws-ckpt/src/crates/common" }
```

该 path 从 `cosh-ng/crates/cosh-types/` 出发,3 个 `..` 跨出 cosh-ng workspace 根目录,指向 `anolisa/src/ws-ckpt/src/crates/common/`(monorepo 内有效)。

rpm-build.sh 在打包 tarball 时只 include `cosh-ng/` 子树(`tar -cf - -C "$COSH_DIR" .`),不 include `ws-ckpt/`。rpmbuild 解包到 `BUILD/cosh-ng-0.13.0/`,path 解析后指向 `BUILD/ws-ckpt/src/crates/common/` —— 该目录在 tarball 外不存在。

cargo 在 `cargo build --workspace --release` 时需要为所有 workspace 成员(含 cosh-types)的 dev-dependency 计算并写入 Cargo.lock,因此必须读取 ws-ckpt-common 的 Cargo.toml —— path 失败 → build failed。dev-dep 实际只被 `tests/checkpoint_wire_conformance.rs` 使用,不进 release binary,但 cargo 仍需要加载 manifest。

## 修复

`scripts/rpm-build.sh` build_cosh_ng 在创建 tarball 时额外 vendor ws-ckpt-common 源码作为 tarball 顶层 sibling dir `ws-ckpt/`:

- 拷贝 `${ROOT_DIR}/src/ws-ckpt/src/crates/common/` 到 `${tmp_dir}/ws-ckpt/src/crates/common/`
- 写入 trimmed workspace Cargo.toml 到 `${tmp_dir}/ws-ckpt/src/Cargo.toml`(只声明 `common` member,避免拉 daemon/cli 进一步的 deps)
- tar 命令改为同时打包 `${pkg_name}-${version}` + `ws-ckpt` 两个顶层 dir

`%setup -q` 解包后 BUILD/ 下同时有 `cosh-ng-0.13.0/` 和 `ws-ckpt/`,path 正确解析,cargo 加载 manifest 成功。

不动 `crates/cosh-types/Cargo.toml` 和 test 文件 —— dev-dep path 在 monorepo 内仍正常,conformance test `cargo test --locked -p cosh-types` 在本地 dev workflow 不受影响。

## 验证

ECS 47.239.57.210(cosh-ng nightly ECS)上跑:
```
bash scripts/rpm-build.sh cosh-ng
...
[OK] cosh-ng RPM built successfully
  cosh-ng-0.13.0-2.alnx4.x86_64.rpm  (7.9M)
  cosh-ng-0.13.0-2.alnx4.src.rpm  (1.9M)
```

附:同时发现 cosh-core 通过 reqwest → hyper-tls → native-tls → openssl-sys 拉 openssl-sys,需要 `openssl-devel` 在构建 ECS 上预装(spec.in 虽 BuildRequires 但 rpm-build.sh 用 `rpmbuild --nodeps` 不自动装)—— 这个在 agentic-os-tests 仓 cosh-ng-tests SKILL.md Step 1 单独修(显式 yum install -y openssl-devel)。

## 测试计划

- [x] `bash scripts/rpm-build.sh cosh-ng` 在 nightly ECS 上产 RPM
- [ ] 下次 nightly cosh-ng worker 不再 BUILD_FAILED
- [ ] ws-ckpt daemon/cli member 不被拉入 tarball(trimmed workspace Cargo.toml 只声明 common)