### PR TITLE
fix(cosh-ng): [shell] route punctuated prompts

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
@@ -110,12 +110,24 @@ _cosh_command_veto() {
       ;;
   esac
 
+  # Neutral punctuation (#1992): a question mark and a bare ASCII quote are
+  # ordinary prose in every language cosh sees, so neither may veto the
+  # natural-language evidence on its own. Erase them from the scan instead of
+  # counting them as Shell syntax; everything a quote could have wrapped
+  # ($, |, backtick, redirection, ...) stays in the scan and still vetoes, so
+  # real Shell constructs such as `帮我看看 "$PATH"` remain command-owned.
+  # A doubled `??` keeps its existing agent-marker meaning and still vetoes.
   case "$scan" in
-    *'?') scan="${scan%\?}" ;;
-    *'？') scan="${scan%？}" ;;
+    *'??'*)
+      return 0
+      ;;
   esac
+  scan="${scan//\?/}"
+  scan="${scan//？/}"
+  scan="${scan//\'/}"
+  scan="${scan//\"/}"
   case "$scan" in
-    *"'"*|*'"'*|*'\'*|*'|'*|*'&'*|*';'*|*'<'*|*'>'*|*'$'*|*'`'*|*'('*|*')'*|*'{'*|*'}'*|*'['*|*']'*|*'*'*|*'?'*|*'？'*|*'~'*|*[[:cntrl:]]*)
+    *'\'*|*'|'*|*'&'*|*';'*|*'<'*|*'>'*|*'$'*|*'`'*|*'('*|*')'*|*'{'*|*'}'*|*'['*|*']'*|*'*'*|*'~'*|*[[:cntrl:]]*)
       return 0
       ;;
   esac
@@ -138,6 +150,41 @@ _cosh_command_veto() {
     esac
   done
   return 1
+}
+
+# Quote-stripped token match (#1992): both shells remove ASCII quotes while
+# parsing, so `子曰"三人行必有我师"` arrives at the missing-command handler as
+# the single command word `子曰三人行必有我师` while cosh recorded the raw
+# first token with the quotes still attached. The strict token guard rejects
+# that pair and the input is delegated before the classifier ever runs.
+#
+# This is an equality proof, not a quoting parser: reaching the handler at all
+# already proves the shell accepted the quoting, so the only thing left to
+# show is that the raw input and the command word describe the *same single*
+# word. Erasing every ASCII quote from the raw input must reproduce the
+# command word byte for byte, and the shell must have reported exactly one
+# command word (argc 1). A second word, an escape, a command substitution or
+# any other construct that would make the two differ keeps the strict path.
+#
+# The builtin-only guards run first so the ordinary mismatch (no quote in the
+# input) still returns without forking a subshell.
+_cosh_quote_stripped_token_match() {
+  local input="$1"
+  local command="$2"
+  local argc="$3"
+  local stripped
+  (( argc == 1 )) || return 1
+  case "$input" in
+    *"'"*|*'"'*) ;;
+    *) return 1 ;;
+  esac
+  case "$input" in
+    *'\'*) return 1 ;;
+  esac
+  input="$(_cosh_ascii_trim "$input")"
+  stripped="${input//\'/}"
+  stripped="${stripped//\"/}"
+  [[ "$stripped" == "$command" ]]
 }
 
 # Proves the path is missing with ENOENT semantics: walk the components

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -378,7 +378,15 @@ command_not_found_handle() {
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
   fi
-  if [[ "${_COSH_ATTEMPT_TOKEN:-}" != "$command" || -z "$original" ]]; then
+  if [[ -z "$original" ]]; then
+    _cosh_delegate_bash_command_not_found "$command" "$@"
+    return $?
+  fi
+  # The recorded first token must be the word bash failed to run. Quotes are
+  # the one shape where the two legitimately differ (#1992), and only when the
+  # quote-stripped input provably *is* that single command word.
+  if [[ "${_COSH_ATTEMPT_TOKEN:-}" != "$command" ]] \
+     && ! _cosh_quote_stripped_token_match "$original" "$command" "$(($# + 1))"; then
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
   fi

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -331,7 +331,15 @@ command_not_found_handler() {
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
   fi
-  if [[ "${_COSH_ATTEMPT_TOKEN:-}" != "$command" || -z "$original" ]]; then
+  if [[ -z "$original" ]]; then
+    _cosh_delegate_zsh_command_not_found "$command" "$@"
+    return $?
+  fi
+  # The recorded first token must be the word zsh failed to run. Quotes are
+  # the one shape where the two legitimately differ (#1992), and only when the
+  # quote-stripped input provably *is* that single command word.
+  if [[ "${_COSH_ATTEMPT_TOKEN:-}" != "$command" ]] \
+     && ! _cosh_quote_stripped_token_match "$original" "$command" "$(($# + 1))"; then
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
   fi

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
@@ -268,6 +268,122 @@ fn composed_natural_language_matrix_is_consistent() {
     }
 }
 
+// Issue #1992: a question mark or a bare ASCII quote is prose punctuation,
+// not Shell syntax, and must not flip an otherwise natural-language line to
+// command. `top_token` mirrors what the shells actually report (verified
+// against bash/zsh: quotes are stripped from the command word, an unmatched
+// `?` survives because cosh unsets NOMATCH in zsh).
+#[test]
+fn prose_punctuation_does_not_veto_natural_language() {
+    for (input, top_token) in [
+        // full-width question mark mid-line, followed by more prose
+        ("你还好吗？ 我想问问", "你还好吗？"),
+        // only ASCII `??` is a control marker; full-width and mixed pairs
+        // remain ordinary prose punctuation
+        ("你还好吗？？ 我想问问", "你还好吗？？"),
+        ("你还好吗？? 我想问问", "你还好吗？?"),
+        ("你还好吗?？ 我想问问", "你还好吗?？"),
+        // ASCII question mark, glued and spaced variants
+        ("你还好吗?我想问问", "你还好吗?我想问问"),
+        ("你还好吗? 我想问问", "你还好吗?"),
+        // control prompt from the issue: no target punctuation at all
+        ("你好，我是李华", "你好，我是李华"),
+        // Chinese curly quotes already worked; keep them pinned
+        ("子曰“三人行必有我师”", "子曰“三人行必有我师”"),
+        // paired ASCII quotes: the shells hand over the de-quoted word
+        ("子曰\"三人行必有我师\"", "子曰三人行必有我师"),
+        ("子曰\" 三人行必有我师\"", "子曰 三人行必有我师"),
+        ("子曰'三人行必有我师'", "子曰三人行必有我师"),
+        // English prose keeps its punctuation neutral too
+        ("is this safe? really", "is"),
+        ("what is 'this' file", "what"),
+    ] {
+        assert_bash_zsh(input, top_token, "natural_language");
+    }
+}
+
+// The downgrade is limited to `?`/`？`/`'`/`"`. Everything a quote could have
+// wrapped stays in the veto scan, so quoted Shell constructs, options and
+// assignments remain command-owned; `??` keeps its agent-marker veto.
+#[test]
+fn quoted_shell_constructs_still_veto() {
+    for (input, top_token) in [
+        // doubled question mark keeps the existing agent-marker semantics
+        ("Who are you??", "Who"),
+        ("你还好吗?? 我想问问", "你还好吗??"),
+        // quoting a metacharacter does not hide it from the veto
+        ("帮我看看 \"$PATH\"", "帮我看看"),
+        ("帮我看看 '$PATH'", "帮我看看"),
+        ("帮我看看 \"a;b\"", "帮我看看"),
+        ("帮我看看 \"a`id`\"", "帮我看看"),
+        ("帮我看看 \"a|b\"", "帮我看看"),
+        ("帮我看看 \"a>b\"", "帮我看看"),
+        ("帮我看看 \"$(id)\"", "帮我看看"),
+        // an escape is still strong Shell evidence
+        ("帮我看看 a\\?b", "帮我看看"),
+        // quoted option / assignment tokens still veto
+        ("帮我看看 \"--all\"", "帮我看看"),
+        ("帮我看看 \"FOO=bar\"", "帮我看看"),
+        // glob metacharacters other than `?` are untouched
+        ("帮我看看 ./*.log", "帮我看看"),
+    ] {
+        assert_bash_zsh(input, top_token, "command");
+    }
+}
+
+// Quote-stripped token match (#1992): the narrow fallback that lets the
+// missing-command handlers reach the classifier when the shell de-quoted the
+// single command word. `argc` is the command-word count the shell reported.
+fn quote_stripped_token_match(shell: &str, input: &str, command: &str, argc: u32) -> Option<bool> {
+    let mut process = Process::new(shell);
+    if shell == "bash" {
+        process.args(["--noprofile", "--norc"]);
+    } else {
+        process.arg("-f");
+    }
+    let script = format!(
+        "{}\n_cosh_quote_stripped_token_match \"$1\" \"$2\" \"$3\"",
+        shell_intent_helpers(),
+    );
+    let output = process
+        .args(["-c", &script, "cosh-intent-test"])
+        .args([input, command, &argc.to_string()])
+        .output()
+        .ok()?;
+    Some(output.status.success())
+}
+
+#[test]
+fn quote_stripped_token_match_proves_single_command_word() {
+    for shell in ["bash", "zsh"] {
+        if !shell_available(shell) {
+            continue;
+        }
+        for (input, command, argc, expected) in [
+            // the issue's inputs, exactly as bash/zsh report them
+            ("子曰\"三人行必有我师\"", "子曰三人行必有我师", 1, true),
+            ("子曰\" 三人行必有我师\"", "子曰 三人行必有我师", 1, true),
+            ("子曰'三人行必有我师'", "子曰三人行必有我师", 1, true),
+            // surrounding blanks are removed by word splitting anyway
+            ("  子曰\"三人行必有我师\"  ", "子曰三人行必有我师", 1, true),
+            // no quote in the raw input: the strict guard already covers it
+            ("子曰三人行必有我师", "子曰三人行必有我师", 1, false),
+            // a second command word means the raw line is not one word
+            ("子曰\"三人行\" 必有我师", "子曰三人行", 2, false),
+            // the equality proof must fail when the words differ
+            ("子曰\"三人行必有我师\"啊", "子曰三人行必有我师", 1, false),
+            // escapes keep the strict path: quoting is not re-implemented here
+            ("子曰\\\"三人行", "子曰\"三人行", 1, false),
+        ] {
+            assert_eq!(
+                quote_stripped_token_match(shell, input, command, argc),
+                Some(expected),
+                "{shell}: {input:?} vs {command:?}"
+            );
+        }
+    }
+}
+
 #[test]
 fn command_veto_matrix_is_consistent() {
     for (input, top_token) in [

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -373,6 +373,154 @@ fn shell_host_zsh_missing_natural_language_closes_started_command() {
     }
 }
 
+// Issue #1992: prose punctuation must not reroute a natural-language line
+// into the shell. The quote inputs also exercise the narrow token fallback:
+// bash hands `command_not_found_handle` the de-quoted word
+// `子曰三人行必有我师`, which no longer equals the recorded first token.
+#[test]
+fn shell_host_bash_prose_punctuation_routes_to_agent() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-prose-punctuation-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config =
+        with_raw_byte_readline(ShellHostConfig::new("bash-prose-punctuation", &work_dir));
+    config.native_mode = false;
+
+    for input in [
+        "你好，我是李华",
+        "你还好吗？ 我想问问",
+        "你还好吗?我想问问",
+        "你还好吗? 我想问问",
+        "子曰“三人行必有我师”",
+        "子曰\"三人行必有我师\"",
+        "子曰\" 三人行必有我师\"",
+        "子曰'三人行必有我师'",
+    ] {
+        let output =
+            run_scripted_bash(&config, &[ScriptedInput::user_line(input)]).expect("scripted bash");
+        let terminal = String::from_utf8_lossy(&output.terminal_output);
+        assert!(
+            output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.input.as_deref() == Some(input)
+                    && event.component.as_deref() == Some("natural_language")
+            }),
+            "{input:?}: {:?}\n{terminal}",
+            output.events
+        );
+        assert!(
+            !terminal.contains("command not found"),
+            "{input:?}: {terminal}"
+        );
+    }
+}
+
+// Counterpart to the above: real commands carrying the same punctuation keep
+// running in bash. Their first word resolves, so the classifier never sees
+// them — pin that so the veto downgrade cannot start stealing shell syntax.
+#[test]
+fn shell_host_bash_quoted_shell_syntax_stays_in_shell() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-quoted-shell-syntax-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    std::fs::write(home_dir.join("glob1.txt"), "x\n").expect("glob file");
+    let mut config =
+        with_raw_byte_readline(ShellHostConfig::new("bash-quoted-shell-syntax", &work_dir))
+            .with_env("HOME", home_dir.display().to_string());
+    config.native_mode = false;
+
+    let inputs = [
+        "printf '%s\\n' \"hello?\"",
+        "printf '%s\\n' 'hello'",
+        // quoted expansion plus an unquoted `?` glob on the same line
+        "printf '%s\\n' \"$HOME\"/glob?.txt",
+    ];
+    let output = run_scripted_bash(
+        &config,
+        &inputs
+            .iter()
+            .map(|input| ScriptedInput::user_line(*input))
+            .collect::<Vec<_>>(),
+    )
+    .expect("scripted bash");
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+
+    assert!(terminal.contains("hello?"), "{terminal}");
+    assert!(terminal.contains("glob1.txt"), "{terminal}");
+    for input in inputs {
+        assert!(
+            !output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.input.as_deref() == Some(input)
+            }),
+            "{input:?}: {:?}",
+            output.events
+        );
+    }
+}
+
+// zsh shares the classifier and has NOMATCH unset, so an unmatched `?` glob
+// reaches `command_not_found_handler` instead of erroring out (#1992).
+#[test]
+fn shell_host_zsh_prose_punctuation_routes_to_agent() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-zsh-prose-punctuation-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config = ShellHostConfig::new("zsh-prose-punctuation", &work_dir);
+    config.native_mode = false;
+
+    for input in [
+        "你好，我是李华",
+        "你还好吗？ 我想问问",
+        "你还好吗?我想问问",
+        "你还好吗? 我想问问",
+        "子曰“三人行必有我师”",
+        "子曰\"三人行必有我师\"",
+        "子曰\" 三人行必有我师\"",
+        "子曰'三人行必有我师'",
+    ] {
+        let output =
+            run_scripted_zsh(&config, &[ScriptedInput::user_line(input)]).expect("scripted zsh");
+        let terminal = String::from_utf8_lossy(&output.terminal_output);
+        assert!(
+            output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.input.as_deref() == Some(input)
+                    && event.component.as_deref() == Some("natural_language")
+            }),
+            "{input:?}: {:?}\n{terminal}",
+            output.events
+        );
+        assert!(
+            !terminal.contains("command not found"),
+            "{input:?}: {terminal}"
+        );
+    }
+}
+
 #[test]
 fn shell_host_zsh_ambiguous_phrase_stays_in_shell() {
     if Command::new("zsh").arg("--version").output().is_err() {

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -96,7 +96,10 @@ fn shell_host_runs_bash_pty_and_emits_command_events() {
         .as_deref()
         .expect("terminal output ref");
     let output_ref_text = std::fs::read_to_string(output_ref).expect("output ref text");
-    assert!(output_ref_text.contains("No such file") || output_ref_text.contains("cannot access"));
+    assert!(
+        output_ref_text.contains("/path/that/does/not/exist"),
+        "{output_ref_text}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Treat question marks and ASCII quotes as neutral prose punctuation while preserving strong Shell vetoes. Add a narrow quote-stripped equality proof so Bash and Zsh can correlate de-quoted single-word commands before natural-language classification. Make the existing PTY output assertion locale-independent and add classifier plus PTY regressions for the reported inputs and native Shell counterexamples.

## Related Issue

closes #1992

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] cosh-ng (cosh-ng)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project code style
- [x] I have added tests that prove my fix is effective
- [x] For cosh-ng: cargo clippy --all-targets -- -D warnings and cargo fmt --check pass
- [x] Lock files are up to date

## Testing

- cargo fmt --all -- --check
- cargo clippy --package cosh-shell --all-targets -- -D warnings
- crates/cosh-shell/scripts/check-layout.sh
- LC_ALL=C.UTF-8 cargo test --package cosh-shell
- Locale regression under both C.UTF-8 and zh_CN.utf8
- cargo build --package cosh-shell --release

The first full-suite attempt hit a transient ETXTBSY in extensions_update_all_queries_batch_after_transport_failure. Its exact rerun passed, and the second complete suite passed with no failures.

## Additional Notes

No provider, authentication, or external service path is involved; validation was deterministic and local.