### PR TITLE
fix(cosh-ng): [shell] show full /health checks when healthy

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/diagnostics/doctor.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/diagnostics/doctor.rs
@@ -68,15 +68,8 @@ pub(crate) fn format_doctor_report_plain(report: &HealthScanReport, i18n: I18n) 
         doctor_status(report).token()
     ));
 
-    if !report.checks_done.is_empty() {
-        let mut checks = report.checks_done.clone();
-        checks.sort();
-        checks.dedup();
-        lines.push(format!(
-            "{}: {}",
-            i18n.t(MessageId::DoctorChecksLabel),
-            checks.join(", ")
-        ));
+    if let Some(line) = doctor_checks_line(report, i18n) {
+        lines.push(line);
     }
 
     let mut findings: Vec<_> = report.findings.iter().collect();
@@ -120,6 +113,24 @@ pub(crate) fn format_doctor_report_plain(report: &HealthScanReport, i18n: I18n) 
     }
 
     lines
+}
+
+/// Render the sorted, deduplicated `checks: <names>` line.
+///
+/// Shared by `cosh-shell doctor` and the `/health` slash command so both
+/// entry points surface the identical checks coverage.
+pub(crate) fn doctor_checks_line(report: &HealthScanReport, i18n: I18n) -> Option<String> {
+    if report.checks_done.is_empty() {
+        return None;
+    }
+    let mut checks = report.checks_done.clone();
+    checks.sort();
+    checks.dedup();
+    Some(format!(
+        "{}: {}",
+        i18n.t(MessageId::DoctorChecksLabel),
+        checks.join(", ")
+    ))
 }
 
 fn collector_token(collector: HealthCollector) -> &'static str {
@@ -197,6 +208,19 @@ mod tests {
         assert!(joined.contains("status: healthy"), "{joined}");
         assert!(joined.contains("all checks passed"), "{joined}");
         assert!(joined.contains("checks: provider"), "{joined}");
+    }
+
+    #[test]
+    fn checks_line_sorts_and_dedups_checks() {
+        let mut report = HealthScanReport::new("health-5", 0);
+        report
+            .checks_done
+            .extend(["provider", "config", "provider"].map(String::from));
+        let line = doctor_checks_line(&report, en()).expect("checks line");
+        assert_eq!(line, "checks: config, provider");
+
+        let empty = HealthScanReport::new("health-6", 0);
+        assert!(doctor_checks_line(&empty, en()).is_none());
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/slash/health.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/health.rs
@@ -2,7 +2,7 @@
 //! inline card. Uses the same [`run_doctor_report`] engine and status model as
 //! the `cosh-shell doctor` CLI, so both entry points report identical checks.
 
-use crate::diagnostics::doctor::run_doctor_report;
+use crate::diagnostics::doctor::{doctor_checks_line, run_doctor_report};
 use crate::diagnostics::health::finding_remediation;
 use crate::runtime::prelude::*;
 
@@ -22,12 +22,19 @@ pub(crate) fn render_health_command<W: Write>(
     let report = run_doctor_report(&config, &cwd);
 
     let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
-    renderer.write_health_banner(output, HealthBannerModel::new(&report))?;
+    // Force the full panel so a healthy report is not collapsed into the
+    // compact one-line startup row: TUI users must see the same checks
+    // coverage the `cosh-shell doctor` CLI prints.
+    renderer.write_health_banner(output, HealthBannerModel::new(&report).with_full_panel())?;
 
-    // Match the `cosh-shell doctor` CLI by surfacing the actionable remediation
-    // carried on each finding. Kept in this small slash module instead of the
-    // large agent_render/health.rs renderer to avoid growing that file.
+    // Match the `cosh-shell doctor` CLI by surfacing the checks list and the
+    // actionable remediation carried on each finding. Kept in this small slash
+    // module instead of the large agent_render/health.rs renderer to avoid
+    // growing that file.
     let i18n = I18n::new(state.language);
+    if let Some(line) = doctor_checks_line(&report, i18n) {
+        writeln!(output, "  {line}")?;
+    }
     let label = i18n.t(MessageId::DoctorRemediationLabel);
     for finding in &report.findings {
         if let Some(text) = finding_remediation(finding, i18n) {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/health.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/health.rs
@@ -31,11 +31,23 @@ const HEALTH_MAX_VISIBLE_PROMPTS: usize = 3;
 #[derive(Debug, Clone, Copy)]
 pub struct HealthBannerModel<'a> {
     pub report: &'a HealthScanReport,
+    /// Render the full panel even for healthy reports instead of collapsing
+    /// them into the compact one-line startup row. Used by the `/health`
+    /// slash command so its output stays aligned with `cosh-shell doctor`.
+    pub full_panel: bool,
 }
 
 impl<'a> HealthBannerModel<'a> {
     pub fn new(report: &'a HealthScanReport) -> Self {
-        Self { report }
+        Self {
+            report,
+            full_panel: false,
+        }
+    }
+
+    pub fn with_full_panel(mut self) -> Self {
+        self.full_panel = true;
+        self
     }
 }
 
@@ -53,7 +65,7 @@ impl RatatuiInlineRenderer {
     }
 
     pub fn health_banner_lines(&self, model: HealthBannerModel<'_>) -> Vec<String> {
-        if health_uses_startup_row(model.report) {
+        if !model.full_panel && health_uses_startup_row(model.report) {
             return self.health_startup_row_lines(model);
         }
         if self.plain {
@@ -71,7 +83,7 @@ impl RatatuiInlineRenderer {
     }
 
     fn health_banner_write_lines(&self, model: HealthBannerModel<'_>) -> Vec<String> {
-        if health_uses_startup_row(model.report) {
+        if !model.full_panel && health_uses_startup_row(model.report) {
             return self.health_startup_row_lines(model);
         }
         if self.plain {

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests.rs
@@ -1744,6 +1744,30 @@ fn health_banner_compresses_healthy_report() {
 }
 
 #[test]
+fn health_banner_full_panel_expands_healthy_report() {
+    let mut report = HealthScanReport::new("health-ok-full", 0);
+    report.elapsed_ms = 24;
+    report.facts = vec![
+        health_float_fact("cpu.load_per_core_1m", 0.2),
+        health_float_fact("cpu.load_1m", 0.8),
+        health_float_fact("cpu.cores", 4.0),
+        health_float_fact("memory.used_ratio", 0.38),
+        health_float_fact("filesystem.root_used_ratio", 0.41),
+    ];
+    report.recompute_overall_severity();
+
+    let text = RatatuiInlineRenderer::with_width(80)
+        .health_banner_lines(HealthBannerModel::new(&report).with_full_panel())
+        .join("\n");
+
+    assert!(text.lines().count() > 2, "{text}");
+    assert!(text.contains("Health check"), "{text}");
+    assert!(text.contains("ok"), "{text}");
+    assert!(text.contains("Mem used 38%"), "{text}");
+    assert!(!text.contains("Health: ok"), "{text}");
+}
+
+#[test]
 fn health_banner_caps_try_lines_and_hides_suppressed_try_items() {
     let mut report = warning_health_report();
     report.findings.clear();


### PR DESCRIPTION
## 改动说明

修复 TUI `/health` slash 命令在系统 healthy 状态下只输出一行简要摘要、缺失 provider/config/hooks/PTY/permissions 5 项 env collector checks 展示的问题（GitHub issue #1745）。

数据收集层本来就正确（`/health` 与 `cosh-shell doctor` 共享同一 `run_doctor_report` engine），问题出在渲染层：healthy 报告被 `health_uses_startup_row` 折叠成一行 startup row。

具体改动：

- `ui/agent_render/health.rs`：`HealthBannerModel` 新增 `full_panel` 标志（`with_full_panel()`），置位时即使 healthy 也渲染完整 panel，不再折叠成 startup row。启动横幅路径不受影响，保持原有紧凑行为。
- `diagnostics/doctor.rs`：从 `format_doctor_report_plain` 中提取共享的 `doctor_checks_line`（排序 + 去重的 `checks: <names>` 行），CLI 输出不变。
- `slash/health.rs`：`/health` 走 full panel 渲染，并在 panel 后追加与 doctor CLI 一致的 `checks:` 行，展示全部 10 项 checks 覆盖（status + checks 列表 + findings/remediation 与 CLI 对齐）。

## 关联 Issue

Fixes ANO-703（对应 GitHub issue #1745）

## 测试情况

- 新增 `health_banner_full_panel_expands_healthy_report`：healthy 报告 + full panel 渲染完整 panel（不再是一行摘要）
- 新增 `checks_line_sorts_and_dedups_checks`：checks 行排序、去重、空列表返回 None
- `cargo test --package cosh-shell --lib`：1148 passed, 0 failed
- `cargo test --package cosh-shell --test logic`：8 passed
- `cargo clippy --package cosh-shell --all-targets`：0 warnings