### PR TITLE
feat(blaze): reconcile sandbox create and destroy

### DIFF
--- a/src/blaze/AGENTS.md
+++ b/src/blaze/AGENTS.md
@@ -29,7 +29,11 @@ Platform: Linux (x86_64 + aarch64) for production. macOS builds succeed but spaw
 - **Daemon-only API model**: No CLI client for sandbox operations. All instance/pool/template management is done via HTTP endpoints on UDS (`/run/blaze/api.sock`) or TCP (`:14159`). The CLI subcommands (`daemon start`, `daemon reload`, `daemon doctor`) only manage daemon lifecycle.
 - **BackendSpawner trait**: All backend-specific process management is behind `BackendSpawner`. Adding a new backend means implementing `spawn()`, `wait()`, `kill()`, `probe()` and registering it in `daemon::build_spawner()`.
 - **Policy-driven backend selection**: Workload class → policy file → prioritized backend list. The daemon probes backends at startup and selects the first available. Never hardcode backend preference in application logic.
-- **Lifecycle state machine**: 8 states (Pending → Creating → Running → Paused → Checkpointed → Reset → Warm → Destroyed). State transitions are enforced by `blaze_core::lifecycle`. Do not bypass via direct field mutation.
+- **Lifecycle state machine**: 9 states. The main branches are Pending →
+  Creating → Running, Running ↔ Paused → Checkpointed, and Running → Reset →
+  Warm → Creating. Any non-terminal state can enter Destroyed; incomplete
+  cleanup enters RecoveryRequired. State transitions are enforced by
+  `blaze_core::lifecycle`. Do not bypass via direct field mutation.
 - **MockSpawner fallback**: When the configured backend binary is missing or fails `probe()`, the daemon auto-downgrades to `MockSpawner` with a warning. This keeps API/integration tests functional without a real backend.
 
 ## Adding a New Backend

--- a/src/blaze/README.md
+++ b/src/blaze/README.md
@@ -13,7 +13,8 @@ Designed as the per-host agent for E2B-style orchestrator platforms.
 
 - **HTTP API** — Unix domain socket (`/run/blaze/api.sock`) + TCP (`:14159`)
 - **Policy-driven backend selection** — workload class → backend priority list
-- **Lifecycle state machine** — 8 states (Pending → Creating → Running → Paused → Checkpointed → Reset → Warm → Destroyed)
+- **Lifecycle state machine** — 9 states: Pending, Creating, Running, Paused,
+  Checkpointed, RecoveryRequired, Reset, Warm, and Destroyed
 - **Warm pool management** — pre-warmed instances with TTL-based GC
 - **Template registry** — in-memory template tracking with idle eviction
 - **Kernel hook registry** — state tracking for pre/post hooks
@@ -38,7 +39,7 @@ sudo ./target/release/blazed daemon start --config examples/config.toml
 curl --unix-socket /run/blaze/api.sock http://localhost/v1/health
 
 # Create a sandbox
-curl -X POST --unix-socket /run/blaze/api.sock http://localhost/v1/instances \
+curl -X POST --unix-socket /run/blaze/api.sock http://localhost/v1/sandboxes \
   -H 'Content-Type: application/json' \
   -d '{"workload_class":"agent-rl","image_digest":"sha256:..."}'
 ```
@@ -100,12 +101,17 @@ The `file` provider uses standard filesystem operations for sandbox storage. The
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/v1/health` | Health check |
-| GET | `/v1/instances` | List all instances |
-| POST | `/v1/instances` | Create a new sandbox instance |
-| GET | `/v1/instances/{id}` | Get instance details |
-| POST | `/v1/instances/{id}/checkpoint` | Checkpoint an instance |
-| POST | `/v1/instances/{id}/reset` | Reset instance to checkpoint |
-| POST | `/v1/instances/{id}/destroy` | Destroy an instance |
+| GET | `/v1/sandboxes` | List all sandboxes |
+| POST | `/v1/sandboxes` | Create a sandbox |
+| GET | `/v1/sandboxes/{id}` | Get sandbox details |
+| DELETE | `/v1/sandboxes/{id}` | Destroy a sandbox |
+| GET | `/v1/instances` | Alias for listing sandboxes |
+| POST | `/v1/instances` | Alias for creating a sandbox |
+| GET | `/v1/instances/{id}` | Alias for sandbox details |
+| DELETE | `/v1/instances/{id}` | Alias for destroying a sandbox |
+| POST | `/v1/instances/{id}/destroy` | Compatible destroy action |
+| POST | `/v1/instances/{id}/checkpoint` | Record checkpoint state |
+| POST | `/v1/instances/{id}/reset` | Record reset and return to the warm pool |
 | GET | `/v1/pools` | List warm pools |
 | GET | `/v1/pools/{backend}/{class}` | Get pool status |
 | POST | `/v1/pools/{backend}/{class}/drain` | Drain a pool |
@@ -117,6 +123,24 @@ The `file` provider uses standard filesystem operations for sandbox storage. The
 | GET | `/v1/hooks` | List kernel hooks |
 | GET | `/v1/metrics` | Prometheus metrics |
 | POST | `/v1/admin/reload` | Hot-reload policies |
+
+### Managed lifecycle and recovery
+
+Create and destroy record their operation before changing storage or backend
+resources. A successful create finishes in `Running`; a successful destroy
+finishes in `Destroyed`. If compensation cannot release every owned resource,
+the sandbox remains visible as `RecoveryRequired` so destroy can be retried.
+
+At startup, the daemon reconciles each non-terminal sandbox independently.
+Failure to clean up one sandbox does not prevent the remaining records from
+being processed or the API from starting.
+
+The operation journal records the operation and start time, not completion of
+each resource step. An interrupted create is cleaned up rather than resumed,
+and an existing backend process is not adopted after restart. Failed recovery
+does not run in a background retry loop. The checkpoint and reset endpoints
+retain their existing metadata transitions; this recovery flow does not add
+backend snapshot or restore operations.
 
 #### Health Check
 
@@ -148,4 +172,3 @@ src/blaze/
 - Linux host with root privileges for sandbox backends
 
 ## License
-

--- a/src/blaze/README_zh.md
+++ b/src/blaze/README_zh.md
@@ -12,7 +12,8 @@ Prometheus 指标导出，设计为 E2B 类编排平台的单机执行代理。
 
 - **HTTP API** — Unix domain socket (`/run/blaze/api.sock`) + TCP (`:14159`)
 - **策略驱动后端选择** — workload class → 后端优先级列表
-- **生命周期状态机** — 8 种状态（Pending → Creating → Running → Paused → Checkpointed → Reset → Warm → Destroyed）
+- **生命周期状态机** — 9 种状态：Pending、Creating、Running、Paused、
+  Checkpointed、RecoveryRequired、Reset、Warm 和 Destroyed
 - **Warm pool 管理** — 预热实例 + 基于 TTL 的 GC
 - **模板注册表** — 内存中模板追踪，支持空闲驱逐
 - **内核 hook 注册** — 前/后置 hook 状态追踪
@@ -37,7 +38,7 @@ sudo ./target/release/blazed daemon start --config examples/config.toml
 curl --unix-socket /run/blaze/api.sock http://localhost/v1/health
 
 # 创建 sandbox
-curl -X POST --unix-socket /run/blaze/api.sock http://localhost/v1/instances \
+curl -X POST --unix-socket /run/blaze/api.sock http://localhost/v1/sandboxes \
   -H 'Content-Type: application/json' \
   -d '{"workload_class":"agent-rl","image_digest":"sha256:..."}'
 ```
@@ -99,12 +100,17 @@ images_dir = "/var/lib/blaze/images"
 | 方法 | 路径 | 说明 |
 |--------|------|-------------|
 | GET | `/v1/health` | 健康检查 |
-| GET | `/v1/instances` | 列出所有实例 |
-| POST | `/v1/instances` | 创建新 sandbox 实例 |
-| GET | `/v1/instances/{id}` | 获取实例详情 |
-| POST | `/v1/instances/{id}/checkpoint` | 对实例做 checkpoint |
-| POST | `/v1/instances/{id}/reset` | 将实例重置到 checkpoint |
-| POST | `/v1/instances/{id}/destroy` | 销毁实例 |
+| GET | `/v1/sandboxes` | 列出所有 sandbox |
+| POST | `/v1/sandboxes` | 创建 sandbox |
+| GET | `/v1/sandboxes/{id}` | 获取 sandbox 详情 |
+| DELETE | `/v1/sandboxes/{id}` | 销毁 sandbox |
+| GET | `/v1/instances` | 列出 sandbox 的兼容入口 |
+| POST | `/v1/instances` | 创建 sandbox 的兼容入口 |
+| GET | `/v1/instances/{id}` | 获取 sandbox 详情的兼容入口 |
+| DELETE | `/v1/instances/{id}` | 销毁 sandbox 的兼容入口 |
+| POST | `/v1/instances/{id}/destroy` | 保留的销毁 action |
+| POST | `/v1/instances/{id}/checkpoint` | 记录 checkpoint 状态 |
+| POST | `/v1/instances/{id}/reset` | 记录 reset 并返回 warm pool |
 | GET | `/v1/pools` | 列出 warm pool |
 | GET | `/v1/pools/{backend}/{class}` | 获取 pool 状态 |
 | POST | `/v1/pools/{backend}/{class}/drain` | 排空 pool |
@@ -116,6 +122,20 @@ images_dir = "/var/lib/blaze/images"
 | GET | `/v1/hooks` | 列出内核 hook |
 | GET | `/v1/metrics` | Prometheus 指标 |
 | POST | `/v1/admin/reload` | 热加载策略 |
+
+### 生命周期管理与恢复
+
+创建和销毁会在修改存储或后端资源之前记录当前操作。创建成功后状态为
+`Running`，销毁成功后状态为 `Destroyed`。如果失败补偿不能释放全部已有
+资源，sandbox 会保留为可查询的 `RecoveryRequired`，后续可以再次执行销毁。
+
+daemon 启动时会逐个处理未结束的 sandbox。单个 sandbox 清理失败不会阻止
+其他记录继续处理，也不会阻止 API 启动。
+
+操作记录只保存操作类型和开始时间，不记录每个资源步骤是否已经完成。中断的
+创建会被清理而不是从原位置继续，重启后也不会接管先前的后端进程。恢复失败
+后目前没有后台循环自动重试。checkpoint 和 reset 接口保持原有的元数据状态
+变化；这里的恢复流程没有增加后端 snapshot 或 restore 操作。
 
 #### 健康检查
 

--- a/src/blaze/crates/blaze-core/src/lifecycle.rs
+++ b/src/blaze/crates/blaze-core/src/lifecycle.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Sandbox lifecycle state machine + JSON persistence.
 
-use std::fs;
+use std::fs::{self, File};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -21,6 +22,7 @@ pub enum SandboxState {
     Running,
     Paused,
     Checkpointed,
+    RecoveryRequired,
     Reset,
     Warm,
     Destroyed,
@@ -34,11 +36,31 @@ impl SandboxState {
             SandboxState::Running => "running",
             SandboxState::Paused => "paused",
             SandboxState::Checkpointed => "checkpointed",
+            SandboxState::RecoveryRequired => "recovery-required",
             SandboxState::Reset => "reset",
             SandboxState::Warm => "warm",
             SandboxState::Destroyed => "destroyed",
         }
     }
+}
+
+/// Persisted multi-step operation used for crash diagnosis and recovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OperationKind {
+    /// Sandbox creation is acquiring resources or starting a backend.
+    Create,
+    /// Runtime resources are being destroyed.
+    Destroy,
+}
+
+/// Durable journal entry for one active lifecycle operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OperationJournal {
+    /// Operation being performed.
+    pub kind: OperationKind,
+    /// UTC time at which the operation became externally visible.
+    pub started_at: DateTime<Utc>,
 }
 
 impl std::fmt::Display for SandboxState {
@@ -85,6 +107,9 @@ pub struct SandboxInstance {
     /// Last durably known backend ownership state.
     #[serde(default)]
     pub backend_ownership: BackendOwnership,
+    /// Active multi-step operation, if any.
+    #[serde(default)]
+    pub operation: Option<OperationJournal>,
 }
 
 impl SandboxInstance {
@@ -110,7 +135,23 @@ impl SandboxInstance {
             updated_at: now,
             policy_name,
             backend_ownership: BackendOwnership::NotStarted,
+            operation: None,
         }
+    }
+
+    /// Persist an operation before starting its first data-plane mutation.
+    pub fn begin_operation(&mut self, kind: OperationKind) {
+        self.operation = Some(OperationJournal {
+            kind,
+            started_at: Utc::now(),
+        });
+        self.updated_at = Utc::now();
+    }
+
+    /// Clear the marker before atomically persisting the final state.
+    pub fn finish_operation(&mut self) {
+        self.operation = None;
+        self.updated_at = Utc::now();
     }
 
     /// Apply a state transition. Returns
@@ -154,8 +195,14 @@ impl SandboxInstance {
         let final_path = dir.join("state.json");
         let tmp_path = dir.join("state.json.tmp");
         let json = serde_json::to_vec_pretty(self)?;
-        fs::write(&tmp_path, &json)?;
+        {
+            let mut file = File::create(&tmp_path)?;
+            file.write_all(&json)?;
+            file.write_all(b"\n")?;
+            file.sync_all()?;
+        }
         fs::rename(&tmp_path, &final_path)?;
+        File::open(&dir)?.sync_all()?;
         Ok(())
     }
 
@@ -169,10 +216,15 @@ impl SandboxInstance {
 }
 
 fn is_valid_transition(from: SandboxState, to: SandboxState) -> bool {
-    use SandboxState::{Checkpointed, Creating, Destroyed, Paused, Pending, Reset, Running, Warm};
+    use SandboxState::{
+        Checkpointed, Creating, Destroyed, Paused, Pending, RecoveryRequired, Reset, Running, Warm,
+    };
     if to == Destroyed {
         // `* → destroyed` is always valid (terminal sink).
         return from != Destroyed;
+    }
+    if to == RecoveryRequired {
+        return !matches!(from, Destroyed | RecoveryRequired);
     }
     match (from, to) {
         (Pending, Creating) => true,
@@ -240,6 +292,29 @@ mod tests {
     }
 
     #[test]
+    fn recovery_required_can_finish_but_cannot_be_reentered() {
+        let mut inst = fresh();
+        inst.transition(SandboxState::Creating).expect("creating");
+        inst.transition(SandboxState::Running).expect("running");
+        inst.transition(SandboxState::RecoveryRequired)
+            .expect("recovery required");
+
+        let repeated = inst.transition(SandboxState::RecoveryRequired);
+        assert!(matches!(
+            repeated,
+            Err(BlazeError::InvalidStateTransition { .. })
+        ));
+
+        inst.transition(SandboxState::Destroyed)
+            .expect("destroyed from recovery");
+        let terminal = inst.transition(SandboxState::RecoveryRequired);
+        assert!(matches!(
+            terminal,
+            Err(BlazeError::InvalidStateTransition { .. })
+        ));
+    }
+
+    #[test]
     fn illegal_pending_to_running() {
         let mut inst = fresh();
         let err = inst.transition(SandboxState::Running).expect_err("illegal");
@@ -277,5 +352,40 @@ mod tests {
         assert_eq!(loaded.id, inst.id);
         assert_eq!(loaded.state, SandboxState::Creating);
         assert_eq!(loaded.policy_name, inst.policy_name);
+    }
+
+    #[test]
+    fn legacy_state_without_optional_fields_deserializes() {
+        let inst = fresh();
+        let value = serde_json::json!({
+            "id": inst.id,
+            "state": "running",
+            "backend": "mock",
+            "workload_class": "agent-rl",
+            "image_digest": "sha256:old",
+            "start_path": "cold",
+            "created_at": inst.created_at,
+            "updated_at": inst.updated_at,
+            "policy_name": "legacy"
+        });
+        let loaded: SandboxInstance = serde_json::from_value(value).expect("legacy state");
+        assert!(loaded.operation.is_none());
+        assert_eq!(loaded.backend_ownership, BackendOwnership::Unknown);
+    }
+
+    #[test]
+    fn create_journal_round_trips() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let mut instance = fresh();
+        instance.begin_operation(OperationKind::Create);
+        instance.persist(tmp.path()).expect("persist");
+
+        let mut loaded = SandboxInstance::load(tmp.path(), instance.id).expect("load");
+        assert_eq!(
+            loaded.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Create)
+        );
+        loaded.finish_operation();
+        assert!(loaded.operation.is_none());
     }
 }

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -10,13 +10,11 @@ use std::convert::Infallible;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use blaze_core::BlazeError;
-use blaze_core::backend::{BackendKind, BackendStatus, SpawnRequest, select_backend};
+use blaze_core::backend::{BackendKind, BackendStatus, select_backend};
 use blaze_core::kernel::HookKind;
-use blaze_core::lifecycle::{BackendOwnership, SandboxInstance, SandboxState, StartPath};
+use blaze_core::lifecycle::{SandboxInstance, SandboxState, StartPath};
 use blaze_core::policy::{ImageMetadata, RuntimeDecision, WorkloadClass, parse_duration};
 use blaze_core::pool::{PoolConfig, PoolKey};
-use blaze_core::storage::AcquireOpts;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::header::CONTENT_TYPE;
@@ -26,6 +24,7 @@ use serde_json::json;
 use uuid::Uuid;
 
 use crate::error::{BlazeDaemonError, Result};
+use crate::sandbox::CreateSandbox;
 use crate::state::ServerState;
 
 /// Top-level request handler. Always returns `Ok(Response)`; internal
@@ -161,55 +160,39 @@ struct CreateInstanceResp {
 }
 
 fn list_instances(state: &Arc<ServerState>) -> Result<Response<Full<Bytes>>> {
-    let map = state
-        .instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?;
-    let list: Vec<&SandboxInstance> = map.values().collect();
-    json_ok(&list)
+    json_ok(&state.manager.list()?)
 }
 
 fn get_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
-    let uuid = parse_uuid(id)?;
-    let map = state
-        .instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?;
-    let inst = map
-        .get(&uuid)
-        .ok_or_else(|| BlazeDaemonError::NotFound(format!("instance {uuid}")))?;
-    json_ok(inst)
+    json_ok(&state.manager.get(parse_uuid(id)?)?)
 }
 
 async fn create_instance(state: &Arc<ServerState>, body: &[u8]) -> Result<Response<Full<Bytes>>> {
     let req: CreateInstanceReq = serde_json::from_slice(body)
         .map_err(|e| BlazeDaemonError::BadRequest(format!("invalid create body: {e}")))?;
 
-    let img = ImageMetadata {
+    let image = ImageMetadata {
         digest: req.image_digest.clone(),
         workload_class: Some(req.workload_class),
         kernel_version: req.kernel_version.clone(),
     };
-
-    // 1. Policy evaluation.
     let decision = {
         let engine = state
             .policy
             .lock()
             .map_err(|_| BlazeDaemonError::Internal("policy lock poisoned".into()))?;
-        match engine.evaluate(&req.labels, &img) {
-            Ok(d) => d,
-            Err(e) => {
+        match engine.evaluate(&req.labels, &image) {
+            Ok(decision) => decision,
+            Err(error) => {
                 state.metrics.inc(&state.metrics.policy_eval_failures);
-                return Err(e.into());
+                return Err(error.into());
             }
         }
     };
 
-    // 2. Backend selection. Constrain availability to the daemon's active
-    // spawner — only the backend that was actually probed at boot can execute.
+    // Constrain availability to the implementation selected at daemon boot.
     let availability: Vec<BackendStatus> = {
-        let cfg = state
+        let config = state
             .config
             .lock()
             .map_err(|_| BlazeDaemonError::Internal("config lock poisoned".into()))?;
@@ -219,10 +202,10 @@ async fn create_instance(state: &Arc<ServerState>, body: &[u8]) -> Result<Respon
             .map(|kind| {
                 let available = *kind == state.active_backend
                     && (state.active_backend == BackendKind::Mock
-                        || cfg
+                        || config
                             .backends
                             .get(kind.as_str())
-                            .map(|p| p.exists())
+                            .map(|path| path.exists())
                             .unwrap_or(false));
                 BackendStatus {
                     kind: *kind,
@@ -232,658 +215,44 @@ async fn create_instance(state: &Arc<ServerState>, body: &[u8]) -> Result<Respon
             })
             .collect()
     };
-    // Select backend from available options. If no match is found:
-    // - Mock mode: fall back to the first policy entry (dev convenience)
-    // - Real backend: propagate BackendUnavailable (policy does not permit
-    //   the active backend, refusing to silently bypass policy)
     let policy_backend = match select_backend(&decision.backend_priority, &availability) {
-        Ok(b) => b,
-        Err(e) => {
-            if state.active_backend == BackendKind::Mock {
-                *decision.backend_priority.first().ok_or_else(|| {
-                    BlazeDaemonError::Internal("policy has empty backend_priority".into())
-                })?
-            } else {
-                return Err(e.into());
-            }
+        Ok(backend) => backend,
+        Err(_) if state.active_backend == BackendKind::Mock => {
+            *decision.backend_priority.first().ok_or_else(|| {
+                BlazeDaemonError::Internal("policy has empty backend_priority".into())
+            })?
         }
+        Err(error) => return Err(error.into()),
     };
-    // Policy chooses an allowed backend preference. Runtime ownership must
-    // record the spawner that actually serves the request. In portable Mock
-    // mode those can differ because Mock is an explicit local fallback.
     let runtime_backend = if state.active_backend == BackendKind::Mock {
         BackendKind::Mock
     } else {
         policy_backend
     };
+    let binary_path = state
+        .config
+        .lock()
+        .map_err(|_| BlazeDaemonError::Internal("config lock poisoned".into()))?
+        .backends
+        .get(state.active_backend.as_str())
+        .cloned()
+        .unwrap_or_default();
 
-    let pool_key = PoolKey::new(
-        runtime_backend,
-        decision.workload_class,
-        req.image_digest.clone(),
-    );
-    if decision.pool_eligible {
-        if let Some((instance, selected_backend)) = activate_warm_instance(state, &pool_key).await?
-        {
-            state.metrics.inc(&state.metrics.pool_hits);
-            return json_created(&CreateInstanceResp {
-                start_path: instance.start_path,
-                instance,
-                decision,
-                selected_backend,
-            });
-        }
-        state.metrics.inc(&state.metrics.pool_misses);
-    }
-
-    let start_path = StartPath::Cold;
-    let mut instance = SandboxInstance::new(
-        runtime_backend,
-        decision.workload_class,
-        req.image_digest.clone(),
-        start_path,
-        decision.policy_name.clone(),
-    );
-    instance.transition(SandboxState::Creating)?;
-    let operation_lock = state.operation_lock(instance.id);
-    let _operation = operation_lock.lock().await;
-
-    let (binary_path, rootfs_size, mem_size) = {
-        let cfg = state
-            .config
-            .lock()
-            .map_err(|_| BlazeDaemonError::Internal("config lock poisoned".into()))?;
-        (
-            cfg.backends
-                .get(state.active_backend.as_str())
-                .cloned()
-                .unwrap_or_default(),
-            cfg.storage.rootfs_size,
-            cfg.storage.mem_size,
-        )
-    };
-    // Publish ownership before allocation. A restart can now discover this
-    // stable ID and release either an absent slot or a completed allocation.
-    instance.persist(&state.state_dir)?;
-    if let Some(error) = retain_instance_state(state, instance.clone()) {
-        return Err(BlazeDaemonError::RecoveryRequired(format!(
-            "create {}: {error}",
-            instance.id
-        )));
-    }
-    let storage = match state
-        .storage
-        .acquire(&AcquireOpts {
-            instance_id: instance.id.to_string(),
-            rootfs_size,
-            mem_size,
+    let created = state
+        .manager
+        .create(CreateSandbox {
+            decision: decision.clone(),
+            image_digest: req.image_digest,
+            runtime_backend,
+            binary_path,
         })
-        .await
-    {
-        Ok(storage) => storage,
-        Err(error) => {
-            let (source, residual) = error.into_parts();
-            return Err(retain_failed_acquire(
-                state,
-                &mut instance,
-                residual,
-                source.into(),
-            ));
-        }
-    };
-    crate::failpoint::pause("create-after-storage-acquire").await;
-
-    instance.backend_ownership = BackendOwnership::Starting;
-    if let Err(error) = instance.persist(&state.state_dir) {
-        instance.backend_ownership = BackendOwnership::NotStarted;
-        return Err(cleanup_failed_create(
-            state,
-            &mut instance,
-            storage,
-            None,
-            false,
-            error.into(),
-        )
-        .await);
-    }
-    if let Some(error) = retain_instance_state(state, instance.clone()) {
-        instance.backend_ownership = BackendOwnership::NotStarted;
-        return Err(cleanup_failed_create(
-            state,
-            &mut instance,
-            storage,
-            None,
-            false,
-            BlazeDaemonError::Internal(error),
-        )
-        .await);
-    }
-
-    let work_dir = state.state_dir.join(instance.id.to_string());
-    let spawner = match state.spawner_for(state.active_backend) {
-        Some(spawner) => spawner,
-        None => {
-            instance.backend_ownership = BackendOwnership::NotStarted;
-            return Err(cleanup_failed_create(
-                state,
-                &mut instance,
-                storage,
-                None,
-                false,
-                BlazeDaemonError::Internal(format!(
-                    "active backend {} has no registered spawner",
-                    state.active_backend
-                )),
-            )
-            .await);
-        }
-    };
-    let spawn = match crate::failpoint::backend("create-spawn") {
-        Ok(()) => {
-            spawner
-                .spawn(SpawnRequest {
-                    instance_id: instance.id,
-                    run_dir: work_dir,
-                    binary_path,
-                    storage: storage.clone(),
-                    backend: decision.backend.clone(),
-                    vm: decision.vm.clone(),
-                })
-                .await
-        }
-        Err(error) => Err(crate::spawner::SpawnFailure::clean(error)),
-    };
-    let actual_backend = match spawn {
-        Ok(backend_instance) => {
-            instance.backend_ownership = BackendOwnership::Running;
-            let real_backend = backend_instance.backend();
-            let mut backend_instance = Some(backend_instance);
-            let registered = match state.backend_instances.lock() {
-                Ok(mut instances) => {
-                    instances.insert(
-                        instance.id,
-                        backend_instance
-                            .take()
-                            .expect("backend instance is present"),
-                    );
-                    true
-                }
-                Err(_) => false,
-            };
-            if !registered {
-                return Err(cleanup_failed_create(
-                    state,
-                    &mut instance,
-                    storage,
-                    backend_instance,
-                    false,
-                    BlazeDaemonError::Internal("backend_instances lock poisoned".to_string()),
-                )
-                .await);
-            }
-            real_backend
-        }
-        Err(error) => {
-            let (source, backend) = error.into_parts();
-            instance.backend_ownership = if backend.is_some() {
-                BackendOwnership::Running
-            } else {
-                BackendOwnership::Stopped
-            };
-            return Err(cleanup_failed_create(
-                state,
-                &mut instance,
-                storage,
-                backend,
-                false,
-                source.into(),
-            )
-            .await);
-        }
-    };
-    if let Err(error) = instance.transition(SandboxState::Running) {
-        return Err(
-            cleanup_failed_create(state, &mut instance, storage, None, true, error.into()).await,
-        );
-    }
-    if let Err(error) = crate::failpoint::state("create-state-commit")
-        .and_then(|_| instance.persist(&state.state_dir).map_err(Into::into))
-    {
-        return Err(cleanup_failed_create(state, &mut instance, storage, None, true, error).await);
-    }
-
-    let inserted = match state.instances.lock() {
-        Ok(mut instances) => {
-            instances.insert(instance.id, instance.clone());
-            true
-        }
-        Err(_) => false,
-    };
-    if !inserted {
-        return Err(cleanup_failed_create(
-            state,
-            &mut instance,
-            storage,
-            None,
-            true,
-            BlazeDaemonError::Internal("instances lock poisoned".to_string()),
-        )
-        .await);
-    }
-    state.metrics.inc(&state.metrics.instances_created);
-
+        .await?;
     json_created(&CreateInstanceResp {
-        instance,
+        start_path: created.instance.start_path,
+        instance: created.instance,
         decision,
-        start_path,
-        selected_backend: actual_backend,
+        selected_backend: created.selected_backend,
     })
-}
-
-async fn activate_warm_instance(
-    state: &Arc<ServerState>,
-    key: &PoolKey,
-) -> Result<Option<(SandboxInstance, BackendKind)>> {
-    let candidate = state
-        .pool
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("pool lock poisoned".into()))?
-        .lookup(key);
-    let Some(id) = candidate else {
-        return Ok(None);
-    };
-    let operation_lock = state.operation_lock(id);
-    let _operation = operation_lock.lock().await;
-
-    let instance = state
-        .instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
-        .get(&id)
-        .cloned();
-    let backend = state
-        .backend_instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("backend_instances lock poisoned".into()))?
-        .get(&id)
-        .cloned();
-
-    let invalid_reason = match (&instance, &backend) {
-        (None, _) => Some("lifecycle metadata is missing".to_string()),
-        (_, None) => Some("backend owner is missing".to_string()),
-        (Some(instance), Some(_)) if instance.state != SandboxState::Warm => {
-            Some(format!("lifecycle state is {}", instance.state))
-        }
-        (Some(instance), Some(backend)) if backend.backend() != instance.backend => Some(format!(
-            "backend owner is {}, metadata is {}",
-            backend.backend(),
-            instance.backend
-        )),
-        (_, Some(backend)) => match backend.try_wait().await {
-            Ok(None) => None,
-            Ok(Some(status)) => Some(format!("backend exited: {status:?}")),
-            Err(error) => Some(format!("backend liveness check failed: {error}")),
-        },
-    };
-
-    if let Some(reason) = invalid_reason {
-        quarantine_warm_instance(state, key, id, instance, backend, &reason).await;
-        return Ok(None);
-    }
-
-    let original = instance.expect("validated warm metadata");
-    match state.storage.reconstruct(&id.to_string()).await {
-        Ok(_) => {}
-        Err(error @ BlazeError::StorageIncomplete { .. }) => {
-            quarantine_warm_instance(
-                state,
-                key,
-                id,
-                Some(original),
-                backend,
-                &format!("storage validation failed: {error}"),
-            )
-            .await;
-            return Ok(None);
-        }
-        Err(error) => {
-            return Err(restore_warm_claim(state, key, original, error.into()));
-        }
-    }
-
-    crate::failpoint::pause("warm-before-state-commit").await;
-    let mut instance = original.clone();
-    let selected_backend = backend.expect("validated warm backend").backend();
-    if let Err(error) = instance
-        .transition(SandboxState::Creating)
-        .and_then(|_| instance.transition(SandboxState::Running))
-        .and_then(|_| instance.persist(&state.state_dir))
-    {
-        return Err(restore_warm_claim(state, key, original, error.into()));
-    }
-    state
-        .instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
-        .insert(id, instance.clone());
-    Ok(Some((instance, selected_backend)))
-}
-
-fn restore_warm_claim(
-    state: &Arc<ServerState>,
-    key: &PoolKey,
-    instance: SandboxInstance,
-    cause: BlazeDaemonError,
-) -> BlazeDaemonError {
-    let id = instance.id;
-    let mut errors = Vec::new();
-    if let Err(error) = instance.persist(&state.state_dir) {
-        errors.push(format!("restore warm state persistence failed: {error}"));
-    }
-    if let Some(error) = retain_instance_state(state, instance) {
-        errors.push(error);
-    }
-    match state.pool.lock() {
-        Ok(mut pool) => pool.restore_lookup(key.clone(), id),
-        Err(poisoned) => {
-            poisoned.into_inner().restore_lookup(key.clone(), id);
-            errors.push("pool lock poisoned while restoring warm claim".to_string());
-        }
-    }
-    let details = if errors.is_empty() {
-        "warm claim restored for retry".to_string()
-    } else {
-        format!("warm claim restored with errors: {}", errors.join("; "))
-    };
-    BlazeDaemonError::RecoveryRequired(format!("{cause}; instance {id}: {details}"))
-}
-
-async fn quarantine_warm_instance(
-    state: &Arc<ServerState>,
-    key: &PoolKey,
-    id: Uuid,
-    mut instance: Option<SandboxInstance>,
-    backend: Option<crate::spawner::DynBackendInstance>,
-    reason: &str,
-) {
-    match state.pool.lock() {
-        Ok(mut pool) => pool.quarantine(key, id),
-        Err(poisoned) => poisoned.into_inner().quarantine(key, id),
-    }
-    tracing::warn!(instance = %id, reason, "warm instance validation failed");
-
-    let backend_stopped = match backend.as_ref() {
-        Some(backend) => match backend.kill().await {
-            Ok(()) => true,
-            Err(error) => {
-                tracing::error!(instance = %id, %error, "quarantined backend cleanup failed");
-                false
-            }
-        },
-        None => match instance.as_ref() {
-            Some(instance)
-                if matches!(
-                    instance.backend_ownership,
-                    BackendOwnership::NotStarted | BackendOwnership::Stopped
-                ) =>
-            {
-                true
-            }
-            Some(instance) => match state.spawner_for(instance.backend) {
-                Some(spawner) => match spawner
-                    .cleanup_orphan(id, &state.state_dir.join(id.to_string()))
-                    .await
-                {
-                    Ok(()) => true,
-                    Err(error) => {
-                        tracing::error!(
-                            instance = %id,
-                            %error,
-                            "quarantined orphan cleanup failed"
-                        );
-                        false
-                    }
-                },
-                None => {
-                    tracing::error!(
-                        instance = %id,
-                        backend = %instance.backend,
-                        "quarantined backend has no recovery spawner"
-                    );
-                    false
-                }
-            },
-            None => false,
-        },
-    };
-    if !backend_stopped {
-        return;
-    }
-    let Some(instance) = instance.as_mut() else {
-        tracing::error!(
-            instance = %id,
-            "quarantined lifecycle metadata missing; retaining storage"
-        );
-        return;
-    };
-    instance.backend_ownership = BackendOwnership::Stopped;
-    if let Err(error) = instance.persist(&state.state_dir) {
-        tracing::error!(instance = %id, %error, "quarantined stop state commit failed");
-        return;
-    }
-    if let Some(error) = retain_instance_state(state, instance.clone()) {
-        tracing::error!(instance = %id, %error, "quarantined stop state retention failed");
-        return;
-    }
-    if let Err(error) = state.storage.release_by_id(&id.to_string()).await {
-        tracing::error!(instance = %id, %error, "quarantined storage cleanup failed");
-        return;
-    }
-
-    if instance.state != SandboxState::Destroyed
-        && let Err(error) = instance.transition(SandboxState::Destroyed)
-    {
-        tracing::error!(instance = %id, %error, "quarantined lifecycle cleanup failed");
-        return;
-    }
-    if let Err(error) = instance.persist(&state.state_dir) {
-        tracing::error!(instance = %id, %error, "quarantined state commit failed");
-        return;
-    }
-    match state.instances.lock() {
-        Ok(mut instances) => {
-            instances.insert(id, instance.clone());
-        }
-        Err(poisoned) => {
-            poisoned.into_inner().insert(id, instance.clone());
-        }
-    }
-    match state.backend_instances.lock() {
-        Ok(mut instances) => {
-            instances.remove(&id);
-        }
-        Err(poisoned) => {
-            poisoned.into_inner().remove(&id);
-        }
-    }
-}
-
-async fn cleanup_failed_create(
-    state: &Arc<ServerState>,
-    instance: &mut SandboxInstance,
-    storage: blaze_core::storage::StorageSlot,
-    backend: Option<crate::spawner::DynBackendInstance>,
-    registered: bool,
-    original: BlazeDaemonError,
-) -> BlazeDaemonError {
-    let mut cleanup_errors = Vec::new();
-    let backend = if registered {
-        match state.backend_instances.lock() {
-            Ok(mut instances) => instances.remove(&instance.id),
-            Err(poisoned) => poisoned.into_inner().remove(&instance.id),
-        }
-    } else {
-        backend
-    };
-    let mut backend_stopped = matches!(
-        instance.backend_ownership,
-        BackendOwnership::NotStarted | BackendOwnership::Stopped
-    );
-    if registered && backend.is_none() {
-        backend_stopped = false;
-        cleanup_errors.push("registered backend owner is missing".to_string());
-    }
-    if let Some(backend) = backend.as_ref() {
-        match backend.kill().await {
-            Ok(()) => {
-                backend_stopped = true;
-                instance.backend_ownership = BackendOwnership::Stopped;
-            }
-            Err(error) => {
-                backend_stopped = false;
-                cleanup_errors.push(format!("backend termination failed: {error}"));
-            }
-        }
-    }
-
-    let mut storage_released = false;
-    if backend_stopped {
-        match state.storage.release(storage).await {
-            Ok(()) => storage_released = true,
-            Err(error) => cleanup_errors.push(format!("storage release failed: {error}")),
-        }
-    } else {
-        cleanup_errors.push("storage retained until backend termination succeeds".to_string());
-    }
-
-    if backend_stopped && storage_released {
-        instance.backend_ownership = BackendOwnership::Stopped;
-        if let Err(error) = instance.transition(SandboxState::Destroyed) {
-            let mut recovery_errors = vec![format!("lifecycle update failed: {error}")];
-            if let Err(persist_error) = instance.persist(&state.state_dir) {
-                recovery_errors.push(format!("state persistence failed: {persist_error}"));
-            }
-            if let Some(retain_error) = retain_instance_state(state, instance.clone()) {
-                recovery_errors.push(retain_error);
-            }
-            return BlazeDaemonError::RecoveryRequired(format!(
-                "{original}; cleanup completed but {}",
-                recovery_errors.join("; ")
-            ));
-        }
-        if let Err(error) = instance.persist(&state.state_dir) {
-            let mut recovery_errors = vec![format!("state persistence failed: {error}")];
-            if let Some(retain_error) = retain_instance_state(state, instance.clone()) {
-                recovery_errors.push(retain_error);
-            }
-            return BlazeDaemonError::RecoveryRequired(format!(
-                "{original}; cleanup completed but {}",
-                recovery_errors.join("; ")
-            ));
-        }
-        if let Some(error) = retain_instance_state(state, instance.clone()) {
-            return BlazeDaemonError::RecoveryRequired(format!(
-                "{original}; cleanup completed but {error}"
-            ));
-        }
-        state.metrics.inc(&state.metrics.instances_destroyed);
-        return original;
-    }
-
-    if let Some(backend) = backend
-        && let Some(error) = retain_backend_owner(state, instance.id, backend)
-    {
-        cleanup_errors.push(error);
-    }
-    if let Err(error) = instance.persist(&state.state_dir) {
-        cleanup_errors.push(format!("state persistence failed: {error}"));
-    }
-    if let Some(error) = retain_instance_state(state, instance.clone()) {
-        cleanup_errors.push(error);
-    }
-    BlazeDaemonError::RecoveryRequired(format!(
-        "{original}; cleanup incomplete: {}",
-        cleanup_errors.join("; ")
-    ))
-}
-
-fn retain_failed_acquire(
-    state: &Arc<ServerState>,
-    instance: &mut SandboxInstance,
-    residual: Option<blaze_core::storage::StorageSlot>,
-    original: BlazeDaemonError,
-) -> BlazeDaemonError {
-    if residual.is_some() {
-        let mut errors = Vec::new();
-        if let Err(error) = instance.persist(&state.state_dir) {
-            errors.push(format!("state persistence failed: {error}"));
-        }
-        if let Some(error) = retain_instance_state(state, instance.clone()) {
-            errors.push(error);
-        }
-        let suffix = if errors.is_empty() {
-            "residual storage retained for destroy retry".to_string()
-        } else {
-            format!(
-                "residual storage retained with recovery errors: {}",
-                errors.join("; ")
-            )
-        };
-        return BlazeDaemonError::RecoveryRequired(format!(
-            "{original}; instance {}: {suffix}",
-            instance.id
-        ));
-    }
-
-    let mut errors = Vec::new();
-    instance.backend_ownership = BackendOwnership::Stopped;
-    if let Err(error) = instance.transition(SandboxState::Destroyed) {
-        errors.push(format!("lifecycle update failed: {error}"));
-    }
-    if let Err(error) = instance.persist(&state.state_dir) {
-        errors.push(format!("state persistence failed: {error}"));
-    }
-    if let Some(error) = retain_instance_state(state, instance.clone()) {
-        errors.push(error);
-    }
-    if errors.is_empty() {
-        original
-    } else {
-        BlazeDaemonError::RecoveryRequired(format!(
-            "{original}; acquire rollback completed but {}",
-            errors.join("; ")
-        ))
-    }
-}
-
-fn retain_backend_owner(
-    state: &Arc<ServerState>,
-    id: Uuid,
-    backend: crate::spawner::DynBackendInstance,
-) -> Option<String> {
-    match state.backend_instances.lock() {
-        Ok(mut instances) => {
-            instances.insert(id, backend);
-            None
-        }
-        Err(poisoned) => {
-            poisoned.into_inner().insert(id, backend);
-            Some("backend owner retained in poisoned runtime map".to_string())
-        }
-    }
-}
-
-fn retain_instance_state(state: &Arc<ServerState>, instance: SandboxInstance) -> Option<String> {
-    match state.instances.lock() {
-        Ok(mut instances) => {
-            instances.insert(instance.id, instance);
-            None
-        }
-        Err(poisoned) => {
-            poisoned.into_inner().insert(instance.id, instance);
-            Some("instance state retained in poisoned lifecycle map".to_string())
-        }
-    }
 }
 
 async fn checkpoint(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
@@ -947,93 +316,10 @@ async fn reset_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<F
 
 async fn destroy_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<Bytes>>> {
     let uuid = parse_uuid(id)?;
-    let operation_lock = state.operation_lock(uuid);
-    let _operation = operation_lock.lock().await;
-    let mut original = state
-        .instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
-        .get(&uuid)
-        .cloned()
-        .ok_or_else(|| BlazeDaemonError::NotFound(format!("instance {uuid}")))?;
-    let backend = state
-        .backend_instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("backend_instances lock poisoned".into()))?
-        .get(&uuid)
-        .cloned();
-
-    let stop_result = match crate::failpoint::backend("destroy-kill") {
-        Ok(()) => {
-            if let Some(backend) = backend.as_ref() {
-                backend.kill().await
-            } else if matches!(
-                original.backend_ownership,
-                BackendOwnership::NotStarted | BackendOwnership::Stopped
-            ) {
-                Ok(())
-            } else {
-                match state.spawner_for(original.backend) {
-                    Some(spawner) => {
-                        spawner
-                            .cleanup_orphan(uuid, &state.state_dir.join(uuid.to_string()))
-                            .await
-                    }
-                    None => Err(BlazeError::BackendError {
-                        msg: format!(
-                            "no recovery spawner registered for persisted backend {}",
-                            original.backend
-                        ),
-                    }),
-                }
-            }
-        }
-        Err(error) => Err(error),
-    };
-    if let Err(error) = stop_result {
-        return Err(BlazeDaemonError::RecoveryRequired(format!(
-            "destroy {uuid}: backend termination failed: {error}; owner and storage retained"
-        )));
-    }
-
-    original.backend_ownership = BackendOwnership::Stopped;
-    if let Err(error) = original.persist(&state.state_dir) {
-        return Err(BlazeDaemonError::RecoveryRequired(format!(
-            "destroy {uuid}: backend stopped but stop state persistence failed: {error}; storage retained"
-        )));
-    }
-    if let Some(error) = retain_instance_state(state, original.clone()) {
-        return Err(BlazeDaemonError::RecoveryRequired(format!(
-            "destroy {uuid}: backend stopped but lifecycle retention failed: {error}; storage retained"
-        )));
-    }
-
-    if let Err(error) = state.storage.release_by_id(&uuid.to_string()).await {
-        return Err(BlazeDaemonError::RecoveryRequired(format!(
-            "destroy {uuid}: backend stopped but storage release failed: {error}; lifecycle retained for retry"
-        )));
-    }
-
-    let mut destroyed = original;
-    if destroyed.state != SandboxState::Destroyed {
-        destroyed.transition(SandboxState::Destroyed)?;
-    }
-    destroyed.persist(&state.state_dir)?;
-    state
-        .instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("instances lock poisoned".into()))?
-        .insert(uuid, destroyed.clone());
-    state
-        .backend_instances
-        .lock()
-        .map_err(|_| BlazeDaemonError::Internal("backend_instances lock poisoned".into()))?
-        .remove(&uuid);
-
-    state.metrics.inc(&state.metrics.instances_destroyed);
+    state.manager.destroy(uuid).await?;
     json_ok(&json!({
         "destroyed": true,
-        "instance_id": destroyed.id,
+        "instance_id": uuid,
     }))
 }
 
@@ -1305,9 +591,11 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use async_trait::async_trait;
-    use blaze_core::backend::BackendKind;
+    use blaze_core::BlazeError;
+    use blaze_core::backend::{BackendKind, SpawnRequest};
     use blaze_core::config::DaemonConfig;
     use blaze_core::kernel::HookRegistry;
+    use blaze_core::lifecycle::{BackendOwnership, OperationKind};
     use blaze_core::policy::{
         BackendConfigs, FallbackOnMissingHook, PolicyEngine, PolicyFile, PolicyHooks, PolicyMatch,
         PolicyPool, PolicySelect, ResetMode, WorkloadClass,
@@ -1508,6 +796,10 @@ mod tests {
             let instance = SandboxInstance::load(&self.state_dir, id).expect("ownership published");
             assert_eq!(instance.state, SandboxState::Creating);
             assert_eq!(instance.backend_ownership, BackendOwnership::NotStarted);
+            assert_eq!(
+                instance.operation.as_ref().map(|operation| operation.kind),
+                Some(OperationKind::Create)
+            );
             self.observed.store(true, Ordering::Release);
             self.inner.acquire(opts).await
         }
@@ -1624,6 +916,180 @@ mod tests {
             self.cleanup_count.fetch_add(1, Ordering::AcqRel);
             Ok(())
         }
+    }
+
+    struct SelectiveCleanupSpawner {
+        failed_id: Uuid,
+        cleanup_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl BackendSpawner for SelectiveCleanupSpawner {
+        async fn spawn(
+            &self,
+            request: SpawnRequest,
+        ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+            MockSpawner.spawn(request).await
+        }
+
+        async fn probe(&self, _binary_path: &Path) -> blaze_core::Result<bool> {
+            Ok(true)
+        }
+
+        async fn cleanup_orphan(
+            &self,
+            instance_id: Uuid,
+            _run_dir: &Path,
+        ) -> blaze_core::Result<()> {
+            self.cleanup_count.fetch_add(1, Ordering::AcqRel);
+            if instance_id == self.failed_id {
+                return Err(BlazeError::BackendError {
+                    msg: "cleanup deferred".into(),
+                });
+            }
+            Ok(())
+        }
+    }
+
+    struct CountingOwner {
+        instance_id: Uuid,
+        kill_count: Arc<AtomicUsize>,
+        killed: AtomicBool,
+    }
+
+    #[async_trait]
+    impl BackendInstance for CountingOwner {
+        fn backend(&self) -> BackendKind {
+            BackendKind::Mock
+        }
+
+        async fn try_wait(&self) -> blaze_core::Result<Option<SpawnResult>> {
+            Ok(self.killed.load(Ordering::Acquire).then_some(SpawnResult {
+                instance_id: self.instance_id,
+                exit_code: Some(0),
+                signal: None,
+            }))
+        }
+
+        async fn kill(&self) -> blaze_core::Result<()> {
+            if !self.killed.swap(true, Ordering::AcqRel) {
+                self.kill_count.fetch_add(1, Ordering::AcqRel);
+            }
+            Ok(())
+        }
+    }
+
+    struct CountingSpawner {
+        kill_count: Arc<AtomicUsize>,
+        orphan_cleanup_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl BackendSpawner for CountingSpawner {
+        async fn spawn(
+            &self,
+            request: SpawnRequest,
+        ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+            Ok(Arc::new(CountingOwner {
+                instance_id: request.instance_id,
+                kill_count: self.kill_count.clone(),
+                killed: AtomicBool::new(false),
+            }))
+        }
+
+        async fn probe(&self, _binary_path: &Path) -> blaze_core::Result<bool> {
+            Ok(true)
+        }
+
+        async fn cleanup_orphan(
+            &self,
+            _instance_id: Uuid,
+            _run_dir: &Path,
+        ) -> blaze_core::Result<()> {
+            self.orphan_cleanup_count.fetch_add(1, Ordering::AcqRel);
+            Ok(())
+        }
+    }
+
+    struct CountingStorage {
+        inner: FileStorageProvider,
+        release_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl StorageProvider for CountingStorage {
+        async fn probe(&self) -> blaze_core::Result<bool> {
+            self.inner.probe().await
+        }
+
+        async fn acquire(
+            &self,
+            opts: &AcquireOpts,
+        ) -> std::result::Result<StorageSlot, StorageAcquireError> {
+            self.inner.acquire(opts).await
+        }
+
+        async fn release(&self, slot: StorageSlot) -> blaze_core::Result<()> {
+            self.release_count.fetch_add(1, Ordering::AcqRel);
+            self.inner.release(slot).await
+        }
+
+        async fn release_by_id(&self, instance_id: &str) -> blaze_core::Result<()> {
+            self.release_count.fetch_add(1, Ordering::AcqRel);
+            self.inner.release_by_id(instance_id).await
+        }
+
+        async fn reconstruct(&self, instance_id: &str) -> blaze_core::Result<StorageSlot> {
+            self.inner.reconstruct(instance_id).await
+        }
+
+        async fn flush_dirty(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
+            self.inner.flush_dirty(slot).await
+        }
+
+        fn pool_status(&self) -> PoolStatus {
+            self.inner.pool_status()
+        }
+
+        async fn drain_pool(&self) -> blaze_core::Result<usize> {
+            self.inner.drain_pool().await
+        }
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    fn counting_state(
+        temp: &tempfile::TempDir,
+    ) -> (
+        Arc<ServerState>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+    ) {
+        let config = test_config(temp);
+        let kill_count = Arc::new(AtomicUsize::new(0));
+        let orphan_cleanup_count = Arc::new(AtomicUsize::new(0));
+        let release_count = Arc::new(AtomicUsize::new(0));
+        let storage: Arc<dyn StorageProvider> = Arc::new(CountingStorage {
+            inner: FileStorageProvider::with_images(
+                config.storage.images_dir.clone(),
+                config.storage.instances_dir.clone(),
+            ),
+            release_count: release_count.clone(),
+        });
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(
+                BackendKind::Mock,
+                Arc::new(CountingSpawner {
+                    kill_count: kill_count.clone(),
+                    orphan_cleanup_count: orphan_cleanup_count.clone(),
+                }),
+            ),
+            BackendKind::Mock,
+            storage,
+        );
+        (state, kill_count, orphan_cleanup_count, release_count)
     }
 
     /// When multiple backend binaries exist on disk but the daemon probed
@@ -1797,11 +1263,8 @@ mod tests {
             .await
             .expect("return live owner");
         let owner = state
-            .backend_instances
-            .lock()
-            .expect("owners")
-            .get(&Uuid::parse_str(&id).expect("uuid"))
-            .cloned()
+            .manager
+            .backend_owner(Uuid::parse_str(&id).expect("uuid"))
             .expect("owner");
         owner.kill().await.expect("simulate backend exit");
 
@@ -1881,6 +1344,7 @@ mod tests {
         let id = cold["instance"]["id"].as_str().expect("id").to_string();
         assert_eq!(cold["instance"]["backend"], "mock");
         assert_eq!(cold["selected_backend"], "mock");
+        assert!(cold["instance"]["operation"].is_null());
 
         reset_instance(&state, &id).await.expect("return to pool");
         let warm = created_json(&state, &request).await;
@@ -1888,6 +1352,7 @@ mod tests {
         assert_eq!(warm["instance"]["backend"], "mock");
         assert_eq!(warm["selected_backend"], "mock");
         assert_eq!(warm["start_path"], "warm");
+        assert!(warm["instance"]["operation"].is_null());
     }
 
     #[tokio::test]
@@ -1919,15 +1384,14 @@ mod tests {
             .next()
             .cloned()
             .expect("retained lifecycle");
+        assert_eq!(instance.state, SandboxState::RecoveryRequired);
         assert_eq!(instance.backend_ownership, BackendOwnership::Running);
-        assert!(instances_dir.join(instance.id.to_string()).is_dir());
-        assert!(
-            state
-                .backend_instances
-                .lock()
-                .expect("owners")
-                .contains_key(&instance.id)
+        assert_eq!(
+            instance.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Create)
         );
+        assert!(instances_dir.join(instance.id.to_string()).is_dir());
+        assert!(state.manager.backend_owner(instance.id).is_some());
 
         destroy_instance(&state, &instance.id.to_string())
             .await
@@ -2182,6 +1646,64 @@ mod tests {
     }
 
     #[cfg(feature = "test-failpoints")]
+    async fn assert_warm_state_commit_failure_restores_claim(failpoint: &'static str) {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, true);
+        let request = test_request();
+        let cold = created_json(&state, &request).await;
+        let id = cold["instance"]["id"].as_str().expect("id").to_string();
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        reset_instance(&state, &id).await.expect("warm");
+        let owner = state.manager.backend_owner(uuid).expect("backend owner");
+        let key = PoolKey::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:ownership-test".into(),
+        );
+
+        let hook = crate::failpoint::TestFailpoint::new(&[failpoint]);
+        let error = hook
+            .run(create_instance(&state, &request))
+            .await
+            .expect_err("state commit failure");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        let restored = state.instances.lock().expect("instances")[&uuid].clone();
+        assert_eq!(restored.state, SandboxState::Warm);
+        assert!(restored.operation.is_none());
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted warm state");
+        assert_eq!(persisted.state, SandboxState::Warm);
+        assert_eq!(persisted.backend_ownership, BackendOwnership::Running);
+        assert!(persisted.operation.is_none());
+        let retained_owner = state.manager.backend_owner(uuid).expect("retained owner");
+        assert!(Arc::ptr_eq(&owner, &retained_owner));
+        assert_eq!(state.pool.lock().expect("pool").stats(&key).warm_count, 1);
+        assert!(retained_owner.try_wait().await.expect("liveness").is_none());
+
+        let retried = created_json(&state, &request).await;
+        assert_eq!(retried["instance"]["id"], id);
+        assert_eq!(retried["start_path"], "warm");
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted running state");
+        assert_eq!(persisted.state, SandboxState::Running);
+        assert_eq!(persisted.backend_ownership, BackendOwnership::Running);
+        assert!(persisted.operation.is_none());
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn warm_intent_commit_failure_restores_the_claim() {
+        assert_warm_state_commit_failure_restores_claim("warm-intent-state-commit").await;
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn warm_final_commit_failure_restores_the_claim() {
+        assert_warm_state_commit_failure_restores_claim("warm-final-state-commit").await;
+    }
+
+    #[cfg(feature = "test-failpoints")]
     #[tokio::test]
     async fn failure_hooks_drive_create_and_destroy_compensation() {
         let request = test_request();
@@ -2221,10 +1743,9 @@ mod tests {
         assert_eq!(commit_instance.state, SandboxState::Destroyed);
         assert!(
             commit_state
-                .backend_instances
-                .lock()
-                .expect("owners")
-                .is_empty()
+                .manager
+                .backend_owner(commit_instance.id)
+                .is_none()
         );
 
         let destroy_temp = tempfile::tempdir().expect("temp");
@@ -2237,13 +1758,16 @@ mod tests {
             .await
             .expect_err("kill boundary");
         let uuid = Uuid::parse_str(&id).expect("uuid");
-        assert!(
-            destroy_state
-                .backend_instances
-                .lock()
-                .expect("owners")
-                .contains_key(&uuid)
+        let failed_destroy = destroy_state.instances.lock().expect("instances")[&uuid].clone();
+        assert_eq!(failed_destroy.state, SandboxState::RecoveryRequired);
+        assert_eq!(
+            failed_destroy
+                .operation
+                .as_ref()
+                .map(|operation| operation.kind),
+            Some(OperationKind::Destroy)
         );
+        assert!(destroy_state.manager.backend_owner(uuid).is_some());
         destroy_instance(&destroy_state, &id)
             .await
             .expect("destroy retry");
@@ -2262,9 +1786,151 @@ mod tests {
             release_state.instances.lock().expect("instances")[&uuid].backend_ownership,
             BackendOwnership::Stopped
         );
+        assert_eq!(
+            release_state.instances.lock().expect("instances")[&uuid]
+                .operation
+                .as_ref()
+                .map(|operation| operation.kind),
+            Some(OperationKind::Destroy)
+        );
         destroy_instance(&release_state, &id)
             .await
             .expect("release retry");
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn destroy_intent_failure_does_not_touch_owned_resources() {
+        let temp = tempfile::tempdir().expect("temp");
+        let (state, kill_count, orphan_cleanup_count, release_count) = counting_state(&temp);
+        let created = created_json(&state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("id").to_string();
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        let hook = crate::failpoint::TestFailpoint::new(&["destroy-intent-state-commit"]);
+
+        let error = hook
+            .run(destroy_instance(&state, &id))
+            .await
+            .expect_err("intent failure");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        assert_eq!(kill_count.load(Ordering::Acquire), 0);
+        assert_eq!(orphan_cleanup_count.load(Ordering::Acquire), 0);
+        assert_eq!(release_count.load(Ordering::Acquire), 0);
+        let retained = state.instances.lock().expect("instances")[&uuid].clone();
+        assert_eq!(retained.state, SandboxState::RecoveryRequired);
+        assert!(retained.operation.is_none());
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted recovery state");
+        assert_eq!(persisted.state, SandboxState::RecoveryRequired);
+        assert_eq!(persisted.backend_ownership, BackendOwnership::Running);
+        assert!(persisted.operation.is_none());
+        assert!(temp.path().join("instances").join(&id).is_dir());
+
+        destroy_instance(&state, &id).await.expect("destroy retry");
+        assert_eq!(kill_count.load(Ordering::Acquire), 1);
+        assert_eq!(release_count.load(Ordering::Acquire), 1);
+        assert_eq!(
+            state.instances.lock().expect("instances")[&uuid].state,
+            SandboxState::Destroyed
+        );
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted destroyed state");
+        assert_eq!(persisted.state, SandboxState::Destroyed);
+        assert!(persisted.operation.is_none());
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn destroy_stop_commit_failure_retains_storage_for_retry() {
+        let temp = tempfile::tempdir().expect("temp");
+        let (state, kill_count, orphan_cleanup_count, release_count) = counting_state(&temp);
+        let created = created_json(&state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("id").to_string();
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        let hook = crate::failpoint::TestFailpoint::new(&["destroy-stop-state-commit"]);
+
+        let error = hook
+            .run(destroy_instance(&state, &id))
+            .await
+            .expect_err("stop commit failure");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        assert_eq!(kill_count.load(Ordering::Acquire), 1);
+        assert_eq!(orphan_cleanup_count.load(Ordering::Acquire), 0);
+        assert_eq!(release_count.load(Ordering::Acquire), 0);
+        let retained = state.instances.lock().expect("instances")[&uuid].clone();
+        assert_eq!(retained.state, SandboxState::RecoveryRequired);
+        assert_eq!(retained.backend_ownership, BackendOwnership::Stopped);
+        assert_eq!(
+            retained.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Destroy)
+        );
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted recovery state");
+        assert_eq!(persisted.state, SandboxState::RecoveryRequired);
+        assert_eq!(persisted.backend_ownership, BackendOwnership::Stopped);
+        assert_eq!(
+            persisted.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Destroy)
+        );
+        assert!(temp.path().join("instances").join(&id).is_dir());
+
+        destroy_instance(&state, &id).await.expect("destroy retry");
+        assert_eq!(kill_count.load(Ordering::Acquire), 1);
+        assert_eq!(release_count.load(Ordering::Acquire), 1);
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted destroyed state");
+        assert_eq!(persisted.state, SandboxState::Destroyed);
+        assert!(persisted.operation.is_none());
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn destroy_final_commit_failure_retains_retryable_metadata() {
+        let temp = tempfile::tempdir().expect("temp");
+        let (state, kill_count, orphan_cleanup_count, release_count) = counting_state(&temp);
+        let created = created_json(&state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("id").to_string();
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        let hook = crate::failpoint::TestFailpoint::new(&["destroy-final-state-commit"]);
+
+        let error = hook
+            .run(destroy_instance(&state, &id))
+            .await
+            .expect_err("final commit failure");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        assert_eq!(kill_count.load(Ordering::Acquire), 1);
+        assert_eq!(orphan_cleanup_count.load(Ordering::Acquire), 0);
+        assert_eq!(release_count.load(Ordering::Acquire), 1);
+        assert!(!temp.path().join("instances").join(&id).exists());
+        let retained = state.instances.lock().expect("instances")[&uuid].clone();
+        assert_eq!(retained.state, SandboxState::RecoveryRequired);
+        assert_eq!(retained.backend_ownership, BackendOwnership::Stopped);
+        assert_eq!(
+            retained.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Destroy)
+        );
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted recovery state");
+        assert_eq!(persisted.state, SandboxState::RecoveryRequired);
+        assert_eq!(persisted.backend_ownership, BackendOwnership::Stopped);
+        assert_eq!(
+            persisted.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Destroy)
+        );
+
+        destroy_instance(&state, &id).await.expect("destroy retry");
+        assert_eq!(kill_count.load(Ordering::Acquire), 1);
+        assert_eq!(release_count.load(Ordering::Acquire), 2);
+        let destroyed = state.instances.lock().expect("instances")[&uuid].clone();
+        assert_eq!(destroyed.state, SandboxState::Destroyed);
+        assert!(destroyed.operation.is_none());
+        let persisted =
+            SandboxInstance::load(&state.state_dir, uuid).expect("persisted destroyed state");
+        assert_eq!(persisted.state, SandboxState::Destroyed);
+        assert!(persisted.operation.is_none());
     }
 
     #[cfg(feature = "test-failpoints")]
@@ -2290,8 +1956,12 @@ mod tests {
             .next()
             .cloned()
             .expect("recovery record");
-        assert_eq!(instance.state, SandboxState::Creating);
+        assert_eq!(instance.state, SandboxState::RecoveryRequired);
         assert_eq!(instance.backend_ownership, BackendOwnership::NotStarted);
+        assert_eq!(
+            instance.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Create)
+        );
         assert!(
             temp.path()
                 .join("instances")
@@ -2341,6 +2011,10 @@ mod tests {
         let id = instance.id;
         assert_eq!(instance.state, SandboxState::Creating);
         assert_eq!(instance.backend_ownership, BackendOwnership::NotStarted);
+        assert_eq!(
+            instance.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Create)
+        );
         assert!(
             config
                 .daemon
@@ -2417,6 +2091,14 @@ mod tests {
                 .await
         });
         pause_hook.wait_until_paused().await;
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        assert_eq!(
+            state.instances.lock().expect("instances")[&uuid]
+                .operation
+                .as_ref()
+                .map(|operation| operation.kind),
+            Some(OperationKind::Create)
+        );
 
         let destroy_state = state.clone();
         let destroy_id = id.clone();
@@ -2431,9 +2113,179 @@ mod tests {
             .expect("activation task")
             .expect("activation");
         destroy.await.expect("destroy task").expect("destroy");
-        let uuid = Uuid::parse_str(&id).expect("uuid");
         assert_eq!(
             state.instances.lock().expect("instances")[&uuid].state,
+            SandboxState::Destroyed
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_continues_after_one_cleanup_failure() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let failed_id = Uuid::new_v4();
+        let completed_id = Uuid::new_v4();
+        for id in [failed_id, completed_id] {
+            let mut instance = SandboxInstance::new(
+                BackendKind::Mock,
+                WorkloadClass::AgentTool,
+                "sha256:reconcile".into(),
+                StartPath::Cold,
+                "reconcile-test".into(),
+            );
+            instance.id = id;
+            instance
+                .transition(SandboxState::Creating)
+                .expect("creating");
+            instance.transition(SandboxState::Running).expect("running");
+            instance.backend_ownership = BackendOwnership::Running;
+            instance.persist(&config.daemon.state_dir).expect("persist");
+            storage
+                .acquire(&AcquireOpts {
+                    instance_id: id.to_string(),
+                    rootfs_size: 64,
+                    mem_size: 32,
+                })
+                .await
+                .expect("storage");
+        }
+        let cleanup_count = Arc::new(AtomicUsize::new(0));
+        let state = build_test_state(
+            config.clone(),
+            test_policy(BackendKind::Mock, false),
+            spawners(
+                BackendKind::Mock,
+                Arc::new(SelectiveCleanupSpawner {
+                    failed_id,
+                    cleanup_count: cleanup_count.clone(),
+                }),
+            ),
+            BackendKind::Mock,
+            storage,
+        );
+
+        let report = state.manager.reconcile_startup().await;
+
+        assert_eq!(report.attempted, 2);
+        assert_eq!(report.completed, 1);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].instance_id, failed_id);
+        assert_eq!(cleanup_count.load(Ordering::Acquire), 2);
+        assert_eq!(
+            state.instances.lock().expect("instances")[&failed_id].state,
+            SandboxState::RecoveryRequired
+        );
+        assert_eq!(
+            state.instances.lock().expect("instances")[&completed_id].state,
+            SandboxState::Destroyed
+        );
+        assert!(
+            config
+                .storage
+                .instances_dir
+                .join(failed_id.to_string())
+                .is_dir()
+        );
+        assert!(
+            !config
+                .storage
+                .instances_dir
+                .join(completed_id.to_string())
+                .exists()
+        );
+        let created = created_json(&state, &test_request()).await;
+        assert_eq!(created["instance"]["state"], "running");
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_skips_cleanup_for_known_stopped_states() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let release_count = Arc::new(AtomicUsize::new(0));
+        let storage: Arc<dyn StorageProvider> = Arc::new(CountingStorage {
+            inner: FileStorageProvider::with_images(
+                config.storage.images_dir.clone(),
+                config.storage.instances_dir.clone(),
+            ),
+            release_count: release_count.clone(),
+        });
+        let not_started_id = Uuid::new_v4();
+        let stopped_id = Uuid::new_v4();
+
+        let mut not_started = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:not-started".into(),
+            StartPath::Cold,
+            "reconcile-test".into(),
+        );
+        not_started.id = not_started_id;
+        not_started
+            .transition(SandboxState::Creating)
+            .expect("creating");
+        not_started
+            .persist(&config.daemon.state_dir)
+            .expect("persist");
+
+        let mut stopped = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:stopped".into(),
+            StartPath::Cold,
+            "reconcile-test".into(),
+        );
+        stopped.id = stopped_id;
+        stopped
+            .transition(SandboxState::Creating)
+            .expect("creating");
+        stopped.transition(SandboxState::Running).expect("running");
+        stopped.backend_ownership = BackendOwnership::Stopped;
+        stopped.persist(&config.daemon.state_dir).expect("persist");
+
+        for id in [not_started_id, stopped_id] {
+            storage
+                .acquire(&AcquireOpts {
+                    instance_id: id.to_string(),
+                    rootfs_size: 64,
+                    mem_size: 32,
+                })
+                .await
+                .expect("storage");
+        }
+        let kill_count = Arc::new(AtomicUsize::new(0));
+        let orphan_cleanup_count = Arc::new(AtomicUsize::new(0));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(
+                BackendKind::Mock,
+                Arc::new(CountingSpawner {
+                    kill_count: kill_count.clone(),
+                    orphan_cleanup_count: orphan_cleanup_count.clone(),
+                }),
+            ),
+            BackendKind::Mock,
+            storage,
+        );
+
+        let report = state.manager.reconcile_startup().await;
+
+        assert_eq!(report.attempted, 2);
+        assert_eq!(report.completed, 2);
+        assert!(report.failures.is_empty());
+        assert_eq!(kill_count.load(Ordering::Acquire), 0);
+        assert_eq!(orphan_cleanup_count.load(Ordering::Acquire), 0);
+        assert_eq!(release_count.load(Ordering::Acquire), 2);
+        assert_eq!(
+            state.instances.lock().expect("instances")[&not_started_id].state,
+            SandboxState::Destroyed
+        );
+        assert_eq!(
+            state.instances.lock().expect("instances")[&stopped_id].state,
             SandboxState::Destroyed
         );
     }

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -72,12 +72,18 @@ async fn dispatch(
 
     match (m, parts.as_slice()) {
         ("GET", ["v1", "health"]) => health(state),
-        ("GET", ["v1", "instances"]) => list_instances(state),
-        ("POST", ["v1", "instances"]) => create_instance(state, &body).await,
-        ("GET", ["v1", "instances", id]) => get_instance(state, id),
+        ("GET", ["v1", "instances"]) | ("GET", ["v1", "sandboxes"]) => list_instances(state),
+        ("POST", ["v1", "instances"]) | ("POST", ["v1", "sandboxes"]) => {
+            create_instance(state, &body).await
+        }
+        ("GET", ["v1", "instances", id]) | ("GET", ["v1", "sandboxes", id]) => {
+            get_instance(state, id)
+        }
         ("POST", ["v1", "instances", id, "checkpoint"]) => checkpoint(state, id).await,
         ("POST", ["v1", "instances", id, "reset"]) => reset_instance(state, id).await,
-        ("POST", ["v1", "instances", id, "destroy"]) => destroy_instance(state, id).await,
+        ("DELETE", ["v1", "instances", id])
+        | ("DELETE", ["v1", "sandboxes", id])
+        | ("POST", ["v1", "instances", id, "destroy"]) => destroy_instance(state, id).await,
         ("GET", ["v1", "pools"]) => list_pools(state),
         ("GET", ["v1", "pools", backend, class]) => pool_status(state, backend, class),
         ("POST", ["v1", "pools", backend, class, "drain"]) => drain_pool(state, backend, class),
@@ -719,6 +725,26 @@ mod tests {
         .expect("created json")
     }
 
+    async fn dispatched_json(
+        state: &Arc<ServerState>,
+        method: Method,
+        path: &str,
+        body: Vec<u8>,
+    ) -> (StatusCode, serde_json::Value) {
+        let response = dispatch(&method, path, "", body, state)
+            .await
+            .expect("dispatch");
+        let status = response.status();
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        let value = serde_json::from_slice(&body).expect("response json");
+        (status, value)
+    }
+
     struct TransientReconstructStorage {
         inner: FileStorageProvider,
         fail_reconstruct: AtomicBool,
@@ -1090,6 +1116,97 @@ mod tests {
             storage,
         );
         (state, kill_count, orphan_cleanup_count, release_count)
+    }
+
+    #[tokio::test]
+    async fn sandbox_collection_and_item_routes_match_instance_routes() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+
+        let (status, created) =
+            dispatched_json(&state, Method::POST, "/v1/sandboxes", test_request()).await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(created["instance"]["state"], "running");
+        let id = created["instance"]["id"].as_str().expect("instance id");
+
+        let (_, sandboxes) =
+            dispatched_json(&state, Method::GET, "/v1/sandboxes", Vec::new()).await;
+        let (_, instances) =
+            dispatched_json(&state, Method::GET, "/v1/instances", Vec::new()).await;
+        assert_eq!(sandboxes, instances);
+
+        let (_, sandbox) = dispatched_json(
+            &state,
+            Method::GET,
+            &format!("/v1/sandboxes/{id}"),
+            Vec::new(),
+        )
+        .await;
+        let (_, instance) = dispatched_json(
+            &state,
+            Method::GET,
+            &format!("/v1/instances/{id}"),
+            Vec::new(),
+        )
+        .await;
+        assert_eq!(sandbox, instance);
+    }
+
+    #[tokio::test]
+    async fn destroy_route_forms_share_managed_cleanup() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+
+        let mut ids = Vec::new();
+        for _ in 0..3 {
+            let created = created_json(&state, &test_request()).await;
+            ids.push(
+                Uuid::parse_str(created["instance"]["id"].as_str().expect("instance id"))
+                    .expect("uuid"),
+            );
+        }
+        let routes = [
+            (Method::DELETE, format!("/v1/sandboxes/{}", ids[0]), ids[0]),
+            (Method::DELETE, format!("/v1/instances/{}", ids[1]), ids[1]),
+            (
+                Method::POST,
+                format!("/v1/instances/{}/destroy", ids[2]),
+                ids[2],
+            ),
+        ];
+
+        for (method, path, id) in routes {
+            let (status, response) = dispatched_json(&state, method, &path, Vec::new()).await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(response["destroyed"], true);
+            assert_eq!(response["instance_id"], id.to_string());
+            assert_eq!(
+                state.manager.get(id).expect("destroyed state").state,
+                SandboxState::Destroyed
+            );
+        }
     }
 
     /// When multiple backend binaries exist on disk but the daemon probed

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -78,6 +78,20 @@ pub async fn run(config_path: &Path) -> Result<()> {
         active_backend,
         storage,
     ));
+    let reconciliation = state.manager.reconcile_startup().await;
+    tracing::info!(
+        attempted = reconciliation.attempted,
+        completed = reconciliation.completed,
+        failed = reconciliation.failures.len(),
+        "startup sandbox reconciliation completed"
+    );
+    for failure in reconciliation.failures {
+        tracing::warn!(
+            instance = %failure.instance_id,
+            error = %failure.error,
+            "sandbox remains recovery-required after startup reconciliation"
+        );
+    }
 
     if socket_path.exists() {
         std::fs::remove_file(&socket_path)?;

--- a/src/blaze/crates/blazed/src/main.rs
+++ b/src/blaze/crates/blazed/src/main.rs
@@ -15,6 +15,7 @@ mod failpoint;
 mod failpoint;
 mod file_provider;
 mod metrics;
+mod sandbox;
 mod spawner;
 mod state;
 

--- a/src/blaze/crates/blazed/src/sandbox.rs
+++ b/src/blaze/crates/blazed/src/sandbox.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Managed sandbox lifecycle and runtime ownership.
+
+mod manager;
+
+pub use manager::{CreateSandbox, SandboxManager, SandboxManagerInit};

--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -1,0 +1,1024 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Recoverable sandbox create, warm activation, destroy, and startup cleanup.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use blaze_core::BlazeError;
+use blaze_core::backend::{BackendKind, SpawnRequest};
+use blaze_core::lifecycle::{
+    BackendOwnership, OperationKind, SandboxInstance, SandboxState, StartPath,
+};
+use blaze_core::policy::RuntimeDecision;
+use blaze_core::pool::{PoolKey, PoolManager};
+use blaze_core::storage::{AcquireOpts, StorageProvider, StorageSlot};
+use tokio::sync::Mutex as AsyncMutex;
+use uuid::Uuid;
+
+use crate::error::{BlazeDaemonError, Result};
+use crate::metrics::Metrics;
+use crate::spawner::{DynBackendInstance, SpawnerRegistry};
+
+/// Inputs already parsed and policy-evaluated by the API.
+#[derive(Debug, Clone)]
+pub struct CreateSandbox {
+    /// Policy decision for this request.
+    pub decision: RuntimeDecision,
+    /// Image identity used by storage and warm-pool matching.
+    pub image_digest: String,
+    /// Concrete backend selected from the policy and daemon availability.
+    pub runtime_backend: BackendKind,
+    /// Executable selected during daemon startup.
+    pub binary_path: PathBuf,
+}
+
+/// Result of one managed create request.
+#[derive(Debug, Clone)]
+pub struct CreateSandboxResult {
+    /// Persisted sandbox metadata.
+    pub instance: SandboxInstance,
+    /// Backend implementation that owns the runtime.
+    pub selected_backend: BackendKind,
+}
+
+/// One startup cleanup failure. Other records continue to be reconciled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconcileFailure {
+    /// Sandbox whose cleanup remains incomplete.
+    pub instance_id: Uuid,
+    /// Actionable failure description.
+    pub error: String,
+}
+
+/// Aggregate startup cleanup outcome.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    /// Number of non-terminal records examined.
+    pub attempted: usize,
+    /// Number moved to the terminal state.
+    pub completed: usize,
+    /// Records that remain recoverable.
+    pub failures: Vec<ReconcileFailure>,
+}
+
+/// Owns durable lifecycle metadata and non-serializable runtime handles.
+///
+/// The maps are shared with read-only and non-lifecycle API paths. All
+/// create, warm activation, destroy, and restart cleanup mutations enter
+/// through this type and are serialized by a per-sandbox async lock.
+pub struct SandboxManager {
+    instances: Arc<Mutex<HashMap<Uuid, SandboxInstance>>>,
+    backend_instances: Arc<Mutex<HashMap<Uuid, DynBackendInstance>>>,
+    operation_locks: Mutex<HashMap<Uuid, Arc<AsyncMutex<()>>>>,
+    pool: Arc<Mutex<PoolManager>>,
+    spawners: Arc<SpawnerRegistry>,
+    active_backend: BackendKind,
+    storage: Arc<dyn StorageProvider>,
+    state_dir: PathBuf,
+    rootfs_size: u64,
+    mem_size: u64,
+    metrics: Arc<Metrics>,
+}
+
+/// Construction inputs grouped to keep daemon wiring explicit.
+pub struct SandboxManagerInit {
+    pub instances: HashMap<Uuid, SandboxInstance>,
+    pub pool: PoolManager,
+    pub spawners: SpawnerRegistry,
+    pub active_backend: BackendKind,
+    pub storage: Arc<dyn StorageProvider>,
+    pub state_dir: PathBuf,
+    pub rootfs_size: u64,
+    pub mem_size: u64,
+}
+
+/// Shared resources exposed to API paths that do not change runtime
+/// ownership, such as checkpoint and reset.
+pub struct SandboxManagerResources {
+    pub instances: Arc<Mutex<HashMap<Uuid, SandboxInstance>>>,
+    pub pool: Arc<Mutex<PoolManager>>,
+    pub metrics: Arc<Metrics>,
+}
+
+impl SandboxManager {
+    /// Build a manager around state loaded from the durable state directory.
+    pub fn new(init: SandboxManagerInit) -> (Self, SandboxManagerResources) {
+        let SandboxManagerInit {
+            instances,
+            pool,
+            spawners,
+            active_backend,
+            storage,
+            state_dir,
+            rootfs_size,
+            mem_size,
+        } = init;
+        let operation_locks = instances
+            .keys()
+            .copied()
+            .map(|id| (id, Arc::new(AsyncMutex::new(()))))
+            .collect();
+        let instances = Arc::new(Mutex::new(instances));
+        let backend_instances = Arc::new(Mutex::new(HashMap::new()));
+        let pool = Arc::new(Mutex::new(pool));
+        let metrics = Arc::new(Metrics::new());
+        let resources = SandboxManagerResources {
+            instances: instances.clone(),
+            pool: pool.clone(),
+            metrics: metrics.clone(),
+        };
+        (
+            Self {
+                instances,
+                backend_instances,
+                operation_locks: Mutex::new(operation_locks),
+                pool,
+                spawners: Arc::new(spawners),
+                active_backend,
+                storage,
+                state_dir,
+                rootfs_size,
+                mem_size,
+                metrics,
+            },
+            resources,
+        )
+    }
+
+    /// Return the async operation lock that serializes one sandbox mutation.
+    pub fn operation_lock(&self, id: Uuid) -> Arc<AsyncMutex<()>> {
+        match self.operation_locks.lock() {
+            Ok(mut locks) => locks
+                .entry(id)
+                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+                .clone(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .entry(id)
+                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+                .clone(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn backend_owner(&self, id: Uuid) -> Option<DynBackendInstance> {
+        match self.backend_instances.lock() {
+            Ok(instances) => instances.get(&id).cloned(),
+            Err(poisoned) => poisoned.into_inner().get(&id).cloned(),
+        }
+    }
+
+    /// Return all persisted sandbox metadata.
+    pub fn list(&self) -> Result<Vec<SandboxInstance>> {
+        Ok(self
+            .instances
+            .lock()
+            .map_err(|_| poisoned("instances"))?
+            .values()
+            .cloned()
+            .collect())
+    }
+
+    /// Return one persisted sandbox.
+    pub fn get(&self, id: Uuid) -> Result<SandboxInstance> {
+        self.instances
+            .lock()
+            .map_err(|_| poisoned("instances"))?
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| BlazeDaemonError::NotFound(format!("instance {id}")))
+    }
+
+    /// Create a cold sandbox or activate a compatible warm runtime.
+    pub async fn create(&self, request: CreateSandbox) -> Result<CreateSandboxResult> {
+        let pool_key = PoolKey::new(
+            request.runtime_backend,
+            request.decision.workload_class,
+            request.image_digest.clone(),
+        );
+        if request.decision.pool_eligible {
+            if let Some(result) = self.activate_warm(&pool_key).await? {
+                self.metrics.inc(&self.metrics.pool_hits);
+                return Ok(result);
+            }
+            self.metrics.inc(&self.metrics.pool_misses);
+        }
+
+        let mut instance = SandboxInstance::new(
+            request.runtime_backend,
+            request.decision.workload_class,
+            request.image_digest,
+            StartPath::Cold,
+            request.decision.policy_name.clone(),
+        );
+        let operation_lock = self.operation_lock(instance.id);
+        let _operation = operation_lock.lock().await;
+        instance.transition(SandboxState::Creating)?;
+        instance.begin_operation(OperationKind::Create);
+
+        // Publish the stable identity and create intent before allocation.
+        instance.persist(&self.state_dir)?;
+        if let Some(error) = self.retain_instance(instance.clone()) {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "create {}: {error}",
+                instance.id
+            )));
+        }
+
+        let storage = match self
+            .storage
+            .acquire(&AcquireOpts {
+                instance_id: instance.id.to_string(),
+                rootfs_size: self.rootfs_size,
+                mem_size: self.mem_size,
+            })
+            .await
+        {
+            Ok(storage) => storage,
+            Err(error) => {
+                let (source, residual) = error.into_parts();
+                return Err(self.retain_failed_acquire(&mut instance, residual, source.into()));
+            }
+        };
+        crate::failpoint::pause("create-after-storage-acquire").await;
+
+        instance.backend_ownership = BackendOwnership::Starting;
+        if let Err(error) = instance.persist(&self.state_dir) {
+            instance.backend_ownership = BackendOwnership::NotStarted;
+            return Err(self
+                .cleanup_failed_create(&mut instance, storage, None, false, error.into())
+                .await);
+        }
+        if let Some(error) = self.retain_instance(instance.clone()) {
+            instance.backend_ownership = BackendOwnership::NotStarted;
+            return Err(self
+                .cleanup_failed_create(
+                    &mut instance,
+                    storage,
+                    None,
+                    false,
+                    BlazeDaemonError::Internal(error),
+                )
+                .await);
+        }
+
+        let spawner = match self.spawners.get(self.active_backend) {
+            Some(spawner) => spawner,
+            None => {
+                instance.backend_ownership = BackendOwnership::NotStarted;
+                return Err(self
+                    .cleanup_failed_create(
+                        &mut instance,
+                        storage,
+                        None,
+                        false,
+                        BlazeDaemonError::Internal(format!(
+                            "active backend {} has no registered spawner",
+                            self.active_backend
+                        )),
+                    )
+                    .await);
+            }
+        };
+        let spawn = match crate::failpoint::backend("create-spawn") {
+            Ok(()) => {
+                spawner
+                    .spawn(SpawnRequest {
+                        instance_id: instance.id,
+                        run_dir: self.state_dir.join(instance.id.to_string()),
+                        binary_path: request.binary_path,
+                        storage: storage.clone(),
+                        backend: request.decision.backend,
+                        vm: request.decision.vm,
+                    })
+                    .await
+            }
+            Err(error) => Err(crate::spawner::SpawnFailure::clean(error)),
+        };
+        let actual_backend = match spawn {
+            Ok(backend_instance) => {
+                instance.backend_ownership = BackendOwnership::Running;
+                let actual_backend = backend_instance.backend();
+                let mut backend_instance = Some(backend_instance);
+                let registered = match self.backend_instances.lock() {
+                    Ok(mut instances) => {
+                        instances.insert(
+                            instance.id,
+                            backend_instance
+                                .take()
+                                .expect("backend instance is present"),
+                        );
+                        true
+                    }
+                    Err(_) => false,
+                };
+                if !registered {
+                    return Err(self
+                        .cleanup_failed_create(
+                            &mut instance,
+                            storage,
+                            backend_instance,
+                            false,
+                            BlazeDaemonError::Internal(
+                                "backend_instances lock poisoned".to_string(),
+                            ),
+                        )
+                        .await);
+                }
+                actual_backend
+            }
+            Err(error) => {
+                let (source, backend) = error.into_parts();
+                instance.backend_ownership = if backend.is_some() {
+                    BackendOwnership::Running
+                } else {
+                    BackendOwnership::Stopped
+                };
+                return Err(self
+                    .cleanup_failed_create(&mut instance, storage, backend, false, source.into())
+                    .await);
+            }
+        };
+
+        if let Err(error) = instance.transition(SandboxState::Running) {
+            return Err(self
+                .cleanup_failed_create(&mut instance, storage, None, true, error.into())
+                .await);
+        }
+        instance.finish_operation();
+        if let Err(error) = crate::failpoint::state("create-state-commit")
+            .and_then(|_| instance.persist(&self.state_dir).map_err(Into::into))
+        {
+            return Err(self
+                .cleanup_failed_create(&mut instance, storage, None, true, error)
+                .await);
+        }
+        if let Some(error) = self.retain_instance(instance.clone()) {
+            return Err(self
+                .cleanup_failed_create(
+                    &mut instance,
+                    storage,
+                    None,
+                    true,
+                    BlazeDaemonError::Internal(error),
+                )
+                .await);
+        }
+        self.metrics.inc(&self.metrics.instances_created);
+        Ok(CreateSandboxResult {
+            instance,
+            selected_backend: actual_backend,
+        })
+    }
+
+    async fn activate_warm(&self, key: &PoolKey) -> Result<Option<CreateSandboxResult>> {
+        let candidate = self.pool.lock().map_err(|_| poisoned("pool"))?.lookup(key);
+        let Some(id) = candidate else {
+            return Ok(None);
+        };
+        let operation_lock = self.operation_lock(id);
+        let _operation = operation_lock.lock().await;
+
+        let instance = self
+            .instances
+            .lock()
+            .map_err(|_| poisoned("instances"))?
+            .get(&id)
+            .cloned();
+        let backend = self
+            .backend_instances
+            .lock()
+            .map_err(|_| poisoned("backend_instances"))?
+            .get(&id)
+            .cloned();
+
+        let invalid_reason = match (&instance, &backend) {
+            (None, _) => Some("lifecycle metadata is missing".to_string()),
+            (_, None) => Some("backend owner is missing".to_string()),
+            (Some(instance), Some(_))
+                if instance.state != SandboxState::Warm || instance.operation.is_some() =>
+            {
+                Some(format!("lifecycle state is {}", instance.state))
+            }
+            (Some(instance), Some(backend)) if backend.backend() != instance.backend => {
+                Some(format!(
+                    "backend owner is {}, metadata is {}",
+                    backend.backend(),
+                    instance.backend
+                ))
+            }
+            (_, Some(backend)) => match backend.try_wait().await {
+                Ok(None) => None,
+                Ok(Some(status)) => Some(format!("backend exited: {status:?}")),
+                Err(error) => Some(format!("backend liveness check failed: {error}")),
+            },
+        };
+        if let Some(reason) = invalid_reason {
+            self.quarantine_warm(key, id, instance, backend, &reason)
+                .await;
+            return Ok(None);
+        }
+
+        let original = instance.expect("validated warm metadata");
+        match self.storage.reconstruct(&id.to_string()).await {
+            Ok(_) => {}
+            Err(error @ BlazeError::StorageIncomplete { .. }) => {
+                self.quarantine_warm(
+                    key,
+                    id,
+                    Some(original),
+                    backend,
+                    &format!("storage validation failed: {error}"),
+                )
+                .await;
+                return Ok(None);
+            }
+            Err(error) => {
+                return Err(self.restore_warm_claim(key, original, error.into()));
+            }
+        }
+
+        let mut activating = original.clone();
+        activating.begin_operation(OperationKind::Create);
+        if let Err(error) = crate::failpoint::state("warm-intent-state-commit").and_then(|_| {
+            activating
+                .persist(&self.state_dir)
+                .map_err(BlazeDaemonError::from)
+        }) {
+            return Err(self.restore_warm_claim(key, original, error));
+        }
+        if let Some(error) = self.retain_instance(activating.clone()) {
+            return Err(self.restore_warm_claim(key, original, BlazeDaemonError::Internal(error)));
+        }
+
+        crate::failpoint::pause("warm-before-state-commit").await;
+        let selected_backend = backend.expect("validated warm backend").backend();
+        if let Err(error) = activating
+            .transition(SandboxState::Creating)
+            .and_then(|_| activating.transition(SandboxState::Running))
+        {
+            return Err(self.restore_warm_claim(key, original, error.into()));
+        }
+        activating.finish_operation();
+        if let Err(error) = crate::failpoint::state("warm-final-state-commit").and_then(|_| {
+            activating
+                .persist(&self.state_dir)
+                .map_err(BlazeDaemonError::from)
+        }) {
+            return Err(self.restore_warm_claim(key, original, error));
+        }
+        if let Some(error) = self.retain_instance(activating.clone()) {
+            return Err(self.restore_warm_claim(key, original, BlazeDaemonError::Internal(error)));
+        }
+        Ok(Some(CreateSandboxResult {
+            instance: activating,
+            selected_backend,
+        }))
+    }
+
+    fn restore_warm_claim(
+        &self,
+        key: &PoolKey,
+        instance: SandboxInstance,
+        cause: BlazeDaemonError,
+    ) -> BlazeDaemonError {
+        let id = instance.id;
+        let mut errors = Vec::new();
+        if let Err(error) = instance.persist(&self.state_dir) {
+            errors.push(format!("restore warm state persistence failed: {error}"));
+        }
+        if let Some(error) = self.retain_instance(instance) {
+            errors.push(error);
+        }
+        match self.pool.lock() {
+            Ok(mut pool) => pool.restore_lookup(key.clone(), id),
+            Err(poisoned) => {
+                poisoned.into_inner().restore_lookup(key.clone(), id);
+                errors.push("pool lock poisoned while restoring warm claim".to_string());
+            }
+        }
+        let details = if errors.is_empty() {
+            "warm claim restored for retry".to_string()
+        } else {
+            format!("warm claim restored with errors: {}", errors.join("; "))
+        };
+        BlazeDaemonError::RecoveryRequired(format!("{cause}; instance {id}: {details}"))
+    }
+
+    async fn quarantine_warm(
+        &self,
+        key: &PoolKey,
+        id: Uuid,
+        mut instance: Option<SandboxInstance>,
+        backend: Option<DynBackendInstance>,
+        reason: &str,
+    ) {
+        match self.pool.lock() {
+            Ok(mut pool) => pool.quarantine(key, id),
+            Err(poisoned) => poisoned.into_inner().quarantine(key, id),
+        }
+        tracing::warn!(instance = %id, reason, "warm instance validation failed");
+
+        let Some(metadata) = instance.as_mut() else {
+            if let Some(backend) = backend.as_ref()
+                && let Err(error) = backend.kill().await
+            {
+                tracing::error!(
+                    instance = %id,
+                    %error,
+                    "quarantined backend cleanup failed"
+                );
+            }
+            tracing::error!(
+                instance = %id,
+                "quarantined lifecycle metadata missing; retaining storage"
+            );
+            return;
+        };
+        metadata.begin_operation(OperationKind::Destroy);
+        if let Err(error) = metadata.persist(&self.state_dir) {
+            tracing::error!(instance = %id, %error, "quarantine intent commit failed");
+            return;
+        }
+        if let Some(error) = self.retain_instance(metadata.clone()) {
+            tracing::error!(instance = %id, %error, "quarantine intent retention failed");
+            return;
+        }
+
+        let backend_stopped = match backend.as_ref() {
+            Some(backend) => match backend.kill().await {
+                Ok(()) => true,
+                Err(error) => {
+                    tracing::error!(instance = %id, %error, "quarantined backend cleanup failed");
+                    false
+                }
+            },
+            None if matches!(
+                metadata.backend_ownership,
+                BackendOwnership::NotStarted | BackendOwnership::Stopped
+            ) =>
+            {
+                true
+            }
+            None => match self.spawners.get(metadata.backend) {
+                Some(spawner) => match spawner
+                    .cleanup_orphan(id, &self.state_dir.join(id.to_string()))
+                    .await
+                {
+                    Ok(()) => true,
+                    Err(error) => {
+                        tracing::error!(
+                            instance = %id,
+                            %error,
+                            "quarantined orphan cleanup failed"
+                        );
+                        false
+                    }
+                },
+                None => {
+                    tracing::error!(
+                        instance = %id,
+                        backend = %metadata.backend,
+                        "quarantined backend has no recovery spawner"
+                    );
+                    false
+                }
+            },
+        };
+        if !backend_stopped {
+            let _ = self.mark_recovery(id);
+            return;
+        }
+
+        metadata.backend_ownership = BackendOwnership::Stopped;
+        if let Err(error) = metadata.persist(&self.state_dir) {
+            tracing::error!(instance = %id, %error, "quarantined stop state commit failed");
+            let _ = self.mark_recovery(id);
+            return;
+        }
+        if let Some(error) = self.retain_instance(metadata.clone()) {
+            tracing::error!(instance = %id, %error, "quarantined stop state retention failed");
+            let _ = self.mark_recovery(id);
+            return;
+        }
+        if let Err(error) = self.storage.release_by_id(&id.to_string()).await {
+            tracing::error!(instance = %id, %error, "quarantined storage cleanup failed");
+            let _ = self.mark_recovery(id);
+            return;
+        }
+
+        if metadata.state != SandboxState::Destroyed
+            && let Err(error) = metadata.transition(SandboxState::Destroyed)
+        {
+            tracing::error!(instance = %id, %error, "quarantined lifecycle cleanup failed");
+            let _ = self.mark_recovery(id);
+            return;
+        }
+        metadata.finish_operation();
+        if let Err(error) = metadata.persist(&self.state_dir) {
+            tracing::error!(instance = %id, %error, "quarantined state commit failed");
+            let _ = self.mark_recovery(id);
+            return;
+        }
+        let _ = self.retain_instance(metadata.clone());
+        match self.backend_instances.lock() {
+            Ok(mut instances) => {
+                instances.remove(&id);
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().remove(&id);
+            }
+        }
+    }
+
+    /// Idempotently destroy one sandbox and its owned runtime resources.
+    pub async fn destroy(&self, id: Uuid) -> Result<bool> {
+        let operation_lock = self.operation_lock(id);
+        let _operation = operation_lock.lock().await;
+        self.destroy_locked(id).await
+    }
+
+    async fn destroy_locked(&self, id: Uuid) -> Result<bool> {
+        let mut original = self.get(id)?;
+        if original.state == SandboxState::Destroyed {
+            return Ok(false);
+        }
+
+        if original.operation.as_ref().map(|operation| operation.kind)
+            != Some(OperationKind::Destroy)
+        {
+            original.begin_operation(OperationKind::Destroy);
+        }
+        if let Err(error) = crate::failpoint::state("destroy-intent-state-commit").and_then(|_| {
+            original
+                .persist(&self.state_dir)
+                .map_err(BlazeDaemonError::from)
+        }) {
+            let _ = self.mark_recovery(id);
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: intent persistence failed: {error}; resources retained"
+            )));
+        }
+        if let Some(error) = self.retain_instance(original.clone()) {
+            let _ = self.mark_recovery(id);
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: {error}; resources retained"
+            )));
+        }
+
+        let backend = self
+            .backend_instances
+            .lock()
+            .map_err(|_| poisoned("backend_instances"))?
+            .get(&id)
+            .cloned();
+        let stop_result = match crate::failpoint::backend("destroy-kill") {
+            Ok(()) => {
+                if let Some(backend) = backend.as_ref() {
+                    backend.kill().await
+                } else if matches!(
+                    original.backend_ownership,
+                    BackendOwnership::NotStarted | BackendOwnership::Stopped
+                ) {
+                    Ok(())
+                } else {
+                    match self.spawners.get(original.backend) {
+                        Some(spawner) => {
+                            spawner
+                                .cleanup_orphan(id, &self.state_dir.join(id.to_string()))
+                                .await
+                        }
+                        None => Err(BlazeError::BackendError {
+                            msg: format!(
+                                "no recovery spawner registered for persisted backend {}",
+                                original.backend
+                            ),
+                        }),
+                    }
+                }
+            }
+            Err(error) => Err(error),
+        };
+        if let Err(error) = stop_result {
+            let recovery = self.mark_recovery(id).err();
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: backend termination failed: {error}; owner and storage retained{}",
+                recovery
+                    .map(|error| format!("; recovery state persistence failed: {error}"))
+                    .unwrap_or_default()
+            )));
+        }
+
+        original.backend_ownership = BackendOwnership::Stopped;
+        if let Err(error) = crate::failpoint::state("destroy-stop-state-commit").and_then(|_| {
+            original
+                .persist(&self.state_dir)
+                .map_err(BlazeDaemonError::from)
+        }) {
+            let recovery = self.mark_instance_recovery(original.clone()).err();
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: backend stopped but stop state persistence failed: {error}; \
+                 storage retained{}",
+                recovery
+                    .map(|error| format!("; recovery state persistence failed: {error}"))
+                    .unwrap_or_default()
+            )));
+        }
+        if let Some(error) = self.retain_instance(original.clone()) {
+            let _ = self.mark_recovery(id);
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: backend stopped but lifecycle retention failed: {error}; \
+                 storage retained"
+            )));
+        }
+
+        if let Err(error) = self.storage.release_by_id(&id.to_string()).await {
+            let recovery = self.mark_recovery(id).err();
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: backend stopped but storage release failed: {error}; \
+                 lifecycle retained for retry{}",
+                recovery
+                    .map(|error| format!("; recovery state persistence failed: {error}"))
+                    .unwrap_or_default()
+            )));
+        }
+
+        let mut destroyed = original;
+        if destroyed.state != SandboxState::Destroyed {
+            destroyed.transition(SandboxState::Destroyed)?;
+        }
+        destroyed.finish_operation();
+        if let Err(error) = crate::failpoint::state("destroy-final-state-commit").and_then(|_| {
+            destroyed
+                .persist(&self.state_dir)
+                .map_err(BlazeDaemonError::from)
+        }) {
+            let recovery = self.mark_recovery(id).err();
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: resources released but final state persistence failed: {error}{}",
+                recovery
+                    .map(|error| format!("; recovery state persistence failed: {error}"))
+                    .unwrap_or_default()
+            )));
+        }
+        if let Some(error) = self.retain_instance(destroyed) {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: resources released but {error}"
+            )));
+        }
+        match self.backend_instances.lock() {
+            Ok(mut instances) => {
+                instances.remove(&id);
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().remove(&id);
+            }
+        }
+        self.metrics.inc(&self.metrics.instances_destroyed);
+        Ok(true)
+    }
+
+    /// Reconcile every non-terminal record without aborting on one failure.
+    pub async fn reconcile_startup(&self) -> ReconcileReport {
+        let ids = match self.instances.lock() {
+            Ok(instances) => instances
+                .values()
+                .filter(|instance| instance.state != SandboxState::Destroyed)
+                .map(|instance| instance.id)
+                .collect::<Vec<_>>(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .values()
+                .filter(|instance| instance.state != SandboxState::Destroyed)
+                .map(|instance| instance.id)
+                .collect::<Vec<_>>(),
+        };
+        let mut report = ReconcileReport {
+            attempted: ids.len(),
+            ..ReconcileReport::default()
+        };
+        for id in ids {
+            let operation_lock = self.operation_lock(id);
+            let _operation = operation_lock.lock().await;
+            match self.destroy_locked(id).await {
+                Ok(_) => report.completed += 1,
+                Err(error) => {
+                    let recovery = self.mark_recovery(id).err();
+                    report.failures.push(ReconcileFailure {
+                        instance_id: id,
+                        error: match recovery {
+                            Some(recovery) => {
+                                format!("{error}; recovery state persistence failed: {recovery}")
+                            }
+                            None => error.to_string(),
+                        },
+                    });
+                }
+            }
+        }
+        report
+    }
+
+    async fn cleanup_failed_create(
+        &self,
+        instance: &mut SandboxInstance,
+        storage: StorageSlot,
+        backend: Option<DynBackendInstance>,
+        registered: bool,
+        original: BlazeDaemonError,
+    ) -> BlazeDaemonError {
+        if instance.operation.is_none() {
+            instance.begin_operation(OperationKind::Create);
+        }
+        let mut cleanup_errors = Vec::new();
+        let backend = if registered {
+            match self.backend_instances.lock() {
+                Ok(mut instances) => instances.remove(&instance.id),
+                Err(poisoned) => poisoned.into_inner().remove(&instance.id),
+            }
+        } else {
+            backend
+        };
+        let mut backend_stopped = matches!(
+            instance.backend_ownership,
+            BackendOwnership::NotStarted | BackendOwnership::Stopped
+        );
+        if registered && backend.is_none() {
+            backend_stopped = false;
+            cleanup_errors.push("registered backend owner is missing".to_string());
+        }
+        if let Some(backend) = backend.as_ref() {
+            match backend.kill().await {
+                Ok(()) => {
+                    backend_stopped = true;
+                    instance.backend_ownership = BackendOwnership::Stopped;
+                }
+                Err(error) => {
+                    backend_stopped = false;
+                    cleanup_errors.push(format!("backend termination failed: {error}"));
+                }
+            }
+        }
+
+        let mut storage_released = false;
+        if backend_stopped {
+            match self.storage.release(storage).await {
+                Ok(()) => storage_released = true,
+                Err(error) => cleanup_errors.push(format!("storage release failed: {error}")),
+            }
+        } else {
+            cleanup_errors.push("storage retained until backend termination succeeds".to_string());
+        }
+
+        if backend_stopped && storage_released {
+            instance.backend_ownership = BackendOwnership::Stopped;
+            if let Err(error) = instance.transition(SandboxState::Destroyed) {
+                cleanup_errors.push(format!("lifecycle update failed: {error}"));
+            } else {
+                instance.finish_operation();
+            }
+            if let Err(error) = instance.persist(&self.state_dir) {
+                cleanup_errors.push(format!("state persistence failed: {error}"));
+            }
+            if let Some(error) = self.retain_instance(instance.clone()) {
+                cleanup_errors.push(error);
+            }
+            if cleanup_errors.is_empty() {
+                self.metrics.inc(&self.metrics.instances_destroyed);
+                return original;
+            }
+            return BlazeDaemonError::RecoveryRequired(format!(
+                "{original}; cleanup completed but {}",
+                cleanup_errors.join("; ")
+            ));
+        }
+
+        if let Some(backend) = backend
+            && let Some(error) = self.retain_backend(instance.id, backend)
+        {
+            cleanup_errors.push(error);
+        }
+        if instance.state != SandboxState::RecoveryRequired
+            && let Err(error) = instance.transition(SandboxState::RecoveryRequired)
+        {
+            cleanup_errors.push(format!("recovery state update failed: {error}"));
+        }
+        if let Err(error) = instance.persist(&self.state_dir) {
+            cleanup_errors.push(format!("state persistence failed: {error}"));
+        }
+        if let Some(error) = self.retain_instance(instance.clone()) {
+            cleanup_errors.push(error);
+        }
+        BlazeDaemonError::RecoveryRequired(format!(
+            "{original}; cleanup incomplete: {}",
+            cleanup_errors.join("; ")
+        ))
+    }
+
+    fn retain_failed_acquire(
+        &self,
+        instance: &mut SandboxInstance,
+        residual: Option<StorageSlot>,
+        original: BlazeDaemonError,
+    ) -> BlazeDaemonError {
+        if residual.is_some() {
+            let mut errors = Vec::new();
+            if instance.state != SandboxState::RecoveryRequired
+                && let Err(error) = instance.transition(SandboxState::RecoveryRequired)
+            {
+                errors.push(format!("recovery state update failed: {error}"));
+            }
+            if let Err(error) = instance.persist(&self.state_dir) {
+                errors.push(format!("state persistence failed: {error}"));
+            }
+            if let Some(error) = self.retain_instance(instance.clone()) {
+                errors.push(error);
+            }
+            let suffix = if errors.is_empty() {
+                "residual storage retained for destroy retry".to_string()
+            } else {
+                format!(
+                    "residual storage retained with recovery errors: {}",
+                    errors.join("; ")
+                )
+            };
+            return BlazeDaemonError::RecoveryRequired(format!(
+                "{original}; instance {}: {suffix}",
+                instance.id
+            ));
+        }
+
+        let mut errors = Vec::new();
+        instance.backend_ownership = BackendOwnership::Stopped;
+        if let Err(error) = instance.transition(SandboxState::Destroyed) {
+            errors.push(format!("lifecycle update failed: {error}"));
+        } else {
+            instance.finish_operation();
+        }
+        if let Err(error) = instance.persist(&self.state_dir) {
+            errors.push(format!("state persistence failed: {error}"));
+        }
+        if let Some(error) = self.retain_instance(instance.clone()) {
+            errors.push(error);
+        }
+        if errors.is_empty() {
+            original
+        } else {
+            BlazeDaemonError::RecoveryRequired(format!(
+                "{original}; acquire rollback completed but {}",
+                errors.join("; ")
+            ))
+        }
+    }
+
+    fn mark_recovery(&self, id: Uuid) -> Result<()> {
+        self.mark_instance_recovery(self.get(id)?)
+    }
+
+    fn mark_instance_recovery(&self, mut instance: SandboxInstance) -> Result<()> {
+        if instance.state != SandboxState::RecoveryRequired {
+            instance.transition(SandboxState::RecoveryRequired)?;
+        }
+        let persist = instance.persist(&self.state_dir);
+        let retained = self.retain_instance(instance);
+        match (persist, retained) {
+            (Ok(()), None) => Ok(()),
+            (Err(error), None) => Err(error.into()),
+            (Ok(()), Some(error)) => Err(BlazeDaemonError::Internal(error)),
+            (Err(persist), Some(retain)) => Err(BlazeDaemonError::RecoveryRequired(format!(
+                "recovery state persistence failed: {persist}; {retain}"
+            ))),
+        }
+    }
+
+    fn retain_backend(&self, id: Uuid, backend: DynBackendInstance) -> Option<String> {
+        match self.backend_instances.lock() {
+            Ok(mut instances) => {
+                instances.insert(id, backend);
+                None
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().insert(id, backend);
+                Some("backend owner retained in poisoned runtime map".to_string())
+            }
+        }
+    }
+
+    fn retain_instance(&self, instance: SandboxInstance) -> Option<String> {
+        match self.instances.lock() {
+            Ok(mut instances) => {
+                instances.insert(instance.id, instance);
+                None
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().insert(instance.id, instance);
+                Some("instance state retained in poisoned lifecycle map".to_string())
+            }
+        }
+    }
+}
+
+fn poisoned(name: &str) -> BlazeDaemonError {
+    BlazeDaemonError::Internal(format!("{name} lock poisoned"))
+}

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -17,32 +17,30 @@ use blaze_core::policy::PolicyEngine;
 use blaze_core::pool::PoolManager;
 use blaze_core::storage::StorageProvider;
 use blaze_core::template::TemplateRegistry;
-use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use crate::error::Result;
 use crate::metrics::Metrics;
-use crate::spawner::{DynBackendInstance, DynSpawner, SpawnerRegistry};
+use crate::sandbox::{SandboxManager, SandboxManagerInit};
+use crate::spawner::SpawnerRegistry;
 
 /// All daemon mutable state. Cloning is via `Arc` (see the `state.clone()`
 /// idiom in `daemon.rs`); the struct itself is never `Clone`.
 pub struct ServerState {
     pub config: Mutex<DaemonConfig>,
     pub policy: Mutex<PolicyEngine>,
-    pub pool: Mutex<PoolManager>,
+    pub pool: Arc<Mutex<PoolManager>>,
     pub template: Mutex<TemplateRegistry>,
     pub hook: Mutex<HookRegistry>,
-    pub instances: Mutex<HashMap<Uuid, SandboxInstance>>,
-    pub backend_instances: Mutex<HashMap<Uuid, DynBackendInstance>>,
-    operation_locks: Mutex<HashMap<Uuid, Arc<AsyncMutex<()>>>>,
-    pub spawners: SpawnerRegistry,
+    pub instances: Arc<Mutex<HashMap<Uuid, SandboxInstance>>>,
+    pub manager: SandboxManager,
     /// The backend kind that `build_spawner` actually probed and selected.
     /// API handlers use this to constrain availability to the single active
     /// backend rather than reporting all configured binaries.
     pub active_backend: BackendKind,
     pub storage: Arc<dyn StorageProvider>,
     pub state_dir: PathBuf,
-    pub metrics: Metrics,
+    pub metrics: Arc<Metrics>,
 }
 
 impl ServerState {
@@ -65,47 +63,35 @@ impl ServerState {
             tracing::warn!(error = %err, "failed to scan state_dir, starting empty");
             HashMap::new()
         });
-        let operation_locks = instances
-            .keys()
-            .copied()
-            .map(|id| (id, Arc::new(AsyncMutex::new(()))))
-            .collect();
+        let (manager, resources) = SandboxManager::new(SandboxManagerInit {
+            instances,
+            pool,
+            spawners,
+            active_backend,
+            storage: storage.clone(),
+            state_dir: state_dir.clone(),
+            rootfs_size: config.storage.rootfs_size,
+            mem_size: config.storage.mem_size,
+        });
 
         Self {
             config: Mutex::new(config),
             policy: Mutex::new(policy),
-            pool: Mutex::new(pool),
+            pool: resources.pool,
             template: Mutex::new(template),
             hook: Mutex::new(hook),
-            instances: Mutex::new(instances),
-            backend_instances: Mutex::new(HashMap::new()),
-            operation_locks: Mutex::new(operation_locks),
-            spawners,
+            instances: resources.instances,
+            manager,
             active_backend,
             storage,
             state_dir,
-            metrics: Metrics::new(),
+            metrics: resources.metrics,
         }
     }
 
     /// Return the async operation lock that serializes one sandbox mutation.
-    pub fn operation_lock(&self, id: Uuid) -> Arc<AsyncMutex<()>> {
-        match self.operation_locks.lock() {
-            Ok(mut locks) => locks
-                .entry(id)
-                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-                .clone(),
-            Err(poisoned) => poisoned
-                .into_inner()
-                .entry(id)
-                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-                .clone(),
-        }
-    }
-
-    /// Return the implementation responsible for a persisted backend kind.
-    pub fn spawner_for(&self, kind: BackendKind) -> Option<DynSpawner> {
-        self.spawners.get(kind)
+    pub fn operation_lock(&self, id: Uuid) -> Arc<tokio::sync::Mutex<()>> {
+        self.manager.operation_lock(id)
     }
 }
 


### PR DESCRIPTION
## Description

This PR makes sandbox create and destroy recoverable across daemon failures.
It records the active operation before changing storage or backend resources,
routes the existing instance API through one `SandboxManager`, reconciles
unfinished records at startup, and adds sandbox-named API aliases.

### Why this is needed

The current API can create, list, inspect, and destroy instances, but the HTTP
handlers directly coordinate durable records, provider slots, backend handles,
and warm-pool claims. If the daemon exits between those steps, the next process
can load the final lifecycle state but cannot reliably tell which operation was
in progress or which cleanup still needs to run.

The daemon needs a durable operation intent and one component that owns the
ordering and compensation rules. A failed record must remain visible and
retryable without preventing the daemon from processing other sandboxes.

### Before

- `/v1/instances` handlers coordinated lifecycle resources directly.
- Persistent state did not record an active create or destroy operation.
- Startup loaded lifecycle files but did not reconcile non-terminal records.
- The API exposed only instance-named lifecycle routes, and destroy used a
  POST action.

### After

- Create and destroy persist their operation intent before storage or backend
  changes.
- One manager owns durable state, backend handles, warm claims, per-sandbox
  serialization, compensation, and destroy retry.
- Failed cleanup retains the remaining ownership as `RecoveryRequired`.
- Startup reconciles each non-terminal record independently; one failure does
  not prevent other records from being processed or the API from starting.
- `/v1/sandboxes` and DELETE aliases use the same handlers as the compatible
  `/v1/instances` routes.

```mermaid
flowchart TD
    A["Create request"] --> B{"Warm claim available?"}
    B -- no --> C["Persist Create intent"]
    C --> D["Acquire storage"]
    D --> E["Start backend"]
    E --> F["Persist Running and clear intent"]
    D -. failure .-> G["Compensate completed steps"]
    E -. failure .-> G
    F -. state failure .-> G
    G --> H{"Cleanup complete?"}
    H -- yes --> I["Persist Destroyed"]
    H -- no --> J["Persist RecoveryRequired for retry"]
    B -- yes --> K["Claim warm candidate"]
    K --> V{"Validation result"}
    V -- valid --> L["Persist Create intent"]
    V -- incomplete or invalid --> W["Quarantine candidate"]
    W --> C
    V -- transient failure --> N["Restore Warm state, owner, and pool claim"]
    L --> M["Persist Running and clear intent"]
    L -. state failure .-> N
    M -. state failure .-> N
    O["Destroy request or startup reconciliation"] --> P["Persist Destroy intent"]
    P -. state failure .-> J
    P --> Q{"Backend ownership"}
    Q -- active or unknown --> R["Stop or clean up backend"]
    Q -- NotStarted or Stopped --> S["Skip backend cleanup"]
    R --> X["Persist Stopped ownership"]
    S --> X
    X --> T["Release storage"]
    T --> U["Persist Destroyed and clear intent"]
    R -. failure .-> J
    X -. state failure .-> J
    T -. failure .-> J
    U -. state failure .-> J
```

### Commit delivery

1. `feat(blaze): journal sandbox ownership changes`
   - Adds `OperationJournal` and `OperationKind` to durable lifecycle state.
   - Publishes state with a synced temporary file, atomic rename, and parent
     directory sync.
   - Keeps older state files readable through optional journal fields.

2. `feat(blaze): manage recoverable sandboxes`
   - Routes the existing instance create, list, inspect, and destroy behavior
     through `SandboxManager`.
   - Preserves backend selection, warm validation, partial ownership, and
     provider cleanup while adding operation ordering and compensation.
   - Restores a warm record, backend owner, and pool claim when activation
     state publication fails.
   - Reconciles records independently at startup and retains failed cleanup
     for a later destroy retry.

3. `feat(blaze): expose sandbox lifecycle routes`
   - Adds collection and item aliases under `/v1/sandboxes`.
   - Adds DELETE forms for sandbox and instance resources.
   - Proves the aliases and compatible routes call the same managed handlers.

4. `docs(blaze): describe managed sandboxes`
   - Documents both route families, `RecoveryRequired`, startup behavior, and
     current recovery limits in English and Chinese.

### Why these commits belong in one PR

The journal is consumed immediately by the manager; the route aliases expose
that manager without duplicating lifecycle rules; the documentation describes
the same observable behavior. Together they form one reviewable daemon
lifecycle boundary. New storage providers, VM networking, guest
operations, checkpoint data-plane work, background warm-pool refill, and
client SDK work remain separate.

### Remaining work

1. The journal records operation type and start time, not each completed
   resource step.
2. Startup cleans interrupted sandboxes instead of resuming creation or
   adopting a pre-existing backend process.
3. Failed startup recovery remains retryable through destroy, but there is no
   background retry loop.
4. Checkpoint and reset retain their existing metadata behavior; this PR does
   not add backend snapshot or restore operations.

## Related Issue

refs #1829

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [x] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Every final commit was exported from its exact Git tree and checked
independently on Linux x86_64 with an empty target directory:

```text
cargo fmt --all -- --check
cargo build --workspace --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
```

| Commit | Default tests (core + daemon) | All-features tests (core + daemon) | Result |
|---|---:|---:|---|
| `216d942b` | `50 + 34` | `50 + 38` | PASS |
| `4405b163` | `50 + 36` | `50 + 45` | PASS |
| `6b75f546` | `50 + 38` | `50 + 47` | PASS |
| `162bb41a` | `50 + 38` | `50 + 47` | PASS |

All seven commands completed without warnings for every current commit.

Focused coverage includes:

- `RecoveryRequired` can finish in `Destroyed` but cannot be re-entered;
- cold create and warm activation success and compensation;
- durable warm-claim restoration after intent or final-state write failure;
- destroy failures before termination, after termination, and after storage
  release, including persisted state and successful retry;
- startup reconciliation for `NotStarted`, `Stopped`, and active ownership;
- one failed startup cleanup not blocking other records or later API service;
- sandbox and instance route equivalence, including all destroy forms.

Documentation checks:

```text
bash scripts/docs-lint.sh
python3 scripts/docs-link-check.py
```

### Integration with current `main`

After #1997 merged, the automatic merge of `main` at `5db7a3fe` and this
PR at `162bb41a` produced tree `4431dbf0` without conflicts. That exact
tree passed format, locked build, default and all-features strict Clippy,
default tests (`50 + 70`), all-features tests (`50 + 79`), strict rustdoc,
and both documentation checks on Linux x86_64.

## Additional Notes

PR #1997 has merged. The networking and managed-lifecycle changes remain
independent capabilities; this PR does not require VM networking to be enabled.

Review follow-ups that are intentionally not claimed as fixed here are tracked
in #2180, #2194, and #2202. They remain separate robustness work rather than
part of this feature's four-commit lifecycle boundary.
