### PR TITLE
feat(tokenless): add stats diff command

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -188,6 +188,19 @@ tokenless stats list -l 50
 # Show before/after text for a record
 tokenless stats show 42
 
+# Explain one record's estimated savings and changed content
+tokenless stats diff 42
+tokenless stats diff 42 -U 5
+tokenless stats diff 42 --json
+
+# Rank end-to-end savings in a session (metrics only)
+tokenless stats diff --session <session-id>
+tokenless stats diff --session <session-id> -l 50 --sort time
+
+# Expand the independently linked stages for one tool call
+tokenless stats diff --session <session-id> \
+  --tool-use-id <tool-use-id>
+
 # Clear all stats
 tokenless stats clear --yes
 
@@ -198,6 +211,41 @@ tokenless stats status
 tokenless stats enable
 tokenless stats disable
 ```
+
+`show` is the verbatim record viewer: it prints the complete stored before and
+after payloads. `diff` is the savings analysis view: it reports estimated
+before/after/emitted tokens, per-stage contribution, stash metrics, and unified
+changed lines. Its options are:
+
+| Argument | Description |
+|------|------|
+| `<RECORD_ID>` | Inspect one recorded compression stage; conflicts with `--session` |
+| `--session <id>` | Show a session overview, or select the scope for `--tool-use-id` |
+| `--tool-use-id <id>` | Expand one tool call; requires `--session` |
+| `-l, --limit <n>` | Maximum session-overview chains (default 20) |
+| `--sort saved\|time` | Sort session chains by estimated savings (default) or newest time |
+| `-U, --context <n>` | Unchanged lines around each change (default 3) |
+| `--no-color` | Disable ANSI colors |
+| `--json` | Emit schema `1.0` JSON with structured `context`/`delete`/`insert` hunk lines |
+
+Session overview JSON contains metrics and stages but no source content.
+Record/tool-use JSON includes structured hunks. When both endpoints are valid
+JSON values, including scalars, they are canonicalized for display before
+comparison. Object keys are sorted, so lexical-only differences such as key
+order may be hidden; stored content is never modified. Content diffing is
+omitted when either side is missing or exceeds 1 MiB, and rendered hunks stop
+after 500 lines; use `stats show` for the complete payload.
+
+For active records, consecutive stages with the same session/tool-use ID are
+linked only when the previous stored output exactly matches the next stored
+input. End-to-end savings then use the first `before` and final `after`, so
+intermediate inputs are not counted twice. Disconnected, dry-run, mixed-mode,
+and records without a tool-use ID remain separate.
+
+All displayed token counts are estimates, not model billing data. In dry-run,
+`after` is the predicted compressed size while `emitted` remains the original
+`before` size. Operations that produce no savings are not stored, so session
+views cover recorded saving operations only.
 
 #### Dual-run comparison (dry-run baseline vs active)
 

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -188,6 +188,19 @@ tokenless stats list -l 50
 # 查看某条记录的压缩前后文本
 tokenless stats show 42
 
+# 解释单条记录的估算节省和内容变化
+tokenless stats diff 42
+tokenless stats diff 42 -U 5
+tokenless stats diff 42 --json
+
+# 按端到端节省量排列 Session 明细（仅指标）
+tokenless stats diff --session <session-id>
+tokenless stats diff --session <session-id> -l 50 --sort time
+
+# 展开一次工具调用中可确认衔接的阶段
+tokenless stats diff --session <session-id> \
+  --tool-use-id <tool-use-id>
+
 # 清空统计
 tokenless stats clear --yes
 
@@ -198,6 +211,36 @@ tokenless stats status
 tokenless stats enable
 tokenless stats disable
 ```
+
+`show` 是原始记录查看器，会完整打印存储的 before 和 after payload；
+`diff` 是节省分析视图，显示估算的 before/after/emitted Token、各阶段贡献、
+stash 指标及 unified 差异行。支持以下选项：
+
+| 参数 | 说明 |
+|------|------|
+| `<RECORD_ID>` | 查看一个压缩阶段；与 `--session` 冲突 |
+| `--session <id>` | 查看 Session 总览，或限定 `--tool-use-id` 的范围 |
+| `--tool-use-id <id>` | 展开一次工具调用；必须配合 `--session` |
+| `-l, --limit <n>` | Session 总览最多显示的链路数（默认 20） |
+| `--sort saved\|time` | 按估算节省量（默认）或最新时间排列 |
+| `-U, --context <n>` | 每处变化周围保留的未变化行数（默认 3） |
+| `--no-color` | 关闭 ANSI 颜色 |
+| `--json` | 输出 schema `1.0` JSON，hunk 行类型为 `context`/`delete`/`insert` |
+
+Session 总览 JSON 只包含指标和阶段，不包含源内容；单记录/tool-use JSON
+包含结构化 hunks。两端均为合法 JSON 值时（包括标量），输出会先做仅用于展示
+的规范化；对象 key 会排序，因此可能隐藏仅 key 顺序不同的词法差异，但不会修改
+存储内容。任一端缺失或超过 1 MiB 时不计算内容差异，渲染的 hunk 最多 500 行；
+完整 payload 仍使用 `stats show` 查看。
+
+对于 active 记录，只有 session/tool-use ID 相同，且上一阶段存储的输出与下一
+阶段输入完全一致时才会串联。端到端节省使用第一阶段 before 和最后阶段
+after，避免重复计算中间输入。断链、dry-run、mode 混合及缺少 tool-use ID
+的记录保持独立。
+
+所有 Token 数均为估算值，不是模型计费数据。dry-run 的 after 表示预测压缩
+大小，实际 emitted 仍为原始 before 大小。无节省操作不会入库，因此 Session
+视图只覆盖已记录的有效压缩。
 
 #### 双跑对比（dry-run baseline vs active）
 

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -647,6 +647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +781,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "similar",
  "tempfile",
  "thiserror 2.0.18",
 ]

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -27,6 +27,7 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 blake3 = "1.5"
 dirs = "5.0"
 libc = "0.2"
+similar = "2"
 
 [profile.release]
 opt-level = 3

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -180,6 +180,25 @@ echo 'name: Alice\nage: 30' | tokenless decompress-toon
 # {"name":"Alice","age":30}
 ```
 
+### Inspect token savings
+
+Use `show` to print the complete stored before/after payload, or `diff` to
+explain the estimated token saving and highlight only changed lines:
+
+```bash
+tokenless stats show 42
+tokenless stats diff 42
+tokenless stats diff --session <session-id>
+tokenless stats diff --session <session-id> --tool-use-id <tool-use-id>
+tokenless stats diff 42 --json
+```
+
+Session overviews contain metrics only. Record and tool-use reports include a
+unified content diff; consecutive active stages are linked only when their
+stored output/input content matches exactly, avoiding duplicate intermediate
+token counts. See the [user manual](../../docs/user-guide/en/token-saving/tokenless/user-manual.md#statistics--measurement)
+for options and measurement limits.
+
 ## copilot-shell Hooks
 
 The adapter provides hooks that are auto-discovered by copilot-shell via the cosh extension manifest:

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -69,6 +69,24 @@ make setup
 
 安装完成后 `tokenless` 命令位于 `~/.local/bin`，RTK/TOON 辅助二进制同目录。
 
+## 查看 Token 节省明细
+
+`show` 用于原样打印完整的压缩前后内容；`diff` 用于解释估算 Token
+节省，并只突出发生变化的行：
+
+```bash
+tokenless stats show 42
+tokenless stats diff 42
+tokenless stats diff --session <session-id>
+tokenless stats diff --session <session-id> --tool-use-id <tool-use-id>
+tokenless stats diff 42 --json
+```
+
+Session 总览只包含指标；单记录和 tool-use 报告包含 unified content
+diff。只有相邻 active 阶段的输出与输入内容完全一致时才会串成一条链，
+从而避免重复计算中间阶段的 Token。完整选项和度量限制见
+[用户手册](../../docs/user-guide/zh/token-saving/tokenless/user-manual.md#统计与效果度量)。
+
 ## 架构
 
 - `crates/tokenless-schema/` — 核心库：SchemaCompressor + ResponseCompressor

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -69,7 +69,6 @@ make setup
 
 安装完成后 `tokenless` 命令位于 `~/.local/bin`，RTK/TOON 辅助二进制同目录。
 
-
 ## npm 安装
 
 ```bash
@@ -78,6 +77,24 @@ npm install -g anolisa-tokenless
 
 自动安装适合您平台的预编译二进制文件（`tokenless`、`rtk`、`toon`）。
 支持 Linux 和 macOS 的 x86_64 和 arm64 架构。
+
+## 查看 Token 节省明细
+
+`show` 用于原样打印完整的压缩前后内容；`diff` 用于解释估算 Token
+节省，并只突出发生变化的行：
+
+```bash
+tokenless stats show 42
+tokenless stats diff 42
+tokenless stats diff --session <session-id>
+tokenless stats diff --session <session-id> --tool-use-id <tool-use-id>
+tokenless stats diff 42 --json
+```
+
+Session 总览只包含指标；单记录和 tool-use 报告包含 unified content
+diff。只有相邻 active 阶段的输出与输入内容完全一致时才会串成一条链，
+从而避免重复计算中间阶段的 Token。完整选项和度量限制见
+[用户手册](../../docs/user-guide/zh/token-saving/tokenless/user-manual.md#统计与效果度量)。
 
 ## 架构
 

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -364,7 +364,7 @@ fn normalize_dep(value: &Value) -> DepEntry {
     }
 }
 
-/// Normalize an array of dep values (strings or objects) into Vec<DepEntry>.
+/// Normalize an array of dep values (strings or objects) into `Vec<DepEntry>`.
 fn normalize_deps(array: &Value) -> Vec<DepEntry> {
     array
         .as_array()

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -2,19 +2,20 @@
 mod env_check;
 mod mcp;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, IsTerminal as _, Read};
 use std::process;
 use std::sync::Arc;
 use tokenless_ccr::{SqliteStore, StashStore, extract_hash, is_valid_hash};
 use tokenless_schema::{ResponseCompressor, SchemaCompressor};
 use tokenless_stats::{
-    CompressionMode, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
+    CompressionMode, DiffSort, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
 };
 use tokenless_stats::{estimate_tokens, estimate_tokens_from_bytes};
 use tokenless_stats::{
-    format_compare, format_compare_json, format_list, format_show, format_summary,
+    format_compare, format_compare_json, format_diff_report, format_list, format_show,
+    format_summary, record_report, session_report, tool_use_report,
 };
 
 #[derive(Parser)]
@@ -150,6 +151,23 @@ enum McpCommands {
     Serve,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum DiffSortArg {
+    Saved,
+    Time,
+}
+
+const DEFAULT_DIFF_LIMIT: usize = 20;
+
+impl From<DiffSortArg> for DiffSort {
+    fn from(value: DiffSortArg) -> Self {
+        match value {
+            DiffSortArg::Saved => DiffSort::Saved,
+            DiffSortArg::Time => DiffSort::Time,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 enum StatsCommands {
     /// Show summary statistics with breakdown by operation
@@ -174,6 +192,43 @@ enum StatsCommands {
         /// Record database ID
         id: i64,
     },
+    /// Explain estimated token savings with a unified content diff
+    Diff {
+        /// Record database ID
+        #[arg(
+            value_name = "RECORD_ID",
+            required_unless_present = "session",
+            conflicts_with = "session"
+        )]
+        id: Option<i64>,
+        /// Session ID to summarize or inspect
+        #[arg(long, required_unless_present = "id")]
+        session: Option<String>,
+        /// Restrict a session diff to one tool call
+        #[arg(long, requires = "session")]
+        tool_use_id: Option<String>,
+        /// Maximum number of chains in a session overview
+        #[arg(
+            short,
+            long,
+            default_value_t = DEFAULT_DIFF_LIMIT,
+            value_parser = parse_positive_usize,
+            conflicts_with_all = ["id", "tool_use_id"]
+        )]
+        limit: usize,
+        /// Session overview ordering
+        #[arg(long, value_enum, conflicts_with_all = ["id", "tool_use_id"])]
+        sort: Option<DiffSortArg>,
+        /// Unchanged lines around each content change
+        #[arg(short = 'U', long, default_value_t = 3)]
+        context: usize,
+        /// Disable ANSI colors even when stdout is a terminal
+        #[arg(long)]
+        no_color: bool,
+        /// Output machine-readable JSON with structured diff hunks
+        #[arg(long)]
+        json: bool,
+    },
     /// Clear all statistics
     Clear {
         #[arg(long)]
@@ -189,6 +244,16 @@ enum StatsCommands {
 
 /// Maximum input size (64 MiB) to prevent OOM on accidental large-file stdin.
 const MAX_INPUT_BYTES: usize = 64 * 1024 * 1024;
+
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| format!("invalid positive integer: {value}"))?;
+    if parsed == 0 {
+        return Err("value must be greater than zero".to_string());
+    }
+    Ok(parsed)
+}
 
 fn read_input(file: &Option<String>) -> Result<String, String> {
     // Cap stream reads at MAX_INPUT_BYTES + 1 via Read::take so a hostile
@@ -676,6 +741,66 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                         .map_err(|e| (format!("Failed to query record: {}", e), 1))?
                         .ok_or_else(|| (format!("Record not found: {}", id), 1))?;
                     println!("{}", format_show(&record));
+                }
+                StatsCommands::Diff {
+                    id,
+                    session,
+                    tool_use_id,
+                    limit,
+                    sort,
+                    context,
+                    no_color,
+                    json,
+                } => {
+                    let report = match (id, session) {
+                        (Some(id), None) => {
+                            let record = recorder
+                                .record_by_id(id)
+                                .map_err(|e| (format!("Failed to query record: {}", e), 1))?
+                                .ok_or_else(|| (format!("Record not found: {}", id), 1))?;
+                            record_report(&record, context)
+                        }
+                        (None, Some(session_id)) => {
+                            let records = recorder
+                                .records_for_diff(&session_id, tool_use_id.as_deref())
+                                .map_err(|e| (format!("Failed to query diff records: {}", e), 1))?;
+                            if records.is_empty() {
+                                let scope = tool_use_id.as_deref().map_or_else(
+                                    || format!("session '{}'", session_id),
+                                    |tool| {
+                                        format!("tool use '{}' in session '{}'", tool, session_id)
+                                    },
+                                );
+                                return Err((format!("No records found for {}", scope), 1));
+                            }
+                            if let Some(tool_use_id) = tool_use_id {
+                                tool_use_report(&records, &session_id, &tool_use_id, context)
+                            } else {
+                                session_report(
+                                    &records,
+                                    &session_id,
+                                    limit,
+                                    sort.map(DiffSort::from).unwrap_or_default(),
+                                )
+                            }
+                        }
+                        _ => {
+                            return Err((
+                                "Specify exactly one of RECORD_ID or --session".to_string(),
+                                2,
+                            ));
+                        }
+                    };
+                    if json {
+                        let output = serde_json::to_string_pretty(&report)
+                            .map_err(|e| (format!("Failed to serialize diff report: {}", e), 1))?;
+                        println!("{}", output);
+                    } else {
+                        let color = !no_color
+                            && std::env::var_os("NO_COLOR").is_none()
+                            && io::stdout().is_terminal();
+                        println!("{}", format_diff_report(&report, color));
+                    }
                 }
                 StatsCommands::Clear { yes } => {
                     if !yes {

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -2,19 +2,20 @@
 mod env_check;
 mod mcp;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, IsTerminal as _, Read};
 use std::process;
 use std::sync::Arc;
 use tokenless_ccr::{SqliteStore, StashStore, extract_hash, is_valid_hash};
 use tokenless_schema::{ResponseCompressor, SchemaCompressor};
 use tokenless_stats::{
-    CompressionMode, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
+    CompressionMode, DiffSort, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
 };
 use tokenless_stats::{estimate_tokens, estimate_tokens_from_bytes};
 use tokenless_stats::{
-    format_compare, format_compare_json, format_list, format_show, format_summary,
+    format_compare, format_compare_json, format_diff_report, format_list, format_show,
+    format_summary, record_report, session_report, tool_use_report,
 };
 
 #[derive(Parser)]
@@ -150,6 +151,23 @@ enum McpCommands {
     Serve,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum DiffSortArg {
+    Saved,
+    Time,
+}
+
+const DEFAULT_DIFF_LIMIT: usize = 20;
+
+impl From<DiffSortArg> for DiffSort {
+    fn from(value: DiffSortArg) -> Self {
+        match value {
+            DiffSortArg::Saved => DiffSort::Saved,
+            DiffSortArg::Time => DiffSort::Time,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 enum StatsCommands {
     /// Show summary statistics with breakdown by operation
@@ -174,6 +192,43 @@ enum StatsCommands {
         /// Record database ID
         id: i64,
     },
+    /// Explain estimated token savings with a unified content diff
+    Diff {
+        /// Record database ID
+        #[arg(
+            value_name = "RECORD_ID",
+            required_unless_present = "session",
+            conflicts_with = "session"
+        )]
+        id: Option<i64>,
+        /// Session ID to summarize or inspect
+        #[arg(long, required_unless_present = "id")]
+        session: Option<String>,
+        /// Restrict a session diff to one tool call
+        #[arg(long, requires = "session")]
+        tool_use_id: Option<String>,
+        /// Maximum number of chains in a session overview
+        #[arg(
+            short,
+            long,
+            default_value_t = DEFAULT_DIFF_LIMIT,
+            value_parser = parse_positive_usize,
+            conflicts_with_all = ["id", "tool_use_id"]
+        )]
+        limit: usize,
+        /// Session overview ordering
+        #[arg(long, value_enum, conflicts_with_all = ["id", "tool_use_id"])]
+        sort: Option<DiffSortArg>,
+        /// Unchanged lines around each content change
+        #[arg(short = 'U', long, default_value_t = 3)]
+        context: usize,
+        /// Disable ANSI colors even when stdout is a terminal
+        #[arg(long)]
+        no_color: bool,
+        /// Output machine-readable JSON with structured diff hunks
+        #[arg(long)]
+        json: bool,
+    },
     /// Clear all statistics
     Clear {
         #[arg(long)]
@@ -189,6 +244,16 @@ enum StatsCommands {
 
 /// Maximum input size (64 MiB) to prevent OOM on accidental large-file stdin.
 const MAX_INPUT_BYTES: usize = 64 * 1024 * 1024;
+
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| format!("invalid positive integer: {value}"))?;
+    if parsed == 0 {
+        return Err("value must be greater than zero".to_string());
+    }
+    Ok(parsed)
+}
 
 fn read_input(file: &Option<String>) -> Result<String, String> {
     // Cap stream reads at MAX_INPUT_BYTES + 1 via Read::take so a hostile
@@ -676,6 +741,64 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                         .map_err(|e| (format!("Failed to query record: {}", e), 1))?
                         .ok_or_else(|| (format!("Record not found: {}", id), 1))?;
                     println!("{}", format_show(&record));
+                }
+                StatsCommands::Diff {
+                    id,
+                    session,
+                    tool_use_id,
+                    limit,
+                    sort,
+                    context,
+                    no_color,
+                    json,
+                } => {
+                    let report = match (id, session) {
+                        (Some(id), None) => {
+                            let record = recorder
+                                .record_by_id(id)
+                                .map_err(|e| (format!("Failed to query record: {}", e), 1))?
+                                .ok_or_else(|| (format!("Record not found: {}", id), 1))?;
+                            record_report(&record, context)
+                        }
+                        (None, Some(session_id)) => {
+                            let records = recorder
+                                .records_for_diff(&session_id, tool_use_id.as_deref())
+                                .map_err(|e| (format!("Failed to query diff records: {}", e), 1))?;
+                            if records.is_empty() {
+                                let scope = tool_use_id.as_deref().map_or_else(
+                                    || format!("session {session_id:?}"),
+                                    |tool| format!("tool use {tool:?} in session {session_id:?}"),
+                                );
+                                return Err((format!("No records found for {}", scope), 1));
+                            }
+                            if let Some(tool_use_id) = tool_use_id {
+                                tool_use_report(&records, &session_id, &tool_use_id, context)
+                            } else {
+                                session_report(
+                                    &records,
+                                    &session_id,
+                                    limit,
+                                    sort.map(DiffSort::from).unwrap_or_default(),
+                                )
+                            }
+                        }
+                        _ => {
+                            return Err((
+                                "Specify exactly one of RECORD_ID or --session".to_string(),
+                                2,
+                            ));
+                        }
+                    };
+                    if json {
+                        let output = serde_json::to_string_pretty(&report)
+                            .map_err(|e| (format!("Failed to serialize diff report: {}", e), 1))?;
+                        println!("{}", output);
+                    } else {
+                        let color = !no_color
+                            && std::env::var_os("NO_COLOR").is_none()
+                            && io::stdout().is_terminal();
+                        println!("{}", format_diff_report(&report, color));
+                    }
                 }
                 StatsCommands::Clear { yes } => {
                     if !yes {

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -662,6 +662,157 @@ fn run_command_stats_show_existing_record() {
 }
 
 #[test]
+fn run_command_stats_diff_existing_record() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let recorder = match open_recorder() {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    let record = StatsRecord::new(
+        OperationType::CompressResponse,
+        "test-agent".to_string(),
+        500,
+        125,
+        100,
+        25,
+    )
+    .with_session_id("diff-session")
+    .with_tool_use_id("diff-tool")
+    .with_text(
+        "line one\nline removed\n".to_string(),
+        "line one\n".to_string(),
+    );
+    let id = recorder.record(&record).unwrap();
+
+    let result = run_command(Commands::Stats(StatsCommands::Diff {
+        id: Some(id),
+        session: None,
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }));
+    assert!(result.is_ok());
+}
+
+#[test]
+fn run_command_stats_diff_session_and_tool() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let recorder = match open_recorder() {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    recorder
+        .record(
+            &StatsRecord::new(
+                OperationType::CompressResponse,
+                "test-agent".to_string(),
+                500,
+                125,
+                100,
+                25,
+            )
+            .with_session_id("diff-session")
+            .with_tool_use_id("diff-tool")
+            .with_text("before".to_string(), "after".to_string()),
+        )
+        .unwrap();
+
+    let session = run_command(Commands::Stats(StatsCommands::Diff {
+        id: None,
+        session: Some("diff-session".to_string()),
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: Some(DiffSortArg::Saved),
+        context: 3,
+        no_color: true,
+        json: true,
+    }));
+    assert!(session.is_ok());
+
+    let tool = run_command(Commands::Stats(StatsCommands::Diff {
+        id: None,
+        session: Some("diff-session".to_string()),
+        tool_use_id: Some("diff-tool".to_string()),
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }));
+    assert!(tool.is_ok());
+}
+
+#[test]
+fn stats_diff_cli_validates_scope_and_limit() {
+    let record = Cli::try_parse_from(["tokenless", "stats", "diff", "42"]).unwrap();
+    match record.command {
+        Commands::Stats(StatsCommands::Diff {
+            id,
+            session,
+            limit,
+            context,
+            ..
+        }) => {
+            assert_eq!(id, Some(42));
+            assert_eq!(session, None);
+            assert_eq!(limit, DEFAULT_DIFF_LIMIT);
+            assert_eq!(context, 3);
+        }
+        _ => panic!("expected stats diff"),
+    }
+
+    assert!(
+        Cli::try_parse_from([
+            "tokenless",
+            "stats",
+            "diff",
+            "42",
+            "--session",
+            "session-1"
+        ])
+        .is_err()
+    );
+    assert!(
+        Cli::try_parse_from(["tokenless", "stats", "diff", "--session", "session-1", "-l", "0"])
+            .is_err()
+    );
+    assert!(
+        Cli::try_parse_from(["tokenless", "stats", "diff", "42", "--limit", "1"]).is_err()
+    );
+    assert!(
+        Cli::try_parse_from(["tokenless", "stats", "diff", "--tool-use-id", "tool-1"]).is_err()
+    );
+    let help = match Cli::try_parse_from(["tokenless", "stats", "diff", "--help"]) {
+        Err(error) => error.to_string(),
+        Ok(_) => panic!("expected help output"),
+    };
+    assert!(help.contains("[default: 20]"));
+    assert!(
+        Cli::try_parse_from([
+            "tokenless",
+            "stats",
+            "diff",
+            "--session",
+            "session-1",
+            "--tool-use-id",
+            "tool-1",
+            "--sort",
+            "time"
+        ])
+        .is_err()
+    );
+}
+
+#[test]
 fn run_command_compress_response_large_with_truncation() {
     let _guard = TempDbGuard::new();
 
@@ -745,6 +896,56 @@ fn run_command_stats_show_nonexistent() {
     let result = run_command(Commands::Stats(StatsCommands::Show { id: 999999 }));
     assert!(result.is_err());
     assert!(result.unwrap_err().0.contains("not found"));
+}
+
+#[test]
+fn run_command_stats_diff_nonexistent_scopes() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let record = run_command(Commands::Stats(StatsCommands::Diff {
+        id: Some(999999),
+        session: None,
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }))
+    .unwrap_err();
+    assert!(record.0.contains("not found"));
+    assert_eq!(record.1, 1);
+
+    let session = run_command(Commands::Stats(StatsCommands::Diff {
+        id: None,
+        session: Some("missing-session".to_string()),
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }))
+    .unwrap_err();
+    assert!(session.0.contains("No records found"));
+    assert_eq!(session.1, 1);
+
+    let injected = run_command(Commands::Stats(StatsCommands::Diff {
+        id: None,
+        session: Some("missing\u{1b}]0;INJECTED\u{7}".to_string()),
+        tool_use_id: Some("tool\u{1b}]52;c;INJECTED\u{7}".to_string()),
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }))
+    .unwrap_err();
+    assert!(!injected.0.contains('\u{1b}'));
+    assert!(!injected.0.contains('\u{7}'));
+    assert!(injected.0.contains("INJECTED"));
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -662,6 +662,157 @@ fn run_command_stats_show_existing_record() {
 }
 
 #[test]
+fn run_command_stats_diff_existing_record() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let recorder = match open_recorder() {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    let record = StatsRecord::new(
+        OperationType::CompressResponse,
+        "test-agent".to_string(),
+        500,
+        125,
+        100,
+        25,
+    )
+    .with_session_id("diff-session")
+    .with_tool_use_id("diff-tool")
+    .with_text(
+        "line one\nline removed\n".to_string(),
+        "line one\n".to_string(),
+    );
+    let id = recorder.record(&record).unwrap();
+
+    let result = run_command(Commands::Stats(StatsCommands::Diff {
+        id: Some(id),
+        session: None,
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }));
+    assert!(result.is_ok());
+}
+
+#[test]
+fn run_command_stats_diff_session_and_tool() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let recorder = match open_recorder() {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    recorder
+        .record(
+            &StatsRecord::new(
+                OperationType::CompressResponse,
+                "test-agent".to_string(),
+                500,
+                125,
+                100,
+                25,
+            )
+            .with_session_id("diff-session")
+            .with_tool_use_id("diff-tool")
+            .with_text("before".to_string(), "after".to_string()),
+        )
+        .unwrap();
+
+    let session = run_command(Commands::Stats(StatsCommands::Diff {
+        id: None,
+        session: Some("diff-session".to_string()),
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: Some(DiffSortArg::Saved),
+        context: 3,
+        no_color: true,
+        json: true,
+    }));
+    assert!(session.is_ok());
+
+    let tool = run_command(Commands::Stats(StatsCommands::Diff {
+        id: None,
+        session: Some("diff-session".to_string()),
+        tool_use_id: Some("diff-tool".to_string()),
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }));
+    assert!(tool.is_ok());
+}
+
+#[test]
+fn stats_diff_cli_validates_scope_and_limit() {
+    let record = Cli::try_parse_from(["tokenless", "stats", "diff", "42"]).unwrap();
+    match record.command {
+        Commands::Stats(StatsCommands::Diff {
+            id,
+            session,
+            limit,
+            context,
+            ..
+        }) => {
+            assert_eq!(id, Some(42));
+            assert_eq!(session, None);
+            assert_eq!(limit, DEFAULT_DIFF_LIMIT);
+            assert_eq!(context, 3);
+        }
+        _ => panic!("expected stats diff"),
+    }
+
+    assert!(
+        Cli::try_parse_from([
+            "tokenless",
+            "stats",
+            "diff",
+            "42",
+            "--session",
+            "session-1"
+        ])
+        .is_err()
+    );
+    assert!(
+        Cli::try_parse_from(["tokenless", "stats", "diff", "--session", "session-1", "-l", "0"])
+            .is_err()
+    );
+    assert!(
+        Cli::try_parse_from(["tokenless", "stats", "diff", "42", "--limit", "1"]).is_err()
+    );
+    assert!(
+        Cli::try_parse_from(["tokenless", "stats", "diff", "--tool-use-id", "tool-1"]).is_err()
+    );
+    let help = match Cli::try_parse_from(["tokenless", "stats", "diff", "--help"]) {
+        Err(error) => error.to_string(),
+        Ok(_) => panic!("expected help output"),
+    };
+    assert!(help.contains("[default: 20]"));
+    assert!(
+        Cli::try_parse_from([
+            "tokenless",
+            "stats",
+            "diff",
+            "--session",
+            "session-1",
+            "--tool-use-id",
+            "tool-1",
+            "--sort",
+            "time"
+        ])
+        .is_err()
+    );
+}
+
+#[test]
 fn run_command_compress_response_large_with_truncation() {
     let _guard = TempDbGuard::new();
 
@@ -745,6 +896,41 @@ fn run_command_stats_show_nonexistent() {
     let result = run_command(Commands::Stats(StatsCommands::Show { id: 999999 }));
     assert!(result.is_err());
     assert!(result.unwrap_err().0.contains("not found"));
+}
+
+#[test]
+fn run_command_stats_diff_nonexistent_scopes() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    let record = run_command(Commands::Stats(StatsCommands::Diff {
+        id: Some(999999),
+        session: None,
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }))
+    .unwrap_err();
+    assert!(record.0.contains("not found"));
+    assert_eq!(record.1, 1);
+
+    let session = run_command(Commands::Stats(StatsCommands::Diff {
+        id: None,
+        session: Some("missing-session".to_string()),
+        tool_use_id: None,
+        limit: DEFAULT_DIFF_LIMIT,
+        sort: None,
+        context: 3,
+        no_color: true,
+        json: false,
+    }))
+    .unwrap_err();
+    assert!(session.0.contains("No records found"));
+    assert_eq!(session.1, 1);
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -1,7 +1,68 @@
 use std::process::Command;
 
+use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, get_home_dir};
+
 fn tokenless_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_tokenless"))
+}
+
+struct TempStatsDb {
+    dir: std::path::PathBuf,
+    path: std::path::PathBuf,
+    record_id: i64,
+}
+
+impl TempStatsDb {
+    fn new() -> Option<Self> {
+        let home = get_home_dir();
+        if home.is_empty() {
+            return None;
+        }
+        let unique = format!(
+            ".tokenless-cli-integration-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?
+                .as_nanos()
+        );
+        let dir = std::path::PathBuf::from(home).join(unique);
+        std::fs::create_dir_all(&dir).ok()?;
+        let path = dir.join("stats.db");
+        let recorder = StatsRecorder::new(&path).ok()?;
+        let record_id = recorder
+            .record(
+                &StatsRecord::new(
+                    OperationType::CompressResponse,
+                    "integration-agent".to_string(),
+                    17,
+                    10,
+                    9,
+                    5,
+                )
+                .with_session_id("integration-session")
+                .with_tool_use_id("integration-tool")
+                .with_text("keep\nremove\n".to_string(), "keep\n".to_string()),
+            )
+            .ok()?;
+        Some(Self {
+            dir,
+            path,
+            record_id,
+        })
+    }
+
+    fn command(&self) -> Command {
+        let mut command = tokenless_bin();
+        command.env("TOKENLESS_STATS_DB", &self.path);
+        command
+    }
+}
+
+impl Drop for TempStatsDb {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.dir).ok();
+    }
 }
 
 #[test]
@@ -261,4 +322,99 @@ fn stats_show_single_nonexistent() {
         .unwrap();
     // Should fail gracefully for nonexistent record
     let _ = output.status;
+}
+
+#[test]
+fn stats_diff_record_json_contains_structured_hunks() {
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let output = db
+        .command()
+        .args(["stats", "diff", &db.record_id.to_string(), "--json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["schema_version"], "1.0");
+    assert_eq!(json["scope"]["kind"], "record");
+    assert_eq!(json["chains"][0]["diff"]["available"], true);
+    assert!(json["chains"][0]["diff"]["hunks"].is_array());
+}
+
+#[test]
+fn stats_diff_session_omits_content_hunks() {
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let output = db
+        .command()
+        .args([
+            "stats",
+            "diff",
+            "--session",
+            "integration-session",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["scope"]["kind"], "session");
+    assert!(json["chains"][0].get("diff").is_none());
+}
+
+#[test]
+fn stats_diff_tool_use_renders_terminal_diff() {
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let output = db
+        .command()
+        .args([
+            "stats",
+            "diff",
+            "--session",
+            "integration-session",
+            "--tool-use-id",
+            "integration-tool",
+            "--no-color",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Estimated tokens: 10 -> 5"));
+    assert!(stdout.contains("-remove"));
+    assert!(!stdout.contains("\u{1b}["));
+}
+
+#[test]
+fn stats_diff_invalid_scope_and_missing_record_use_expected_exit_codes() {
+    let invalid = tokenless_bin()
+        .args(["stats", "diff", "42", "--session", "session"])
+        .output()
+        .unwrap();
+    assert_eq!(invalid.status.code(), Some(2));
+
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let missing = db
+        .command()
+        .args(["stats", "diff", "999999"])
+        .output()
+        .unwrap();
+    assert_eq!(missing.status.code(), Some(1));
 }

--- a/src/tokenless/crates/tokenless-stats/Cargo.toml
+++ b/src/tokenless/crates/tokenless-stats/Cargo.toml
@@ -13,6 +13,7 @@ rusqlite.workspace = true
 thiserror.workspace = true
 dirs.workspace = true
 libc.workspace = true
+similar.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/tokenless/crates/tokenless-stats/src/diff.rs
+++ b/src/tokenless/crates/tokenless-stats/src/diff.rs
@@ -1,0 +1,829 @@
+//! Detailed before/after reports for recorded token-saving operations.
+//!
+//! Reports keep per-stage metrics while linking only content-identical active
+//! stages, so a multi-stage pipeline is measured from its first input to its
+//! final output without counting intermediate inputs more than once.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::Write as _;
+
+use chrono::{DateTime, Local};
+use serde::Serialize;
+use similar::{ChangeTag, TextDiff};
+
+use crate::record::{CompressionMode, OperationType, StatsRecord};
+
+const SCHEMA_VERSION: &str = "1.0";
+const MAX_DIFF_INPUT_BYTES: usize = 1024 * 1024;
+const MAX_DIFF_LINES: usize = 500;
+
+/// Ordering applied to chains in a session overview.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DiffSort {
+    /// Largest estimated token saving first.
+    #[default]
+    Saved,
+    /// Most recently started chain first.
+    Time,
+}
+
+/// Records and verified adjacency metadata used to build diff chains.
+///
+/// Recorder queries can provide database-side link decisions without loading
+/// stored payloads. Manually constructed sets fall back to comparing content
+/// in memory.
+#[derive(Debug)]
+pub struct DiffRecords {
+    records: Vec<StatsRecord>,
+    linked_to_previous: Option<HashSet<i64>>,
+}
+
+impl DiffRecords {
+    /// Wraps records whose links should be inferred from their loaded content.
+    pub fn from_records(records: Vec<StatsRecord>) -> Self {
+        Self {
+            records,
+            linked_to_previous: None,
+        }
+    }
+
+    /// Returns the records in this diff input.
+    pub fn as_slice(&self) -> &[StatsRecord] {
+        &self.records
+    }
+
+    /// Returns whether the diff input contains no records.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub(crate) fn from_prelinked(
+        records: Vec<StatsRecord>,
+        linked_to_previous: HashSet<i64>,
+    ) -> Self {
+        Self {
+            records,
+            linked_to_previous: Some(linked_to_previous),
+        }
+    }
+
+    fn links(&self, previous: &StatsRecord, next: &StatsRecord) -> bool {
+        self.linked_to_previous.as_ref().map_or_else(
+            || records_link(previous, next),
+            |ids| ids.contains(&next.id),
+        )
+    }
+}
+
+/// Serializable report for a record, session, or tool-use diff.
+#[derive(Debug, Serialize)]
+pub struct DiffReport {
+    schema_version: String,
+    scope: DiffScope,
+    saving_records_only: bool,
+    split_chains: bool,
+    chains: Vec<DiffChain>,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffScope {
+    kind: DiffScopeKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    record_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_use_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffScopeKind {
+    Record,
+    Session,
+    ToolUse,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffChain {
+    status: ChainStatus,
+    mode: String,
+    agent_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_use_id: Option<String>,
+    started_at: String,
+    #[serde(skip)]
+    sort_timestamp: DateTime<Local>,
+    before_bytes: usize,
+    after_bytes: usize,
+    before_tokens: usize,
+    after_tokens: usize,
+    emitted_tokens: usize,
+    saved_tokens: i64,
+    saved_percent: f64,
+    stages: Vec<DiffStage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diff: Option<ContentDiff>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum ChainStatus {
+    Standalone,
+    Linked,
+}
+
+impl ChainStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Standalone => "standalone",
+            Self::Linked => "linked",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DiffStage {
+    record_id: i64,
+    timestamp: String,
+    operation: String,
+    agent_id: String,
+    mode: String,
+    before_bytes: usize,
+    after_bytes: usize,
+    before_tokens: usize,
+    after_tokens: usize,
+    emitted_tokens: usize,
+    saved_tokens: i64,
+    saved_percent: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stash: Option<StashMetrics>,
+}
+
+#[derive(Debug, Serialize)]
+struct StashMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    writes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    errors: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ContentDiff {
+    available: bool,
+    normalization: DiffNormalization,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    omitted_reason: Option<DiffOmittedReason>,
+    hunks: Vec<DiffHunk>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffNormalization {
+    None,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffOmittedReason {
+    MissingContent,
+    ContentTooLarge,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffHunk {
+    old_start: usize,
+    old_len: usize,
+    new_start: usize,
+    new_len: usize,
+    lines: Vec<DiffLine>,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffLine {
+    kind: DiffLineKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old_line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_line: Option<usize>,
+    text: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffLineKind {
+    Context,
+    Delete,
+    Insert,
+}
+
+/// Builds a detailed report for one stored record.
+pub fn record_report(record: &StatsRecord, context: usize) -> DiffReport {
+    DiffReport {
+        schema_version: SCHEMA_VERSION.to_string(),
+        scope: DiffScope {
+            kind: DiffScopeKind::Record,
+            record_id: Some(record.id),
+            session_id: record.session_id.clone(),
+            tool_use_id: record.tool_use_id.clone(),
+        },
+        saving_records_only: true,
+        split_chains: false,
+        chains: vec![build_chain(&[record], true, context)],
+    }
+}
+
+/// Builds a metrics-only session overview and applies the requested chain limit.
+pub fn session_report(
+    records: &DiffRecords,
+    session_id: &str,
+    limit: usize,
+    sort: DiffSort,
+) -> DiffReport {
+    let (mut chains, split_chains) = build_chains(records, false, 0);
+    sort_chains(&mut chains, sort);
+    chains.truncate(limit);
+
+    DiffReport {
+        schema_version: SCHEMA_VERSION.to_string(),
+        scope: DiffScope {
+            kind: DiffScopeKind::Session,
+            record_id: None,
+            session_id: Some(session_id.to_string()),
+            tool_use_id: None,
+        },
+        saving_records_only: true,
+        split_chains,
+        chains,
+    }
+}
+
+/// Builds detailed reports for every independently linked chain of one tool use.
+pub fn tool_use_report(
+    records: &DiffRecords,
+    session_id: &str,
+    tool_use_id: &str,
+    context: usize,
+) -> DiffReport {
+    let (chains, split_chains) = build_chains(records, true, context);
+    DiffReport {
+        schema_version: SCHEMA_VERSION.to_string(),
+        scope: DiffScope {
+            kind: DiffScopeKind::ToolUse,
+            record_id: None,
+            session_id: Some(session_id.to_string()),
+            tool_use_id: Some(tool_use_id.to_string()),
+        },
+        saving_records_only: true,
+        split_chains,
+        chains,
+    }
+}
+
+/// Formats a diff report for interactive terminal display.
+pub fn format_diff_report(report: &DiffReport, color: bool) -> String {
+    let mut output = String::new();
+    output.push_str("Tokenless Diff\n");
+    output.push_str(&"=".repeat(72));
+    output.push('\n');
+    match report.scope.kind {
+        DiffScopeKind::Record => {
+            let _ = writeln!(
+                output,
+                "Record:  {}",
+                report.scope.record_id.unwrap_or_default()
+            );
+        }
+        DiffScopeKind::Session => {
+            let _ = writeln!(
+                output,
+                "Session: {}",
+                escape_terminal_controls(report.scope.session_id.as_deref().unwrap_or("-"))
+            );
+        }
+        DiffScopeKind::ToolUse => {
+            let _ = writeln!(
+                output,
+                "Session: {}\nTool:    {}",
+                escape_terminal_controls(report.scope.session_id.as_deref().unwrap_or("-")),
+                escape_terminal_controls(report.scope.tool_use_id.as_deref().unwrap_or("-"))
+            );
+        }
+    }
+    output.push_str("Token counts are estimated; only operations with savings are recorded.\n");
+
+    if matches!(report.scope.kind, DiffScopeKind::Session) {
+        output.push('\n');
+        output.push_str(&format!(
+            "{:<28} {:<8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>9}\n",
+            "tool / record", "mode", "stages", "before", "after", "emitted", "saved", "saved%"
+        ));
+        output.push_str(&"-".repeat(97));
+        output.push('\n');
+        for chain in &report.chains {
+            let label = chain
+                .tool_use_id
+                .as_deref()
+                .map(escape_terminal_controls)
+                .map(|tool| truncate_label(&tool, 28))
+                .unwrap_or_else(|| format!("record:{}", chain.stages[0].record_id));
+            let _ = writeln!(
+                output,
+                "{:<28} {:<8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>8.1}%",
+                label,
+                chain.mode,
+                chain.stages.len(),
+                format_num(chain.before_tokens),
+                format_num(chain.after_tokens),
+                format_num(chain.emitted_tokens),
+                format_signed(chain.saved_tokens),
+                chain.saved_percent
+            );
+        }
+        if report
+            .chains
+            .iter()
+            .any(|chain| chain.mode == CompressionMode::DryRun.as_str())
+        {
+            output.push_str(
+                "\nFor dry-run rows, after and saved are predictions; emitted remains before.\n",
+            );
+        }
+        if report.split_chains {
+            output.push_str(
+                "\nSome tool uses contain disconnected records and are shown as separate chains.\n",
+            );
+        }
+        return output;
+    }
+
+    for (index, chain) in report.chains.iter().enumerate() {
+        if report.chains.len() > 1 {
+            let _ = writeln!(output, "\nChain {} of {}", index + 1, report.chains.len());
+        }
+        format_chain(&mut output, chain, color);
+    }
+    output
+}
+
+fn format_chain(output: &mut String, chain: &DiffChain, color: bool) {
+    let dry_run = chain.mode == CompressionMode::DryRun.as_str();
+    let label = if dry_run {
+        "Estimated predicted tokens"
+    } else {
+        "Estimated tokens"
+    };
+    let saved_label = if dry_run { "Predicted saved" } else { "Saved" };
+    let _ = writeln!(
+        output,
+        "\nAgent: {}\nSession: {}\nTool: {}\nMode: {}\nStatus: {}\n{}: {} -> {}\nEmitted tokens: {}\n{}: {} ({:.1}%)\nBytes: {} -> {}",
+        escape_terminal_controls(&chain.agent_id),
+        escape_terminal_controls(chain.session_id.as_deref().unwrap_or("-")),
+        escape_terminal_controls(chain.tool_use_id.as_deref().unwrap_or("-")),
+        chain.mode,
+        chain.status.as_str(),
+        label,
+        format_num(chain.before_tokens),
+        format_num(chain.after_tokens),
+        format_num(chain.emitted_tokens),
+        saved_label,
+        format_signed(chain.saved_tokens),
+        chain.saved_percent,
+        format_num(chain.before_bytes),
+        format_num(chain.after_bytes)
+    );
+
+    output.push_str("\nStages:\n");
+    output.push_str(&format!(
+        "{:<8} {:<22} {:>10} {:>10} {:>10} {:<18}\n",
+        "record", "operation", "before", "after", "saved", "stash (w/e/size)"
+    ));
+    for stage in &chain.stages {
+        let _ = writeln!(
+            output,
+            "{:<8} {:<22} {:>10} {:>10} {:>10} {:<18}",
+            stage.record_id,
+            stage.operation,
+            format_num(stage.before_tokens),
+            format_num(stage.after_tokens),
+            format_signed(stage.saved_tokens),
+            format_stash(stage.stash.as_ref())
+        );
+    }
+
+    let Some(diff) = &chain.diff else {
+        return;
+    };
+    output.push('\n');
+    if !diff.available {
+        let reason = match diff.omitted_reason {
+            Some(DiffOmittedReason::MissingContent) => "missing content",
+            Some(DiffOmittedReason::ContentTooLarge) => "content exceeds 1 MiB",
+            None => "unavailable",
+        };
+        let _ = writeln!(
+            output,
+            "Content diff omitted: {reason}. Use `tokenless stats show <id>` for full content."
+        );
+        return;
+    }
+
+    if matches!(diff.normalization, DiffNormalization::Json) {
+        output.push_str("Content diff (JSON normalized for display):\n");
+    } else {
+        output.push_str("Content diff:\n");
+    }
+    output.push_str("--- before\n+++ after\n");
+    for hunk in &diff.hunks {
+        let _ = writeln!(
+            output,
+            "@@ -{},{} +{},{} @@",
+            hunk.old_start, hunk.old_len, hunk.new_start, hunk.new_len
+        );
+        for line in &hunk.lines {
+            let text = escape_terminal_controls(&line.text);
+            let (prefix, ansi) = match line.kind {
+                DiffLineKind::Context => (' ', None),
+                DiffLineKind::Delete => ('-', Some("\x1b[31m")),
+                DiffLineKind::Insert => ('+', Some("\x1b[32m")),
+            };
+            if color && let Some(ansi) = ansi {
+                let _ = writeln!(output, "{ansi}{prefix}{text}\x1b[0m");
+            } else {
+                let _ = writeln!(output, "{prefix}{text}");
+            }
+        }
+    }
+    if diff.truncated {
+        output.push_str("... diff truncated after 500 lines; use `stats show` for full content.\n");
+    }
+}
+
+fn build_chains(
+    records: &DiffRecords,
+    include_content: bool,
+    context: usize,
+) -> (Vec<DiffChain>, bool) {
+    let mut ordered: Vec<&StatsRecord> = records.records.iter().collect();
+    ordered.sort_by(|left, right| {
+        left.timestamp
+            .cmp(&right.timestamp)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let mut groups: BTreeMap<String, Vec<&StatsRecord>> = BTreeMap::new();
+    let mut standalone = Vec::new();
+    for record in ordered {
+        if let Some(tool_use_id) = &record.tool_use_id {
+            groups.entry(tool_use_id.clone()).or_default().push(record);
+        } else {
+            standalone.push(build_chain(&[record], include_content, context));
+        }
+    }
+
+    let mut chains = standalone;
+    for grouped_records in groups.values() {
+        let mut current: Vec<&StatsRecord> = Vec::new();
+        for record in grouped_records {
+            if current
+                .last()
+                .is_some_and(|previous| records.links(previous, record))
+            {
+                current.push(record);
+            } else {
+                if !current.is_empty() {
+                    chains.push(build_chain(&current, include_content, context));
+                }
+                current = vec![record];
+            }
+        }
+        if !current.is_empty() {
+            chains.push(build_chain(&current, include_content, context));
+        }
+    }
+
+    chains.sort_by(|left, right| {
+        left.sort_timestamp
+            .cmp(&right.sort_timestamp)
+            .then_with(|| left.stages[0].record_id.cmp(&right.stages[0].record_id))
+    });
+
+    let mut tool_counts: HashMap<&str, usize> = HashMap::new();
+    for chain in &chains {
+        if let Some(tool) = chain.tool_use_id.as_deref() {
+            *tool_counts.entry(tool).or_default() += 1;
+        }
+    }
+    let split_chains = tool_counts.values().any(|count| *count > 1);
+    (chains, split_chains)
+}
+
+fn records_link(previous: &StatsRecord, next: &StatsRecord) -> bool {
+    if previous.mode != CompressionMode::Active || next.mode != CompressionMode::Active {
+        return false;
+    }
+    match (content_pair(previous), content_pair(next)) {
+        (Some((_, previous_after)), Some((next_before, _))) => previous_after == next_before,
+        _ => false,
+    }
+}
+
+fn build_chain(records: &[&StatsRecord], include_content: bool, context: usize) -> DiffChain {
+    let first = records[0];
+    let last = records[records.len() - 1];
+    let before_tokens = first.before_tokens;
+    let after_tokens = last.after_tokens;
+    let mode = first.mode.clone();
+    let diff = if include_content {
+        Some(build_content_diff(
+            content_pair(first).map(|pair| pair.0),
+            content_pair(last).map(|pair| pair.1),
+            context,
+        ))
+    } else {
+        None
+    };
+
+    DiffChain {
+        status: if records.len() > 1 {
+            ChainStatus::Linked
+        } else {
+            ChainStatus::Standalone
+        },
+        mode: mode.as_str().to_string(),
+        agent_id: first.agent_id.clone(),
+        session_id: first.session_id.clone(),
+        tool_use_id: first.tool_use_id.clone(),
+        started_at: first.timestamp.to_rfc3339(),
+        sort_timestamp: first.timestamp,
+        before_bytes: first.before_chars,
+        after_bytes: last.after_chars,
+        before_tokens,
+        after_tokens,
+        emitted_tokens: match mode {
+            CompressionMode::Active => after_tokens,
+            CompressionMode::DryRun => before_tokens,
+        },
+        saved_tokens: token_delta(before_tokens, after_tokens),
+        saved_percent: saved_percent(before_tokens, after_tokens),
+        stages: records.iter().map(|record| build_stage(record)).collect(),
+        diff,
+    }
+}
+
+fn build_stage(record: &StatsRecord) -> DiffStage {
+    let stash = if record.stash_writes.is_some()
+        || record.stash_errors.is_some()
+        || record.stash_size.is_some()
+    {
+        Some(StashMetrics {
+            writes: record.stash_writes,
+            errors: record.stash_errors,
+            size: record.stash_size,
+        })
+    } else {
+        None
+    };
+    DiffStage {
+        record_id: record.id,
+        timestamp: record.timestamp.to_rfc3339(),
+        operation: record.operation.as_str().to_string(),
+        agent_id: record.agent_id.clone(),
+        mode: record.mode.as_str().to_string(),
+        before_bytes: record.before_chars,
+        after_bytes: record.after_chars,
+        before_tokens: record.before_tokens,
+        after_tokens: record.after_tokens,
+        emitted_tokens: match record.mode {
+            CompressionMode::Active => record.after_tokens,
+            CompressionMode::DryRun => record.before_tokens,
+        },
+        saved_tokens: token_delta(record.before_tokens, record.after_tokens),
+        saved_percent: saved_percent(record.before_tokens, record.after_tokens),
+        stash,
+    }
+}
+
+fn content_pair(record: &StatsRecord) -> Option<(&str, &str)> {
+    if record.operation == OperationType::RewriteCommand
+        && let (Some(before), Some(after)) = (&record.before_output, &record.after_output)
+    {
+        return Some((before, after));
+    }
+    match (&record.before_text, &record.after_text) {
+        (Some(before), Some(after)) => Some((before, after)),
+        _ => None,
+    }
+}
+
+fn build_content_diff(before: Option<&str>, after: Option<&str>, context: usize) -> ContentDiff {
+    let (Some(before), Some(after)) = (before, after) else {
+        return omitted_diff(DiffOmittedReason::MissingContent);
+    };
+    if before.len() > MAX_DIFF_INPUT_BYTES || after.len() > MAX_DIFF_INPUT_BYTES {
+        return omitted_diff(DiffOmittedReason::ContentTooLarge);
+    }
+
+    let (before, after, normalization) = match (
+        serde_json::from_str::<serde_json::Value>(before),
+        serde_json::from_str::<serde_json::Value>(after),
+    ) {
+        (Ok(before_json), Ok(after_json)) => (
+            serde_json::to_string_pretty(&before_json).unwrap_or_else(|_| before.to_string()),
+            serde_json::to_string_pretty(&after_json).unwrap_or_else(|_| after.to_string()),
+            DiffNormalization::Json,
+        ),
+        _ => (
+            before.to_string(),
+            after.to_string(),
+            DiffNormalization::None,
+        ),
+    };
+
+    let text_diff = TextDiff::from_lines(&before, &after);
+    let context = context.min(MAX_DIFF_LINES);
+    let mut hunks = Vec::new();
+    let mut emitted_lines = 0usize;
+    let mut truncated = false;
+    for group in text_diff.grouped_ops(context) {
+        if emitted_lines >= MAX_DIFF_LINES {
+            truncated = true;
+            break;
+        }
+        let old_start = group.first().map_or(0, |op| op.old_range().start);
+        let new_start = group.first().map_or(0, |op| op.new_range().start);
+        let mut lines = Vec::new();
+        'ops: for op in &group {
+            for change in text_diff.iter_changes(op) {
+                if emitted_lines >= MAX_DIFF_LINES {
+                    truncated = true;
+                    break 'ops;
+                }
+                let kind = match change.tag() {
+                    ChangeTag::Equal => DiffLineKind::Context,
+                    ChangeTag::Delete => DiffLineKind::Delete,
+                    ChangeTag::Insert => DiffLineKind::Insert,
+                };
+                lines.push(DiffLine {
+                    kind,
+                    old_line: change.old_index().map(|index| index + 1),
+                    new_line: change.new_index().map(|index| index + 1),
+                    text: trim_diff_newline(change.value()).to_string(),
+                });
+                emitted_lines += 1;
+            }
+        }
+        // A group can be cut mid-operation by the output cap. Derive the
+        // ranges from the emitted prefix so each hunk remains self-consistent.
+        let old_len = lines.iter().filter(|line| line.old_line.is_some()).count();
+        let new_len = lines.iter().filter(|line| line.new_line.is_some()).count();
+        hunks.push(DiffHunk {
+            old_start: if old_len == 0 {
+                old_start
+            } else {
+                old_start + 1
+            },
+            old_len,
+            new_start: if new_len == 0 {
+                new_start
+            } else {
+                new_start + 1
+            },
+            new_len,
+            lines,
+        });
+    }
+
+    ContentDiff {
+        available: true,
+        normalization,
+        truncated,
+        omitted_reason: None,
+        hunks,
+    }
+}
+
+fn omitted_diff(reason: DiffOmittedReason) -> ContentDiff {
+    ContentDiff {
+        available: false,
+        normalization: DiffNormalization::None,
+        truncated: false,
+        omitted_reason: Some(reason),
+        hunks: Vec::new(),
+    }
+}
+
+fn trim_diff_newline(value: &str) -> &str {
+    let value = value.strip_suffix('\n').unwrap_or(value);
+    value.strip_suffix('\r').unwrap_or(value)
+}
+
+fn escape_terminal_controls(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_control() {
+            escaped.extend(character.escape_default());
+        } else {
+            escaped.push(character);
+        }
+    }
+    escaped
+}
+
+fn sort_chains(chains: &mut [DiffChain], sort: DiffSort) {
+    match sort {
+        DiffSort::Saved => chains.sort_by(|left, right| {
+            right
+                .saved_tokens
+                .cmp(&left.saved_tokens)
+                .then_with(|| right.sort_timestamp.cmp(&left.sort_timestamp))
+        }),
+        DiffSort::Time => chains.sort_by(|left, right| {
+            right
+                .sort_timestamp
+                .cmp(&left.sort_timestamp)
+                .then_with(|| right.stages[0].record_id.cmp(&left.stages[0].record_id))
+        }),
+    }
+}
+
+fn token_delta(before: usize, after: usize) -> i64 {
+    match before.cmp(&after) {
+        Ordering::Greater => i64::try_from(before - after).unwrap_or(i64::MAX),
+        Ordering::Less => -i64::try_from(after - before).unwrap_or(i64::MAX),
+        Ordering::Equal => 0,
+    }
+}
+
+fn saved_percent(before: usize, after: usize) -> f64 {
+    if before == 0 {
+        0.0
+    } else {
+        ((before as f64 - after as f64) / before as f64) * 100.0
+    }
+}
+
+fn truncate_label(value: &str, width: usize) -> String {
+    let count = value.chars().count();
+    if count <= width {
+        return value.to_string();
+    }
+    value
+        .chars()
+        .take(width.saturating_sub(1))
+        .chain(std::iter::once('…'))
+        .collect()
+}
+
+fn format_num(value: usize) -> String {
+    let digits = value.to_string();
+    let mut output = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, character) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            output.push(',');
+        }
+        output.push(character);
+    }
+    output
+}
+
+fn format_signed(value: i64) -> String {
+    if value < 0 {
+        format!("-{}", format_num(value.unsigned_abs() as usize))
+    } else {
+        format_num(value as usize)
+    }
+}
+
+fn format_stash(stash: Option<&StashMetrics>) -> String {
+    stash.map_or_else(
+        || "-".to_string(),
+        |stash| {
+            format!(
+                "{}/{}/{}",
+                stash
+                    .writes
+                    .map_or_else(|| "-".to_string(), |value| value.to_string()),
+                stash
+                    .errors
+                    .map_or_else(|| "-".to_string(), |value| value.to_string()),
+                stash
+                    .size
+                    .map_or_else(|| "-".to_string(), |value| value.to_string())
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    include!("tests/diff_tests.rs");
+}

--- a/src/tokenless/crates/tokenless-stats/src/diff.rs
+++ b/src/tokenless/crates/tokenless-stats/src/diff.rs
@@ -1,0 +1,780 @@
+//! Detailed before/after reports for recorded token-saving operations.
+//!
+//! Reports keep per-stage metrics while linking only content-identical active
+//! stages, so a multi-stage pipeline is measured from its first input to its
+//! final output without counting intermediate inputs more than once.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write as _;
+
+use chrono::{DateTime, Local};
+use serde::Serialize;
+use similar::{ChangeTag, TextDiff};
+
+use crate::record::{CompressionMode, OperationType, StatsRecord};
+
+const SCHEMA_VERSION: &str = "1.0";
+const MAX_DIFF_INPUT_BYTES: usize = 1024 * 1024;
+const MAX_DIFF_LINES: usize = 500;
+
+/// Ordering applied to chains in a session overview.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DiffSort {
+    /// Largest estimated token saving first.
+    #[default]
+    Saved,
+    /// Most recently started chain first.
+    Time,
+}
+
+/// Serializable report for a record, session, or tool-use diff.
+#[derive(Debug, Serialize)]
+pub struct DiffReport {
+    schema_version: String,
+    scope: DiffScope,
+    saving_records_only: bool,
+    split_chains: bool,
+    chains: Vec<DiffChain>,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffScope {
+    kind: DiffScopeKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    record_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_use_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffScopeKind {
+    Record,
+    Session,
+    ToolUse,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffChain {
+    status: ChainStatus,
+    mode: String,
+    agent_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_use_id: Option<String>,
+    started_at: String,
+    #[serde(skip)]
+    sort_timestamp: DateTime<Local>,
+    before_bytes: usize,
+    after_bytes: usize,
+    before_tokens: usize,
+    after_tokens: usize,
+    emitted_tokens: usize,
+    saved_tokens: i64,
+    saved_percent: f64,
+    stages: Vec<DiffStage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diff: Option<ContentDiff>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum ChainStatus {
+    Standalone,
+    Linked,
+}
+
+impl ChainStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Standalone => "standalone",
+            Self::Linked => "linked",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DiffStage {
+    record_id: i64,
+    timestamp: String,
+    operation: String,
+    agent_id: String,
+    mode: String,
+    before_bytes: usize,
+    after_bytes: usize,
+    before_tokens: usize,
+    after_tokens: usize,
+    emitted_tokens: usize,
+    saved_tokens: i64,
+    saved_percent: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stash: Option<StashMetrics>,
+}
+
+#[derive(Debug, Serialize)]
+struct StashMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    writes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    errors: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ContentDiff {
+    available: bool,
+    normalization: DiffNormalization,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    omitted_reason: Option<DiffOmittedReason>,
+    hunks: Vec<DiffHunk>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffNormalization {
+    None,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffOmittedReason {
+    MissingContent,
+    ContentTooLarge,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffHunk {
+    old_start: usize,
+    old_len: usize,
+    new_start: usize,
+    new_len: usize,
+    lines: Vec<DiffLine>,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffLine {
+    kind: DiffLineKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old_line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_line: Option<usize>,
+    text: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DiffLineKind {
+    Context,
+    Delete,
+    Insert,
+}
+
+/// Builds a detailed report for one stored record.
+pub fn record_report(record: &StatsRecord, context: usize) -> DiffReport {
+    DiffReport {
+        schema_version: SCHEMA_VERSION.to_string(),
+        scope: DiffScope {
+            kind: DiffScopeKind::Record,
+            record_id: Some(record.id),
+            session_id: record.session_id.clone(),
+            tool_use_id: record.tool_use_id.clone(),
+        },
+        saving_records_only: true,
+        split_chains: false,
+        chains: vec![build_chain(&[record], true, context)],
+    }
+}
+
+/// Builds a metrics-only session overview and applies the requested chain limit.
+pub fn session_report(
+    records: &[StatsRecord],
+    session_id: &str,
+    limit: usize,
+    sort: DiffSort,
+) -> DiffReport {
+    let (mut chains, split_chains) = build_chains(records, false, 0);
+    sort_chains(&mut chains, sort);
+    chains.truncate(limit);
+
+    DiffReport {
+        schema_version: SCHEMA_VERSION.to_string(),
+        scope: DiffScope {
+            kind: DiffScopeKind::Session,
+            record_id: None,
+            session_id: Some(session_id.to_string()),
+            tool_use_id: None,
+        },
+        saving_records_only: true,
+        split_chains,
+        chains,
+    }
+}
+
+/// Builds detailed reports for every independently linked chain of one tool use.
+pub fn tool_use_report(
+    records: &[StatsRecord],
+    session_id: &str,
+    tool_use_id: &str,
+    context: usize,
+) -> DiffReport {
+    let (chains, split_chains) = build_chains(records, true, context);
+    DiffReport {
+        schema_version: SCHEMA_VERSION.to_string(),
+        scope: DiffScope {
+            kind: DiffScopeKind::ToolUse,
+            record_id: None,
+            session_id: Some(session_id.to_string()),
+            tool_use_id: Some(tool_use_id.to_string()),
+        },
+        saving_records_only: true,
+        split_chains,
+        chains,
+    }
+}
+
+/// Formats a diff report for interactive terminal display.
+pub fn format_diff_report(report: &DiffReport, color: bool) -> String {
+    let mut output = String::new();
+    output.push_str("Tokenless Diff\n");
+    output.push_str(&"=".repeat(72));
+    output.push('\n');
+    match report.scope.kind {
+        DiffScopeKind::Record => {
+            let _ = writeln!(
+                output,
+                "Record:  {}",
+                report.scope.record_id.unwrap_or_default()
+            );
+        }
+        DiffScopeKind::Session => {
+            let _ = writeln!(
+                output,
+                "Session: {}",
+                report.scope.session_id.as_deref().unwrap_or("-")
+            );
+        }
+        DiffScopeKind::ToolUse => {
+            let _ = writeln!(
+                output,
+                "Session: {}\nTool:    {}",
+                report.scope.session_id.as_deref().unwrap_or("-"),
+                report.scope.tool_use_id.as_deref().unwrap_or("-")
+            );
+        }
+    }
+    output.push_str("Token counts are estimated; only operations with savings are recorded.\n");
+
+    if matches!(report.scope.kind, DiffScopeKind::Session) {
+        output.push('\n');
+        output.push_str(&format!(
+            "{:<28} {:<8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>9}\n",
+            "tool / record", "mode", "stages", "before", "after", "emitted", "saved", "saved%"
+        ));
+        output.push_str(&"-".repeat(97));
+        output.push('\n');
+        for chain in &report.chains {
+            let label = chain
+                .tool_use_id
+                .as_deref()
+                .map(|tool| truncate_label(tool, 28))
+                .unwrap_or_else(|| format!("record:{}", chain.stages[0].record_id));
+            let _ = writeln!(
+                output,
+                "{:<28} {:<8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>8.1}%",
+                label,
+                chain.mode,
+                chain.stages.len(),
+                format_num(chain.before_tokens),
+                format_num(chain.after_tokens),
+                format_num(chain.emitted_tokens),
+                format_signed(chain.saved_tokens),
+                chain.saved_percent
+            );
+        }
+        if report
+            .chains
+            .iter()
+            .any(|chain| chain.mode == CompressionMode::DryRun.as_str())
+        {
+            output.push_str(
+                "\nFor dry-run rows, after and saved are predictions; emitted remains before.\n",
+            );
+        }
+        if report.split_chains {
+            output.push_str(
+                "\nSome tool uses contain disconnected records and are shown as separate chains.\n",
+            );
+        }
+        return output;
+    }
+
+    for (index, chain) in report.chains.iter().enumerate() {
+        if report.chains.len() > 1 {
+            let _ = writeln!(output, "\nChain {} of {}", index + 1, report.chains.len());
+        }
+        format_chain(&mut output, chain, color);
+    }
+    output
+}
+
+fn format_chain(output: &mut String, chain: &DiffChain, color: bool) {
+    let dry_run = chain.mode == CompressionMode::DryRun.as_str();
+    let label = if dry_run {
+        "Estimated predicted tokens"
+    } else {
+        "Estimated tokens"
+    };
+    let saved_label = if dry_run { "Predicted saved" } else { "Saved" };
+    let _ = writeln!(
+        output,
+        "\nAgent: {}\nSession: {}\nTool: {}\nMode: {}\nStatus: {}\n{}: {} -> {}\nEmitted tokens: {}\n{}: {} ({:.1}%)\nBytes: {} -> {}",
+        chain.agent_id,
+        chain.session_id.as_deref().unwrap_or("-"),
+        chain.tool_use_id.as_deref().unwrap_or("-"),
+        chain.mode,
+        chain.status.as_str(),
+        label,
+        format_num(chain.before_tokens),
+        format_num(chain.after_tokens),
+        format_num(chain.emitted_tokens),
+        saved_label,
+        format_signed(chain.saved_tokens),
+        chain.saved_percent,
+        format_num(chain.before_bytes),
+        format_num(chain.after_bytes)
+    );
+
+    output.push_str("\nStages:\n");
+    output.push_str(&format!(
+        "{:<8} {:<22} {:>10} {:>10} {:>10} {:<18}\n",
+        "record", "operation", "before", "after", "saved", "stash (w/e/size)"
+    ));
+    for stage in &chain.stages {
+        let _ = writeln!(
+            output,
+            "{:<8} {:<22} {:>10} {:>10} {:>10} {:<18}",
+            stage.record_id,
+            stage.operation,
+            format_num(stage.before_tokens),
+            format_num(stage.after_tokens),
+            format_signed(stage.saved_tokens),
+            format_stash(stage.stash.as_ref())
+        );
+    }
+
+    let Some(diff) = &chain.diff else {
+        return;
+    };
+    output.push('\n');
+    if !diff.available {
+        let reason = match diff.omitted_reason {
+            Some(DiffOmittedReason::MissingContent) => "missing content",
+            Some(DiffOmittedReason::ContentTooLarge) => "content exceeds 1 MiB",
+            None => "unavailable",
+        };
+        let _ = writeln!(
+            output,
+            "Content diff omitted: {reason}. Use `tokenless stats show <id>` for full content."
+        );
+        return;
+    }
+
+    if matches!(diff.normalization, DiffNormalization::Json) {
+        output.push_str("Content diff (JSON normalized for display):\n");
+    } else {
+        output.push_str("Content diff:\n");
+    }
+    output.push_str("--- before\n+++ after\n");
+    for hunk in &diff.hunks {
+        let _ = writeln!(
+            output,
+            "@@ -{},{} +{},{} @@",
+            hunk.old_start, hunk.old_len, hunk.new_start, hunk.new_len
+        );
+        for line in &hunk.lines {
+            let text = escape_terminal_controls(&line.text);
+            let (prefix, ansi) = match line.kind {
+                DiffLineKind::Context => (' ', None),
+                DiffLineKind::Delete => ('-', Some("\x1b[31m")),
+                DiffLineKind::Insert => ('+', Some("\x1b[32m")),
+            };
+            if color && let Some(ansi) = ansi {
+                let _ = writeln!(output, "{ansi}{prefix}{text}\x1b[0m");
+            } else {
+                let _ = writeln!(output, "{prefix}{text}");
+            }
+        }
+    }
+    if diff.truncated {
+        output.push_str("... diff truncated after 500 lines; use `stats show` for full content.\n");
+    }
+}
+
+fn build_chains(
+    records: &[StatsRecord],
+    include_content: bool,
+    context: usize,
+) -> (Vec<DiffChain>, bool) {
+    let mut ordered: Vec<&StatsRecord> = records.iter().collect();
+    ordered.sort_by(|left, right| {
+        left.timestamp
+            .cmp(&right.timestamp)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let mut groups: BTreeMap<String, Vec<&StatsRecord>> = BTreeMap::new();
+    let mut standalone = Vec::new();
+    for record in ordered {
+        if let Some(tool_use_id) = &record.tool_use_id {
+            groups.entry(tool_use_id.clone()).or_default().push(record);
+        } else {
+            standalone.push(build_chain(&[record], include_content, context));
+        }
+    }
+
+    let mut chains = standalone;
+    for records in groups.values() {
+        let mut current: Vec<&StatsRecord> = Vec::new();
+        for record in records {
+            if current
+                .last()
+                .is_some_and(|previous| records_link(previous, record))
+            {
+                current.push(record);
+            } else {
+                if !current.is_empty() {
+                    chains.push(build_chain(&current, include_content, context));
+                }
+                current = vec![record];
+            }
+        }
+        if !current.is_empty() {
+            chains.push(build_chain(&current, include_content, context));
+        }
+    }
+
+    chains.sort_by(|left, right| {
+        left.sort_timestamp
+            .cmp(&right.sort_timestamp)
+            .then_with(|| left.stages[0].record_id.cmp(&right.stages[0].record_id))
+    });
+
+    let mut tool_counts: HashMap<&str, usize> = HashMap::new();
+    for chain in &chains {
+        if let Some(tool) = chain.tool_use_id.as_deref() {
+            *tool_counts.entry(tool).or_default() += 1;
+        }
+    }
+    let split_chains = tool_counts.values().any(|count| *count > 1);
+    (chains, split_chains)
+}
+
+fn records_link(previous: &StatsRecord, next: &StatsRecord) -> bool {
+    if previous.mode != CompressionMode::Active || next.mode != CompressionMode::Active {
+        return false;
+    }
+    match (content_pair(previous), content_pair(next)) {
+        (Some((_, previous_after)), Some((next_before, _))) => previous_after == next_before,
+        _ => false,
+    }
+}
+
+fn build_chain(records: &[&StatsRecord], include_content: bool, context: usize) -> DiffChain {
+    let first = records[0];
+    let last = records[records.len() - 1];
+    let before_tokens = first.before_tokens;
+    let after_tokens = last.after_tokens;
+    let mode = first.mode.clone();
+    let diff = if include_content {
+        Some(build_content_diff(
+            content_pair(first).map(|pair| pair.0),
+            content_pair(last).map(|pair| pair.1),
+            context,
+        ))
+    } else {
+        None
+    };
+
+    DiffChain {
+        status: if records.len() > 1 {
+            ChainStatus::Linked
+        } else {
+            ChainStatus::Standalone
+        },
+        mode: mode.as_str().to_string(),
+        agent_id: first.agent_id.clone(),
+        session_id: first.session_id.clone(),
+        tool_use_id: first.tool_use_id.clone(),
+        started_at: first.timestamp.to_rfc3339(),
+        sort_timestamp: first.timestamp,
+        before_bytes: first.before_chars,
+        after_bytes: last.after_chars,
+        before_tokens,
+        after_tokens,
+        emitted_tokens: match mode {
+            CompressionMode::Active => after_tokens,
+            CompressionMode::DryRun => before_tokens,
+        },
+        saved_tokens: token_delta(before_tokens, after_tokens),
+        saved_percent: saved_percent(before_tokens, after_tokens),
+        stages: records.iter().map(|record| build_stage(record)).collect(),
+        diff,
+    }
+}
+
+fn build_stage(record: &StatsRecord) -> DiffStage {
+    let stash = if record.stash_writes.is_some()
+        || record.stash_errors.is_some()
+        || record.stash_size.is_some()
+    {
+        Some(StashMetrics {
+            writes: record.stash_writes,
+            errors: record.stash_errors,
+            size: record.stash_size,
+        })
+    } else {
+        None
+    };
+    DiffStage {
+        record_id: record.id,
+        timestamp: record.timestamp.to_rfc3339(),
+        operation: record.operation.as_str().to_string(),
+        agent_id: record.agent_id.clone(),
+        mode: record.mode.as_str().to_string(),
+        before_bytes: record.before_chars,
+        after_bytes: record.after_chars,
+        before_tokens: record.before_tokens,
+        after_tokens: record.after_tokens,
+        emitted_tokens: match record.mode {
+            CompressionMode::Active => record.after_tokens,
+            CompressionMode::DryRun => record.before_tokens,
+        },
+        saved_tokens: token_delta(record.before_tokens, record.after_tokens),
+        saved_percent: saved_percent(record.before_tokens, record.after_tokens),
+        stash,
+    }
+}
+
+fn content_pair(record: &StatsRecord) -> Option<(&str, &str)> {
+    if record.operation == OperationType::RewriteCommand
+        && let (Some(before), Some(after)) = (&record.before_output, &record.after_output)
+    {
+        return Some((before, after));
+    }
+    match (&record.before_text, &record.after_text) {
+        (Some(before), Some(after)) => Some((before, after)),
+        _ => None,
+    }
+}
+
+fn build_content_diff(before: Option<&str>, after: Option<&str>, context: usize) -> ContentDiff {
+    let (Some(before), Some(after)) = (before, after) else {
+        return omitted_diff(DiffOmittedReason::MissingContent);
+    };
+    if before.len() > MAX_DIFF_INPUT_BYTES || after.len() > MAX_DIFF_INPUT_BYTES {
+        return omitted_diff(DiffOmittedReason::ContentTooLarge);
+    }
+
+    let (before, after, normalization) = match (
+        serde_json::from_str::<serde_json::Value>(before),
+        serde_json::from_str::<serde_json::Value>(after),
+    ) {
+        (Ok(before_json), Ok(after_json)) => (
+            serde_json::to_string_pretty(&before_json).unwrap_or_else(|_| before.to_string()),
+            serde_json::to_string_pretty(&after_json).unwrap_or_else(|_| after.to_string()),
+            DiffNormalization::Json,
+        ),
+        _ => (
+            before.to_string(),
+            after.to_string(),
+            DiffNormalization::None,
+        ),
+    };
+
+    let text_diff = TextDiff::from_lines(&before, &after);
+    let context = context.min(MAX_DIFF_LINES);
+    let mut hunks = Vec::new();
+    let mut emitted_lines = 0usize;
+    let mut truncated = false;
+    for group in text_diff.grouped_ops(context) {
+        if emitted_lines >= MAX_DIFF_LINES {
+            truncated = true;
+            break;
+        }
+        let old_start = group.first().map_or(0, |op| op.old_range().start);
+        let new_start = group.first().map_or(0, |op| op.new_range().start);
+        let mut lines = Vec::new();
+        'ops: for op in &group {
+            for change in text_diff.iter_changes(op) {
+                if emitted_lines >= MAX_DIFF_LINES {
+                    truncated = true;
+                    break 'ops;
+                }
+                let kind = match change.tag() {
+                    ChangeTag::Equal => DiffLineKind::Context,
+                    ChangeTag::Delete => DiffLineKind::Delete,
+                    ChangeTag::Insert => DiffLineKind::Insert,
+                };
+                lines.push(DiffLine {
+                    kind,
+                    old_line: change.old_index().map(|index| index + 1),
+                    new_line: change.new_index().map(|index| index + 1),
+                    text: trim_diff_newline(change.value()).to_string(),
+                });
+                emitted_lines += 1;
+            }
+        }
+        // A group can be cut mid-operation by the output cap. Derive the
+        // ranges from the emitted prefix so each hunk remains self-consistent.
+        let old_len = lines.iter().filter(|line| line.old_line.is_some()).count();
+        let new_len = lines.iter().filter(|line| line.new_line.is_some()).count();
+        hunks.push(DiffHunk {
+            old_start: if old_len == 0 {
+                old_start
+            } else {
+                old_start + 1
+            },
+            old_len,
+            new_start: if new_len == 0 {
+                new_start
+            } else {
+                new_start + 1
+            },
+            new_len,
+            lines,
+        });
+    }
+
+    ContentDiff {
+        available: true,
+        normalization,
+        truncated,
+        omitted_reason: None,
+        hunks,
+    }
+}
+
+fn omitted_diff(reason: DiffOmittedReason) -> ContentDiff {
+    ContentDiff {
+        available: false,
+        normalization: DiffNormalization::None,
+        truncated: false,
+        omitted_reason: Some(reason),
+        hunks: Vec::new(),
+    }
+}
+
+fn trim_diff_newline(value: &str) -> &str {
+    let value = value.strip_suffix('\n').unwrap_or(value);
+    value.strip_suffix('\r').unwrap_or(value)
+}
+
+fn escape_terminal_controls(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_control() {
+            escaped.extend(character.escape_default());
+        } else {
+            escaped.push(character);
+        }
+    }
+    escaped
+}
+
+fn sort_chains(chains: &mut [DiffChain], sort: DiffSort) {
+    match sort {
+        DiffSort::Saved => chains.sort_by(|left, right| {
+            right
+                .saved_tokens
+                .cmp(&left.saved_tokens)
+                .then_with(|| right.sort_timestamp.cmp(&left.sort_timestamp))
+        }),
+        DiffSort::Time => chains.sort_by(|left, right| {
+            right
+                .sort_timestamp
+                .cmp(&left.sort_timestamp)
+                .then_with(|| right.stages[0].record_id.cmp(&left.stages[0].record_id))
+        }),
+    }
+}
+
+fn token_delta(before: usize, after: usize) -> i64 {
+    match before.cmp(&after) {
+        Ordering::Greater => i64::try_from(before - after).unwrap_or(i64::MAX),
+        Ordering::Less => -i64::try_from(after - before).unwrap_or(i64::MAX),
+        Ordering::Equal => 0,
+    }
+}
+
+fn saved_percent(before: usize, after: usize) -> f64 {
+    if before == 0 {
+        0.0
+    } else {
+        ((before as f64 - after as f64) / before as f64) * 100.0
+    }
+}
+
+fn truncate_label(value: &str, width: usize) -> String {
+    let count = value.chars().count();
+    if count <= width {
+        return value.to_string();
+    }
+    value
+        .chars()
+        .take(width.saturating_sub(1))
+        .chain(std::iter::once('…'))
+        .collect()
+}
+
+fn format_num(value: usize) -> String {
+    let digits = value.to_string();
+    let mut output = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, character) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            output.push(',');
+        }
+        output.push(character);
+    }
+    output
+}
+
+fn format_signed(value: i64) -> String {
+    if value < 0 {
+        format!("-{}", format_num(value.unsigned_abs() as usize))
+    } else {
+        format_num(value as usize)
+    }
+}
+
+fn format_stash(stash: Option<&StashMetrics>) -> String {
+    stash.map_or_else(
+        || "-".to_string(),
+        |stash| {
+            format!(
+                "{}/{}/{}",
+                stash
+                    .writes
+                    .map_or_else(|| "-".to_string(), |value| value.to_string()),
+                stash
+                    .errors
+                    .map_or_else(|| "-".to_string(), |value| value.to_string()),
+                stash
+                    .size
+                    .map_or_else(|| "-".to_string(), |value| value.to_string())
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    include!("tests/diff_tests.rs");
+}

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -5,6 +5,7 @@
 //! schema compression, response compression, and command rewriting.
 
 pub mod config;
+pub mod diff;
 pub mod home;
 pub mod query;
 pub mod record;
@@ -24,6 +25,11 @@ pub use query::{
 pub use tokenizer::{Tokenizer, count_chars, estimate_tokens, estimate_tokens_from_bytes};
 
 pub use config::TokenlessConfig;
+
+pub use diff::{
+    DiffRecords, DiffReport, DiffSort, format_diff_report, record_report, session_report,
+    tool_use_report,
+};
 
 pub use home::get_home_dir;
 

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -5,6 +5,7 @@
 //! schema compression, response compression, and command rewriting.
 
 pub mod config;
+pub mod diff;
 pub mod home;
 pub mod query;
 pub mod record;
@@ -24,6 +25,10 @@ pub use query::{
 pub use tokenizer::{Tokenizer, count_chars, estimate_tokens, estimate_tokens_from_bytes};
 
 pub use config::TokenlessConfig;
+
+pub use diff::{
+    DiffReport, DiffSort, format_diff_report, record_report, session_report, tool_use_report,
+};
 
 pub use home::get_home_dir;
 

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -2,9 +2,11 @@
 //!
 //! Provides SQLite-based storage for compression and rewriting metrics.
 
+use crate::diff::DiffRecords;
 use crate::record::{CompressionMode, OperationType, StatsRecord};
 use chrono::DateTime;
 use rusqlite::Connection;
+use std::collections::HashSet;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Mutex;
@@ -86,6 +88,10 @@ impl StatsRecorder {
         )?;
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_session_id ON stats(session_id)",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_tool ON stats(session_id, tool_use_id)",
             [],
         )?;
 
@@ -258,6 +264,149 @@ impl StatsRecorder {
         ))?;
         let rows = stmt.query_map(rusqlite::params![session_id, n as i64], Self::row_to_record)?;
         Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Queries the newest records used to build a session or tool-use diff.
+    ///
+    /// Results are returned oldest first. Session overviews load only metrics
+    /// and metadata; SQLite compares adjacent payloads to preserve exact chain
+    /// linking without materializing every payload in the Rust process.
+    /// Explicit tool-use queries retain content for their detailed diff.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when SQLite cannot prepare or execute the query, or a
+    /// stored row cannot be converted into a statistics record.
+    pub fn records_for_diff(
+        &self,
+        session_id: &str,
+        tool_use_id: Option<&str>,
+    ) -> StatsResult<DiffRecords> {
+        match tool_use_id {
+            Some(tool_use_id) => self.records_for_tool_diff(session_id, tool_use_id),
+            None => self.records_for_session_diff(session_id),
+        }
+    }
+
+    fn records_for_tool_diff(
+        &self,
+        session_id: &str,
+        tool_use_id: &str,
+    ) -> StatsResult<DiffRecords> {
+        let conn = self.lock_conn();
+        let newest_first = format!(
+            "SELECT {} FROM stats
+             WHERE session_id = ? AND tool_use_id = ?
+             ORDER BY id DESC LIMIT ?",
+            Self::SELECT_COLS
+        );
+        let mut stmt = conn.prepare(&newest_first)?;
+        let rows = stmt.query_map(
+            rusqlite::params![session_id, tool_use_id, Self::DEFAULT_LIMIT as i64],
+            Self::row_to_record,
+        )?;
+        let mut records = rows
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(StatsError::from)?;
+        Self::sort_diff_records(&mut records);
+        Ok(DiffRecords::from_records(records))
+    }
+
+    fn records_for_session_diff(&self, session_id: &str) -> StatsResult<DiffRecords> {
+        let conn = self.lock_conn();
+        let query = "
+            WITH newest AS (
+                SELECT id
+                FROM stats
+                WHERE session_id = ?
+                ORDER BY id DESC
+                LIMIT ?
+            ),
+            ordered AS (
+                SELECT
+                    stats.id, stats.timestamp, stats.operation, stats.agent_id,
+                    stats.source_pid, stats.session_id, stats.tool_use_id,
+                    stats.before_chars, stats.before_tokens, stats.after_chars,
+                    stats.after_tokens, stats.mode, stats.stash_writes,
+                    stats.stash_errors, stats.stash_size,
+                    LAG(stats.id) OVER (
+                        PARTITION BY stats.tool_use_id
+                        ORDER BY stats.timestamp, stats.id
+                    ) AS previous_id
+                FROM stats
+                INNER JOIN newest ON newest.id = stats.id
+            )
+            SELECT
+                ordered.id, ordered.timestamp, ordered.operation, ordered.agent_id,
+                ordered.source_pid, ordered.session_id, ordered.tool_use_id,
+                ordered.before_chars, ordered.before_tokens, ordered.after_chars,
+                ordered.after_tokens,
+                NULL AS before_text, NULL AS after_text,
+                NULL AS before_output, NULL AS after_output,
+                ordered.mode, ordered.stash_writes, ordered.stash_errors,
+                ordered.stash_size,
+                CASE
+                    WHEN ordered.tool_use_id IS NOT NULL
+                        AND COALESCE(previous.mode, 'active')
+                            NOT IN ('dry-run', 'dryrun')
+                        AND COALESCE(current.mode, 'active')
+                            NOT IN ('dry-run', 'dryrun')
+                        AND (
+                            CASE
+                                WHEN previous.operation = 'rewrite-command'
+                                    AND previous.before_output IS NOT NULL
+                                    AND previous.after_output IS NOT NULL
+                                THEN previous.after_output
+                                WHEN previous.before_text IS NOT NULL
+                                    AND previous.after_text IS NOT NULL
+                                THEN previous.after_text
+                            END
+                        ) = (
+                            CASE
+                                WHEN current.operation = 'rewrite-command'
+                                    AND current.before_output IS NOT NULL
+                                    AND current.after_output IS NOT NULL
+                                THEN current.before_output
+                                WHEN current.before_text IS NOT NULL
+                                    AND current.after_text IS NOT NULL
+                                THEN current.before_text
+                            END
+                        )
+                    THEN 1
+                    ELSE 0
+                END AS linked_to_previous
+            FROM ordered
+            INNER JOIN stats AS current ON current.id = ordered.id
+            LEFT JOIN stats AS previous ON previous.id = ordered.previous_id
+            ORDER BY ordered.timestamp, ordered.id
+        ";
+        let mut stmt = conn.prepare(query)?;
+        let rows = stmt.query_map(
+            rusqlite::params![session_id, Self::DEFAULT_LIMIT as i64],
+            |row| {
+                let record = Self::row_to_record(row)?;
+                let linked_to_previous = row.get::<_, i64>(19)? != 0;
+                Ok((record, linked_to_previous))
+            },
+        )?;
+        let mut records = Vec::new();
+        let mut linked_to_previous = HashSet::new();
+        for row in rows {
+            let (record, is_linked) = row?;
+            if is_linked {
+                linked_to_previous.insert(record.id);
+            }
+            records.push(record);
+        }
+        Ok(DiffRecords::from_prelinked(records, linked_to_previous))
+    }
+
+    fn sort_diff_records(records: &mut [StatsRecord]) {
+        records.sort_by(|left, right| {
+            left.timestamp
+                .cmp(&right.timestamp)
+                .then_with(|| left.id.cmp(&right.id))
+        });
     }
 
     /// Get record count

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -88,6 +88,10 @@ impl StatsRecorder {
             "CREATE INDEX IF NOT EXISTS idx_session_id ON stats(session_id)",
             [],
         )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_tool ON stats(session_id, tool_use_id)",
+            [],
+        )?;
 
         // Schema migration: add columns introduced after the initial schema if
         // missing. Use PRAGMA table_info to check column existence before
@@ -258,6 +262,58 @@ impl StatsRecorder {
         ))?;
         let rows = stmt.query_map(rusqlite::params![session_id, n as i64], Self::row_to_record)?;
         Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Queries the newest records used to build a session or tool-use diff.
+    ///
+    /// Results are returned oldest first so callers can validate consecutive
+    /// before/after content. The internal cap bounds memory for long-running
+    /// sessions while retaining the most recent records.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when SQLite cannot prepare or execute the query, or a
+    /// stored row cannot be converted into a statistics record.
+    pub fn records_for_diff(
+        &self,
+        session_id: &str,
+        tool_use_id: Option<&str>,
+    ) -> StatsResult<Vec<StatsRecord>> {
+        let conn = self.lock_conn();
+        let newest_first = match tool_use_id {
+            Some(_) => format!(
+                "SELECT {} FROM stats
+                 WHERE session_id = ? AND tool_use_id = ?
+                 ORDER BY id DESC LIMIT ?",
+                Self::SELECT_COLS
+            ),
+            None => format!(
+                "SELECT {} FROM stats
+                 WHERE session_id = ?
+                 ORDER BY id DESC LIMIT ?",
+                Self::SELECT_COLS
+            ),
+        };
+        let mut stmt = conn.prepare(&newest_first)?;
+        let rows = match tool_use_id {
+            Some(tool_use_id) => stmt.query_map(
+                rusqlite::params![session_id, tool_use_id, Self::DEFAULT_LIMIT as i64],
+                Self::row_to_record,
+            )?,
+            None => stmt.query_map(
+                rusqlite::params![session_id, Self::DEFAULT_LIMIT as i64],
+                Self::row_to_record,
+            )?,
+        };
+        let mut records = rows
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(StatsError::from)?;
+        records.sort_by(|left, right| {
+            left.timestamp
+                .cmp(&right.timestamp)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        Ok(records)
     }
 
     /// Get record count

--- a/src/tokenless/crates/tokenless-stats/src/tests/diff_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/diff_tests.rs
@@ -1,0 +1,553 @@
+use chrono::{Duration, Local};
+
+fn sample_record(
+    id: i64,
+    operation: OperationType,
+    before: &str,
+    after: &str,
+    tokens: (usize, usize),
+    tool_use_id: Option<&str>,
+    mode: CompressionMode,
+) -> StatsRecord {
+    let mut record = StatsRecord::new(
+        operation,
+        "test-agent".to_string(),
+        before.len(),
+        tokens.0,
+        after.len(),
+        tokens.1,
+    )
+    .with_session_id("session-1")
+    .with_text(before.to_string(), after.to_string())
+    .with_mode(mode);
+    record.id = id;
+    record.timestamp = Local::now() + Duration::seconds(id);
+    if let Some(tool_use_id) = tool_use_id {
+        record = record.with_tool_use_id(tool_use_id);
+    }
+    record
+}
+
+fn diff_records(records: Vec<StatsRecord>) -> DiffRecords {
+    DiffRecords::from_records(records)
+}
+
+#[test]
+fn record_report_contains_structured_hunks() {
+    let record = sample_record(
+        1,
+        OperationType::CompressResponse,
+        "keep\nremove\n",
+        "keep\nreplace\n",
+        (20, 12),
+        Some("tool-1"),
+        CompressionMode::Active,
+    );
+    let report = record_report(&record, 3);
+    let json = serde_json::to_value(&report).unwrap();
+
+    assert_eq!(json["schema_version"], "1.0");
+    assert_eq!(json["scope"]["kind"], "record");
+    assert_eq!(json["chains"][0]["saved_tokens"], 8);
+    let lines = json["chains"][0]["diff"]["hunks"][0]["lines"]
+        .as_array()
+        .unwrap();
+    assert!(lines.iter().any(|line| line["kind"] == "delete"));
+    assert!(lines.iter().any(|line| line["kind"] == "insert"));
+    assert!(!serde_json::to_string(&report).unwrap().contains("\u{1b}["));
+}
+
+#[test]
+fn record_report_respects_zero_context() {
+    let record = sample_record(
+        90,
+        OperationType::CompressResponse,
+        "unchanged before\nremoved\nunchanged after\n",
+        "unchanged before\ninserted\nunchanged after\n",
+        (20, 12),
+        Some("tool-context"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 0)).unwrap();
+    let lines = json["chains"][0]["diff"]["hunks"][0]["lines"]
+        .as_array()
+        .unwrap();
+
+    assert!(lines.iter().all(|line| line["kind"] != "context"));
+}
+
+#[test]
+fn record_report_truncates_rendered_hunks() {
+    let before = (0..600)
+        .flat_map(|index| [format!("before-{index}"), format!("keep-{index}")])
+        .collect::<Vec<_>>()
+        .join("\n");
+    let after = (0..600)
+        .flat_map(|index| [format!("after-{index}"), format!("keep-{index}")])
+        .collect::<Vec<_>>()
+        .join("\n");
+    let record = sample_record(
+        91,
+        OperationType::CompressResponse,
+        &before,
+        &after,
+        (1_000, 500),
+        Some("tool-truncated"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+    let line_count: usize = json["chains"][0]["diff"]["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hunk| hunk["lines"].as_array().unwrap().len())
+        .sum();
+
+    assert_eq!(json["chains"][0]["diff"]["truncated"], true);
+    assert_eq!(line_count, MAX_DIFF_LINES);
+    for hunk in json["chains"][0]["diff"]["hunks"].as_array().unwrap() {
+        let lines = hunk["lines"].as_array().unwrap();
+        let old_len = lines
+            .iter()
+            .filter(|line| !line["old_line"].is_null())
+            .count() as u64;
+        let new_len = lines
+            .iter()
+            .filter(|line| !line["new_line"].is_null())
+            .count() as u64;
+        assert_eq!(hunk["old_len"].as_u64(), Some(old_len));
+        assert_eq!(hunk["new_len"].as_u64(), Some(new_len));
+        if let Some(first_old_line) = lines.iter().find_map(|line| line["old_line"].as_u64()) {
+            assert_eq!(hunk["old_start"].as_u64(), Some(first_old_line));
+        }
+        if let Some(first_new_line) = lines.iter().find_map(|line| line["new_line"].as_u64()) {
+            assert_eq!(hunk["new_start"].as_u64(), Some(first_new_line));
+        }
+    }
+}
+
+#[test]
+fn record_report_normalizes_json_for_display() {
+    let record = sample_record(
+        2,
+        OperationType::CompressResponse,
+        r#"{"b":2,"a":1}"#,
+        r#"{"a":1}"#,
+        (8, 4),
+        None,
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 1)).unwrap();
+
+    assert_eq!(json["chains"][0]["diff"]["normalization"], "json");
+    let formatted = format_diff_report(&record_report(&record, 1), false);
+    assert!(formatted.contains("JSON normalized for display"));
+}
+
+#[test]
+fn record_report_normalizes_json_scalars_for_display() {
+    let record = sample_record(
+        92,
+        OperationType::CompressResponse,
+        " 42 ",
+        "42",
+        (2, 1),
+        None,
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 1)).unwrap();
+
+    assert_eq!(json["chains"][0]["diff"]["normalization"], "json");
+    assert_eq!(
+        json["chains"][0]["diff"]["hunks"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn terminal_report_escapes_content_control_characters() {
+    let record = sample_record(
+        93,
+        OperationType::CompressResponse,
+        "safe\n\u{1b}[2Jdanger\n",
+        "safe\nclean\n",
+        (10, 4),
+        None,
+        CompressionMode::Active,
+    );
+    let formatted = format_diff_report(&record_report(&record, 1), false);
+
+    assert!(!formatted.contains('\u{1b}'));
+    assert!(formatted.contains("danger"));
+}
+
+#[test]
+fn terminal_report_escapes_persisted_metadata() {
+    let mut record = sample_record(
+        94,
+        OperationType::CompressResponse,
+        "before",
+        "after",
+        (10, 4),
+        Some("tool\u{1b}]0;TOOL\u{7}"),
+        CompressionMode::Active,
+    );
+    record.agent_id = "agent\u{1b}]0;AGENT\u{7}".to_string();
+    record.session_id = Some("session\u{1b}]0;SESSION\u{7}".to_string());
+
+    let detailed = format_diff_report(&record_report(&record, 1), false);
+    let session = format_diff_report(
+        &session_report(
+            &diff_records(vec![record]),
+            "session\u{1b}]0;SESSION\u{7}",
+            20,
+            DiffSort::Saved,
+        ),
+        false,
+    );
+
+    for formatted in [detailed, session] {
+        assert!(!formatted.contains('\u{1b}'));
+        assert!(!formatted.contains('\u{7}'));
+        assert!(formatted.contains("SESSION"));
+    }
+}
+
+#[test]
+fn record_report_marks_missing_content() {
+    let mut record = sample_record(
+        3,
+        OperationType::CompressSchema,
+        "before",
+        "after",
+        (10, 4),
+        None,
+        CompressionMode::Active,
+    );
+    record.after_text = None;
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+
+    assert_eq!(
+        json["chains"][0]["diff"]["omitted_reason"],
+        "missing-content"
+    );
+    assert_eq!(json["chains"][0]["diff"]["available"], false);
+}
+
+#[test]
+fn record_report_omits_oversized_content() {
+    let before = "x".repeat(MAX_DIFF_INPUT_BYTES + 1);
+    let record = sample_record(
+        4,
+        OperationType::CompressResponse,
+        &before,
+        "small",
+        (300_000, 2),
+        None,
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+
+    assert_eq!(
+        json["chains"][0]["diff"]["omitted_reason"],
+        "content-too-large"
+    );
+}
+
+#[test]
+fn active_stages_link_without_double_counting_intermediate_tokens() {
+    let first = sample_record(
+        10,
+        OperationType::RewriteCommand,
+        "raw output",
+        "filtered",
+        (100, 60),
+        Some("tool-chain"),
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        11,
+        OperationType::CompressResponse,
+        "filtered",
+        "short",
+        (60, 30),
+        Some("tool-chain"),
+        CompressionMode::Active,
+    );
+    let report = tool_use_report(
+        &diff_records(vec![second, first]),
+        "session-1",
+        "tool-chain",
+        3,
+    );
+    let json = serde_json::to_value(report).unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 1);
+    assert_eq!(json["chains"][0]["status"], "linked");
+    assert_eq!(json["chains"][0]["before_tokens"], 100);
+    assert_eq!(json["chains"][0]["after_tokens"], 30);
+    assert_eq!(json["chains"][0]["saved_tokens"], 70);
+    assert_eq!(json["chains"][0]["stages"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn disconnected_records_for_same_tool_are_split() {
+    let first = sample_record(
+        20,
+        OperationType::CompressResponse,
+        "one",
+        "two",
+        (20, 10),
+        Some("tool-split"),
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        21,
+        OperationType::CompressToon,
+        "different",
+        "three",
+        (10, 5),
+        Some("tool-split"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(tool_use_report(
+        &diff_records(vec![first, second]),
+        "session-1",
+        "tool-split",
+        3,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+    assert_eq!(json["split_chains"], true);
+}
+
+#[test]
+fn records_without_tool_ids_remain_standalone() {
+    let first = sample_record(
+        30,
+        OperationType::CompressSchema,
+        "one",
+        "two",
+        (20, 10),
+        None,
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        31,
+        OperationType::CompressSchema,
+        "two",
+        "three",
+        (10, 5),
+        None,
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(session_report(
+        &diff_records(vec![first, second]),
+        "session-1",
+        20,
+        DiffSort::Saved,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+    assert!(json["chains"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|chain| chain["status"] == "standalone"));
+}
+
+#[test]
+fn dry_run_records_do_not_link_and_report_emitted_input() {
+    let first = sample_record(
+        40,
+        OperationType::CompressResponse,
+        "raw",
+        "predicted",
+        (100, 40),
+        Some("tool-dry"),
+        CompressionMode::DryRun,
+    );
+    let second = sample_record(
+        41,
+        OperationType::CompressToon,
+        "predicted",
+        "smaller",
+        (40, 20),
+        Some("tool-dry"),
+        CompressionMode::DryRun,
+    );
+    let json = serde_json::to_value(tool_use_report(
+        &diff_records(vec![first, second]),
+        "session-1",
+        "tool-dry",
+        3,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+    assert_eq!(json["chains"][0]["emitted_tokens"], 100);
+    assert_eq!(json["chains"][1]["emitted_tokens"], 40);
+}
+
+#[test]
+fn mode_changes_split_otherwise_matching_records() {
+    let first = sample_record(
+        50,
+        OperationType::CompressResponse,
+        "raw",
+        "middle",
+        (100, 50),
+        Some("tool-mode"),
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        51,
+        OperationType::CompressToon,
+        "middle",
+        "small",
+        (50, 20),
+        Some("tool-mode"),
+        CompressionMode::DryRun,
+    );
+    let json = serde_json::to_value(tool_use_report(
+        &diff_records(vec![first, second]),
+        "session-1",
+        "tool-mode",
+        3,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn rewrite_command_prefers_output_fields() {
+    let mut record = sample_record(
+        60,
+        OperationType::RewriteCommand,
+        "legacy before",
+        "legacy after",
+        (100, 10),
+        Some("tool-output"),
+        CompressionMode::Active,
+    );
+    record.before_output = Some("actual before".to_string());
+    record.after_output = Some("actual after".to_string());
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+    let lines = json["chains"][0]["diff"]["hunks"][0]["lines"]
+        .as_array()
+        .unwrap();
+
+    assert!(lines
+        .iter()
+        .any(|line| line["text"] == "actual before"));
+    assert!(!lines
+        .iter()
+        .any(|line| line["text"] == "legacy before"));
+}
+
+#[test]
+fn stage_json_includes_stash_metrics_when_recorded() {
+    let record = sample_record(
+        65,
+        OperationType::CompressResponse,
+        "before",
+        "after",
+        (100, 50),
+        Some("tool-stash"),
+        CompressionMode::Active,
+    )
+    .with_stash(Some(2), Some(0), Some(9));
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+    let stash = &json["chains"][0]["stages"][0]["stash"];
+
+    assert_eq!(stash["writes"], 2);
+    assert_eq!(stash["errors"], 0);
+    assert_eq!(stash["size"], 9);
+}
+
+#[test]
+fn session_report_sorts_by_savings_and_applies_chain_limit() {
+    let small = sample_record(
+        70,
+        OperationType::CompressSchema,
+        "small before",
+        "small after",
+        (20, 10),
+        Some("small"),
+        CompressionMode::Active,
+    );
+    let large = sample_record(
+        71,
+        OperationType::CompressSchema,
+        "large before",
+        "large after",
+        (200, 20),
+        Some("large"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(session_report(
+        &diff_records(vec![small, large]),
+        "session-1",
+        1,
+        DiffSort::Saved,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 1);
+    assert_eq!(json["chains"][0]["tool_use_id"], "large");
+    assert!(json["chains"][0].get("diff").is_none());
+}
+
+#[test]
+fn session_report_can_sort_by_latest_time() {
+    let older = sample_record(
+        72,
+        OperationType::CompressSchema,
+        "older before",
+        "older after",
+        (200, 20),
+        Some("older"),
+        CompressionMode::Active,
+    );
+    let newer = sample_record(
+        73,
+        OperationType::CompressSchema,
+        "newer before",
+        "newer after",
+        (20, 10),
+        Some("newer"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(session_report(
+        &diff_records(vec![older, newer]),
+        "session-1",
+        20,
+        DiffSort::Time,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"][0]["tool_use_id"], "newer");
+}
+
+#[test]
+fn terminal_color_is_opt_in() {
+    let record = sample_record(
+        80,
+        OperationType::CompressResponse,
+        "before",
+        "after",
+        (10, 5),
+        None,
+        CompressionMode::Active,
+    );
+    let report = record_report(&record, 3);
+
+    assert!(!format_diff_report(&report, false).contains("\u{1b}["));
+    assert!(format_diff_report(&report, true).contains("\u{1b}["));
+}

--- a/src/tokenless/crates/tokenless-stats/src/tests/diff_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/diff_tests.rs
@@ -1,0 +1,502 @@
+use chrono::{Duration, Local};
+
+fn sample_record(
+    id: i64,
+    operation: OperationType,
+    before: &str,
+    after: &str,
+    tokens: (usize, usize),
+    tool_use_id: Option<&str>,
+    mode: CompressionMode,
+) -> StatsRecord {
+    let mut record = StatsRecord::new(
+        operation,
+        "test-agent".to_string(),
+        before.len(),
+        tokens.0,
+        after.len(),
+        tokens.1,
+    )
+    .with_session_id("session-1")
+    .with_text(before.to_string(), after.to_string())
+    .with_mode(mode);
+    record.id = id;
+    record.timestamp = Local::now() + Duration::seconds(id);
+    if let Some(tool_use_id) = tool_use_id {
+        record = record.with_tool_use_id(tool_use_id);
+    }
+    record
+}
+
+#[test]
+fn record_report_contains_structured_hunks() {
+    let record = sample_record(
+        1,
+        OperationType::CompressResponse,
+        "keep\nremove\n",
+        "keep\nreplace\n",
+        (20, 12),
+        Some("tool-1"),
+        CompressionMode::Active,
+    );
+    let report = record_report(&record, 3);
+    let json = serde_json::to_value(&report).unwrap();
+
+    assert_eq!(json["schema_version"], "1.0");
+    assert_eq!(json["scope"]["kind"], "record");
+    assert_eq!(json["chains"][0]["saved_tokens"], 8);
+    let lines = json["chains"][0]["diff"]["hunks"][0]["lines"]
+        .as_array()
+        .unwrap();
+    assert!(lines.iter().any(|line| line["kind"] == "delete"));
+    assert!(lines.iter().any(|line| line["kind"] == "insert"));
+    assert!(!serde_json::to_string(&report).unwrap().contains("\u{1b}["));
+}
+
+#[test]
+fn record_report_respects_zero_context() {
+    let record = sample_record(
+        90,
+        OperationType::CompressResponse,
+        "unchanged before\nremoved\nunchanged after\n",
+        "unchanged before\ninserted\nunchanged after\n",
+        (20, 12),
+        Some("tool-context"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 0)).unwrap();
+    let lines = json["chains"][0]["diff"]["hunks"][0]["lines"]
+        .as_array()
+        .unwrap();
+
+    assert!(lines.iter().all(|line| line["kind"] != "context"));
+}
+
+#[test]
+fn record_report_truncates_rendered_hunks() {
+    let before = (0..600)
+        .map(|index| format!("before-{index}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let after = (0..600)
+        .map(|index| format!("after-{index}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let record = sample_record(
+        91,
+        OperationType::CompressResponse,
+        &before,
+        &after,
+        (1_000, 500),
+        Some("tool-truncated"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+    let line_count: usize = json["chains"][0]["diff"]["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hunk| hunk["lines"].as_array().unwrap().len())
+        .sum();
+
+    assert_eq!(json["chains"][0]["diff"]["truncated"], true);
+    assert_eq!(line_count, MAX_DIFF_LINES);
+    for hunk in json["chains"][0]["diff"]["hunks"].as_array().unwrap() {
+        let lines = hunk["lines"].as_array().unwrap();
+        let old_len = lines
+            .iter()
+            .filter(|line| !line["old_line"].is_null())
+            .count() as u64;
+        let new_len = lines
+            .iter()
+            .filter(|line| !line["new_line"].is_null())
+            .count() as u64;
+        assert_eq!(hunk["old_len"].as_u64(), Some(old_len));
+        assert_eq!(hunk["new_len"].as_u64(), Some(new_len));
+    }
+}
+
+#[test]
+fn record_report_normalizes_json_for_display() {
+    let record = sample_record(
+        2,
+        OperationType::CompressResponse,
+        r#"{"b":2,"a":1}"#,
+        r#"{"a":1}"#,
+        (8, 4),
+        None,
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 1)).unwrap();
+
+    assert_eq!(json["chains"][0]["diff"]["normalization"], "json");
+    let formatted = format_diff_report(&record_report(&record, 1), false);
+    assert!(formatted.contains("JSON normalized for display"));
+}
+
+#[test]
+fn record_report_normalizes_json_scalars_for_display() {
+    let record = sample_record(
+        92,
+        OperationType::CompressResponse,
+        " 42 ",
+        "42",
+        (2, 1),
+        None,
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 1)).unwrap();
+
+    assert_eq!(json["chains"][0]["diff"]["normalization"], "json");
+    assert_eq!(
+        json["chains"][0]["diff"]["hunks"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn terminal_report_escapes_content_control_characters() {
+    let record = sample_record(
+        93,
+        OperationType::CompressResponse,
+        "safe\n\u{1b}[2Jdanger\n",
+        "safe\nclean\n",
+        (10, 4),
+        None,
+        CompressionMode::Active,
+    );
+    let formatted = format_diff_report(&record_report(&record, 1), false);
+
+    assert!(!formatted.contains('\u{1b}'));
+    assert!(formatted.contains("danger"));
+}
+
+#[test]
+fn record_report_marks_missing_content() {
+    let mut record = sample_record(
+        3,
+        OperationType::CompressSchema,
+        "before",
+        "after",
+        (10, 4),
+        None,
+        CompressionMode::Active,
+    );
+    record.after_text = None;
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+
+    assert_eq!(
+        json["chains"][0]["diff"]["omitted_reason"],
+        "missing-content"
+    );
+    assert_eq!(json["chains"][0]["diff"]["available"], false);
+}
+
+#[test]
+fn record_report_omits_oversized_content() {
+    let before = "x".repeat(MAX_DIFF_INPUT_BYTES + 1);
+    let record = sample_record(
+        4,
+        OperationType::CompressResponse,
+        &before,
+        "small",
+        (300_000, 2),
+        None,
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+
+    assert_eq!(
+        json["chains"][0]["diff"]["omitted_reason"],
+        "content-too-large"
+    );
+}
+
+#[test]
+fn active_stages_link_without_double_counting_intermediate_tokens() {
+    let first = sample_record(
+        10,
+        OperationType::RewriteCommand,
+        "raw output",
+        "filtered",
+        (100, 60),
+        Some("tool-chain"),
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        11,
+        OperationType::CompressResponse,
+        "filtered",
+        "short",
+        (60, 30),
+        Some("tool-chain"),
+        CompressionMode::Active,
+    );
+    let report = tool_use_report(&[second, first], "session-1", "tool-chain", 3);
+    let json = serde_json::to_value(report).unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 1);
+    assert_eq!(json["chains"][0]["status"], "linked");
+    assert_eq!(json["chains"][0]["before_tokens"], 100);
+    assert_eq!(json["chains"][0]["after_tokens"], 30);
+    assert_eq!(json["chains"][0]["saved_tokens"], 70);
+    assert_eq!(json["chains"][0]["stages"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn disconnected_records_for_same_tool_are_split() {
+    let first = sample_record(
+        20,
+        OperationType::CompressResponse,
+        "one",
+        "two",
+        (20, 10),
+        Some("tool-split"),
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        21,
+        OperationType::CompressToon,
+        "different",
+        "three",
+        (10, 5),
+        Some("tool-split"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(tool_use_report(
+        &[first, second],
+        "session-1",
+        "tool-split",
+        3,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+    assert_eq!(json["split_chains"], true);
+}
+
+#[test]
+fn records_without_tool_ids_remain_standalone() {
+    let first = sample_record(
+        30,
+        OperationType::CompressSchema,
+        "one",
+        "two",
+        (20, 10),
+        None,
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        31,
+        OperationType::CompressSchema,
+        "two",
+        "three",
+        (10, 5),
+        None,
+        CompressionMode::Active,
+    );
+    let json =
+        serde_json::to_value(session_report(&[first, second], "session-1", 20, DiffSort::Saved))
+            .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+    assert!(json["chains"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|chain| chain["status"] == "standalone"));
+}
+
+#[test]
+fn dry_run_records_do_not_link_and_report_emitted_input() {
+    let first = sample_record(
+        40,
+        OperationType::CompressResponse,
+        "raw",
+        "predicted",
+        (100, 40),
+        Some("tool-dry"),
+        CompressionMode::DryRun,
+    );
+    let second = sample_record(
+        41,
+        OperationType::CompressToon,
+        "predicted",
+        "smaller",
+        (40, 20),
+        Some("tool-dry"),
+        CompressionMode::DryRun,
+    );
+    let json = serde_json::to_value(tool_use_report(
+        &[first, second],
+        "session-1",
+        "tool-dry",
+        3,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+    assert_eq!(json["chains"][0]["emitted_tokens"], 100);
+    assert_eq!(json["chains"][1]["emitted_tokens"], 40);
+}
+
+#[test]
+fn mode_changes_split_otherwise_matching_records() {
+    let first = sample_record(
+        50,
+        OperationType::CompressResponse,
+        "raw",
+        "middle",
+        (100, 50),
+        Some("tool-mode"),
+        CompressionMode::Active,
+    );
+    let second = sample_record(
+        51,
+        OperationType::CompressToon,
+        "middle",
+        "small",
+        (50, 20),
+        Some("tool-mode"),
+        CompressionMode::DryRun,
+    );
+    let json = serde_json::to_value(tool_use_report(
+        &[first, second],
+        "session-1",
+        "tool-mode",
+        3,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn rewrite_command_prefers_output_fields() {
+    let mut record = sample_record(
+        60,
+        OperationType::RewriteCommand,
+        "legacy before",
+        "legacy after",
+        (100, 10),
+        Some("tool-output"),
+        CompressionMode::Active,
+    );
+    record.before_output = Some("actual before".to_string());
+    record.after_output = Some("actual after".to_string());
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+    let lines = json["chains"][0]["diff"]["hunks"][0]["lines"]
+        .as_array()
+        .unwrap();
+
+    assert!(lines
+        .iter()
+        .any(|line| line["text"] == "actual before"));
+    assert!(!lines
+        .iter()
+        .any(|line| line["text"] == "legacy before"));
+}
+
+#[test]
+fn stage_json_includes_stash_metrics_when_recorded() {
+    let record = sample_record(
+        65,
+        OperationType::CompressResponse,
+        "before",
+        "after",
+        (100, 50),
+        Some("tool-stash"),
+        CompressionMode::Active,
+    )
+    .with_stash(Some(2), Some(0), Some(9));
+    let json = serde_json::to_value(record_report(&record, 3)).unwrap();
+    let stash = &json["chains"][0]["stages"][0]["stash"];
+
+    assert_eq!(stash["writes"], 2);
+    assert_eq!(stash["errors"], 0);
+    assert_eq!(stash["size"], 9);
+}
+
+#[test]
+fn session_report_sorts_by_savings_and_applies_chain_limit() {
+    let small = sample_record(
+        70,
+        OperationType::CompressSchema,
+        "small before",
+        "small after",
+        (20, 10),
+        Some("small"),
+        CompressionMode::Active,
+    );
+    let large = sample_record(
+        71,
+        OperationType::CompressSchema,
+        "large before",
+        "large after",
+        (200, 20),
+        Some("large"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(session_report(
+        &[small, large],
+        "session-1",
+        1,
+        DiffSort::Saved,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 1);
+    assert_eq!(json["chains"][0]["tool_use_id"], "large");
+    assert!(json["chains"][0].get("diff").is_none());
+}
+
+#[test]
+fn session_report_can_sort_by_latest_time() {
+    let older = sample_record(
+        72,
+        OperationType::CompressSchema,
+        "older before",
+        "older after",
+        (200, 20),
+        Some("older"),
+        CompressionMode::Active,
+    );
+    let newer = sample_record(
+        73,
+        OperationType::CompressSchema,
+        "newer before",
+        "newer after",
+        (20, 10),
+        Some("newer"),
+        CompressionMode::Active,
+    );
+    let json = serde_json::to_value(session_report(
+        &[older, newer],
+        "session-1",
+        20,
+        DiffSort::Time,
+    ))
+    .unwrap();
+
+    assert_eq!(json["chains"][0]["tool_use_id"], "newer");
+}
+
+#[test]
+fn terminal_color_is_opt_in() {
+    let record = sample_record(
+        80,
+        OperationType::CompressResponse,
+        "before",
+        "after",
+        (10, 5),
+        None,
+        CompressionMode::Active,
+    );
+    let report = record_report(&record, 3);
+
+    assert!(!format_diff_report(&report, false).contains("\u{1b}["));
+    assert!(format_diff_report(&report, true).contains("\u{1b}["));
+}

--- a/src/tokenless/crates/tokenless-stats/src/tests/recorder_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/recorder_tests.rs
@@ -104,6 +104,150 @@ fn records_by_session_filters() {
 }
 
 #[test]
+fn records_for_diff_filters_tool_and_orders_oldest_first() {
+    let (rec, _dir) = new_recorder();
+    let first = sample(
+        OperationType::CompressResponse,
+        CompressionMode::Active,
+        "session-diff",
+    )
+    .with_tool_use_id("tool-a");
+    let second = sample(
+        OperationType::CompressToon,
+        CompressionMode::Active,
+        "session-diff",
+    )
+    .with_tool_use_id("tool-a");
+    let other = sample(
+        OperationType::CompressSchema,
+        CompressionMode::Active,
+        "session-diff",
+    )
+    .with_tool_use_id("tool-b");
+    let first_id = rec.record(&first).unwrap();
+    let second_id = rec.record(&second).unwrap();
+    rec.record(&other).unwrap();
+
+    let records = rec
+        .records_for_diff("session-diff", Some("tool-a"))
+        .unwrap();
+    assert_eq!(records.as_slice().len(), 2);
+    assert_eq!(records.as_slice()[0].id, first_id);
+    assert_eq!(records.as_slice()[1].id, second_id);
+
+    let session = rec.records_for_diff("session-diff", None).unwrap();
+    assert_eq!(session.as_slice().len(), 3);
+    assert!(
+        session
+            .as_slice()
+            .windows(2)
+            .all(|pair| pair[0].id < pair[1].id)
+    );
+}
+
+#[test]
+fn session_diff_avoids_loading_payloads_and_preserves_links() {
+    let (rec, _dir) = new_recorder();
+    let middle = "middle".repeat(350_000);
+    let first = sample(
+        OperationType::CompressResponse,
+        CompressionMode::Active,
+        "bounded-session",
+    )
+    .with_tool_use_id("tool-chain")
+    .with_text("before".to_string(), middle.clone());
+    let second = sample(
+        OperationType::CompressToon,
+        CompressionMode::Active,
+        "bounded-session",
+    )
+    .with_tool_use_id("tool-chain")
+    .with_text(middle, "after".to_string());
+    rec.record(&first).unwrap();
+    rec.record(&second).unwrap();
+
+    let records = rec.records_for_diff("bounded-session", None).unwrap();
+    assert!(records.as_slice().iter().all(|record| {
+        record.before_text.is_none()
+            && record.after_text.is_none()
+            && record.before_output.is_none()
+            && record.after_output.is_none()
+    }));
+
+    let report = crate::diff::session_report(
+        &records,
+        "bounded-session",
+        20,
+        crate::diff::DiffSort::Saved,
+    );
+    let json = serde_json::to_value(report).unwrap();
+    assert_eq!(json["chains"].as_array().unwrap().len(), 1);
+    assert_eq!(json["chains"][0]["status"], "linked");
+}
+
+#[test]
+fn session_diff_database_linking_matches_record_semantics() {
+    let (rec, _dir) = new_recorder();
+    let first = sample(
+        OperationType::RewriteCommand,
+        CompressionMode::Active,
+        "linked-session",
+    )
+    .with_tool_use_id("tool-chain")
+    .with_text("legacy before".to_string(), "legacy after".to_string())
+    .with_output("raw output".to_string(), "middle".to_string());
+    let second = sample(
+        OperationType::CompressResponse,
+        CompressionMode::Active,
+        "linked-session",
+    )
+    .with_tool_use_id("tool-chain")
+    .with_text("middle".to_string(), "short".to_string());
+    let dry_run = sample(
+        OperationType::CompressToon,
+        CompressionMode::DryRun,
+        "linked-session",
+    )
+    .with_tool_use_id("tool-chain")
+    .with_text("short".to_string(), "predicted".to_string());
+    rec.record(&first).unwrap();
+    rec.record(&second).unwrap();
+    rec.record(&dry_run).unwrap();
+
+    let records = rec.records_for_diff("linked-session", None).unwrap();
+    let report = crate::diff::session_report(
+        &records,
+        "linked-session",
+        20,
+        crate::diff::DiffSort::Time,
+    );
+    let json = serde_json::to_value(report).unwrap();
+
+    assert_eq!(json["chains"].as_array().unwrap().len(), 2);
+    assert_eq!(json["chains"][0]["status"], "standalone");
+    assert_eq!(json["chains"][0]["mode"], "dry-run");
+    assert_eq!(json["chains"][1]["status"], "linked");
+    assert_eq!(json["chains"][1]["stages"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn records_for_diff_caps_to_newest_records() {
+    let (rec, _dir) = new_recorder();
+    for _ in 0..(StatsRecorder::DEFAULT_LIMIT + 1) {
+        rec.record(&sample(
+            OperationType::CompressSchema,
+            CompressionMode::Active,
+            "large-session",
+        ))
+        .unwrap();
+    }
+
+    let records = rec.records_for_diff("large-session", None).unwrap();
+    assert_eq!(records.as_slice().len(), StatsRecorder::DEFAULT_LIMIT);
+    assert_eq!(records.as_slice()[0].id, 2);
+}
+
+#[test]
 fn count_returns_total_records() {
     let (rec, _dir) = new_recorder();
     assert_eq!(rec.count().unwrap(), 0);
@@ -268,6 +412,17 @@ fn schema_migration_adds_missing_columns() {
     let got = rec.record_by_id(id).unwrap().unwrap();
     assert_eq!(got.mode, CompressionMode::Active);
     assert_eq!(got.stash_writes, Some(1));
+
+    let conn = rec.lock_conn();
+    let mut stmt = conn
+        .prepare("SELECT name FROM pragma_index_info('idx_session_tool') ORDER BY seqno")
+        .unwrap();
+    let indexed_columns = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(indexed_columns, ["session_id", "tool_use_id"]);
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-stats/src/tests/recorder_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/recorder_tests.rs
@@ -104,6 +104,60 @@ fn records_by_session_filters() {
 }
 
 #[test]
+fn records_for_diff_filters_tool_and_orders_oldest_first() {
+    let (rec, _dir) = new_recorder();
+    let first = sample(
+        OperationType::CompressResponse,
+        CompressionMode::Active,
+        "session-diff",
+    )
+    .with_tool_use_id("tool-a");
+    let second = sample(
+        OperationType::CompressToon,
+        CompressionMode::Active,
+        "session-diff",
+    )
+    .with_tool_use_id("tool-a");
+    let other = sample(
+        OperationType::CompressSchema,
+        CompressionMode::Active,
+        "session-diff",
+    )
+    .with_tool_use_id("tool-b");
+    let first_id = rec.record(&first).unwrap();
+    let second_id = rec.record(&second).unwrap();
+    rec.record(&other).unwrap();
+
+    let records = rec
+        .records_for_diff("session-diff", Some("tool-a"))
+        .unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].id, first_id);
+    assert_eq!(records[1].id, second_id);
+
+    let session = rec.records_for_diff("session-diff", None).unwrap();
+    assert_eq!(session.len(), 3);
+    assert!(session.windows(2).all(|pair| pair[0].id < pair[1].id));
+}
+
+#[test]
+fn records_for_diff_caps_to_newest_records() {
+    let (rec, _dir) = new_recorder();
+    for _ in 0..(StatsRecorder::DEFAULT_LIMIT + 1) {
+        rec.record(&sample(
+            OperationType::CompressSchema,
+            CompressionMode::Active,
+            "large-session",
+        ))
+        .unwrap();
+    }
+
+    let records = rec.records_for_diff("large-session", None).unwrap();
+    assert_eq!(records.len(), StatsRecorder::DEFAULT_LIMIT);
+    assert_eq!(records[0].id, 2);
+}
+
+#[test]
 fn count_returns_total_records() {
     let (rec, _dir) = new_recorder();
     assert_eq!(rec.count().unwrap(), 0);
@@ -268,6 +322,17 @@ fn schema_migration_adds_missing_columns() {
     let got = rec.record_by_id(id).unwrap().unwrap();
     assert_eq!(got.mode, CompressionMode::Active);
     assert_eq!(got.stash_writes, Some(1));
+
+    let conn = rec.lock_conn();
+    let mut stmt = conn
+        .prepare("SELECT name FROM pragma_index_info('idx_session_tool') ORDER BY seqno")
+        .unwrap();
+    let indexed_columns = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(indexed_columns, ["session_id", "tool_use_id"]);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Adds `tokenless stats diff` for inspecting estimated token savings by record, session, or tool use while preserving the full-content behavior of `stats show`. The implementation builds schema-versioned reports in `tokenless-stats`, links only content-identical active stages, and keeps session overviews metrics-only to avoid bulk content exposure. Detailed modes provide bounded unified diffs, JSON normalization, structured hunks, dry-run emitted/predicted metrics, and stash observability.

## Related Issue

no-issue: implemented from a direct maintainer request

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 460 passed, 2 ignored
- `cargo doc --workspace --no-deps --locked`
- Remote Linux x86_64 smoke test covering active multi-stage chains, dry-run semantics, session privacy, saved/time sorting, limits, exit codes, TTY color handling, and unchanged `stats show` output

## Additional Notes

Token counts remain estimates. Content diffs are omitted when either side exceeds 1 MiB, session reads are capped at 10,000 records, and session overview JSON intentionally contains no hunks.