### PR TITLE
fix(cosh-ng): [shell] replay input typed during card settle

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
@@ -210,9 +210,16 @@ pub(crate) fn complete_capture_chain_if_pending(
     true
 }
 
-pub(crate) fn complete_capture_replay(input_mode: &Arc<Mutex<RawInputMode>>, generation: u64) {
+/// Completes a drained submission: chains to the pending next capture when
+/// one is installed, otherwise hands input back to the shell via `Terminal`.
+/// Returns `true` only for the `Terminal` hand-back (GH-1913: the caller may
+/// replay input quarantined during the settle window in that case).
+pub(crate) fn complete_capture_replay(
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    generation: u64,
+) -> bool {
     let Ok(mut mode) = input_mode.lock() else {
-        return;
+        return false;
     };
     let RawInputMode::Draining {
         previous_capture,
@@ -221,24 +228,26 @@ pub(crate) fn complete_capture_replay(input_mode: &Arc<Mutex<RawInputMode>>, gen
         ..
     } = &*mode
     else {
-        return;
+        return false;
     };
     if *active != generation {
-        return;
+        return false;
     }
     let previous_capture = previous_capture.clone();
-    *mode = if let Some(capture) = next_capture.clone() {
-        RawInputMode::Capture {
+    if let Some(capture) = next_capture.clone() {
+        *mode = RawInputMode::Capture {
             capture,
             generation: CAPTURE_GENERATION.fetch_add(1, Ordering::Relaxed),
             installed_at: std::time::Instant::now(),
-        }
+        };
+        false
     } else {
-        RawInputMode::Terminal {
+        *mode = RawInputMode::Terminal {
             previous_capture,
             generation,
-        }
-    };
+        };
+        true
+    }
 }
 
 pub(crate) fn expire_capture_submission(input_mode: &Arc<Mutex<RawInputMode>>, generation: u64) {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -6,21 +6,77 @@ const CAPTURE_QUARANTINE_MAX_BYTES: usize = 64 * 1024;
 pub(super) struct CaptureOwnedInput {
     bytes: usize,
     overflowed: bool,
+    /// Input typed while a submitted card action is settling (GH-1913):
+    /// retained so a clean close can replay it instead of silently dropping
+    /// it. Same-read submit remainders are never buffered (observe-only) and
+    /// an overflow discards the whole buffer.
+    buffered: Vec<u8>,
+    /// Generation of the last capture that closed cleanly back to the shell
+    /// (GH-1913). Late reads still stamped with this generation were typed
+    /// while the card action settled and are delivered to the shell; without
+    /// the marker (expired, overflowed, or chained closes) they keep the
+    /// historical discard.
+    last_clean_close: Option<u64>,
 }
 
 impl CaptureOwnedInput {
+    /// Count-only observation for bytes that must never be replayed (e.g.
+    /// the same-read remainder behind a submit): they were composed before
+    /// the card released, so they stay quarantined.
     fn observe(&mut self, bytes: &[u8]) -> bool {
         self.bytes = self.bytes.saturating_add(bytes.len());
         if self.overflowed || self.bytes <= CAPTURE_QUARANTINE_MAX_BYTES {
             return false;
         }
         self.overflowed = true;
+        self.buffered = Vec::new();
         true
+    }
+
+    /// Buffers input typed while the submission is settling so a clean close
+    /// to Terminal can replay it (GH-1913); shares the overflow budget with
+    /// `observe`.
+    fn buffer(&mut self, bytes: &[u8]) -> bool {
+        let overflow = self.observe(bytes);
+        if !self.overflowed {
+            self.buffered.extend_from_slice(bytes);
+        }
+        overflow
+    }
+
+    fn take_buffered(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.buffered)
     }
 
     fn clear(&mut self) {
         *self = Self::default();
     }
+}
+
+/// Replays input quarantined during a card submission once the capture chain
+/// closed cleanly (GH-1913): the mode is `Terminal` for the same generation,
+/// or already back to `Passthrough` (the observer acknowledges the terminal
+/// hand-back with a `Continue`, which can land before the replay runs). Any
+/// other live mode (a replacement capture, hold, delay) keeps the historical
+/// discard semantics: the bytes may have been aimed at an owner that no
+/// longer exists.
+fn replay_quarantined_input(
+    bytes: &[u8],
+    generation: u64,
+    relay: &mut InputRelayContext<'_>,
+) -> io::Result<()> {
+    if bytes.is_empty() {
+        return Ok(());
+    }
+    match current_raw_input_mode(relay.input_mode) {
+        RawInputMode::Terminal {
+            generation: active, ..
+        } if active == generation => {}
+        RawInputMode::Passthrough => {}
+        _ => return Ok(()),
+    }
+    relay_passthrough_input(bytes, relay)?;
+    Ok(())
 }
 
 pub(super) fn capture_owns_input(mode: &RawInputMode) -> bool {
@@ -184,6 +240,9 @@ pub(super) fn drain_capture_submission(
     let Some(generation) = result.generation else {
         return Ok(());
     };
+    // A new submission owns the quarantine from here on; a clean-close
+    // marker from an earlier capture no longer applies.
+    capture_owned_input.last_clean_close = None;
     let mut overflow = capture_owned_input.observe(&result.remainder);
     if overflow {
         let _ = relay
@@ -193,10 +252,12 @@ pub(super) fn drain_capture_submission(
     }
 
     let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
+    let invalidated = loop {
         match current_raw_input_mode(relay.input_mode) {
             RawInputMode::Draining {
-                generation: active, ..
+                generation: active,
+                invalidated: drain_invalidated,
+                ..
             } if active == generation => {
                 if !overflow {
                     overflow = drain_capture_read_ahead(
@@ -207,7 +268,7 @@ pub(super) fn drain_capture_submission(
                         relay,
                     );
                 }
-                break;
+                break drain_invalidated;
             }
             RawInputMode::Submitted {
                 generation: active, ..
@@ -221,7 +282,7 @@ pub(super) fn drain_capture_submission(
                 };
                 match receiver.recv_timeout(wait) {
                     Ok(InputRead::Bytes { bytes, .. }) => {
-                        if !overflow && capture_owned_input.observe(&bytes) {
+                        if !overflow && capture_owned_input.buffer(&bytes) {
                             overflow = true;
                             let _ = relay
                                 .input_events
@@ -248,9 +309,12 @@ pub(super) fn drain_capture_submission(
                     .send(RawInputEvent::CaptureExpired { generation });
                 expire_capture_submission(relay.input_mode, generation);
             }
-            _ => return Ok(()),
+            _ => {
+                capture_owned_input.clear();
+                return Ok(());
+            }
         }
-    }
+    };
     if !overflow && complete_capture_chain_if_pending(relay.input_mode, generation) {
         capture_owned_input.clear();
         let _ = relay
@@ -259,11 +323,19 @@ pub(super) fn drain_capture_submission(
         return Ok(());
     }
 
+    let buffered = capture_owned_input.take_buffered();
     capture_owned_input.clear();
-    complete_capture_replay(relay.input_mode, generation);
+    let closed_to_terminal = complete_capture_replay(relay.input_mode, generation);
+    let clean_close = closed_to_terminal && !invalidated && !overflow;
+    if clean_close {
+        capture_owned_input.last_clean_close = Some(generation);
+    }
     let _ = relay
         .input_events
         .send(RawInputEvent::CaptureDrained { generation });
+    if clean_close {
+        replay_quarantined_input(&buffered, generation, relay)?;
+    }
     Ok(())
 }
 
@@ -309,7 +381,8 @@ fn relay_late_capture_bytes(
     capture_owned_input: &mut CaptureOwnedInput,
     relay: &mut InputRelayContext<'_>,
 ) -> io::Result<()> {
-    let active_generation = match current_raw_input_mode(relay.input_mode) {
+    let mode = current_raw_input_mode(relay.input_mode);
+    let active_generation = match &mode {
         RawInputMode::Capture {
             generation: active, ..
         }
@@ -318,15 +391,46 @@ fn relay_late_capture_bytes(
         }
         | RawInputMode::Draining {
             generation: active, ..
-        } => Some(active),
+        } => Some(*active),
         _ => None,
     };
     if active_generation != Some(generation) {
+        // GH-1913: when the quarantining capture already closed cleanly back
+        // to the shell (Terminal for this generation, or Passthrough once the
+        // observer acknowledged the hand-back), late reads still stamped with
+        // that generation were typed while the card action settled and belong
+        // to the shell — deliver them together with anything buffered during
+        // the settle window. Any other close (expired, overflowed, chained,
+        // replaced owner) keeps the historical discard.
+        let mut buffered = capture_owned_input.take_buffered();
+        let last_clean_close = capture_owned_input.last_clean_close;
         capture_owned_input.clear();
+        capture_owned_input.last_clean_close = last_clean_close;
+        let closed_cleanly = last_clean_close == Some(generation)
+            && match &mode {
+                RawInputMode::Terminal {
+                    generation: active, ..
+                } => *active == generation,
+                RawInputMode::Passthrough => true,
+                _ => false,
+            };
+        if closed_cleanly {
+            buffered.extend_from_slice(bytes);
+            if !buffered.is_empty() {
+                relay_passthrough_input(&buffered, relay)?;
+            }
+        }
         return Ok(());
     }
 
-    let overflow = capture_owned_input.observe(bytes);
+    // Bytes typed while the submission settles are buffered for the clean
+    // close replay (GH-1913); bytes aimed at a still-armed card stay
+    // observe-only so a later replay can never re-trigger card actions.
+    let overflow = if matches!(mode, RawInputMode::Capture { .. }) {
+        capture_owned_input.observe(bytes)
+    } else {
+        capture_owned_input.buffer(bytes)
+    };
     if overflow {
         let _ = relay
             .input_events
@@ -368,7 +472,7 @@ fn drain_capture_read_ahead(
     loop {
         match receiver.try_recv() {
             Ok(InputRead::Bytes { bytes, .. }) => {
-                if capture_owned_input.observe(&bytes) {
+                if capture_owned_input.buffer(&bytes) {
                     let _ = relay
                         .input_events
                         .send(RawInputEvent::CaptureOverflow { generation });
@@ -389,14 +493,27 @@ pub(super) fn drain_abandoned_capture(
     capture_owned_input: &mut CaptureOwnedInput,
     relay: &mut InputRelayContext<'_>,
 ) -> io::Result<()> {
-    let RawInputMode::Draining { generation, .. } = current_raw_input_mode(relay.input_mode) else {
+    let RawInputMode::Draining {
+        generation,
+        invalidated,
+        ..
+    } = current_raw_input_mode(relay.input_mode)
+    else {
         return Ok(());
     };
+    let buffered = capture_owned_input.take_buffered();
     capture_owned_input.clear();
-    complete_capture_replay(relay.input_mode, generation);
+    let closed_to_terminal = complete_capture_replay(relay.input_mode, generation);
+    let clean_close = closed_to_terminal && !invalidated;
+    if clean_close {
+        capture_owned_input.last_clean_close = Some(generation);
+    }
     let _ = relay
         .input_events
         .send(RawInputEvent::CaptureDrained { generation });
+    if clean_close {
+        replay_quarantined_input(&buffered, generation, relay)?;
+    }
     Ok(())
 }
 
@@ -636,6 +753,300 @@ mod tests {
         assert!(!input_rx
             .try_iter()
             .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
+        master.sync_all().expect("sync test output");
+        assert!(fs::read(&path).expect("read test output").is_empty());
+        fs::remove_file(path).ok();
+    }
+
+    fn config_capture() -> RawInputCapture {
+        RawInputCapture::Config {
+            id: "config".to_string(),
+            option_count: 2,
+            selected: 0,
+        }
+    }
+
+    /// GH-1913: input typed as a separate read while a submitted card action
+    /// settles must be buffered and replayed once the capture closes cleanly
+    /// to Terminal, instead of being silently discarded.
+    #[test]
+    fn processing_window_read_is_replayed_after_clean_close() {
+        let path =
+            std::env::temp_dir().join(format!("cosh-shell-capture-replay-{}", std::process::id()));
+        let mut master = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("test output file");
+        let capture = config_capture();
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Draining {
+            previous_capture: capture.clone(),
+            generation: 7,
+            next_capture: None,
+            invalidated: false,
+        }));
+        let (read_tx, read_rx) = mpsc::channel();
+        read_tx
+            .send(InputRead::Bytes {
+                bytes: b"echo processing-window\r".to_vec(),
+                received_at: Instant::now(),
+                observed_mode: RawInputMode::Submitted {
+                    capture: capture.clone(),
+                    generation: 7,
+                },
+                ownership_changed_during_read: false,
+            })
+            .expect("queue read-ahead input");
+        drop(read_tx);
+        let (input_tx, input_rx) = mpsc::channel();
+        let classifier = InputClassifier::default();
+        let mut quarantine = CaptureOwnedInput::default();
+        let mut deferred_input = None;
+        let mut line_buffer = CandidateLineBuffer::default();
+        let mut native_line_state = NativeLineState::default();
+        let mut exit_tracker = ExplicitExitTracker::default();
+        let input_generation = UserPtyInputGeneration::default();
+        let mut line_submits = LineSubmitCounter::default();
+        let main_prompt_gate = super::super::super::MainPromptGate::default();
+        let mut relay = InputRelayContext {
+            master: &mut master,
+            input_classifier: &classifier,
+            input_events: &input_tx,
+            input_mode: &input_mode,
+            input_generation: &input_generation,
+            line_submits: &mut line_submits,
+            line_buffer: &mut line_buffer,
+            native_line_state: &mut native_line_state,
+            exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: false,
+        };
+
+        drain_capture_submission(
+            CaptureConsumeResult {
+                generation: Some(7),
+                remainder: Vec::new(),
+                retry: false,
+            },
+            &mut quarantine,
+            &mut deferred_input,
+            Some(&read_rx),
+            &mut relay,
+        )
+        .expect("drain submitted capture");
+
+        assert!(matches!(
+            current_raw_input_mode(&input_mode),
+            RawInputMode::Terminal { generation: 7, .. }
+        ));
+        assert!(input_rx
+            .try_iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureDrained { generation: 7 })));
+        master.sync_all().expect("sync test output");
+        assert_eq!(
+            fs::read(&path).expect("read test output"),
+            b"echo processing-window\r"
+        );
+        fs::remove_file(path).ok();
+    }
+
+    /// GH-1913: bytes stamped with the closed generation that arrive after
+    /// the chain reached Terminal are delivered, not dropped.
+    #[test]
+    fn late_bytes_after_terminal_close_are_delivered() {
+        let path = std::env::temp_dir().join(format!(
+            "cosh-shell-capture-late-terminal-{}",
+            std::process::id()
+        ));
+        let mut master = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("test output file");
+        let capture = config_capture();
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Terminal {
+            previous_capture: capture,
+            generation: 7,
+        }));
+        let (input_tx, _input_rx) = mpsc::channel();
+        let classifier = InputClassifier::default();
+        // The drain loop records the clean close before flipping to Terminal.
+        let mut quarantine = CaptureOwnedInput {
+            last_clean_close: Some(7),
+            ..CaptureOwnedInput::default()
+        };
+        let mut line_buffer = CandidateLineBuffer::default();
+        let mut native_line_state = NativeLineState::default();
+        let mut exit_tracker = ExplicitExitTracker::default();
+        let input_generation = UserPtyInputGeneration::default();
+        let mut line_submits = LineSubmitCounter::default();
+        let main_prompt_gate = super::super::super::MainPromptGate::default();
+        let mut relay = InputRelayContext {
+            master: &mut master,
+            input_classifier: &classifier,
+            input_events: &input_tx,
+            input_mode: &input_mode,
+            input_generation: &input_generation,
+            line_submits: &mut line_submits,
+            line_buffer: &mut line_buffer,
+            native_line_state: &mut native_line_state,
+            exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: false,
+        };
+
+        relay_late_capture_bytes(b"echo late-bytes\r", 7, &mut quarantine, &mut relay)
+            .expect("relay late bytes");
+
+        master.sync_all().expect("sync test output");
+        assert_eq!(
+            fs::read(&path).expect("read test output"),
+            b"echo late-bytes\r"
+        );
+        fs::remove_file(path).ok();
+    }
+
+    /// Bytes stamped with a generation that no longer matches the closed
+    /// chain keep the historical discard: their owner is gone or replaced.
+    #[test]
+    fn late_bytes_for_a_different_generation_stay_discarded() {
+        let path = std::env::temp_dir().join(format!(
+            "cosh-shell-capture-late-mismatch-{}",
+            std::process::id()
+        ));
+        let mut master = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("test output file");
+        let capture = config_capture();
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Terminal {
+            previous_capture: capture,
+            generation: 8,
+        }));
+        let (input_tx, _input_rx) = mpsc::channel();
+        let classifier = InputClassifier::default();
+        let mut quarantine = CaptureOwnedInput::default();
+        let mut line_buffer = CandidateLineBuffer::default();
+        let mut native_line_state = NativeLineState::default();
+        let mut exit_tracker = ExplicitExitTracker::default();
+        let input_generation = UserPtyInputGeneration::default();
+        let mut line_submits = LineSubmitCounter::default();
+        let main_prompt_gate = super::super::super::MainPromptGate::default();
+        let mut relay = InputRelayContext {
+            master: &mut master,
+            input_classifier: &classifier,
+            input_events: &input_tx,
+            input_mode: &input_mode,
+            input_generation: &input_generation,
+            line_submits: &mut line_submits,
+            line_buffer: &mut line_buffer,
+            native_line_state: &mut native_line_state,
+            exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: false,
+        };
+
+        relay_late_capture_bytes(b"echo stale-bytes\r", 7, &mut quarantine, &mut relay)
+            .expect("relay stale bytes");
+
+        master.sync_all().expect("sync test output");
+        assert!(fs::read(&path).expect("read test output").is_empty());
+        fs::remove_file(path).ok();
+    }
+
+    /// The chained-card close keeps discarding the settle-window bytes: they
+    /// may have been aimed at a card that was replaced mid-flight.
+    #[test]
+    fn processing_window_read_is_discarded_when_a_next_capture_chains() {
+        let path = std::env::temp_dir().join(format!(
+            "cosh-shell-capture-chain-discard-{}",
+            std::process::id()
+        ));
+        let mut master = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("test output file");
+        let capture = config_capture();
+        let next = RawInputCapture::Question {
+            id: "q-next".to_string(),
+            option_count: 0,
+            allow_free_text: true,
+            multiple: false,
+            secret: false,
+        };
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Draining {
+            previous_capture: capture.clone(),
+            generation: 7,
+            next_capture: Some(next),
+            invalidated: false,
+        }));
+        let (read_tx, read_rx) = mpsc::channel();
+        read_tx
+            .send(InputRead::Bytes {
+                bytes: b"echo chained-discard\r".to_vec(),
+                received_at: Instant::now(),
+                observed_mode: RawInputMode::Submitted {
+                    capture: capture.clone(),
+                    generation: 7,
+                },
+                ownership_changed_during_read: false,
+            })
+            .expect("queue read-ahead input");
+        drop(read_tx);
+        let (input_tx, _input_rx) = mpsc::channel();
+        let classifier = InputClassifier::default();
+        let mut quarantine = CaptureOwnedInput::default();
+        let mut deferred_input = None;
+        let mut line_buffer = CandidateLineBuffer::default();
+        let mut native_line_state = NativeLineState::default();
+        let mut exit_tracker = ExplicitExitTracker::default();
+        let input_generation = UserPtyInputGeneration::default();
+        let mut line_submits = LineSubmitCounter::default();
+        let main_prompt_gate = super::super::super::MainPromptGate::default();
+        let mut relay = InputRelayContext {
+            master: &mut master,
+            input_classifier: &classifier,
+            input_events: &input_tx,
+            input_mode: &input_mode,
+            input_generation: &input_generation,
+            line_submits: &mut line_submits,
+            line_buffer: &mut line_buffer,
+            native_line_state: &mut native_line_state,
+            exit_tracker: &mut exit_tracker,
+            main_prompt_gate: &main_prompt_gate,
+            slash_route_enabled: false,
+        };
+
+        drain_capture_submission(
+            CaptureConsumeResult {
+                generation: Some(7),
+                remainder: Vec::new(),
+                retry: false,
+            },
+            &mut quarantine,
+            &mut deferred_input,
+            Some(&read_rx),
+            &mut relay,
+        )
+        .expect("drain submitted capture");
+
+        assert!(matches!(
+            current_raw_input_mode(&input_mode),
+            RawInputMode::Capture {
+                capture: RawInputCapture::Question { ref id, .. },
+                ..
+            } if id == "q-next"
+        ));
         master.sync_all().expect("sync test output");
         assert!(fs::read(&path).expect("read test output").is_empty());
         fs::remove_file(path).ok();

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/public.rs
@@ -5,8 +5,9 @@ mod implementation;
 pub use implementation::{
     run_line_interactive_bash, run_raw_relay_bash, run_raw_relay_bash_with_actions,
     run_raw_relay_bash_with_actions_output_control, run_raw_relay_bash_with_observer,
-    run_raw_relay_zsh_with_actions, run_raw_relay_zsh_with_output_control, run_scripted_bash,
-    run_scripted_zsh, LineInteractiveOutput, ScriptedInput, ShellHostConfig, ShellHostOutput,
+    run_raw_relay_bash_with_output_control, run_raw_relay_zsh_with_actions,
+    run_raw_relay_zsh_with_output_control, run_scripted_bash, run_scripted_zsh,
+    LineInteractiveOutput, ScriptedInput, ShellHostConfig, ShellHostOutput,
 };
 
 pub(crate) use implementation::run_streaming_line_bash;

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
@@ -199,6 +199,27 @@ where
     shell_run_raw_relay_bash_with_actions_output_control(&config, actions, output, event_observer)
 }
 
+fn run_raw_relay_bash_with_output_control<R, W, F>(
+    config: &ShellHostConfig,
+    input: R,
+    output: W,
+    event_observer: F,
+) -> io::Result<ShellHostOutput>
+where
+    R: Read + Send + 'static,
+    W: Write,
+    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+{
+    let _guard = shell_host_run_guard();
+    let config = shell_host_test_config(config);
+    cosh_shell::shell_host::run_raw_relay_bash_with_output_control(
+        &config,
+        input,
+        output,
+        event_observer,
+    )
+}
+
 fn run_raw_relay_zsh_with_output_control<R, W, F>(
     config: &ShellHostConfig,
     input: R,

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -1046,3 +1046,69 @@ fn raw_relay_capture_owned_input_overflow_is_visible_and_discarded() {
         .iter()
         .any(|event| event.message.as_deref() == Some("capture_overflow")));
 }
+
+#[test]
+fn raw_relay_capture_slow_ack_replays_processing_window_input() {
+    // GH-1913: input typed while a submitted card action is still being
+    // processed (e.g. the slow /config Save handler) must be replayed to the
+    // shell once the capture closes cleanly, never silently dropped.
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-capture-slow-ack-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config = ShellHostConfig::new("capture-slow-ack-test", &work_dir);
+    config.native_mode = false;
+    let capture = RawInputCapture::Question {
+        id: "question-1".to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    };
+    // DelayedInput yields one chunk per read(), so "yes\n" is delivered in a
+    // first read, and "echo ..." in a later read while the observer is still
+    // busy processing the card answer (the Save processing window).
+    let input = DelayedInput::new(vec![
+        (b"yes\n".to_vec(), Duration::from_millis(50)),
+        (
+            b"echo processing-window-ok\n".to_vec(),
+            Duration::from_millis(150),
+        ),
+        (b"exit\n".to_vec(), Duration::from_millis(500)),
+    ]);
+    let mut slept = false;
+    let output =
+        run_raw_relay_bash_with_output_control(&config, input, Vec::new(), move |events, _| {
+            if events.iter().any(|event| {
+                event.component.as_deref() == Some("card")
+                    && event.message.as_deref() == Some("answer")
+            }) {
+                if !slept {
+                    // Model the slow card action: the observer holds the
+                    // input mode lock while the config save settles.
+                    slept = true;
+                    std::thread::sleep(Duration::from_millis(300));
+                }
+                Ok(RawObserverAction::Continue)
+            } else {
+                Ok(RawObserverAction::CaptureInput(capture.clone()))
+            }
+        })
+        .expect("capture slow ack relay");
+
+    assert_eq!(
+        ledger_from_output(&output)
+            .blocks
+            .iter()
+            .filter(|block| block.command == "echo processing-window-ok")
+            .count(),
+        1,
+        "{:?}",
+        output.events
+    );
+    assert!(output
+        .events
+        .iter()
+        .any(|event| event.message.as_deref() == Some("capture_drained")));
+}


### PR DESCRIPTION
## 改动说明

修复 #1913：在 `/config` 卡片 Save 动作处理窗口内输入的内容会被静默丢弃的问题。

根因：`cosh-shell` 的 raw input relay 在卡片提交后的 settle 窗口（`Submitted → Draining`）内，将用户输入送入 `CaptureOwnedInput` 隔离区时只做计数（`observe`），排空捕获后直接丢弃字节。当卡片动作处理很慢（如 Save 处理约 6 秒持有 input mode 锁）时，用户在此期间输入的命令会消失，且无任何提示。

修复方式（按 issue 期望的第一种行为——缓冲并在卡片完成后送达）：

- `CaptureOwnedInput` 新增 `buffered` 缓冲区：settle 窗口内独立读取到的输入被缓冲（与原有 64KB 隔离上限共享额度）；提交同一读取内的剩余字节仍保持 observe-only，不会被重放。
- `complete_capture_replay` 返回是否干净地回到 `Terminal`；只有「干净关闭」（未过期、未溢出、未链到下一个卡片、owner 未被替换）才会把缓冲的输入重放给 shell。
- 新增 `last_clean_close` 标记：由于观察者以 `Continue` 确认 Terminal 交还时机不确定（模式可能已翻回 `Passthrough`），仍带着已关闭 generation 戳记的迟到读取通过该标记安全送达；其余情况（过期、溢出、链式、换主）保持原有丢弃语义，保证重放永远不会重新触发卡片动作。

## 关联 Issue

Fixes ANO-1372（对应 GitHub #1913）。

Save 动作本身约 6 秒的延迟（`write_user_language_config`）是独立问题，不在本 PR 范围内。

## 测试情况

- 新增 4 个单元测试（`raw_input/spawn/capture.rs`）：
  - `processing_window_read_is_replayed_after_clean_close`：settle 窗口读入在干净关闭后被重放
  - `late_bytes_after_terminal_close_are_delivered`：Terminal 关闭后带旧 generation 的迟到字节被送达
  - `late_bytes_for_a_different_generation_stay_discarded`：generation 不匹配的迟到字节保持丢弃
  - `processing_window_read_is_discarded_when_a_next_capture_chains`：链式卡片场景不重放
- 新增 1 个端到端测试（`tests/shell_host/relay.rs`）：`raw_relay_capture_slow_ack_replays_processing_window_input`，用慢速观察者模拟 Save 处理窗口，验证窗口内输入的命令最终被 shell 执行（连续运行 5 次无抖动）。
- `cargo test -p cosh-shell --lib capture`：73 通过。
- `cargo test -p cosh-shell --no-fail-fast`：除 15 个与本改动无关、在干净 main 树上同样失败的环境相关用例（TMPDIR 长路径、性能计时、sudo/信号等沙箱限制）外全部通过；已逐一在未打补丁的树上复现确认为预先存在。
- `cargo clippy -p cosh-shell --all-targets` 与 `cargo fmt --check` 无告警。