### PR TITLE
fix(sight): restore known-agent listing in discover CLI

### DIFF
--- a/src/agentsight/src/bin/cli/discover.rs
+++ b/src/agentsight/src/bin/cli/discover.rs
@@ -3,7 +3,9 @@
 //! This module provides the `discover` subcommand which scans the system
 //! for running AI agent processes.
 
-use agentsight::{AgentScanner, CmdlineGlobMatcher};
+use std::collections::HashMap;
+
+use agentsight::AgentScanner;
 use structopt::StructOpt;
 
 /// Discover subcommand for finding AI agents running on the system
@@ -30,23 +32,34 @@ impl DiscoverCommand {
 
     /// List all known agents that can be detected
     fn list_known_agents(&self) {
+        // Group allow-rule patterns by agent name, preserving first-seen order.
+        // One agent may have several cmdline rules (variants), so grouping is
+        // required to avoid printing the same agent once per rule.
         let rules = agentsight::default_cmdline_rules();
-        let scanner = AgentScanner::from_rules(&rules, &[]);
-        let count = scanner.matcher_count();
+        let mut names: Vec<String> = Vec::new();
+        let mut rules_by_name: HashMap<String, Vec<String>> = HashMap::new();
+        for rule in rules.iter().filter(|r| r.allow && !r.patterns.is_empty()) {
+            let name = rule.agent_name.as_deref().unwrap_or("Custom Agent");
+            if !rules_by_name.contains_key(name) {
+                names.push(name.to_string());
+            }
+            rules_by_name
+                .entry(name.to_string())
+                .or_default()
+                .push(rule.patterns.join(" "));
+        }
 
-        println!("Known AI Agents ({count} total):");
+        println!("Known AI Agents ({} total):", names.len());
         println!("{}", "=".repeat(60));
         println!();
 
-        // Use CmdlineGlobMatcher to list agent info
-        for matcher in agentsight::default_cmdline_rules()
-            .iter()
-            .filter_map(CmdlineGlobMatcher::from_config)
-        {
-            let agent = matcher.info();
-            println!("  {} ({})", agent.name, agent.category);
-            println!("    Process names: {}", agent.process_names.join(", "));
-            println!("    {}", agent.description);
+        for name in &names {
+            println!("  {name}");
+            if let Some(patterns) = rules_by_name.get(name) {
+                for pattern in patterns {
+                    println!("    Match rule: {pattern}");
+                }
+            }
             println!();
         }
     }


### PR DESCRIPTION
## 改动说明

修复 `agentsight discover --list-known`（known-agent 列表）展示不可用的问题。

自 Agent 发现改为 config 驱动的 cmdline 规则后（`cb76227c`），`CmdlineGlobMatcher` 构造的 `AgentInfo` 中 `process_names` 恒为空、description/category 恒为占位符（"Config-driven agent" / "custom"），且每条规则被当作一个独立 agent 输出，导致 `--list-known` 输出完全不可用：

**修复前**（22 条重复条目，Process names 全部为空）：

```
Known AI Agents (22 total):
============================================================

  Hermes (custom)
    Process names: 
    Config-driven agent

  Hermes (custom)
    Process names: 
    Config-driven agent
  ...
```

**修复后**（按 agent 名称分组、展示真实匹配规则）：

```
Known AI Agents (7 total):
============================================================

  Hermes
    Match rule: hermes*
    Match rule: *python* *hermes*
    Match rule: *python* -m *hermes*

  Codex
    Match rule: *codex*
    Match rule: *node* *codex*
  ...
```

实现上仅改动 `list_known_agents()`（Footprint Ladder 级别 1，扩展现有函数）：直接遍历 `default_cmdline_rules()` 的 allow 规则，按 agent_name 分组（保持首次出现顺序），逐条展示 cmdline 匹配规则。

## 关联 Issue

Fixes ANO-1583（Aone 84716600: [BUG][sight] AgentSight known-agent 展示不可用）

## 测试情况

- `cargo fmt --check` 通过
- `cargo clippy --bin agentsight -- -D warnings` 通过
- `cargo test --bin agentsight`（31 passed）、`cargo test --lib discovery`（28 passed）通过
- 本地实际运行 `agentsight discover --list-known` 验证修复前后输出（见上）