### PR TITLE
feat(blaze): manage VM network slots at startup

### DIFF
--- a/docs/user-guide/en/README.md
+++ b/docs/user-guide/en/README.md
@@ -72,6 +72,7 @@ ANOLISA provides a complete server-side runtime for AI Agent workloads. Componen
 
 | Document | Component | Description |
 |----------|-----------|-------------|
+| [Blaze Firecracker Networking](runtime/blaze.md) | blaze | Opt-in per-sandbox VM networking, host requirements, lifecycle, and operator boundary |
 | [Workspace Checkpoints](runtime/ws-ckpt.md) | ws-ckpt | Instant snapshot/rollback via btrfs COW |
 | [Skill Filesystem](runtime/skillfs.md) | skillfs | FUSE virtual views with progressive disclosure |
 

--- a/docs/user-guide/en/runtime/blaze.md
+++ b/docs/user-guide/en/runtime/blaze.md
@@ -1,0 +1,67 @@
+# Blaze Firecracker Networking
+
+[中文版](../../zh/runtime/blaze.md)
+
+Blaze can give each Firecracker sandbox a dedicated network namespace, tap
+device, veth pair, and address slot. This capability is opt-in and is disabled
+by default.
+
+## Prerequisites
+
+The Blaze daemon must run on Linux with permission to manage host networking.
+The `ip`, `sysctl`, and `iptables` commands must be installed and executable.
+Firecracker and its kernel and root filesystem images must also be available.
+
+Blaze checks these prerequisites when a loaded policy both enables networking
+and selects Firecracker as an eligible backend. Policies that leave networking
+disabled do not require these host capabilities.
+
+## Configuration
+
+Set `enable_network` in the Firecracker section of a workload policy:
+
+```toml
+[select]
+backend_priority = ["firecracker"]
+
+[backend.firecracker]
+enable_network = true
+```
+
+The option applies only to Firecracker. Its default is `false`, so existing
+policies retain their previous behavior until they opt in.
+
+## Runtime Behavior
+
+When a request selects a network-enabled Firecracker policy, sandbox creation:
+
+1. allocates a host-wide network slot;
+2. creates an owner-qualified network namespace;
+3. creates the tap and veth devices and configures addresses, forwarding, and
+   namespace-local NAT; and
+4. starts Firecracker with the tap device attached.
+
+Allocation and deletion use `/run/lock/blaze-network.lock`, which prevents two
+Blaze daemon processes on the same host from choosing the same slot at the same
+time. Blaze records the namespace owner before creating dependent devices so a
+partially completed setup remains attributable to the sandbox.
+
+Explicit sandbox destruction removes the owned namespace and devices after the
+backend process has stopped. A compensated startup failure performs the same
+cleanup. If cleanup cannot be confirmed, Blaze retains ownership and does not
+return the slot to the allocator, allowing a later destroy attempt to retry the
+operation.
+
+After a daemon restart, a later destroy request can reconstruct a recorded
+network slot. Blaze does not run a background scan or retry controller for
+orphaned network resources.
+
+## Host Integration Boundary
+
+Blaze configures the sandbox-local network path. Routing beyond the host and DNS
+configuration remain the host operator's responsibility. Before enabling the
+option in production, configure the required upstream routing or translation
+and verify guest connectivity for the host environment.
+
+To disable the capability, set `enable_network = false` or remove the key, then
+destroy existing network-enabled sandboxes through the normal instance API.

--- a/docs/user-guide/zh/README.md
+++ b/docs/user-guide/zh/README.md
@@ -72,6 +72,7 @@ ANOLISA 为 AI Agent 提供完整的服务端运行时能力。通过 `anolisa` 
 
 | 文档 | 组件 | 说明 |
 |------|------|------|
+| [Blaze Firecracker 网络](runtime/blaze.md) | blaze | 可选的单 sandbox VM 网络、主机要求、生命周期与运维边界 |
 | [工作区快照](runtime/ws-ckpt.md) | ws-ckpt | 秒级快照创建/回滚，基于 btrfs COW |
 | [技能文件系统](runtime/skillfs.md) | skillfs | FUSE 虚拟视图、渐进披露 |
 

--- a/docs/user-guide/zh/runtime/blaze.md
+++ b/docs/user-guide/zh/runtime/blaze.md
@@ -1,0 +1,60 @@
+# Blaze Firecracker 网络
+
+[English](../../en/runtime/blaze.md)
+
+Blaze 可以为每个 Firecracker sandbox 分配独立的 network namespace、tap
+设备、veth pair 和地址 slot。该能力需要显式开启，默认保持关闭。
+
+## 前置条件
+
+Blaze daemon 必须运行在 Linux 上，并具有管理主机网络的权限。主机需要安装且
+能够执行 `ip`、`sysctl` 和 `iptables`。此外还需要准备可用的 Firecracker、
+guest kernel 和 root filesystem image。
+
+当已加载的策略同时启用网络并将 Firecracker 作为候选 backend 时，Blaze 会
+检查这些前置条件。网络保持关闭的策略不要求主机提供这些能力。
+
+## 配置方法
+
+在 workload 策略的 Firecracker 配置中设置 `enable_network`：
+
+```toml
+[select]
+backend_priority = ["firecracker"]
+
+[backend.firecracker]
+enable_network = true
+```
+
+该选项仅作用于 Firecracker，默认值为 `false`。现有策略只有在显式开启后才会
+改变原有行为。
+
+## 运行行为
+
+请求选中已启用网络的 Firecracker 策略后，sandbox 创建流程会：
+
+1. 分配一个主机级 network slot；
+2. 创建带有实例 owner 标识的 network namespace；
+3. 创建 tap 和 veth 设备，并配置地址、转发和 namespace 内的 NAT；
+4. 启动 Firecracker，并将 tap 设备连接到 VM。
+
+分配与删除过程使用 `/run/lock/blaze-network.lock`，避免同一主机上的两个
+Blaze daemon 进程同时选中相同 slot。Blaze 会在创建依赖设备前记录 namespace
+的 owner，使未完全完成的网络配置仍能归属于对应 sandbox。
+
+显式销毁 sandbox 时，Blaze 会先确认 backend 进程已经停止，再删除其拥有的
+namespace 和设备。启动失败的补偿流程执行相同的清理。如果无法确认清理完成，
+Blaze 会保留 ownership，不会将 slot 重新交给分配器，以便后续 destroy 请求
+重试。
+
+daemon 重启后，后续 destroy 请求可以根据已有记录重新识别 network slot。
+Blaze 不会在后台扫描或自动重试孤立的网络资源。
+
+## 主机集成边界
+
+Blaze 负责配置 sandbox 本地的网络路径。主机以外的路由和 DNS 仍由主机运维方
+负责。生产环境开启该选项前，需要配置所需的上游路由或地址转换，并在目标主机
+环境中验证 guest 连通性。
+
+如需关闭该能力，将 `enable_network` 设置为 `false` 或删除该配置项，再通过
+正常的 instance API 销毁已经启用网络的 sandbox。

--- a/src/blaze/Cargo.lock
+++ b/src/blaze/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/src/blaze/Cargo.toml
+++ b/src/blaze/Cargo.toml
@@ -33,6 +33,7 @@ hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
 async-trait = "0.1"
+libc = "0.2"
 
 # Logging
 tracing = "0.1"

--- a/src/blaze/README.md
+++ b/src/blaze/README.md
@@ -19,6 +19,7 @@ Designed as the per-host agent for E2B-style orchestrator platforms.
 - **Kernel hook registry** — state tracking for pre/post hooks
 - **Prometheus metrics** — request counts, instance gauges, pool sizes
 - **Spawners** — FirecrackerSpawner, BubblewrapSpawner, MockSpawner
+- **Optional VM networking** — isolated namespace, tap, veth, and NAT per Firecracker VM
 
 ## Quick Start
 
@@ -76,7 +77,19 @@ memory = "512Mi"
 [backend.firecracker]
 vcpus = 4        # overrides [vm].vcpus for Firecracker only
 memory = "1Gi"   # overrides [vm].memory for Firecracker only
+enable_network = false
 ```
+
+Set `enable_network = true` to create an isolated network slot for each
+Firecracker VM. Explicit sandbox destroy and compensated startup failure remove
+the namespace, tap, and veth after process termination. A destroy retried after
+a daemon restart can reconstruct the recorded slot; there is no background
+cleanup scan. Slot creation and deletion use a host-wide lock so independent
+daemon processes cannot allocate the same host device names concurrently.
+When a loaded Firecracker policy enables this option, backend probing also
+checks the required commands and host privileges. The checks are skipped when
+networking is disabled. Upstream routing and DNS remain host operator
+responsibilities.
 
 ### Storage Configuration
 
@@ -146,6 +159,7 @@ src/blaze/
 
 - Rust 1.88+ (see `src/blaze/rust-toolchain.toml`)
 - Linux host with root privileges for sandbox backends
+- `ip`, `iptables`, `sysctl`, and network namespace privileges when VM
+  networking is enabled
 
 ## License
-

--- a/src/blaze/README_zh.md
+++ b/src/blaze/README_zh.md
@@ -18,6 +18,7 @@ Prometheus 指标导出，设计为 E2B 类编排平台的单机执行代理。
 - **内核 hook 注册** — 前/后置 hook 状态追踪
 - **Prometheus 指标** — 请求计数、实例 gauge、池大小
 - **Spawner 后端** — FirecrackerSpawner、BubblewrapSpawner、MockSpawner
+- **可选 VM 网络** — 每台 Firecracker VM 独立使用 netns、tap、veth 和 NAT
 
 ## 快速开始
 
@@ -75,7 +76,16 @@ memory = "512Mi"
 [backend.firecracker]
 vcpus = 4        # 仅对 Firecracker 覆盖 [vm].vcpus
 memory = "1Gi"   # 仅对 Firecracker 覆盖 [vm].memory
+enable_network = false
 ```
+
+设置 `enable_network = true` 后，每台 Firecracker VM 会获得独立的网络
+slot。显式销毁 sandbox 和启动失败补偿会在进程确认终止后删除对应的 netns、
+tap 和 veth。daemon 重启后再次销毁时可以根据记录恢复清理，但不会在后台
+自动扫描。slot 创建和删除使用主机级锁，避免多个 daemon 同时分配相同的主机
+设备名。加载的 Firecracker 策略启用该选项时，backend probe 还会检查所需
+命令和主机权限；网络关闭时跳过这些检查。上游路由和 DNS 仍由主机运维方
+配置。
 
 ### 存储配置
 
@@ -145,6 +155,7 @@ src/blaze/
 
 - Rust 1.88+（参见 `src/blaze/rust-toolchain.toml`）
 - 具有 root 权限的 Linux 主机（sandbox 后端需要）
+- 启用 VM 网络时需要 `ip`、`iptables`、`sysctl` 和 netns 管理权限
 
 ## 许可证
 

--- a/src/blaze/crates/blaze-core/src/policy.rs
+++ b/src/blaze/crates/blaze-core/src/policy.rs
@@ -361,6 +361,9 @@ pub struct FirecrackerConfig {
     /// Enable virtio-vsock (Phase 2+; parsed today but not yet wired).
     #[serde(default)]
     pub enable_vsock: bool,
+    /// Create an isolated network namespace, veth uplink, tap, and NAT.
+    #[serde(default)]
+    pub enable_network: bool,
     /// Capture guest ttyS0 output (Firecracker stdout) to `serial.log`.
     #[serde(default)]
     pub serial_log: bool,
@@ -377,6 +380,7 @@ impl Default for FirecrackerConfig {
         Self {
             boot_args: default_fc_boot_args(),
             enable_vsock: false,
+            enable_network: false,
             serial_log: false,
             vcpus: None,
             memory: None,
@@ -817,6 +821,7 @@ memory = "4G"
 
 [backend.firecracker]
 boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
+enable_network = true
 serial_log = true
 
 [hooks.on_create]
@@ -831,6 +836,13 @@ sequence = ["template-reg:bind-mm-template"]
         assert_eq!(pf.match_.workload_class, WorkloadClass::AgentRl);
         assert_eq!(pf.select.backend_priority[0], BackendKind::KataFc);
         assert!(pf.pool.as_ref().expect("pool").enabled);
+        assert!(
+            pf.backend
+                .firecracker
+                .as_ref()
+                .expect("firecracker")
+                .enable_network
+        );
     }
 
     #[test]
@@ -929,6 +941,7 @@ memory = "2G"
             .expect("firecracker config");
         assert_eq!(fc.vcpus, Some(2));
         assert_eq!(fc.memory, Some("2G".to_string()));
+        assert!(!fc.enable_network);
     }
 
     #[test]

--- a/src/blaze/crates/blazed/Cargo.toml
+++ b/src/blaze/crates/blazed/Cargo.toml
@@ -30,6 +30,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 http-body-util = { workspace = true }
 async-trait = { workspace = true }
+libc = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -37,7 +37,18 @@ pub async fn run(config_path: &Path) -> Result<()> {
     let pool = PoolManager::new();
     let template = TemplateRegistry::new();
     let hook = HookRegistry::new();
-    let (spawners, active_backend) = build_spawners(&config).await;
+    let network_required = policy.policies().iter().any(|policy| {
+        policy
+            .backend
+            .firecracker
+            .as_ref()
+            .is_some_and(|config| config.enable_network)
+            && policy
+                .select
+                .backend_priority
+                .contains(&BackendKind::Firecracker)
+    });
+    let (spawners, active_backend) = build_spawners(&config, network_required).await;
 
     // Build storage provider
     if config.storage.provider != "file" && config.storage.provider != "auto" {
@@ -123,8 +134,14 @@ fn ensure_dirs(cfg: &DaemonConfig) -> Result<()> {
 ///   1. `firecracker` → [`FirecrackerSpawner`]
 ///   2. `bubblewrap` → [`BubblewrapSpawner`]
 ///   3. fallback → [`MockSpawner`]
-async fn build_spawners(cfg: &DaemonConfig) -> (SpawnerRegistry, BackendKind) {
-    let firecracker: DynSpawner = Arc::new(FirecrackerSpawner::new(cfg.storage.images_dir.clone()));
+async fn build_spawners(
+    cfg: &DaemonConfig,
+    network_required: bool,
+) -> (SpawnerRegistry, BackendKind) {
+    let firecracker: DynSpawner = Arc::new(FirecrackerSpawner::with_network_requirement(
+        cfg.storage.images_dir.clone(),
+        network_required,
+    ));
     let bubblewrap: DynSpawner = Arc::new(BubblewrapSpawner);
     let mock: DynSpawner = Arc::new(MockSpawner);
     let mut spawners = SpawnerRegistry::new();

--- a/src/blaze/crates/blazed/src/spawner.rs
+++ b/src/blaze/crates/blazed/src/spawner.rs
@@ -2,6 +2,7 @@
 //! Backend process ownership and runtime lifecycle abstraction.
 
 pub mod firecracker;
+mod netns;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/blaze/crates/blazed/src/spawner/firecracker.rs
+++ b/src/blaze/crates/blazed/src/spawner/firecracker.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Firecracker process ownership and HTTP API over Unix domain sockets.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -16,6 +17,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+use super::netns::{NetworkManager, NetworkSlot};
 #[cfg(target_os = "linux")]
 use super::terminate_recorded_process;
 use super::{
@@ -23,21 +25,60 @@ use super::{
     record_backend_stopped, remove_file_if_exists, spawn_result, stopped_marker, terminate_child,
 };
 
+const NETWORK_BOOT_IP: &str = "ip=169.254.0.2::169.254.0.1:255.255.255.252::eth0:off";
+
 /// Firecracker backend factory.
 pub struct FirecrackerSpawner {
     images_dir: PathBuf,
     socket_timeout: Duration,
+    network: Arc<NetworkManager>,
+    network_required: bool,
     version: Mutex<Option<String>>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum NetworkProcessState {
+    PreSpawn,
+    #[default]
+    Launching,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct NetworkRecord {
+    slot: usize,
+    owner: Uuid,
+    #[serde(default)]
+    process_state: NetworkProcessState,
+}
+
 impl FirecrackerSpawner {
-    /// Create a spawner resolving the guest kernel from `images_dir`.
+    /// Create a spawner without requiring host networking during startup
+    /// probing. Individual network-enabled requests still run the full probe.
     pub fn new(images_dir: PathBuf) -> Self {
         Self {
             images_dir,
             socket_timeout: Duration::from_secs(5),
+            network: Arc::new(NetworkManager::default()),
+            network_required: false,
             version: Mutex::new(None),
         }
+    }
+
+    /// Create a spawner whose startup probe includes network prerequisites
+    /// when at least one loaded policy enables Firecracker networking.
+    pub fn with_network_requirement(images_dir: PathBuf, network_required: bool) -> Self {
+        Self {
+            network_required,
+            ..Self::new(images_dir)
+        }
+    }
+
+    async fn network_probe_ready(&self) -> Result<bool> {
+        if !self.network_required {
+            return Ok(true);
+        }
+        self.network.probe().await
     }
 
     async fn start(
@@ -52,59 +93,259 @@ impl FirecrackerSpawner {
         let guest_socket = request.run_dir.join("vsock.uds");
         let pid_file = request.run_dir.join("firecracker.pid");
         let stopped_marker = stopped_marker(&request.run_dir);
+        let network_file = request.run_dir.join("network.json");
+        let network_temp_file = network_metadata_temp(&network_file);
         remove_if_exists(&api_socket).await?;
         remove_if_exists(&guest_socket).await?;
         remove_if_exists(&pid_file).await?;
         remove_file_if_exists(&stopped_marker).await?;
+        remove_if_exists(&network_file).await?;
+        remove_if_exists(&network_temp_file).await?;
         let fc_config = request
             .backend
             .firecracker
             .as_ref()
             .cloned()
             .unwrap_or_default();
-        let mut command = build_launch_command(&request.binary_path, &api_socket);
-        let config_path = write_vm_config(&self.images_dir, &request, &fc_config, &guest_socket)?;
+        let network = if fc_config.enable_network {
+            if !self.network.probe().await? {
+                return Err(BlazeError::BackendError {
+                    msg: "Firecracker networking is unavailable; it requires Linux root and executable ip, sysctl, and iptables commands".to_string(),
+                }
+                .into());
+            }
+            match self
+                .network
+                .create(request.instance_id, |slot| {
+                    write_network_metadata(&network_file, slot)
+                })
+                .await
+            {
+                Ok(network) => Some(network),
+                Err(error) => {
+                    let (source, residual) = error.into_parts();
+                    if let Some(network) = residual {
+                        let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+                            request.instance_id,
+                            None,
+                            runtime_files(
+                                api_socket,
+                                guest_socket,
+                                pid_file,
+                                stopped_marker,
+                                network_file,
+                            ),
+                            Some(network),
+                            self.network.clone(),
+                        ));
+                        return Err(SpawnFailure::compensate_started(source, owner).await);
+                    }
+                    if let Err(cleanup) = remove_if_exists(&network_file).await {
+                        let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+                            request.instance_id,
+                            None,
+                            runtime_files(
+                                api_socket,
+                                guest_socket,
+                                pid_file,
+                                stopped_marker,
+                                network_file,
+                            ),
+                            None,
+                            self.network.clone(),
+                        ));
+                        return Err(SpawnFailure::compensate_started(
+                            BlazeError::BackendError {
+                                msg: format!(
+                                    "{source}; network metadata cleanup failed: {cleanup}"
+                                ),
+                            },
+                            owner,
+                        )
+                        .await);
+                    }
+                    if let Err(cleanup) = remove_if_exists(&network_temp_file).await {
+                        let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+                            request.instance_id,
+                            None,
+                            runtime_files(
+                                api_socket,
+                                guest_socket,
+                                pid_file,
+                                stopped_marker,
+                                network_file,
+                            ),
+                            None,
+                            self.network.clone(),
+                        ));
+                        return Err(SpawnFailure::compensate_started(
+                            BlazeError::BackendError {
+                                msg: format!(
+                                    "{source}; temporary network metadata cleanup failed: {cleanup}"
+                                ),
+                            },
+                            owner,
+                        )
+                        .await);
+                    }
+                    return Err(source.into());
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut command = build_launch_command(&request.binary_path, network.as_ref(), &api_socket);
+        let config_path = match write_vm_config(
+            &self.images_dir,
+            &request,
+            &fc_config,
+            &guest_socket,
+            network.as_ref(),
+        ) {
+            Ok(path) => path,
+            Err(error) => {
+                return Err(self
+                    .compensate_before_spawn(
+                        request.instance_id,
+                        runtime_files(
+                            api_socket,
+                            guest_socket,
+                            pid_file,
+                            stopped_marker,
+                            network_file,
+                        ),
+                        network,
+                        error,
+                    )
+                    .await);
+            }
+        };
         command.arg("--config-file").arg(config_path);
-        configure_logs(&mut command, &request.run_dir, fc_config.serial_log)?;
+        if let Err(error) = configure_logs(&mut command, &request.run_dir, fc_config.serial_log) {
+            return Err(self
+                .compensate_before_spawn(
+                    request.instance_id,
+                    runtime_files(
+                        api_socket,
+                        guest_socket,
+                        pid_file,
+                        stopped_marker,
+                        network_file,
+                    ),
+                    network,
+                    error,
+                )
+                .await);
+        }
         command.env("BLAZE_INSTANCE_ID", request.instance_id.to_string());
+        if let Some(slot) = network.as_ref()
+            && let Err(error) =
+                write_network_record(&network_file, slot, NetworkProcessState::Launching)
+        {
+            return Err(self
+                .compensate_before_spawn(
+                    request.instance_id,
+                    runtime_files(
+                        api_socket,
+                        guest_socket,
+                        pid_file,
+                        stopped_marker,
+                        network_file,
+                    ),
+                    network,
+                    error,
+                )
+                .await);
+        }
         let mut child = match command.spawn() {
             Ok(child) => child,
-            Err(source) => return Err(source.into()),
+            Err(source) => {
+                return Err(self
+                    .compensate_before_spawn(
+                        request.instance_id,
+                        runtime_files(
+                            api_socket,
+                            guest_socket,
+                            pid_file,
+                            stopped_marker,
+                            network_file,
+                        ),
+                        network,
+                        source.into(),
+                    )
+                    .await);
+            }
         };
         if let Some(pid) = child.id()
             && let Err(error) = tokio::fs::write(&pid_file, format!("{pid}\n")).await
         {
             let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
                 request.instance_id,
-                child,
-                api_socket,
-                guest_socket,
-                pid_file,
-                stopped_marker,
+                Some(child),
+                runtime_files(
+                    api_socket,
+                    guest_socket,
+                    pid_file,
+                    stopped_marker,
+                    network_file,
+                ),
+                network,
+                self.network.clone(),
             ));
             return Err(SpawnFailure::compensate_started(error.into(), owner).await);
         }
         if let Err(error) = wait_for_socket(&api_socket, &mut child, self.socket_timeout).await {
             let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
                 request.instance_id,
-                child,
-                api_socket,
-                guest_socket,
-                pid_file,
-                stopped_marker,
+                Some(child),
+                runtime_files(
+                    api_socket,
+                    guest_socket,
+                    pid_file,
+                    stopped_marker,
+                    network_file,
+                ),
+                network,
+                self.network.clone(),
             ));
             return Err(SpawnFailure::compensate_started(error, owner).await);
         }
 
         let instance = FirecrackerInstance::new(
             request.instance_id,
-            child,
-            api_socket,
-            guest_socket,
-            pid_file,
-            stopped_marker,
+            Some(child),
+            runtime_files(
+                api_socket,
+                guest_socket,
+                pid_file,
+                stopped_marker,
+                network_file,
+            ),
+            network,
+            self.network.clone(),
         );
         Ok(Arc::new(instance))
+    }
+
+    async fn compensate_before_spawn(
+        &self,
+        instance_id: Uuid,
+        files: FirecrackerRuntimeFiles,
+        network: Option<NetworkSlot>,
+        source: BlazeError,
+    ) -> SpawnFailure {
+        if network.is_none() {
+            return SpawnFailure::clean(source);
+        }
+        let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+            instance_id,
+            None,
+            files,
+            network,
+            self.network.clone(),
+        ));
+        SpawnFailure::compensate_started(source, owner).await
     }
 }
 
@@ -121,6 +362,9 @@ impl BackendSpawner for FirecrackerSpawner {
         if !binary_path.is_file() || !executable_in_path("unshare") {
             return Ok(false);
         }
+        if !self.network_probe_ready().await? {
+            return Ok(false);
+        }
         match read_backend_version(binary_path).await {
             Ok(version) => {
                 *self.version.lock().await = Some(version);
@@ -134,36 +378,61 @@ impl BackendSpawner for FirecrackerSpawner {
     }
 
     async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &Path) -> Result<()> {
-        cleanup_orphan_run_dir(instance_id, run_dir).await
+        cleanup_orphan_run_dir_with(instance_id, run_dir, &self.network).await
     }
 }
 
 struct FirecrackerInstance {
     instance_id: Uuid,
     child: Mutex<Option<Child>>,
+    exit_result: Mutex<Option<SpawnResult>>,
+    files: FirecrackerRuntimeFiles,
+    network: Mutex<Option<NetworkSlot>>,
+    network_manager: Arc<NetworkManager>,
+    cleanup_complete: AtomicBool,
+    killed: AtomicBool,
+}
+
+struct FirecrackerRuntimeFiles {
     api_socket: PathBuf,
     guest_socket: PathBuf,
     pid_file: PathBuf,
     stopped_marker: PathBuf,
-    killed: AtomicBool,
+    network_file: PathBuf,
+}
+
+fn runtime_files(
+    api_socket: PathBuf,
+    guest_socket: PathBuf,
+    pid_file: PathBuf,
+    stopped_marker: PathBuf,
+    network_file: PathBuf,
+) -> FirecrackerRuntimeFiles {
+    FirecrackerRuntimeFiles {
+        api_socket,
+        guest_socket,
+        pid_file,
+        stopped_marker,
+        network_file,
+    }
 }
 
 impl FirecrackerInstance {
     fn new(
         instance_id: Uuid,
-        child: Child,
-        api_socket: PathBuf,
-        guest_socket: PathBuf,
-        pid_file: PathBuf,
-        stopped_marker: PathBuf,
+        child: Option<Child>,
+        files: FirecrackerRuntimeFiles,
+        network: Option<NetworkSlot>,
+        network_manager: Arc<NetworkManager>,
     ) -> Self {
         Self {
             instance_id,
-            child: Mutex::new(Some(child)),
-            api_socket,
-            guest_socket,
-            pid_file,
-            stopped_marker,
+            child: Mutex::new(child),
+            exit_result: Mutex::new(None),
+            files,
+            network: Mutex::new(network),
+            network_manager,
+            cleanup_complete: AtomicBool::new(false),
             killed: AtomicBool::new(false),
         }
     }
@@ -176,24 +445,29 @@ impl BackendInstance for FirecrackerInstance {
     }
 
     async fn try_wait(&self) -> Result<Option<SpawnResult>> {
-        let status = {
+        let result = {
             let mut guard = self.child.lock().await;
             let Some(child) = guard.as_mut() else {
-                return Ok(Some(SpawnResult {
+                let result = self.exit_result.lock().await.unwrap_or(SpawnResult {
                     instance_id: self.instance_id,
                     exit_code: None,
                     signal: None,
-                }));
+                });
+                drop(guard);
+                self.cleanup().await?;
+                return Ok(Some(result));
             };
             let Some(status) = child.try_wait()? else {
                 return Ok(None);
             };
-            record_backend_stopped(&self.stopped_marker).await?;
+            record_backend_stopped(&self.files.stopped_marker).await?;
+            let result = spawn_result(self.instance_id, status);
+            *self.exit_result.lock().await = Some(result);
             *guard = None;
-            status
+            result
         };
         self.cleanup().await?;
-        Ok(Some(spawn_result(self.instance_id, status)))
+        Ok(Some(result))
     }
 
     async fn kill(&self) -> Result<()> {
@@ -207,7 +481,7 @@ impl BackendInstance for FirecrackerInstance {
         if let Some(child) = guard.as_mut() {
             terminate_child(child, "firecracker").await?;
         }
-        record_backend_stopped(&self.stopped_marker).await?;
+        record_backend_stopped(&self.files.stopped_marker).await?;
         *guard = None;
         drop(guard);
         self.cleanup().await?;
@@ -218,9 +492,20 @@ impl BackendInstance for FirecrackerInstance {
 
 impl FirecrackerInstance {
     async fn cleanup(&self) -> Result<()> {
-        remove_if_exists(&self.api_socket).await?;
-        remove_if_exists(&self.guest_socket).await?;
-        remove_if_exists(&self.pid_file).await?;
+        if self.cleanup_complete.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        remove_if_exists(&self.files.api_socket).await?;
+        remove_if_exists(&self.files.guest_socket).await?;
+        remove_if_exists(&self.files.pid_file).await?;
+        let mut network = self.network.lock().await;
+        if let Some(slot) = network.as_ref().cloned() {
+            self.network_manager.destroy(&slot).await?;
+            *network = None;
+        }
+        remove_if_exists(&self.files.network_file).await?;
+        remove_if_exists(&network_metadata_temp(&self.files.network_file)).await?;
+        self.cleanup_complete.store(true, Ordering::Release);
         Ok(())
     }
 }
@@ -230,16 +515,43 @@ fn write_vm_config(
     request: &SpawnRequest,
     config: &FirecrackerConfig,
     guest_socket: &Path,
+    network: Option<&NetworkSlot>,
 ) -> Result<PathBuf> {
     let vcpus = config
         .vcpus
         .or(request.vm.as_ref().map(|vm| vm.vcpus))
         .unwrap_or(1);
     let memory_mib = resolve_memory(config, request.vm.as_ref())?;
+    let mut boot_args = config.boot_args.clone();
+    if network.is_some() {
+        let network_arguments = boot_args
+            .split_whitespace()
+            .filter(|argument| argument.starts_with("ip="))
+            .collect::<Vec<_>>();
+        match network_arguments.as_slice() {
+            [] => {
+                boot_args.push(' ');
+                boot_args.push_str(NETWORK_BOOT_IP);
+            }
+            [argument] if *argument == NETWORK_BOOT_IP => {}
+            arguments => {
+                return Err(BlazeError::BackendError {
+                    msg: format!(
+                        "Firecracker networking requires exactly {NETWORK_BOOT_IP:?}, found {}",
+                        arguments
+                            .iter()
+                            .map(|argument| format!("{argument:?}"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                });
+            }
+        }
+    }
     let mut value = serde_json::json!({
         "boot-source": {
             "kernel_image_path": path_string(&images_dir.join("vmlinux"), "vmlinux")?,
-            "boot_args": config.boot_args
+            "boot_args": boot_args
         },
         "drives": [{
             "drive_id": "rootfs",
@@ -257,6 +569,13 @@ fn write_vm_config(
             "guest_cid": 3,
             "uds_path": path_string(guest_socket, "guest socket")?
         });
+    }
+    if let Some(network) = network {
+        value["network-interfaces"] = serde_json::json!([{
+            "iface_id": "eth0",
+            "guest_mac": "02:FC:00:00:00:02",
+            "host_dev_name": network.tap_name()
+        }]);
     }
     let path = request.run_dir.join("vmconfig.json");
     std::fs::write(
@@ -281,9 +600,26 @@ fn resolve_memory(config: &FirecrackerConfig, vm: Option<&VmConfig>) -> Result<u
         })
 }
 
-fn build_launch_command(binary: &Path, api_socket: &Path) -> Command {
+fn build_launch_command(
+    binary: &Path,
+    network: Option<&NetworkSlot>,
+    api_socket: &Path,
+) -> Command {
     #[cfg(target_os = "linux")]
-    let mut command = {
+    let mut command = if let Some(network) = network {
+        let mut command = Command::new("ip");
+        command
+            .arg("netns")
+            .arg("exec")
+            .arg(network.netns())
+            .arg("unshare")
+            .arg("--mount")
+            .arg("--propagation")
+            .arg("private")
+            .arg("--")
+            .arg(binary);
+        command
+    } else {
         let mut command = Command::new("unshare");
         command
             .arg("--mount")
@@ -294,7 +630,10 @@ fn build_launch_command(binary: &Path, api_socket: &Path) -> Command {
         command
     };
     #[cfg(not(target_os = "linux"))]
-    let mut command = Command::new(binary);
+    let mut command = {
+        let _ = network;
+        Command::new(binary)
+    };
     command.arg("--api-sock").arg(api_socket);
     command.arg("--id").arg(format!(
         "fc-{}",
@@ -405,6 +744,57 @@ async fn remove_if_exists(path: &Path) -> Result<()> {
     }
 }
 
+fn write_network_metadata(path: &Path, network: &NetworkSlot) -> Result<()> {
+    write_network_record(path, network, NetworkProcessState::PreSpawn)
+}
+
+fn write_network_record(
+    path: &Path,
+    network: &NetworkSlot,
+    process_state: NetworkProcessState,
+) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| BlazeError::BackendError {
+        msg: format!("network metadata has no parent: {}", path.display()),
+    })?;
+    let temporary = network_metadata_temp(path);
+    (|| -> Result<()> {
+        let bytes = serde_json::to_vec_pretty(&NetworkRecord {
+            slot: network.slot(),
+            owner: network.owner(),
+            process_state,
+        })
+        .map_err(|error| BlazeError::BackendError {
+            msg: format!("serialize network metadata: {error}"),
+        })?;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        std::fs::rename(&temporary, path)?;
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })()
+}
+
+fn read_network_metadata(path: &Path) -> Result<(NetworkSlot, NetworkProcessState)> {
+    let record: NetworkRecord = serde_json::from_slice(&std::fs::read(path)?).map_err(|error| {
+        BlazeError::BackendError {
+            msg: format!("parse network metadata {}: {error}", path.display()),
+        }
+    })?;
+    Ok((
+        NetworkSlot::from_record(record.slot, record.owner)?,
+        record.process_state,
+    ))
+}
+
+fn network_metadata_temp(path: &Path) -> PathBuf {
+    path.with_extension("json.tmp")
+}
+
 fn validate_regular_file(path: &Path, label: &str) -> Result<()> {
     if !path.is_file() {
         return Err(BlazeError::BackendError {
@@ -462,30 +852,81 @@ fn path_string<'a>(path: &'a Path, label: &str) -> Result<&'a str> {
     })
 }
 
-pub(super) async fn cleanup_orphan_run_dir(instance_id: Uuid, run_dir: &Path) -> Result<()> {
+async fn cleanup_orphan_run_dir_with(
+    instance_id: Uuid,
+    run_dir: &Path,
+    network_manager: &NetworkManager,
+) -> Result<()> {
     let stopped_marker = stopped_marker(run_dir);
-    if stopped_marker.is_file() {
-        return Ok(());
-    }
     let pid_file = run_dir.join("firecracker.pid");
-    #[cfg(target_os = "linux")]
-    {
-        terminate_recorded_process(instance_id, &pid_file, "firecracker").await?;
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = instance_id;
-        if pid_file.exists() {
-            return Err(BlazeError::BackendError {
-                msg: format!(
-                    "cannot validate Firecracker orphan {} outside Linux",
-                    pid_file.display()
-                ),
-            });
+    let network_file = run_dir.join("network.json");
+    let network_temp_file = network_metadata_temp(&network_file);
+    let record_path = if network_file.is_file() {
+        Some(network_file.as_path())
+    } else if network_temp_file.is_file() {
+        Some(network_temp_file.as_path())
+    } else {
+        None
+    };
+    let network_record = match record_path {
+        Some(path) => match read_network_metadata(path) {
+            Ok((network, state)) => {
+                if network.owner() != instance_id {
+                    return Err(BlazeError::BackendError {
+                        msg: format!(
+                            "network record owner {} does not match instance {instance_id}",
+                            network.owner()
+                        ),
+                    });
+                }
+                Some((network, Some(state)))
+            }
+            Err(error) if path == network_temp_file.as_path() && !network_file.exists() => {
+                match network_manager.find_by_owner(instance_id).await? {
+                    // The namespace name proves ownership, but it cannot prove
+                    // whether the backend crossed the spawn boundary.
+                    Some(network) => Some((network, None)),
+                    None => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
+        },
+        None => network_manager
+            .find_by_owner(instance_id)
+            .await?
+            .map(|network| (network, None)),
+    };
+    let process_may_exist = pid_file.exists()
+        || network_record
+            .as_ref()
+            .is_none_or(|(_, state)| *state != Some(NetworkProcessState::PreSpawn));
+    if !stopped_marker.is_file() {
+        #[cfg(target_os = "linux")]
+        {
+            if process_may_exist {
+                terminate_recorded_process(instance_id, &pid_file, "firecracker").await?;
+            }
         }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = instance_id;
+            if process_may_exist {
+                return Err(BlazeError::BackendError {
+                    msg: format!(
+                        "cannot validate Firecracker orphan {} outside Linux",
+                        pid_file.display()
+                    ),
+                });
+            }
+        }
+        record_backend_stopped(&stopped_marker).await?;
     }
 
-    record_backend_stopped(&stopped_marker).await?;
+    if let Some((network, _)) = network_record {
+        network_manager.destroy(&network).await?;
+        remove_if_exists(&network_file).await?;
+    }
+    remove_if_exists(&network_temp_file).await?;
     remove_if_exists(&run_dir.join("api.sock")).await?;
     remove_if_exists(&run_dir.join("vsock.uds")).await?;
     remove_if_exists(&pid_file).await?;
@@ -494,7 +935,11 @@ pub(super) async fn cleanup_orphan_run_dir(instance_id: Uuid, run_dir: &Path) ->
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use blaze_core::storage::StorageSlot;
+
+    use crate::spawner::netns::{IpCommandRunner, IpOutput, NetworkManager, test_network_slot};
 
     use super::*;
 
@@ -525,12 +970,507 @@ mod tests {
             &request,
             &FirecrackerConfig::default(),
             &temp.path().join("guest.sock"),
+            None,
         )
         .expect("write config");
         let value: serde_json::Value =
             serde_json::from_slice(&std::fs::read(path).expect("read config"))
                 .expect("parse config");
         assert!(value.get("network-interfaces").is_none());
+    }
+
+    #[test]
+    fn vm_config_wires_an_allocated_network_slot() {
+        let temp = tempfile::tempdir().expect("temp");
+        let request = spawn_request(temp.path());
+        let network = test_network_slot(0);
+
+        let path = write_vm_config(
+            &temp.path().join("images"),
+            &request,
+            &FirecrackerConfig::default(),
+            &temp.path().join("guest.sock"),
+            Some(&network),
+        )
+        .expect("write config");
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(value["network-interfaces"][0]["iface_id"], "eth0");
+        assert_eq!(value["network-interfaces"][0]["host_dev_name"], "tap0");
+        assert!(
+            value["boot-source"]["boot_args"]
+                .as_str()
+                .expect("boot args")
+                .contains("::eth0:off")
+        );
+    }
+
+    #[test]
+    fn vm_config_accepts_the_matching_network_boot_argument() {
+        let temp = tempfile::tempdir().expect("temp");
+        let request = spawn_request(temp.path());
+        let network = test_network_slot(0);
+        let config = FirecrackerConfig {
+            boot_args: format!("console=ttyS0 {NETWORK_BOOT_IP}"),
+            ..FirecrackerConfig::default()
+        };
+
+        write_vm_config(
+            &temp.path().join("images"),
+            &request,
+            &config,
+            &temp.path().join("guest.sock"),
+            Some(&network),
+        )
+        .expect("matching network boot argument");
+    }
+
+    #[test]
+    fn vm_config_rejects_an_incompatible_network_boot_argument() {
+        let temp = tempfile::tempdir().expect("temp");
+        let request = spawn_request(temp.path());
+        let network = test_network_slot(0);
+        let config = FirecrackerConfig {
+            boot_args: "console=ttyS0 ip=dhcp".to_string(),
+            ..FirecrackerConfig::default()
+        };
+
+        let error = write_vm_config(
+            &temp.path().join("images"),
+            &request,
+            &config,
+            &temp.path().join("guest.sock"),
+            Some(&network),
+        )
+        .expect_err("incompatible network boot argument");
+
+        assert!(error.to_string().contains("requires"));
+        assert!(error.to_string().contains("ip=dhcp"));
+    }
+
+    #[test]
+    fn vm_config_rejects_conflicting_network_boot_arguments() {
+        let temp = tempfile::tempdir().expect("temp");
+        let request = spawn_request(temp.path());
+        let network = test_network_slot(0);
+        let config = FirecrackerConfig {
+            boot_args: format!("console=ttyS0 {NETWORK_BOOT_IP} ip=dhcp"),
+            ..FirecrackerConfig::default()
+        };
+
+        let error = write_vm_config(
+            &temp.path().join("images"),
+            &request,
+            &config,
+            &temp.path().join("guest.sock"),
+            Some(&network),
+        )
+        .expect_err("conflicting network boot arguments");
+
+        assert!(error.to_string().contains("exactly"));
+        assert!(error.to_string().contains("ip=dhcp"));
+    }
+
+    #[test]
+    fn network_metadata_is_published_atomically() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("network.json");
+        let slot = test_network_slot(7);
+
+        write_network_metadata(&path, &slot).expect("write metadata");
+
+        let (stored, state) = read_network_metadata(&path).expect("parse metadata");
+        assert_eq!(stored, slot);
+        assert_eq!(state, NetworkProcessState::PreSpawn);
+        assert!(!network_metadata_temp(&path).exists());
+    }
+
+    #[test]
+    fn network_metadata_records_launch_intent_before_spawn() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("network.json");
+        let slot = test_network_slot(7);
+        write_network_metadata(&path, &slot).expect("write pre-spawn metadata");
+
+        write_network_record(&path, &slot, NetworkProcessState::Launching)
+            .expect("record launch intent");
+
+        let (stored, state) = read_network_metadata(&path).expect("parse metadata");
+        assert_eq!(stored, slot);
+        assert_eq!(state, NetworkProcessState::Launching);
+        assert!(!network_metadata_temp(&path).exists());
+    }
+
+    #[test]
+    fn network_metadata_rejects_out_of_range_slots() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("network.json");
+        std::fs::write(
+            &path,
+            br#"{"slot":16383,"owner":"00000000-0000-0000-0000-000000000001"}"#,
+        )
+        .expect("metadata");
+
+        let error = read_network_metadata(&path).expect_err("invalid slot");
+
+        assert!(error.to_string().contains("outside"));
+    }
+
+    #[tokio::test]
+    async fn network_cleanup_failure_retains_a_retryable_backend_owner() {
+        let temp = tempfile::tempdir().expect("temp");
+        let network_file = temp.path().join("network.json");
+        let slot = test_network_slot(0);
+        write_network_metadata(&network_file, &slot).expect("network metadata");
+        let namespace = format!("{}\n", slot.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([
+            ip_success(namespace.as_bytes()),
+            ip_failure("delete peer failed"),
+            ip_success(namespace.as_bytes()),
+            ip_success(b""),
+            ip_success(b""),
+        ]));
+        let network_manager = Arc::new(NetworkManager::with_runner(runner.clone()));
+        let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
+            slot.owner(),
+            None,
+            runtime_files(
+                temp.path().join("api.sock"),
+                temp.path().join("guest.sock"),
+                temp.path().join("firecracker.pid"),
+                stopped_marker(temp.path()),
+                network_file.clone(),
+            ),
+            Some(slot.clone()),
+            network_manager,
+        ));
+
+        owner.kill().await.expect_err("first cleanup must fail");
+        assert!(network_file.exists());
+        owner.kill().await.expect("retry cleanup");
+        assert!(!network_file.exists());
+        assert!(
+            runner
+                .calls()
+                .iter()
+                .any(|args| args == &["netns", "del", slot.netns()])
+        );
+        assert!(
+            !runner
+                .calls()
+                .iter()
+                .any(|args| args == &["link", "del", "blz-veth-0"])
+        );
+    }
+
+    #[tokio::test]
+    async fn try_wait_retries_cleanup_after_observing_process_exit() {
+        let temp = tempfile::tempdir().expect("temp");
+        let network_file = temp.path().join("network.json");
+        let slot = test_network_slot(0);
+        write_network_metadata(&network_file, &slot).expect("network metadata");
+        let namespace = format!("{}\n", slot.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([
+            ip_success(namespace.as_bytes()),
+            ip_failure("delete peer failed"),
+            ip_success(namespace.as_bytes()),
+            ip_success(b""),
+            ip_success(b""),
+        ]));
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 7")
+            .spawn()
+            .expect("spawn child");
+        let instance = FirecrackerInstance::new(
+            slot.owner(),
+            Some(child),
+            runtime_files(
+                temp.path().join("api.sock"),
+                temp.path().join("guest.sock"),
+                temp.path().join("firecracker.pid"),
+                stopped_marker(temp.path()),
+                network_file.clone(),
+            ),
+            Some(slot.clone()),
+            Arc::new(NetworkManager::with_runner(runner.clone())),
+        );
+
+        let first_error = loop {
+            match instance.try_wait().await {
+                Ok(None) => tokio::time::sleep(Duration::from_millis(5)).await,
+                Ok(Some(result)) => {
+                    panic!("cleanup failure must not report completion: {result:?}")
+                }
+                Err(error) => break error,
+            }
+        };
+        assert!(first_error.to_string().contains("delete peer failed"));
+        assert!(network_file.exists());
+
+        let result = instance
+            .try_wait()
+            .await
+            .expect("retry cleanup")
+            .expect("completed process");
+        assert_eq!(result.exit_code, Some(7));
+        assert!(!network_file.exists());
+        assert!(
+            runner
+                .calls()
+                .iter()
+                .any(|args| args == &["netns", "del", slot.netns()])
+        );
+    }
+
+    #[tokio::test]
+    async fn stopped_orphan_still_releases_recorded_network() {
+        let temp = tempfile::tempdir().expect("temp");
+        record_backend_stopped(&stopped_marker(temp.path()))
+            .await
+            .expect("stopped marker");
+        let network_file = temp.path().join("network.json");
+        let network = test_network_slot(0);
+        write_network_metadata(&network_file, &network).expect("network metadata");
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([
+            ip_success(namespace.as_bytes()),
+            ip_success(b""),
+            ip_success(b""),
+        ]));
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        cleanup_orphan_run_dir_with(network.owner(), temp.path(), &network_manager)
+            .await
+            .expect("orphan cleanup");
+
+        assert!(!network_file.exists());
+        let calls = runner.calls();
+        assert!(calls.iter().any(|args| {
+            args == &[
+                "netns",
+                "exec",
+                network.netns(),
+                "ip",
+                "link",
+                "del",
+                "blz-vpeer-0",
+            ]
+        }));
+        assert!(
+            calls
+                .iter()
+                .any(|args| args == &["netns", "del", network.netns()])
+        );
+    }
+
+    #[tokio::test]
+    async fn orphan_cleanup_recovers_a_complete_temporary_network_record() {
+        let temp = tempfile::tempdir().expect("temp");
+        record_backend_stopped(&stopped_marker(temp.path()))
+            .await
+            .expect("stopped marker");
+        let network_file = temp.path().join("network.json");
+        let network_temp_file = network_metadata_temp(&network_file);
+        let network = test_network_slot(0);
+        let bytes = serde_json::to_vec(&NetworkRecord {
+            slot: network.slot(),
+            owner: network.owner(),
+            process_state: NetworkProcessState::PreSpawn,
+        })
+        .expect("serialize metadata");
+        std::fs::write(&network_temp_file, bytes).expect("temporary metadata");
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([
+            ip_success(namespace.as_bytes()),
+            ip_success(b""),
+            ip_success(b""),
+        ]));
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        cleanup_orphan_run_dir_with(network.owner(), temp.path(), &network_manager)
+            .await
+            .expect("orphan cleanup");
+
+        assert!(!network_file.exists());
+        assert!(!network_temp_file.exists());
+        assert!(
+            runner
+                .calls()
+                .iter()
+                .any(|args| args == &["netns", "del", network.netns()])
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn orphan_cleanup_retains_a_truncated_network_record_without_pid_proof() {
+        let temp = tempfile::tempdir().expect("temp");
+        let network_file = temp.path().join("network.json");
+        let network_temp_file = network_metadata_temp(&network_file);
+        std::fs::write(&network_temp_file, b"{").expect("truncated metadata");
+        let network = test_network_slot(0);
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([ip_success(
+            namespace.as_bytes(),
+        )]));
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        let error = cleanup_orphan_run_dir_with(network.owner(), temp.path(), &network_manager)
+            .await
+            .expect_err("unknown launch state must fail closed");
+
+        assert!(error.to_string().contains("missing PID metadata"));
+        assert!(network_temp_file.exists());
+        assert!(!stopped_marker(temp.path()).exists());
+        assert_eq!(
+            runner.calls(),
+            vec![vec!["netns".to_string(), "list".to_string()]]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn orphan_cleanup_retains_an_unrecorded_namespace_without_pid_proof() {
+        let temp = tempfile::tempdir().expect("temp");
+        let network = test_network_slot(0);
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([ip_success(
+            namespace.as_bytes(),
+        )]));
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        let error = cleanup_orphan_run_dir_with(network.owner(), temp.path(), &network_manager)
+            .await
+            .expect_err("unknown launch state must fail closed");
+
+        assert!(error.to_string().contains("missing PID metadata"));
+        assert!(!stopped_marker(temp.path()).exists());
+        assert_eq!(
+            runner.calls(),
+            vec![vec!["netns".to_string(), "list".to_string()]]
+        );
+    }
+
+    #[tokio::test]
+    async fn stopped_orphan_releases_an_unrecorded_owner_namespace() {
+        let temp = tempfile::tempdir().expect("temp");
+        record_backend_stopped(&stopped_marker(temp.path()))
+            .await
+            .expect("stopped marker");
+        let network = test_network_slot(0);
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([
+            ip_success(namespace.as_bytes()),
+            ip_success(namespace.as_bytes()),
+            ip_success(b""),
+            ip_success(b""),
+        ]));
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        cleanup_orphan_run_dir_with(network.owner(), temp.path(), &network_manager)
+            .await
+            .expect("stopped process permits network recovery");
+
+        assert!(
+            runner
+                .calls()
+                .iter()
+                .any(|args| args == &["netns", "del", network.netns()])
+        );
+    }
+
+    #[tokio::test]
+    async fn network_record_owner_mismatch_issues_no_host_commands() {
+        let temp = tempfile::tempdir().expect("temp");
+        let network_file = temp.path().join("network.json");
+        let network = test_network_slot(0);
+        write_network_metadata(&network_file, &network).expect("network metadata");
+        let runner = Arc::new(TestIpRunner::default());
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        let error = cleanup_orphan_run_dir_with(Uuid::from_u128(2), temp.path(), &network_manager)
+            .await
+            .expect_err("mismatched owner must fail");
+
+        assert!(error.to_string().contains("does not match instance"));
+        assert!(network_file.exists());
+        assert!(runner.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_network_record_does_not_delete_a_reused_slot() {
+        let temp = tempfile::tempdir().expect("temp");
+        record_backend_stopped(&stopped_marker(temp.path()))
+            .await
+            .expect("stopped marker");
+        let network_file = temp.path().join("network.json");
+        let old_network = test_network_slot(0);
+        write_network_metadata(&network_file, &old_network).expect("network metadata");
+        let new_network =
+            NetworkSlot::from_record(0, Uuid::from_u128(2)).expect("new network owner");
+        let namespace = format!("{}\n", new_network.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([ip_success(
+            namespace.as_bytes(),
+        )]));
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        cleanup_orphan_run_dir_with(old_network.owner(), temp.path(), &network_manager)
+            .await
+            .expect("retire stale record");
+
+        assert!(!network_file.exists());
+        let calls = runner.calls();
+        assert_eq!(calls, vec![vec!["netns".to_string(), "list".to_string()]]);
+    }
+
+    #[tokio::test]
+    async fn pre_spawn_orphan_releases_network_without_pid_metadata() {
+        let temp = tempfile::tempdir().expect("temp");
+        let network_file = temp.path().join("network.json");
+        let network = test_network_slot(0);
+        write_network_metadata(&network_file, &network).expect("network metadata");
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(TestIpRunner::with_responses([
+            ip_success(namespace.as_bytes()),
+            ip_success(b""),
+            ip_success(b""),
+        ]));
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        cleanup_orphan_run_dir_with(network.owner(), temp.path(), &network_manager)
+            .await
+            .expect("pre-spawn cleanup");
+
+        assert!(!network_file.exists());
+        assert!(stopped_marker(temp.path()).exists());
+        assert!(
+            runner
+                .calls()
+                .iter()
+                .any(|args| args == &["netns", "del", network.netns()])
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn unconfirmed_process_ownership_retains_network_metadata() {
+        let temp = tempfile::tempdir().expect("temp");
+        let network_file = temp.path().join("network.json");
+        let network = test_network_slot(0);
+        write_network_record(&network_file, &network, NetworkProcessState::Launching)
+            .expect("network metadata");
+        let runner = Arc::new(TestIpRunner::default());
+        let network_manager = NetworkManager::with_runner(runner.clone());
+
+        let error = cleanup_orphan_run_dir_with(network.owner(), temp.path(), &network_manager)
+            .await
+            .expect_err("missing process metadata must block cleanup");
+
+        assert!(error.to_string().contains("missing PID metadata"));
+        assert!(network_file.exists());
+        assert!(runner.calls().is_empty());
     }
 
     #[test]
@@ -568,6 +1508,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn backend_probe_skips_network_checks_when_no_policy_enables_them() {
+        let temp = tempfile::tempdir().expect("temp");
+        let called = Arc::new(AtomicBool::new(false));
+        let network = Arc::new(NetworkManager::with_runner(Arc::new(
+            UnavailableNetworkRunner {
+                called: called.clone(),
+            },
+        )));
+        let spawner = FirecrackerSpawner {
+            images_dir: temp.path().join("images"),
+            socket_timeout: Duration::from_secs(1),
+            network,
+            network_required: false,
+            version: Mutex::new(None),
+        };
+
+        assert!(spawner.network_probe_ready().await.expect("probe"));
+        assert!(!called.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
     async fn start_failure_terminates_child_and_removes_process_metadata() {
         let temp = tempfile::tempdir().expect("temp");
         let pid_file = temp.path().join("firecracker.pid");
@@ -583,11 +1544,16 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
         let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
             Uuid::new_v4(),
-            child,
-            temp.path().join("api.sock"),
-            temp.path().join("guest.sock"),
-            pid_file.clone(),
-            stopped_marker(temp.path()),
+            Some(child),
+            runtime_files(
+                temp.path().join("api.sock"),
+                temp.path().join("guest.sock"),
+                pid_file.clone(),
+                stopped_marker(temp.path()),
+                temp.path().join("network.json"),
+            ),
+            None,
+            Arc::new(NetworkManager::default()),
         ));
         let failure = SpawnFailure::compensate_started(
             BlazeError::BackendError {
@@ -629,6 +1595,78 @@ mod tests {
             },
             backend: blaze_core::policy::BackendConfigs::default(),
             vm: None,
+        }
+    }
+
+    #[derive(Default)]
+    struct TestIpRunner {
+        responses: std::sync::Mutex<VecDeque<IpOutput>>,
+        calls: std::sync::Mutex<Vec<Vec<String>>>,
+    }
+
+    struct UnavailableNetworkRunner {
+        called: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl IpCommandRunner for UnavailableNetworkRunner {
+        async fn output(&self, _args: &[String], _timeout: Duration) -> Result<IpOutput> {
+            self.called.store(true, Ordering::Release);
+            Ok(ip_failure("network commands unavailable"))
+        }
+
+        #[cfg(target_os = "linux")]
+        fn executable_in_path(&self, _name: &str) -> bool {
+            false
+        }
+
+        #[cfg(target_os = "linux")]
+        fn has_network_admin(&self) -> bool {
+            false
+        }
+    }
+
+    impl TestIpRunner {
+        fn with_responses<const N: usize>(responses: [IpOutput; N]) -> Self {
+            Self {
+                responses: std::sync::Mutex::new(responses.into()),
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.lock().expect("calls lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl IpCommandRunner for TestIpRunner {
+        async fn output(&self, args: &[String], _timeout: Duration) -> Result<IpOutput> {
+            self.calls.lock().expect("calls lock").push(args.to_vec());
+            Ok(self
+                .responses
+                .lock()
+                .expect("responses lock")
+                .pop_front()
+                .unwrap_or_else(|| ip_success(b"")))
+        }
+    }
+
+    fn ip_success(stdout: &[u8]) -> IpOutput {
+        IpOutput {
+            success: true,
+            status: "exit status: 0".to_string(),
+            stdout: stdout.to_vec(),
+            stderr: Vec::new(),
+        }
+    }
+
+    fn ip_failure(stderr: &str) -> IpOutput {
+        IpOutput {
+            success: false,
+            status: "exit status: 1".to_string(),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
         }
     }
 }

--- a/src/blaze/crates/blazed/src/spawner/netns.rs
+++ b/src/blaze/crates/blazed/src/spawner/netns.rs
@@ -1,0 +1,1192 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Per-VM network namespace allocation and compensated setup.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use blaze_core::{BlazeError, Result};
+use thiserror::Error;
+use tokio::process::Command;
+use uuid::Uuid;
+
+const NET_VETH_BASE: usize = 4;
+const NET_VETH_TOP: usize = 0x1_0000;
+const NET_MAX_SLOT: usize = (NET_VETH_TOP - NET_VETH_BASE) / 4;
+const HOST_NETWORK_LOCK: &str = "/run/lock/blaze-network.lock";
+const HOST_LOCK_RETRY: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Default)]
+struct SlotState {
+    used: HashSet<usize>,
+    next: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct IpOutput {
+    pub(super) success: bool,
+    pub(super) status: String,
+    pub(super) stdout: Vec<u8>,
+    pub(super) stderr: Vec<u8>,
+}
+
+#[async_trait]
+pub(super) trait IpCommandRunner: Send + Sync {
+    async fn output(&self, args: &[String], timeout: Duration) -> Result<IpOutput>;
+
+    #[cfg(target_os = "linux")]
+    fn executable_in_path(&self, _name: &str) -> bool {
+        true
+    }
+
+    #[cfg(target_os = "linux")]
+    fn has_network_admin(&self) -> bool {
+        true
+    }
+}
+
+struct SystemIpCommandRunner;
+
+#[async_trait]
+impl IpCommandRunner for SystemIpCommandRunner {
+    async fn output(&self, args: &[String], timeout: Duration) -> Result<IpOutput> {
+        let mut command = Command::new("ip");
+        command.kill_on_drop(true).env("LC_ALL", "C").args(args);
+        let output = tokio::time::timeout(timeout, command.output())
+            .await
+            .map_err(|_| BlazeError::BackendError {
+                msg: format!("ip {} timed out", args.join(" ")),
+            })??;
+        Ok(IpOutput {
+            success: output.status.success(),
+            status: output.status.to_string(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn executable_in_path(&self, name: &str) -> bool {
+        executable_in_path(name)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn has_network_admin(&self) -> bool {
+        // The current implementation relies on root-owned netns mounts,
+        // tap creation, forwarding changes, and NAT rules.
+        unsafe { libc::geteuid() == 0 }
+    }
+}
+
+/// Process-local allocator and lifecycle owner for Blaze network namespaces.
+pub(super) struct NetworkManager {
+    state: Mutex<SlotState>,
+    command_timeout: Duration,
+    runner: Arc<dyn IpCommandRunner>,
+    coordination_file: Option<PathBuf>,
+}
+
+impl fmt::Debug for NetworkManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NetworkManager")
+            .field("command_timeout", &self.command_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for NetworkManager {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(SlotState::default()),
+            command_timeout: Duration::from_secs(5),
+            runner: Arc::new(SystemIpCommandRunner),
+            coordination_file: Some(PathBuf::from(HOST_NETWORK_LOCK)),
+        }
+    }
+}
+
+struct HostNetworkGuard {
+    #[cfg(unix)]
+    _file: Option<std::fs::File>,
+}
+
+/// One fully configured per-VM network namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct NetworkSlot {
+    slot: usize,
+    owner: Uuid,
+    netns: String,
+    tap_name: String,
+    veth_host: String,
+    veth_peer: String,
+}
+
+/// Network setup failure with an optional residual slot owner.
+#[derive(Debug, Error)]
+#[error("{source}")]
+pub(super) struct NetworkCreateError {
+    #[source]
+    source: BlazeError,
+    residual: Option<NetworkSlot>,
+}
+
+impl NetworkCreateError {
+    fn clean(source: BlazeError) -> Self {
+        Self {
+            source,
+            residual: None,
+        }
+    }
+
+    fn with_residual(source: BlazeError, residual: NetworkSlot) -> Self {
+        Self {
+            source,
+            residual: Some(residual),
+        }
+    }
+
+    /// Split the setup error from any network slot that still needs cleanup.
+    pub(super) fn into_parts(self) -> (BlazeError, Option<NetworkSlot>) {
+        (self.source, self.residual)
+    }
+}
+
+impl From<BlazeError> for NetworkCreateError {
+    fn from(source: BlazeError) -> Self {
+        Self::clean(source)
+    }
+}
+
+impl NetworkSlot {
+    pub(super) fn from_record(slot: usize, owner: Uuid) -> Result<Self> {
+        if slot >= NET_MAX_SLOT {
+            return Err(BlazeError::BackendError {
+                msg: format!("network slot {slot} is outside 0..{NET_MAX_SLOT}"),
+            });
+        }
+        Ok(network_slot(slot, owner))
+    }
+
+    pub(super) fn slot(&self) -> usize {
+        self.slot
+    }
+
+    pub(super) fn owner(&self) -> Uuid {
+        self.owner
+    }
+
+    /// Network namespace name.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(super) fn netns(&self) -> &str {
+        &self.netns
+    }
+
+    /// Tap device visible inside the namespace.
+    pub(super) fn tap_name(&self) -> &str {
+        &self.tap_name
+    }
+}
+
+impl NetworkManager {
+    #[cfg(test)]
+    pub(super) fn with_runner(runner: Arc<dyn IpCommandRunner>) -> Self {
+        Self {
+            state: Mutex::new(SlotState::default()),
+            command_timeout: Duration::from_secs(1),
+            runner,
+            coordination_file: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_runner_and_lock(
+        runner: Arc<dyn IpCommandRunner>,
+        coordination_file: PathBuf,
+    ) -> Self {
+        Self {
+            state: Mutex::new(SlotState::default()),
+            command_timeout: Duration::from_secs(1),
+            runner,
+            coordination_file: Some(coordination_file),
+        }
+    }
+
+    /// Check the commands and host conditions required by the network path.
+    pub(super) async fn probe(&self) -> Result<bool> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            Ok(false)
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if !self.runner.has_network_admin()
+                || ["ip", "sysctl", "iptables"]
+                    .iter()
+                    .any(|command| !self.runner.executable_in_path(command))
+            {
+                return Ok(false);
+            }
+            let args = vec!["netns".to_string(), "list".to_string()];
+            Ok(self.run_ip_output(&args).await?.success)
+        }
+    }
+
+    /// Create an isolated namespace, veth uplink, tap, route, and NAT rule.
+    ///
+    /// `record` runs immediately after this manager creates the namespace and
+    /// before any dependent resources are added. Callers use it to publish
+    /// ownership without ever recording a namespace created by another process.
+    pub(super) async fn create<F>(
+        &self,
+        owner: Uuid,
+        mut record: F,
+    ) -> std::result::Result<NetworkSlot, NetworkCreateError>
+    where
+        F: FnMut(&NetworkSlot) -> Result<()>,
+    {
+        let _host_guard = self.acquire_host_guard().await?;
+        let mut blocked = self.existing_slots().await?;
+        let (slot, network) = loop {
+            let slot = self.allocate(&blocked)?;
+            let network = network_slot(slot, owner);
+            let add_namespace = vec!["netns".into(), "add".into(), network.netns.clone()];
+            match self.run_ip(&add_namespace).await {
+                Ok(()) => {
+                    if let Err(error) = record(&network) {
+                        return self.fail_setup(&network, error).await;
+                    }
+                    break (slot, network);
+                }
+                Err(error) => {
+                    let refreshed = match self.list_namespaces().await {
+                        Ok(output) => output,
+                        Err(confirmation) => {
+                            let error = BlazeError::BackendError {
+                                msg: format!(
+                                    "{error}; cannot determine whether namespace {} was created: {confirmation}",
+                                    network.netns
+                                ),
+                            };
+                            let error = match record(&network) {
+                                Ok(()) => error,
+                                Err(recording) => BlazeError::BackendError {
+                                    msg: format!(
+                                        "{error}; cannot record uncertain namespace ownership: {recording}"
+                                    ),
+                                },
+                            };
+                            return self.fail_setup(&network, error).await;
+                        }
+                    };
+                    if namespace_exists_in_output(&refreshed.stdout, &network.netns) {
+                        let error = match record(&network) {
+                            Ok(()) => error,
+                            Err(recording) => BlazeError::BackendError {
+                                msg: format!(
+                                    "{error}; cannot record created namespace ownership: {recording}"
+                                ),
+                            },
+                        };
+                        return self.fail_setup(&network, error).await;
+                    }
+                    self.release(slot);
+                    let refreshed = parse_existing_slots(&refreshed.stdout);
+                    if refreshed.contains(&slot) {
+                        blocked.extend(refreshed);
+                        continue;
+                    }
+                    return Err(NetworkCreateError::clean(error));
+                }
+            }
+        };
+        let (host_ip, peer_ip) = veth_ips(slot);
+        let add_veth = vec![
+            "link".into(),
+            "add".into(),
+            network.veth_host.clone(),
+            "type".into(),
+            "veth".into(),
+            "peer".into(),
+            "name".into(),
+            network.veth_peer.clone(),
+            "netns".into(),
+            network.netns.clone(),
+        ];
+        if let Err(error) = self.run_ip(&add_veth).await {
+            return self.fail_setup(&network, error).await;
+        }
+        let host_steps = vec![
+            vec![
+                "addr".into(),
+                "add".into(),
+                format!("{host_ip}/30"),
+                "dev".into(),
+                network.veth_host.clone(),
+            ],
+            vec![
+                "link".into(),
+                "set".into(),
+                network.veth_host.clone(),
+                "up".into(),
+            ],
+        ];
+        for args in host_steps {
+            if let Err(error) = self.run_ip(&args).await {
+                return self.fail_setup(&network, error).await;
+            }
+        }
+
+        let ns_steps = vec![
+            vec![
+                "ip".into(),
+                "addr".into(),
+                "add".into(),
+                format!("{peer_ip}/30"),
+                "dev".into(),
+                network.veth_peer.clone(),
+            ],
+            vec![
+                "ip".into(),
+                "link".into(),
+                "set".into(),
+                network.veth_peer.clone(),
+                "up".into(),
+            ],
+            vec![
+                "ip".into(),
+                "link".into(),
+                "set".into(),
+                "lo".into(),
+                "up".into(),
+            ],
+            vec![
+                "ip".into(),
+                "tuntap".into(),
+                "add".into(),
+                network.tap_name.clone(),
+                "mode".into(),
+                "tap".into(),
+            ],
+            vec![
+                "ip".into(),
+                "addr".into(),
+                "add".into(),
+                "169.254.0.1/30".into(),
+                "dev".into(),
+                network.tap_name.clone(),
+            ],
+            vec![
+                "ip".into(),
+                "link".into(),
+                "set".into(),
+                network.tap_name.clone(),
+                "up".into(),
+            ],
+            vec![
+                "ip".into(),
+                "route".into(),
+                "add".into(),
+                "default".into(),
+                "via".into(),
+                host_ip,
+            ],
+            vec!["sysctl".into(), "-w".into(), "net.ipv4.ip_forward=1".into()],
+            vec![
+                "iptables".into(),
+                "-t".into(),
+                "nat".into(),
+                "-A".into(),
+                "POSTROUTING".into(),
+                "-s".into(),
+                "169.254.0.2".into(),
+                "-o".into(),
+                network.veth_peer.clone(),
+                "-j".into(),
+                "SNAT".into(),
+                "--to".into(),
+                peer_ip,
+            ],
+        ];
+        for command in ns_steps {
+            if let Err(error) = self.run_in_namespace(&network.netns, &command).await {
+                return self.fail_setup(&network, error).await;
+            }
+        }
+        Ok(network)
+    }
+
+    /// Remove all resources for a slot and return it to the allocator.
+    pub(super) async fn destroy(&self, network: &NetworkSlot) -> Result<()> {
+        let _host_guard = self.acquire_host_guard().await?;
+        self.cleanup_commands(network).await?;
+        self.release(network.slot);
+        Ok(())
+    }
+
+    async fn acquire_host_guard(&self) -> Result<HostNetworkGuard> {
+        let Some(path) = self.coordination_file.as_deref() else {
+            return Ok(HostNetworkGuard {
+                #[cfg(unix)]
+                _file: None,
+            });
+        };
+        acquire_host_guard(path, self.command_timeout).await
+    }
+
+    fn allocate(&self, blocked: &HashSet<usize>) -> Result<usize> {
+        let mut state = self.state.lock().map_err(|_| BlazeError::BackendError {
+            msg: "network slot allocator lock poisoned".to_string(),
+        })?;
+        for offset in 0..NET_MAX_SLOT {
+            let slot = (state.next + offset) % NET_MAX_SLOT;
+            if !blocked.contains(&slot) && state.used.insert(slot) {
+                state.next = (slot + 1) % NET_MAX_SLOT;
+                return Ok(slot);
+            }
+        }
+        Err(BlazeError::BackendError {
+            msg: format!("network slots exhausted (max {NET_MAX_SLOT})"),
+        })
+    }
+
+    async fn existing_slots(&self) -> Result<HashSet<usize>> {
+        let output = self.list_namespaces().await?;
+        Ok(parse_existing_slots(&output.stdout))
+    }
+
+    async fn list_namespaces(&self) -> Result<IpOutput> {
+        let args = vec!["netns".to_string(), "list".to_string()];
+        let output = self.run_ip_output(&args).await?;
+        if !output.success {
+            return Err(command_error(&args, &output, "listing namespaces"));
+        }
+        Ok(output)
+    }
+
+    fn release(&self, slot: usize) {
+        if let Ok(mut state) = self.state.lock() {
+            state.used.remove(&slot);
+        }
+    }
+
+    async fn cleanup_commands(&self, network: &NetworkSlot) -> Result<()> {
+        if !self.namespace_exists(&network.netns).await? {
+            return Ok(());
+        }
+        self.run_in_namespace_cleanup(
+            &network.netns,
+            &[
+                "ip".into(),
+                "link".into(),
+                "del".into(),
+                network.veth_peer.clone(),
+            ],
+        )
+        .await?;
+        self.delete_namespace(&network.netns).await?;
+        Ok(())
+    }
+
+    pub(super) async fn find_by_owner(&self, owner: Uuid) -> Result<Option<NetworkSlot>> {
+        let output = self.list_namespaces().await?;
+        Ok(parse_existing_networks(&output.stdout)
+            .into_iter()
+            .find(|network| network.owner == owner))
+    }
+
+    async fn namespace_exists(&self, name: &str) -> Result<bool> {
+        let output = self.list_namespaces().await?;
+        Ok(namespace_exists_in_output(&output.stdout, name))
+    }
+
+    async fn delete_namespace(&self, name: &str) -> Result<()> {
+        let args = vec!["netns".to_string(), "del".to_string(), name.to_string()];
+        let output = self.run_ip_output(&args).await?;
+        if output.success {
+            return Ok(());
+        }
+        let deletion = command_error(&args, &output, "cleaning up");
+        match self.namespace_exists(name).await {
+            Ok(false) => Ok(()),
+            Ok(true) => Err(deletion),
+            Err(confirmation) => Err(BlazeError::BackendError {
+                msg: format!(
+                    "{deletion}; cannot confirm namespace {name} was removed: {confirmation}"
+                ),
+            }),
+        }
+    }
+
+    async fn fail_setup<T>(
+        &self,
+        network: &NetworkSlot,
+        original: BlazeError,
+    ) -> std::result::Result<T, NetworkCreateError> {
+        match self.cleanup_commands(network).await {
+            Ok(()) => {
+                self.release(network.slot);
+                Err(NetworkCreateError::clean(original))
+            }
+            Err(cleanup) => Err(NetworkCreateError::with_residual(
+                BlazeError::BackendError {
+                    msg: format!(
+                        "network setup failed ({original}); cleanup failed ({cleanup}); slot {} retained",
+                        network.slot
+                    ),
+                },
+                network.clone(),
+            )),
+        }
+    }
+
+    async fn run_in_namespace(&self, netns: &str, command: &[String]) -> Result<()> {
+        let mut args = vec!["netns".to_string(), "exec".to_string(), netns.to_string()];
+        args.extend_from_slice(command);
+        self.run_ip(&args).await
+    }
+
+    async fn run_in_namespace_cleanup(&self, netns: &str, command: &[String]) -> Result<()> {
+        let mut args = vec!["netns".to_string(), "exec".to_string(), netns.to_string()];
+        args.extend_from_slice(command);
+        self.run_ip_cleanup(&args).await
+    }
+
+    async fn run_ip(&self, args: &[String]) -> Result<()> {
+        let output = self.run_ip_output(args).await?;
+        if output.success {
+            return Ok(());
+        }
+        Err(command_error(args, &output, "running command"))
+    }
+
+    async fn run_ip_cleanup(&self, args: &[String]) -> Result<()> {
+        let output = self.run_ip_output(args).await?;
+        if output.success {
+            return Ok(());
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if [
+            "Cannot find device",
+            "No such file",
+            "Invalid \"netns\" value",
+        ]
+        .iter()
+        .any(|marker| stderr.contains(marker))
+        {
+            return Ok(());
+        }
+        Err(command_error(args, &output, "cleaning up"))
+    }
+
+    async fn run_ip_output(&self, args: &[String]) -> Result<IpOutput> {
+        self.runner.output(args, self.command_timeout).await
+    }
+}
+
+fn command_error(args: &[String], output: &IpOutput, context: &str) -> BlazeError {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.chars().take(4096).collect::<String>();
+    BlazeError::BackendError {
+        msg: format!(
+            "ip {} failed while {context} ({}): {}",
+            args.join(" "),
+            output.status,
+            stderr.trim()
+        ),
+    }
+}
+
+#[cfg(unix)]
+async fn acquire_host_guard(path: &Path, timeout: Duration) -> Result<HostNetworkGuard> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let deadline = Instant::now() + timeout;
+    loop {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+            .open(path)?;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            return Ok(HostNetworkGuard { _file: Some(file) });
+        }
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EAGAIN)
+            && error.raw_os_error() != Some(libc::EWOULDBLOCK)
+        {
+            return Err(error.into());
+        }
+        if Instant::now() >= deadline {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "timed out acquiring host network allocation lock {}",
+                    path.display()
+                ),
+            });
+        }
+        tokio::time::sleep(HOST_LOCK_RETRY).await;
+    }
+}
+
+#[cfg(not(unix))]
+async fn acquire_host_guard(_path: &Path, _timeout: Duration) -> Result<HostNetworkGuard> {
+    Ok(HostNetworkGuard {})
+}
+
+#[cfg(target_os = "linux")]
+fn executable_in_path(name: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|directory| {
+        let candidate = directory.join(name);
+        if !candidate.is_file() {
+            return false;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::metadata(candidate)
+                .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            true
+        }
+    })
+}
+
+fn parse_existing_slots(stdout: &[u8]) -> HashSet<usize> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter_map(|name| name.strip_prefix("blz-ns-"))
+        .filter_map(|suffix| suffix.split('-').next())
+        .filter_map(|slot| slot.parse::<usize>().ok())
+        .filter(|slot| *slot < NET_MAX_SLOT)
+        .collect()
+}
+
+fn namespace_exists_in_output(stdout: &[u8], name: &str) -> bool {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .any(|candidate| candidate == name)
+}
+
+fn parse_existing_networks(stdout: &[u8]) -> Vec<NetworkSlot> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter_map(|name| name.strip_prefix("blz-ns-"))
+        .filter_map(|suffix| suffix.split_once('-'))
+        .filter_map(|(slot, owner)| {
+            Some(network_slot(
+                slot.parse::<usize>().ok()?,
+                owner.parse::<Uuid>().ok()?,
+            ))
+        })
+        .filter(|network| network.slot < NET_MAX_SLOT)
+        .collect()
+}
+
+fn network_slot(slot: usize, owner: Uuid) -> NetworkSlot {
+    NetworkSlot {
+        slot,
+        owner,
+        netns: format!("blz-ns-{slot}-{owner}"),
+        tap_name: "tap0".to_string(),
+        veth_host: format!("blz-veth-{slot}"),
+        veth_peer: format!("blz-vpeer-{slot}"),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn test_network_slot(slot: usize) -> NetworkSlot {
+    network_slot(slot, Uuid::from_u128(1))
+}
+
+fn veth_ips(slot: usize) -> (String, String) {
+    let base = NET_VETH_BASE + slot * 4;
+    let third = (base >> 8) & 0xff;
+    (
+        format!("169.254.{third}.{}", (base & 0xff) + 1),
+        format!("169.254.{third}.{}", (base & 0xff) + 2),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::*;
+
+    #[test]
+    fn allocator_is_unique_and_recycles() {
+        let manager = NetworkManager::default();
+        let first = manager.allocate(&HashSet::new()).expect("first");
+        let second = manager.allocate(&HashSet::new()).expect("second");
+        assert_ne!(first, second);
+        manager.release(first);
+        for _ in 0..NET_MAX_SLOT {
+            if manager.allocate(&HashSet::new()).expect("slot") == first {
+                return;
+            }
+        }
+        panic!("released slot was not recycled");
+    }
+
+    #[test]
+    fn addresses_follow_the_slot_layout() {
+        assert_eq!(
+            veth_ips(0),
+            ("169.254.0.5".to_string(), "169.254.0.6".to_string())
+        );
+        assert_eq!(
+            veth_ips(63),
+            ("169.254.1.1".to_string(), "169.254.1.2".to_string())
+        );
+    }
+
+    #[test]
+    fn existing_slot_parser_ignores_unrelated_and_invalid_names() {
+        let slots = parse_existing_slots(
+            b"blz-ns-0-00000000-0000-0000-0000-000000000001\n\
+              blz-ns-17 (id: 2)\nunrelated\nblz-ns-nope\nblz-ns-16383\n",
+        );
+        assert_eq!(slots, HashSet::from([0, 17]));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn host_lock_serializes_independent_network_managers() {
+        let temp = tempfile::tempdir().expect("temp");
+        let lock = temp.path().join("network.lock");
+        let first =
+            NetworkManager::with_runner_and_lock(Arc::new(FakeIpRunner::default()), lock.clone());
+        let second = NetworkManager::with_runner_and_lock(Arc::new(FakeIpRunner::default()), lock);
+
+        let first_guard = first.acquire_host_guard().await.expect("first lock");
+        let blocked =
+            tokio::time::timeout(Duration::from_millis(50), second.acquire_host_guard()).await;
+        assert!(
+            blocked.is_err(),
+            "a second daemon must not allocate while the host lock is held"
+        );
+
+        drop(first_guard);
+        second
+            .acquire_host_guard()
+            .await
+            .expect("lock becomes available");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn network_probe_checks_tools_privileges_and_ip_access() {
+        let missing_tool = Arc::new(FakeIpRunner::without_tool("iptables"));
+        let manager = NetworkManager::with_runner(missing_tool.clone());
+        assert!(!manager.probe().await.expect("missing tool probe"));
+        assert!(missing_tool.calls().is_empty());
+
+        let unprivileged = Arc::new(FakeIpRunner::without_admin());
+        let manager = NetworkManager::with_runner(unprivileged.clone());
+        assert!(!manager.probe().await.expect("privilege probe"));
+        assert!(unprivileged.calls().is_empty());
+
+        let available = Arc::new(FakeIpRunner::with_responses([success(b"")]));
+        let manager = NetworkManager::with_runner(available.clone());
+        assert!(manager.probe().await.expect("ready probe"));
+        assert_eq!(
+            available.calls(),
+            vec![vec!["netns".to_string(), "list".to_string()]]
+        );
+
+        let inaccessible = Arc::new(FakeIpRunner::with_responses([failure(
+            "network namespace access denied",
+        )]));
+        let manager = NetworkManager::with_runner(inaccessible);
+        assert!(!manager.probe().await.expect("inaccessible probe"));
+    }
+
+    #[tokio::test]
+    async fn create_skips_namespaces_owned_by_another_process() {
+        let runner = Arc::new(FakeIpRunner::with_responses([success(
+            b"blz-ns-0 (id: 4)\n",
+        )]));
+        let manager = NetworkManager::with_runner(runner.clone());
+
+        let owner = Uuid::from_u128(1);
+        let slot = manager
+            .create(owner, |_| Ok(()))
+            .await
+            .expect("create slot");
+
+        assert_eq!(slot.slot, 1);
+        let calls = runner.calls();
+        assert!(
+            calls
+                .iter()
+                .any(|args| args == &["netns", "add", test_network_slot(1).netns()])
+        );
+        assert!(
+            !calls
+                .iter()
+                .any(|args| args == &["netns", "del", "blz-ns-0"])
+        );
+    }
+
+    #[tokio::test]
+    async fn create_retries_when_namespace_appears_during_allocation() {
+        let runner = Arc::new(FakeIpRunner::with_responses([
+            success(b""),
+            failure("namespace already exists"),
+            success(b"blz-ns-0\n"),
+        ]));
+        let manager = NetworkManager::with_runner(runner.clone());
+
+        let owner = Uuid::from_u128(1);
+        let slot = manager
+            .create(owner, |_| Ok(()))
+            .await
+            .expect("create slot");
+
+        assert_eq!(slot.slot, 1);
+        assert!(
+            runner
+                .calls()
+                .iter()
+                .any(|args| args == &["netns", "add", test_network_slot(1).netns()])
+        );
+    }
+
+    #[tokio::test]
+    async fn uncertain_namespace_add_cleans_the_exact_owner() {
+        let network = test_network_slot(0);
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(FakeIpRunner::with_responses([
+            success(b""),
+            failure("namespace add timed out"),
+            success(namespace.as_bytes()),
+            success(namespace.as_bytes()),
+            failure("Cannot find device blz-vpeer-0"),
+            success(b""),
+        ]));
+        let manager = NetworkManager::with_runner(runner.clone());
+        let mut recorded = None;
+
+        let failure = manager
+            .create(network.owner(), |slot| {
+                recorded = Some(slot.clone());
+                Ok(())
+            })
+            .await
+            .expect_err("an uncertain add result must fail after compensation");
+        let (source, residual) = failure.into_parts();
+
+        assert!(source.to_string().contains("namespace add timed out"));
+        assert_eq!(recorded, Some(network.clone()));
+        assert!(residual.is_none());
+        assert!(
+            runner
+                .calls()
+                .iter()
+                .any(|args| args == &["netns", "del", network.netns()])
+        );
+        assert!(
+            !manager
+                .state
+                .lock()
+                .expect("state lock")
+                .used
+                .contains(&network.slot)
+        );
+    }
+
+    #[tokio::test]
+    async fn uncertain_namespace_add_retains_owner_when_cleanup_fails() {
+        let network = test_network_slot(0);
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(FakeIpRunner::with_responses([
+            success(b""),
+            failure("namespace add timed out"),
+            success(namespace.as_bytes()),
+            success(namespace.as_bytes()),
+            failure("Cannot find device blz-vpeer-0"),
+            failure("namespace delete failed"),
+            success(namespace.as_bytes()),
+        ]));
+        let manager = NetworkManager::with_runner(runner);
+        let mut recorded = None;
+
+        let failure = manager
+            .create(network.owner(), |slot| {
+                recorded = Some(slot.clone());
+                Ok(())
+            })
+            .await
+            .expect_err("failed compensation must retain ownership");
+        let (source, residual) = failure.into_parts();
+
+        assert!(source.to_string().contains("slot 0 retained"));
+        assert_eq!(recorded, Some(network.clone()));
+        assert_eq!(residual, Some(network.clone()));
+        assert!(
+            manager
+                .state
+                .lock()
+                .expect("state lock")
+                .used
+                .contains(&network.slot)
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_veth_creation_only_removes_new_namespace() {
+        let runner = Arc::new(FakeIpRunner::with_responses([
+            success(b""),
+            success(b""),
+            failure("veth already exists"),
+            success(b"blz-ns-0-00000000-0000-0000-0000-000000000001\n"),
+        ]));
+        let manager = NetworkManager::with_runner(runner.clone());
+
+        manager
+            .create(Uuid::from_u128(1), |_| Ok(()))
+            .await
+            .expect_err("veth creation must fail");
+
+        let calls = runner.calls();
+        assert!(
+            calls
+                .iter()
+                .any(|args| args == &["netns", "del", test_network_slot(0).netns()])
+        );
+        assert!(
+            !calls
+                .iter()
+                .any(|args| args == &["link", "del", "blz-veth-0"])
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_cleanup_returns_the_residual_slot_owner() {
+        let runner = Arc::new(FakeIpRunner::with_responses([
+            success(b""),
+            success(b""),
+            success(b""),
+            failure("host address failed"),
+            success(b"blz-ns-0-00000000-0000-0000-0000-000000000001\n"),
+            failure("delete peer failed"),
+            success(b"blz-ns-0-00000000-0000-0000-0000-000000000001\n"),
+            success(b""),
+            success(b""),
+        ]));
+        let manager = NetworkManager::with_runner(runner.clone());
+
+        let failure = manager
+            .create(Uuid::from_u128(1), |_| Ok(()))
+            .await
+            .expect_err("setup must fail");
+        let (source, residual) = failure.into_parts();
+        let residual = residual.expect("cleanup failure must retain the slot");
+
+        assert!(source.to_string().contains("slot 0 retained"));
+        assert_eq!(residual, test_network_slot(0));
+        manager
+            .destroy(&residual)
+            .await
+            .expect("a later cleanup can release the retained slot");
+        let calls = runner.calls();
+        assert!(calls.iter().any(|args| {
+            args == &[
+                "netns",
+                "exec",
+                test_network_slot(0).netns(),
+                "ip",
+                "link",
+                "del",
+                "blz-vpeer-0",
+            ]
+        }));
+        assert!(
+            calls
+                .iter()
+                .any(|args| args == &["netns", "del", test_network_slot(0).netns()])
+        );
+    }
+
+    #[tokio::test]
+    async fn namespace_delete_failure_retains_a_present_slot() {
+        let network = test_network_slot(0);
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(FakeIpRunner::with_responses([
+            success(namespace.as_bytes()),
+            success(b""),
+            failure("Cannot remove namespace file: Permission denied"),
+            success(namespace.as_bytes()),
+        ]));
+        let manager = NetworkManager::with_runner(runner);
+        manager
+            .state
+            .lock()
+            .expect("state lock")
+            .used
+            .insert(network.slot);
+
+        let error = manager
+            .destroy(&network)
+            .await
+            .expect_err("present namespace must retain its slot");
+
+        assert!(error.to_string().contains("Permission denied"));
+        assert!(
+            manager
+                .state
+                .lock()
+                .expect("state lock")
+                .used
+                .contains(&network.slot)
+        );
+    }
+
+    #[tokio::test]
+    async fn namespace_delete_failure_accepts_confirmed_absence() {
+        let network = test_network_slot(0);
+        let namespace = format!("{}\n", network.netns());
+        let runner = Arc::new(FakeIpRunner::with_responses([
+            success(namespace.as_bytes()),
+            success(b""),
+            failure("Cannot remove namespace file: already removed"),
+            success(b""),
+        ]));
+        let manager = NetworkManager::with_runner(runner);
+        manager
+            .state
+            .lock()
+            .expect("state lock")
+            .used
+            .insert(network.slot);
+
+        manager
+            .destroy(&network)
+            .await
+            .expect("confirmed absence completes cleanup");
+
+        assert!(
+            !manager
+                .state
+                .lock()
+                .expect("state lock")
+                .used
+                .contains(&network.slot)
+        );
+    }
+
+    struct FakeIpRunner {
+        responses: Mutex<VecDeque<IpOutput>>,
+        calls: Mutex<Vec<Vec<String>>>,
+        #[cfg(target_os = "linux")]
+        unavailable_tool: Option<String>,
+        #[cfg(target_os = "linux")]
+        network_admin: bool,
+    }
+
+    impl Default for FakeIpRunner {
+        fn default() -> Self {
+            Self {
+                responses: Mutex::new(VecDeque::new()),
+                calls: Mutex::new(Vec::new()),
+                #[cfg(target_os = "linux")]
+                unavailable_tool: None,
+                #[cfg(target_os = "linux")]
+                network_admin: true,
+            }
+        }
+    }
+
+    impl FakeIpRunner {
+        fn with_responses<const N: usize>(responses: [IpOutput; N]) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+                calls: Mutex::new(Vec::new()),
+                #[cfg(target_os = "linux")]
+                unavailable_tool: None,
+                #[cfg(target_os = "linux")]
+                network_admin: true,
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        fn without_tool(tool: &str) -> Self {
+            Self {
+                unavailable_tool: Some(tool.to_string()),
+                ..Self::default()
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        fn without_admin() -> Self {
+            Self {
+                network_admin: false,
+                ..Self::default()
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.lock().expect("calls lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl IpCommandRunner for FakeIpRunner {
+        async fn output(&self, args: &[String], _timeout: Duration) -> Result<IpOutput> {
+            self.calls.lock().expect("calls lock").push(args.to_vec());
+            Ok(self
+                .responses
+                .lock()
+                .expect("responses lock")
+                .pop_front()
+                .unwrap_or_else(|| success(b"")))
+        }
+
+        #[cfg(target_os = "linux")]
+        fn executable_in_path(&self, name: &str) -> bool {
+            self.unavailable_tool.as_deref() != Some(name)
+        }
+
+        #[cfg(target_os = "linux")]
+        fn has_network_admin(&self) -> bool {
+            self.network_admin
+        }
+    }
+
+    fn success(stdout: &[u8]) -> IpOutput {
+        IpOutput {
+            success: true,
+            status: "exit status: 0".to_string(),
+            stdout: stdout.to_vec(),
+            stderr: Vec::new(),
+        }
+    }
+
+    fn failure(stderr: &str) -> IpOutput {
+        IpOutput {
+            success: false,
+            status: "exit status: 1".to_string(),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+}

--- a/src/blaze/examples/policies/agent-rl.toml
+++ b/src/blaze/examples/policies/agent-rl.toml
@@ -118,6 +118,7 @@ memory = "4G"
 [backend.firecracker]
 boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
 enable_vsock = true   # parsed but not yet wired (Phase 2+)
+enable_network = false # opt in to a per-sandbox netns, tap, veth, and NAT
 serial_log = false
 
 # ---------------------------------------------------------------------------

--- a/src/blaze/examples/policies/agent-tool.toml
+++ b/src/blaze/examples/policies/agent-tool.toml
@@ -106,6 +106,7 @@ memory = "1G"
 [backend.firecracker]
 boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
 enable_vsock = false  # parsed but not yet wired (Phase 2+)
+enable_network = false # opt in to a per-sandbox netns, tap, veth, and NAT
 memory = "2G"
 vcpus = 2
 serial_log = false


### PR DESCRIPTION
## Description

This PR implements optional isolated networking for Firecracker sandboxes. When
a selected workload policy sets `backend.firecracker.enable_network = true`,
Blaze creates the sandbox network before launching Firecracker, attaches the VM
to a tap device, and retains ownership of the created resources until startup
compensation or explicit destroy finishes.

Networking remains disabled by default and does not change Bubblewrap or Mock
sandbox behavior.

### Why this is needed

Before this change, Blaze could start and stop Firecracker processes but could
not give an opted-in VM its own network namespace or track the corresponding
host resources as part of that sandbox's lifecycle. Adding setup commands alone
would make partial startup failures unsafe: Blaze also needs durable ownership,
ordered compensation, restart reconstruction, and slot coordination.

After this change, an opted-in Firecracker sandbox can be created with an
isolated namespace, tap, veth pair, fixed IPv4 path, forwarding, and
namespace-local address translation. The same backend owner releases those
resources after process termination. If cleanup cannot be confirmed, ownership
is retained for a later retry rather than reporting a clean result.

### Before

- Firecracker policies had no switch for per-sandbox networking.
- Firecracker configuration did not attach a tap-backed network interface.
- Blaze did not associate namespace and link resources with the backend
  instance that created them.
- Restart-time destroy could not reconstruct network ownership from the
  instance run directory.

### After

- `backend.firecracker.enable_network` opts a policy into the capability; its
  default remains `false`.
- Startup prerequisites are checked only when an eligible loaded Firecracker
  policy enables networking.
- Allocation is serialized across daemon processes with
  `/run/lock/blaze-network.lock` and excludes slots found in existing Blaze
  namespaces.
- Namespace names include both the slot and full instance UUID. Ownership is
  recorded before dependent devices are created, then marked as launch intent
  before Firecracker crosses the process boundary.
- A failed namespace-add command is rechecked by exact owner-qualified name.
  If the namespace exists, Blaze compensates that exact object; if compensation
  cannot be confirmed, the backend retains ownership and the slot.
- Firecracker runs inside the namespace with a tap-backed interface. Missing
  guest `ip=` configuration receives the fixed address, while conflicting
  configuration is rejected before launch.
- Explicit destroy and restart-time orphan cleanup reconstruct and remove the
  exact owner's resources only after process termination is confirmed.
- Paired English and Chinese user-guide pages document prerequisites,
  configuration, lifecycle behavior, and the host-operator boundary.

```mermaid
flowchart TD
    A["POST /v1/instances"] --> B{"Selected Firecracker policy enables networking?"}
    B -- "No" --> C["Existing Firecracker start path"]
    B -- "Yes" --> D["Acquire host-wide allocation lock"]
    D --> E["Allocate slot and create owner-qualified namespace"]
    E --> F["Persist pre-spawn ownership"]
    F --> G["Create veth, tap, addresses, route, and namespace NAT"]
    G --> H["Persist launch intent"]
    H --> I["Start Firecracker in the namespace"]
    I --> J["Backend owns process and network resources"]
    E -. "Uncertain result" .-> K["Re-enumerate exact namespace"]
    F -. "Failure" .-> L["Compensate exact owned resources"]
    K --> L
    L --> M{"Cleanup confirmed?"}
    M -- "Yes" --> N["Release slot and return startup error"]
    M -- "No" --> O["Retain owner and slot for retry"]
    J --> P["Destroy or restart-time cleanup"]
    P --> Q{"Process termination confirmed?"}
    Q -- "No" --> O
    Q -- "Yes" --> L
```

### Commit delivery

#### Commit 1 — `feat(blaze): manage isolated VM networking`

- **Intent:** Make isolated Firecracker networking a complete sandbox
  capability rather than a set of unowned setup commands.
- **Implementation:** Adds the default-disabled policy field, conditional
  prerequisite probing, host-wide slot coordination, owner-qualified metadata,
  namespace/tap/veth/address setup, Firecracker launch wiring, ordered cleanup,
  restart reconstruction, and failure-path tests.
- **Result:** An opted-in sandbox can be created and destroyed with one
  attributable network slot; uncertain setup or cleanup retains enough
  ownership to avoid reusing a resource that may still exist.
- **Verified commit:** `5934737264328cede87b33747e4e071895b8fe4d`.

#### Commit 2 — `docs(blaze): explain isolated VM networking`

- **Intent:** Make the new policy switch and its operational boundary
  discoverable to users in both supported documentation languages.
- **Implementation:** Updates the component README pair, adds paired
  English/Chinese user-guide references, and links both pages from the runtime
  navigation.
- **Result:** Operators can see how to enable the capability, which host
  prerequisites it needs, what Blaze cleans up, and which routing and DNS work
  remains outside Blaze.
- **Verified commit:** `eae99d3b992a6e33f1593667b075efadd8a6c770`.

### Why these commits belong in one PR

The implementation and its tests form one backend-owned lifecycle invariant:
an opted-in Firecracker sandbox either owns one reconstructable network slot or
returns an error while retaining any resource whose cleanup was not confirmed.
The documentation commit describes that exact user-facing configuration and
runtime contract, and repository documentation policy requires the README and
full bilingual user guide to accompany the configuration change in the same
PR. Neither commit introduces a separate subsystem or independently deployable
feature.

### Remaining capability work

1. Networking is available only for opted-in Firecracker policies; other
   backends retain their existing behavior.
2. The address layout is fixed IPv4. IPv6 and caller-defined addressing are not
   included.
3. Routing beyond the host and DNS remain host-operator responsibilities.
4. Cleanup is retried through retained ownership and later destroy; Blaze does
   not run a background orphan scan or retry controller.
5. PID-less launch-intent recovery is tracked separately in #2180 and must be
   fixed before release; it is intentionally not mixed into this networking
   feature PR.

## Related Issue

refs #1829

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [x] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Each commit was checked from a separate clean Linux clone with an initially
empty build target.

For both exact commits:

```bash
cd src/blaze
cargo fmt --all -- --check
cargo build --workspace --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
```

All commands passed for `5934737264328cede87b33747e4e071895b8fe4d`
and `eae99d3b992a6e33f1593667b075efadd8a6c770`. The documentation commit
also passed:

```bash
bash scripts/docs-lint.sh
python3 scripts/docs-link-check.py
```

The two focused uncertain-create tests passed on Linux:

- `uncertain_namespace_add_cleans_the_exact_owner`
- `uncertain_namespace_add_retains_owner_when_cleanup_fails`

The two commit headers satisfy the repository's configured type, `blaze`
scope, and length rules, and both commits contain author DCO signoffs.

## Additional Notes

- This PR contains two commits: one production capability commit and its
  tests, followed by one required user-documentation commit.
- It builds directly on `main` and has no sibling feature-branch dependency.
- The issue reference is intentionally non-closing because this PR implements
  one independently useful part of the broader issue.
