### PR TITLE
fix(sight): capture Claude Code launched via absolute path or node wrapper

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -83,7 +83,9 @@
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
       {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},
       {"rule": ["openclaw"], "agent_name": "OpenClaw"},
-      {"rule": ["claude*"], "agent_name": "Claude"}
+      {"rule": ["claude*"], "agent_name": "Claude"},
+      {"rule": ["*/claude*"], "agent_name": "Claude"},
+      {"rule": ["*node*", "*claude*"], "agent_name": "Claude"}
     ]
   },
   "codex_offsets": {

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -267,4 +267,99 @@ mod tests {
         };
         assert!(CmdlineGlobMatcher::from_deny_rule(&rule).is_none());
     }
+
+    /// Match a cmdline against the embedded default rules and return the
+    /// first matching agent name (mirrors `AgentScanner::find_match`).
+    fn match_default_rules(args: &[&str], exe_path: &str) -> Option<String> {
+        let ctx = ProcessContext {
+            comm: String::new(),
+            cmdline_args: args.iter().map(|s| s.to_string()).collect(),
+            exe_path: exe_path.to_string(),
+        };
+        crate::config::default_cmdline_rules()
+            .iter()
+            .filter_map(CmdlineGlobMatcher::from_config)
+            .find(|m| m.matches(&ctx))
+            .map(|m| m.info().name.clone())
+    }
+
+    #[test]
+    fn test_default_rules_capture_claude_code_bare_name() {
+        // Launched from a shell as `claude`
+        assert_eq!(
+            match_default_rules(&["claude"], "").as_deref(),
+            Some("Claude")
+        );
+    }
+
+    #[test]
+    fn test_default_rules_capture_claude_code_absolute_path() {
+        // Launched via absolute path (native binary install)
+        assert_eq!(
+            match_default_rules(&["/usr/local/bin/claude"], "").as_deref(),
+            Some("Claude")
+        );
+        assert_eq!(
+            match_default_rules(
+                &["/home/user/.local/share/claude/versions/2.0.14/claude"],
+                ""
+            )
+            .as_deref(),
+            Some("Claude")
+        );
+    }
+
+    #[test]
+    fn test_default_rules_capture_claude_code_node_wrapper() {
+        // npm global install: `claude` is a shebang script, the kernel rewrites
+        // argv to `node <script>` so argv[0] is node, not claude
+        assert_eq!(
+            match_default_rules(
+                &[
+                    "node",
+                    "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+                ],
+                ""
+            )
+            .as_deref(),
+            Some("Claude")
+        );
+        assert_eq!(
+            match_default_rules(
+                &[
+                    "/usr/bin/node",
+                    "/home/user/.claude/local/node_modules/.bin/claude"
+                ],
+                ""
+            )
+            .as_deref(),
+            Some("Claude")
+        );
+    }
+
+    #[test]
+    fn test_default_rules_no_false_positive_for_unrelated_process() {
+        assert_eq!(match_default_rules(&["vim", "main.rs"], ""), None);
+    }
+
+    #[test]
+    fn test_default_rules_match_with_exe_path_set() {
+        // Verify matching works when exe_path carries a real path,
+        // as it does in production eBPF-captured ProcessContext.
+        assert_eq!(
+            match_default_rules(
+                &[
+                    "node",
+                    "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+                ],
+                "/usr/bin/node"
+            )
+            .as_deref(),
+            Some("Claude")
+        );
+        assert_eq!(
+            match_default_rules(&["/usr/local/bin/claude"], "/usr/local/bin/claude").as_deref(),
+            Some("Claude")
+        );
+    }
 }

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -267,4 +267,66 @@ mod tests {
         };
         assert!(CmdlineGlobMatcher::from_deny_rule(&rule).is_none());
     }
+
+    /// Match a cmdline against the embedded default rules and return the
+    /// first matching agent name (mirrors `AgentScanner::find_match`).
+    fn match_default_rules(args: &[&str]) -> Option<String> {
+        let ctx = ProcessContext {
+            comm: String::new(),
+            cmdline_args: args.iter().map(|s| s.to_string()).collect(),
+            exe_path: String::new(),
+        };
+        crate::config::default_cmdline_rules()
+            .iter()
+            .filter_map(CmdlineGlobMatcher::from_config)
+            .find(|m| m.matches(&ctx))
+            .map(|m| m.info().name.clone())
+    }
+
+    #[test]
+    fn test_default_rules_capture_claude_code_bare_name() {
+        // Launched from a shell as `claude`
+        assert_eq!(match_default_rules(&["claude"]).as_deref(), Some("Claude"));
+    }
+
+    #[test]
+    fn test_default_rules_capture_claude_code_absolute_path() {
+        // Launched via absolute path (native binary install)
+        assert_eq!(
+            match_default_rules(&["/usr/local/bin/claude"]).as_deref(),
+            Some("Claude")
+        );
+        assert_eq!(
+            match_default_rules(&["/home/user/.local/share/claude/versions/2.0.14/claude"])
+                .as_deref(),
+            Some("Claude")
+        );
+    }
+
+    #[test]
+    fn test_default_rules_capture_claude_code_node_wrapper() {
+        // npm global install: `claude` is a shebang script, the kernel rewrites
+        // argv to `node <script>` so argv[0] is node, not claude
+        assert_eq!(
+            match_default_rules(&[
+                "node",
+                "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+            ])
+            .as_deref(),
+            Some("Claude")
+        );
+        assert_eq!(
+            match_default_rules(&[
+                "/usr/bin/node",
+                "/home/user/.claude/local/node_modules/.bin/claude"
+            ])
+            .as_deref(),
+            Some("Claude")
+        );
+    }
+
+    #[test]
+    fn test_default_rules_no_false_positive_for_unrelated_process() {
+        assert_eq!(match_default_rules(&["vim", "main.rs"]), None);
+    }
 }


### PR DESCRIPTION
## Description

AgentSight never captured Claude Code sessions. The default cmdline allow rules in `agentsight.json` only contained `["claude*"]`, which matches argv[0] that *begins with* `claude`. Claude Code is commonly launched as:

- an absolute path (`/usr/local/bin/claude`, versioned native installs under `~/.local/share/claude/versions/...`), or
- an npm shebang wrapper, where the kernel rewrites argv to `node <path>/cli.js` so argv[0] is `node`.

Neither shape matched any rule, so `AgentScanner` never attached and Claude Code traffic was invisible.

## Fix

Add two default allow rules alongside the existing one (level 1 change — extend existing rule set, no code change):

- `["*/claude*"]` — absolute/relative path launches
- `["*node*", "*claude*"]` — node shebang wrapper launches (`@anthropic-ai/claude-code/cli.js`, `.bin/claude`)

Rules addition only appends entries to the existing `cmdline.allow` array; no schema/field change, so `schema_version` stays at 2 per AGENTS.md.

## Related Issue

Related to ANO-1580 ([BUG][sight] Claude Code 当前未被 AgentSight 捕获)

no-issue: tracked in Multica/Aone (Aone-84716738), no GitHub issue exists

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `sight` (agentsight)

## Testing

- New regression tests pin all supported Claude Code cmdline variants (bare name, absolute path, versioned native install, npm node wrapper) plus a false-positive guard
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 1235 lib tests + all bins/integration pass