### PR TITLE
fix(cosh-ng): [core] fail closed on emit error

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/audit.rs
+++ b/src/cosh-ng/crates/cosh-core/src/audit.rs
@@ -27,6 +27,15 @@ enum CoreAuditSink {
     Noop,
     #[cfg(test)]
     Failing,
+    /// Captures every event except one type, whose writes fail.
+    ///
+    /// A sink that fails everything aborts a run at its first barrier, which
+    /// cannot reach a later boundary under test.
+    #[cfg(test)]
+    CaptureExcept {
+        events: Vec<AuditEventV1>,
+        failing: KnownAuditEventType,
+    },
 }
 
 /// Independent audit side path for Core semantic lifecycle boundaries.
@@ -367,6 +376,22 @@ impl CoreAuditRecorder {
                 )),
                 false,
             ),
+            #[cfg(test)]
+            CoreAuditSink::CaptureExcept { events, failing } => {
+                if event_type == *failing {
+                    (
+                        Err(cosh_types::error::CoshError::new(
+                            cosh_types::error::ErrorCode::AuditUnavailable,
+                            "injected audit failure",
+                            "audit",
+                        )),
+                        false,
+                    )
+                } else {
+                    events.push(event);
+                    (Ok(()), true)
+                }
+            }
         };
 
         match write_result {
@@ -529,7 +554,7 @@ impl CoreAuditRecorder {
     #[cfg(test)]
     pub(crate) fn captured_tool_event_types(&self, tool_use_id: &str) -> Vec<&str> {
         match &self.sink {
-            CoreAuditSink::Capture(events) => events
+            CoreAuditSink::Capture(events) | CoreAuditSink::CaptureExcept { events, .. } => events
                 .iter()
                 .filter(|event| event.identity.tool_use_id.as_deref() == Some(tool_use_id))
                 .map(|event| event.event_type.as_str())
@@ -538,10 +563,49 @@ impl CoreAuditRecorder {
         }
     }
 
+    /// A required-mode recorder that fails only `failing` writes.
+    ///
+    /// Lets a test drive the second failure that matters at a security
+    /// boundary — the control transport is gone *and* that boundary's terminal
+    /// record cannot be persisted — without aborting the run at an earlier one.
+    #[cfg(test)]
+    pub(crate) fn test_capture_except(session_id: &str, failing: KnownAuditEventType) -> Self {
+        let settings = AuditSettings {
+            mode: AuditMode::Required,
+            ..AuditSettings::default()
+        };
+        Self {
+            sink: CoreAuditSink::CaptureExcept {
+                events: Vec::new(),
+                failing,
+            },
+            state: AuditOperationalState::new(settings.clone()),
+            settings,
+            root: None,
+            session_id: session_id.to_string(),
+            degraded: false,
+            warned: false,
+            pending_terminal_gap: false,
+        }
+    }
+
+    /// Captured events with their payloads.
+    ///
+    /// Lets a test assert what an event says (decision, reason code) and not
+    /// only that its type was emitted.
+    #[cfg(test)]
+    pub(crate) fn captured_events(&self) -> &[AuditEventV1] {
+        match &self.sink {
+            CoreAuditSink::Capture(events) => events,
+            CoreAuditSink::CaptureExcept { events, .. } => events,
+            _ => &[],
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn captured_event_types(&self) -> Vec<&str> {
         match &self.sink {
-            CoreAuditSink::Capture(events) => events
+            CoreAuditSink::Capture(events) | CoreAuditSink::CaptureExcept { events, .. } => events
                 .iter()
                 .map(|event| event.event_type.as_str())
                 .collect(),

--- a/src/cosh-ng/crates/cosh-core/src/audit/orchestration.rs
+++ b/src/cosh-ng/crates/cosh-core/src/audit/orchestration.rs
@@ -284,6 +284,36 @@ impl CoreAuditRecorder {
         )
     }
 
+    /// Records an approval request that could not be sent to its decider.
+    ///
+    /// The approval still owes a terminal event, so this is an
+    /// `approval.resolved` with `decision=emit_failed` and the transport
+    /// failure class as the reason code. Delivery is unknown, not proven
+    /// absent — what the record asserts is that this core never obtained a
+    /// decision, which production audit must not fold into a user deny (#1994).
+    pub(crate) fn record_approval_emit_failed(
+        &mut self,
+        scope: CoreAuditScope<'_>,
+        subject: &str,
+        assessment: Option<&str>,
+        error_class: &str,
+    ) -> Result<(), String> {
+        let identity = self.scope_identity(scope);
+        self.barrier(
+            KnownAuditEventType::ApprovalResolved,
+            identity,
+            AuditOutcomeStatus::Failed,
+            "approval",
+            Some(subject),
+            &AuditApprovalData {
+                assessment: assessment.map(str::to_string),
+                decision: Some("emit_failed".to_string()),
+                reason_code: Some(format!("control_transport_{error_class}")),
+                ..AuditApprovalData::default()
+            },
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn record_approval_resolved(
         &mut self,

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
 use futures::StreamExt;
@@ -62,6 +62,12 @@ pub struct CoshCore {
     request_counter: AtomicU32,
     truncator: OutputTruncator,
     loop_detector: LoopDetector,
+    /// First control-transport failure of this process, if any.
+    ///
+    /// Set from `&self` paths (`handle_ask_user`, `handle_shell_evidence`), so
+    /// it is a `OnceLock` rather than a plain field: the first failure is the
+    /// diagnostic one and the session is over either way.
+    control_transport_failure: OnceLock<String>,
 }
 
 impl CoshCore {
@@ -74,6 +80,81 @@ impl CoshCore {
             let _ = writeln!(writer, "{json}");
             let _ = writer.flush();
         }
+    }
+
+    /// Emits a control request whose response the core will then block on.
+    ///
+    /// [`Self::emit`] drops transport errors on the floor, which is fine for
+    /// fire-and-forget stream events but not for a request that gates a
+    /// blocking read: if the request did not arrive it can never be answered,
+    /// so the wait would only end when the session dies.
+    ///
+    /// An error means *delivery is unknown*, not that nothing was sent.
+    /// `write_all` may issue several underlying writes, a writer may accept a
+    /// prefix before failing, and `BufWriter::flush` can fail after draining
+    /// part of its buffer. Writing the line in one call keeps a failure from
+    /// interleaving with other output; it cannot make the write atomic. The
+    /// only safe reaction is therefore to stop waiting and end the session,
+    /// whichever side of the pipe the bytes reached.
+    fn emit_control_request_checked<W: Write>(
+        &self,
+        writer: &mut W,
+        msg: &OutputMessage,
+    ) -> Result<(), ControlTransportError> {
+        let json = serde_json::to_string(msg)
+            .map_err(|error| ControlTransportError::new("serialize", error.to_string()))?;
+        let mut line = json.into_bytes();
+        line.push(b'\n');
+        writer
+            .write_all(&line)
+            .map_err(|error| ControlTransportError::new("write", error.to_string()))?;
+        writer
+            .flush()
+            .map_err(|error| ControlTransportError::new("flush", error.to_string()))
+    }
+
+    /// Records a control-transport failure as session-fatal.
+    ///
+    /// The transport carries every request/response pair, so once a write on it
+    /// fails there is no reliable way to reach the Shell and no way to learn
+    /// what the user decided. Callers must return instead of waiting; the
+    /// process then exits non-zero and the Shell recovers the run through its
+    /// existing child-failure path, which also closes a card the Shell may have
+    /// managed to display.
+    fn note_control_transport_failure(&self, request_id: &str, error: &ControlTransportError) {
+        let detail = format!("control transport {error} (request_id={request_id})");
+        tracing::error!(
+            request_id = %request_id,
+            error_class = error.class(),
+            "{detail}"
+        );
+        if self.control_transport_failure.set(detail.clone()).is_ok() {
+            // The log file is not visible to the Shell; stderr is, and the
+            // Shell surfaces its tail when the child exits non-zero.
+            emit_fatal_diagnostic(&mut std::io::stderr().lock(), &detail);
+        }
+    }
+
+    /// The session-fatal control-transport failure, if one happened.
+    pub fn control_transport_failure(&self) -> Option<&str> {
+        self.control_transport_failure.get().map(String::as_str)
+    }
+
+    /// Turns a control-transport failure into the error that ends this batch.
+    ///
+    /// [`Self::handle_ask_user`] and [`Self::handle_shell_evidence`] take
+    /// `&self`, so the session flag is the only channel they have. Promoting it
+    /// in the tool loop is what stops the remaining calls of the batch from
+    /// running after the transport died; an already-set fatal turn wins.
+    fn promote_control_transport_failure(&self, fatal_turn: &mut Option<FatalTurn>) {
+        if fatal_turn.is_some() {
+            return;
+        }
+        let Some(failure) = self.control_transport_failure() else {
+            return;
+        };
+        let error = format!("{failure}; session cannot continue");
+        *fatal_turn = Some(FatalTurn::new(error, CONTROL_TRANSPORT_AUDIT_REASON));
     }
 
     fn emit_hook_notifications<W: Write>(
@@ -266,7 +347,10 @@ impl CoshCore {
                     .record_approval_requested(approval_scope, "hook", "hook_ask", None);
 
             // Emit approval request with HOOK: prefix and empty input.
-            self.emit(
+            // Checked like every other request the core then blocks on (#1994):
+            // nothing has been appended to the transcript yet, so this one can
+            // fail the turn immediately.
+            if let Err(error) = self.emit_control_request_checked(
                 writer,
                 &OutputMessage::can_use_tool_with_audit_ref(
                     &request_id,
@@ -276,7 +360,18 @@ impl CoshCore {
                     true, // hook_requires_approval
                     audit_ref,
                 ),
-            );
+            ) {
+                self.note_control_transport_failure(&request_id, &error);
+                let audit_error = self
+                    .audit
+                    .record_approval_emit_failed(approval_scope, "hook", None, error.class())
+                    .err();
+                return Err(control_transport_turn_error(
+                    &request_id,
+                    &error,
+                    audit_error.as_deref(),
+                ));
+            }
 
             let approval = self.wait_for_approval(&request_id, false, reader).await;
             let (approval_status, approval_decision) = approval_audit_outcome(&approval);
@@ -848,17 +943,23 @@ impl CoshCore {
             let mut interrupted = false;
             // Set once a tool call ends the run. The error is returned only after
             // this batch is fully answered.
-            let mut fatal_error: Option<String> = None;
+            let mut fatal_turn: Option<FatalTurn> = None;
 
             for tc in &tool_calls {
                 if tc.name.is_empty() {
                     continue;
                 }
 
+                // A transport failure seen on a `&self` path can only surface
+                // through the session flag, so it becomes fatal here: the rest
+                // of the batch must be skipped, not executed against a peer the
+                // core can no longer talk to.
+                self.promote_control_transport_failure(&mut fatal_turn);
+
                 // Every id in the assistant message needs exactly one tool result,
                 // or the next provider request violates tool-message pairing — and
                 // headless persists and reuses the session even when a turn fails.
-                if fatal_error.is_some() {
+                if fatal_turn.is_some() {
                     self.skip_unexecuted_tool_call(
                         CoreAuditScope::tool(&run_id, &turn_id, &tc.id),
                         writer,
@@ -957,16 +1058,13 @@ impl CoshCore {
                         // looks like it is still generating arguments.
                         self.emit_provider_native_tool_result(writer, &tc.id, &result);
                         if attempt >= MAX_INVALID_ARGUMENT_ATTEMPTS {
-                            self.audit.record_turn_terminal(
-                                turn_scope,
-                                AuditOutcomeStatus::Failed,
-                                Some("invalid_tool_arguments_exhausted"),
-                            );
-                            // Recorded, not returned: the assistant message already
+                            // Held, not returned: the assistant message already
                             // declared every call in this batch, and the loop must
                             // still answer the rest before the run ends.
-                            fatal_error =
-                                Some(invalid_arguments_exhausted_error(&tc.name, &parse_error));
+                            fatal_turn = Some(FatalTurn::new(
+                                invalid_arguments_exhausted_error(&tc.name, &parse_error),
+                                "invalid_tool_arguments_exhausted",
+                            ));
                         }
                         continue;
                     }
@@ -1124,7 +1222,10 @@ impl CoshCore {
                             },
                             Some(hash_json(&params)),
                         );
-                        self.emit(
+                        // Checked, not fire-and-forget: waiting for a decision
+                        // on a request that may never have arrived is the silent
+                        // permanent hang from #1994.
+                        if let Err(error) = self.emit_control_request_checked(
                             writer,
                             &OutputMessage::can_use_tool_with_audit_ref(
                                 &request_id,
@@ -1134,66 +1235,96 @@ impl CoshCore {
                                 hook_requires_approval,
                                 audit_ref,
                             ),
-                        );
-
-                        let accepts_host_executed_shell = self
-                            .tools
-                            .get(&tc.name)
-                            .map(|tool| tool.kind() == ToolKind::ShellExec)
-                            .unwrap_or(false);
-                        // ─── SLS: approval wait timing ───
-                        let approval_start = Instant::now();
-                        let approval_result = self
-                            .wait_for_approval(&request_id, accepts_host_executed_shell, reader)
-                            .await;
-                        let approval_wait_ms = approval_start.elapsed().as_millis() as u64;
-                        let (approval_status, approval_decision) =
-                            approval_audit_outcome(&approval_result);
-                        if !matches!(&approval_result, ApprovalResult::HostExecutedShell { .. }) {
-                            self.audit.record_approval_resolved(
-                                approval_scope,
-                                &tc.name,
-                                approval_status,
-                                None,
-                                approval_decision,
-                                Some(approval_wait_ms),
-                            )?;
-                        }
-                        self.metrics.approval_wait_ms += approval_wait_ms;
-                        self.metrics.approval_count += 1;
-                        match approval_result {
-                            ApprovalResult::Allowed => {
-                                self.metrics.approval_allow += 1;
-                                self.audit.record_tool_execution_started(
-                                    tool_scope, &tc.name, &tool_data,
+                        ) {
+                            self.note_control_transport_failure(&request_id, &error);
+                            // Held, not propagated with `?`: this barrier can
+                            // fail too, and returning here would leave the
+                            // assistant's tool call without a result in a
+                            // transcript headless still persists.
+                            let audit_error = self
+                                .audit
+                                .record_approval_emit_failed(
+                                    approval_scope,
+                                    &tc.name,
+                                    None,
+                                    error.class(),
+                                )
+                                .err();
+                            // No interaction reached the wait, so this is
+                            // neither an approval decision nor part of the
+                            // average approval-wait denominator.
+                            if fatal_turn.is_none() {
+                                fatal_turn = Some(FatalTurn::new(
+                                    control_transport_turn_error(
+                                        &request_id,
+                                        &error,
+                                        audit_error.as_deref(),
+                                    ),
+                                    CONTROL_TRANSPORT_AUDIT_REASON,
+                                ));
+                            }
+                            ToolResult::error(approval_emit_failed_tool_error(&error))
+                        } else {
+                            let accepts_host_executed_shell = self
+                                .tools
+                                .get(&tc.name)
+                                .map(|tool| tool.kind() == ToolKind::ShellExec)
+                                .unwrap_or(false);
+                            // ─── SLS: approval wait timing ───
+                            let approval_start = Instant::now();
+                            let approval_result = self
+                                .wait_for_approval(&request_id, accepts_host_executed_shell, reader)
+                                .await;
+                            let approval_wait_ms = approval_start.elapsed().as_millis() as u64;
+                            let (approval_status, approval_decision) =
+                                approval_audit_outcome(&approval_result);
+                            if !matches!(&approval_result, ApprovalResult::HostExecutedShell { .. })
+                            {
+                                self.audit.record_approval_resolved(
+                                    approval_scope,
+                                    &tc.name,
+                                    approval_status,
+                                    None,
+                                    approval_decision,
+                                    Some(approval_wait_ms),
                                 )?;
-                                let result = self.execute_tool(&tc.name, params, &ctx).await;
-                                self.emit_provider_native_tool_result(writer, &tc.id, &result);
-                                tool_result_already_emitted = true;
-                                result
                             }
-                            ApprovalResult::HostExecutedShell {
-                                llm_content,
-                                exit_code,
-                            } => {
-                                self.metrics.approval_allow += 1;
-                                let is_error = exit_code.is_some_and(|c| c != 0);
-                                ToolResult {
-                                    output: llm_content,
-                                    is_error,
+                            self.metrics.approval_wait_ms += approval_wait_ms;
+                            self.metrics.approval_count += 1;
+                            match approval_result {
+                                ApprovalResult::Allowed => {
+                                    self.metrics.approval_allow += 1;
+                                    self.audit.record_tool_execution_started(
+                                        tool_scope, &tc.name, &tool_data,
+                                    )?;
+                                    let result = self.execute_tool(&tc.name, params, &ctx).await;
+                                    self.emit_provider_native_tool_result(writer, &tc.id, &result);
+                                    tool_result_already_emitted = true;
+                                    result
                                 }
-                            }
-                            ApprovalResult::Denied(reason) => {
-                                self.metrics.approval_deny += 1;
-                                ToolResult::error(format!(
-                                    "Tool call denied: {}",
-                                    reason.unwrap_or_else(|| "no reason given".to_string())
-                                ))
-                            }
-                            ApprovalResult::Interrupted => {
-                                self.metrics.approval_deny += 1;
-                                interrupted = true;
-                                ToolResult::error("Interrupted by user")
+                                ApprovalResult::HostExecutedShell {
+                                    llm_content,
+                                    exit_code,
+                                } => {
+                                    self.metrics.approval_allow += 1;
+                                    let is_error = exit_code.is_some_and(|c| c != 0);
+                                    ToolResult {
+                                        output: llm_content,
+                                        is_error,
+                                    }
+                                }
+                                ApprovalResult::Denied(reason) => {
+                                    self.metrics.approval_deny += 1;
+                                    ToolResult::error(format!(
+                                        "Tool call denied: {}",
+                                        reason.unwrap_or_else(|| "no reason given".to_string())
+                                    ))
+                                }
+                                ApprovalResult::Interrupted => {
+                                    self.metrics.approval_deny += 1;
+                                    interrupted = true;
+                                    ToolResult::error("Interrupted by user")
+                                }
                             }
                         }
                     }
@@ -1321,7 +1452,11 @@ impl CoshCore {
                                 "command": &bypass.original_command
                             }))),
                         );
-                        self.emit(
+                        // Same #1994 guard as the policy approval above: an
+                        // unsent bypass panel must not become a blocking
+                        // read. The sandbox failure stays as the tool result,
+                        // exactly as for a denied bypass.
+                        if let Err(error) = self.emit_control_request_checked(
                             writer,
                             &OutputMessage::can_use_tool_with_audit_ref(
                                 &request_id,
@@ -1331,51 +1466,74 @@ impl CoshCore {
                                 true,
                                 audit_ref,
                             ),
-                        );
-
-                        let approval_start = Instant::now();
-                        let approval_result =
-                            self.wait_for_approval(&request_id, true, reader).await;
-                        let (approval_status, approval_decision) =
-                            approval_audit_outcome(&approval_result);
-                        if !matches!(&approval_result, ApprovalResult::HostExecutedShell { .. }) {
-                            self.audit.record_approval_resolved(
-                                approval_scope,
-                                &tc.name,
-                                approval_status,
-                                Some("sandbox_bypass"),
-                                approval_decision,
-                                Some(approval_start.elapsed().as_millis() as u64),
-                            )?;
-                        }
-
-                        match approval_result {
-                            ApprovalResult::Allowed => {
-                                self.audit.record_tool_execution_started(
-                                    tool_scope, &tc.name, &tool_data,
+                        ) {
+                            self.note_control_transport_failure(&request_id, &error);
+                            let audit_error = self
+                                .audit
+                                .record_approval_emit_failed(
+                                    approval_scope,
+                                    &tc.name,
+                                    Some("sandbox_bypass"),
+                                    error.class(),
+                                )
+                                .err();
+                            if fatal_turn.is_none() {
+                                fatal_turn = Some(FatalTurn::new(
+                                    control_transport_turn_error(
+                                        &request_id,
+                                        &error,
+                                        audit_error.as_deref(),
+                                    ),
+                                    CONTROL_TRANSPORT_AUDIT_REASON,
+                                ));
+                            }
+                        } else {
+                            let approval_start = Instant::now();
+                            let approval_result =
+                                self.wait_for_approval(&request_id, true, reader).await;
+                            let (approval_status, approval_decision) =
+                                approval_audit_outcome(&approval_result);
+                            if !matches!(&approval_result, ApprovalResult::HostExecutedShell { .. })
+                            {
+                                self.audit.record_approval_resolved(
+                                    approval_scope,
+                                    &tc.name,
+                                    approval_status,
+                                    Some("sandbox_bypass"),
+                                    approval_decision,
+                                    Some(approval_start.elapsed().as_millis() as u64),
                                 )?;
-                                self.hook_system.set_hook_disabled("sandbox-guard", true);
-                                let retry_params =
-                                    serde_json::json!({"command": &bypass.original_command});
-                                let retry = self.execute_tool(&tc.name, retry_params, &ctx).await;
-                                // Re-enable immediately after execute, before any other
-                                // operation. execute_tool returns ToolResult (infallible),
-                                // so this line is always reached.
-                                self.hook_system.set_hook_disabled("sandbox-guard", false);
-                                self.emit_provider_native_tool_result(writer, &tc.id, &retry);
-                                result = retry;
                             }
-                            ApprovalResult::HostExecutedShell {
-                                llm_content,
-                                exit_code,
-                            } => {
-                                let is_error = exit_code.is_some_and(|c| c != 0);
-                                result = ToolResult {
-                                    output: llm_content,
-                                    is_error,
-                                };
+
+                            match approval_result {
+                                ApprovalResult::Allowed => {
+                                    self.audit.record_tool_execution_started(
+                                        tool_scope, &tc.name, &tool_data,
+                                    )?;
+                                    self.hook_system.set_hook_disabled("sandbox-guard", true);
+                                    let retry_params =
+                                        serde_json::json!({"command": &bypass.original_command});
+                                    let retry =
+                                        self.execute_tool(&tc.name, retry_params, &ctx).await;
+                                    // Re-enable immediately after execute, before any other
+                                    // operation. execute_tool returns ToolResult (infallible),
+                                    // so this line is always reached.
+                                    self.hook_system.set_hook_disabled("sandbox-guard", false);
+                                    self.emit_provider_native_tool_result(writer, &tc.id, &retry);
+                                    result = retry;
+                                }
+                                ApprovalResult::HostExecutedShell {
+                                    llm_content,
+                                    exit_code,
+                                } => {
+                                    let is_error = exit_code.is_some_and(|c| c != 0);
+                                    result = ToolResult {
+                                        output: llm_content,
+                                        is_error,
+                                    };
+                                }
+                                _ => { /* denied / interrupted: keep original error */ }
                             }
-                            _ => { /* denied / interrupted: keep original error */ }
                         }
                     }
                 }
@@ -1408,10 +1566,18 @@ impl CoshCore {
                     return Ok(());
                 }
             }
-            // The turn was already audited as failed at the rejection; every call in
-            // the batch now has a result, so the run can end on a paired history.
-            if let Some(error) = fatal_error {
-                return Err(error);
+            // Also checked after the last call: a failure there never re-enters
+            // the loop boundary above.
+            self.promote_control_transport_failure(&mut fatal_turn);
+            // A turn terminal is emitted only after every declared call has a
+            // terminal event and a paired history result.
+            if let Some(fatal) = fatal_turn {
+                self.audit.record_turn_terminal(
+                    turn_scope,
+                    AuditOutcomeStatus::Failed,
+                    Some(fatal.reason_code),
+                );
+                return Err(fatal.error);
             }
             self.audit
                 .record_turn_terminal(turn_scope, AuditOutcomeStatus::Success, None);
@@ -1540,7 +1706,7 @@ impl CoshCore {
                         }
                     },
                 };
-                self.emit(
+                if let Err(error) = self.emit_control_request_checked(
                     writer,
                     &OutputMessage::shell_evidence_list_commands(
                         &request_id,
@@ -1548,7 +1714,9 @@ impl CoshCore {
                         limit,
                         cursor,
                     ),
-                );
+                ) {
+                    return self.evidence_request_emit_failed(&request_id, &error);
+                }
             }
             "read_output" => {
                 let Some(output_id) = params.get("output_id").and_then(|v| v.as_str()) else {
@@ -1591,7 +1759,7 @@ impl CoshCore {
                     None => false,
                 };
 
-                self.emit(
+                if let Err(error) = self.emit_control_request_checked(
                     writer,
                     &OutputMessage::shell_evidence_read_output(
                         &request_id,
@@ -1601,7 +1769,9 @@ impl CoshCore {
                         lines,
                         bypass_recent_filter,
                     ),
-                );
+                ) {
+                    return self.evidence_request_emit_failed(&request_id, &error);
+                }
             }
             _ => {
                 return ToolResult::error(
@@ -1611,6 +1781,23 @@ impl CoshCore {
         }
 
         self.wait_for_shell_evidence(&request_id, reader).await
+    }
+
+    /// Fails an evidence request that could not be sent.
+    ///
+    /// Returning instead of calling [`Self::wait_for_shell_evidence`] keeps the
+    /// core off a read that no response can end (#1994); the flag makes the
+    /// session fatal, and the tool loop promotes it before the next call runs.
+    fn evidence_request_emit_failed(
+        &self,
+        request_id: &str,
+        error: &ControlTransportError,
+    ) -> ToolResult {
+        self.note_control_transport_failure(request_id, error);
+        ToolResult::error(format!(
+            "cosh_shell_evidence request was not answered: delivery could not be confirmed ({})",
+            error.class()
+        ))
     }
 
     async fn wait_for_shell_evidence<R: AsyncBufReadExt + Unpin>(
@@ -1749,6 +1936,82 @@ impl CoshCore {
             }
         }
         ApprovalResult::Interrupted
+    }
+}
+
+/// Audit reason code for a turn ended by a dead control transport.
+const CONTROL_TRANSPORT_AUDIT_REASON: &str = "control_transport_failed";
+
+/// One fatal turn outcome held until every declared tool call is closed.
+struct FatalTurn {
+    error: String,
+    reason_code: &'static str,
+}
+
+impl FatalTurn {
+    fn new(error: String, reason_code: &'static str) -> Self {
+        Self { error, reason_code }
+    }
+}
+
+/// Writes the fatal diagnostic without letting a broken stderr abort cleanup.
+fn emit_fatal_diagnostic<W: Write>(writer: &mut W, detail: &str) {
+    let _ = writeln!(writer, "cosh-core fatal: {detail}");
+}
+
+/// Why a control request that must be answered could not be sent intact.
+///
+/// Delivery is unknown after any of these: the Shell may have received the
+/// whole line, part of it, or nothing at all.
+#[derive(Debug)]
+pub(crate) struct ControlTransportError {
+    /// Stable failure class: `serialize`, `write`, or `flush`.
+    class: &'static str,
+    detail: String,
+}
+
+impl ControlTransportError {
+    fn new(class: &'static str, detail: String) -> Self {
+        Self { class, detail }
+    }
+
+    pub(crate) fn class(&self) -> &'static str {
+        self.class
+    }
+}
+
+impl std::fmt::Display for ControlTransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} failed: {}", self.class, self.detail)
+    }
+}
+
+/// Tool-result text for a call whose approval request could not be sent.
+///
+/// Not phrased as a denial: nobody decided anything, and the transcript must
+/// not teach the model that the user refused. The call did not run, so it still
+/// owes a result rather than an unpaired tool call.
+fn approval_emit_failed_tool_error(error: &ControlTransportError) -> String {
+    format!(
+        "Tool call not executed: delivery of the approval request could not be confirmed ({})",
+        error.class()
+    )
+}
+
+/// Turn-level error for a broken control transport.
+///
+/// Carries the audit failure too when the terminal approval record could not be
+/// persisted either: both are session-fatal, and the transport is the cause.
+fn control_transport_turn_error(
+    request_id: &str,
+    error: &ControlTransportError,
+    audit_error: Option<&str>,
+) -> String {
+    let base =
+        format!("control transport {error} (request_id={request_id}); session cannot continue");
+    match audit_error {
+        Some(audit_error) => format!("{base}; audit record failed: {audit_error}"),
+        None => base,
     }
 }
 

--- a/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
@@ -76,6 +76,7 @@ impl CoshCore {
             request_counter: AtomicU32::new(0),
             truncator: OutputTruncator::default(),
             loop_detector: LoopDetector::new(),
+            control_transport_failure: std::sync::OnceLock::new(),
         }
     }
 

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -2453,3 +2453,529 @@ async fn cosh_question_text_with_valid_schema_still_asks() {
         Some("Which branch?")
     );
 }
+
+// ─── #1994: control transport failures must never precede a blocking read ───
+
+/// How a control-request write fails.
+#[derive(Clone, Copy)]
+enum FailStep {
+    /// The first `write` call fails outright.
+    Write,
+    /// The first `write` accepts a prefix, the next one fails: `write_all` has
+    /// already put bytes on the wire, so delivery is genuinely unknown.
+    PartialThenWrite,
+    /// Writes succeed, `flush` fails.
+    Flush,
+}
+
+/// A stdout whose write or flush fails, standing in for a broken pipe.
+struct FailingWriter {
+    fail_on: FailStep,
+    written: Vec<u8>,
+    writes: usize,
+}
+
+impl FailingWriter {
+    fn new(fail_on: FailStep) -> Self {
+        Self {
+            fail_on,
+            written: Vec::new(),
+            writes: 0,
+        }
+    }
+
+    fn broken_pipe(detail: &'static str) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::BrokenPipe, detail)
+    }
+}
+
+impl std::io::Write for FailingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.writes += 1;
+        match self.fail_on {
+            FailStep::Write => Err(Self::broken_pipe("broken pipe")),
+            FailStep::PartialThenWrite => {
+                if self.writes == 1 && buf.len() > 1 {
+                    let accepted = buf.len() / 2;
+                    self.written.extend_from_slice(&buf[..accepted]);
+                    Ok(accepted)
+                } else {
+                    Err(Self::broken_pipe("broken pipe after partial write"))
+                }
+            }
+            FailStep::Flush => {
+                self.written.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self.fail_on {
+            FailStep::Write | FailStep::PartialThenWrite => Ok(()),
+            FailStep::Flush => Err(Self::broken_pipe("flush failed")),
+        }
+    }
+}
+
+#[test]
+fn fatal_diagnostic_is_best_effort() {
+    let mut failing = FailingWriter::new(FailStep::Write);
+    emit_fatal_diagnostic(&mut failing, "transport failed");
+
+    let mut output = Vec::new();
+    emit_fatal_diagnostic(&mut output, "transport failed");
+    assert_eq!(
+        String::from_utf8(output).expect("diagnostic is UTF-8"),
+        "cosh-core fatal: transport failed\n"
+    );
+}
+
+/// A stdin that fails the test if the core reads it at all.
+///
+/// This is the #1994 assertion: once a control request could not be sent, the
+/// core must return, not park on a read that only a dead peer could end.
+struct NeverReadStdin;
+
+impl tokio::io::AsyncRead for NeverReadStdin {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        _buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        panic!("core read stdin after a control request it failed to send");
+    }
+}
+
+/// One shell call that needs approval, so the turn reaches the control request.
+fn approval_provider() -> MockProvider {
+    MockProvider::new(vec![vec![
+        GenerateEvent::ToolCallStart {
+            index: 0,
+            id: "call-1".to_string(),
+            name: "shell".to_string(),
+        },
+        GenerateEvent::ToolCallDelta {
+            index: 0,
+            arguments_delta: r#"{"command":"echo hi"}"#.to_string(),
+        },
+        GenerateEvent::ToolCallEnd { index: 0 },
+        GenerateEvent::MessageEnd,
+    ]])
+}
+
+fn approval_core(calls: Arc<AtomicUsize>) -> CoshCore {
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "suggest".to_string();
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool { calls }));
+    let mut core = CoshCore::new(config, Box::new(approval_provider()), tools);
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+    core
+}
+
+async fn assert_approval_emit_failure_is_session_fatal(fail_on: FailStep, expected_reason: &str) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut core = approval_core(Arc::clone(&calls));
+    let mut reader = tokio::io::BufReader::new(NeverReadStdin).lines();
+    let mut writer = FailingWriter::new(fail_on);
+
+    let error = core
+        .handle_user_message("run echo hi", &mut reader, &mut writer)
+        .await
+        .expect_err("an unsent approval request must fail the turn");
+
+    assert!(
+        error.contains("control transport"),
+        "turn error must name the transport: {error}"
+    );
+    assert!(
+        core.control_transport_failure().is_some(),
+        "the failure must be session-fatal so the process exits non-zero"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a tool whose approval request could not be sent must not run"
+    );
+    assert_eq!(
+        core.metrics.approval_count, 0,
+        "a request that never entered the wait is not an approval interaction"
+    );
+    assert_eq!(core.metrics.approval_allow, 0);
+    assert_eq!(core.metrics.approval_deny, 0);
+
+    // The approval still owes a terminal audit event, and it must be
+    // distinguishable from a user decision.
+    let events = core.audit.captured_events();
+    let resolved = events
+        .iter()
+        .find(|event| event.event_type.as_str() == "approval.resolved")
+        .expect("an unsent approval must still be audited as resolved");
+    assert_eq!(
+        resolved.data().get("decision").and_then(|v| v.as_str()),
+        Some("emit_failed")
+    );
+    assert_eq!(
+        resolved.data().get("reason_code").and_then(|v| v.as_str()),
+        Some(expected_reason)
+    );
+    assert!(
+        resolved.identity.request_id.is_some(),
+        "the audit record must carry the request id"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.event_type.as_str() == "approval.requested"),
+        "the request must still be audited before its failure"
+    );
+    // The turn owes a terminal event too, or audit shows a run that never ended.
+    let turn_failed = events
+        .iter()
+        .find(|event| event.event_type.as_str() == "turn.failed")
+        .expect("a transport-killed turn must be audited as failed");
+    assert_eq!(
+        turn_failed
+            .data()
+            .get("reason_code")
+            .and_then(|v| v.as_str()),
+        Some("control_transport_failed")
+    );
+    assert_eq!(
+        events.last().map(|event| event.event_type.as_str()),
+        Some("turn.failed"),
+        "the turn terminal must follow every child lifecycle event"
+    );
+}
+
+#[tokio::test]
+async fn approval_write_failure_never_waits_for_a_response() {
+    assert_approval_emit_failure_is_session_fatal(FailStep::Write, "control_transport_write").await;
+}
+
+#[tokio::test]
+async fn approval_partial_write_then_failure_never_waits_for_a_response() {
+    // Bytes did reach the wire, so delivery is unknown rather than absent. The
+    // core must still stop instead of waiting for a decision it cannot get.
+    assert_approval_emit_failure_is_session_fatal(
+        FailStep::PartialThenWrite,
+        "control_transport_write",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn approval_flush_failure_never_waits_for_a_response() {
+    assert_approval_emit_failure_is_session_fatal(FailStep::Flush, "control_transport_flush").await;
+}
+
+/// A PreToolUse hook that answers `ask`, so only the hook demands approval.
+fn ask_hook(name: &str) -> crate::config::HookDefinition {
+    crate::config::HookDefinition {
+        command: r#"python3 -c 'print("""{"decision":"ask","reason":"needs review"}""")'"#
+            .to_string(),
+        name: Some(name.to_string()),
+        matcher: None,
+        timeout: Some(10_000),
+        sequential: None,
+        env: Default::default(),
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn hook_ask_writes_a_complete_can_use_tool_line_to_a_real_pipe() {
+    // The #1994 report claimed the request never reached stdout. Over a real
+    // kernel transport, with a stdin that never answers, the full JSONL record
+    // is there.
+    let provider = approval_provider();
+    let mut config = CoreConfig::default();
+    // Trust mode: only the hook asks, so this also pins that a hook `ask`
+    // cannot be auto-approved away.
+    config.agent.approval_mode = "trust".to_string();
+    config.hooks.enabled = true;
+    config.hooks.pre_tool_use = vec![ask_hook("ask-hook")];
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::clone(&calls),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+
+    // A socket pair rather than `std::io::pipe`: same kernel-buffered
+    // byte stream, without raising the toolchain this crate needs.
+    let (pipe_reader, pipe_writer) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+    let mut writer = std::io::BufWriter::new(pipe_writer);
+    // No approval response ever arrives: EOF, not a decision.
+    let mut reader = empty_reader().await;
+
+    core.handle_user_message("run echo hi", &mut reader, &mut writer)
+        .await
+        .expect("an unanswered approval ends the turn as interrupted, not as an error");
+
+    drop(writer);
+    let mut lines = std::io::BufRead::lines(std::io::BufReader::new(pipe_reader));
+    let request = lines
+        .by_ref()
+        .map_while(Result::ok)
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
+        .find(|value| value["request"]["subtype"] == "can_use_tool")
+        .expect("can_use_tool must reach the pipe even though stdin never answers");
+    assert_eq!(request["request"]["tool_name"], "shell");
+    assert_eq!(
+        request["request"]["hook_requires_approval"], true,
+        "a hook ask must be shown, not auto-approved in trust mode"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "no decision arrived, so the tool must not have run"
+    );
+    assert!(
+        core.control_transport_failure().is_none(),
+        "a healthy pipe is not a transport failure"
+    );
+}
+
+#[tokio::test]
+async fn evidence_emit_failure_never_waits_for_a_response() {
+    let core = make_core(MockProvider::new(vec![]));
+    let mut reader = tokio::io::BufReader::new(NeverReadStdin).lines();
+    let mut writer = FailingWriter::new(FailStep::Write);
+
+    let result = core
+        .handle_shell_evidence(
+            "call-evidence",
+            &serde_json::json!({"action":"list_commands"}),
+            &mut reader,
+            &mut writer,
+        )
+        .await;
+
+    assert!(result.is_error);
+    assert!(
+        result.output.contains("delivery could not be confirmed"),
+        "{}",
+        result.output
+    );
+    assert!(
+        core.control_transport_failure().is_some(),
+        "the transport failure must end the session, not just this tool call"
+    );
+}
+
+#[tokio::test]
+async fn question_emit_failure_never_waits_for_an_answer() {
+    let core = make_core(MockProvider::new(vec![]));
+    let mut reader = tokio::io::BufReader::new(NeverReadStdin).lines();
+    let mut writer = FailingWriter::new(FailStep::Flush);
+
+    let result = core
+        .handle_ask_user(
+            &crate::tool::ask_user_question::AskUserQuestionParams {
+                question: "Which branch?".to_string(),
+                options: vec![],
+                allow_free_text: true,
+                multi_select: false,
+            },
+            &mut reader,
+            &mut writer,
+        )
+        .await;
+
+    assert!(result.is_error);
+    assert!(
+        result.output.contains("delivery could not be confirmed"),
+        "{}",
+        result.output
+    );
+    assert!(core.control_transport_failure().is_some());
+}
+
+#[tokio::test]
+async fn evidence_emit_failure_ends_the_turn_and_pairs_the_history() {
+    let provider = MockProvider::new(vec![vec![
+        GenerateEvent::ToolCallStart {
+            index: 0,
+            id: "call-evidence".to_string(),
+            name: "cosh_shell_evidence".to_string(),
+        },
+        GenerateEvent::ToolCallDelta {
+            index: 0,
+            arguments_delta: r#"{"action":"list_commands"}"#.to_string(),
+        },
+        GenerateEvent::ToolCallEnd { index: 0 },
+        GenerateEvent::MessageEnd,
+    ]]);
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(crate::tool::shell_evidence::ShellEvidenceTool));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    let mut reader = tokio::io::BufReader::new(NeverReadStdin).lines();
+    let mut writer = FailingWriter::new(FailStep::Write);
+
+    let error = core
+        .handle_user_message("what ran?", &mut reader, &mut writer)
+        .await
+        .expect_err("a dead transport must end the turn");
+
+    assert!(error.contains("control transport"), "{error}");
+    // Every declared call still owes a result, or the persisted transcript
+    // cannot be replayed.
+    let tool_results = core
+        .messages
+        .iter()
+        .filter(|message| message.role == "tool")
+        .count();
+    assert_eq!(tool_results, 1);
+}
+
+#[tokio::test]
+async fn user_prompt_submit_ask_emit_failure_never_waits_for_a_response() {
+    // The prompt-level hook panel gates a wait exactly like the tool-level one,
+    // and it happens before any transcript entry exists.
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    config.hooks.enabled = true;
+    config.hooks.user_prompt_submit = vec![ask_hook("prompt-ask-hook")];
+    let mut core = CoshCore::new(
+        config,
+        Box::new(MockProvider::text_only("must never be reached")),
+        ToolRegistry::new(),
+    );
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+    let mut reader = tokio::io::BufReader::new(NeverReadStdin).lines();
+    let mut writer = FailingWriter::new(FailStep::Write);
+
+    let error = core
+        .handle_user_message("do something", &mut reader, &mut writer)
+        .await
+        .expect_err("an unsent prompt approval must fail the turn");
+
+    assert!(error.contains("control transport"), "{error}");
+    assert!(core.control_transport_failure().is_some());
+    assert!(
+        core.messages.is_empty(),
+        "the prompt was never approved, so it must not enter the transcript"
+    );
+    let resolved = core
+        .audit
+        .captured_events()
+        .iter()
+        .find(|event| event.event_type.as_str() == "approval.resolved")
+        .expect("the prompt approval owes a terminal event")
+        .clone();
+    assert_eq!(
+        resolved.data().get("decision").and_then(|v| v.as_str()),
+        Some("emit_failed")
+    );
+}
+
+#[tokio::test]
+async fn transport_failure_on_one_call_skips_the_rest_of_the_batch() {
+    // The evidence path can only report the failure through the session flag,
+    // so without promoting it at the loop boundary the second call would run.
+    let provider = MockProvider::new(vec![vec![
+        GenerateEvent::ToolCallStart {
+            index: 0,
+            id: "call-evidence".to_string(),
+            name: "cosh_shell_evidence".to_string(),
+        },
+        GenerateEvent::ToolCallDelta {
+            index: 0,
+            arguments_delta: r#"{"action":"list_commands"}"#.to_string(),
+        },
+        GenerateEvent::ToolCallEnd { index: 0 },
+        GenerateEvent::ToolCallStart {
+            index: 1,
+            id: "call-shell".to_string(),
+            name: "shell".to_string(),
+        },
+        GenerateEvent::ToolCallDelta {
+            index: 1,
+            arguments_delta: r#"{"command":"echo hi"}"#.to_string(),
+        },
+        GenerateEvent::ToolCallEnd { index: 1 },
+        GenerateEvent::MessageEnd,
+    ]]);
+    let mut config = CoreConfig::default();
+    // Trust mode: the shell call would otherwise stop at an approval instead of
+    // proving that a skipped call is what kept it from running.
+    config.agent.approval_mode = "trust".to_string();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(crate::tool::shell_evidence::ShellEvidenceTool));
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::clone(&calls),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+    let mut reader = tokio::io::BufReader::new(NeverReadStdin).lines();
+    let mut writer = FailingWriter::new(FailStep::Write);
+
+    let error = core
+        .handle_user_message("what ran?", &mut reader, &mut writer)
+        .await
+        .expect_err("a dead transport must end the turn");
+
+    assert!(error.contains("control transport"), "{error}");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "the second call must be skipped, not executed on a dead transport"
+    );
+    // Both declared calls still owe a result.
+    assert_eq!(
+        core.messages
+            .iter()
+            .filter(|message| message.role == "tool")
+            .count(),
+        2
+    );
+    assert_eq!(
+        core.audit
+            .captured_events()
+            .last()
+            .map(|event| event.event_type.as_str()),
+        Some("turn.failed"),
+        "all skipped tool terminals must precede the turn terminal"
+    );
+}
+
+#[tokio::test]
+async fn audit_failure_after_transport_failure_still_pairs_the_history() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut core = approval_core(Arc::clone(&calls));
+    // Required mode with a sink that always fails: the terminal approval record
+    // cannot be persisted either.
+    core.audit = CoreAuditRecorder::test_capture_except(
+        &core.session_id,
+        cosh_types::audit::KnownAuditEventType::ApprovalResolved,
+    );
+    let mut reader = tokio::io::BufReader::new(NeverReadStdin).lines();
+    let mut writer = FailingWriter::new(FailStep::Write);
+
+    let error = core
+        .handle_user_message("run echo hi", &mut reader, &mut writer)
+        .await
+        .expect_err("both failures are session-fatal");
+
+    assert!(
+        error.contains("control transport") && error.contains("audit record failed"),
+        "the turn error must report both failures: {error}"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    // The point of the fix: the audit error must not escape before the declared
+    // tool call has its result, because headless persists this transcript.
+    assert_eq!(
+        core.messages
+            .iter()
+            .filter(|message| message.role == "tool")
+            .count(),
+        1,
+        "every declared tool call must still be answered: {:?}",
+        core.messages
+    );
+}

--- a/src/cosh-ng/crates/cosh-core/src/core/tool_execution.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tool_execution.rs
@@ -548,7 +548,9 @@ impl CoshCore {
             .collect();
 
         let request_id = self.next_request_id();
-        self.emit(
+        // Checked: an unasked question can never be answered, so waiting for
+        // one is the silent permanent hang from #1994.
+        if let Err(error) = self.emit_control_request_checked(
             writer,
             &OutputMessage::ControlRequest {
                 request_id: request_id.clone(),
@@ -559,7 +561,13 @@ impl CoshCore {
                     multi_select: params.multi_select,
                 },
             },
-        );
+        ) {
+            self.note_control_transport_failure(&request_id, &error);
+            return ToolResult::error(format!(
+                "question was not answered: delivery could not be confirmed ({})",
+                error.class()
+            ));
+        }
 
         match self.wait_for_answer(&request_id, reader).await {
             Some(answer) => ToolResult::success(answer),

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -17,6 +17,13 @@ mod auth;
 
 use auth::request_auth;
 
+/// Exit code for a session that lost the JSONL control transport.
+///
+/// The Shell owns recovery: it already replaces a missing terminal result when
+/// the child exits non-zero, and stderr carries the reason. Staying alive on a
+/// transport we cannot write to would only reproduce the #1994 hang.
+const EXIT_CONTROL_TRANSPORT_FAILURE: i32 = 74;
+
 pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> {
     apply_cli_overrides(args, &mut config);
 
@@ -165,8 +172,13 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
                 engine.emit(&mut writer, &err_msg);
             }
         }
+        let transport_failed = engine.control_transport_failure().is_some();
         engine.shutdown_extension_runtime().await;
-        return Ok(0);
+        return Ok(if transport_failed {
+            EXIT_CONTROL_TRANSPORT_FAILURE
+        } else {
+            0
+        });
     }
 
     let mut extensions = HeadlessExtensionRuntime {
@@ -197,6 +209,10 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
                 return Ok(1);
             }
         }
+        if engine.control_transport_failure().is_some() {
+            engine.shutdown_extension_runtime().await;
+            return Ok(EXIT_CONTROL_TRANSPORT_FAILURE);
+        }
     }
 
     while let Ok(Some(line)) = lines.next_line().await {
@@ -225,6 +241,12 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
                 engine.shutdown_extension_runtime().await;
                 return Ok(1);
             }
+        }
+        // Checked after every line, not only after a turn: once the transport
+        // is gone the process can neither answer nor be answered.
+        if engine.control_transport_failure().is_some() {
+            engine.shutdown_extension_runtime().await;
+            return Ok(EXIT_CONTROL_TRANSPORT_FAILURE);
         }
     }
     engine.shutdown_extension_runtime().await;

--- a/src/cosh-ng/docs/design/audit-log.md
+++ b/src/cosh-ng/docs/design/audit-log.md
@@ -220,6 +220,13 @@ A provider stream, control permission, and foreground handoff for one tool share
 `run_id + tool_use_id`; they are lifecycle events, not three executions. A Shell handoff adds
 `command_id`. Readers display missing starts or terminals as gaps instead of inventing completion.
 
+An approval whose request could not be sent is still terminal: Core writes `approval.resolved` with
+`outcome.status=failed`, `decision=emit_failed`, and `reason_code=control_transport_<class>` when the
+control request could not be serialized, written, or flushed. The claim is that this producer never
+obtained a decision, not that the request was provably lost — a failed write may still have put bytes
+on the wire, so delivery could not be confirmed either way. Readers must not fold it into a user
+`deny`: nobody decided anything.
+
 ## Field Minimization and Redaction
 
 ### Default persisted content


### PR DESCRIPTION
## Description

Hardens `cosh-core` control requests that are immediately followed by a
blocking stdin read. The checked path serializes, writes, and flushes the
complete JSONL request before waiting; transport failures terminate the
session without reading stdin, preserve paired tool history, and let
`cosh-shell` recover through the existing non-zero child-exit path.

Audit records distinguish an undelivered request (`emit_failed`) from a user
denial. This mitigates the silent-wait class reported in #1994, but does not
claim to reproduce or fix the original field root cause.

## Related Issue

refs #1994

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cosh-core`
- `cargo test -p cosh-shell --test protocol`
- `cargo build --workspace --release`
- `git diff --check`

## Additional Notes

No second flush, lock, or generic timeout is introduced. Live provider and
manual TUI validation were not required because this change is limited to
deterministic transport-failure handling and protocol tests.
