### PR TITLE
fix(sight): skip agent_crash on clean exit

### DIFF
--- a/src/agentsight/src/bpf/procmon.bpf.c
+++ b/src/agentsight/src/bpf/procmon.bpf.c
@@ -61,6 +61,8 @@ int trace_execve_exit(struct syscall_trace_exit *ctx)
     event->uid = uid;
     event->event_type = PROCMON_EVENT_EXEC;
     bpf_get_current_comm(&event->comm, sizeof(event->comm));
+    // exit_code only carries data for EXIT events
+    event->exit_code = 0;
 
     bpf_ringbuf_submit(event, 0);
     return 0;
@@ -80,6 +82,7 @@ int trace_process_exit(void *ctx)
 
     u32 uid = bpf_get_current_uid_gid();
     u64 ts = bpf_ktime_get_ns();
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 
     // Reserve space in ring buffer
     struct procmon_event *event = bpf_ringbuf_reserve(&rb, sizeof(*event), 0);
@@ -95,6 +98,11 @@ int trace_process_exit(void *ctx)
     event->uid = uid;
     event->event_type = PROCMON_EVENT_EXIT;
     bpf_get_current_comm(&event->comm, sizeof(event->comm));
+    // The sched_process_exit tracepoint format exposes no exit_code field, so
+    // read it from the current task via CO-RE. By the time this tracepoint
+    // fires, do_exit() has already stored the raw wait(2)-encoded status in
+    // task_struct->exit_code; decoding is done in userspace.
+    event->exit_code = (u32)BPF_CORE_READ(task, exit_code);
 
     bpf_ringbuf_submit(event, 0);
     return 0;

--- a/src/agentsight/src/bpf/procmon.h
+++ b/src/agentsight/src/bpf/procmon.h
@@ -33,6 +33,11 @@ struct procmon_event {
     u32 uid;
     u32 event_type;         // enum procmon_event_type
     char comm[TASK_COMM_LEN];
+    // Raw task_struct->exit_code (wait(2) encoding), only meaningful for
+    // PROCMON_EVENT_EXIT; 0 for other event types. Appended at the tail so
+    // the offsets of all preceding fields stay unchanged, and it fills the
+    // trailing padding after comm (struct size stays 56 bytes).
+    u32 exit_code;
 };
 
 #endif /* __PROCMON_H */

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -11,7 +11,9 @@ use std::time::{Duration, Instant};
 use super::port_detector::detect_listening_ports;
 use super::store::{AgentHealthState, AgentHealthStatus, AgentRole, HealthStore, now_ms};
 use crate::discovery::AgentScanner;
-use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+use crate::interruption::{
+    InterruptionEvent, InterruptionType, ProcessExitStatus, was_pid_oom_killed,
+};
 use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore};
 
 /// Infer the UI role for a discovered agent.
@@ -139,16 +141,78 @@ impl HealthChecker {
             vec![]
         };
 
-        // Write agent_crash interruption events for processes that just went offline.
-        //
-        // Deduplication strategy:
-        //   - Cosh spawns 2 node processes per session (parent + worker). LLM traffic
-        //     may be recorded under either pid. We group all pids for the same agent_name
-        //     and query them together so we see all calls in one pass.
-        //   - OpenClaw is a single-pid gateway that may serve multiple concurrent sessions.
-        //     All sessions for that pid are returned and each gets its own event.
-        //   - Deduplication key is (agent_name, session_id, conversation_id): at most one
-        //     agent_crash event is written per unique (agent, session, conversation) triple.
+        self.record_offline_agent_crashes(&newly_offline);
+
+        log::debug!("Health check: found {} agent(s)", agents.len());
+
+        // Collect agent names by PID for role inference (detect parent-child within same agent)
+        let agent_name_by_pid: HashMap<u32, String> = agents
+            .iter()
+            .map(|a| (a.pid, a.agent_info.name.clone()))
+            .collect();
+
+        // Pre-scan listening ports per pid (also avoids scanning /proc twice).
+        let ports_by_pid: HashMap<u32, Vec<u16>> = agents
+            .iter()
+            .map(|a| (a.pid, detect_listening_ports(a.pid)))
+            .collect();
+
+        for agent in &agents {
+            let ports = ports_by_pid.get(&agent.pid).cloned().unwrap_or_default();
+            // Cosh has no daemon process and does not support keepalive/restart.
+            // Build restart_cmd only for agents that support it.
+            let restart_cmd = if agent.agent_info.name == "Cosh" {
+                None
+            } else {
+                Some(build_restart_cmd(&agent.exe_path, &agent.cmdline_args))
+            };
+
+            // Read parent PID from /proc/<pid>/stat for role inference
+            let ppid = read_ppid(agent.pid);
+
+            let role = infer_agent_role(&agent.agent_info.name, &ports, ppid, &agent_name_by_pid);
+
+            let status = if ports.is_empty() {
+                AgentHealthStatus {
+                    pid: agent.pid,
+                    agent_name: agent.agent_info.name.clone(),
+                    category: agent.agent_info.category.clone(),
+                    exe_path: agent.exe_path.clone(),
+                    ports: vec![],
+                    status: AgentHealthState::NoPort,
+                    last_check_time: now_ms(),
+                    latency_ms: None,
+                    error_message: None,
+                    restart_cmd,
+                    offline_since: None,
+                    role,
+                    parent_pid: ppid,
+                    has_crash: false,
+                }
+            } else {
+                self.probe_agent(agent, &ports, restart_cmd, role, ppid)
+            };
+
+            if let Ok(mut store) = self.store.write() {
+                store.update(agent.pid, status);
+            }
+        }
+    }
+
+    /// Write agent_crash interruption events for processes that just went offline.
+    ///
+    /// Deduplication strategy:
+    ///   - Cosh spawns 2 node processes per session (parent + worker). LLM traffic
+    ///     may be recorded under either pid. We group all pids for the same agent_name
+    ///     and query them together so we see all calls in one pass.
+    ///   - OpenClaw is a single-pid gateway that may serve multiple concurrent sessions.
+    ///     All sessions for that pid are returned and each gets its own event.
+    ///   - Deduplication key is (agent_name, session_id, conversation_id): at most one
+    ///     agent_crash event is written per unique (agent, session, conversation) triple.
+    ///
+    /// Split out of `check_once` so the crash-vs-normal-shutdown decision can
+    /// be unit-tested by injecting offline entries without scanning /proc.
+    fn record_offline_agent_crashes(&self, newly_offline: &[AgentHealthStatus]) {
         if !newly_offline.is_empty() {
             if let Some(ref istore) = self.interruption_store {
                 let now_ns = std::time::SystemTime::now()
@@ -159,7 +223,7 @@ impl HealthChecker {
                 // Group newly-offline entries by agent_name so multi-process agents
                 // (e.g. Cosh) are processed together in a single DB query.
                 let mut by_agent: HashMap<String, Vec<&AgentHealthStatus>> = HashMap::new();
-                for offline in &newly_offline {
+                for offline in newly_offline {
                     by_agent
                         .entry(offline.agent_name.clone())
                         .or_default()
@@ -183,6 +247,32 @@ impl HealthChecker {
                     // ── Branch A: pending (in-flight) LLM calls ──────────────────────────
                     let pending_calls = self.get_pending_calls_for_pids(&pids);
                     if !pending_calls.is_empty() {
+                        // Trace mode records each agent's raw exit status into
+                        // the shared interruption DB. When every offline pid in
+                        // this group is a trace-confirmed clean exit, this is a
+                        // single-shot agent shutting down normally (issue
+                        // #1989): trace deliberately wrote no agent_crash, so
+                        // this backup path must not re-add one. Missing records
+                        // keep the historical fallback (offline + pending →
+                        // crash) for exits trace did not observe.
+                        let exit_status_by_pid: HashMap<i32, ProcessExitStatus> = pids
+                            .iter()
+                            .filter_map(|&p| {
+                                istore
+                                    .get_process_exit_recent(p, 120)
+                                    .map(|raw| (p, ProcessExitStatus::decode(raw)))
+                            })
+                            .collect();
+                        let all_clean_exit = exit_status_by_pid.len() == pids.len()
+                            && exit_status_by_pid.values().all(|s| s.is_clean());
+                        if all_clean_exit {
+                            log::debug!(
+                                "Agent {agent_name} (pids={pids:?}) exited cleanly (trace-recorded exit status) — treating as normal shutdown despite {} pending call(s)",
+                                pending_calls.len()
+                            );
+                            continue;
+                        }
+
                         // Check if any of the crashed PIDs were OOM-killed
                         let is_oom = pids.iter().any(|&p| was_pid_oom_killed(p));
                         if is_oom {
@@ -233,6 +323,14 @@ impl HealthChecker {
                             if is_oom {
                                 detail["oom"] = serde_json::json!(true);
                                 detail["source"] = serde_json::json!("healthchecker+dmesg");
+                            }
+                            // Attach the trace-recorded exit status when
+                            // available; omitted (not fabricated) when trace
+                            // did not observe this pid's exit.
+                            if let Some(status) = exit_status_by_pid.get(&(rep.pid as i32)) {
+                                detail["exit_code"] = serde_json::json!(status.code);
+                                detail["signal"] = serde_json::json!(status.signal);
+                                detail["core_dump"] = serde_json::json!(status.core_dump);
                             }
                             let event = InterruptionEvent::new(
                                 InterruptionType::AgentCrash,
@@ -289,61 +387,6 @@ impl HealthChecker {
                         );
                     }
                 }
-            }
-        }
-
-        log::debug!("Health check: found {} agent(s)", agents.len());
-
-        // Collect agent names by PID for role inference (detect parent-child within same agent)
-        let agent_name_by_pid: HashMap<u32, String> = agents
-            .iter()
-            .map(|a| (a.pid, a.agent_info.name.clone()))
-            .collect();
-
-        // Pre-scan listening ports per pid (also avoids scanning /proc twice).
-        let ports_by_pid: HashMap<u32, Vec<u16>> = agents
-            .iter()
-            .map(|a| (a.pid, detect_listening_ports(a.pid)))
-            .collect();
-
-        for agent in &agents {
-            let ports = ports_by_pid.get(&agent.pid).cloned().unwrap_or_default();
-            // Cosh has no daemon process and does not support keepalive/restart.
-            // Build restart_cmd only for agents that support it.
-            let restart_cmd = if agent.agent_info.name == "Cosh" {
-                None
-            } else {
-                Some(build_restart_cmd(&agent.exe_path, &agent.cmdline_args))
-            };
-
-            // Read parent PID from /proc/<pid>/stat for role inference
-            let ppid = read_ppid(agent.pid);
-
-            let role = infer_agent_role(&agent.agent_info.name, &ports, ppid, &agent_name_by_pid);
-
-            let status = if ports.is_empty() {
-                AgentHealthStatus {
-                    pid: agent.pid,
-                    agent_name: agent.agent_info.name.clone(),
-                    category: agent.agent_info.category.clone(),
-                    exe_path: agent.exe_path.clone(),
-                    ports: vec![],
-                    status: AgentHealthState::NoPort,
-                    last_check_time: now_ms(),
-                    latency_ms: None,
-                    error_message: None,
-                    restart_cmd,
-                    offline_since: None,
-                    role,
-                    parent_pid: ppid,
-                    has_crash: false,
-                }
-            } else {
-                self.probe_agent(agent, &ports, restart_cmd, role, ppid)
-            };
-
-            if let Ok(mut store) = self.store.write() {
-                store.update(agent.pid, status);
             }
         }
     }
@@ -572,5 +615,182 @@ mod tests {
             infer_agent_role("Hermes", &[], None, &map),
             AgentRole::Gateway
         );
+    }
+
+    // ── Tests for record_offline_agent_crashes (issue #1989 backup path) ──
+
+    fn unique_tmp_dir(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir =
+            std::env::temp_dir().join(format!("agentsight-hc-{}-{tag}-{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// Build a checker wired to fresh temp stores plus one pending call for
+    /// `pid`, mirroring the serve-mode setup in `run_server`.
+    fn setup_checker(
+        tag: &str,
+        pid: i32,
+    ) -> (
+        std::path::PathBuf,
+        HealthChecker,
+        Arc<GenAISqliteStore>,
+        Arc<InterruptionStore>,
+    ) {
+        let dir = unique_tmp_dir(tag);
+        let genai_store = Arc::new(
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store"),
+        );
+        let istore = Arc::new(
+            InterruptionStore::new_with_path(&dir.join("interruption_events.db"))
+                .expect("interruption store"),
+        );
+        let info = crate::storage::sqlite::genai::PendingCallInfo {
+            call_id: format!("hc-call-{tag}"),
+            trace_id: None,
+            conversation_id: None,
+            session_id: None,
+            start_timestamp_ns: 1_000_000_000,
+            pid,
+            process_name: "test".to_string(),
+            agent_name: Some("cosh-core".to_string()),
+            http_method: Some("POST".to_string()),
+            http_path: Some("/v1/chat/completions".to_string()),
+            input_messages: None,
+            system_instructions: None,
+            user_query: None,
+            is_sse: false,
+            model: Some("gpt-4".to_string()),
+            provider: Some("openai".to_string()),
+            call_kind: "main".to_string(),
+            pending_origin: crate::storage::sqlite::genai::PendingOrigin::RequestCapture,
+            pending_match_key: None,
+        };
+        genai_store.insert_pending(&info).expect("insert_pending");
+        let checker = HealthChecker::new(
+            Arc::new(RwLock::new(HealthStore::new())),
+            Duration::from_secs(30),
+        )
+        .with_interruption_store(Arc::clone(&istore))
+        .with_genai_store(Arc::clone(&genai_store));
+        (dir, checker, genai_store, istore)
+    }
+
+    fn offline_status(pid: u32) -> AgentHealthStatus {
+        AgentHealthStatus {
+            pid,
+            agent_name: "cosh-core".to_string(),
+            category: "cli".to_string(),
+            exe_path: "/usr/bin/cosh-core".to_string(),
+            ports: vec![],
+            status: AgentHealthState::Offline,
+            last_check_time: now_ms(),
+            latency_ms: None,
+            error_message: None,
+            restart_cmd: None,
+            offline_since: Some(now_ms()),
+            role: AgentRole::Client,
+            parent_pid: None,
+            has_crash: false,
+        }
+    }
+
+    fn list_crash_events(
+        istore: &InterruptionStore,
+    ) -> Vec<crate::storage::sqlite::interruption::InterruptionRecord> {
+        istore
+            .list(0, i64::MAX, None, Some("agent_crash"), None, None, 100)
+            .expect("list interruptions")
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_clean_exit_record_skips_agent_crash() {
+        // PID large enough to never collide with dmesg OOM records.
+        let pid = 4_100_001;
+        let (dir, checker, genai_store, istore) = setup_checker("clean", pid);
+
+        // trace mode recorded a clean exit (exit 0 → raw 0x0) for this pid
+        istore.record_process_exit(pid, 0x0).expect("record exit");
+
+        checker.record_offline_agent_crashes(&[offline_status(pid as u32)]);
+
+        assert!(
+            list_crash_events(&istore).is_empty(),
+            "clean exit recorded by trace must not be re-reported as agent_crash"
+        );
+        // Pending call must stay pending: marking it interrupted would pollute
+        // grader root_cause attribution just like the crash event itself.
+        assert_eq!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .len(),
+            1,
+            "pending call must not be marked interrupted on clean exit"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_no_exit_record_still_records_agent_crash() {
+        let pid = 4_100_002;
+        let (dir, checker, genai_store, istore) = setup_checker("norec", pid);
+
+        // No process_exits record: trace did not observe this exit, so the
+        // historical fallback (offline + pending → crash) must be preserved.
+        checker.record_offline_agent_crashes(&[offline_status(pid as u32)]);
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "fallback path must still record the crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["pid"], pid);
+        // Exit status is unknown here — fields must be omitted, not fabricated.
+        assert!(detail.get("exit_code").is_none());
+        assert!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .is_empty(),
+            "fallback path must mark the pending call as interrupted"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_sigkill_exit_record_records_crash_with_detail() {
+        let pid = 4_100_003;
+        let (dir, checker, genai_store, istore) = setup_checker("sigkill", pid);
+
+        // SIGKILL → raw 0x9 (measured on a real kernel): not a clean exit,
+        // so the checker must behave exactly as before the #1989 fix.
+        istore.record_process_exit(pid, 0x9).expect("record exit");
+
+        checker.record_offline_agent_crashes(&[offline_status(pid as u32)]);
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "SIGKILL must still be recorded as crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["signal"], 9);
+        assert_eq!(detail["exit_code"], 0);
+        assert_eq!(detail["core_dump"], false);
+        assert!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .is_empty(),
+            "crash path must mark the pending call as interrupted"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -12,6 +12,7 @@ use super::port_detector::detect_listening_ports;
 use super::store::{AgentHealthState, AgentHealthStatus, AgentRole, HealthStore, now_ms};
 use crate::discovery::AgentScanner;
 use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+use crate::probes::procmon::ProcessExitStatus;
 use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore};
 
 /// Infer the UI role for a discovered agent.
@@ -139,16 +140,78 @@ impl HealthChecker {
             vec![]
         };
 
-        // Write agent_crash interruption events for processes that just went offline.
-        //
-        // Deduplication strategy:
-        //   - Cosh spawns 2 node processes per session (parent + worker). LLM traffic
-        //     may be recorded under either pid. We group all pids for the same agent_name
-        //     and query them together so we see all calls in one pass.
-        //   - OpenClaw is a single-pid gateway that may serve multiple concurrent sessions.
-        //     All sessions for that pid are returned and each gets its own event.
-        //   - Deduplication key is (agent_name, session_id, conversation_id): at most one
-        //     agent_crash event is written per unique (agent, session, conversation) triple.
+        self.record_offline_agent_crashes(&newly_offline);
+
+        log::debug!("Health check: found {} agent(s)", agents.len());
+
+        // Collect agent names by PID for role inference (detect parent-child within same agent)
+        let agent_name_by_pid: HashMap<u32, String> = agents
+            .iter()
+            .map(|a| (a.pid, a.agent_info.name.clone()))
+            .collect();
+
+        // Pre-scan listening ports per pid (also avoids scanning /proc twice).
+        let ports_by_pid: HashMap<u32, Vec<u16>> = agents
+            .iter()
+            .map(|a| (a.pid, detect_listening_ports(a.pid)))
+            .collect();
+
+        for agent in &agents {
+            let ports = ports_by_pid.get(&agent.pid).cloned().unwrap_or_default();
+            // Cosh has no daemon process and does not support keepalive/restart.
+            // Build restart_cmd only for agents that support it.
+            let restart_cmd = if agent.agent_info.name == "Cosh" {
+                None
+            } else {
+                Some(build_restart_cmd(&agent.exe_path, &agent.cmdline_args))
+            };
+
+            // Read parent PID from /proc/<pid>/stat for role inference
+            let ppid = read_ppid(agent.pid);
+
+            let role = infer_agent_role(&agent.agent_info.name, &ports, ppid, &agent_name_by_pid);
+
+            let status = if ports.is_empty() {
+                AgentHealthStatus {
+                    pid: agent.pid,
+                    agent_name: agent.agent_info.name.clone(),
+                    category: agent.agent_info.category.clone(),
+                    exe_path: agent.exe_path.clone(),
+                    ports: vec![],
+                    status: AgentHealthState::NoPort,
+                    last_check_time: now_ms(),
+                    latency_ms: None,
+                    error_message: None,
+                    restart_cmd,
+                    offline_since: None,
+                    role,
+                    parent_pid: ppid,
+                    has_crash: false,
+                }
+            } else {
+                self.probe_agent(agent, &ports, restart_cmd, role, ppid)
+            };
+
+            if let Ok(mut store) = self.store.write() {
+                store.update(agent.pid, status);
+            }
+        }
+    }
+
+    /// Write agent_crash interruption events for processes that just went offline.
+    ///
+    /// Deduplication strategy:
+    ///   - Cosh spawns 2 node processes per session (parent + worker). LLM traffic
+    ///     may be recorded under either pid. We group all pids for the same agent_name
+    ///     and query them together so we see all calls in one pass.
+    ///   - OpenClaw is a single-pid gateway that may serve multiple concurrent sessions.
+    ///     All sessions for that pid are returned and each gets its own event.
+    ///   - Deduplication key is (agent_name, session_id, conversation_id): at most one
+    ///     agent_crash event is written per unique (agent, session, conversation) triple.
+    ///
+    /// Split out of `check_once` so the crash-vs-normal-shutdown decision can
+    /// be unit-tested by injecting offline entries without scanning /proc.
+    fn record_offline_agent_crashes(&self, newly_offline: &[AgentHealthStatus]) {
         if !newly_offline.is_empty() {
             if let Some(ref istore) = self.interruption_store {
                 let now_ns = std::time::SystemTime::now()
@@ -159,7 +222,7 @@ impl HealthChecker {
                 // Group newly-offline entries by agent_name so multi-process agents
                 // (e.g. Cosh) are processed together in a single DB query.
                 let mut by_agent: HashMap<String, Vec<&AgentHealthStatus>> = HashMap::new();
-                for offline in &newly_offline {
+                for offline in newly_offline {
                     by_agent
                         .entry(offline.agent_name.clone())
                         .or_default()
@@ -183,6 +246,32 @@ impl HealthChecker {
                     // ── Branch A: pending (in-flight) LLM calls ──────────────────────────
                     let pending_calls = self.get_pending_calls_for_pids(&pids);
                     if !pending_calls.is_empty() {
+                        // Trace mode records each agent's raw exit status into
+                        // the shared interruption DB. When every offline pid in
+                        // this group is a trace-confirmed clean exit, this is a
+                        // single-shot agent shutting down normally (issue
+                        // #1989): trace deliberately wrote no agent_crash, so
+                        // this backup path must not re-add one. Missing records
+                        // keep the historical fallback (offline + pending →
+                        // crash) for exits trace did not observe.
+                        let exit_status_by_pid: HashMap<i32, ProcessExitStatus> = pids
+                            .iter()
+                            .filter_map(|&p| {
+                                istore
+                                    .get_process_exit_recent(p, 120)
+                                    .map(|raw| (p, ProcessExitStatus::decode(raw)))
+                            })
+                            .collect();
+                        let all_clean_exit = exit_status_by_pid.len() == pids.len()
+                            && exit_status_by_pid.values().all(|s| s.is_clean());
+                        if all_clean_exit {
+                            log::debug!(
+                                "Agent {agent_name} (pids={pids:?}) exited cleanly (trace-recorded exit status) — treating as normal shutdown despite {} pending call(s)",
+                                pending_calls.len()
+                            );
+                            continue;
+                        }
+
                         // Check if any of the crashed PIDs were OOM-killed
                         let is_oom = pids.iter().any(|&p| was_pid_oom_killed(p));
                         if is_oom {
@@ -233,6 +322,14 @@ impl HealthChecker {
                             if is_oom {
                                 detail["oom"] = serde_json::json!(true);
                                 detail["source"] = serde_json::json!("healthchecker+dmesg");
+                            }
+                            // Attach the trace-recorded exit status when
+                            // available; omitted (not fabricated) when trace
+                            // did not observe this pid's exit.
+                            if let Some(status) = exit_status_by_pid.get(&(rep.pid as i32)) {
+                                detail["exit_code"] = serde_json::json!(status.code);
+                                detail["signal"] = serde_json::json!(status.signal);
+                                detail["core_dump"] = serde_json::json!(status.core_dump);
                             }
                             let event = InterruptionEvent::new(
                                 InterruptionType::AgentCrash,
@@ -289,61 +386,6 @@ impl HealthChecker {
                         );
                     }
                 }
-            }
-        }
-
-        log::debug!("Health check: found {} agent(s)", agents.len());
-
-        // Collect agent names by PID for role inference (detect parent-child within same agent)
-        let agent_name_by_pid: HashMap<u32, String> = agents
-            .iter()
-            .map(|a| (a.pid, a.agent_info.name.clone()))
-            .collect();
-
-        // Pre-scan listening ports per pid (also avoids scanning /proc twice).
-        let ports_by_pid: HashMap<u32, Vec<u16>> = agents
-            .iter()
-            .map(|a| (a.pid, detect_listening_ports(a.pid)))
-            .collect();
-
-        for agent in &agents {
-            let ports = ports_by_pid.get(&agent.pid).cloned().unwrap_or_default();
-            // Cosh has no daemon process and does not support keepalive/restart.
-            // Build restart_cmd only for agents that support it.
-            let restart_cmd = if agent.agent_info.name == "Cosh" {
-                None
-            } else {
-                Some(build_restart_cmd(&agent.exe_path, &agent.cmdline_args))
-            };
-
-            // Read parent PID from /proc/<pid>/stat for role inference
-            let ppid = read_ppid(agent.pid);
-
-            let role = infer_agent_role(&agent.agent_info.name, &ports, ppid, &agent_name_by_pid);
-
-            let status = if ports.is_empty() {
-                AgentHealthStatus {
-                    pid: agent.pid,
-                    agent_name: agent.agent_info.name.clone(),
-                    category: agent.agent_info.category.clone(),
-                    exe_path: agent.exe_path.clone(),
-                    ports: vec![],
-                    status: AgentHealthState::NoPort,
-                    last_check_time: now_ms(),
-                    latency_ms: None,
-                    error_message: None,
-                    restart_cmd,
-                    offline_since: None,
-                    role,
-                    parent_pid: ppid,
-                    has_crash: false,
-                }
-            } else {
-                self.probe_agent(agent, &ports, restart_cmd, role, ppid)
-            };
-
-            if let Ok(mut store) = self.store.write() {
-                store.update(agent.pid, status);
             }
         }
     }
@@ -572,5 +614,182 @@ mod tests {
             infer_agent_role("Hermes", &[], None, &map),
             AgentRole::Gateway
         );
+    }
+
+    // ── Tests for record_offline_agent_crashes (issue #1989 backup path) ──
+
+    fn unique_tmp_dir(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir =
+            std::env::temp_dir().join(format!("agentsight-hc-{}-{tag}-{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// Build a checker wired to fresh temp stores plus one pending call for
+    /// `pid`, mirroring the serve-mode setup in `run_server`.
+    fn setup_checker(
+        tag: &str,
+        pid: i32,
+    ) -> (
+        std::path::PathBuf,
+        HealthChecker,
+        Arc<GenAISqliteStore>,
+        Arc<InterruptionStore>,
+    ) {
+        let dir = unique_tmp_dir(tag);
+        let genai_store = Arc::new(
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store"),
+        );
+        let istore = Arc::new(
+            InterruptionStore::new_with_path(&dir.join("interruption_events.db"))
+                .expect("interruption store"),
+        );
+        let info = crate::storage::sqlite::genai::PendingCallInfo {
+            call_id: format!("hc-call-{tag}"),
+            trace_id: None,
+            conversation_id: None,
+            session_id: None,
+            start_timestamp_ns: 1_000_000_000,
+            pid,
+            process_name: "test".to_string(),
+            agent_name: Some("cosh-core".to_string()),
+            http_method: Some("POST".to_string()),
+            http_path: Some("/v1/chat/completions".to_string()),
+            input_messages: None,
+            system_instructions: None,
+            user_query: None,
+            is_sse: false,
+            model: Some("gpt-4".to_string()),
+            provider: Some("openai".to_string()),
+            call_kind: "main".to_string(),
+            pending_origin: crate::storage::sqlite::genai::PendingOrigin::RequestCapture,
+            pending_match_key: None,
+        };
+        genai_store.insert_pending(&info).expect("insert_pending");
+        let checker = HealthChecker::new(
+            Arc::new(RwLock::new(HealthStore::new())),
+            Duration::from_secs(30),
+        )
+        .with_interruption_store(Arc::clone(&istore))
+        .with_genai_store(Arc::clone(&genai_store));
+        (dir, checker, genai_store, istore)
+    }
+
+    fn offline_status(pid: u32) -> AgentHealthStatus {
+        AgentHealthStatus {
+            pid,
+            agent_name: "cosh-core".to_string(),
+            category: "cli".to_string(),
+            exe_path: "/usr/bin/cosh-core".to_string(),
+            ports: vec![],
+            status: AgentHealthState::Offline,
+            last_check_time: now_ms(),
+            latency_ms: None,
+            error_message: None,
+            restart_cmd: None,
+            offline_since: Some(now_ms()),
+            role: AgentRole::Client,
+            parent_pid: None,
+            has_crash: false,
+        }
+    }
+
+    fn list_crash_events(
+        istore: &InterruptionStore,
+    ) -> Vec<crate::storage::sqlite::interruption::InterruptionRecord> {
+        istore
+            .list(0, i64::MAX, None, Some("agent_crash"), None, None, 100)
+            .expect("list interruptions")
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_clean_exit_record_skips_agent_crash() {
+        // PID large enough to never collide with dmesg OOM records.
+        let pid = 4_100_001;
+        let (dir, checker, genai_store, istore) = setup_checker("clean", pid);
+
+        // trace mode recorded a clean exit (exit 0 → raw 0x0) for this pid
+        istore.record_process_exit(pid, 0x0).expect("record exit");
+
+        checker.record_offline_agent_crashes(&[offline_status(pid as u32)]);
+
+        assert!(
+            list_crash_events(&istore).is_empty(),
+            "clean exit recorded by trace must not be re-reported as agent_crash"
+        );
+        // Pending call must stay pending: marking it interrupted would pollute
+        // grader root_cause attribution just like the crash event itself.
+        assert_eq!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .len(),
+            1,
+            "pending call must not be marked interrupted on clean exit"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_no_exit_record_still_records_agent_crash() {
+        let pid = 4_100_002;
+        let (dir, checker, genai_store, istore) = setup_checker("norec", pid);
+
+        // No process_exits record: trace did not observe this exit, so the
+        // historical fallback (offline + pending → crash) must be preserved.
+        checker.record_offline_agent_crashes(&[offline_status(pid as u32)]);
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "fallback path must still record the crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["pid"], pid);
+        // Exit status is unknown here — fields must be omitted, not fabricated.
+        assert!(detail.get("exit_code").is_none());
+        assert!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .is_empty(),
+            "fallback path must mark the pending call as interrupted"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_sigkill_exit_record_records_crash_with_detail() {
+        let pid = 4_100_003;
+        let (dir, checker, genai_store, istore) = setup_checker("sigkill", pid);
+
+        // SIGKILL → raw 0x9 (measured on a real kernel): not a clean exit,
+        // so the checker must behave exactly as before the #1989 fix.
+        istore.record_process_exit(pid, 0x9).expect("record exit");
+
+        checker.record_offline_agent_crashes(&[offline_status(pid as u32)]);
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "SIGKILL must still be recorded as crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["signal"], 9);
+        assert_eq!(detail["exit_code"], 0);
+        assert_eq!(detail["core_dump"], false);
+        assert!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .is_empty(),
+            "crash path must mark the pending call as interrupted"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/agentsight/src/interruption/mod.rs
+++ b/src/agentsight/src/interruption/mod.rs
@@ -9,4 +9,4 @@ pub mod types;
 pub use detector::{DetectorConfig, InterruptionDetector};
 pub use loop_detector::{LoopDetector, LoopDetectorConfig, RecentCallSummary};
 pub use oom_recovery::{recover_oom_events, was_pid_oom_killed};
-pub use types::{InterruptionEvent, InterruptionType, Severity};
+pub use types::{InterruptionEvent, InterruptionType, ProcessExitStatus, Severity};

--- a/src/agentsight/src/interruption/types.rs
+++ b/src/agentsight/src/interruption/types.rs
@@ -207,6 +207,38 @@ fn new_id() -> String {
     uuid::Uuid::new_v4().simple().to_string()
 }
 
+/// Decoded `task_struct->exit_code` (wait(2) status encoding).
+///
+/// Assumes the Linux wait(2) encoding of the raw value; this matches the
+/// procmon BPF probe, which is Linux-only, so no other platform layout is
+/// supported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessExitStatus {
+    /// Terminating signal number; 0 when the process exited voluntarily.
+    pub signal: u32,
+    /// Whether the kernel produced a core dump.
+    pub core_dump: bool,
+    /// Exit code passed to exit(); meaningful only when `signal == 0`.
+    pub code: u32,
+}
+
+impl ProcessExitStatus {
+    /// Decode the raw kernel exit_code: low 7 bits = terminating signal,
+    /// bit 7 = core-dump flag, bits 8..=15 = exit code.
+    pub fn decode(raw: u32) -> Self {
+        Self {
+            signal: raw & 0x7f,
+            core_dump: (raw & 0x80) != 0,
+            code: (raw >> 8) & 0xff,
+        }
+    }
+
+    /// True when the process terminated voluntarily with exit code 0.
+    pub fn is_clean(self) -> bool {
+        self.signal == 0 && self.code == 0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -524,5 +556,53 @@ mod tests {
             let back: Severity = serde_json::from_str(&json).unwrap();
             assert_eq!(s, back);
         }
+    }
+
+    // Raw values below were captured on a real kernel (issue #1989):
+    // exit 0 → 0x0, exit 3 → 0x300, SIGKILL → 0x9, SIGSEGV+core → 0x8b.
+
+    #[test]
+    fn test_decode_clean_exit() {
+        let s = ProcessExitStatus::decode(0x0);
+        assert_eq!(s.signal, 0);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 0);
+        assert!(s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_nonzero_exit_code() {
+        let s = ProcessExitStatus::decode(0x300);
+        assert_eq!(s.signal, 0);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 3);
+        assert!(!s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_sigkill() {
+        let s = ProcessExitStatus::decode(0x9);
+        assert_eq!(s.signal, 9);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 0);
+        assert!(!s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_sigsegv_with_core_dump() {
+        let s = ProcessExitStatus::decode(0x8b);
+        assert_eq!(s.signal, 11);
+        assert!(s.core_dump);
+        assert_eq!(s.code, 0);
+        assert!(!s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_exit_code_255_boundary() {
+        let s = ProcessExitStatus::decode(0xff00);
+        assert_eq!(s.signal, 0);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 255);
+        assert!(!s.is_clean());
     }
 }

--- a/src/agentsight/src/probes/procmon.rs
+++ b/src/agentsight/src/probes/procmon.rs
@@ -50,6 +50,9 @@ pub enum Event {
         uid: u32,
         timestamp_ns: u64,
         comm: String,
+        /// Raw `task_struct->exit_code` in wait(2) encoding; decode with
+        /// [`crate::interruption::ProcessExitStatus::decode`].
+        exit_code: u32,
     },
 }
 
@@ -88,6 +91,7 @@ impl Event {
                 uid: raw.uid,
                 timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
                 comm,
+                exit_code: raw.exit_code,
             }),
             _ => None,
         }
@@ -184,5 +188,56 @@ impl ProcMon {
 
         self._links = links;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Locks the C/Rust shared layout: exit_code fills the tail padding after
+    // comm[16], so the struct size must stay 56 bytes and any accidental
+    // mid-struct insertion (which would shift exit_code away from offset 52)
+    // fails here.
+    #[test]
+    fn test_procmon_event_layout() {
+        assert_eq!(std::mem::size_of::<ProcMonEvent>(), 56);
+        assert_eq!(std::mem::offset_of!(ProcMonEvent, comm), 36);
+        assert_eq!(std::mem::offset_of!(ProcMonEvent, exit_code), 52);
+    }
+
+    #[test]
+    fn test_exit_event_from_bytes_carries_exit_code() {
+        // SAFETY: procmon_event is a plain-old-data C struct; all-zero is valid.
+        let mut raw: ProcMonEvent = unsafe { std::mem::zeroed() };
+        raw.timestamp_ns = 1;
+        raw.pid = 42;
+        raw.tid = 42;
+        raw.ppid = 1;
+        raw.event_type = PROCMON_EVENT_EXIT;
+        raw.exit_code = 0x8b;
+        // c_char is i8 on x86_64 but u8 on aarch64; let inference pick.
+        for (i, &b) in b"cosh".iter().enumerate() {
+            raw.comm[i] = b as _;
+        }
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                (&raw as *const ProcMonEvent) as *const u8,
+                std::mem::size_of::<ProcMonEvent>(),
+            )
+        };
+        match Event::from_bytes(bytes) {
+            Some(Event::Exit {
+                pid,
+                comm,
+                exit_code,
+                ..
+            }) => {
+                assert_eq!(pid, 42);
+                assert_eq!(comm, "cosh");
+                assert_eq!(exit_code, 0x8b);
+            }
+            other => panic!("expected Exit event, got {other:?}"),
+        }
     }
 }

--- a/src/agentsight/src/probes/procmon.rs
+++ b/src/agentsight/src/probes/procmon.rs
@@ -50,7 +50,38 @@ pub enum Event {
         uid: u32,
         timestamp_ns: u64,
         comm: String,
+        /// Raw `task_struct->exit_code` in wait(2) encoding; decode with
+        /// [`ProcessExitStatus::decode`].
+        exit_code: u32,
     },
+}
+
+/// Decoded `task_struct->exit_code` (wait(2) status encoding).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessExitStatus {
+    /// Terminating signal number; 0 when the process exited voluntarily.
+    pub signal: u32,
+    /// Whether the kernel produced a core dump.
+    pub core_dump: bool,
+    /// Exit code passed to exit(); meaningful only when `signal == 0`.
+    pub code: u32,
+}
+
+impl ProcessExitStatus {
+    /// Decode the raw kernel exit_code: low 7 bits = terminating signal,
+    /// bit 7 = core-dump flag, bits 8..=15 = exit code.
+    pub fn decode(raw: u32) -> Self {
+        Self {
+            signal: raw & 0x7f,
+            core_dump: (raw & 0x80) != 0,
+            code: (raw >> 8) & 0xff,
+        }
+    }
+
+    /// True when the process terminated voluntarily with exit code 0.
+    pub fn is_clean(self) -> bool {
+        self.signal == 0 && self.code == 0
+    }
 }
 
 impl Event {
@@ -88,6 +119,7 @@ impl Event {
                 uid: raw.uid,
                 timestamp_ns: config::ktime_to_unix_ns(raw.timestamp_ns),
                 comm,
+                exit_code: raw.exit_code,
             }),
             _ => None,
         }
@@ -184,5 +216,104 @@ impl ProcMon {
 
         self._links = links;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Raw values below were captured on a real kernel (issue #1989):
+    // exit 0 → 0x0, exit 3 → 0x300, SIGKILL → 0x9, SIGSEGV+core → 0x8b.
+
+    #[test]
+    fn test_decode_clean_exit() {
+        let s = ProcessExitStatus::decode(0x0);
+        assert_eq!(s.signal, 0);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 0);
+        assert!(s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_nonzero_exit_code() {
+        let s = ProcessExitStatus::decode(0x300);
+        assert_eq!(s.signal, 0);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 3);
+        assert!(!s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_sigkill() {
+        let s = ProcessExitStatus::decode(0x9);
+        assert_eq!(s.signal, 9);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 0);
+        assert!(!s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_sigsegv_with_core_dump() {
+        let s = ProcessExitStatus::decode(0x8b);
+        assert_eq!(s.signal, 11);
+        assert!(s.core_dump);
+        assert_eq!(s.code, 0);
+        assert!(!s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_exit_code_255_boundary() {
+        let s = ProcessExitStatus::decode(0xff00);
+        assert_eq!(s.signal, 0);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 255);
+        assert!(!s.is_clean());
+    }
+
+    // Locks the C/Rust shared layout: exit_code fills the tail padding after
+    // comm[16], so the struct size must stay 56 bytes and any accidental
+    // mid-struct insertion (which would shift exit_code away from offset 52)
+    // fails here.
+    #[test]
+    fn test_procmon_event_layout() {
+        assert_eq!(std::mem::size_of::<ProcMonEvent>(), 56);
+        assert_eq!(std::mem::offset_of!(ProcMonEvent, comm), 36);
+        assert_eq!(std::mem::offset_of!(ProcMonEvent, exit_code), 52);
+    }
+
+    #[test]
+    fn test_exit_event_from_bytes_carries_exit_code() {
+        // SAFETY: procmon_event is a plain-old-data C struct; all-zero is valid.
+        let mut raw: ProcMonEvent = unsafe { std::mem::zeroed() };
+        raw.timestamp_ns = 1;
+        raw.pid = 42;
+        raw.tid = 42;
+        raw.ppid = 1;
+        raw.event_type = PROCMON_EVENT_EXIT;
+        raw.exit_code = 0x8b;
+        // c_char is i8 on x86_64 but u8 on aarch64; let inference pick.
+        for (i, &b) in b"cosh".iter().enumerate() {
+            raw.comm[i] = b as _;
+        }
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                (&raw as *const ProcMonEvent) as *const u8,
+                std::mem::size_of::<ProcMonEvent>(),
+            )
+        };
+        match Event::from_bytes(bytes) {
+            Some(Event::Exit {
+                pid,
+                comm,
+                exit_code,
+                ..
+            }) => {
+                assert_eq!(pid, 42);
+                assert_eq!(comm, "cosh");
+                assert_eq!(exit_code, 0x8b);
+            }
+            other => panic!("expected Exit event, got {other:?}"),
+        }
     }
 }

--- a/src/agentsight/src/storage/sqlite/interruption.rs
+++ b/src/agentsight/src/storage/sqlite/interruption.rs
@@ -74,7 +74,12 @@ impl InterruptionStore {
             CREATE INDEX IF NOT EXISTS idx_interruption_type     ON interruption_events(interruption_type);
             CREATE INDEX IF NOT EXISTS idx_interruption_agent    ON interruption_events(agent_name);
             CREATE INDEX IF NOT EXISTS idx_interruption_resolved ON interruption_events(resolved);
-            CREATE INDEX IF NOT EXISTS idx_interruption_conversation ON interruption_events(conversation_id);",
+            CREATE INDEX IF NOT EXISTS idx_interruption_conversation ON interruption_events(conversation_id);
+            CREATE TABLE IF NOT EXISTS process_exits (
+                pid           INTEGER PRIMARY KEY,
+                raw_exit_code INTEGER NOT NULL,
+                exited_at_ns  INTEGER NOT NULL
+            );",
         )?;
         // Migration: add conversation_id column for existing databases
         let _ =
@@ -534,6 +539,75 @@ impl InterruptionStore {
         )
         .unwrap_or(0)
             > 0
+    }
+
+    // ─── Process exit status (trace → serve channel) ───────────────────────
+
+    /// TTL for `process_exits` rows, pruned on every write. Must comfortably
+    /// exceed the HealthChecker offline-detection latency (30s cycle + 120s
+    /// lookup window) while keeping the table bounded.
+    const PROCESS_EXIT_TTL_SECS: i64 = 600;
+
+    /// Record the raw `task_struct->exit_code` (wait(2) encoding) observed by
+    /// trace mode when an agent process exits.
+    ///
+    /// trace and serve run as separate processes and only share the SQLite
+    /// files, so this table is the channel that lets the serve-mode
+    /// HealthChecker distinguish a trace-confirmed clean exit from a crash
+    /// (issue #1989). Keyed by pid via INSERT OR REPLACE so pid reuse keeps
+    /// only the latest exit; stale rows are pruned to bound growth.
+    pub fn record_process_exit(
+        &self,
+        pid: i32,
+        raw_exit_code: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        conn.execute(
+            "INSERT OR REPLACE INTO process_exits (pid, raw_exit_code, exited_at_ns)
+             VALUES (?1, ?2, ?3)",
+            params![pid, raw_exit_code as i64, now_ns],
+        )?;
+        conn.execute(
+            "DELETE FROM process_exits WHERE exited_at_ns < ?1",
+            params![now_ns - Self::PROCESS_EXIT_TTL_SECS * 1_000_000_000],
+        )?;
+        Ok(())
+    }
+
+    /// Return the raw exit code trace mode recorded for `pid` within the last
+    /// `window_secs`, or `None` when trace did not observe the exit (e.g. the
+    /// collector was not running) — callers must then keep their fallback
+    /// behavior.
+    pub fn get_process_exit_recent(&self, pid: i32, window_secs: u64) -> Option<u32> {
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        let cutoff_ns = now_ns - (window_secs as i64 * 1_000_000_000);
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        conn.query_row(
+            "SELECT raw_exit_code FROM process_exits WHERE pid=?1 AND exited_at_ns > ?2",
+            params![pid, cutoff_ns],
+            |row| row.get::<_, i64>(0),
+        )
+        .ok()
+        .map(|v| v as u32)
+    }
+
+    /// Best-effort removal of the recorded exit status for `pid`.
+    ///
+    /// Called when `record_process_exit` fails: a stale row from a previous
+    /// process could otherwise be read for a reused pid within the lookup
+    /// window, misclassifying a real crash as a clean exit. Clearing restores
+    /// the safe "no record → fallback crash handling" semantics.
+    pub fn clear_process_exit(&self, pid: i32) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        conn.execute("DELETE FROM process_exits WHERE pid=?1", params![pid])?;
+        Ok(())
     }
 
     /// Purge interruption events older than cutoff_ns.
@@ -1145,6 +1219,43 @@ mod tests {
 
         assert!(store.agent_crash_exists_recent(5555, 60));
         assert!(!store.agent_crash_exists_recent(6666, 60));
+    }
+
+    // ── process_exits (trace → serve exit-status channel) ───────────────────
+
+    #[test]
+    fn record_process_exit_roundtrip_replace_and_window() {
+        let store = temp_store();
+        assert!(store.get_process_exit_recent(7777, 60).is_none());
+
+        store.record_process_exit(7777, 0x0).unwrap();
+        assert_eq!(store.get_process_exit_recent(7777, 60), Some(0x0));
+
+        // pid reuse: the latest exit wins
+        store.record_process_exit(7777, 0x9).unwrap();
+        assert_eq!(store.get_process_exit_recent(7777, 60), Some(0x9));
+
+        // other pids and an expired window stay invisible
+        assert!(store.get_process_exit_recent(8888, 60).is_none());
+        assert!(store.get_process_exit_recent(7777, 0).is_none());
+    }
+
+    #[test]
+    fn clear_process_exit_removes_stale_record_for_reused_pid() {
+        let store = temp_store();
+
+        // A clean-exit row is left over from a previous process with this pid
+        // (write of the new exit status failed, so it was never replaced).
+        store.record_process_exit(9999, 0x0).unwrap();
+        assert_eq!(store.get_process_exit_recent(9999, 60), Some(0x0));
+
+        // Best-effort cleanup must drop the stale row so the serve-mode
+        // reader falls back to "no record → crash handling" for a reused pid.
+        store.clear_process_exit(9999).unwrap();
+        assert!(store.get_process_exit_recent(9999, 60).is_none());
+
+        // Clearing an absent pid is a no-op, not an error.
+        store.clear_process_exit(9999).unwrap();
     }
 
     // ── purge ────────────────────────────────────────────────────────────────

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -33,7 +33,9 @@ use crate::event::Event;
 use crate::ffi::{FfiEvent, FfiEventSender};
 use crate::genai::semantic::GenAISemanticEvent;
 use crate::genai::{GenAIBuilder, GenAIExporter, LogtailExporter};
-use crate::interruption::{DetectorConfig, InterruptionDetector, recover_oom_events};
+use crate::interruption::{
+    DetectorConfig, InterruptionDetector, ProcessExitStatus, recover_oom_events,
+};
 use crate::parser::Parser;
 use crate::probes::{FileWatchEvent, FileWriteEvent, Probes, ProbesPoller};
 use crate::response_map::ResponseSessionMapper;
@@ -911,12 +913,12 @@ impl AgentSight {
                     self.attach_process(*pid, &agent_name);
                 }
             }
-            ProcMonEvent::Exit { pid, .. } => {
+            ProcMonEvent::Exit { pid, exit_code, .. } => {
                 // Remove from tracking if it was an agent
                 if let Some(agent) = self.scanner.on_process_exit(*pid) {
                     let agent_name = agent.agent_info.name.clone();
                     self.probes.detach_ssl_probes(*pid);
-                    self.handle_agent_crash_detection(*pid, &agent_name);
+                    self.handle_agent_crash_detection(*pid, &agent_name, *exit_code);
                 }
             }
         }
@@ -1277,11 +1279,33 @@ impl AgentSight {
     /// Immediate crash detection when a tracked agent process exits.
     ///
     /// Called from `ProcMon::Exit` handler. Drains in-flight connections for
-    /// the PID, persists them as pending calls, then generates an `agent_crash`
-    /// interruption event if any pending calls exist.
-    fn handle_agent_crash_detection(&mut self, pid: u32, agent_name: &str) {
+    /// the PID and persists them as pending calls regardless of how the
+    /// process terminated, then delegates the crash decision to
+    /// [`record_agent_crash_interruptions`], passing the decoded raw
+    /// `task_struct->exit_code` so clean exits are not misreported.
+    fn handle_agent_crash_detection(&mut self, pid: u32, agent_name: &str, raw_exit_code: u32) {
         use crate::aggregator::ConnectionState;
-        use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+
+        // Persist the raw exit status to the shared interruption DB first: the
+        // serve-mode HealthChecker runs in a separate process and re-detects
+        // this exit as "offline + pending" on its next cycle. Without this
+        // record it would re-report a clean exit as agent_crash, undoing the
+        // issue #1989 fix on the backup path.
+        if let Some(ref istore) = self.interruption_store {
+            if let Err(e) = istore.record_process_exit(pid as i32, raw_exit_code) {
+                log::warn!("[CrashDetect] Failed to record exit status for pid={pid}: {e}");
+                // Best-effort: drop any stale row from a previous process with
+                // this pid so serve mode cannot misread an old clean exit as
+                // this exit within the lookup window. If the DB is broken the
+                // delete likely fails too — serve then merely degrades to the
+                // pre-fix behavior (offline + pending → crash), never worse.
+                if let Err(e) = istore.clear_process_exit(pid as i32) {
+                    log::warn!(
+                        "[CrashDetect] Failed to clear stale exit status for pid={pid}: {e}"
+                    );
+                }
+            }
+        }
 
         // 1. Drain in-flight connections for this PID from the aggregator
         let drained = self.aggregator.drain_connections_for_pid(pid);
@@ -1325,73 +1349,16 @@ impl AgentSight {
             return;
         }
 
-        // 4. Generate agent_crash interruption event
+        // 4. Record agent_crash interruptions unless the exit was clean
         if let Some(ref istore) = self.interruption_store {
-            let now_ns = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as i64)
-                .unwrap_or(0);
-
-            let is_oom = was_pid_oom_killed(pid as i32);
-
-            // Group by (session_id, conversation_id) to produce one event per conversation
-            let mut by_conv: std::collections::HashMap<
-                (Option<String>, Option<String>),
-                Vec<String>,
-            > = std::collections::HashMap::new();
-            for (call_id, session_id, _trace_id, conversation_id) in &pending_calls {
-                by_conv
-                    .entry((session_id.clone(), conversation_id.clone()))
-                    .or_default()
-                    .push(call_id.clone());
-            }
-
-            for ((session_id, conversation_id), call_ids) in &by_conv {
-                let mut detail = serde_json::json!({
-                    "pid": pid,
-                    "agent_name": agent_name,
-                    "call_ids": call_ids,
-                    "source": "trace_procmon_exit",
-                });
-                if is_oom {
-                    detail["oom"] = serde_json::json!(true);
-                }
-                let event = InterruptionEvent::new(
-                    InterruptionType::AgentCrash,
-                    session_id.clone(),
-                    None,
-                    conversation_id.clone(),
-                    None,
-                    Some(pid as i32),
-                    Some(agent_name.to_string()),
-                    now_ns,
-                    Some(detail),
-                );
-                if let Err(e) = istore.insert(&event) {
-                    log::warn!("[CrashDetect] Failed to record agent_crash for pid={pid}: {e}");
-                } else {
-                    log::info!(
-                        "[CrashDetect] Recorded agent_crash for {} (pid={}, session={:?}, conversation={:?}, {} call(s), oom={})",
-                        agent_name,
-                        pid,
-                        session_id,
-                        conversation_id,
-                        call_ids.len(),
-                        is_oom,
-                    );
-                }
-                crate::genai::logtail::export_interruption_events(std::slice::from_ref(&event));
-            }
-
-            // Mark all pending calls for this PID as interrupted
-            if let Some(ref store) = self.genai_sqlite_store {
-                let itype = if is_oom { "oom_crash" } else { "agent_crash" };
-                if let Err(e) = store.mark_pending_interrupted_for_pid(pid as i32, itype) {
-                    log::warn!(
-                        "[CrashDetect] Failed to mark pending interrupted for pid={pid}: {e}"
-                    );
-                }
-            }
+            record_agent_crash_interruptions(
+                pid,
+                agent_name,
+                ProcessExitStatus::decode(raw_exit_code),
+                &pending_calls,
+                istore,
+                self.genai_sqlite_store.as_deref(),
+            );
         }
     }
 
@@ -2076,6 +2043,109 @@ fn complete_deferred_genai(
     }
 }
 
+/// Record `agent_crash` interruption events for the pending calls of an
+/// exited agent process, and mark those calls as interrupted.
+///
+/// Skips entirely when the process terminated voluntarily with exit code 0:
+/// a single-shot agent finishing its run with still-unresolved pending calls
+/// is not a crash (issue #1989). Abnormal exits (non-zero code or fatal
+/// signal, which covers the SIGKILL sent by the OOM killer) keep the previous
+/// behavior, with the decoded exit status embedded in the detail JSON.
+///
+/// Extracted as a free function so the crash decision is unit-testable
+/// without constructing a full `AgentSight` instance.
+fn record_agent_crash_interruptions(
+    pid: u32,
+    agent_name: &str,
+    exit_status: ProcessExitStatus,
+    pending_calls: &[(String, Option<String>, Option<String>, Option<String>)],
+    istore: &InterruptionStore,
+    genai_store: Option<&GenAISqliteStore>,
+) {
+    use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+
+    // Nothing to record without pending calls; guard here so future callers
+    // cannot emit call-less crash events by accident.
+    if pending_calls.is_empty() {
+        return;
+    }
+
+    if exit_status.is_clean() {
+        log::info!(
+            "[CrashDetect] Agent {agent_name} (pid={pid}) exited cleanly with {} pending call(s) — not a crash",
+            pending_calls.len(),
+        );
+        return;
+    }
+
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0);
+
+    let is_oom = was_pid_oom_killed(pid as i32);
+
+    // Group by (session_id, conversation_id) to produce one event per conversation
+    let mut by_conv: std::collections::HashMap<(Option<String>, Option<String>), Vec<String>> =
+        std::collections::HashMap::new();
+    for (call_id, session_id, _trace_id, conversation_id) in pending_calls {
+        by_conv
+            .entry((session_id.clone(), conversation_id.clone()))
+            .or_default()
+            .push(call_id.clone());
+    }
+
+    for ((session_id, conversation_id), call_ids) in &by_conv {
+        let mut detail = serde_json::json!({
+            "pid": pid,
+            "agent_name": agent_name,
+            "call_ids": call_ids,
+            "source": "trace_procmon_exit",
+            "exit_code": exit_status.code,
+            "signal": exit_status.signal,
+            "core_dump": exit_status.core_dump,
+        });
+        if is_oom {
+            detail["oom"] = serde_json::json!(true);
+        }
+        let event = InterruptionEvent::new(
+            InterruptionType::AgentCrash,
+            session_id.clone(),
+            None,
+            conversation_id.clone(),
+            None,
+            Some(pid as i32),
+            Some(agent_name.to_string()),
+            now_ns,
+            Some(detail),
+        );
+        if let Err(e) = istore.insert(&event) {
+            log::warn!("[CrashDetect] Failed to record agent_crash for pid={pid}: {e}");
+        } else {
+            log::info!(
+                "[CrashDetect] Recorded agent_crash for {} (pid={}, session={:?}, conversation={:?}, {} call(s), exit_code={}, signal={}, oom={})",
+                agent_name,
+                pid,
+                session_id,
+                conversation_id,
+                call_ids.len(),
+                exit_status.code,
+                exit_status.signal,
+                is_oom,
+            );
+        }
+        crate::genai::logtail::export_interruption_events(std::slice::from_ref(&event));
+    }
+
+    // Mark all pending calls for this PID as interrupted
+    if let Some(store) = genai_store {
+        let itype = if is_oom { "oom_crash" } else { "agent_crash" };
+        if let Err(e) = store.mark_pending_interrupted_for_pid(pid as i32, itype) {
+            log::warn!("[CrashDetect] Failed to mark pending interrupted for pid={pid}: {e}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2090,6 +2160,174 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    // ── Tests for record_agent_crash_interruptions (issue #1989) ──
+
+    /// Build the stores + one pending call for `pid`, returning the paths so
+    /// tests can assert on both databases.
+    fn setup_crash_stores(
+        tag: &str,
+        pid: i32,
+    ) -> (PathBuf, Arc<GenAISqliteStore>, Arc<InterruptionStore>) {
+        let dir = unique_tmp_dir(tag);
+        let genai_store = Arc::new(
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store"),
+        );
+        let istore = Arc::new(
+            InterruptionStore::new_with_path(&dir.join("interruption_events.db"))
+                .expect("interruption store"),
+        );
+        let mut info = make_test_pending_info("crash-call-1");
+        info.pid = pid;
+        genai_store.insert_pending(&info).expect("insert_pending");
+        (dir, genai_store, istore)
+    }
+
+    fn list_crash_events(
+        istore: &InterruptionStore,
+    ) -> Vec<crate::storage::sqlite::interruption::InterruptionRecord> {
+        istore
+            .list(0, i64::MAX, None, Some("agent_crash"), None, None, 100)
+            .expect("list interruptions")
+    }
+
+    #[test]
+    fn test_clean_exit_with_pending_call_records_no_agent_crash() {
+        // Use a PID that cannot appear in dmesg OOM logs.
+        let pid = 3_999_991;
+        let (dir, genai_store, istore) = setup_crash_stores("clean-exit", pid);
+
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+        assert_eq!(pending.len(), 1, "precondition: one pending call");
+
+        // exit 0 → raw exit_code 0x0 (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x0),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        assert!(
+            list_crash_events(&istore).is_empty(),
+            "clean exit must not produce an agent_crash interruption"
+        );
+        // The pending call must NOT be stamped as interrupted either — that
+        // column is what pollutes grader root_cause attribution.
+        assert_eq!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .len(),
+            1,
+            "pending call must stay pending on clean exit"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_sigkill_exit_records_agent_crash_with_signal_detail() {
+        let pid = 3_999_992;
+        let (dir, genai_store, istore) = setup_crash_stores("sigkill-exit", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        // SIGKILL → raw exit_code 0x9 (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x9),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "SIGKILL must produce one agent_crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["signal"], 9);
+        assert_eq!(detail["exit_code"], 0);
+        assert_eq!(detail["core_dump"], false);
+        assert_eq!(detail["source"], "trace_procmon_exit");
+
+        // Pending call is marked interrupted on the crash path.
+        assert!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .is_empty(),
+            "crash path must mark the pending call as interrupted"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_nonzero_exit_code_records_agent_crash_with_code_detail() {
+        let pid = 3_999_993;
+        let (dir, genai_store, istore) = setup_crash_stores("exit3", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        // exit 3 → raw exit_code 0x300 (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x300),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "exit 3 must produce one agent_crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["exit_code"], 3);
+        assert_eq!(detail["signal"], 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_sigsegv_core_dump_records_agent_crash_with_core_detail() {
+        let pid = 3_999_994;
+        let (dir, genai_store, istore) = setup_crash_stores("segv-core", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        // SIGSEGV with core dump → raw exit_code 0x8b (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x8b),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "SIGSEGV must produce one agent_crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["signal"], 11);
+        assert_eq!(detail["core_dump"], true);
+        assert_eq!(detail["exit_code"], 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ── Tests for conn_scan_agent_name (agent identity, never a domain) ──

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -35,6 +35,7 @@ use crate::genai::semantic::GenAISemanticEvent;
 use crate::genai::{GenAIBuilder, GenAIExporter, LogtailExporter};
 use crate::interruption::{DetectorConfig, InterruptionDetector, recover_oom_events};
 use crate::parser::Parser;
+use crate::probes::procmon::ProcessExitStatus;
 use crate::probes::{FileWatchEvent, FileWriteEvent, Probes, ProbesPoller};
 use crate::response_map::ResponseSessionMapper;
 use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore, sibling_db_path};
@@ -911,12 +912,12 @@ impl AgentSight {
                     self.attach_process(*pid, &agent_name);
                 }
             }
-            ProcMonEvent::Exit { pid, .. } => {
+            ProcMonEvent::Exit { pid, exit_code, .. } => {
                 // Remove from tracking if it was an agent
                 if let Some(agent) = self.scanner.on_process_exit(*pid) {
                     let agent_name = agent.agent_info.name.clone();
                     self.probes.detach_ssl_probes(*pid);
-                    self.handle_agent_crash_detection(*pid, &agent_name);
+                    self.handle_agent_crash_detection(*pid, &agent_name, *exit_code);
                 }
             }
         }
@@ -1277,11 +1278,33 @@ impl AgentSight {
     /// Immediate crash detection when a tracked agent process exits.
     ///
     /// Called from `ProcMon::Exit` handler. Drains in-flight connections for
-    /// the PID, persists them as pending calls, then generates an `agent_crash`
-    /// interruption event if any pending calls exist.
-    fn handle_agent_crash_detection(&mut self, pid: u32, agent_name: &str) {
+    /// the PID and persists them as pending calls regardless of how the
+    /// process terminated, then delegates the crash decision to
+    /// [`record_agent_crash_interruptions`], passing the decoded raw
+    /// `task_struct->exit_code` so clean exits are not misreported.
+    fn handle_agent_crash_detection(&mut self, pid: u32, agent_name: &str, raw_exit_code: u32) {
         use crate::aggregator::ConnectionState;
-        use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+
+        // Persist the raw exit status to the shared interruption DB first: the
+        // serve-mode HealthChecker runs in a separate process and re-detects
+        // this exit as "offline + pending" on its next cycle. Without this
+        // record it would re-report a clean exit as agent_crash, undoing the
+        // issue #1989 fix on the backup path.
+        if let Some(ref istore) = self.interruption_store {
+            if let Err(e) = istore.record_process_exit(pid as i32, raw_exit_code) {
+                log::warn!("[CrashDetect] Failed to record exit status for pid={pid}: {e}");
+                // Best-effort: drop any stale row from a previous process with
+                // this pid so serve mode cannot misread an old clean exit as
+                // this exit within the lookup window. If the DB is broken the
+                // delete likely fails too — serve then merely degrades to the
+                // pre-fix behavior (offline + pending → crash), never worse.
+                if let Err(e) = istore.clear_process_exit(pid as i32) {
+                    log::warn!(
+                        "[CrashDetect] Failed to clear stale exit status for pid={pid}: {e}"
+                    );
+                }
+            }
+        }
 
         // 1. Drain in-flight connections for this PID from the aggregator
         let drained = self.aggregator.drain_connections_for_pid(pid);
@@ -1325,73 +1348,16 @@ impl AgentSight {
             return;
         }
 
-        // 4. Generate agent_crash interruption event
+        // 4. Record agent_crash interruptions unless the exit was clean
         if let Some(ref istore) = self.interruption_store {
-            let now_ns = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as i64)
-                .unwrap_or(0);
-
-            let is_oom = was_pid_oom_killed(pid as i32);
-
-            // Group by (session_id, conversation_id) to produce one event per conversation
-            let mut by_conv: std::collections::HashMap<
-                (Option<String>, Option<String>),
-                Vec<String>,
-            > = std::collections::HashMap::new();
-            for (call_id, session_id, _trace_id, conversation_id) in &pending_calls {
-                by_conv
-                    .entry((session_id.clone(), conversation_id.clone()))
-                    .or_default()
-                    .push(call_id.clone());
-            }
-
-            for ((session_id, conversation_id), call_ids) in &by_conv {
-                let mut detail = serde_json::json!({
-                    "pid": pid,
-                    "agent_name": agent_name,
-                    "call_ids": call_ids,
-                    "source": "trace_procmon_exit",
-                });
-                if is_oom {
-                    detail["oom"] = serde_json::json!(true);
-                }
-                let event = InterruptionEvent::new(
-                    InterruptionType::AgentCrash,
-                    session_id.clone(),
-                    None,
-                    conversation_id.clone(),
-                    None,
-                    Some(pid as i32),
-                    Some(agent_name.to_string()),
-                    now_ns,
-                    Some(detail),
-                );
-                if let Err(e) = istore.insert(&event) {
-                    log::warn!("[CrashDetect] Failed to record agent_crash for pid={pid}: {e}");
-                } else {
-                    log::info!(
-                        "[CrashDetect] Recorded agent_crash for {} (pid={}, session={:?}, conversation={:?}, {} call(s), oom={})",
-                        agent_name,
-                        pid,
-                        session_id,
-                        conversation_id,
-                        call_ids.len(),
-                        is_oom,
-                    );
-                }
-                crate::genai::logtail::export_interruption_events(std::slice::from_ref(&event));
-            }
-
-            // Mark all pending calls for this PID as interrupted
-            if let Some(ref store) = self.genai_sqlite_store {
-                let itype = if is_oom { "oom_crash" } else { "agent_crash" };
-                if let Err(e) = store.mark_pending_interrupted_for_pid(pid as i32, itype) {
-                    log::warn!(
-                        "[CrashDetect] Failed to mark pending interrupted for pid={pid}: {e}"
-                    );
-                }
-            }
+            record_agent_crash_interruptions(
+                pid,
+                agent_name,
+                ProcessExitStatus::decode(raw_exit_code),
+                &pending_calls,
+                istore,
+                self.genai_sqlite_store.as_deref(),
+            );
         }
     }
 
@@ -2076,6 +2042,103 @@ fn complete_deferred_genai(
     }
 }
 
+/// Record `agent_crash` interruption events for the pending calls of an
+/// exited agent process, and mark those calls as interrupted.
+///
+/// Skips entirely when the process terminated voluntarily with exit code 0:
+/// a single-shot agent finishing its run with still-unresolved pending calls
+/// is not a crash (issue #1989). Abnormal exits (non-zero code or fatal
+/// signal, which covers the SIGKILL sent by the OOM killer) keep the previous
+/// behavior, with the decoded exit status embedded in the detail JSON.
+///
+/// Extracted as a free function so the crash decision is unit-testable
+/// without constructing a full `AgentSight` instance.
+fn record_agent_crash_interruptions(
+    pid: u32,
+    agent_name: &str,
+    exit_status: ProcessExitStatus,
+    pending_calls: &[(String, Option<String>, Option<String>, Option<String>)],
+    istore: &InterruptionStore,
+    genai_store: Option<&GenAISqliteStore>,
+) {
+    use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+
+    if exit_status.is_clean() {
+        log::info!(
+            "[CrashDetect] Agent {agent_name} (pid={pid}) exited cleanly with {} pending call(s) — not a crash",
+            pending_calls.len(),
+        );
+        return;
+    }
+
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0);
+
+    let is_oom = was_pid_oom_killed(pid as i32);
+
+    // Group by (session_id, conversation_id) to produce one event per conversation
+    let mut by_conv: std::collections::HashMap<(Option<String>, Option<String>), Vec<String>> =
+        std::collections::HashMap::new();
+    for (call_id, session_id, _trace_id, conversation_id) in pending_calls {
+        by_conv
+            .entry((session_id.clone(), conversation_id.clone()))
+            .or_default()
+            .push(call_id.clone());
+    }
+
+    for ((session_id, conversation_id), call_ids) in &by_conv {
+        let mut detail = serde_json::json!({
+            "pid": pid,
+            "agent_name": agent_name,
+            "call_ids": call_ids,
+            "source": "trace_procmon_exit",
+            "exit_code": exit_status.code,
+            "signal": exit_status.signal,
+            "core_dump": exit_status.core_dump,
+        });
+        if is_oom {
+            detail["oom"] = serde_json::json!(true);
+        }
+        let event = InterruptionEvent::new(
+            InterruptionType::AgentCrash,
+            session_id.clone(),
+            None,
+            conversation_id.clone(),
+            None,
+            Some(pid as i32),
+            Some(agent_name.to_string()),
+            now_ns,
+            Some(detail),
+        );
+        if let Err(e) = istore.insert(&event) {
+            log::warn!("[CrashDetect] Failed to record agent_crash for pid={pid}: {e}");
+        } else {
+            log::info!(
+                "[CrashDetect] Recorded agent_crash for {} (pid={}, session={:?}, conversation={:?}, {} call(s), exit_code={}, signal={}, oom={})",
+                agent_name,
+                pid,
+                session_id,
+                conversation_id,
+                call_ids.len(),
+                exit_status.code,
+                exit_status.signal,
+                is_oom,
+            );
+        }
+        crate::genai::logtail::export_interruption_events(std::slice::from_ref(&event));
+    }
+
+    // Mark all pending calls for this PID as interrupted
+    if let Some(store) = genai_store {
+        let itype = if is_oom { "oom_crash" } else { "agent_crash" };
+        if let Err(e) = store.mark_pending_interrupted_for_pid(pid as i32, itype) {
+            log::warn!("[CrashDetect] Failed to mark pending interrupted for pid={pid}: {e}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2090,6 +2153,174 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    // ── Tests for record_agent_crash_interruptions (issue #1989) ──
+
+    /// Build the stores + one pending call for `pid`, returning the paths so
+    /// tests can assert on both databases.
+    fn setup_crash_stores(
+        tag: &str,
+        pid: i32,
+    ) -> (PathBuf, Arc<GenAISqliteStore>, Arc<InterruptionStore>) {
+        let dir = unique_tmp_dir(tag);
+        let genai_store = Arc::new(
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store"),
+        );
+        let istore = Arc::new(
+            InterruptionStore::new_with_path(&dir.join("interruption_events.db"))
+                .expect("interruption store"),
+        );
+        let mut info = make_test_pending_info("crash-call-1");
+        info.pid = pid;
+        genai_store.insert_pending(&info).expect("insert_pending");
+        (dir, genai_store, istore)
+    }
+
+    fn list_crash_events(
+        istore: &InterruptionStore,
+    ) -> Vec<crate::storage::sqlite::interruption::InterruptionRecord> {
+        istore
+            .list(0, i64::MAX, None, Some("agent_crash"), None, None, 100)
+            .expect("list interruptions")
+    }
+
+    #[test]
+    fn test_clean_exit_with_pending_call_records_no_agent_crash() {
+        // Use a PID that cannot appear in dmesg OOM logs.
+        let pid = 3_999_991;
+        let (dir, genai_store, istore) = setup_crash_stores("clean-exit", pid);
+
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+        assert_eq!(pending.len(), 1, "precondition: one pending call");
+
+        // exit 0 → raw exit_code 0x0 (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x0),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        assert!(
+            list_crash_events(&istore).is_empty(),
+            "clean exit must not produce an agent_crash interruption"
+        );
+        // The pending call must NOT be stamped as interrupted either — that
+        // column is what pollutes grader root_cause attribution.
+        assert_eq!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .len(),
+            1,
+            "pending call must stay pending on clean exit"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_sigkill_exit_records_agent_crash_with_signal_detail() {
+        let pid = 3_999_992;
+        let (dir, genai_store, istore) = setup_crash_stores("sigkill-exit", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        // SIGKILL → raw exit_code 0x9 (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x9),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "SIGKILL must produce one agent_crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["signal"], 9);
+        assert_eq!(detail["exit_code"], 0);
+        assert_eq!(detail["core_dump"], false);
+        assert_eq!(detail["source"], "trace_procmon_exit");
+
+        // Pending call is marked interrupted on the crash path.
+        assert!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .is_empty(),
+            "crash path must mark the pending call as interrupted"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_nonzero_exit_code_records_agent_crash_with_code_detail() {
+        let pid = 3_999_993;
+        let (dir, genai_store, istore) = setup_crash_stores("exit3", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        // exit 3 → raw exit_code 0x300 (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x300),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "exit 3 must produce one agent_crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["exit_code"], 3);
+        assert_eq!(detail["signal"], 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_sigsegv_core_dump_records_agent_crash_with_core_detail() {
+        let pid = 3_999_994;
+        let (dir, genai_store, istore) = setup_crash_stores("segv-core", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        // SIGSEGV with core dump → raw exit_code 0x8b (measured on a real kernel)
+        record_agent_crash_interruptions(
+            pid as u32,
+            "cosh-core",
+            ProcessExitStatus::decode(0x8b),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        let events = list_crash_events(&istore);
+        assert_eq!(events.len(), 1, "SIGSEGV must produce one agent_crash");
+        let detail: serde_json::Value =
+            serde_json::from_str(events[0].detail.as_deref().expect("detail json"))
+                .expect("parse detail");
+        assert_eq!(detail["signal"], 11);
+        assert_eq!(detail["core_dump"], true);
+        assert_eq!(detail["exit_code"], 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ── Tests for conn_scan_agent_name (agent identity, never a domain) ──


### PR DESCRIPTION
## Description

`trace_procmon_exit` treated every disappearing agent process with a pending LLM call as an `agent_crash`, so single-shot agents (e.g. one-off CLI runs) that exited normally produced false-positive critical interruptions. This PR collects `task->exit_code` via CO-RE at the `sched_process_exit` tracepoint (reusing `procmon_event` tail padding, struct size stays 56B), so the trace path skips `agent_crash` and pending-interruption marking for clean exits (signal 0, code 0) while abnormal exits keep alerting with `exit_code`/`signal`/`core_dump` detail. Exit status is shared with serve through a new `process_exits` table (600s TTL) in the interruption DB, letting `HealthChecker` skip crash backfill for offline groups that exited fully clean within 120s; groups without exit records retain the pre-fix fallback behavior. Stale records are cleaned up on write failure to avoid PID-reuse misattribution.

## Related Issue

closes #1989

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

**Unit / lint** (ECS, kernel 6.6, rustc 1.89.0):
- `cargo test --workspace` — 1232 passed, 3 consecutive green runs
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean

**E2E on real kernel** (discriminative verification):
- Agent with a pending LLM call exiting with code 0 no longer produces `agent_crash`; the pre-fix false positive was reproduced with the old binary as a control.
- `SIGKILL` and `exit 3` still raise `agent_crash`, with `signal` / `exit_code` / `core_dump` in the detail field.
- `HealthChecker` both paths verified: skip-backfill for offline groups fully clean within 120s, and fallback backfill when no exit records exist (serve-only deployments keep pre-fix behavior).
- BPF path verified bit-by-bit: `exit_code` field layout matches kernel `task->exit_code` encoding (signal low byte, code bits 8-15, core dump bit 7).

**Edge cases verified**: multi-thread group exit (only group-leader exit consulted), core-dump bit handling, stale `process_exits` cleanup on write failure to prevent PID-reuse misattribution, serve-only deployment behavior unchanged.

## Additional Notes

Total diff is 983 lines, above the 800-line guideline in `src/agentsight/AGENTS.md`; 480 of the added lines are tests colocated in the same files per the repo test-colocation convention. Production logic changes are ~364 added lines, within the 500-line complex-logic budget, and the change is a single atomic logical unit (BPF field + trace gate + DB sharing + HealthChecker consumer) that would not compile/test independently if split.
