### PR TITLE
fix(sight): widen Claude Code cmdline discovery rules

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -85,6 +85,7 @@
       {"rule": ["openclaw"], "agent_name": "OpenClaw"},
       {"rule": ["claude*"], "agent_name": "Claude"},
       {"rule": ["*/claude*"], "agent_name": "Claude"},
+      {"rule": ["*claude*"], "agent_name": "Claude"},
       {"rule": ["*node*", "*claude*"], "agent_name": "Claude"}
     ]
   },

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -83,7 +83,8 @@
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
       {"rule": ["*node*", "*openclaw*", "gatewa*"], "agent_name": "OpenClaw"},
       {"rule": ["openclaw"], "agent_name": "OpenClaw"},
-      {"rule": ["claude*"], "agent_name": "Claude"}
+      {"rule": ["*claude*"], "agent_name": "Claude"},
+      {"rule": ["*node*", "*claude*"], "agent_name": "Claude"}
     ]
   },
   "codex_offsets": {

--- a/src/agentsight/docs/agent-diagnostics-guide.md
+++ b/src/agentsight/docs/agent-diagnostics-guide.md
@@ -41,7 +41,8 @@ AgentSight 支持两种 Agent 发现机制：
       {"rule": ["hermes*"], "agent_name": "Hermes"},
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
       {"rule": ["*node*", "*cosh*"], "agent_name": "Cosh"},
-      {"rule": ["claude*"], "agent_name": "Claude"}
+      {"rule": ["*claude*"], "agent_name": "Claude"},
+      {"rule": ["*node*", "*claude*"], "agent_name": "Claude"}
     ]
   }
 }
@@ -74,7 +75,7 @@ AgentSight 支持两种 Agent 发现机制：
 | Hermes | 进程命令行包含 `hermes` |
 | Cosh (Copilot Shell) | Node.js 进程，命令行包含 `cosh` / `copilot-shell` |
 | OpenClaw | 进程名包含 `openclaw-gatewa` |
-| Claude Code | 进程名以 `claude` 开头 |
+| Claude Code | 进程命令行包含 `claude`（含 `node` 启动方式） |
 | 自定义 Agent | 通过 `cmdline.allow` 配置自定义规则 |
 
 ---
@@ -389,7 +390,8 @@ sudo agentsight trace --daemon
       {"rule": ["hermes*"], "agent_name": "Hermes"},
       {"rule": ["node*", "*openclaw*"], "agent_name": "OpenClaw"},
       {"rule": ["*node*", "*cosh*"], "agent_name": "Cosh"},
-      {"rule": ["claude*"], "agent_name": "Claude"},
+      {"rule": ["*claude*"], "agent_name": "Claude"},
+      {"rule": ["*node*", "*claude*"], "agent_name": "Claude"},
       {"rule": ["*python3*", "*my-agent*"], "agent_name": "MyAgent"}
     ]
   },

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -368,6 +368,15 @@ mod tests {
     }
 
     #[test]
+    fn test_default_rules_no_false_positive_for_unrelated_node_process() {
+        // An unrelated node process must not match as Claude
+        assert_eq!(
+            match_default_rules(&["node", "/srv/app/server.js"], ""),
+            None
+        );
+    }
+
+    #[test]
     fn test_default_rules_match_with_exe_path_set() {
         // Verify matching works when exe_path carries a real path,
         // as it does in production eBPF-captured ProcessContext.

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -267,4 +267,48 @@ mod tests {
         };
         assert!(CmdlineGlobMatcher::from_deny_rule(&rule).is_none());
     }
+
+    /// Regression test: default rules must capture Claude Code across its
+    /// common launch styles (native binary, absolute path, npm shebang via
+    /// node). See rule set in agentsight.json.
+    #[test]
+    fn test_default_rules_match_claude_code_invocations() {
+        let matchers: Vec<CmdlineGlobMatcher> = crate::config::default_cmdline_rules()
+            .iter()
+            .filter_map(CmdlineGlobMatcher::from_config)
+            .collect();
+        let match_name = |cmdline: &[&str]| -> Option<String> {
+            let ctx = ProcessContext {
+                comm: String::new(),
+                cmdline_args: cmdline.iter().map(|s| s.to_string()).collect(),
+                exe_path: String::new(),
+            };
+            matchers
+                .iter()
+                .find(|m| m.matches(&ctx))
+                .map(|m| m.info().name.clone())
+        };
+
+        // Native binary launched from shell
+        assert_eq!(match_name(&["claude"]), Some("Claude".to_string()));
+        // Launched with absolute path (e.g. by IDE extensions)
+        assert_eq!(
+            match_name(&["/root/.local/bin/claude"]),
+            Some("Claude".to_string())
+        );
+        // npm install: shebang expands to `node <bin> ...`
+        assert_eq!(
+            match_name(&["node", "/usr/local/bin/claude"]),
+            Some("Claude".to_string())
+        );
+        assert_eq!(
+            match_name(&[
+                "/usr/bin/node",
+                "/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+            ]),
+            Some("Claude".to_string())
+        );
+        // Unrelated node process must not match
+        assert_eq!(match_name(&["node", "/srv/app/server.js"]), None);
+    }
 }

--- a/src/agentsight/tests/reproduce_link_leak.sh
+++ b/src/agentsight/tests/reproduce_link_leak.sh
@@ -72,8 +72,8 @@ INITIAL_FDS=$(count_fds "$AGENTSIGHT_PID")
 echo -e "${GREEN}[step 2]${NC} baseline fd count: $INITIAL_FDS"
 
 # --- Step 3-6: Cycle claude processes and watch fd growth ---
-# Config has: {"rule": ["claude*"], "agent_name": "Claude"}
-# We create a script whose argv[0] matches "claude*" by using exec -a
+# Config has: {"rule": ["*claude*"], "agent_name": "Claude"}
+# We create a script whose argv[0] matches "*claude*" by using exec -a
 NUM_CYCLES=5
 
 echo ""
@@ -84,7 +84,7 @@ echo "  agentsight attaches uprobe, process exits, repeat."
 FD_COUNTS=("$INITIAL_FDS")
 
 for i in $(seq 1 $NUM_CYCLES); do
-    # Use exec -a to set argv[0] to "claude-fake" (matches "claude*" rule)
+    # Use exec -a to set argv[0] to "claude-fake" (matches "*claude*" rule)
     # Then run python3 which loads libssl.so
     bash -c 'exec -a claude-fake python3 -c "import ssl; import time; time.sleep(3)"' &
     AGENT_PID=$!


### PR DESCRIPTION
## 改动说明

修复 Claude Code 未被 AgentSight 捕获的问题（Aone-84716738）。

**根因**：内置默认发现规则中 Claude 只有 `{"rule": ["claude*"]}`，该 glob 按 argv 逐位置匹配，仅当 argv[0] 字面以 `claude` 开头时命中。而 Claude Code 的常见启动方式均不满足：

- npm 安装：shebang 展开后 cmdline 为 `node /usr/local/bin/claude ...`（argv[0] 是 `node`）
- 绝对路径 / IDE 插件拉起：argv[0] 为 `/root/.local/bin/claude` 等全路径

导致进程发现阶段就未命中，后续 sslsniff attach、SSE 解析等均不会发生。

**修复**：对齐 Codex 的规则写法（`["*codex*"]` + `["*node*", "*codex*"]`），将 Claude 规则改为：

```json
{"rule": ["*claude*"], "agent_name": "Claude"},
{"rule": ["*node*", "*claude*"], "agent_name": "Claude"}
```

集成测试文档 `integration-tests/test_claude_code.md` 中使用的也正是 `*claude*`，本次将内置默认与其对齐。

其余改动：
- `src/discovery/matcher.rs`：新增回归测试，覆盖 native 二进制、绝对路径、npm shebang（node 启动）三种 Claude Code 启动方式，并断言无关 node 进程不误报
- `docs/agent-diagnostics-guide.md`、`tests/reproduce_link_leak.sh`：同步更新对旧规则 `claude*` 的引用

## 关联 Issue

Fixes ANO-1580（Aone-84716738 [BUG][sight] Claude Code 当前未被 AgentSight 捕获）

## 测试情况

- `cargo test --lib discovery`：29 passed（含新增 `test_default_rules_match_claude_code_invocations`）
- `cargo test --lib config` / `cargo test --lib default_`：全部通过（含 `test_default_agents_json_valid`、`test_default_cmdline_rules`）
- `cargo clippy --lib`：无警告
- `cargo fmt --check`：通过