### PR TITLE
fix(cosh-ng): [core] show real session prompt

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
@@ -483,6 +483,37 @@ fn summary_preview_is_single_line_unicode_safe_and_bounded() {
 }
 
 #[test]
+fn listing_distinguishes_persisted_shell_envelope_sessions() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let envelope = |input: &str| {
+        format!(
+            "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
+             Decide based on user intent:\n\
+             Do not mention Claude Code, plan mode, implementation status, or internal workflow.\n\n\
+             user_input: {input}\n\n\nruntime_frame:\ncwd: /root\n\n\
+             cosh-shell Agent contract:\n- User modes: recommend and agent."
+        )
+    };
+    let mut older = new_session(&store, &envelope("查看当前目录下的文件"));
+    store.persist(&mut older).unwrap();
+    let mut newer = new_session(&store, &envelope("帮我检查 nginx 服务状态"));
+    newer.updated_at_ms = older.updated_at_ms.saturating_add(10);
+    store.persist(&mut newer).unwrap();
+
+    let (summaries, _) = store.list(10, None).unwrap();
+
+    assert_eq!(
+        summaries[0].first_prompt.as_deref(),
+        Some("帮我检查 nginx 服务状态")
+    );
+    assert_eq!(
+        summaries[1].first_prompt.as_deref(),
+        Some("查看当前目录下的文件")
+    );
+}
+
+#[test]
 fn inspect_reports_invalid_utf8_as_corrupt_summary() {
     let temp = tempfile::tempdir().unwrap();
     let store = store(&temp);

--- a/src/cosh-ng/crates/cosh-core/src/session/summary.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/summary.rs
@@ -10,6 +10,16 @@ pub(super) const MAX_SUMMARY_MODEL_BYTES: usize = 256;
 /// Maximum UTF-8 bytes retained from untrusted workspace metadata.
 pub(super) const MAX_SUMMARY_WORKSPACE_BYTES: usize = 4096;
 
+/// First line of the cosh-shell natural-language prompt envelope.
+const SHELL_ENVELOPE_PREFIX: &str =
+    "Handle this natural-language shell prompt request for a Shell-first assistant.\n";
+/// Envelope marker that precedes the raw text the user typed.
+const SHELL_ENVELOPE_INPUT_MARKER: &str = "\nuser_input: ";
+/// Envelope section that always follows the raw user input.
+const SHELL_ENVELOPE_RUNTIME_MARKER: &str = "\n\nruntime_frame:\n";
+/// Trailing envelope section appended by the cosh-shell adapter.
+const SHELL_ENVELOPE_CONTRACT_MARKER: &str = "\n\ncosh-shell Agent contract:\n";
+
 pub(super) fn summary_from_session(
     session: &PersistedSession,
     health: SessionHealth,
@@ -56,12 +66,47 @@ pub(crate) fn bounded_summary_text(value: &str, max_bytes: usize) -> String {
     format!("{}{}", &sanitized[..boundary], ELLIPSIS)
 }
 
+/// Projects a persisted user message onto the text worth showing in a picker.
+///
+/// cosh-shell hands cosh-core one `user` message whose fixed instruction
+/// envelope wraps the text the user typed, so previewing the message verbatim
+/// labels every session with the same envelope prefix. Text markers cannot
+/// delimit arbitrary user input unambiguously, so this is a bounded
+/// compatibility heuristic, not a parse: every anchor must be present in order,
+/// otherwise the message is previewed as-is and plain cosh-core prompts keep
+/// their behavior.
+fn preview_source(text: &str) -> &str {
+    shell_envelope_input(text).unwrap_or(text)
+}
+
+/// Recovers the raw input from a cosh-shell prompt envelope.
+///
+/// Both trailing sections are appended after the input, so their last
+/// occurrences bound it: an input that quotes a marker keeps its full text, and
+/// only untrusted evidence repeating the runtime marker can push the boundary
+/// late — which pads the preview instead of losing what the user typed.
+fn shell_envelope_input(text: &str) -> Option<&str> {
+    if !text.starts_with(SHELL_ENVELOPE_PREFIX) {
+        return None;
+    }
+    let contract_start = text.rfind(SHELL_ENVELOPE_CONTRACT_MARKER)?;
+    let input_start = text
+        .find(SHELL_ENVELOPE_INPUT_MARKER)
+        .map(|offset| offset + SHELL_ENVELOPE_INPUT_MARKER.len())
+        .filter(|start| *start <= contract_start)?;
+    let input_end = text[input_start..contract_start]
+        .rfind(SHELL_ENVELOPE_RUNTIME_MARKER)
+        .map(|offset| input_start + offset)?;
+    let input = text[input_start..input_end].trim();
+    (!input.is_empty()).then_some(input)
+}
+
 fn bounded_message_preview(content: &MessageContent) -> Option<String> {
     let mut preview = String::new();
     let mut char_count = 0;
     match content {
         MessageContent::Text(text) => {
-            append_preview_fragment(&mut preview, &mut char_count, text);
+            append_preview_fragment(&mut preview, &mut char_count, preview_source(text));
         }
         MessageContent::Blocks(blocks) => {
             for block in blocks {
@@ -69,7 +114,7 @@ fn bounded_message_preview(content: &MessageContent) -> Option<String> {
                     MessageContentBlock::Text { text }
                     | MessageContentBlock::ToolResult { content: text, .. } => text,
                 };
-                if append_preview_fragment(&mut preview, &mut char_count, text) {
+                if append_preview_fragment(&mut preview, &mut char_count, preview_source(text)) {
                     break;
                 }
             }
@@ -106,4 +151,121 @@ fn append_preview_fragment(preview: &mut String, char_count: &mut usize, fragmen
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirrors the envelope cosh-shell sends for a natural-language prompt.
+    fn shell_envelope(input: &str) -> String {
+        format!(
+            "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
+             Decide based on user intent:\n\
+             history_access: Recent shell history is not included by default.\n\
+             Do not mention Claude Code, plan mode, implementation status, or internal workflow.\n\n\
+             user_input: {input}\n\n\nruntime_frame:\ncwd: /root\n\ncosh-shell Agent contract:\n\
+             - User modes: recommend and agent.\n\
+             - Keep provider-specific names out of visible responses unless already shown by cosh-shell."
+        )
+    }
+
+    fn preview(text: &str) -> Option<String> {
+        bounded_message_preview(&MessageContent::Text(text.to_string()))
+    }
+
+    #[test]
+    fn shell_envelope_preview_shows_raw_user_input() {
+        let envelope = shell_envelope("查看当前目录下的文件");
+
+        assert_eq!(preview(&envelope).as_deref(), Some("查看当前目录下的文件"));
+    }
+
+    #[test]
+    fn shell_envelope_preview_stays_single_line_and_bounded() {
+        let envelope = shell_envelope(&format!(
+            "检查\u{7}nginx\t服务 {}",
+            "界".repeat(MAX_PROMPT_PREVIEW_CHARS + 50)
+        ));
+
+        let preview = preview(&envelope).expect("bounded preview");
+
+        assert!(preview.starts_with("检查nginx 服务 "));
+        assert!(!preview.contains('\n') && !preview.contains('\t'));
+        assert!(!preview.chars().any(char::is_control));
+        assert_eq!(preview.chars().count(), MAX_PROMPT_PREVIEW_CHARS);
+        assert!(preview.ends_with('…'));
+        assert!(!preview.contains("runtime_frame"));
+    }
+
+    #[test]
+    fn shell_envelope_preview_keeps_input_that_quotes_envelope_markers() {
+        let envelope = shell_envelope(
+            "user_input: still mine\n\ncosh-shell Agent contract: quoted by the user",
+        );
+
+        assert_eq!(
+            preview(&envelope).as_deref(),
+            Some("user_input: still mine cosh-shell Agent contract: quoted by the user")
+        );
+    }
+
+    #[test]
+    fn shell_envelope_preview_keeps_input_that_quotes_the_runtime_marker() {
+        let envelope = shell_envelope("比较下面两段：\n\nruntime_frame:\ncwd: /tmp\n后一段更旧");
+
+        assert_eq!(
+            preview(&envelope).as_deref(),
+            Some("比较下面两段： runtime_frame: cwd: /tmp 后一段更旧")
+        );
+    }
+
+    #[test]
+    fn envelope_without_runtime_marker_preview_falls_back_to_verbatim_text() {
+        let without_runtime_frame =
+            "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
+             Decide based on user intent:\n\n\
+             user_input: 查看当前目录下的文件\n\ncosh-shell Agent contract:\n\
+             - User modes: recommend and agent.";
+
+        let preview = preview(without_runtime_frame).expect("verbatim preview");
+
+        assert!(preview.starts_with("Handle this natural-language shell prompt request"));
+    }
+
+    #[test]
+    fn plain_core_prompt_preview_is_unchanged() {
+        assert_eq!(
+            preview("查看当前目录下的文件").as_deref(),
+            Some("查看当前目录下的文件")
+        );
+        assert_eq!(
+            preview("user_input: not an envelope").as_deref(),
+            Some("user_input: not an envelope")
+        );
+    }
+
+    #[test]
+    fn partial_envelope_preview_falls_back_to_verbatim_text() {
+        // No trailing contract section, so the text is not a recognized envelope.
+        let truncated =
+            "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
+             Decide based on user intent:\n\nuser_input: 查看当前目录下的文件\n";
+
+        let preview = preview(truncated).expect("verbatim preview");
+
+        assert!(preview.starts_with("Handle this natural-language shell prompt request"));
+    }
+
+    #[test]
+    fn shell_envelope_preview_applies_to_content_blocks() {
+        let content = MessageContent::Blocks(vec![MessageContentBlock::Text {
+            text: shell_envelope("帮我检查 nginx 服务状态"),
+        }]);
+
+        assert_eq!(
+            bounded_message_preview(&content).as_deref(),
+            Some("帮我检查 nginx 服务状态")
+        );
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
@@ -290,6 +290,35 @@ fn prepare_invocation_prompt_includes_cosh_shell_contract() {
         .contains("at most one primary recommendation command"));
 }
 
+// cosh-core recovers the raw user input from this envelope for session
+// summaries, so the anchors it matches on must keep their exact spelling and
+// order. Changing them silently degrades `/session list` previews.
+#[test]
+fn prepare_invocation_prompt_keeps_session_summary_anchors() {
+    const PREFIX: &str =
+        "Handle this natural-language shell prompt request for a Shell-first assistant.\n";
+    const INPUT_MARKER: &str = "\nuser_input: ";
+    const RUNTIME_MARKER: &str = "\n\nruntime_frame:\n";
+    const CONTRACT_MARKER: &str = "\n\ncosh-shell Agent contract:\n";
+    let mut request = test_request();
+    request.user_input = Some("查看当前目录下的文件".to_string());
+
+    let prompt = test_adapter()
+        .prepare_invocation(&request, CoshApprovalMode::Auto)
+        .prompt;
+
+    assert!(prompt.starts_with(PREFIX), "{prompt}");
+    let input_start = prompt.find(INPUT_MARKER).expect("input marker") + INPUT_MARKER.len();
+    let runtime_start = prompt.find(RUNTIME_MARKER).expect("runtime marker");
+    let contract_start = prompt.rfind(CONTRACT_MARKER).expect("contract marker");
+    assert!(input_start < runtime_start, "{prompt}");
+    assert!(runtime_start < contract_start, "{prompt}");
+    assert_eq!(
+        prompt[input_start..runtime_start].trim(),
+        "查看当前目录下的文件"
+    );
+}
+
 #[test]
 fn prepare_invocation_prompt_preserves_user_provided_secret() {
     let secret = "api_key=sk-cosh-shell-runtime-secret";


### PR DESCRIPTION
## Description

`/session list` showed the shared cosh-shell instruction prefix instead of the user's first prompt, making persisted sessions indistinguishable. This change recognizes the bounded cosh-shell prompt envelope only when all expected anchors are present, then projects the original user input through the existing sanitized 160-character preview path. Provider-visible prompts and persisted session data remain unchanged, so existing sessions are repaired without a migration.

## Related Issue

closes #1995

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test -p cosh-core`
- `cargo test -p cosh-shell --lib`
- `cargo clippy -p cosh-core -p cosh-shell --all-targets --locked`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`

The regression coverage includes persisted-session listing, Unicode-safe bounded previews, control-character filtering, incomplete-envelope fallback, content blocks, and user input that quotes envelope markers.

## Additional Notes

No provider, PTY, or persistence protocol behavior changed. ECS/manual validation was not required for this deterministic projection-layer fix.
