### PR TITLE
fix(cosh-ng): [shell] keep card submit type-ahead

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/config.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/config.rs
@@ -30,6 +30,11 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigLanguageKeysFooter => {
             "Keys: Left/Right select | Enter choose | Esc cancel"
         }
+        MessageId::CaptureInputRejectedTitle => "Input not delivered",
+        MessageId::CaptureInputRejectedBody => {
+            "Input typed while a card action was processing could not be \
+             delivered safely; please retype it."
+        }
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -94,4 +94,5 @@ collect_message_ids!([
     mcp_registry_ids,
     approval_foreground_interactive_ids,
     approval_turn_extension_ids,
+    capture_notice_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -92,4 +92,5 @@ collect_message_ids!([
     tool_argument_status_ids,
     multiline_entry_ids,
     mcp_registry_ids,
+    capture_notice_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/config.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/config.rs
@@ -30,3 +30,16 @@ macro_rules! config_ids {
         );
     };
 }
+
+// #1913 additions live in a trailing segment so the existing MessageId
+// discriminants (a registered stable runtime interface) never shift.
+macro_rules! capture_notice_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            CaptureInputRejectedTitle,
+            CaptureInputRejectedBody,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -137,10 +137,23 @@ mod tests {
             MessageId::ApprovalReceiptForegroundInteractiveHint as usize,
             836
         );
+        // The #2029 turn-extension segment keeps its pinned discriminants.
         assert_eq!(MessageId::ApprovalTurnExtensionSubject as usize, 837);
         assert_eq!(
             MessageId::ApprovalTurnExtensionUnavailableBody as usize,
+            846
+        );
+        // The #1913 capture-notice segment is the current tail; the tail
+        // ownership assertions move with each appended segment.
+        assert_eq!(MessageId::CaptureInputRejectedTitle as usize, 847);
+        assert_eq!(MessageId::CaptureInputRejectedBody as usize, 848);
+        assert_eq!(
+            MessageId::CaptureInputRejectedBody as usize,
             MessageId::ALL.len() - 1
+        );
+        assert_eq!(
+            MessageId::CaptureInputRejectedTitle as usize,
+            MessageId::ALL.len() - 2
         );
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -131,8 +131,18 @@ mod tests {
         // segment so pre-existing discriminants never shift.
         assert_eq!(MessageId::HelpSummaryMcp as usize, 834);
         assert_eq!(MessageId::SlashMcpTitle as usize, 835);
-        assert_eq!(MessageId::SlashMcpTitle as usize, MessageId::ALL.len() - 1);
-        assert_eq!(MessageId::HelpSummaryMcp as usize, MessageId::ALL.len() - 2);
+        // The #1913 capture-notice segment is the current tail; the tail
+        // ownership assertions move with each appended segment.
+        assert_eq!(MessageId::CaptureInputRejectedTitle as usize, 836);
+        assert_eq!(MessageId::CaptureInputRejectedBody as usize, 837);
+        assert_eq!(
+            MessageId::CaptureInputRejectedBody as usize,
+            MessageId::ALL.len() - 1
+        );
+        assert_eq!(
+            MessageId::CaptureInputRejectedTitle as usize,
+            MessageId::ALL.len() - 2
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/config.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/config.rs
@@ -26,6 +26,10 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigLanguageEnLine => "en-US   英语",
         MessageId::ConfigLanguageZhLine => "zh-CN   简体中文",
         MessageId::ConfigLanguageKeysFooter => "按键: Left/Right 选择 | Enter 确认 | Esc 取消",
+        MessageId::CaptureInputRejectedTitle => "输入未投递",
+        MessageId::CaptureInputRejectedBody => {
+            "卡片操作处理期间键入的内容无法安全投递，请重新输入。"
+        }
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -139,6 +139,13 @@ pub(crate) enum RawInputEvent {
     CaptureOverflow {
         generation: u64,
     },
+    /// Quarantined submit-window bytes were discarded on an unsafe chain
+    /// terminal state (follow-up card, invalidated chain, late arrival);
+    /// the runtime renders a visible rejection notice (#1913).
+    CaptureInputRejected {
+        generation: u64,
+        byte_len: usize,
+    },
     CardFocus(String, usize),
     CardToggle(String, usize),
     CardInput(String, String),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -135,6 +135,13 @@ pub(crate) enum RawInputEvent {
     CaptureOverflow {
         generation: u64,
     },
+    /// Quarantined submit-window bytes were discarded on an unsafe chain
+    /// terminal state (follow-up card, invalidated chain, late arrival);
+    /// the runtime renders a visible rejection notice (#1913).
+    CaptureInputRejected {
+        generation: u64,
+        byte_len: usize,
+    },
     CardFocus(String, usize),
     CardToggle(String, usize),
     CardInput(String, String),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 mod model;
 
-pub(crate) use model::{InputOwnership, RawInputMode};
+pub(crate) use model::{InputOwnership, PostCaptureOwner, RawInputMode};
 pub use model::{PromptGhostCandidate, PromptGhostRoute, RawInputCapture, RawObserverAction};
 
 static CAPTURE_GENERATION: AtomicU64 = AtomicU64::new(1);
@@ -63,6 +63,7 @@ pub(crate) fn update_locked_input_mode(
             generation: *generation,
             next_capture,
             invalidated: false,
+            post_owner: PostCaptureOwner::from_action(action),
         };
         return;
     }
@@ -71,6 +72,7 @@ pub(crate) fn update_locked_input_mode(
         next_capture,
         invalidated,
         generation,
+        post_owner,
         ..
     } = &mut *mode
     {
@@ -82,7 +84,12 @@ pub(crate) fn update_locked_input_mode(
                 *next_capture = Some(next.clone());
             }
             RawObserverAction::CaptureInput(_) => {}
-            _ => *next_capture = None,
+            _ => {
+                *next_capture = None;
+                // The latest acknowledged owner wins, mirroring the
+                // next-capture replacement semantics above.
+                *post_owner = PostCaptureOwner::from_action(action);
+            }
         }
         return;
     }
@@ -120,6 +127,7 @@ pub(crate) fn update_locked_input_mode(
             generation: *generation,
             next_capture: None,
             invalidated: false,
+            post_owner: PostCaptureOwner::from_action(action),
         };
         return;
     }
@@ -210,23 +218,32 @@ pub(crate) fn complete_capture_chain_if_pending(
     true
 }
 
-pub(crate) fn complete_capture_replay(input_mode: &Arc<Mutex<RawInputMode>>, generation: u64) {
+/// Completes a drained chain by installing the observer-acknowledged
+/// post-capture owner (main prompt, delay, raw passthrough, hold) or the
+/// pending next capture. Returns the installed mode so the caller can
+/// route the quarantined replay against the exact owner snapshot.
+pub(crate) fn complete_capture_replay(
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    generation: u64,
+) -> Option<(RawInputMode, PostCaptureOwner)> {
     let Ok(mut mode) = input_mode.lock() else {
-        return;
+        return None;
     };
     let RawInputMode::Draining {
         previous_capture,
         generation: active,
         next_capture,
+        post_owner,
         ..
     } = &*mode
     else {
-        return;
+        return None;
     };
     if *active != generation {
-        return;
+        return None;
     }
     let previous_capture = previous_capture.clone();
+    let post_owner = *post_owner;
     *mode = if let Some(capture) = next_capture.clone() {
         RawInputMode::Capture {
             capture,
@@ -234,11 +251,22 @@ pub(crate) fn complete_capture_replay(input_mode: &Arc<Mutex<RawInputMode>>, gen
             installed_at: std::time::Instant::now(),
         }
     } else {
-        RawInputMode::Terminal {
-            previous_capture,
-            generation,
+        match post_owner {
+            PostCaptureOwner::Delay => new_delay_input_mode(),
+            PostCaptureOwner::RawPassthrough => RawInputMode::RawPassthrough,
+            PostCaptureOwner::Hold => RawInputMode::Hold,
+            // A ghost owner cannot be reconstructed here; the host replays
+            // its pending prompt restore, so land on the terminal state and
+            // let the replay verdict reject instead of driving the ghost.
+            PostCaptureOwner::MainPrompt | PostCaptureOwner::PromptGhost => {
+                RawInputMode::Terminal {
+                    previous_capture,
+                    generation,
+                }
+            }
         }
     };
+    Some((mode.clone(), post_owner))
 }
 
 pub(crate) fn expire_capture_submission(input_mode: &Arc<Mutex<RawInputMode>>, generation: u64) {
@@ -253,6 +281,7 @@ pub(crate) fn expire_capture_submission(input_mode: &Arc<Mutex<RawInputMode>>, g
                 generation,
                 next_capture: None,
                 invalidated: true,
+                post_owner: PostCaptureOwner::MainPrompt,
             };
         } else if let RawInputMode::Draining {
             generation: active,
@@ -282,6 +311,7 @@ pub(crate) fn abandon_active_capture(input_mode: &Arc<Mutex<RawInputMode>>) {
                 generation: *generation,
                 next_capture: None,
                 invalidated: true,
+                post_owner: PostCaptureOwner::MainPrompt,
             };
         }
     }
@@ -524,7 +554,7 @@ mod tests {
             None,
         );
         assert!(!complete_capture_chain_if_pending(&state, generation));
-        complete_capture_replay(&state, generation);
+        let _ = complete_capture_replay(&state, generation);
         assert!(matches!(
             current_raw_input_mode(&state),
             RawInputMode::Capture { capture: active, .. } if active == next_capture
@@ -545,7 +575,7 @@ mod tests {
         let generation = submit_capture(&state, &capture).expect("submitted capture");
         update_input_mode(&state, &RawObserverAction::Continue, Some(generation));
         assert!(!complete_capture_chain_if_pending(&state, generation));
-        complete_capture_replay(&state, generation);
+        let _ = complete_capture_replay(&state, generation);
 
         update_input_mode(
             &state,
@@ -606,7 +636,7 @@ mod tests {
         update_input_mode(&state, &RawObserverAction::Continue, Some(generation));
 
         assert!(!complete_capture_chain_if_pending(&state, generation));
-        complete_capture_replay(&state, generation);
+        let _ = complete_capture_replay(&state, generation);
         assert!(matches!(
             current_raw_input_mode(&state),
             RawInputMode::Terminal { .. }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -104,11 +104,52 @@ pub(crate) enum RawInputMode {
         generation: u64,
         next_capture: Option<RawInputCapture>,
         invalidated: bool,
+        post_owner: PostCaptureOwner,
     },
     Terminal {
         previous_capture: RawInputCapture,
         generation: u64,
     },
+}
+
+/// Input owner acknowledged by the observer for after the capture chain
+/// drains. The drain terminal installs this owner (instead of assuming
+/// the main prompt) so quarantined submit-window bytes replay with the
+/// same routing a live keystroke would get under that owner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PostCaptureOwner {
+    MainPrompt,
+    Delay,
+    RawPassthrough,
+    Hold,
+    /// A prompt ghost cannot be reconstructed from the drain terminal;
+    /// replaying into its interactive Tab/Enter interpreter could submit
+    /// text the user never confirmed, so this owner rejects the replay.
+    PromptGhost,
+}
+
+impl PostCaptureOwner {
+    /// Exhaustive on purpose: a new observer action must pick an owner
+    /// classification before it can follow a submitted capture.
+    pub(crate) fn from_action(action: &RawObserverAction) -> Self {
+        match action {
+            RawObserverAction::DelayShellOutput => Self::Delay,
+            RawObserverAction::RawPassthrough => Self::RawPassthrough,
+            RawObserverAction::HoldShellOutput => Self::Hold,
+            RawObserverAction::RestorePrompt {
+                ghost_text: Some(_),
+                ..
+            } => Self::PromptGhost,
+            RawObserverAction::CaptureInput(_)
+            | RawObserverAction::Continue
+            | RawObserverAction::EmitToPty(_)
+            | RawObserverAction::EmitToPtyWithPromptRestore(_)
+            | RawObserverAction::InterruptForeground
+            | RawObserverAction::RestorePrompt {
+                ghost_text: None, ..
+            } => Self::MainPrompt,
+        }
+    }
 }
 
 /// Input ownership boundary for a [`RawInputMode`]. Display-only updates

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -13,7 +13,7 @@ use super::event_parser::{CandidateLineBuffer, NativeLineState};
 use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::{
     abandon_active_capture, complete_capture_chain_if_pending, complete_capture_replay,
-    current_raw_input_mode, expire_capture_submission, RawInputMode,
+    current_raw_input_mode, expire_capture_submission, PostCaptureOwner, RawInputMode,
 };
 use super::pty::write_all_pty;
 use super::relay::{

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -2,20 +2,50 @@ use super::*;
 
 const CAPTURE_QUARANTINE_MAX_BYTES: usize = 64 * 1024;
 
+/// Submit-window deadline before an unacknowledged capture chain expires.
+/// Production keeps the pre-existing 5s bound: the observer ack normally
+/// lands within milliseconds, and past the bound the chain is invalidated
+/// so the buffered bytes surface as a visible rejection instead of a
+/// silent drop. Tests shrink it so expiry paths stay testable without
+/// real waits, while leaving headroom for ack helpers on loaded CI hosts.
+fn capture_submit_drain_deadline() -> Duration {
+    if cfg!(test) {
+        Duration::from_millis(250)
+    } else {
+        Duration::from_secs(5)
+    }
+}
+
+/// Bounded buffer for bytes that arrive while a submitted capture chain is
+/// still draining. The bytes are retained (not just counted) so a cleanly
+/// finished chain can replay them into the main-prompt owner instead of
+/// silently dropping type-ahead (#1913); unsafe terminal states reject them
+/// with user-visible feedback instead.
 #[derive(Default)]
 pub(super) struct CaptureOwnedInput {
-    bytes: usize,
+    bytes: Vec<u8>,
     overflowed: bool,
 }
 
 impl CaptureOwnedInput {
     fn observe(&mut self, bytes: &[u8]) -> bool {
-        self.bytes = self.bytes.saturating_add(bytes.len());
-        if self.overflowed || self.bytes <= CAPTURE_QUARANTINE_MAX_BYTES {
+        if self.overflowed {
             return false;
         }
-        self.overflowed = true;
-        true
+        if self.bytes.len().saturating_add(bytes.len()) > CAPTURE_QUARANTINE_MAX_BYTES {
+            // Past the cap nothing can be replayed faithfully anymore:
+            // discard the whole batch and report the overflow edge once.
+            self.bytes.clear();
+            self.overflowed = true;
+            return true;
+        }
+        self.bytes.extend_from_slice(bytes);
+        false
+    }
+
+    fn take_bytes(&mut self) -> Vec<u8> {
+        self.overflowed = false;
+        std::mem::take(&mut self.bytes)
     }
 
     fn clear(&mut self) {
@@ -82,6 +112,7 @@ pub(super) fn relay_input_chunk(
                         relay_late_capture_bytes(
                             bytes,
                             expected_generation,
+                            card_state,
                             capture_owned_input,
                             relay,
                         )?;
@@ -101,6 +132,7 @@ pub(super) fn relay_input_chunk(
                         relay_late_capture_bytes(
                             bytes,
                             expected_generation,
+                            card_state,
                             capture_owned_input,
                             relay,
                         )?;
@@ -114,6 +146,7 @@ pub(super) fn relay_input_chunk(
                     relay.native_line_state.clear();
                     drain_capture_submission(
                         result,
+                        card_state,
                         capture_owned_input,
                         deferred_input,
                         read_ahead,
@@ -128,7 +161,7 @@ pub(super) fn relay_input_chunk(
             }
             RawInputMode::Draining { .. } => {
                 card_state.reset();
-                drain_abandoned_capture(capture_owned_input, relay)?;
+                drain_abandoned_capture(card_state, capture_owned_input, relay)?;
                 mode = current_raw_input_mode(relay.input_mode);
             }
             RawInputMode::Hold => {
@@ -176,6 +209,7 @@ pub(super) fn relay_input_chunk(
 
 pub(super) fn drain_capture_submission(
     result: CaptureConsumeResult,
+    card_state: &mut CardInputState,
     capture_owned_input: &mut CaptureOwnedInput,
     deferred_input: &mut Option<InputRead>,
     read_ahead: Option<&Receiver<InputRead>>,
@@ -192,12 +226,16 @@ pub(super) fn drain_capture_submission(
         expire_capture_submission(relay.input_mode, generation);
     }
 
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let chain_invalidated;
+    let deadline = Instant::now() + capture_submit_drain_deadline();
     loop {
         match current_raw_input_mode(relay.input_mode) {
             RawInputMode::Draining {
-                generation: active, ..
+                generation: active,
+                invalidated,
+                ..
             } if active == generation => {
+                chain_invalidated = invalidated;
                 if !overflow {
                     overflow = drain_capture_read_ahead(
                         generation,
@@ -248,23 +286,127 @@ pub(super) fn drain_capture_submission(
                     .send(RawInputEvent::CaptureExpired { generation });
                 expire_capture_submission(relay.input_mode, generation);
             }
-            _ => return Ok(()),
+            _ => {
+                // Ownership cutover mid-wait (e.g. the observer replaced the
+                // draining mode with a prompt ghost): the quarantined bytes
+                // can no longer reach any safe owner, so surface them as a
+                // rejection instead of returning with a silent buffer.
+                reject_quarantined_input(capture_owned_input, generation, relay);
+                return Ok(());
+            }
         }
     }
     if !overflow && complete_capture_chain_if_pending(relay.input_mode, generation) {
-        capture_owned_input.clear();
+        // T2: a follow-up card armed; the no-leak invariant outranks
+        // delivery, so the quarantined bytes are rejected visibly (#1913 D5).
+        reject_quarantined_input(capture_owned_input, generation, relay);
         let _ = relay
             .input_events
             .send(RawInputEvent::CaptureDrained { generation });
         return Ok(());
     }
 
-    capture_owned_input.clear();
-    complete_capture_replay(relay.input_mode, generation);
+    let installed = complete_capture_replay(relay.input_mode, generation);
     let _ = relay
         .input_events
         .send(RawInputEvent::CaptureDrained { generation });
-    Ok(())
+    if overflow || chain_invalidated {
+        // T3/T4: expired or overflowed chains never replay (#1913 D6).
+        reject_quarantined_input(capture_owned_input, generation, relay);
+        return Ok(());
+    }
+    replay_or_reject_after_drain(
+        installed,
+        card_state,
+        capture_owned_input,
+        generation,
+        relay,
+    )
+}
+
+/// Deliver the quarantined bytes to the observer-acknowledged
+/// post-capture owner; they re-enter the relay exactly like live input
+/// read under that owner's snapshot (no PTY bypass, #1913 D4), so a
+/// buffered Ctrl-C under a delay owner still cancels the agent instead
+/// of leaking into bash. Unroutable landings (follow-up capture, prompt
+/// ghost) reject visibly (fail-safe C4).
+fn replay_or_reject_after_drain(
+    installed: Option<(RawInputMode, PostCaptureOwner)>,
+    card_state: &mut CardInputState,
+    capture_owned_input: &mut CaptureOwnedInput,
+    generation: u64,
+    relay: &mut InputRelayContext<'_>,
+) -> io::Result<()> {
+    let bytes = capture_owned_input.take_bytes();
+    if bytes.is_empty() {
+        return Ok(());
+    }
+    // The drain terminal released the mode lock before the Drained event
+    // went out; an observer may have armed a new owner in that window.
+    // Verify live ownership against the installed snapshot before ANY
+    // side effect (delivery or held-control events): a superseded owner
+    // must neither receive these bytes nor have its replacement disturbed
+    // by the dead chain's controls.
+    let owner_alive = installed.as_ref().is_some_and(|(mode, _)| {
+        current_raw_input_mode(relay.input_mode).input_ownership() == mode.input_ownership()
+    });
+    let replay_mode = match installed {
+        Some((mode @ RawInputMode::Terminal { .. }, PostCaptureOwner::MainPrompt))
+        | Some((mode @ RawInputMode::Delay { .. }, PostCaptureOwner::Delay))
+        | Some((mode @ RawInputMode::RawPassthrough, PostCaptureOwner::RawPassthrough))
+            if owner_alive =>
+        {
+            Some(mode)
+        }
+        Some((RawInputMode::Hold, PostCaptureOwner::Hold)) if owner_alive => {
+            // A hold owner has no consumer that could deliver ordinary
+            // text (held input only recognizes cancel controls), so the
+            // batch cannot count as delivered. Preserve the live-typing
+            // cancel semantics for recognized controls, then surface the
+            // batch as a visible rejection.
+            send_held_input_events(&bytes, relay.input_events);
+            None
+        }
+        _ => None,
+    };
+    let Some(mode) = replay_mode else {
+        let _ = relay
+            .input_events
+            .send(RawInputEvent::CaptureInputRejected {
+                generation,
+                byte_len: bytes.len(),
+            });
+        return Ok(());
+    };
+    let mut deferred_input = None;
+    relay_input_chunk(
+        &bytes,
+        mode,
+        card_state,
+        capture_owned_input,
+        &mut deferred_input,
+        None,
+        None,
+        relay,
+    )
+}
+
+/// Discard the quarantined bytes with user-visible feedback; an empty
+/// buffer stays silent (nothing was lost).
+fn reject_quarantined_input(
+    capture_owned_input: &mut CaptureOwnedInput,
+    generation: u64,
+    relay: &mut InputRelayContext<'_>,
+) {
+    let bytes = capture_owned_input.take_bytes();
+    if !bytes.is_empty() {
+        let _ = relay
+            .input_events
+            .send(RawInputEvent::CaptureInputRejected {
+                generation,
+                byte_len: bytes.len(),
+            });
+    }
 }
 
 pub(in super::super) fn relay_late_capture_input(
@@ -277,6 +419,7 @@ pub(in super::super) fn relay_late_capture_input(
     state: &mut RawInputRelayState,
 ) -> io::Result<()> {
     let RawInputRelayState {
+        card_state,
         line_buffer,
         native_line_state,
         exit_tracker,
@@ -300,12 +443,19 @@ pub(in super::super) fn relay_late_capture_input(
         main_prompt_gate,
         slash_route_enabled: *slash_route_enabled,
     };
-    relay_late_capture_bytes(bytes, generation, capture_owned_input, &mut relay)
+    relay_late_capture_bytes(
+        bytes,
+        generation,
+        card_state,
+        capture_owned_input,
+        &mut relay,
+    )
 }
 
 fn relay_late_capture_bytes(
     bytes: &[u8],
     generation: u64,
+    card_state: &mut CardInputState,
     capture_owned_input: &mut CaptureOwnedInput,
     relay: &mut InputRelayContext<'_>,
 ) -> io::Result<()> {
@@ -322,7 +472,27 @@ fn relay_late_capture_bytes(
         _ => None,
     };
     if active_generation != Some(generation) {
-        capture_owned_input.clear();
+        // The chain these bytes were typed against is gone; delivering them
+        // to whatever owns input now would be a leak, so reject visibly
+        // instead of the pre-#1913 silent discard. Orphaned leftovers and
+        // the current batch merge into one rejection so a chain never
+        // stacks duplicate notices.
+        let mut rejected_len = bytes.len();
+        if active_generation.is_none() {
+            // No live chain owns the quarantine buffer anymore: leftover
+            // bytes join the rejection instead of being wiped silently.
+            rejected_len += capture_owned_input.take_bytes().len();
+        }
+        // With a live chain of a different generation the buffer holds that
+        // chain's type-ahead; it keeps its own terminal verdict untouched.
+        if rejected_len > 0 {
+            let _ = relay
+                .input_events
+                .send(RawInputEvent::CaptureInputRejected {
+                    generation,
+                    byte_len: rejected_len,
+                });
+        }
         return Ok(());
     }
 
@@ -347,9 +517,11 @@ fn relay_late_capture_bytes(
 
     match current_raw_input_mode(relay.input_mode) {
         RawInputMode::Capture { .. } | RawInputMode::Submitted { .. } if !overflow => Ok(()),
-        RawInputMode::Draining { .. } => drain_abandoned_capture(capture_owned_input, relay),
+        RawInputMode::Draining { .. } => {
+            drain_abandoned_capture(card_state, capture_owned_input, relay)
+        }
         _ => {
-            capture_owned_input.clear();
+            reject_quarantined_input(capture_owned_input, generation, relay);
             Ok(())
         }
     }
@@ -386,18 +558,36 @@ fn drain_capture_read_ahead(
 }
 
 pub(super) fn drain_abandoned_capture(
+    card_state: &mut CardInputState,
     capture_owned_input: &mut CaptureOwnedInput,
     relay: &mut InputRelayContext<'_>,
 ) -> io::Result<()> {
-    let RawInputMode::Draining { generation, .. } = current_raw_input_mode(relay.input_mode) else {
+    let RawInputMode::Draining {
+        generation,
+        invalidated,
+        ..
+    } = current_raw_input_mode(relay.input_mode)
+    else {
         return Ok(());
     };
-    capture_owned_input.clear();
-    complete_capture_replay(relay.input_mode, generation);
+    let installed = complete_capture_replay(relay.input_mode, generation);
     let _ = relay
         .input_events
         .send(RawInputEvent::CaptureDrained { generation });
-    Ok(())
+    if invalidated {
+        // T3/T6: an invalidated chain never replays (#1913 D6).
+        reject_quarantined_input(capture_owned_input, generation, relay);
+        return Ok(());
+    }
+    // T8: the buffered bytes replay before whatever live input triggered
+    // this drain, preserving arrival order (#1913 C3).
+    replay_or_reject_after_drain(
+        installed,
+        card_state,
+        capture_owned_input,
+        generation,
+        relay,
+    )
 }
 
 pub(in super::super) fn finish_input_relay(
@@ -433,6 +623,7 @@ pub(in super::super) fn finish_input_relay(
         RawInputMode::Draining { .. }
     ) {
         let RawInputRelayState {
+            card_state,
             line_buffer,
             native_line_state,
             exit_tracker,
@@ -455,7 +646,7 @@ pub(in super::super) fn finish_input_relay(
             main_prompt_gate,
             slash_route_enabled: false,
         };
-        drain_abandoned_capture(capture_owned_input, &mut relay)?;
+        drain_abandoned_capture(card_state, capture_owned_input, &mut relay)?;
     }
     // Candidate bytes were never submitted to the Shell. EOF cancels them;
     // flushing a lone `?`, slash prefix, or partial paste delimiter before
@@ -483,147 +674,9 @@ pub(in super::super) fn finish_input_relay(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::fs::{self, OpenOptions};
-    use std::io::{Seek, SeekFrom};
+#[path = "capture_matrix_tests.rs"]
+mod matrix_tests;
 
-    use super::*;
-    use crate::raw_input::RawInputCapture;
-
-    #[test]
-    fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
-        let path = std::env::temp_dir().join(format!(
-            "cosh-shell-capture-cutoff-retry-{}",
-            std::process::id()
-        ));
-        let mut master = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .expect("test output file");
-        let previous = RawInputCapture::Question {
-            id: "q-1".to_string(),
-            option_count: 0,
-            allow_free_text: true,
-            multiple: false,
-            secret: false,
-        };
-        let next = RawInputCapture::Question {
-            id: "q-2".to_string(),
-            option_count: 0,
-            allow_free_text: true,
-            multiple: false,
-            secret: false,
-        };
-        let stale_mode = RawInputMode::Capture {
-            capture: previous.clone(),
-            generation: 41,
-            installed_at: Instant::now(),
-        };
-        let input_mode = Arc::new(Mutex::new(RawInputMode::Draining {
-            previous_capture: previous.clone(),
-            generation: 41,
-            next_capture: Some(next.clone()),
-            invalidated: false,
-        }));
-        let (input_tx, input_rx) = mpsc::channel();
-        let classifier = InputClassifier::default();
-        let mut card_state = CardInputState::default();
-        let mut quarantine = CaptureOwnedInput::default();
-        let mut deferred_input = None;
-        let mut line_buffer = CandidateLineBuffer::default();
-        let mut native_line_state = NativeLineState::default();
-        let mut exit_tracker = ExplicitExitTracker::default();
-        let input_generation = UserPtyInputGeneration::default();
-        let mut line_submits = LineSubmitCounter::default();
-        let main_prompt_gate = super::super::super::MainPromptGate::default();
-        let mut relay = InputRelayContext {
-            master: &mut master,
-            input_classifier: &classifier,
-            input_events: &input_tx,
-            input_mode: &input_mode,
-            input_generation: &input_generation,
-            line_submits: &mut line_submits,
-            line_buffer: &mut line_buffer,
-            native_line_state: &mut native_line_state,
-            exit_tracker: &mut exit_tracker,
-            main_prompt_gate: &main_prompt_gate,
-            slash_route_enabled: false,
-        };
-
-        relay_input_chunk(
-            b"stale",
-            stale_mode,
-            &mut card_state,
-            &mut quarantine,
-            &mut deferred_input,
-            None,
-            Some(41),
-            &mut relay,
-        )
-        .expect("relay stale input");
-
-        assert!(!input_rx
-            .try_iter()
-            .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
-        master.sync_all().expect("sync test output");
-        assert!(fs::read(&path).expect("read test output").is_empty());
-        assert!(matches!(
-            current_raw_input_mode(&input_mode),
-            RawInputMode::Capture {
-                capture: RawInputCapture::Question { id, .. },
-                ..
-            } if id == "q-2"
-        ));
-
-        master.set_len(0).expect("truncate test output");
-        master.seek(SeekFrom::Start(0)).expect("rewind test output");
-        *input_mode.lock().expect("input mode") = RawInputMode::Draining {
-            previous_capture: previous,
-            generation: 41,
-            next_capture: Some(next),
-            invalidated: false,
-        };
-        let draining_snapshot = current_raw_input_mode(&input_mode);
-        let mut card_state = CardInputState::default();
-        let mut quarantine = CaptureOwnedInput::default();
-        let mut deferred_input = None;
-        let mut line_submits = LineSubmitCounter::default();
-        let main_prompt_gate = super::super::super::MainPromptGate::default();
-        let mut relay = InputRelayContext {
-            master: &mut master,
-            input_classifier: &classifier,
-            input_events: &input_tx,
-            input_mode: &input_mode,
-            input_generation: &input_generation,
-            line_submits: &mut line_submits,
-            line_buffer: &mut line_buffer,
-            native_line_state: &mut native_line_state,
-            exit_tracker: &mut exit_tracker,
-            main_prompt_gate: &main_prompt_gate,
-            slash_route_enabled: false,
-        };
-        relay_input_chunk(
-            b"later",
-            draining_snapshot,
-            &mut card_state,
-            &mut quarantine,
-            &mut deferred_input,
-            None,
-            Some(41),
-            &mut relay,
-        )
-        .expect("relay input across draining snapshot");
-        abandon_active_capture(&input_mode);
-        drain_abandoned_capture(&mut quarantine, &mut relay).expect("drain replacement capture");
-
-        assert!(!input_rx
-            .try_iter()
-            .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
-        master.sync_all().expect("sync test output");
-        assert!(fs::read(&path).expect("read test output").is_empty());
-        fs::remove_file(path).ok();
-    }
-}
+#[cfg(test)]
+#[path = "capture_tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -2,20 +2,50 @@ use super::*;
 
 const CAPTURE_QUARANTINE_MAX_BYTES: usize = 64 * 1024;
 
+/// Submit-window deadline before an unacknowledged capture chain expires.
+/// Production keeps the pre-existing 5s bound: the observer ack normally
+/// lands within milliseconds, and past the bound the chain is invalidated
+/// so the buffered bytes surface as a visible rejection instead of a
+/// silent drop. Tests shrink it so expiry paths stay testable without
+/// real waits, while leaving headroom for ack helpers on loaded CI hosts.
+fn capture_submit_drain_deadline() -> Duration {
+    if cfg!(test) {
+        Duration::from_millis(250)
+    } else {
+        Duration::from_secs(5)
+    }
+}
+
+/// Bounded buffer for bytes that arrive while a submitted capture chain is
+/// still draining. The bytes are retained (not just counted) so a cleanly
+/// finished chain can replay them into the main-prompt owner instead of
+/// silently dropping type-ahead (#1913); unsafe terminal states reject them
+/// with user-visible feedback instead.
 #[derive(Default)]
 pub(super) struct CaptureOwnedInput {
-    bytes: usize,
+    bytes: Vec<u8>,
     overflowed: bool,
 }
 
 impl CaptureOwnedInput {
     fn observe(&mut self, bytes: &[u8]) -> bool {
-        self.bytes = self.bytes.saturating_add(bytes.len());
-        if self.overflowed || self.bytes <= CAPTURE_QUARANTINE_MAX_BYTES {
+        if self.overflowed {
             return false;
         }
-        self.overflowed = true;
-        true
+        if self.bytes.len().saturating_add(bytes.len()) > CAPTURE_QUARANTINE_MAX_BYTES {
+            // Past the cap nothing can be replayed faithfully anymore:
+            // discard the whole batch and report the overflow edge once.
+            self.bytes.clear();
+            self.overflowed = true;
+            return true;
+        }
+        self.bytes.extend_from_slice(bytes);
+        false
+    }
+
+    fn take_bytes(&mut self) -> Vec<u8> {
+        self.overflowed = false;
+        std::mem::take(&mut self.bytes)
     }
 
     fn clear(&mut self) {
@@ -82,6 +112,7 @@ pub(super) fn relay_input_chunk(
                         relay_late_capture_bytes(
                             bytes,
                             expected_generation,
+                            card_state,
                             capture_owned_input,
                             relay,
                         )?;
@@ -101,6 +132,7 @@ pub(super) fn relay_input_chunk(
                         relay_late_capture_bytes(
                             bytes,
                             expected_generation,
+                            card_state,
                             capture_owned_input,
                             relay,
                         )?;
@@ -114,6 +146,7 @@ pub(super) fn relay_input_chunk(
                     relay.native_line_state.clear();
                     drain_capture_submission(
                         result,
+                        card_state,
                         capture_owned_input,
                         deferred_input,
                         read_ahead,
@@ -128,7 +161,7 @@ pub(super) fn relay_input_chunk(
             }
             RawInputMode::Draining { .. } => {
                 card_state.reset();
-                drain_abandoned_capture(capture_owned_input, relay)?;
+                drain_abandoned_capture(card_state, capture_owned_input, relay)?;
                 mode = current_raw_input_mode(relay.input_mode);
             }
             RawInputMode::Hold => {
@@ -176,6 +209,7 @@ pub(super) fn relay_input_chunk(
 
 pub(super) fn drain_capture_submission(
     result: CaptureConsumeResult,
+    card_state: &mut CardInputState,
     capture_owned_input: &mut CaptureOwnedInput,
     deferred_input: &mut Option<InputRead>,
     read_ahead: Option<&Receiver<InputRead>>,
@@ -192,12 +226,16 @@ pub(super) fn drain_capture_submission(
         expire_capture_submission(relay.input_mode, generation);
     }
 
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let chain_invalidated;
+    let deadline = Instant::now() + capture_submit_drain_deadline();
     loop {
         match current_raw_input_mode(relay.input_mode) {
             RawInputMode::Draining {
-                generation: active, ..
+                generation: active,
+                invalidated,
+                ..
             } if active == generation => {
+                chain_invalidated = invalidated;
                 if !overflow {
                     overflow = drain_capture_read_ahead(
                         generation,
@@ -252,19 +290,83 @@ pub(super) fn drain_capture_submission(
         }
     }
     if !overflow && complete_capture_chain_if_pending(relay.input_mode, generation) {
-        capture_owned_input.clear();
+        // T2: a follow-up card armed; the no-leak invariant outranks
+        // delivery, so the quarantined bytes are rejected visibly (#1913 D5).
+        reject_quarantined_input(capture_owned_input, generation, relay);
         let _ = relay
             .input_events
             .send(RawInputEvent::CaptureDrained { generation });
         return Ok(());
     }
 
-    capture_owned_input.clear();
     complete_capture_replay(relay.input_mode, generation);
     let _ = relay
         .input_events
         .send(RawInputEvent::CaptureDrained { generation });
+    if overflow || chain_invalidated {
+        // T3/T4: expired or overflowed chains never replay (#1913 D6).
+        reject_quarantined_input(capture_owned_input, generation, relay);
+        return Ok(());
+    }
+    replay_or_reject_after_drain(card_state, capture_owned_input, generation, relay)
+}
+
+/// Deliver the quarantined bytes when the chain landed back at the
+/// main-prompt owner for this generation; the bytes re-enter the relay
+/// exactly like live input read under a Terminal snapshot (no PTY bypass,
+/// #1913 D4). Any other landing rejects visibly (fail-safe C4).
+fn replay_or_reject_after_drain(
+    card_state: &mut CardInputState,
+    capture_owned_input: &mut CaptureOwnedInput,
+    generation: u64,
+    relay: &mut InputRelayContext<'_>,
+) -> io::Result<()> {
+    let bytes = capture_owned_input.take_bytes();
+    if bytes.is_empty() {
+        return Ok(());
+    }
+    let mode = current_raw_input_mode(relay.input_mode);
+    if matches!(
+        mode,
+        RawInputMode::Terminal { generation: active, .. } if active == generation
+    ) {
+        let mut deferred_input = None;
+        return relay_input_chunk(
+            &bytes,
+            mode,
+            card_state,
+            capture_owned_input,
+            &mut deferred_input,
+            None,
+            None,
+            relay,
+        );
+    }
+    let _ = relay
+        .input_events
+        .send(RawInputEvent::CaptureInputRejected {
+            generation,
+            byte_len: bytes.len(),
+        });
     Ok(())
+}
+
+/// Discard the quarantined bytes with user-visible feedback; an empty
+/// buffer stays silent (nothing was lost).
+fn reject_quarantined_input(
+    capture_owned_input: &mut CaptureOwnedInput,
+    generation: u64,
+    relay: &mut InputRelayContext<'_>,
+) {
+    let bytes = capture_owned_input.take_bytes();
+    if !bytes.is_empty() {
+        let _ = relay
+            .input_events
+            .send(RawInputEvent::CaptureInputRejected {
+                generation,
+                byte_len: bytes.len(),
+            });
+    }
 }
 
 pub(in super::super) fn relay_late_capture_input(
@@ -277,6 +379,7 @@ pub(in super::super) fn relay_late_capture_input(
     state: &mut RawInputRelayState,
 ) -> io::Result<()> {
     let RawInputRelayState {
+        card_state,
         line_buffer,
         native_line_state,
         exit_tracker,
@@ -300,12 +403,19 @@ pub(in super::super) fn relay_late_capture_input(
         main_prompt_gate,
         slash_route_enabled: *slash_route_enabled,
     };
-    relay_late_capture_bytes(bytes, generation, capture_owned_input, &mut relay)
+    relay_late_capture_bytes(
+        bytes,
+        generation,
+        card_state,
+        capture_owned_input,
+        &mut relay,
+    )
 }
 
 fn relay_late_capture_bytes(
     bytes: &[u8],
     generation: u64,
+    card_state: &mut CardInputState,
     capture_owned_input: &mut CaptureOwnedInput,
     relay: &mut InputRelayContext<'_>,
 ) -> io::Result<()> {
@@ -322,7 +432,24 @@ fn relay_late_capture_bytes(
         _ => None,
     };
     if active_generation != Some(generation) {
-        capture_owned_input.clear();
+        // The chain these bytes were typed against is gone; delivering them
+        // to whatever owns input now would be a leak, so reject visibly
+        // instead of the pre-#1913 silent discard.
+        if active_generation.is_none() {
+            // No live chain owns the quarantine buffer anymore: any leftover
+            // bytes must surface as a rejection too, never a silent wipe.
+            reject_quarantined_input(capture_owned_input, generation, relay);
+        }
+        // With a live chain of a different generation the buffer holds that
+        // chain's type-ahead; it keeps its own terminal verdict untouched.
+        if !bytes.is_empty() {
+            let _ = relay
+                .input_events
+                .send(RawInputEvent::CaptureInputRejected {
+                    generation,
+                    byte_len: bytes.len(),
+                });
+        }
         return Ok(());
     }
 
@@ -347,9 +474,11 @@ fn relay_late_capture_bytes(
 
     match current_raw_input_mode(relay.input_mode) {
         RawInputMode::Capture { .. } | RawInputMode::Submitted { .. } if !overflow => Ok(()),
-        RawInputMode::Draining { .. } => drain_abandoned_capture(capture_owned_input, relay),
+        RawInputMode::Draining { .. } => {
+            drain_abandoned_capture(card_state, capture_owned_input, relay)
+        }
         _ => {
-            capture_owned_input.clear();
+            reject_quarantined_input(capture_owned_input, generation, relay);
             Ok(())
         }
     }
@@ -386,18 +515,30 @@ fn drain_capture_read_ahead(
 }
 
 pub(super) fn drain_abandoned_capture(
+    card_state: &mut CardInputState,
     capture_owned_input: &mut CaptureOwnedInput,
     relay: &mut InputRelayContext<'_>,
 ) -> io::Result<()> {
-    let RawInputMode::Draining { generation, .. } = current_raw_input_mode(relay.input_mode) else {
+    let RawInputMode::Draining {
+        generation,
+        invalidated,
+        ..
+    } = current_raw_input_mode(relay.input_mode)
+    else {
         return Ok(());
     };
-    capture_owned_input.clear();
     complete_capture_replay(relay.input_mode, generation);
     let _ = relay
         .input_events
         .send(RawInputEvent::CaptureDrained { generation });
-    Ok(())
+    if invalidated {
+        // T3/T6: an invalidated chain never replays (#1913 D6).
+        reject_quarantined_input(capture_owned_input, generation, relay);
+        return Ok(());
+    }
+    // T8: the buffered bytes replay before whatever live input triggered
+    // this drain, preserving arrival order (#1913 C3).
+    replay_or_reject_after_drain(card_state, capture_owned_input, generation, relay)
 }
 
 pub(in super::super) fn finish_input_relay(
@@ -445,6 +586,7 @@ pub(in super::super) fn finish_input_relay(
         RawInputMode::Draining { .. }
     ) {
         let RawInputRelayState {
+            card_state,
             line_buffer,
             native_line_state,
             exit_tracker,
@@ -467,7 +609,7 @@ pub(in super::super) fn finish_input_relay(
             main_prompt_gate,
             slash_route_enabled: false,
         };
-        drain_abandoned_capture(capture_owned_input, &mut relay)?;
+        drain_abandoned_capture(card_state, capture_owned_input, &mut relay)?;
     }
     // Bytes held as a possible split paste delimiter never got a routing
     // verdict: forward them byte-identically before the trailing exit
@@ -497,147 +639,9 @@ pub(in super::super) fn finish_input_relay(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::fs::{self, OpenOptions};
-    use std::io::{Seek, SeekFrom};
+#[path = "capture_matrix_tests.rs"]
+mod matrix_tests;
 
-    use super::*;
-    use crate::raw_input::RawInputCapture;
-
-    #[test]
-    fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
-        let path = std::env::temp_dir().join(format!(
-            "cosh-shell-capture-cutoff-retry-{}",
-            std::process::id()
-        ));
-        let mut master = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .expect("test output file");
-        let previous = RawInputCapture::Question {
-            id: "q-1".to_string(),
-            option_count: 0,
-            allow_free_text: true,
-            multiple: false,
-            secret: false,
-        };
-        let next = RawInputCapture::Question {
-            id: "q-2".to_string(),
-            option_count: 0,
-            allow_free_text: true,
-            multiple: false,
-            secret: false,
-        };
-        let stale_mode = RawInputMode::Capture {
-            capture: previous.clone(),
-            generation: 41,
-            installed_at: Instant::now(),
-        };
-        let input_mode = Arc::new(Mutex::new(RawInputMode::Draining {
-            previous_capture: previous.clone(),
-            generation: 41,
-            next_capture: Some(next.clone()),
-            invalidated: false,
-        }));
-        let (input_tx, input_rx) = mpsc::channel();
-        let classifier = InputClassifier::default();
-        let mut card_state = CardInputState::default();
-        let mut quarantine = CaptureOwnedInput::default();
-        let mut deferred_input = None;
-        let mut line_buffer = CandidateLineBuffer::default();
-        let mut native_line_state = NativeLineState::default();
-        let mut exit_tracker = ExplicitExitTracker::default();
-        let input_generation = UserPtyInputGeneration::default();
-        let mut line_submits = LineSubmitCounter::default();
-        let main_prompt_gate = super::super::super::MainPromptGate::default();
-        let mut relay = InputRelayContext {
-            master: &mut master,
-            input_classifier: &classifier,
-            input_events: &input_tx,
-            input_mode: &input_mode,
-            input_generation: &input_generation,
-            line_submits: &mut line_submits,
-            line_buffer: &mut line_buffer,
-            native_line_state: &mut native_line_state,
-            exit_tracker: &mut exit_tracker,
-            main_prompt_gate: &main_prompt_gate,
-            slash_route_enabled: false,
-        };
-
-        relay_input_chunk(
-            b"stale",
-            stale_mode,
-            &mut card_state,
-            &mut quarantine,
-            &mut deferred_input,
-            None,
-            Some(41),
-            &mut relay,
-        )
-        .expect("relay stale input");
-
-        assert!(!input_rx
-            .try_iter()
-            .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
-        master.sync_all().expect("sync test output");
-        assert!(fs::read(&path).expect("read test output").is_empty());
-        assert!(matches!(
-            current_raw_input_mode(&input_mode),
-            RawInputMode::Capture {
-                capture: RawInputCapture::Question { id, .. },
-                ..
-            } if id == "q-2"
-        ));
-
-        master.set_len(0).expect("truncate test output");
-        master.seek(SeekFrom::Start(0)).expect("rewind test output");
-        *input_mode.lock().expect("input mode") = RawInputMode::Draining {
-            previous_capture: previous,
-            generation: 41,
-            next_capture: Some(next),
-            invalidated: false,
-        };
-        let draining_snapshot = current_raw_input_mode(&input_mode);
-        let mut card_state = CardInputState::default();
-        let mut quarantine = CaptureOwnedInput::default();
-        let mut deferred_input = None;
-        let mut line_submits = LineSubmitCounter::default();
-        let main_prompt_gate = super::super::super::MainPromptGate::default();
-        let mut relay = InputRelayContext {
-            master: &mut master,
-            input_classifier: &classifier,
-            input_events: &input_tx,
-            input_mode: &input_mode,
-            input_generation: &input_generation,
-            line_submits: &mut line_submits,
-            line_buffer: &mut line_buffer,
-            native_line_state: &mut native_line_state,
-            exit_tracker: &mut exit_tracker,
-            main_prompt_gate: &main_prompt_gate,
-            slash_route_enabled: false,
-        };
-        relay_input_chunk(
-            b"later",
-            draining_snapshot,
-            &mut card_state,
-            &mut quarantine,
-            &mut deferred_input,
-            None,
-            Some(41),
-            &mut relay,
-        )
-        .expect("relay input across draining snapshot");
-        abandon_active_capture(&input_mode);
-        drain_abandoned_capture(&mut quarantine, &mut relay).expect("drain replacement capture");
-
-        assert!(!input_rx
-            .try_iter()
-            .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
-        master.sync_all().expect("sync test output");
-        assert!(fs::read(&path).expect("read test output").is_empty());
-        fs::remove_file(path).ok();
-    }
-}
+#[cfg(test)]
+#[path = "capture_tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
@@ -1,0 +1,483 @@
+//! Chain terminal-state matrix tests for the #1913 submit-window input
+//! buffering (design T1/T2/T3/T6/T8): a cleanly drained capture chain
+//! replays quarantined bytes to the main-prompt owner, every unsafe
+//! terminal state rejects them visibly, and nothing leaks into a
+//! follow-up capture or the PTY while a capture owns input.
+
+use std::fs::{self, OpenOptions};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::super::*;
+use super::{
+    drain_abandoned_capture, relay_input_chunk, relay_late_capture_bytes,
+    replay_or_reject_after_drain, CaptureOwnedInput,
+};
+use crate::input::InputClassifier;
+use crate::raw_input::{update_input_mode, PromptGhostRoute, RawInputCapture, RawObserverAction};
+
+fn output_file(tag: &str) -> (std::path::PathBuf, std::fs::File) {
+    let path = std::env::temp_dir().join(format!(
+        "cosh-shell-capture-matrix-{tag}-{}",
+        std::process::id()
+    ));
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .expect("test output file");
+    (path, file)
+}
+
+fn config_capture() -> RawInputCapture {
+    RawInputCapture::Config {
+        id: "config-1".to_string(),
+        option_count: 2,
+        selected: 0,
+    }
+}
+
+fn question_capture(id: &str) -> RawInputCapture {
+    RawInputCapture::Question {
+        id: id.to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    }
+}
+
+struct MatrixHarness {
+    path: std::path::PathBuf,
+    master: std::fs::File,
+    input_mode: Arc<Mutex<RawInputMode>>,
+    event_tx: mpsc::Sender<RawInputEvent>,
+    event_rx: mpsc::Receiver<RawInputEvent>,
+    classifier: InputClassifier,
+    card_state: CardInputState,
+    quarantine: CaptureOwnedInput,
+    line_buffer: CandidateLineBuffer,
+    native_line_state: NativeLineState,
+    exit_tracker: ExplicitExitTracker,
+    input_generation: UserPtyInputGeneration,
+    line_submits: LineSubmitCounter,
+    main_prompt_gate: MainPromptGate,
+}
+
+impl MatrixHarness {
+    fn new(tag: &str, mode: RawInputMode) -> Self {
+        let (path, master) = output_file(tag);
+        let (event_tx, event_rx) = mpsc::channel();
+        Self {
+            path,
+            master,
+            input_mode: Arc::new(Mutex::new(mode)),
+            event_tx,
+            event_rx,
+            classifier: InputClassifier::default(),
+            card_state: CardInputState::default(),
+            quarantine: CaptureOwnedInput::default(),
+            line_buffer: CandidateLineBuffer::default(),
+            native_line_state: NativeLineState::default(),
+            exit_tracker: ExplicitExitTracker::default(),
+            input_generation: UserPtyInputGeneration::default(),
+            line_submits: LineSubmitCounter::default(),
+            main_prompt_gate: MainPromptGate::default(),
+        }
+    }
+
+    fn relay_chunk(&mut self, bytes: &[u8], mode: RawInputMode) {
+        let mut deferred_input = None;
+        let mut relay = InputRelayContext {
+            master: &mut self.master,
+            input_classifier: &self.classifier,
+            input_events: &self.event_tx,
+            input_mode: &self.input_mode,
+            input_generation: &self.input_generation,
+            line_submits: &mut self.line_submits,
+            line_buffer: &mut self.line_buffer,
+            native_line_state: &mut self.native_line_state,
+            exit_tracker: &mut self.exit_tracker,
+            main_prompt_gate: &self.main_prompt_gate,
+            slash_route_enabled: false,
+        };
+        relay_input_chunk(
+            bytes,
+            mode,
+            &mut self.card_state,
+            &mut self.quarantine,
+            &mut deferred_input,
+            None,
+            None,
+            &mut relay,
+        )
+        .expect("relay chunk");
+    }
+
+    fn drain_abandoned(&mut self) {
+        let mut relay = InputRelayContext {
+            master: &mut self.master,
+            input_classifier: &self.classifier,
+            input_events: &self.event_tx,
+            input_mode: &self.input_mode,
+            input_generation: &self.input_generation,
+            line_submits: &mut self.line_submits,
+            line_buffer: &mut self.line_buffer,
+            native_line_state: &mut self.native_line_state,
+            exit_tracker: &mut self.exit_tracker,
+            main_prompt_gate: &self.main_prompt_gate,
+            slash_route_enabled: false,
+        };
+        drain_abandoned_capture(&mut self.card_state, &mut self.quarantine, &mut relay)
+            .expect("drain abandoned capture");
+    }
+
+    fn events(&self) -> Vec<RawInputEvent> {
+        self.event_rx.try_iter().collect()
+    }
+
+    fn pty_bytes(&mut self) -> Vec<u8> {
+        self.master.sync_all().expect("sync test output");
+        fs::read(&self.path).expect("read test output")
+    }
+}
+
+impl Drop for MatrixHarness {
+    fn drop(&mut self) {
+        fs::remove_file(&self.path).ok();
+    }
+}
+
+/// Acknowledge the submitted capture like the host observer would, using
+/// the given action once the relay parks the mode in `Submitted`.
+fn spawn_submission_ack(
+    input_mode: Arc<Mutex<RawInputMode>>,
+    action: RawObserverAction,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            if let RawInputMode::Submitted { generation, .. } = current_raw_input_mode(&input_mode)
+            {
+                update_input_mode(&input_mode, &action, Some(generation));
+                return;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        panic!("capture never reached the submitted state");
+    })
+}
+
+/// T1: a burst chunk carrying the submit Enter plus trailing type-ahead
+/// replays the type-ahead to the shell once the chain drains cleanly.
+#[test]
+fn clean_chain_end_replays_submit_window_bytes_to_the_shell() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "t1-replay",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 7,
+            installed_at: Instant::now(),
+        },
+    );
+    let ack = spawn_submission_ack(harness.input_mode.clone(), RawObserverAction::Continue);
+
+    harness.relay_chunk(
+        b"\recho hi\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 7,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::ConfigSave(id) if id == "config-1")),
+        "{events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureDrained { .. })),
+        "{events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+    assert_eq!(harness.pty_bytes(), b"echo hi\n");
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Passthrough | RawInputMode::Terminal { .. }
+    ));
+}
+
+/// T2: when the chain arms a follow-up capture, the quarantined bytes are
+/// rejected visibly and never reach the new card or the PTY.
+#[test]
+fn chain_continuation_rejects_submit_window_bytes() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "t2-reject",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 9,
+            installed_at: Instant::now(),
+        },
+    );
+    let next = question_capture("q-follow");
+    let ack = spawn_submission_ack(
+        harness.input_mode.clone(),
+        RawObserverAction::CaptureInput(next.clone()),
+    );
+
+    harness.relay_chunk(
+        b"\rleaked text\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 9,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { byte_len, .. } if *byte_len == 12
+        )),
+        "{events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CardInput(id, _) if id == "q-follow")),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Capture { capture: active, .. } if active == next
+    ));
+}
+
+/// T3: an unacknowledged submission expires and rejects instead of
+/// replaying stale bytes seconds later.
+#[test]
+fn expired_chain_rejects_submit_window_bytes() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "t3-expired",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 11,
+            installed_at: Instant::now(),
+        },
+    );
+
+    harness.relay_chunk(
+        b"\rstale line\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 11,
+            installed_at: Instant::now(),
+        },
+    );
+
+    let events = harness.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureExpired { .. })),
+        "{events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+}
+
+/// T8: buffered submit-window bytes replay before the live bytes that
+/// triggered the drain, preserving arrival order.
+#[test]
+fn abandoned_clean_drain_replays_buffered_bytes_before_live_input() {
+    let mut harness = MatrixHarness::new(
+        "t8-order",
+        RawInputMode::Draining {
+            previous_capture: config_capture(),
+            generation: 13,
+            next_capture: None,
+            invalidated: false,
+            post_owner: PostCaptureOwner::MainPrompt,
+        },
+    );
+    assert!(!harness.quarantine.observe(b"early\n"));
+
+    harness.relay_chunk(
+        b"late\n",
+        RawInputMode::Draining {
+            previous_capture: config_capture(),
+            generation: 13,
+            next_capture: None,
+            invalidated: false,
+            post_owner: PostCaptureOwner::MainPrompt,
+        },
+    );
+
+    assert_eq!(harness.pty_bytes(), b"early\nlate\n");
+    let events = harness.events();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+}
+
+/// T6: an invalidated (abandoned) chain never replays; the buffered bytes
+/// are rejected visibly while live input still flows.
+#[test]
+fn invalidated_drain_rejects_buffered_bytes() {
+    let mut harness = MatrixHarness::new(
+        "t6-invalidated",
+        RawInputMode::Draining {
+            previous_capture: config_capture(),
+            generation: 17,
+            next_capture: None,
+            invalidated: true,
+            post_owner: PostCaptureOwner::MainPrompt,
+        },
+    );
+    assert!(!harness.quarantine.observe(b"never delivered"));
+
+    harness.drain_abandoned();
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 17, byte_len } if *byte_len == 15
+        )),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Terminal { generation: 17, .. }
+    ));
+}
+
+/// T7 refinement: a stale-generation batch must not wipe the live chain's
+/// buffered type-ahead; the live chain keeps its own terminal verdict.
+#[test]
+fn stale_generation_batch_keeps_live_chain_buffer() {
+    let mut harness = MatrixHarness::new(
+        "t7-live-buffer",
+        RawInputMode::Capture {
+            capture: config_capture(),
+            generation: 21,
+            installed_at: Instant::now(),
+        },
+    );
+    assert!(!harness.quarantine.observe(b"live chain bytes"));
+
+    let mut relay = InputRelayContext {
+        master: &mut harness.master,
+        input_classifier: &harness.classifier,
+        input_events: &harness.event_tx,
+        input_mode: &harness.input_mode,
+        input_generation: &harness.input_generation,
+        line_submits: &mut harness.line_submits,
+        line_buffer: &mut harness.line_buffer,
+        native_line_state: &mut harness.native_line_state,
+        exit_tracker: &mut harness.exit_tracker,
+        main_prompt_gate: &harness.main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    relay_late_capture_bytes(
+        b"stale batch",
+        20,
+        &mut harness.card_state,
+        &mut harness.quarantine,
+        &mut relay,
+    )
+    .expect("relay stale batch");
+
+    let events = harness.events();
+    // Only the stale batch is rejected; the live buffer stays pending.
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 20, byte_len } if *byte_len == 11
+        )),
+        "{events:?}"
+    );
+    assert_eq!(harness.quarantine.take_bytes(), b"live chain bytes");
+    assert!(harness.pty_bytes().is_empty());
+}
+
+/// T7 refinement: leftovers with no live chain surface as a rejection,
+/// never a silent wipe; leftovers and the late batch merge into ONE
+/// rejection so a single chain never stacks duplicate notices.
+#[test]
+fn stale_generation_batch_rejects_orphan_buffer_visibly() {
+    let mut harness = MatrixHarness::new("t7-orphan-buffer", RawInputMode::Passthrough);
+    assert!(!harness.quarantine.observe(b"orphaned"));
+
+    let mut relay = InputRelayContext {
+        master: &mut harness.master,
+        input_classifier: &harness.classifier,
+        input_events: &harness.event_tx,
+        input_mode: &harness.input_mode,
+        input_generation: &harness.input_generation,
+        line_submits: &mut harness.line_submits,
+        line_buffer: &mut harness.line_buffer,
+        native_line_state: &mut harness.native_line_state,
+        exit_tracker: &mut harness.exit_tracker,
+        main_prompt_gate: &harness.main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    relay_late_capture_bytes(
+        b"stale batch",
+        20,
+        &mut harness.card_state,
+        &mut harness.quarantine,
+        &mut relay,
+    )
+    .expect("relay stale batch");
+
+    let events = harness.events();
+    let rejections: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            RawInputEvent::CaptureInputRejected {
+                generation: 20,
+                byte_len,
+            } => Some(*byte_len),
+            _ => None,
+        })
+        .collect();
+    // "orphaned" (8) + "stale batch" (11) merge into one rejection.
+    assert_eq!(rejections, vec![19], "{events:?}");
+    assert!(harness.quarantine.take_bytes().is_empty());
+    assert!(harness.pty_bytes().is_empty());
+}
+
+#[cfg(test)]
+#[path = "capture_owner_matrix_tests.rs"]
+mod owner;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
@@ -1,0 +1,476 @@
+//! Chain terminal-state matrix tests for the #1913 submit-window input
+//! buffering (design T1/T2/T3/T6/T8): a cleanly drained capture chain
+//! replays quarantined bytes to the main-prompt owner, every unsafe
+//! terminal state rejects them visibly, and nothing leaks into a
+//! follow-up capture or the PTY while a capture owns input.
+
+use std::fs::{self, OpenOptions};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::super::*;
+use super::{
+    drain_abandoned_capture, relay_input_chunk, relay_late_capture_bytes, CaptureOwnedInput,
+};
+use crate::input::InputClassifier;
+use crate::raw_input::{update_input_mode, RawInputCapture, RawObserverAction};
+
+fn output_file(tag: &str) -> (std::path::PathBuf, std::fs::File) {
+    let path = std::env::temp_dir().join(format!(
+        "cosh-shell-capture-matrix-{tag}-{}",
+        std::process::id()
+    ));
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .expect("test output file");
+    (path, file)
+}
+
+fn config_capture() -> RawInputCapture {
+    RawInputCapture::Config {
+        id: "config-1".to_string(),
+        option_count: 2,
+        selected: 0,
+    }
+}
+
+fn question_capture(id: &str) -> RawInputCapture {
+    RawInputCapture::Question {
+        id: id.to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    }
+}
+
+struct MatrixHarness {
+    path: std::path::PathBuf,
+    master: std::fs::File,
+    input_mode: Arc<Mutex<RawInputMode>>,
+    event_tx: mpsc::Sender<RawInputEvent>,
+    event_rx: mpsc::Receiver<RawInputEvent>,
+    classifier: InputClassifier,
+    card_state: CardInputState,
+    quarantine: CaptureOwnedInput,
+    line_buffer: CandidateLineBuffer,
+    native_line_state: NativeLineState,
+    exit_tracker: ExplicitExitTracker,
+    input_generation: UserPtyInputGeneration,
+    line_submits: LineSubmitCounter,
+    main_prompt_gate: MainPromptGate,
+}
+
+impl MatrixHarness {
+    fn new(tag: &str, mode: RawInputMode) -> Self {
+        let (path, master) = output_file(tag);
+        let (event_tx, event_rx) = mpsc::channel();
+        Self {
+            path,
+            master,
+            input_mode: Arc::new(Mutex::new(mode)),
+            event_tx,
+            event_rx,
+            classifier: InputClassifier::default(),
+            card_state: CardInputState::default(),
+            quarantine: CaptureOwnedInput::default(),
+            line_buffer: CandidateLineBuffer::default(),
+            native_line_state: NativeLineState::default(),
+            exit_tracker: ExplicitExitTracker::default(),
+            input_generation: UserPtyInputGeneration::default(),
+            line_submits: LineSubmitCounter::default(),
+            main_prompt_gate: MainPromptGate::default(),
+        }
+    }
+
+    fn relay_chunk(&mut self, bytes: &[u8], mode: RawInputMode) {
+        let mut deferred_input = None;
+        let mut relay = InputRelayContext {
+            master: &mut self.master,
+            input_classifier: &self.classifier,
+            input_events: &self.event_tx,
+            input_mode: &self.input_mode,
+            input_generation: &self.input_generation,
+            line_submits: &mut self.line_submits,
+            line_buffer: &mut self.line_buffer,
+            native_line_state: &mut self.native_line_state,
+            exit_tracker: &mut self.exit_tracker,
+            main_prompt_gate: &self.main_prompt_gate,
+            slash_route_enabled: false,
+        };
+        relay_input_chunk(
+            bytes,
+            mode,
+            &mut self.card_state,
+            &mut self.quarantine,
+            &mut deferred_input,
+            None,
+            None,
+            &mut relay,
+        )
+        .expect("relay chunk");
+    }
+
+    fn drain_abandoned(&mut self) {
+        let mut relay = InputRelayContext {
+            master: &mut self.master,
+            input_classifier: &self.classifier,
+            input_events: &self.event_tx,
+            input_mode: &self.input_mode,
+            input_generation: &self.input_generation,
+            line_submits: &mut self.line_submits,
+            line_buffer: &mut self.line_buffer,
+            native_line_state: &mut self.native_line_state,
+            exit_tracker: &mut self.exit_tracker,
+            main_prompt_gate: &self.main_prompt_gate,
+            slash_route_enabled: false,
+        };
+        drain_abandoned_capture(&mut self.card_state, &mut self.quarantine, &mut relay)
+            .expect("drain abandoned capture");
+    }
+
+    fn events(&self) -> Vec<RawInputEvent> {
+        self.event_rx.try_iter().collect()
+    }
+
+    fn pty_bytes(&mut self) -> Vec<u8> {
+        self.master.sync_all().expect("sync test output");
+        fs::read(&self.path).expect("read test output")
+    }
+}
+
+impl Drop for MatrixHarness {
+    fn drop(&mut self) {
+        fs::remove_file(&self.path).ok();
+    }
+}
+
+/// Acknowledge the submitted capture like the host observer would, using
+/// the given action once the relay parks the mode in `Submitted`.
+fn spawn_submission_ack(
+    input_mode: Arc<Mutex<RawInputMode>>,
+    action: RawObserverAction,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            if let RawInputMode::Submitted { generation, .. } = current_raw_input_mode(&input_mode)
+            {
+                update_input_mode(&input_mode, &action, Some(generation));
+                return;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        panic!("capture never reached the submitted state");
+    })
+}
+
+/// T1: a burst chunk carrying the submit Enter plus trailing type-ahead
+/// replays the type-ahead to the shell once the chain drains cleanly.
+#[test]
+fn clean_chain_end_replays_submit_window_bytes_to_the_shell() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "t1-replay",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 7,
+            installed_at: Instant::now(),
+        },
+    );
+    let ack = spawn_submission_ack(harness.input_mode.clone(), RawObserverAction::Continue);
+
+    harness.relay_chunk(
+        b"\recho hi\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 7,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::ConfigSave(id) if id == "config-1")),
+        "{events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureDrained { .. })),
+        "{events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+    assert_eq!(harness.pty_bytes(), b"echo hi\n");
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Passthrough | RawInputMode::Terminal { .. }
+    ));
+}
+
+/// T2: when the chain arms a follow-up capture, the quarantined bytes are
+/// rejected visibly and never reach the new card or the PTY.
+#[test]
+fn chain_continuation_rejects_submit_window_bytes() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "t2-reject",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 9,
+            installed_at: Instant::now(),
+        },
+    );
+    let next = question_capture("q-follow");
+    let ack = spawn_submission_ack(
+        harness.input_mode.clone(),
+        RawObserverAction::CaptureInput(next.clone()),
+    );
+
+    harness.relay_chunk(
+        b"\rleaked text\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 9,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { byte_len, .. } if *byte_len == 12
+        )),
+        "{events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CardInput(id, _) if id == "q-follow")),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Capture { capture: active, .. } if active == next
+    ));
+}
+
+/// T3: an unacknowledged submission expires and rejects instead of
+/// replaying stale bytes seconds later.
+#[test]
+fn expired_chain_rejects_submit_window_bytes() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "t3-expired",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 11,
+            installed_at: Instant::now(),
+        },
+    );
+
+    harness.relay_chunk(
+        b"\rstale line\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 11,
+            installed_at: Instant::now(),
+        },
+    );
+
+    let events = harness.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureExpired { .. })),
+        "{events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+}
+
+/// T8: buffered submit-window bytes replay before the live bytes that
+/// triggered the drain, preserving arrival order.
+#[test]
+fn abandoned_clean_drain_replays_buffered_bytes_before_live_input() {
+    let mut harness = MatrixHarness::new(
+        "t8-order",
+        RawInputMode::Draining {
+            previous_capture: config_capture(),
+            generation: 13,
+            next_capture: None,
+            invalidated: false,
+        },
+    );
+    assert!(!harness.quarantine.observe(b"early\n"));
+
+    harness.relay_chunk(
+        b"late\n",
+        RawInputMode::Draining {
+            previous_capture: config_capture(),
+            generation: 13,
+            next_capture: None,
+            invalidated: false,
+        },
+    );
+
+    assert_eq!(harness.pty_bytes(), b"early\nlate\n");
+    let events = harness.events();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+}
+
+/// T6: an invalidated (abandoned) chain never replays; the buffered bytes
+/// are rejected visibly while live input still flows.
+#[test]
+fn invalidated_drain_rejects_buffered_bytes() {
+    let mut harness = MatrixHarness::new(
+        "t6-invalidated",
+        RawInputMode::Draining {
+            previous_capture: config_capture(),
+            generation: 17,
+            next_capture: None,
+            invalidated: true,
+        },
+    );
+    assert!(!harness.quarantine.observe(b"never delivered"));
+
+    harness.drain_abandoned();
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 17, byte_len } if *byte_len == 15
+        )),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Terminal { generation: 17, .. }
+    ));
+}
+
+/// T7 refinement: a stale-generation batch must not wipe the live chain's
+/// buffered type-ahead; the live chain keeps its own terminal verdict.
+#[test]
+fn stale_generation_batch_keeps_live_chain_buffer() {
+    let mut harness = MatrixHarness::new(
+        "t7-live-buffer",
+        RawInputMode::Capture {
+            capture: config_capture(),
+            generation: 21,
+            installed_at: Instant::now(),
+        },
+    );
+    assert!(!harness.quarantine.observe(b"live chain bytes"));
+
+    let mut relay = InputRelayContext {
+        master: &mut harness.master,
+        input_classifier: &harness.classifier,
+        input_events: &harness.event_tx,
+        input_mode: &harness.input_mode,
+        input_generation: &harness.input_generation,
+        line_submits: &mut harness.line_submits,
+        line_buffer: &mut harness.line_buffer,
+        native_line_state: &mut harness.native_line_state,
+        exit_tracker: &mut harness.exit_tracker,
+        main_prompt_gate: &harness.main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    relay_late_capture_bytes(
+        b"stale batch",
+        20,
+        &mut harness.card_state,
+        &mut harness.quarantine,
+        &mut relay,
+    )
+    .expect("relay stale batch");
+
+    let events = harness.events();
+    // Only the stale batch is rejected; the live buffer stays pending.
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 20, byte_len } if *byte_len == 11
+        )),
+        "{events:?}"
+    );
+    assert_eq!(harness.quarantine.take_bytes(), b"live chain bytes");
+    assert!(harness.pty_bytes().is_empty());
+}
+
+/// T7 refinement: leftovers with no live chain surface as a rejection,
+/// never a silent wipe.
+#[test]
+fn stale_generation_batch_rejects_orphan_buffer_visibly() {
+    let mut harness = MatrixHarness::new("t7-orphan-buffer", RawInputMode::Passthrough);
+    assert!(!harness.quarantine.observe(b"orphaned"));
+
+    let mut relay = InputRelayContext {
+        master: &mut harness.master,
+        input_classifier: &harness.classifier,
+        input_events: &harness.event_tx,
+        input_mode: &harness.input_mode,
+        input_generation: &harness.input_generation,
+        line_submits: &mut harness.line_submits,
+        line_buffer: &mut harness.line_buffer,
+        native_line_state: &mut harness.native_line_state,
+        exit_tracker: &mut harness.exit_tracker,
+        main_prompt_gate: &harness.main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    relay_late_capture_bytes(
+        b"stale batch",
+        20,
+        &mut harness.card_state,
+        &mut harness.quarantine,
+        &mut relay,
+    )
+    .expect("relay stale batch");
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 20, byte_len } if *byte_len == 8
+        )),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 20, byte_len } if *byte_len == 11
+        )),
+        "{events:?}"
+    );
+    assert!(harness.quarantine.take_bytes().is_empty());
+    assert!(harness.pty_bytes().is_empty());
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_owner_matrix_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_owner_matrix_tests.rs
@@ -1,0 +1,361 @@
+//! Post-capture owner matrix tests (#1913): the drain must land the
+//! quarantined replay on the observer-acknowledged owner, re-verify live
+//! ownership before delivery, and reject visibly whenever no safe owner
+//! can consume the bytes.
+
+use super::*;
+
+/// The ack's post-capture owner must survive the drain: under a delay
+/// owner a buffered Ctrl-C cancels the agent (CtrlC event) instead of
+/// leaking into bash through the terminal passthrough path.
+#[test]
+fn delay_owner_replays_buffered_ctrl_c_as_agent_cancel() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "owner-delay-ctrl-c",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 31,
+            installed_at: Instant::now(),
+        },
+    );
+    let ack = spawn_submission_ack(
+        harness.input_mode.clone(),
+        RawObserverAction::DelayShellOutput,
+    );
+
+    harness.relay_chunk(
+        b"\r\x03",
+        RawInputMode::Capture {
+            capture,
+            generation: 31,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CtrlC)),
+        "{events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Delay { .. }
+    ));
+}
+
+/// The ack's post-capture owner must survive the drain: under a raw
+/// passthrough owner the buffered bytes reach the PTY verbatim instead
+/// of being reinterpreted by the prompt classifier.
+#[test]
+fn raw_passthrough_owner_replays_buffered_bytes_verbatim() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "owner-raw-passthrough",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 33,
+            installed_at: Instant::now(),
+        },
+    );
+    let ack = spawn_submission_ack(
+        harness.input_mode.clone(),
+        RawObserverAction::RawPassthrough,
+    );
+
+    harness.relay_chunk(
+        b"\rvi-keys",
+        RawInputMode::Capture {
+            capture,
+            generation: 33,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CaptureInputRejected { .. })),
+        "{events:?}"
+    );
+    assert_eq!(harness.pty_bytes(), b"vi-keys");
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::RawPassthrough
+    ));
+}
+
+/// The replay verdict must re-check live ownership: if an observer armed
+/// a new capture after the drain terminal was installed, the stale
+/// snapshot never reaches the PTY and the bytes reject visibly.
+#[test]
+fn replay_rejects_when_live_owner_superseded_the_drain_terminal() {
+    let next = question_capture("q-superseded");
+    let mut harness = MatrixHarness::new(
+        "owner-superseded",
+        RawInputMode::Capture {
+            capture: next.clone(),
+            generation: 36,
+            installed_at: Instant::now(),
+        },
+    );
+    assert!(!harness.quarantine.observe(b"must not leak\n"));
+    let installed = Some((
+        RawInputMode::Terminal {
+            previous_capture: config_capture(),
+            generation: 35,
+        },
+        PostCaptureOwner::MainPrompt,
+    ));
+
+    let mut relay = InputRelayContext {
+        master: &mut harness.master,
+        input_classifier: &harness.classifier,
+        input_events: &harness.event_tx,
+        input_mode: &harness.input_mode,
+        input_generation: &harness.input_generation,
+        line_submits: &mut harness.line_submits,
+        line_buffer: &mut harness.line_buffer,
+        native_line_state: &mut harness.native_line_state,
+        exit_tracker: &mut harness.exit_tracker,
+        main_prompt_gate: &harness.main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    replay_or_reject_after_drain(
+        installed,
+        &mut harness.card_state,
+        &mut harness.quarantine,
+        35,
+        &mut relay,
+    )
+    .expect("replay verdict");
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 35, byte_len } if *byte_len == 14
+        )),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Capture { capture, .. } if capture == next
+    ));
+}
+
+/// An ownership cutover during the submit wait (e.g. a prompt ghost
+/// replacing the draining mode) surfaces the quarantined bytes as a
+/// rejection instead of returning with a silent buffer.
+#[test]
+fn ghost_cutover_during_submit_wait_rejects_quarantine() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "owner-ghost-cutover",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 37,
+            installed_at: Instant::now(),
+        },
+    );
+    let mode_for_cutover = harness.input_mode.clone();
+    let cutover = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            if matches!(
+                current_raw_input_mode(&mode_for_cutover),
+                RawInputMode::Submitted { .. }
+            ) {
+                *mode_for_cutover.lock().expect("input mode") = RawInputMode::PromptGhost {
+                    text: "ghost".to_string(),
+                    route: PromptGhostRoute::NativeShell,
+                };
+                return;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        panic!("capture never reached the submitted state");
+    });
+
+    harness.relay_chunk(
+        b"\rmust be surfaced\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 37,
+            installed_at: Instant::now(),
+        },
+    );
+    cutover.join().expect("cutover thread");
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 37, byte_len } if *byte_len == 17
+        )),
+        "{events:?}"
+    );
+    assert!(harness.quarantine.take_bytes().is_empty());
+    assert!(harness.pty_bytes().is_empty());
+}
+
+/// A hold owner cannot deliver ordinary text (held input only recognizes
+/// cancel controls), so the buffered batch surfaces as a visible
+/// rejection instead of vanishing after take_bytes().
+#[test]
+fn hold_owner_rejects_buffered_text_visibly() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "owner-hold-text",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 39,
+            installed_at: Instant::now(),
+        },
+    );
+    let ack = spawn_submission_ack(
+        harness.input_mode.clone(),
+        RawObserverAction::HoldShellOutput,
+    );
+
+    harness.relay_chunk(
+        b"\rmust be delivered or rejected\n",
+        RawInputMode::Capture {
+            capture,
+            generation: 39,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 39, byte_len } if *byte_len == 30
+        )),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&harness.input_mode),
+        RawInputMode::Hold
+    ));
+}
+
+/// The hold owner still honors the cancel semantics of held input: a
+/// buffered Ctrl-C emits the cancel event alongside the rejection.
+#[test]
+fn hold_owner_keeps_cancel_semantics_for_buffered_ctrl_c() {
+    let capture = config_capture();
+    let mut harness = MatrixHarness::new(
+        "owner-hold-ctrl-c",
+        RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 41,
+            installed_at: Instant::now(),
+        },
+    );
+    let ack = spawn_submission_ack(
+        harness.input_mode.clone(),
+        RawObserverAction::HoldShellOutput,
+    );
+
+    harness.relay_chunk(
+        b"\r\x03",
+        RawInputMode::Capture {
+            capture,
+            generation: 41,
+            installed_at: Instant::now(),
+        },
+    );
+    ack.join().expect("ack thread");
+
+    let events = harness.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CtrlC)),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected { generation: 41, .. }
+        )),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+}
+
+/// A superseded hold owner must not disturb its replacement: when a new
+/// capture armed after the drain, the dead chain's buffered Ctrl-C is
+/// rejected without emitting any held-control event.
+#[test]
+fn superseded_hold_owner_rejects_ctrl_c_without_control_events() {
+    let next = question_capture("q-hold-cutover");
+    let mut harness = MatrixHarness::new(
+        "owner-hold-cutover",
+        RawInputMode::Capture {
+            capture: next,
+            generation: 44,
+            installed_at: Instant::now(),
+        },
+    );
+    assert!(!harness.quarantine.observe(b"\x03"));
+    let installed = Some((RawInputMode::Hold, PostCaptureOwner::Hold));
+
+    let mut relay = InputRelayContext {
+        master: &mut harness.master,
+        input_classifier: &harness.classifier,
+        input_events: &harness.event_tx,
+        input_mode: &harness.input_mode,
+        input_generation: &harness.input_generation,
+        line_submits: &mut harness.line_submits,
+        line_buffer: &mut harness.line_buffer,
+        native_line_state: &mut harness.native_line_state,
+        exit_tracker: &mut harness.exit_tracker,
+        main_prompt_gate: &harness.main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    replay_or_reject_after_drain(
+        installed,
+        &mut harness.card_state,
+        &mut harness.quarantine,
+        43,
+        &mut relay,
+    )
+    .expect("replay verdict");
+
+    let events = harness.events();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::CtrlC)),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::CaptureInputRejected {
+                generation: 43,
+                byte_len: 1
+            }
+        )),
+        "{events:?}"
+    );
+    assert!(harness.pty_bytes().is_empty());
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
@@ -1,0 +1,148 @@
+//! Generation-cutoff regression tests for the capture quarantine
+//! (split out of capture.rs to keep it under the 700-line layout gate).
+
+use std::fs::{self, OpenOptions};
+use std::io::{Seek, SeekFrom};
+
+use super::*;
+use crate::raw_input::RawInputCapture;
+
+#[test]
+fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
+    let path = std::env::temp_dir().join(format!(
+        "cosh-shell-capture-cutoff-retry-{}",
+        std::process::id()
+    ));
+    let mut master = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .expect("test output file");
+    let previous = RawInputCapture::Question {
+        id: "q-1".to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    };
+    let next = RawInputCapture::Question {
+        id: "q-2".to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    };
+    let stale_mode = RawInputMode::Capture {
+        capture: previous.clone(),
+        generation: 41,
+        installed_at: Instant::now(),
+    };
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Draining {
+        previous_capture: previous.clone(),
+        generation: 41,
+        next_capture: Some(next.clone()),
+        invalidated: false,
+        post_owner: PostCaptureOwner::MainPrompt,
+    }));
+    let (input_tx, input_rx) = mpsc::channel();
+    let classifier = InputClassifier::default();
+    let mut card_state = CardInputState::default();
+    let mut quarantine = CaptureOwnedInput::default();
+    let mut deferred_input = None;
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::super::MainPromptGate::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &input_tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
+    };
+
+    relay_input_chunk(
+        b"stale",
+        stale_mode,
+        &mut card_state,
+        &mut quarantine,
+        &mut deferred_input,
+        None,
+        Some(41),
+        &mut relay,
+    )
+    .expect("relay stale input");
+
+    assert!(!input_rx
+        .try_iter()
+        .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
+    master.sync_all().expect("sync test output");
+    assert!(fs::read(&path).expect("read test output").is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&input_mode),
+        RawInputMode::Capture {
+            capture: RawInputCapture::Question { id, .. },
+            ..
+        } if id == "q-2"
+    ));
+
+    master.set_len(0).expect("truncate test output");
+    master.seek(SeekFrom::Start(0)).expect("rewind test output");
+    *input_mode.lock().expect("input mode") = RawInputMode::Draining {
+        previous_capture: previous,
+        generation: 41,
+        next_capture: Some(next),
+        invalidated: false,
+        post_owner: PostCaptureOwner::MainPrompt,
+    };
+    let draining_snapshot = current_raw_input_mode(&input_mode);
+    let mut card_state = CardInputState::default();
+    let mut quarantine = CaptureOwnedInput::default();
+    let mut deferred_input = None;
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::super::MainPromptGate::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &input_tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    relay_input_chunk(
+        b"later",
+        draining_snapshot,
+        &mut card_state,
+        &mut quarantine,
+        &mut deferred_input,
+        None,
+        Some(41),
+        &mut relay,
+    )
+    .expect("relay input across draining snapshot");
+    abandon_active_capture(&input_mode);
+    drain_abandoned_capture(&mut card_state, &mut quarantine, &mut relay)
+        .expect("drain replacement capture");
+
+    assert!(!input_rx
+        .try_iter()
+        .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
+    master.sync_all().expect("sync test output");
+    assert!(fs::read(&path).expect("read test output").is_empty());
+    fs::remove_file(path).ok();
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
@@ -1,0 +1,146 @@
+//! Generation-cutoff regression tests for the capture quarantine
+//! (split out of capture.rs to keep it under the 700-line layout gate).
+
+use std::fs::{self, OpenOptions};
+use std::io::{Seek, SeekFrom};
+
+use super::*;
+use crate::raw_input::RawInputCapture;
+
+#[test]
+fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
+    let path = std::env::temp_dir().join(format!(
+        "cosh-shell-capture-cutoff-retry-{}",
+        std::process::id()
+    ));
+    let mut master = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .expect("test output file");
+    let previous = RawInputCapture::Question {
+        id: "q-1".to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    };
+    let next = RawInputCapture::Question {
+        id: "q-2".to_string(),
+        option_count: 0,
+        allow_free_text: true,
+        multiple: false,
+        secret: false,
+    };
+    let stale_mode = RawInputMode::Capture {
+        capture: previous.clone(),
+        generation: 41,
+        installed_at: Instant::now(),
+    };
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Draining {
+        previous_capture: previous.clone(),
+        generation: 41,
+        next_capture: Some(next.clone()),
+        invalidated: false,
+    }));
+    let (input_tx, input_rx) = mpsc::channel();
+    let classifier = InputClassifier::default();
+    let mut card_state = CardInputState::default();
+    let mut quarantine = CaptureOwnedInput::default();
+    let mut deferred_input = None;
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::super::MainPromptGate::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &input_tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
+    };
+
+    relay_input_chunk(
+        b"stale",
+        stale_mode,
+        &mut card_state,
+        &mut quarantine,
+        &mut deferred_input,
+        None,
+        Some(41),
+        &mut relay,
+    )
+    .expect("relay stale input");
+
+    assert!(!input_rx
+        .try_iter()
+        .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
+    master.sync_all().expect("sync test output");
+    assert!(fs::read(&path).expect("read test output").is_empty());
+    assert!(matches!(
+        current_raw_input_mode(&input_mode),
+        RawInputMode::Capture {
+            capture: RawInputCapture::Question { id, .. },
+            ..
+        } if id == "q-2"
+    ));
+
+    master.set_len(0).expect("truncate test output");
+    master.seek(SeekFrom::Start(0)).expect("rewind test output");
+    *input_mode.lock().expect("input mode") = RawInputMode::Draining {
+        previous_capture: previous,
+        generation: 41,
+        next_capture: Some(next),
+        invalidated: false,
+    };
+    let draining_snapshot = current_raw_input_mode(&input_mode);
+    let mut card_state = CardInputState::default();
+    let mut quarantine = CaptureOwnedInput::default();
+    let mut deferred_input = None;
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::super::MainPromptGate::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &input_tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
+    };
+    relay_input_chunk(
+        b"later",
+        draining_snapshot,
+        &mut card_state,
+        &mut quarantine,
+        &mut deferred_input,
+        None,
+        Some(41),
+        &mut relay,
+    )
+    .expect("relay input across draining snapshot");
+    abandon_active_capture(&input_mode);
+    drain_abandoned_capture(&mut card_state, &mut quarantine, &mut relay)
+        .expect("drain replacement capture");
+
+    assert!(!input_rx
+        .try_iter()
+        .any(|event| matches!(event, RawInputEvent::CardInput(target, _) if target == "q-2")));
+    master.sync_all().expect("sync test output");
+    assert!(fs::read(&path).expect("read test output").is_empty());
+    fs::remove_file(path).ok();
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
@@ -134,7 +134,7 @@ pub(super) fn flush_pending_draft_escape(
         );
         if result.generation.is_some() {
             let RawInputRelayState {
-                card_state: _,
+                card_state,
                 line_buffer,
                 native_line_state,
                 exit_tracker,
@@ -163,6 +163,7 @@ pub(super) fn flush_pending_draft_escape(
             relay.native_line_state.clear();
             drain_capture_submission(
                 result,
+                card_state,
                 capture_owned_input,
                 deferred_input,
                 None,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
@@ -265,6 +265,7 @@ fn delayed_ghost_suffix_keeps_capture_generation_across_replacement() {
         generation: 7,
         next_capture: Some(next),
         invalidated: false,
+        post_owner: PostCaptureOwner::MainPrompt,
     };
     let mode = current_raw_input_mode(&input_mode);
     flush_pending_replaced_prompt_ghost_suffix(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -743,6 +743,7 @@ impl OscParser {
             ShellCaptureLifecycle::Drained => "capture_drained",
             ShellCaptureLifecycle::Expired => "capture_expired",
             ShellCaptureLifecycle::Overflow => "capture_overflow",
+            ShellCaptureLifecycle::InputRejected => "capture_input_rejected",
         };
         self.events.push(ShellEvent {
             kind: ShellEventKind::UserInputIntercepted,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -455,7 +455,8 @@ fn latest_capture_submission_generation(events: &[ShellEvent]) -> Option<u64> {
             crate::types::ShellCaptureLifecycle::Submitted => return Some(capture.generation),
             crate::types::ShellCaptureLifecycle::Drained
             | crate::types::ShellCaptureLifecycle::Expired
-            | crate::types::ShellCaptureLifecycle::Overflow => return None,
+            | crate::types::ShellCaptureLifecycle::Overflow
+            | crate::types::ShellCaptureLifecycle::InputRejected => return None,
         }
     }
     None

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -395,7 +395,8 @@ fn latest_capture_submission_generation(events: &[ShellEvent]) -> Option<u64> {
             crate::types::ShellCaptureLifecycle::Submitted => return Some(capture.generation),
             crate::types::ShellCaptureLifecycle::Drained
             | crate::types::ShellCaptureLifecycle::Expired
-            | crate::types::ShellCaptureLifecycle::Overflow => return None,
+            | crate::types::ShellCaptureLifecycle::Overflow
+            | crate::types::ShellCaptureLifecycle::InputRejected => return None,
         }
     }
     None

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -221,6 +221,12 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 None,
                 None,
             ),
+            RawInputEvent::CaptureInputRejected { generation, .. } => parser.push_capture_event(
+                crate::types::ShellCaptureLifecycle::InputRejected,
+                generation,
+                None,
+                None,
+            ),
             RawInputEvent::CardFocus(id, selected) => {
                 parser.push_card_event("focus", &format!("{id}:{selected}"))
             }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -219,6 +219,12 @@ pub(super) fn drain_raw_input_events<W: Write>(
                 None,
                 None,
             ),
+            RawInputEvent::CaptureInputRejected { generation, .. } => parser.push_capture_event(
+                crate::types::ShellCaptureLifecycle::InputRejected,
+                generation,
+                None,
+                None,
+            ),
             RawInputEvent::CardFocus(id, selected) => {
                 parser.push_card_event("focus", &format!("{id}:{selected}"))
             }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/capture_notice.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/capture_notice.rs
@@ -1,0 +1,112 @@
+use crate::runtime::prelude::*;
+use crate::slash::panel::render_notice_panel;
+use crate::slash::prompt::{clear_shell_prompt_line, write_shell_prompt};
+use crate::types::ShellCaptureLifecycle;
+
+/// Visible feedback when quarantined submit-window input was discarded
+/// (#1913 G2): every rejected/overflowed capture chain renders one notice
+/// so the product keeps no silent input-drop path.
+pub(crate) fn render_capture_input_rejected<W: Write>(
+    events: &[ShellEvent],
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    for event in events.iter() {
+        let Some(capture) = event.capture.as_ref() else {
+            continue;
+        };
+        if !matches!(
+            capture.lifecycle,
+            ShellCaptureLifecycle::InputRejected | ShellCaptureLifecycle::Overflow
+        ) {
+            continue;
+        }
+        // One notice per capture chain: repeated rejections against the
+        // same generation (late reads after overflow/expiry) must not
+        // stack duplicate panels, so the dedup key is the generation, not
+        // the event index.
+        let key = format!("capture-input-rejected:{}", capture.generation);
+        if !state.control.claim_config_action(key) {
+            continue;
+        }
+        clear_shell_prompt_line(output)?;
+        let i18n = state.i18n();
+        render_notice_panel(
+            output,
+            i18n.t(MessageId::CaptureInputRejectedTitle),
+            vec![i18n.t(MessageId::CaptureInputRejectedBody).to_string()],
+            None,
+        )?;
+        write_shell_prompt(state, output)?;
+        output.flush()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ShellCaptureMetadata, ShellEventKind};
+
+    fn rejected_event(lifecycle: ShellCaptureLifecycle) -> ShellEvent {
+        let mut event = ShellEvent::user_input_intercepted("session", "");
+        event.kind = ShellEventKind::UserInputIntercepted;
+        event.capture = Some(ShellCaptureMetadata {
+            kind: None,
+            target_id: None,
+            generation: 42,
+            lifecycle,
+        });
+        event
+    }
+
+    #[test]
+    fn rejected_lifecycle_renders_notice_once() {
+        let mut state = InlineState {
+            language: Language::ZhCn,
+            ..InlineState::default()
+        };
+        let event = rejected_event(ShellCaptureLifecycle::InputRejected);
+        let mut output = Vec::new();
+
+        render_capture_input_rejected(std::slice::from_ref(&event), &mut state, &mut output)
+            .expect("render rejected notice");
+        let rendered = String::from_utf8(output).expect("utf8 output");
+        assert!(rendered.contains("输入未投递"), "{rendered}");
+        assert!(rendered.contains("请重新输入"), "{rendered}");
+
+        let mut second = Vec::new();
+        render_capture_input_rejected(&[event], &mut state, &mut second).expect("render duplicate");
+        assert!(second.is_empty(), "duplicate event must not re-render");
+    }
+
+    #[test]
+    fn same_generation_events_render_a_single_notice() {
+        let mut state = InlineState::default();
+        let rejected = rejected_event(ShellCaptureLifecycle::InputRejected);
+        let overflow = rejected_event(ShellCaptureLifecycle::Overflow);
+        let mut output = Vec::new();
+
+        render_capture_input_rejected(&[rejected, overflow], &mut state, &mut output)
+            .expect("render same-generation events");
+
+        let rendered = String::from_utf8(output).expect("utf8 output");
+        assert_eq!(
+            rendered.matches("Input not delivered").count(),
+            1,
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn drained_lifecycle_stays_silent() {
+        let mut state = InlineState::default();
+        let event = rejected_event(ShellCaptureLifecycle::Drained);
+        let mut output = Vec::new();
+
+        render_capture_input_rejected(&[event], &mut state, &mut output)
+            .expect("render drained lifecycle");
+
+        assert!(output.is_empty());
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/slash/capture_notice.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/capture_notice.rs
@@ -1,0 +1,92 @@
+use crate::runtime::prelude::*;
+use crate::slash::panel::render_notice_panel;
+use crate::slash::prompt::{clear_shell_prompt_line, write_shell_prompt};
+use crate::types::ShellCaptureLifecycle;
+
+/// Visible feedback when quarantined submit-window input was discarded
+/// (#1913 G2): every rejected/overflowed capture chain renders one notice
+/// so the product keeps no silent input-drop path.
+pub(crate) fn render_capture_input_rejected<W: Write>(
+    events: &[ShellEvent],
+    state: &mut InlineState,
+    output: &mut W,
+    event_index_base: usize,
+) -> std::io::Result<()> {
+    for (idx, event) in events.iter().enumerate() {
+        let Some(capture) = event.capture.as_ref() else {
+            continue;
+        };
+        if !matches!(
+            capture.lifecycle,
+            ShellCaptureLifecycle::InputRejected | ShellCaptureLifecycle::Overflow
+        ) {
+            continue;
+        }
+        let key = stable_event_key("capture-input-rejected", event_index_base + idx, event);
+        if !state.control.claim_config_action(key) {
+            continue;
+        }
+        clear_shell_prompt_line(output)?;
+        let i18n = state.i18n();
+        render_notice_panel(
+            output,
+            i18n.t(MessageId::CaptureInputRejectedTitle),
+            vec![i18n.t(MessageId::CaptureInputRejectedBody).to_string()],
+            None,
+        )?;
+        write_shell_prompt(state, output)?;
+        output.flush()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ShellCaptureMetadata, ShellEventKind};
+
+    fn rejected_event(lifecycle: ShellCaptureLifecycle) -> ShellEvent {
+        let mut event = ShellEvent::user_input_intercepted("session", "");
+        event.kind = ShellEventKind::UserInputIntercepted;
+        event.capture = Some(ShellCaptureMetadata {
+            kind: None,
+            target_id: None,
+            generation: 42,
+            lifecycle,
+        });
+        event
+    }
+
+    #[test]
+    fn rejected_lifecycle_renders_notice_once() {
+        let mut state = InlineState {
+            language: Language::ZhCn,
+            ..InlineState::default()
+        };
+        let event = rejected_event(ShellCaptureLifecycle::InputRejected);
+        let mut output = Vec::new();
+
+        render_capture_input_rejected(std::slice::from_ref(&event), &mut state, &mut output, 0)
+            .expect("render rejected notice");
+        let rendered = String::from_utf8(output).expect("utf8 output");
+        assert!(rendered.contains("输入未投递"), "{rendered}");
+        assert!(rendered.contains("请重新输入"), "{rendered}");
+
+        let mut second = Vec::new();
+        render_capture_input_rejected(&[event], &mut state, &mut second, 0)
+            .expect("render duplicate");
+        assert!(second.is_empty(), "duplicate event must not re-render");
+    }
+
+    #[test]
+    fn drained_lifecycle_stays_silent() {
+        let mut state = InlineState::default();
+        let event = rejected_event(ShellCaptureLifecycle::Drained);
+        let mut output = Vec::new();
+
+        render_capture_input_rejected(&[event], &mut state, &mut output, 0)
+            .expect("render drained lifecycle");
+
+        assert!(output.is_empty());
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod audit;
+pub(super) mod capture_notice;
 pub(super) mod commands;
 pub(super) mod config;
 pub(super) mod debug;

--- a/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
@@ -1,5 +1,6 @@
 use crate::runtime::mode::render_mode_card_actions;
 use crate::runtime::prelude::*;
+use crate::slash::capture_notice::render_capture_input_rejected;
 use crate::slash::commands::render_slash_command;
 use crate::slash::config::render_config_card_actions;
 use crate::slash::notices::render_slash_parse_error;
@@ -19,6 +20,7 @@ pub(crate) fn render_slash_actions<W: Write>(
     render_session_card_actions(events, adapter, state, output, event_index_base)?;
     render_mode_card_actions(events, state, output, event_index_base)?;
     render_config_card_actions(events, state, output, event_index_base)?;
+    render_capture_input_rejected(events, state, output)?;
 
     for (idx, event) in events.iter().enumerate() {
         let event_index = event_index_base + idx;

--- a/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
@@ -1,5 +1,6 @@
 use crate::runtime::mode::render_mode_card_actions;
 use crate::runtime::prelude::*;
+use crate::slash::capture_notice::render_capture_input_rejected;
 use crate::slash::commands::render_slash_command;
 use crate::slash::config::render_config_card_actions;
 use crate::slash::notices::render_slash_parse_error;
@@ -19,6 +20,7 @@ pub(crate) fn render_slash_actions<W: Write>(
     render_session_card_actions(events, adapter, state, output, event_index_base)?;
     render_mode_card_actions(events, state, output, event_index_base)?;
     render_config_card_actions(events, state, output, event_index_base)?;
+    render_capture_input_rejected(events, state, output, event_index_base)?;
 
     for (idx, event) in events.iter().enumerate() {
         let event_index = event_index_base + idx;

--- a/src/cosh-ng/crates/cosh-shell/src/types/shell_event_metadata.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/shell_event_metadata.rs
@@ -24,4 +24,8 @@ pub enum ShellCaptureLifecycle {
     Drained,
     Expired,
     Overflow,
+    /// Bytes typed during the submit window could not be delivered safely
+    /// (follow-up card armed, chain invalidated, or late arrival after the
+    /// chain ended) and were discarded with user-visible feedback (#1913).
+    InputRejected,
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -734,7 +734,7 @@ fn raw_relay_hold_mode_still_observes_ctrl_c() {
 }
 
 #[test]
-fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
+fn raw_relay_capture_ack_replays_same_read_multiline_suffix() {
     let work_dir = std::env::temp_dir().join(format!(
         "cosh-shell-capture-drain-test-{}-{}",
         std::process::id(),
@@ -754,7 +754,7 @@ fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
         vec![
             RawRelayAction::wait(Duration::from_millis(50)),
             RawRelayAction::write(b"yes\necho capture-drain-ok\n".to_vec()),
-            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::wait(Duration::from_millis(400)),
         ],
         Vec::new(),
         move |events, _| {
@@ -770,12 +770,15 @@ fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
     )
     .expect("capture drain relay");
 
+    // issue #1913: the suffix typed in the same read as the submitting
+    // Enter is type-ahead, not capture input. A cleanly drained chain
+    // replays it to the shell instead of silently discarding it.
     let blocks: Vec<_> = ledger_from_output(&output)
         .blocks
         .into_iter()
         .filter(|block| block.command == "echo capture-drain-ok")
         .collect();
-    assert!(blocks.is_empty(), "{:?}", output.events);
+    assert!(!blocks.is_empty(), "{:?}", output.events);
     assert!(output.events.iter().any(|event| {
         event.message.as_deref() == Some("capture_submitted")
             && event.capture.as_ref().is_some_and(|capture| {
@@ -789,6 +792,11 @@ fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
         .events
         .iter()
         .any(|event| event.message.as_deref() == Some("capture_drained")));
+    // The replayed suffix must not surface a rejection notice.
+    assert!(!output
+        .events
+        .iter()
+        .any(|event| event.message.as_deref() == Some("capture_input_rejected")));
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -707,7 +707,7 @@ fn raw_relay_hold_mode_still_observes_ctrl_c() {
 }
 
 #[test]
-fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
+fn raw_relay_capture_ack_replays_same_read_multiline_suffix() {
     let work_dir = std::env::temp_dir().join(format!(
         "cosh-shell-capture-drain-test-{}-{}",
         std::process::id(),
@@ -727,7 +727,7 @@ fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
         vec![
             RawRelayAction::wait(Duration::from_millis(50)),
             RawRelayAction::write(b"yes\necho capture-drain-ok\n".to_vec()),
-            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::wait(Duration::from_millis(400)),
         ],
         Vec::new(),
         move |events, _| {
@@ -743,12 +743,15 @@ fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
     )
     .expect("capture drain relay");
 
+    // issue #1913: the suffix typed in the same read as the submitting
+    // Enter is type-ahead, not capture input. A cleanly drained chain
+    // replays it to the shell instead of silently discarding it.
     let blocks: Vec<_> = ledger_from_output(&output)
         .blocks
         .into_iter()
         .filter(|block| block.command == "echo capture-drain-ok")
         .collect();
-    assert!(blocks.is_empty(), "{:?}", output.events);
+    assert!(!blocks.is_empty(), "{:?}", output.events);
     assert!(output.events.iter().any(|event| {
         event.message.as_deref() == Some("capture_submitted")
             && event.capture.as_ref().is_some_and(|capture| {
@@ -762,6 +765,11 @@ fn raw_relay_capture_ack_discards_same_read_multiline_suffix() {
         .events
         .iter()
         .any(|event| event.message.as_deref() == Some("capture_drained")));
+    // The replayed suffix must not surface a rejection notice.
+    assert!(!output
+        .events
+        .iter()
+        .any(|event| event.message.as_deref() == Some("capture_input_rejected")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1913.

Bytes typed between a card submit (Enter) and the completion panel were
silently discarded by the capture quarantine: no echo, no execution, no
error. Native bash buffers type-ahead in the kernel tty and never loses
it, so the host broke the zero-intrusion contract. The quarantine now
retains those bytes and a single chain-terminal verdict decides their
fate: cleanly drained chains **replay** them into the main-prompt owner
(classification unchanged, no PTY bypass); unsafe terminal states
(follow-up card, expired/invalidated chain, overflow, late arrival)
**reject** them with a visible bilingual notice, so no silent input-drop
path remains while the no-leak invariant stays intact.

The mechanism is capture-generic: it covers every card type
(approval/question/mode/config/config-language/session/evidence/
prompt-draft), not just `/config`.

## Root cause

- Submit remainder (`consume_split` breaks after the releasing `\r`),
  read-ahead bytes polled while `Submitted`, and late-generation bytes
  were all funneled into `CaptureOwnedInput::observe()` which only
  counted them against the 64KB overflow edge — never delivered,
  never surfaced.
- The drop window equals the observer stall time: the host runs the
  event observer while holding the `input_mode` lock
  (`observe_with_input_mode_lock`), so any slow observer path freezes
  reader + relay and stretches the window (the discovery run showed
  6.2s; reproduced deterministically by injecting a controlled observer
  stall). With buffering in place the typed line survives even a
  stretched window.

## Changes

- `raw_input/spawn/capture.rs`: quarantine counter → bounded byte
  buffer; unified REPLAY/REJECT verdict at the three chain-terminal
  sites (`drain_capture_submission`, `drain_abandoned_capture`,
  `finish_input_relay`); late/mismatched-generation arrivals reject
  visibly instead of silently clearing.
- `raw_input/mod.rs` + `types/shell_event_metadata.rs` + `shell_host`
  (`osc.rs`, `raw_relay.rs`, `raw_relay/input_events.rs`): new
  `CaptureInputRejected` event / `input_rejected` capture lifecycle.
- `slash/capture_notice.rs` (new): renders one notice per
  rejected/overflowed chain ("Input not delivered … please retype",
  zh/en via new trailing `capture_notice_ids` MessageId segment —
  existing discriminants unshifted per the pinned-tail contract).
- Layout: `capture.rs` inline tests split into `capture_tests.rs`;
  matrix tests added as `capture_matrix_tests.rs` (both `#[path]`
  includes, keeping files under the 700-line gate).

## Tests

- New chain-terminal matrix tests (`capture_matrix_tests`):
  `clean_chain_end_replays_submit_window_bytes_to_the_shell` (T1),
  `chain_continuation_rejects_submit_window_bytes` (T2, no-leak),
  `expired_chain_rejects_submit_window_bytes` (T3),
  `invalidated_drain_rejects_buffered_bytes` (T6),
  `abandoned_clean_drain_replays_buffered_bytes_before_live_input`
  (T8, ordering).
- `slash::capture_notice::tests`: notice renders once per event,
  drained lifecycle stays silent.
- Existing no-leak anchors
  (`generation_cutoff_does_not_retry_input_into_the_replacement_capture`,
  `submitted_capture_discards_a_later_owned_read_when_the_chain_ends`)
  pass unchanged.
- i18n ordinal snapshot unchanged for existing ids (new ids appended in
  a trailing segment).

## Verification

- Focused green (container, arm64 Alinux3): `cargo test -p cosh-shell
  --lib` 1147/1147; `--bin cosh-shell capture_notice` 2/2;
  `cargo clippy --workspace --all-targets -- -D warnings` green;
  `cargo fmt --check` green; `check-layout.sh` and
  `check-test-inventory.sh` green; preflight `data.ok=true` (drift
  empty after rebase onto latest main).
- Excluded scope (not run): other workspace crates' test suites beyond
  clippy; non-arm64 targets.
- Real-PTY FAIL→PASS (real cosh-core adapter + real dashscope provider,
  PTY 120x40, same scripted driver both sides):
  - burst probe (Enter+`echo COSH1913PROBE` in one chunk): baseline
    swallowed 3/3 (raw grep = 0) → fixed: replayed and executed.
  - separate-write 12ms-gap probe: baseline dropped when landing inside
    the window (1/5 hit) → fixed: 5/5 delivered.
  - delayed control (+0.6s, outside window): unchanged both sides.
  - chain-continuation shape (`/config language` selection → confirm
    card): probe never leaks into the follow-up card and the rejection
    notice renders once.
  - native bash contrast: identical burst type-ahead is never lost by
    bare bash (kernel tty buffering), anchoring the contract.

## Evidence

Real-PTY screenshots (120x40, agg full-size render; asset branch pinned
at commit `a6fd8a6`):

| Before (baseline) | After (this PR) |
| --- | --- |
| Burst probe swallowed after "Config saved" — no echo, no execution:<br>![baseline burst swallowed](https://raw.githubusercontent.com/SunnyQjm/anolisa/a6fd8a62704e75b9c0cab9b50827ee68aa9f8358/baseline-burst-swallowed.png) | Same burst replayed and executed after the panel:<br>![fixed burst replayed](https://raw.githubusercontent.com/SunnyQjm/anolisa/a6fd8a62704e75b9c0cab9b50827ee68aa9f8358/fixed-burst-replayed.png) |
| Control (typed outside the window) delivered on both sides:<br>![baseline delayed control](https://raw.githubusercontent.com/SunnyQjm/anolisa/a6fd8a62704e75b9c0cab9b50827ee68aa9f8358/baseline-delayed-control-delivered.png) | Chain-continuation shape: no leak into the follow-up card, visible rejection notice:<br>![fixed chain reject notice](https://raw.githubusercontent.com/SunnyQjm/anolisa/a6fd8a62704e75b9c0cab9b50827ee68aa9f8358/fixed-chain-reject-notice.png) |

Cast recordings (asciinema v2) and raw byte streams for every scenario
above are archived in the acceptance evidence set and available on
request.
