### PR TITLE
fix(cosh-ng): [shell] converge Han NL input ownership

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1022,6 +1022,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.cosh_ng == 'true'
     runs-on: anolisa-k8s-general-ci-x64
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/specs/shell-e2e-validation/cases/han-nl-routing.yaml
+++ b/specs/shell-e2e-validation/cases/han-nl-routing.yaml
@@ -1,0 +1,150 @@
+version: 1
+suite: han-nl-routing
+defaults:
+  execution: ci
+  shell_mode: isolated
+  adapter: cosh-core
+  approval_mode: ask
+  analysis_mode: smart
+  render: terminal
+  timeout_ms: 30000
+  real_provider: false
+  command:
+    - bash
+    - -lc
+    - >-
+      cd /work/repo/src/cosh-ng &&
+      cargo build --locked -p cosh-shell --bin cosh-shell >/dev/null &&
+      exec "$CARGO_TARGET_DIR/debug/cosh-shell" raw cosh-core
+cases:
+  - id: HAN-NL-001
+    title: Bash routes Han Tier-A, question, and quoted-word prompts to Agent
+    tags: [shell, bash, issue-1990, issue-1992, han, natural-language]
+    shell: bash
+    env:
+      TERM: xterm-256color
+      COSH_SHELL_WIDTH: "96"
+      COSH_SHELL_ISOLATED: "1"
+      COSH_SHELL_BOOTSTRAP_PATH: "0"
+      COSH_SHELL_HEALTH_SCAN: disabled
+      COSH_RECOMMENDATIONS_ENABLED: "0"
+      COSH_SHELL_LANG: zh-CN
+      COSH_SHELL_RAW_SHELL: bash
+      COSH_SHELL_DEFAULT_SHELL: bash
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    input:
+      - type: wait_for
+        text: "cosh-osc$"
+        timeout_ms: 10000
+      - type: line
+        text: '解释一下 ls -la "当前目录 (preview)"'
+      - id: bash-issue-1990
+        type: wait_for
+        text: "failed to run cosh-core: No such file or directory"
+        timeout_ms: 10000
+      - type: line
+        text: '你还好吗? 我想问问'
+      - id: bash-issue-1992
+        type: wait_for
+        text: "failed to run cosh-core: No such file or directory"
+        occurrence: "+1"
+        timeout_ms: 10000
+      - type: line
+        text: '子曰" 三人行必有我师"'
+      - id: bash-issue-1992-quote
+        type: wait_for
+        text: "failed to run cosh-core: No such file or directory"
+        occurrence: "+1"
+        timeout_ms: 10000
+      - type: delay
+        ms: 1000
+      - type: line
+        text: exit
+    expect:
+      status: 0
+      contains:
+        - "failed to run cosh-core: No such file or directory"
+      not_contains:
+        - "command not found"
+    evidence:
+      points:
+        - id: bash-issue-1990
+          trigger_event: bash-issue-1990
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: bash-issue-1992
+          trigger_event: bash-issue-1992
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: bash-issue-1992-quote
+          trigger_event: bash-issue-1992-quote
+          layout_sensitive: true
+          required_types: [screenshot]
+
+  - id: HAN-NL-002
+    title: Zsh routes Han Tier-A, question, and quoted-word prompts to Agent
+    tags: [shell, zsh, issue-1990, issue-1992, han, natural-language]
+    shell: zsh
+    skip_if_shell_missing: true
+    command: [$COSH_SHELL, raw, cosh-core]
+    env:
+      TERM: xterm-256color
+      COSH_SHELL_WIDTH: "96"
+      COSH_SHELL_ISOLATED: "1"
+      COSH_SHELL_BOOTSTRAP_PATH: "0"
+      COSH_SHELL_HEALTH_SCAN: disabled
+      COSH_RECOMMENDATIONS_ENABLED: "0"
+      COSH_SHELL_LANG: zh-CN
+      COSH_SHELL_RAW_SHELL: zsh
+      COSH_SHELL_DEFAULT_SHELL: zsh
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    input:
+      - type: wait_for
+        text: "cosh-osc$"
+        timeout_ms: 10000
+      - type: line
+        text: '解释一下 ls -la "当前目录 (preview)"'
+      - id: zsh-issue-1990
+        type: wait_for
+        text: "failed to run cosh-core: No such file or directory"
+        timeout_ms: 10000
+      - type: line
+        text: '你还好吗? 我想问问'
+      - id: zsh-issue-1992
+        type: wait_for
+        text: "failed to run cosh-core: No such file or directory"
+        occurrence: "+1"
+        timeout_ms: 10000
+      - type: line
+        text: '子曰" 三人行必有我师"'
+      - id: zsh-issue-1992-quote
+        type: wait_for
+        text: "failed to run cosh-core: No such file or directory"
+        occurrence: "+1"
+        timeout_ms: 10000
+      - type: delay
+        ms: 1000
+      - type: line
+        text: exit
+    expect:
+      status: 0
+      contains:
+        - "failed to run cosh-core: No such file or directory"
+      not_contains:
+        - "command not found"
+    evidence:
+      points:
+        - id: zsh-issue-1990
+          trigger_event: zsh-issue-1990
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: zsh-issue-1992
+          trigger_event: zsh-issue-1992
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: zsh-issue-1992-quote
+          trigger_event: zsh-issue-1992-quote
+          layout_sensitive: true
+          required_types: [screenshot]

--- a/specs/shell-e2e-validation/cases/han-nl-routing.yaml
+++ b/specs/shell-e2e-validation/cases/han-nl-routing.yaml
@@ -148,3 +148,110 @@ cases:
           trigger_event: zsh-issue-1992-quote
           layout_sensitive: true
           required_types: [screenshot]
+
+  - id: HAN-NL-003
+    title: Zsh preserves historical draft, slash, and native-path behavior
+    tags: [shell, zsh, regression, issue-1721, issue-1811, issue-1919, issue-1932]
+    shell: zsh
+    skip_if_shell_missing: true
+    command: [$COSH_SHELL, raw, cosh-core]
+    env:
+      TERM: xterm-256color
+      COSH_SHELL_WIDTH: "96"
+      COSH_SHELL_ISOLATED: "1"
+      COSH_SHELL_BOOTSTRAP_PATH: "0"
+      COSH_SHELL_HEALTH_SCAN: disabled
+      COSH_RECOMMENDATIONS_ENABLED: "0"
+      COSH_SHELL_LANG: zh-CN
+      COSH_SHELL_RAW_SHELL: zsh
+      COSH_SHELL_DEFAULT_SHELL: zsh
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    input:
+      - type: wait_for
+        text: "cosh-osc$"
+        timeout_ms: 10000
+      - type: line
+        text: /draft
+      - id: zsh-issue-1932-draft
+        type: wait_for
+        text: "Prompt 草稿"
+        timeout_ms: 10000
+      - type: bytes
+        text: "analyze load"
+      - type: bytes
+        hex: 1b5b31333b3275
+      - type: wait_for
+        text: "Shift+Enter 换行"
+        timeout_ms: 10000
+      - type: delay
+        ms: 300
+      - type: bytes
+        text: "and suggest fixes"
+      - type: key
+        name: enter
+      - id: zsh-issue-1721-multiline
+        type: wait_for
+        text: "failed to run cosh-core: No such file or directory"
+        timeout_ms: 10000
+      - type: line
+        text: /mode
+      - type: wait_for
+        text: "审批: auto"
+        occurrence: "+1"
+        timeout_ms: 10000
+      - id: zsh-issue-1811-slash
+        type: wait_quiet
+        quiet_ms: 500
+        timeout_ms: 5000
+      - type: line
+        text: "/bin/echo ISSUE_1919_EXISTING_PATH_NATIVE_OK"
+      - id: zsh-issue-1919-existing-path
+        type: wait_for
+        text: "ISSUE_1919_EXISTING_PATH_NATIVE_OK"
+        occurrence: 2
+        timeout_ms: 10000
+      - type: line
+        text: "/usr/bin/printf 'COSH_SESSION_%s\\n' RECOVERED"
+      - id: zsh-session-recovery
+        type: wait_for
+        text: "COSH_SESSION_RECOVERED"
+        occurrence: 1
+        timeout_ms: 10000
+      - type: delay
+        ms: 1000
+      - type: line
+        text: exit
+    expect:
+      status: 0
+      contains:
+        - "Prompt 草稿"
+        - "failed to run cosh-core: No such file or directory"
+        - "审批: auto"
+        - "ISSUE_1919_EXISTING_PATH_NATIVE_OK"
+        - "COSH_SESSION_RECOVERED"
+      not_contains:
+        - "command not found"
+        - ";2u"
+    evidence:
+      points:
+        - id: zsh-issue-1932-draft
+          trigger_event: zsh-issue-1932-draft
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: zsh-issue-1721-multiline
+          trigger_event: zsh-issue-1721-multiline
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: zsh-issue-1811-slash
+          trigger_event: zsh-issue-1811-slash
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: zsh-issue-1919-existing-path
+          trigger_event: zsh-issue-1919-existing-path
+          layout_sensitive: true
+          required_types: [screenshot]
+        - id: zsh-session-recovery
+          trigger_event: zsh-session-recovery
+          layout_sensitive: true
+          required_types: [screenshot]

--- a/specs/shell-e2e-validation/cases/han-nl-routing.yaml
+++ b/specs/shell-e2e-validation/cases/han-nl-routing.yaml
@@ -15,7 +15,12 @@ defaults:
     - >-
       cd /work/repo/src/cosh-ng &&
       cargo build --locked -p cosh-shell --bin cosh-shell >/dev/null &&
-      exec "$CARGO_TARGET_DIR/debug/cosh-shell" raw cosh-core
+      exec env TERM=xterm-256color COSH_SHELL_WIDTH=96
+      COSH_SHELL_ISOLATED=1 COSH_SHELL_BOOTSTRAP_PATH=0
+      COSH_SHELL_HEALTH_SCAN=disabled COSH_RECOMMENDATIONS_ENABLED=0
+      COSH_SHELL_LANG=zh-CN COSH_SHELL_RAW_SHELL=bash
+      COSH_SHELL_DEFAULT_SHELL=bash LANG=C.UTF-8 LC_ALL=C.UTF-8
+      "$CARGO_TARGET_DIR/debug/cosh-shell" raw cosh-core
 cases:
   - id: HAN-NL-001
     title: Bash routes Han Tier-A, question, and quoted-word prompts to Agent

--- a/src/cosh-ng/crates/cosh-shell/scripts/check-han-nl-routing-stage.sh
+++ b/src/cosh-ng/crates/cosh-shell/scripts/check-han-nl-routing-stage.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stage="${1:-}"
+allow_capability_skip="${2:-}"
+case "$stage" in
+  C0|C1|C2|C3|C4) ;;
+  *) echo "usage: $0 C0|C1|C2|C3|C4 [--allow-capability-skip]" >&2; exit 2 ;;
+esac
+if [[ -n "$allow_capability_skip" && "$allow_capability_skip" != "--allow-capability-skip" ]]; then
+  echo "usage: $0 C0|C1|C2|C3|C4 [--allow-capability-skip]" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+cd "$repo_root"
+
+shell_host_tests="$(cargo test --locked -p cosh-shell --test shell_host -- --list 2>/dev/null)"
+raw_cli_tests=""
+lib_tests="$(cargo test --locked -p cosh-shell --lib -- --list 2>/dev/null)"
+
+require_selector() {
+  local inventory="$1"
+  local selector="$2"
+  [[ "$inventory" == *"$selector"* ]] || {
+    echo "missing required test selector: $selector" >&2
+    exit 1
+  }
+}
+
+require_shell_capabilities() {
+  local bash_major
+  bash_major="$(bash -c 'printf %s "${BASH_VERSINFO[0]:-0}"')"
+  if (( bash_major < 4 )) || ! command -v zsh >/dev/null 2>&1; then
+    if [[ "$allow_capability_skip" == "--allow-capability-skip" ]]; then
+      echo "SKIP: $stage requires Bash >= 4 and Zsh" >&2
+      return 1
+    fi
+    echo "$stage requires Bash >= 4 and Zsh" >&2
+    exit 1
+  fi
+}
+
+run_c0() {
+  require_selector "$shell_host_tests" "input_intent::path_provably_missing_requires_enoent_proof"
+  require_selector "$shell_host_tests" "marker::shell_host_bash_stale_history_guard_still_intercepts_deduped_repeats"
+  require_selector "$shell_host_tests" "relay::raw_relay_bash_invalid_utf8_never_enters_event_provenance"
+  require_selector "$lib_tests" "slash::registry::tests::shell_marker_exact_tokens_match_registry"
+  cargo test --locked -p cosh-shell --test shell_host input_intent::path_provably_missing_requires_enoent_proof -- --exact
+  cargo test --locked -p cosh-shell --test shell_host marker::shell_host_bash_stale_history_guard_still_intercepts_deduped_repeats -- --exact
+  cargo test --locked -p cosh-shell --test shell_host relay::raw_relay_bash_invalid_utf8_never_enters_event_provenance -- --exact
+  cargo test --locked -p cosh-shell --lib shell_marker_exact_tokens_match_registry
+}
+
+run_prefixed_stage() {
+  local prefix="$1"
+  shift
+  require_shell_capabilities || return 0
+  for category in "$@"; do
+    require_selector "$shell_host_tests" "${prefix}${category}"
+  done
+  cargo test --locked -p cosh-shell --test shell_host "$prefix" -- --test-threads=1
+}
+
+run_c0
+[[ "$stage" == C0 ]] && exit 0
+run_prefixed_stage routing_c1_ classifier cnf missing_path stale_history tier_b_side_effect zsh_glob_qualifier valid_han_command
+[[ "$stage" == C1 ]] && exit 0
+run_prefixed_stage routing_c2_ matcher_table bash_quote_cnf zsh_quote_cnf expansion_drift nested_provenance delegate_unsupported valid_quoted_command
+[[ "$stage" == C2 ]] && exit 0
+
+require_shell_capabilities || exit 0
+raw_cli_tests="$(cargo test --locked -p cosh-shell --test raw_cli -- --list 2>/dev/null)"
+for category in typed_passthrough wrapped_paste unwrapped_paste mirror eof_partial_line eof_session_shutdown eof_submitted_no_drift eof_error driver_result signal_status valid_slash provider_no_regression explicit_draft; do
+  if [[ "$shell_host_tests" != *"routing_c3_${category}"* && "$raw_cli_tests" != *"routing_c3_${category}"* ]]; then
+    echo "missing required test selector: routing_c3_${category}" >&2
+    exit 1
+  fi
+done
+cargo test --locked -p cosh-shell --test shell_host routing_c3_ -- --test-threads=1
+cargo test --locked -p cosh-shell --test raw_cli routing_c3_ -- --test-threads=1
+cargo test --locked -p cosh-shell --test raw_cli agent_input -- --test-threads=1
+[[ "$stage" == C3 ]] && exit 0
+
+for category in per_shell_registry zsh_stubs bash_route zsh_rust_route draft_grammar_no_drift history_privacy; do
+  if [[ "$lib_tests" != *"routing_c4_${category}"* && "$shell_host_tests" != *"routing_c4_${category}"* ]]; then
+    echo "missing required test selector: routing_c4_${category}" >&2
+    exit 1
+  fi
+done
+cargo test --locked -p cosh-shell --lib routing_c4_
+cargo test --locked -p cosh-shell --test shell_host routing_c4_ -- --test-threads=1

--- a/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
@@ -2,16 +2,10 @@
 pub struct InputClassifier {
     slash_commands: Vec<String>,
     slash_hint_commands: Vec<String>,
-    conservative: bool,
     ai_enabled: bool,
 }
 
 impl InputClassifier {
-    pub fn with_conservative(mut self, conservative: bool) -> Self {
-        self.conservative = conservative;
-        self
-    }
-
     pub fn with_ai_enabled(mut self, ai_enabled: bool) -> Self {
         self.ai_enabled = ai_enabled;
         self
@@ -27,24 +21,12 @@ impl Default for InputClassifier {
             slash_hint_commands: crate::slash::registry::active_slash_hint_commands()
                 .map(str::to_string)
                 .collect(),
-            conservative: false,
             ai_enabled: true,
         }
     }
 }
 
 impl InputClassifier {
-    pub fn conservative() -> Self {
-        Self {
-            conservative: true,
-            ..Self::default()
-        }
-    }
-
-    pub fn is_conservative(&self) -> bool {
-        self.conservative
-    }
-
     pub(crate) fn ai_enabled(&self) -> bool {
         self.ai_enabled
     }
@@ -311,7 +293,6 @@ mod tests {
     fn ordinary_input_is_always_shell_first() {
         for classifier in [
             InputClassifier::default(),
-            InputClassifier::conservative(),
             InputClassifier::default().with_ai_enabled(false),
         ] {
             for input in [
@@ -360,8 +341,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_intercepts_agent_marker() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_intercepts_agent_marker() {
+        let c = InputClassifier::default();
         assert_eq!(
             c.classify("?? what happened"),
             InputDecision::Intercept {
@@ -372,8 +353,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_intercepts_slash_commands() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_intercepts_slash_commands() {
+        let c = InputClassifier::default();
         assert_eq!(
             c.classify("/explain last error"),
             InputDecision::Intercept {
@@ -391,8 +372,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_sends_natural_language_to_shell() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_sends_natural_language_to_shell() {
+        let c = InputClassifier::default();
         for input in [
             "\u{5e2e}\u{6211}\u{5206}\u{6790}",
             "why is the build failing",
@@ -408,8 +389,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_sends_unknown_commands_to_shell() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_sends_unknown_commands_to_shell() {
+        let c = InputClassifier::default();
         assert_eq!(
             c.classify("git status"),
             InputDecision::SendToShell("git status".to_string())
@@ -429,8 +410,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_rejects_nl_with_flags() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_rejects_nl_with_flags() {
+        let c = InputClassifier::default();
         assert_eq!(
             c.classify("why -v"),
             InputDecision::SendToShell("why -v".to_string())
@@ -442,8 +423,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_rejects_nl_with_paths() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_rejects_nl_with_paths() {
+        let c = InputClassifier::default();
         assert_eq!(
             c.classify("explain /etc/passwd"),
             InputDecision::SendToShell("explain /etc/passwd".to_string())
@@ -459,8 +440,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_rejects_nl_with_shell_metacharacters() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_rejects_nl_with_shell_metacharacters() {
+        let c = InputClassifier::default();
         assert_eq!(
             c.classify("why echo | grep foo"),
             InputDecision::SendToShell("why echo | grep foo".to_string())
@@ -476,8 +457,8 @@ mod tests {
     }
 
     #[test]
-    fn conservative_rejects_non_ascii_with_command_tokens() {
-        let c = InputClassifier::conservative();
+    fn routing_classifier_rejects_non_ascii_with_command_tokens() {
+        let c = InputClassifier::default();
         assert_eq!(
             c.classify("cat \u{8bbe}\u{8ba1}\u{6587}\u{6863}.md"),
             InputDecision::SendToShell("cat \u{8bbe}\u{8ba1}\u{6587}\u{6863}.md".to_string())
@@ -486,12 +467,6 @@ mod tests {
             c.classify("\u{67e5}\u{770b} --help"),
             InputDecision::SendToShell("\u{67e5}\u{770b} --help".to_string())
         );
-    }
-
-    #[test]
-    fn conservative_default_is_false() {
-        let d = InputClassifier::default();
-        assert!(!d.conservative);
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -61,13 +61,6 @@ impl CandidateLineBuffer {
         &self.pending_partial
     }
 
-    /// Drains held partial-delimiter bytes at end of input (#1721):
-    /// they never got a routing verdict, so the relay forwards them to the
-    /// PTY byte-identically instead of dropping them.
-    pub(super) fn take_pending_partial(&mut self) -> Vec<u8> {
-        std::mem::take(&mut self.pending_partial)
-    }
-
     pub(super) fn push(&mut self, bytes: &[u8]) {
         // Re-join any held partial paste delimiter from the previous chunk
         // (#1721): PTY reads may split `\x1b[200~` / `\x1b[201~` at any
@@ -249,21 +242,26 @@ pub(super) struct NativeLineState {
     /// newlines stay in readline's buffer without submitting, which the
     /// single-line mirror cannot express, so they poison it (#1932).
     in_paste: bool,
+    pending_paste_delimiter: Vec<u8>,
+    multiline_paste_observed: bool,
 }
 
 impl NativeLineState {
     fn is_at_line_start(&self) -> bool {
-        self.visible.is_empty()
+        self.is_empty()
     }
 
     pub(super) fn is_empty(&self) -> bool {
         self.visible.is_empty()
+            && !self.dirty
+            && !self.in_paste
+            && self.pending_paste_delimiter.is_empty()
     }
 
     /// The observed prompt-line bytes, only while the mirror is trusted
     /// (#1932 F6): `None` once an unobservable edit poisoned it.
     pub(super) fn clean_visible_line(&self) -> Option<&[u8]> {
-        if self.dirty {
+        if self.dirty || self.in_paste || !self.pending_paste_delimiter.is_empty() {
             None
         } else {
             Some(&self.visible)
@@ -271,6 +269,15 @@ impl NativeLineState {
     }
 
     pub(super) fn observe_shell_bytes(&mut self, bytes: &[u8]) {
+        let joined;
+        let bytes = if self.pending_paste_delimiter.is_empty() {
+            bytes
+        } else {
+            let mut value = std::mem::take(&mut self.pending_paste_delimiter);
+            value.extend_from_slice(bytes);
+            joined = value;
+            joined.as_slice()
+        };
         let mut idx = 0;
         while idx < bytes.len() {
             if bytes[idx..].starts_with(BRACKETED_PASTE_START) {
@@ -283,13 +290,20 @@ impl NativeLineState {
                 idx += BRACKETED_PASTE_END.len();
                 continue;
             }
+            if is_partial_paste_delimiter(&bytes[idx..]) {
+                self.pending_paste_delimiter = bytes[idx..].to_vec();
+                break;
+            }
             if self.in_paste {
                 // Paste payload is inserted verbatim by readline. A pasted
                 // newline keeps composing inside readline's buffer, which
                 // this single-line mirror cannot express: poison it instead
                 // of collapsing the buffer to its last line (#1932).
                 match bytes[idx] {
-                    b'\n' | b'\r' => self.dirty = true,
+                    b'\n' | b'\r' => {
+                        self.dirty = true;
+                        self.multiline_paste_observed = true;
+                    }
                     b'\t' => self.visible.push(b'\t'),
                     byte if byte < 0x20 || byte == 0x7f => self.dirty = true,
                     byte => self.visible.push(byte),
@@ -331,14 +345,21 @@ impl NativeLineState {
             }
         }
         if self.visible.len() > 4096 {
-            self.clear();
+            self.visible.clear();
+            self.dirty = true;
         }
+    }
+
+    pub(super) fn take_multiline_paste_observed(&mut self) -> bool {
+        std::mem::take(&mut self.multiline_paste_observed)
     }
 
     pub(super) fn clear(&mut self) {
         self.visible.clear();
         self.dirty = false;
         self.in_paste = false;
+        self.pending_paste_delimiter.clear();
+        self.multiline_paste_observed = false;
     }
 
     fn pop_visible_char(&mut self) {
@@ -408,24 +429,12 @@ pub(crate) fn redact_extension_setting_value(input: &[u8]) -> Vec<u8> {
     redacted
 }
 
-pub(super) fn starts_intercept_candidate(bytes: &[u8]) -> bool {
-    let first = first_visible_input_byte(bytes);
-    matches!(first, Some(b'/' | b'?'))
-        || first.is_some_and(|byte| byte >= 0x80)
-        // A split paste opener (`\x1b[2`, #1721) must be held so the
-        // payload decides the route; joined non-openers re-scan normally.
-        || (bytes.len() >= 2
-            && bytes.len() < BRACKETED_PASTE_START.len()
-            && BRACKETED_PASTE_START.starts_with(bytes))
-}
-
 pub(super) fn starts_native_intercept_candidate(
     bytes: &[u8],
     native_line_state: &NativeLineState,
 ) -> bool {
-    // Line-start gate for the always-on native candidates: `/` (slash) and
-    // `??` (agent marker). CJK line starts are handled separately because
-    // they additionally require the main-prompt gate (#1721 D16).
+    // Only explicit slash and `??` routes are buffered. Ordinary text and
+    // paste bytes stay owned by the Shell.
     if !native_line_state.is_at_line_start() {
         return false;
     }
@@ -447,59 +456,13 @@ fn is_partial_paste_delimiter(suffix: &[u8]) -> bool {
         && (BRACKETED_PASTE_START.starts_with(suffix) || BRACKETED_PASTE_END.starts_with(suffix))
 }
 
-/// Whether bytes start a CJK natural-language candidate at the beginning of
-/// a shell line (#1721 G9). Callers must additionally hold the main-prompt
-/// gate so PS2/heredoc continuations stay bash-owned (D16).
-pub(super) fn starts_native_cjk_candidate(
-    bytes: &[u8],
-    native_line_state: &NativeLineState,
-) -> bool {
-    native_line_state.is_at_line_start()
-        && first_visible_input_byte(bytes).is_some_and(|byte| byte >= 0x80)
-}
-
-/// A bracketed-paste opener arriving as its own chunk at line start: hold it
-/// in the candidate buffer so the paste payload decides the route (#1721).
-/// Without this the opener leaks to bash and a CJK paste scatters (D13).
-pub(super) fn starts_native_paste_opener(
-    bytes: &[u8],
-    native_line_state: &NativeLineState,
-) -> bool {
-    native_line_state.is_at_line_start()
-        && bytes.starts_with(BRACKETED_PASTE_START)
-        && first_visible_input_bytes(bytes).is_empty()
-}
-
-/// PTY reads may split the opener itself at line start (#1721):
-/// `\x1b[2` alone must be held rather than leak to bash; the joined bytes
-/// re-scan as normal input if they turn out not to be an opener. A bare
-/// ESC is excluded: the spawn-level delay-escape path owns that case.
-pub(super) fn starts_native_partial_paste_opener(
-    bytes: &[u8],
-    native_line_state: &NativeLineState,
-) -> bool {
-    native_line_state.is_at_line_start()
-        && bytes.len() >= 2
-        && bytes.len() < BRACKETED_PASTE_START.len()
-        && BRACKETED_PASTE_START.starts_with(bytes)
-}
-
-/// Whether a native candidate may compose soft newlines: `??` agent drafts
-/// and CJK natural-language drafts may; slash commands may not (#1721 D10).
+/// Only an explicit `??` candidate may compose soft newlines.
 pub(super) fn native_candidate_allows_soft_newline(bytes: &[u8]) -> bool {
     match first_visible_input_byte(bytes) {
         Some(b'/') => false,
         Some(b'?') => first_visible_input_bytes(bytes).starts_with(b"??"),
-        Some(byte) => byte >= 0x80,
-        None => false,
+        _ => false,
     }
-}
-
-/// Escape-path variant: slash commands keep pre-#1721 byte semantics
-/// (pasted newlines submit, never compose); every other candidate
-/// (`?` agent prefix, CJK) may compose (#1721 D10 fail-closed).
-pub(super) fn escape_candidate_allows_soft_newline(bytes: &[u8]) -> bool {
-    !matches!(first_visible_input_byte(bytes), Some(b'/') | None)
 }
 
 fn first_visible_input_byte(bytes: &[u8]) -> Option<u8> {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -19,7 +19,8 @@ pub(crate) use generation::UserPtyInputGeneration;
 pub(crate) use mode::{update_input_mode, update_locked_input_mode, RawInputMode};
 pub use mode::{PromptGhostCandidate, PromptGhostRoute, RawInputCapture, RawObserverAction};
 pub(crate) use pty::{
-    set_pty_winsize, signal_foreground_process_group, signal_process_group, write_all_pty,
+    foreground_process_group_for_fds, process_group_exists, set_pty_winsize,
+    signal_foreground_process_group, signal_process_group, signal_process_group_id, write_all_pty,
 };
 pub use relay_action::RawRelayAction;
 pub(crate) use spawn::{spawn_raw_action_relay, spawn_raw_input_relay};
@@ -32,10 +33,9 @@ pub(super) const ESC: u8 = 0x1b;
 ///
 /// Set by the output side when the shell marker emits `prompt_ready` (PS1
 /// only); cleared whenever user bytes carrying a line submit reach the PTY
-/// or a command starts. CJK line-start candidates may only open while the
-/// gate is up, so PS2 continuations, heredocs, and running commands keep
-/// pre-#1721 byte passthrough (fail-closed: a lost signal disables capture,
-/// never the other way around).
+/// or a command starts. Explicit slash/`??` candidates may only open while
+/// the gate is up, so PS2 continuations, heredocs, and running commands keep
+/// byte passthrough (fail-closed: a lost signal disables capture).
 ///
 /// Ordering: `Relaxed` is sufficient because the gate is a standalone
 /// boolean latch — readers only branch on the flag and never rely on it to
@@ -96,6 +96,10 @@ pub(crate) enum RawInputEvent {
     /// A multi-line bracketed paste was relayed straight to bash (#1932):
     /// feeds the failure-insight multi-line entry hint, observe-only.
     MultilinePasteObserved,
+    /// Input ended while the Shell-owned line could not be proven empty.
+    /// The host must terminate the PTY session out-of-band; writing `exit`
+    /// here could append to and execute the user's partial line.
+    EofShutdownRequested,
     /// #1721 D13: the first soft newline in a candidate upgrades the draft
     /// into the multi-line prompt card; carries the buffered text.
     PromptDraftOpen {
@@ -466,7 +470,7 @@ mod tests {
 
     #[test]
     fn native_slash_candidate_returns_paths_and_tab_to_shell() {
-        let classifier = InputClassifier::conservative();
+        let classifier = InputClassifier::default();
         let mut line = CandidateLineBuffer::default();
 
         line.push(b"/m");

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/pty.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/pty.rs
@@ -24,12 +24,19 @@ pub(crate) fn signal_foreground_process_group(
     fallback_child_pid: u32,
     signal: i32,
 ) -> io::Result<()> {
-    if let Some(process_group) =
-        foreground_process_group(master_fd).or_else(|| foreground_process_group(terminal_fd))
-    {
+    if let Some(process_group) = foreground_process_group_for_fds(master_fd, terminal_fd) {
         return signal_process_group_id(process_group, signal);
     }
     signal_process_group(fallback_child_pid, signal)
+}
+
+pub(crate) fn foreground_process_group_for_fds(master_fd: i32, terminal_fd: i32) -> Option<i32> {
+    foreground_process_group(master_fd).or_else(|| foreground_process_group(terminal_fd))
+}
+
+pub(crate) fn process_group_exists(process_group: i32) -> bool {
+    let result = unsafe { libc::kill(-process_group, 0) };
+    result == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 fn foreground_process_group(fd: i32) -> Option<i32> {
@@ -42,7 +49,7 @@ fn foreground_process_group(fd: i32) -> Option<i32> {
     }
 }
 
-fn signal_process_group_id(process_group: i32, signal: i32) -> io::Result<()> {
+pub(crate) fn signal_process_group_id(process_group: i32, signal: i32) -> io::Result<()> {
     let result = unsafe { libc::kill(-process_group, signal) };
     if result < 0 {
         let err = io::Error::last_os_error();

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
@@ -6,8 +6,9 @@ pub use implementation::{RawInputCapture, RawObserverAction, RawRelayAction};
 
 #[allow(unused_imports)]
 pub(crate) use implementation::{
-    redact_extension_setting_value, set_pty_winsize, signal_foreground_process_group,
-    signal_process_group, spawn_raw_action_relay, spawn_raw_input_relay, update_input_mode,
+    foreground_process_group_for_fds, process_group_exists, redact_extension_setting_value,
+    set_pty_winsize, signal_foreground_process_group, signal_process_group,
+    signal_process_group_id, spawn_raw_action_relay, spawn_raw_input_relay, update_input_mode,
     update_locked_input_mode, write_all_pty, MainPromptGate, PromptDraftEditor, PromptGhostRoute,
     RawInputEvent, RawInputMode, UserPtyInputGeneration,
 };

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -6,18 +6,15 @@ use std::sync::{Arc, Mutex};
 use crate::input::{InputClassifier, InputDecision, InterceptReason};
 
 use super::event_parser::{
-    candidate_inline_hint, candidate_line_status, escape_candidate_allows_soft_newline,
-    native_candidate_allows_soft_newline, native_candidate_should_return_to_shell,
-    redact_extension_setting_value, starts_intercept_candidate, starts_native_cjk_candidate,
-    starts_native_intercept_candidate, starts_native_partial_paste_opener,
-    starts_native_paste_opener, CandidateLineBuffer, CandidateLineStatus, NativeLineState,
+    candidate_inline_hint, candidate_line_status, native_candidate_allows_soft_newline,
+    native_candidate_should_return_to_shell, redact_extension_setting_value,
+    starts_native_intercept_candidate, CandidateLineBuffer, CandidateLineStatus, NativeLineState,
     BRACKETED_PASTE_END, BRACKETED_PASTE_START,
 };
 use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::new_delay_input_mode;
 use super::soft_newline::{
-    contains_soft_newline_sequence, draft_text_from_bytes, render_newline_markers,
-    render_soft_newline_markers,
+    contains_soft_newline_sequence, draft_text_from_bytes, render_soft_newline_markers,
 };
 use super::{write_all_pty, MainPromptGate, PromptGhostRoute, RawInputEvent, RawInputMode, CTRL_C};
 
@@ -77,6 +74,17 @@ pub(super) fn send_shell_input_state(empty: bool, input_events: &Sender<RawInput
     let _ = input_events.send(RawInputEvent::ShellInputActivity { empty });
 }
 
+fn observe_native_line(
+    state: &mut NativeLineState,
+    bytes: &[u8],
+    input_events: &Sender<RawInputEvent>,
+) {
+    state.observe_shell_bytes(bytes);
+    if state.take_multiline_paste_observed() {
+        let _ = input_events.send(RawInputEvent::MultilinePasteObserved);
+    }
+}
+
 pub(super) fn relay_passthrough_input(
     bytes: &[u8],
     relay: &mut InputRelayContext<'_>,
@@ -112,53 +120,7 @@ fn relay_passthrough_input_with_activity(
         redraw_candidate_line(relay.input_events, relay.line_buffer);
         return relay_candidate_line(relay, emit_activity);
     }
-    if relay.input_classifier.is_conservative() {
-        return relay_native_passthrough(bytes, relay, emit_activity);
-    }
-    if relay.line_buffer.is_active() || starts_intercept_candidate(bytes) {
-        // Slash commands never compose: pasted newlines keep the pre-#1721
-        // submit semantics (matrix #17 scope, same rule as native D10). The
-        // held partial delimiter must join the classification input so a
-        // split opener cannot mask a slash prefix (#1721).
-        let combined: Vec<u8> = [
-            relay.line_buffer.bytes.as_slice(),
-            relay.line_buffer.pending_partial_bytes(),
-            bytes,
-        ]
-        .concat();
-        relay.line_buffer.soft_newline_enabled = escape_candidate_allows_soft_newline(&combined);
-        relay.line_buffer.push(bytes);
-        redraw_candidate_line(relay.input_events, relay.line_buffer);
-        return relay_candidate_line(relay, emit_activity);
-    }
-
-    // A gated soft-newline shortcut upgrades the bash-owned line into the
-    // draft card; fallback strips the sequence (#1932 F6). The tip only
-    // fires when no upgrade happened.
-    let handled = handle_prompt_line_soft_newline(bytes, relay)?;
-    if matches!(handled, PromptLineSoftNewline::Upgraded) {
-        return Ok(true);
-    }
-    observe_passthrough_soft_newline(bytes, relay.input_events);
-    let bytes = match &handled {
-        PromptLineSoftNewline::Stripped(stripped) => stripped.as_slice(),
-        _ => bytes,
-    };
-    send_raw_input_events(bytes, relay.input_events);
-    relay.native_line_state.observe_shell_bytes(bytes);
-    if emit_activity && !bytes.is_empty() {
-        send_shell_input_state(relay.native_line_state.is_empty(), relay.input_events);
-    }
-    relay.exit_tracker.observe_shell_bytes(bytes);
-    write_user_bytes_to_pty(
-        relay.master,
-        relay.input_generation,
-        relay.line_submits,
-        relay.input_events,
-        relay.main_prompt_gate,
-        bytes,
-    )?;
-    Ok(false)
+    relay_native_passthrough(bytes, relay, emit_activity)
 }
 
 pub(super) fn relay_prompt_ghost_input(
@@ -233,9 +195,11 @@ pub(super) fn relay_prompt_ghost_input(
                 if let Ok(mut mode) = relay.input_mode.lock() {
                     *mode = RawInputMode::RawPassthrough;
                 }
-                relay
-                    .native_line_state
-                    .observe_shell_bytes(ghost_text.as_bytes());
+                observe_native_line(
+                    relay.native_line_state,
+                    ghost_text.as_bytes(),
+                    relay.input_events,
+                );
                 relay
                     .exit_tracker
                     .observe_shell_bytes(ghost_text.as_bytes());
@@ -249,7 +213,7 @@ pub(super) fn relay_prompt_ghost_input(
                 )?;
                 if !remainder.is_empty() {
                     send_raw_input_events(remainder, relay.input_events);
-                    relay.native_line_state.observe_shell_bytes(remainder);
+                    observe_native_line(relay.native_line_state, remainder, relay.input_events);
                     relay.exit_tracker.observe_shell_bytes(remainder);
                     write_user_bytes_to_pty(
                         relay.master,
@@ -345,12 +309,12 @@ fn relay_native_passthrough(
     relay: &mut InputRelayContext<'_>,
     emit_activity: bool,
 ) -> io::Result<bool> {
+    let starts_paste = bytes.starts_with(BRACKETED_PASTE_START)
+        || (bytes.len() >= 2
+            && bytes.len() < BRACKETED_PASTE_START.len()
+            && BRACKETED_PASTE_START.starts_with(bytes));
     if relay.line_buffer.is_active()
-        || starts_native_intercept_candidate(bytes, relay.native_line_state)
-        || (relay.main_prompt_gate.is_at_prompt()
-            && (starts_native_cjk_candidate(bytes, relay.native_line_state)
-                || starts_native_paste_opener(bytes, relay.native_line_state)
-                || starts_native_partial_paste_opener(bytes, relay.native_line_state)))
+        || (!starts_paste && starts_native_intercept_candidate(bytes, relay.native_line_state))
     {
         // Route flags must consider the whole draft so far: a bracketed
         // paste opener may arrive as its own chunk (or split mid-delimiter,
@@ -384,7 +348,7 @@ fn relay_native_passthrough(
         _ => bytes,
     };
     send_raw_input_events(bytes, relay.input_events);
-    relay.native_line_state.observe_shell_bytes(bytes);
+    observe_native_line(relay.native_line_state, bytes, relay.input_events);
     if emit_activity && !bytes.is_empty() {
         send_shell_input_state(relay.native_line_state.is_empty(), relay.input_events);
     }
@@ -449,28 +413,20 @@ fn relay_candidate_line(
                 return Ok(true);
             }
             if line.contains('\n') {
-                // Soft newlines only originate from prompt composition inside
-                // the candidate buffer, so multi-line text always routes to
-                // the agent before classification (#1721 D7). Whitespace-only
-                // drafts are consumed instead of submitting an empty prompt.
                 if line.trim().is_empty() {
                     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
                     send_shell_input_state(true, relay.input_events);
                 } else {
-                    let reason = if line.trim_start().starts_with("??") {
-                        InterceptReason::AgentMarker
-                    } else {
-                        InterceptReason::NaturalLanguage
-                    };
                     let _ = relay.input_events.send(RawInputEvent::CandidateCommit(
-                        render_newline_markers(&redact_extension_setting_value(line.as_bytes())),
+                        redact_extension_setting_value(line.as_bytes()),
                     ));
                     if let Ok(mut mode) = relay.input_mode.lock() {
                         *mode = new_delay_input_mode();
                     }
-                    let _ = relay
-                        .input_events
-                        .send(RawInputEvent::UserIntercept(line, reason));
+                    let _ = relay.input_events.send(RawInputEvent::UserIntercept(
+                        line,
+                        InterceptReason::AgentMarker,
+                    ));
                     send_shell_input_state(true, relay.input_events);
                 }
                 if !remainder.is_empty() {
@@ -587,7 +543,7 @@ fn submit_line_bytes_to_shell(
 ) -> io::Result<bool> {
     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
     send_raw_input_events(&bytes, relay.input_events);
-    relay.native_line_state.observe_shell_bytes(&bytes);
+    observe_native_line(relay.native_line_state, &bytes, relay.input_events);
     if emit_activity && !bytes.is_empty() {
         send_shell_input_state(relay.native_line_state.is_empty(), relay.input_events);
     }
@@ -650,31 +606,6 @@ fn redraw_candidate_line(
 fn observe_passthrough_soft_newline(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
     if contains_soft_newline_sequence(bytes) {
         let _ = input_events.send(RawInputEvent::SoftNewlineShortcutObserved);
-    }
-    observe_passthrough_multiline_paste(bytes, input_events);
-}
-
-/// #1932 F5: a bracketed paste with embedded newlines relayed straight to
-/// bash line-executes on paste-unaware readline setups. Observe-only:
-/// best-effort single-chunk scan feeding the failure-insight hint; never
-/// touches the relayed bytes.
-fn observe_passthrough_multiline_paste(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
-    let Some(start) = bytes
-        .windows(BRACKETED_PASTE_START.len())
-        .position(|window| window == BRACKETED_PASTE_START)
-    else {
-        return;
-    };
-    let payload = &bytes[start + BRACKETED_PASTE_START.len()..];
-    let payload_end = payload
-        .windows(BRACKETED_PASTE_END.len())
-        .position(|window| window == BRACKETED_PASTE_END)
-        .unwrap_or(payload.len());
-    if payload[..payload_end]
-        .iter()
-        .any(|byte| matches!(byte, b'\r' | b'\n'))
-    {
-        let _ = input_events.send(RawInputEvent::MultilinePasteObserved);
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -284,7 +284,8 @@ fn delay_escape_sequence_is_forwarded_without_cancel() {
         !events.contains(&RawInputEvent::Esc),
         "unexpected Esc event for arrow sequence"
     );
-    assert_eq!(output, b"\x1b[Aexit\n");
+    assert_eq!(output, b"\x1b[A");
+    assert!(events.contains(&RawInputEvent::EofShutdownRequested));
     assert!(matches!(mode, RawInputMode::Delay { .. }));
 }
 
@@ -300,7 +301,8 @@ fn delay_split_escape_sequence_is_forwarded_without_cancel() {
         !events.contains(&RawInputEvent::Esc),
         "unexpected Esc event for split arrow sequence"
     );
-    assert_eq!(output, b"\x1b[Aexit\n");
+    assert_eq!(output, b"\x1b[A");
+    assert!(events.contains(&RawInputEvent::EofShutdownRequested));
     assert!(matches!(mode, RawInputMode::Delay { .. }));
 }
 
@@ -316,7 +318,8 @@ fn delay_escape_is_forwarded_when_run_finishes_before_deadline() {
         !events.contains(&RawInputEvent::Esc),
         "unexpected Esc event after run finished"
     );
-    assert_eq!(output, b"\x1bxexit\n");
+    assert_eq!(output, b"\x1bx");
+    assert!(events.contains(&RawInputEvent::EofShutdownRequested));
     assert!(matches!(mode, RawInputMode::Passthrough));
 }
 
@@ -825,7 +828,8 @@ fn prompt_ghost_candidate_cycle_during_read_does_not_drop_input() {
         "{events:?}"
     );
     master.sync_all().expect("sync test output");
-    assert_eq!(fs::read(&path).expect("read test output"), b"xexit\n");
+    assert_eq!(fs::read(&path).expect("read test output"), b"x");
+    assert!(events.contains(&RawInputEvent::EofShutdownRequested));
     fs::remove_file(path).ok();
 }
 
@@ -1055,10 +1059,8 @@ fn tab_after_route_cutover_is_relayed_under_the_new_route() {
         "{events:?}"
     );
     master.sync_all().expect("sync test output");
-    assert_eq!(
-        fs::read(&path).expect("read test output"),
-        b"echo nativeexit\n"
-    );
+    assert_eq!(fs::read(&path).expect("read test output"), b"echo native");
+    assert!(events.contains(&RawInputEvent::EofShutdownRequested));
     fs::remove_file(path).ok();
 }
 
@@ -1213,7 +1215,7 @@ fn selection_bare_escape_times_out_without_waiting_for_another_key() {
     drop(input_tx);
     relay.join().expect("relay thread").expect("relay result");
     master.sync_all().expect("sync test output");
-    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bexit\n");
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1b");
     fs::remove_file(path).ok();
 }
 
@@ -1255,7 +1257,7 @@ fn selection_action_wait_flushes_escape_at_the_deadline() {
 
     relay.join().expect("relay thread").expect("relay result");
     master.sync_all().expect("sync test output");
-    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bexit\n");
+    assert_eq!(fs::read(&path).expect("read test output"), b"\x1b");
     fs::remove_file(path).ok();
 }
 
@@ -1270,10 +1272,8 @@ fn selection_shift_tab_cycles_when_arriving_in_one_chunk() {
     assert!(events.contains(&RawInputEvent::PromptGhostCycle {
         text: "continue deployment".to_string(),
     }));
-    assert!(matches!(
-        mode,
-        RawInputMode::PromptGhost { text, .. } if text == "continue deployment"
-    ));
+    assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
+    assert!(matches!(mode, RawInputMode::Passthrough));
 }
 
 #[test]
@@ -1364,7 +1364,8 @@ fn selection_escape_with_nonmatching_follow_up_dismisses_and_forwards_all_bytes(
 
     let (events, output, mode) = relay.finish();
 
-    assert_eq!(output, b"\x1bxexit\n");
+    assert_eq!(output, b"\x1bx");
+    assert!(events.contains(&RawInputEvent::EofShutdownRequested));
     assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
     assert!(!events
         .iter()
@@ -1378,25 +1379,27 @@ fn selection_partial_csi_times_out_and_forwards_all_bytes() {
     relay.send(b"\x1b[");
     expect_prompt_ghost_dismissal(&relay.event_rx);
 
-    let (_, output, mode) = relay.finish();
-    assert_eq!(output, b"\x1b[exit\n");
+    let (events, output, mode) = relay.finish();
+    assert_eq!(output, b"\x1b[");
+    assert!(events.contains(&RawInputEvent::EofShutdownRequested));
     assert!(matches!(mode, RawInputMode::Passthrough));
 }
 
 #[test]
-fn selection_pending_escape_at_eof_dismisses_and_forwards_escape() {
+fn selection_pending_escape_at_eof_is_cancelled_before_exit() {
     let relay = SelectionRelay::start("selection-escape-eof");
     relay.send(b"\x1b");
 
     let (events, output, mode) = relay.finish();
 
-    assert_eq!(output, b"\x1bexit\n");
+    assert_eq!(output, b"exit\n");
+    assert!(!events.contains(&RawInputEvent::EofShutdownRequested));
     assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
     assert!(matches!(mode, RawInputMode::Passthrough));
 }
 
 #[test]
-fn selection_pending_escape_at_eof_after_route_change_is_not_dropped() {
+fn selection_pending_escape_at_eof_after_route_change_is_cancelled() {
     let (path, mut master) = output_file("selection-escape-route-eof");
     let (tx, rx) = mpsc::channel();
     let old_route = PromptGhostRoute::AgentSelection {
@@ -1435,10 +1438,10 @@ fn selection_pending_escape_at_eof_after_route_change_is_not_dropped() {
     finish_input_relay(&mut master, &tx, &classifier, &input_mode, &mut state)
         .expect("finish relay");
 
-    assert_eq!(fs::read(&path).expect("read test output"), b"\x1bexit\n");
-    assert!(rx
-        .try_iter()
-        .any(|event| event == RawInputEvent::PromptGhostDismissed));
+    assert_eq!(fs::read(&path).expect("read test output"), b"exit\n");
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(events.contains(&RawInputEvent::PromptGhostDismissed));
+    assert!(!events.contains(&RawInputEvent::EofShutdownRequested));
     assert!(matches!(
         *input_mode.lock().expect("input mode"),
         RawInputMode::Passthrough
@@ -1877,7 +1880,7 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2309,10 +2312,8 @@ fn passthrough_relay_fixture<'a>(
     }
 }
 
-// Matrix #15 (#1721): a soft-newline draft submits as one multi-line agent
-// prompt; the commit echo shows markers and nothing reaches the shell.
 #[test]
-fn soft_newline_draft_routes_multiline_prompt_to_agent() {
+fn routing_c3_explicit_draft_upgrade_clears_the_shell_copy() {
     let (path, mut master) = output_file("soft-newline-agent");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
@@ -2338,43 +2339,35 @@ fn soft_newline_draft_routes_multiline_prompt_to_agent() {
     );
 
     relay_passthrough_input("请帮我分析系统负载".as_bytes(), &mut relay)
-        .expect("buffer natural-language draft");
+        .expect("relay Shell-owned Han input");
     relay_passthrough_input(b"\x1b[13;2u", &mut relay).expect("soft newline");
 
     let events = rx.try_iter().collect::<Vec<_>>();
-    let clear_at = events
-        .iter()
-        .position(|event| matches!(event, RawInputEvent::CandidateClearLine))
-        .expect("clear inline echo before the card opens");
-    let open_at = events
-        .iter()
-        .position(|event| {
+    assert!(
+        events.iter().any(|event| {
             matches!(
                 event,
                 RawInputEvent::PromptDraftOpen { text } if text == "请帮我分析系统负载\n"
             )
-        })
-        .expect("soft newline must upgrade the draft to the prompt card");
-    assert!(clear_at < open_at, "erase first, then open: {events:?}");
+        }),
+        "soft newline must upgrade the shell line: {events:?}"
+    );
     assert!(
         !events
             .iter()
             .any(|event| matches!(event, RawInputEvent::UserIntercept(..))),
         "upgrade must not submit early: {events:?}"
     );
-    assert!(!line_buffer.is_active(), "buffer hands off to the card");
-    assert_eq!(
-        fs::read(&path).expect("read test output"),
-        b"",
-        "nothing may reach the shell"
-    );
+    let mut expected = "请帮我分析系统负载".as_bytes().to_vec();
+    expected.extend_from_slice(&[super::super::CTRL_U, b'\r']);
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
     fs::remove_file(path).ok();
 }
 
 // Matrix #19 (#1721): a whitespace-only multi-line draft is consumed
 // without submitting an empty prompt.
 #[test]
-fn whitespace_only_soft_newline_draft_is_consumed() {
+fn routing_c3_explicit_whitespace_upgrade_uses_the_shell_mirror() {
     let (path, mut master) = output_file("soft-newline-empty");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
@@ -2412,7 +2405,6 @@ fn whitespace_only_soft_newline_draft_is_consumed() {
             .any(|event| matches!(event, RawInputEvent::UserIntercept(..))),
         "whitespace draft must not submit: {events:?}"
     );
-    assert!(events.contains(&RawInputEvent::CandidateClearLine));
     assert!(
         events.iter().any(|event| matches!(
             event,
@@ -2420,7 +2412,9 @@ fn whitespace_only_soft_newline_draft_is_consumed() {
         )),
         "whitespace draft still opens the card: {events:?}"
     );
-    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    let mut expected = "\u{3000}".as_bytes().to_vec();
+    expected.extend_from_slice(&[super::super::CTRL_U, b'\r']);
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
     assert!(!line_buffer.is_active());
     fs::remove_file(path).ok();
 }
@@ -2429,7 +2423,7 @@ fn whitespace_only_soft_newline_draft_is_consumed() {
 // contains a soft newline, and the redraw shows the marker instead of raw
 // sequence bytes.
 #[test]
-fn soft_newline_redraw_carries_marker_and_hint() {
+fn routing_c3_explicit_upgrade_does_not_require_candidate_redraw() {
     let (path, mut master) = output_file("soft-newline-hint");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
@@ -2473,7 +2467,9 @@ fn soft_newline_redraw_carries_marker_and_hint() {
             assert!(!display.contains(";2u"), "no literal leak: {display}");
         }
     }
-    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    let mut expected = "请帮我分析".as_bytes().to_vec();
+    expected.extend_from_slice(&[super::super::CTRL_U, b'\r']);
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
     fs::remove_file(path).ok();
 }
 
@@ -2530,7 +2526,7 @@ fn native_cjk_single_line_flushes_bytes_unchanged() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2572,14 +2568,14 @@ fn native_cjk_single_line_flushes_bytes_unchanged() {
 // Matrix #22 (#1721 G9): a native CJK draft with a soft newline submits one
 // multi-line NL prompt and never reaches bash.
 #[test]
-fn native_cjk_multiline_draft_intercepts_as_prompt() {
+fn routing_c3_typed_cjk_then_explicit_upgrade_uses_shell_mirror() {
     let (path, mut master) = output_file("native-cjk-multi");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2608,7 +2604,9 @@ fn native_cjk_multiline_draft_intercepts_as_prompt() {
         )),
         "native CJK soft newline must open the card: {events:?}"
     );
-    assert_eq!(fs::read(&path).expect("read test output"), b"");
+    let mut expected = "请帮我分析".as_bytes().to_vec();
+    expected.extend_from_slice(&[super::super::CTRL_U, b'\r']);
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
     fs::remove_file(path).ok();
 }
 
@@ -2622,7 +2620,7 @@ fn native_agent_marker_multiline_keeps_reason() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2664,7 +2662,7 @@ fn native_midline_cjk_stays_passthrough() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2711,7 +2709,7 @@ fn native_cjk_tab_returns_draft_to_shell() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2757,7 +2755,7 @@ fn cjk_line_start_stays_passthrough_when_gate_is_down() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2810,7 +2808,7 @@ fn submit_lowers_gate_until_next_prompt_ready() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2844,17 +2842,15 @@ fn submit_lowers_gate_until_next_prompt_ready() {
     drop(rx);
     fs::remove_file(path).ok();
 }
-// Matrix #6 under D13: a CJK bracketed paste opens the draft card even when
-// the terminal splits the paste into opener / payload / closer chunks.
 #[test]
-fn native_split_paste_chunks_open_the_draft_card() {
+fn routing_c3_wrapped_multiline_paste_stays_shell_owned_across_chunks() {
     let (path, mut master) = output_file("native-paste-split");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -2881,32 +2877,26 @@ fn native_split_paste_chunks_open_the_draft_card() {
     master.sync_all().expect("sync test output");
 
     let events = rx.try_iter().collect::<Vec<_>>();
-    assert!(
-        events.iter().any(|event| matches!(
-            event,
-            RawInputEvent::PromptDraftOpen { text } if text == "分析负载\n给出建议"
-        )),
-        "split paste must open the card with both lines: {events:?}"
-    );
+    assert!(events.contains(&RawInputEvent::MultilinePasteObserved));
     assert!(
         !events
             .iter()
             .any(|event| matches!(event, RawInputEvent::UserIntercept(..))),
-        "paste must not submit early: {events:?}"
+        "ordinary paste must not become Agent-owned: {events:?}"
     );
-    assert_eq!(
-        fs::read(&path).expect("read test output"),
-        b"",
-        "nothing may reach the shell"
-    );
+    let mut expected = b"\x1b[200~".to_vec();
+    expected.extend_from_slice("分析负载".as_bytes());
+    expected.extend_from_slice(b"\r\n");
+    expected.extend_from_slice("给出建议".as_bytes());
+    expected.extend_from_slice(b"\x1b[201~");
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
     fs::remove_file(path).ok();
 }
 
-// Regression (raw_cli_pasted_trust_confirm_sets_trust_mode): a pasted slash
-// command with a trailing newline submits like before the fix and never
-// upgrades into the draft card (matrix #17 scope: slash never composes).
+// A pasted slash command remains Shell-owned and never upgrades into the
+// draft card; native bracketed-paste semantics require Enter after the closer.
 #[test]
-fn escape_pasted_slash_command_submits_without_card() {
+fn routing_c3_wrapped_slash_paste_stays_shell_owned() {
     let (path, mut master) = output_file("escape-slash-paste");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
@@ -2954,8 +2944,8 @@ fn escape_pasted_slash_command_submits_without_card() {
                     if input == "/mode approval trust confirm"
             ))
             .count(),
-        2,
-        "both pastes must submit as slash: {events:?}"
+        0,
+        "ordinary paste must not enter slash ownership: {events:?}"
     );
     assert!(
         !events
@@ -2966,19 +2956,17 @@ fn escape_pasted_slash_command_submits_without_card() {
     fs::remove_file(path).ok();
 }
 
-// ASCII paste routing (#1721): an ASCII paste whose opener arrives as its own chunk must not
-// leak the payload to the PTY bare — the candidate stays open across the
-// split and the flush replays the bracketed-paste wrapper so bash inserts
-// the bytes instead of executing embedded newlines.
+// ASCII paste routing (#1721): a split opener remains Shell-owned and the
+// wrapper reaches the PTY byte-for-byte, so bash buffers embedded newlines.
 #[test]
-fn native_split_ascii_paste_replays_wrapper_to_shell() {
+fn native_split_ascii_paste_passes_wrapper_to_shell() {
     let (path, mut master) = output_file("native-paste-ascii-split");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3003,13 +2991,7 @@ fn native_split_ascii_paste_replays_wrapper_to_shell() {
     master.sync_all().expect("sync test output");
 
     let written = fs::read(&path).expect("read test output");
-    if !written.is_empty() {
-        assert!(
-            written.starts_with(b"\x1b[200~"),
-            "flushed paste must replay the wrapper so bash defers execution: {:?}",
-            String::from_utf8_lossy(&written)
-        );
-    }
+    assert_eq!(written, b"\x1b[200~touch probe\r\n\x1b[201~");
     let events = rx.try_iter().collect::<Vec<_>>();
     assert!(
         !events
@@ -3020,18 +3002,15 @@ fn native_split_ascii_paste_replays_wrapper_to_shell() {
     fs::remove_file(path).ok();
 }
 
-// Split line-start opener (#1721): the line-start opener itself may split across
-// reads; the partial delimiter must be held at the relay entry instead of
-// leaking to bash, and the joined paste routes exactly like an unsplit one.
 #[test]
-fn native_split_line_start_opener_opens_the_draft_card() {
+fn routing_c3_split_paste_delimiter_is_byte_identical_and_shell_owned() {
     let (path, mut master) = output_file("native-split-opener");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3059,19 +3038,20 @@ fn native_split_line_start_opener_opens_the_draft_card() {
     let _ = relay;
     master.sync_all().expect("sync test output");
 
-    assert_eq!(
-        fs::read(&path).expect("read test output"),
-        b"",
-        "split opener must never leak payload to the shell"
-    );
+    let mut expected = b"\x1b[200~".to_vec();
+    expected.extend_from_slice("分析负载".as_bytes());
+    expected.extend_from_slice(b"\r\n");
+    expected.extend_from_slice("给出建议".as_bytes());
+    expected.extend_from_slice(b"\x1b[201~");
+    assert_eq!(fs::read(&path).expect("read test output"), expected);
     let events = rx.try_iter().collect::<Vec<_>>();
     assert!(
-        events.iter().any(|event| matches!(
-            event,
-            RawInputEvent::PromptDraftOpen { text } if text == "分析负载\n给出建议"
-        )),
-        "split opener paste must open the card with both lines: {events:?}"
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftOpen { .. })),
+        "ordinary split paste must stay Shell-owned: {events:?}"
     );
+    assert!(events.contains(&RawInputEvent::MultilinePasteObserved));
     fs::remove_file(path).ok();
 }
 
@@ -3086,7 +3066,7 @@ fn native_typed_qq_then_paste_composes_in_card() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3139,7 +3119,7 @@ fn native_lone_question_mark_flushes_back_to_shell() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3177,6 +3157,42 @@ fn native_lone_question_mark_flushes_back_to_shell() {
     fs::remove_file(path).ok();
 }
 
+#[test]
+fn routing_c3_eof_candidate_prefix_is_cancelled_before_clean_exit() {
+    for (label, bytes) in [
+        ("question", b"?".as_slice()),
+        ("slash", b"/mode".as_slice()),
+    ] {
+        let (path, mut master) = output_file(label);
+        let (tx, rx) = mpsc::channel();
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+        let classifier = InputClassifier::default();
+        let mut state = RawInputRelayState::default();
+
+        relay_input_bytes(
+            bytes,
+            Instant::now(),
+            &mut master,
+            &tx,
+            &classifier,
+            &input_mode,
+            &mut state,
+        )
+        .expect("buffer explicit prefix");
+        finish_input_relay(&mut master, &tx, &classifier, &input_mode, &mut state)
+            .expect("cancel prefix at EOF");
+
+        assert_eq!(fs::read(&path).expect("read test output"), b"exit\n");
+        let events = rx.try_iter().collect::<Vec<_>>();
+        assert!(events.contains(&RawInputEvent::CandidateClearLine));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::UserIntercept(..) | RawInputEvent::EofShutdownRequested
+        )));
+        fs::remove_file(path).ok();
+    }
+}
+
 // Lone `??` + Enter (#1932): the terminal-agnostic entry opens an empty
 // draft card instead of submitting an empty agent prompt.
 #[test]
@@ -3187,7 +3203,7 @@ fn native_lone_qq_enter_opens_empty_draft() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3238,7 +3254,7 @@ fn native_prompt_line_shortcut_upgrades_the_line() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3288,7 +3304,7 @@ fn native_dirty_line_shortcut_is_stripped() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3332,7 +3348,7 @@ fn native_multiline_paste_marks_mirror_dirty() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3386,7 +3402,7 @@ fn native_delete_at_line_end_keeps_the_mirror() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
@@ -3423,66 +3439,58 @@ fn native_delete_at_line_end_keeps_the_mirror() {
 
 #[test]
 fn native_exact_slash_routes_to_shell_when_at_prompt() {
-    // Covers both relay classifier flavors (issue #1718 G4): conservative is
-    // the production default, non-conservative the explicit opt-out.
-    for conservative in [true, false] {
-        let label = format!("slash-route-exact-{conservative}");
-        let (path, mut master) = output_file(&label);
-        let (tx, rx) = mpsc::channel();
-        let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
-        let main_prompt_gate = super::super::MainPromptGate::default();
-        main_prompt_gate.set_at_prompt(true);
-        let mut line_buffer = CandidateLineBuffer::default();
-        let mut native_line_state = NativeLineState::default();
-        let mut exit_tracker = ExplicitExitTracker::default();
-        let classifier = if conservative {
-            InputClassifier::conservative()
-        } else {
-            InputClassifier::default()
-        };
-        let input_generation = UserPtyInputGeneration::default();
-        let mut line_submits = LineSubmitCounter::default();
-        let mut relay = InputRelayContext {
-            master: &mut master,
-            input_classifier: &classifier,
-            input_events: &tx,
-            input_mode: &input_mode,
-            input_generation: &input_generation,
-            line_submits: &mut line_submits,
-            line_buffer: &mut line_buffer,
-            native_line_state: &mut native_line_state,
-            exit_tracker: &mut exit_tracker,
-            main_prompt_gate: &main_prompt_gate,
-            slash_route_enabled: true,
-        };
+    let label = "slash-route-exact";
+    let (path, mut master) = output_file(label);
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: true,
+    };
 
-        relay_passthrough_input(b"/mode approval\n", &mut relay).expect("route exact slash");
-        master.sync_all().expect("sync test output");
+    relay_passthrough_input(b"/mode approval\n", &mut relay).expect("route exact slash");
+    master.sync_all().expect("sync test output");
 
-        let events = rx.try_iter().collect::<Vec<_>>();
-        // Routed submissions leave interception to the shell marker: no
-        // Rust-side intercept or commit events, bytes written to the PTY.
-        assert!(events
-            .iter()
-            .all(|event| !matches!(event, RawInputEvent::UserIntercept(..))));
-        assert!(events
-            .iter()
-            .all(|event| !matches!(event, RawInputEvent::CandidateCommit(..))));
-        assert!(events.contains(&RawInputEvent::CandidateClearLine));
-        assert_eq!(
-            fs::read(&path).expect("read test output"),
-            b"/mode approval\n"
-        );
-        // The submission lowers the prompt gate until the next prompt_ready
-        // marker (#1721 D16), so racing follow-up slash bytes fall back to
-        // the Rust intercept path.
-        assert!(!main_prompt_gate.is_at_prompt());
-        assert!(matches!(
-            *input_mode.lock().expect("input mode"),
-            RawInputMode::Passthrough
-        ));
-        fs::remove_file(path).ok();
-    }
+    let events = rx.try_iter().collect::<Vec<_>>();
+    // Routed submissions leave interception to the shell marker: no
+    // Rust-side intercept or commit events, bytes written to the PTY.
+    assert!(events
+        .iter()
+        .all(|event| !matches!(event, RawInputEvent::UserIntercept(..))));
+    assert!(events
+        .iter()
+        .all(|event| !matches!(event, RawInputEvent::CandidateCommit(..))));
+    assert!(events.contains(&RawInputEvent::CandidateClearLine));
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"/mode approval\n"
+    );
+    // The submission lowers the prompt gate until the next prompt_ready
+    // marker (#1721 D16), so racing follow-up slash bytes fall back to
+    // the Rust intercept path.
+    assert!(!main_prompt_gate.is_at_prompt());
+    assert!(matches!(
+        *input_mode.lock().expect("input mode"),
+        RawInputMode::Passthrough
+    ));
+    fs::remove_file(path).ok();
 }
 
 #[test]
@@ -3494,7 +3502,7 @@ fn native_exact_slash_falls_back_to_rust_intercept_when_not_at_prompt() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
@@ -3539,7 +3547,7 @@ fn native_shell_submission_lowers_gate_before_follow_up_slash() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {
@@ -3584,7 +3592,7 @@ fn native_hint_prefix_slash_keeps_rust_intercept_when_routed() {
     let mut line_buffer = CandidateLineBuffer::default();
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
-    let classifier = InputClassifier::conservative();
+    let classifier = InputClassifier::default();
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let mut relay = InputRelayContext {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/soft_newline.rs
@@ -99,21 +99,6 @@ pub(super) fn render_soft_newline_markers(bytes: &[u8]) -> Vec<u8> {
     rendered
 }
 
-/// Replaces real newlines in committed text with the display marker for the
-/// commit echo. Data events (`UserIntercept`) keep the real newlines.
-pub(super) fn render_newline_markers(bytes: &[u8]) -> Vec<u8> {
-    let marker = display_marker();
-    let mut rendered = Vec::with_capacity(bytes.len());
-    for byte in bytes {
-        if *byte == b'\n' {
-            rendered.extend_from_slice(marker);
-        } else {
-            rendered.push(*byte);
-        }
-    }
-    rendered
-}
-
 fn display_marker() -> &'static [u8] {
     if utf8_locale() {
         b"\x1b[2m\xe2\x8f\x8e\x1b[22m" // dim ⏎

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -407,35 +407,23 @@ pub(in super::super) fn finish_input_relay(
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
 ) -> io::Result<()> {
-    flush_pending_prompt_ghost_escape(
-        true,
-        Instant::now(),
-        master,
-        input_events,
-        input_classifier,
-        input_mode,
-        state,
-    )?;
-    super::action::flush_pending_delay_escape(
-        true,
-        Instant::now(),
-        master,
-        input_events,
-        input_classifier,
-        input_mode,
-        state,
-    )?;
-    let mode = current_raw_input_mode(input_mode);
-    flush_pending_replaced_prompt_ghost_suffix(
-        true,
-        Instant::now(),
-        &mode,
-        master,
-        input_events,
-        input_classifier,
-        input_mode,
-        state,
-    )?;
+    // EOF is cancellation, not the timeout path. Pending escape/suffix bytes
+    // are Cosh-owned lookahead and must never become PTY input during
+    // shutdown.
+    let current_mode = current_raw_input_mode(input_mode);
+    let dismiss_prompt_ghost = state.pending_prompt_ghost_escape.take().is_some()
+        || state.pending_replaced_prompt_ghost_suffix.take().is_some()
+        || matches!(current_mode, RawInputMode::PromptGhost { .. });
+    state.pending_delay_escape.take();
+    if dismiss_prompt_ghost {
+        let _ = input_events.send(RawInputEvent::CandidateClearLine);
+        let _ = input_events.send(RawInputEvent::PromptGhostDismissed);
+        if matches!(current_mode, RawInputMode::PromptGhost { .. }) {
+            if let Ok(mut mode) = input_mode.lock() {
+                *mode = RawInputMode::Passthrough;
+            }
+        }
+    }
     if let RawInputMode::Submitted { generation, .. } = current_raw_input_mode(input_mode) {
         expire_capture_submission(input_mode, generation);
     }
@@ -469,21 +457,17 @@ pub(in super::super) fn finish_input_relay(
         };
         drain_abandoned_capture(capture_owned_input, &mut relay)?;
     }
-    // Bytes held as a possible split paste delimiter never got a routing
-    // verdict: forward them byte-identically before the trailing exit
-    // (#1721; keeps partial CSI passthrough guarantees at EOF).
-    let held_partial = state.line_buffer.take_pending_partial();
-    if !held_partial.is_empty() {
-        write_user_bytes_to_pty(
-            master,
-            &state.input_generation,
-            &mut state.line_submits,
-            input_events,
-            &state.main_prompt_gate,
-            &held_partial,
-        )?;
+    // Candidate bytes were never submitted to the Shell. EOF cancels them;
+    // flushing a lone `?`, slash prefix, or partial paste delimiter before
+    // `exit` would turn display state into executable input.
+    if state.line_buffer.is_active() {
+        state.line_buffer.clear();
+        let _ = input_events.send(RawInputEvent::CandidateClearLine);
     }
-    if !state.exit_tracker.saw_explicit_exit() {
+    if state.exit_tracker.saw_explicit_exit() {
+        return Ok(());
+    }
+    if state.native_line_state.is_empty() {
         write_user_bytes_to_pty(
             master,
             &state.input_generation,
@@ -492,6 +476,8 @@ pub(in super::super) fn finish_input_relay(
             &state.main_prompt_gate,
             b"exit\n",
         )?;
+    } else {
+        let _ = input_events.send(RawInputEvent::EofShutdownRequested);
     }
     Ok(())
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
@@ -354,6 +354,9 @@ fn ghost_suffix_does_not_consume_input_from_a_new_capture_generation() {
     );
     finish_input_relay(&mut master, &input_tx, &classifier, &input_mode, &mut state)
         .expect("finish relay");
+    let eof_events = input_rx.try_iter().collect::<Vec<_>>();
+    assert!(eof_events.contains(&RawInputEvent::CaptureDrained { generation: 8 }));
+    assert!(!eof_events.contains(&RawInputEvent::EofShutdownRequested));
     master.sync_all().expect("sync test output");
     assert_eq!(fs::read(&path).expect("read test output"), b"exit\n");
     fs::remove_file(path).ok();

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
@@ -98,10 +98,6 @@ pub(crate) fn run_raw(
             }
         }
     }
-    if config.native_mode {
-        config.input_classifier = config.input_classifier.with_conservative(true);
-    }
-
     let login = args.first().is_some_and(|a| a.starts_with('-'))
         || args.iter().any(|a| a == "--login" || a == "-l");
     config.login_shell = login;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/adapter.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/adapter.rs
@@ -8,6 +8,7 @@ pub(super) trait ShellAdapter {
     fn executable<'a>(&self, config: &'a ShellHostConfig) -> &'a str;
     fn marker_filename(&self) -> &'static str;
     fn marker_script(&self) -> &'static str;
+    fn isolates_readline(&self) -> bool;
     fn configure_command(
         &self,
         command: &mut Command,
@@ -29,6 +30,10 @@ impl ShellAdapter for BashAdapter {
 
     fn marker_script(&self) -> &'static str {
         bash_marker_script()
+    }
+
+    fn isolates_readline(&self) -> bool {
+        true
     }
 
     fn configure_command(
@@ -64,6 +69,10 @@ impl ShellAdapter for ZshAdapter {
 
     fn marker_script(&self) -> &'static str {
         zsh_marker_script()
+    }
+
+    fn isolates_readline(&self) -> bool {
+        false
     }
 
     fn configure_command(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
@@ -17,6 +17,7 @@ use super::model::ShellHostConfig;
 use super::osc::OscParser;
 
 const OUTPUT_REF_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+const ISOLATED_INPUTRC: &str = "set input-meta on\nset convert-meta off\nset output-meta on\n";
 
 pub(super) struct PtySession {
     pub(super) master: File,
@@ -62,6 +63,14 @@ fn start_shell_session(
         ),
     )?;
     fs::set_permissions(&rcfile, fs::Permissions::from_mode(0o600))?;
+    let isolated_inputrc = if config.native_mode || !adapter.isolates_readline() {
+        None
+    } else {
+        let path = config.work_dir.join("inputrc");
+        fs::write(&path, ISOLATED_INPUTRC)?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        Some(path)
+    };
 
     let pty = openpty(Some(&config.winsize), None).map_err(nix_to_io)?;
     let master = unsafe { File::from_raw_fd(pty.master.into_raw_fd()) };
@@ -94,6 +103,9 @@ fn start_shell_session(
     }
     for (key, value) in &config.env_overrides {
         command.env(key, value);
+    }
+    if let Some(inputrc) = isolated_inputrc {
+        command.env("INPUTRC", inputrc);
     }
 
     unsafe {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
@@ -89,6 +89,89 @@ _cosh_utf8_han_status() {
   return 1
 }
 
+_cosh_literal_first_word_matches() {
+  local input="$1"
+  local attempt_token="$2"
+  local command="$3"
+  local LC_ALL=C
+  local quote=""
+  local normalized=""
+  local started=0
+  local index=0
+  local length="${#input}"
+  local byte
+
+  [[ -n "$input" && "$length" -le 4096 ]] || return 1
+  [[ "$attempt_token" == "$command" ]] && return 0
+
+  while (( index < length )); do
+    byte="${input:$index:1}"
+    (( index += 1 ))
+    if [[ "$quote" == "'" ]]; then
+      case "$byte" in
+        "'") quote="" ;;
+        *[[:cntrl:]]*) return 1 ;;
+        *) normalized+="$byte"; started=1 ;;
+      esac
+      continue
+    fi
+    if [[ "$quote" == '"' ]]; then
+      case "$byte" in
+        '"') quote="" ;;
+        '\'|'$'|'`'|*[[:cntrl:]]*) return 1 ;;
+        *) normalized+="$byte"; started=1 ;;
+      esac
+      continue
+    fi
+    case "$byte" in
+      ' '|$'\t') (( started == 1 )) && break ;;
+      "'") quote="'"; started=1 ;;
+      '"') quote='"'; started=1 ;;
+      '\'|'$'|'`'|'|'|'&'|';'|'<'|'>'|'('|')'|'*'|'?'|'~'|'{'|'}'|'['|']'|*[[:cntrl:]]*)
+        return 1
+        ;;
+      *) normalized+="$byte"; started=1 ;;
+    esac
+  done
+  [[ -z "$quote" && -n "$normalized" && "$normalized" == "$command" ]]
+}
+
+_cosh_arguments_have_no_unquoted_expansion() {
+  local input="$1"
+  local LC_ALL=C
+  local quote=""
+  local escaped=0
+  local after_first_word=0
+  local index=0
+  local length="${#input}"
+  local byte
+
+  while (( index < length )); do
+    byte="${input:$index:1}"
+    (( index += 1 ))
+    if [[ "$quote" == "'" ]]; then
+      [[ "$byte" == "'" ]] && quote=""
+      continue
+    fi
+    if (( escaped == 1 )); then
+      escaped=0
+      continue
+    fi
+    case "$byte" in
+      '\') escaped=1 ;;
+      "'") quote="'" ;;
+      '"')
+        if [[ "$quote" == '"' ]]; then quote=""; elif [[ -z "$quote" ]]; then quote='"'; fi
+        ;;
+      ' '|$'\t') [[ -z "$quote" ]] && after_first_word=1 ;;
+      '*'|'?'|'~'|'{'|'}'|'['|']')
+        (( after_first_word == 1 )) && [[ -z "$quote" ]] && return 1
+        ;;
+    esac
+  done
+  (( escaped == 0 )) && [[ -z "$quote" ]]
+}
+
 _cosh_command_veto() {
   local input="$1"
   local top_token="$2"

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
@@ -28,6 +28,7 @@ _cosh_utf8_han_status() {
   local LC_ALL=C
   local index=0
   local length="${#value}"
+  local found_han=0
   local b1 b2 b3 b4 codepoint
   local _COSH_BYTE_AT_RESULT
 
@@ -80,10 +81,11 @@ _cosh_utf8_han_status() {
        || (codepoint >= 0x4E00 && codepoint <= 0x9FFF)
        || (codepoint >= 0xF900 && codepoint <= 0xFAFF)
        || (codepoint >= 0x20000 && codepoint <= 0x323AF) )); then
-      return 0
+      found_han=1
     fi
   done
 
+  (( found_han == 1 )) && return 0
   return 1
 }
 
@@ -91,11 +93,12 @@ _cosh_command_veto() {
   local input="$1"
   local top_token="$2"
   local context="${3:-}"
+  local top_han_status="${4:-1}"
   local scan="$input"
   local word name
 
   case "$top_token" in
-    ~/*|command|env|sudo|exec|nohup|time|xargs)
+    '~/'*|command|env|sudo|exec|nohup|time|xargs)
       return 0
       ;;
     /*|*/*)
@@ -114,6 +117,50 @@ _cosh_command_veto() {
     *'?') scan="${scan%\?}" ;;
     *'？') scan="${scan%？}" ;;
   esac
+
+  if (( top_han_status == 0 )); then
+    case "$scan" in
+      *'|'*|*'&'*|*';'*|*'<'*|*'>'*|*'$'*|*'`'*|*[[:cntrl:]]*)
+        return 0
+        ;;
+    esac
+
+    local quote=""
+    local escaped=0
+    local index=0
+    local length="${#scan}"
+    local byte
+    while (( index < length )); do
+      byte="${scan:$index:1}"
+      (( index += 1 ))
+      if [[ "$quote" == "'" ]]; then
+        [[ "$byte" == "'" ]] && quote=""
+        continue
+      fi
+      if (( escaped == 1 )); then
+        escaped=0
+        continue
+      fi
+      case "$byte" in
+        '\') escaped=1 ;;
+        "'") quote="'" ;;
+        '"')
+          if [[ "$quote" == '"' ]]; then
+            quote=""
+          elif [[ -z "$quote" ]]; then
+            quote='"'
+          fi
+          ;;
+        '('|')')
+          [[ -z "$quote" ]] && return 0
+          ;;
+      esac
+    done
+    (( escaped == 1 )) && return 0
+    [[ -n "$quote" ]] && return 0
+    return 1
+  fi
+
   case "$scan" in
     *"'"*|*'"'*|*'\'*|*'|'*|*'&'*|*';'*|*'<'*|*'>'*|*'$'*|*'`'*|*'('*|*')'*|*'{'*|*'}'*|*'['*|*']'*|*'*'*|*'?'*|*'？'*|*'~'*|*[[:cntrl:]]*)
       return 0
@@ -203,26 +250,34 @@ _cosh_classify_missing() {
   original="$(_cosh_ascii_trim "$1")"
   local top_token="$2"
   local context="${3:-}"
-  local han_status had_question=0 polite=0
+  local original_han_status top_han_status had_question=0 polite=0
   local IFS=$' \t\n'
 
   if [[ -z "$original" || ${#original} -gt 4096 ]]; then
     printf '%s' "unsafe"
     return 0
   fi
-  if _cosh_command_veto "$original" "$top_token" "$context"; then
+  _cosh_utf8_han_status "$original"
+  original_han_status=$?
+  if (( original_han_status == 2 )); then
+    printf '%s' "unsafe"
+    return 0
+  fi
+
+  _cosh_utf8_han_status "$top_token"
+  top_han_status=$?
+  if (( top_han_status == 2 )); then
+    printf '%s' "unsafe"
+    return 0
+  fi
+
+  if _cosh_command_veto "$original" "$top_token" "$context" "$top_han_status"; then
     printf '%s' "command"
     return 0
   fi
 
-  _cosh_utf8_han_status "$original"
-  han_status=$?
-  if (( han_status == 0 )); then
+  if (( original_han_status == 0 )); then
     printf '%s' "natural_language"
-    return 0
-  fi
-  if (( han_status == 2 )); then
-    printf '%s' "unsafe"
     return 0
   fi
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/io_loop.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/io_loop.rs
@@ -91,3 +91,19 @@ pub(super) fn wait_child(child: &mut Child) -> io::Result<Option<i32>> {
         None => Ok(child.wait()?.code()),
     }
 }
+
+#[cfg(unix)]
+pub(super) fn wait_child_preserving_signal(
+    child: &mut Child,
+    normalize_signal: bool,
+) -> io::Result<Option<i32>> {
+    use std::os::unix::process::ExitStatusExt;
+
+    let status = match child.try_wait()? {
+        Some(status) => status,
+        None => child.wait()?,
+    };
+    Ok(status
+        .code()
+        .or_else(|| normalize_signal.then(|| status.signal().map(|signal| 128 + signal))?))
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/io_loop.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/io_loop.rs
@@ -1,8 +1,12 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
+use std::os::fd::AsRawFd;
 use std::process::Child;
 use std::thread;
 use std::time::{Duration, Instant};
+use wait_timeout::ChildExt;
+
+use crate::raw_input::{foreground_process_group_for_fds, signal_process_group_id};
 
 use super::osc::OscParser;
 
@@ -85,11 +89,39 @@ pub(super) fn read_until_streaming<W: Write>(
     Ok(condition(parser))
 }
 
-pub(super) fn wait_child(child: &mut Child) -> io::Result<Option<i32>> {
-    match child.try_wait()? {
-        Some(status) => Ok(status.code()),
-        None => Ok(child.wait()?.code()),
+pub(super) fn wait_pty_foreground_bounded(
+    master: &File,
+    terminal: &File,
+    child: &mut Child,
+    timeout: Duration,
+) -> io::Result<Option<i32>> {
+    if let Some(status) = child.wait_timeout(timeout)? {
+        return Ok(status.code());
     }
+
+    let shell_group = child.id() as i32;
+    let mut process_groups =
+        foreground_process_group_for_fds(master.as_raw_fd(), terminal.as_raw_fd())
+            .into_iter()
+            .collect::<Vec<_>>();
+    if !process_groups.contains(&shell_group) {
+        process_groups.push(shell_group);
+    }
+    let mut signal_error = None;
+    for process_group in process_groups {
+        if let Err(error) = signal_process_group_id(process_group, nix::libc::SIGKILL) {
+            signal_error.get_or_insert(error);
+        }
+    }
+    let _ = child.kill();
+    child.wait()?;
+    if let Some(error) = signal_error {
+        return Err(error);
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("shell did not exit within {timeout:?}"),
+    ))
 }
 
 #[cfg(unix)]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -218,12 +218,6 @@ _cosh_emit_top_level_missing_marker() {
 }
 _cosh_should_intercept_unknown() {
   local command="$1"
-  case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
-      printf '%s' "slash"
-      return 0
-      ;;
-  esac
   if _cosh_is_slash_control_candidate "$command"; then
     printf '%s' "slash"
     return 0

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -44,7 +44,10 @@ else
   export PS1="$COSH_POC_PS1"
   set -o history
   export HISTFILE="${COSH_HISTFILE:-/dev/null}"
+  export HISTSIZE=1000
+  export HISTFILESIZE=1000
   export HISTCONTROL=
+  export HISTIGNORE=
   export HISTTIMEFORMAT=
 fi
 _cosh_load_native_bash_history_if_empty
@@ -847,7 +850,10 @@ shopt -s extdebug 2>/dev/null || true
 _COSH_OLD_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null | sed "s/^trap -- '\\(.*\\)' DEBUG$/\\1/" || true)"
 _COSH_ACTIVE_DEBUG_TRAP="trap -- '_cosh_preexec_marker' DEBUG"
 trap '_cosh_preexec_marker' DEBUG
-if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+if [[ -n "${COSH_SHELL_ISOLATED:-}" ]]; then
+  unset _COSH_USER_PROMPT_COMMAND
+  _COSH_USER_PROMPT_COMMAND_IS_ARRAY=0
+elif [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
   _COSH_USER_PROMPT_COMMAND_IS_ARRAY=1
   _COSH_USER_PROMPT_COMMAND=("${PROMPT_COMMAND[@]}")
 elif [[ -n "${PROMPT_COMMAND+x}" ]]; then

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -58,6 +58,8 @@ _COSH_ATTEMPT_TOKEN=
 _COSH_ATTEMPT_TOKEN_FINGERPRINT=
 _COSH_ATTEMPT_SENSITIVE=0
 _COSH_ATTEMPT_UNSAFE=0
+_COSH_ATTEMPT_EXPANSION_DRIFT=0
+_COSH_ATTEMPT_SUBSHELL=
 _COSH_WRAPPER_ID="${COSH_SESSION_ID}:${COSH_MARKER_TOKEN}"
 _cosh_apply_internal_recovery() {
   if [[ -z "${COSH_RECOVERY_REQUEST_FILE:-}" || ! -f "$COSH_RECOVERY_REQUEST_FILE" ]]; then
@@ -415,12 +417,15 @@ _cosh_replace_handoff_history() {
 _cosh_begin_attempt() {
   local input="$1"
   local top_token="$2"
+  local expansion_drift="${3:-0}"
   local utf8_status
   _COSH_ATTEMPT_GENERATION=$((_COSH_ATTEMPT_GENERATION + 1))
   _COSH_ATTEMPT_ACTIVE=1
   _COSH_ATTEMPT_WRAPPER_ID="$_COSH_WRAPPER_ID"
   _COSH_ATTEMPT_SENSITIVE=0
   _COSH_ATTEMPT_UNSAFE=0
+  _COSH_ATTEMPT_EXPANSION_DRIFT="$expansion_drift"
+  _COSH_ATTEMPT_SUBSHELL="${BASH_SUBSHELL:-0}"
   _COSH_ATTEMPT_INPUT=
   _COSH_ATTEMPT_TOKEN=
   _COSH_ATTEMPT_TOKEN_FINGERPRINT=
@@ -481,6 +486,12 @@ command_not_found_handle() {
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
   fi
+  if [[ "${_COSH_ATTEMPT_SUBSHELL:-}" != "${BASH_SUBSHELL:-0}"
+     || "${#FUNCNAME[@]}" != 1
+     || "${_COSH_ATTEMPT_EXPANSION_DRIFT:-0}" == 1 ]]; then
+    _cosh_delegate_bash_command_not_found "$command" "$@"
+    return $?
+  fi
   if [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 || "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]]; then
     local command_fingerprint
     command_fingerprint="$(_cosh_token_fingerprint "$command")"
@@ -498,7 +509,9 @@ command_not_found_handle() {
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
   fi
-  if [[ "${_COSH_ATTEMPT_TOKEN:-}" != "$command" || -z "$original" ]]; then
+  if [[ -z "$original" ]] \
+     || ! _cosh_literal_first_word_matches "$original" "${_COSH_ATTEMPT_TOKEN:-}" "$command" \
+     || ! _cosh_arguments_have_no_unquoted_expansion "$original"; then
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
   fi
@@ -542,6 +555,18 @@ _COSH_HAS_BASH_ALIASES=0
 if (( ${BASH_VERSINFO[0]:-0} >= 4 )); then
   _COSH_HAS_BASH_ALIASES=1
 fi
+
+_cosh_has_leading_alias() {
+  local command="$1"
+  local rest="$command"
+  local word
+  [[ "${_COSH_HAS_BASH_ALIASES:-0}" == 1 ]] || return 1
+  while [[ "$rest" =~ ^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+ ]]; do
+    rest="${rest:${#BASH_REMATCH[0]}}"
+  done
+  word="${rest%%[[:space:]]*}"
+  [[ -n "$word" && -n "${BASH_ALIASES[$word]:-}" ]]
+}
 
 _cosh_compact_alias_expanded() {
   local command="$1" expanded=0 guard=0 prefix rest word expansion done_prefix=""
@@ -653,6 +678,8 @@ _cosh_preexec_marker() {
     # (otherwise every aliased command, e.g. ls='ls --color=auto', loses its
     # preexec marker and an approved shell handoff can never close).
     _COSH_EXPANDED_COMPACT=""
+    local attempt_expansion_drift=0
+    _cosh_has_leading_alias "$command" && attempt_expansion_drift=1
     if [[ -n "$compact_command" && "$compact_bash_command" != *"$compact_command"* && "$compact_command" != *"$compact_bash_command"* ]]; then
       _cosh_compact_alias_expanded "$command"
     fi
@@ -723,7 +750,7 @@ _cosh_preexec_marker() {
           eval "$active_debug_trap" 2>/dev/null || true
           return 1
         fi
-        _cosh_begin_attempt "$command" "$first_word"
+        _cosh_begin_attempt "$command" "$first_word" "$attempt_expansion_drift"
       fi
       if [[ "$command" == trap*DEBUG* ]]; then
         _COSH_DEBUG_TRAP_MAY_CHANGE=1

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -147,12 +147,6 @@ _cosh_emit_top_level_missing_marker() {
 }
 _cosh_should_intercept_unknown() {
   local command="$1"
-  case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
-      printf '%s' "slash"
-      return 0
-      ;;
-  esac
   if _cosh_is_slash_control_candidate "$command"; then
     printf '%s' "slash"
     return 0
@@ -559,7 +553,7 @@ _cosh_precmd_marker() {
 # Slash command function stubs — prevent "zsh: no such file or directory" for
 # commands starting with / that zsh would try to exec as an absolute path.
 # The actual interception and marker emission happens in _cosh_preexec_marker.
-for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mcp mode new recommendations select send-to-shell shell skills stats status; do
+for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details draft explain extensions health help hooks mcp mode new recommendations resume select send-to-shell session shell skills stats status; do
   functions[/$_cosh_sc]=':'
 done
 unset _cosh_sc

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -72,6 +72,8 @@ _COSH_ATTEMPT_TOKEN=
 _COSH_ATTEMPT_TOKEN_FINGERPRINT=
 _COSH_ATTEMPT_SENSITIVE=0
 _COSH_ATTEMPT_UNSAFE=0
+_COSH_ATTEMPT_EXPANSION_DRIFT=0
+_COSH_ATTEMPT_SUBSHELL=
 _COSH_WRAPPER_ID="${COSH_SESSION_ID}:${COSH_MARKER_TOKEN}"
 _cosh_apply_internal_recovery() {
   if [[ -z "${COSH_RECOVERY_REQUEST_FILE:-}" || ! -f "$COSH_RECOVERY_REQUEST_FILE" ]]; then
@@ -360,12 +362,15 @@ _cosh_add_handoff_history() {
 _cosh_begin_attempt() {
   local input="$1"
   local top_token="$2"
+  local expansion_drift="${3:-0}"
   local utf8_status
   _COSH_ATTEMPT_GENERATION=$((_COSH_ATTEMPT_GENERATION + 1))
   _COSH_ATTEMPT_ACTIVE=1
   _COSH_ATTEMPT_WRAPPER_ID="$_COSH_WRAPPER_ID"
   _COSH_ATTEMPT_SENSITIVE=0
   _COSH_ATTEMPT_UNSAFE=0
+  _COSH_ATTEMPT_EXPANSION_DRIFT="$expansion_drift"
+  _COSH_ATTEMPT_SUBSHELL="${ZSH_SUBSHELL:-0}"
   _COSH_ATTEMPT_INPUT=
   _COSH_ATTEMPT_TOKEN=
   _COSH_ATTEMPT_TOKEN_FINGERPRINT=
@@ -426,6 +431,12 @@ command_not_found_handler() {
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
   fi
+  if (( ${ZSH_SUBSHELL:-0} != ${_COSH_ATTEMPT_SUBSHELL:-0} + 1 )) \
+     || (( ${#funcstack[@]} != 1 )) \
+     || [[ "${_COSH_ATTEMPT_EXPANSION_DRIFT:-0}" == 1 ]]; then
+    _cosh_delegate_zsh_command_not_found "$command" "$@"
+    return $?
+  fi
   if [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 || "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]]; then
     local command_fingerprint
     command_fingerprint="$(_cosh_token_fingerprint "$command")"
@@ -443,7 +454,9 @@ command_not_found_handler() {
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
   fi
-  if [[ "${_COSH_ATTEMPT_TOKEN:-}" != "$command" || -z "$original" ]]; then
+  if [[ -z "$original" ]] \
+     || ! _cosh_literal_first_word_matches "$original" "${_COSH_ATTEMPT_TOKEN:-}" "$command" \
+     || ! _cosh_arguments_have_no_unquoted_expansion "$original"; then
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
   fi
@@ -474,6 +487,10 @@ command_not_found_handler() {
 }
 _cosh_preexec_marker() {
   local command="$1"
+  local expanded_command="${2:-$1}"
+  local canonical_command="${(j: :)${(z)command}}"
+  local expansion_drift=0
+  [[ "$canonical_command" != "$expanded_command" ]] && expansion_drift=1
   _COSH_ATTEMPT_ACTIVE=0
   _COSH_ATTEMPT_SENSITIVE=0
   _COSH_ATTEMPT_UNSAFE=0
@@ -497,10 +514,14 @@ _cosh_preexec_marker() {
     _cosh_clear_handoff_request
     unset _COSH_HANDOFF_ACTIVE 2>/dev/null || true
     unset _COSH_HANDOFF_HISTORY_COMMAND 2>/dev/null || true
-    local first_word="$command"
+    local command_word_source="$command"
+    while [[ "$command_word_source" == ' '* || "$command_word_source" == $'\t'* ]]; do
+      command_word_source="${command_word_source#?}"
+    done
+    local first_word="$command_word_source"
     local argc=1
-    if [[ "$command" == *[[:space:]]* ]]; then
-      first_word="${command%%[[:space:]]*}"
+    if [[ "$command_word_source" == *[[:space:]]* ]]; then
+      first_word="${command_word_source%%[[:space:]]*}"
       argc=2
     fi
     local reason
@@ -508,7 +529,7 @@ _cosh_preexec_marker() {
       _cosh_emit_intercept_marker "$command" "$reason"
       return 1
     fi
-    _cosh_begin_attempt "$command" "$first_word"
+    _cosh_begin_attempt "$command" "$first_word" "$expansion_drift"
   fi
   if [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1
      || "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]] \

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use nix::libc;
 use nix::pty::Winsize;
 
 use crate::raw_input::{
@@ -22,6 +21,7 @@ use super::prompt_replay::{
     prompt_prefixed_replay_bytes, prompt_replay_bytes, PromptReplayTracker,
 };
 
+mod eof_shutdown;
 mod input_events;
 mod input_readiness;
 mod pty_emit;
@@ -37,22 +37,22 @@ use terminal_recovery::{restore_terminal_after_interrupted_command, PendingTermi
 use terminal_size::sync_outer_terminal_winsize;
 
 pub(super) struct RawActionWatchdog {
-    driver_done: Arc<Mutex<Option<Instant>>>,
     grace: Duration,
 }
 
 impl RawActionWatchdog {
-    pub(super) fn new(driver_done: Arc<Mutex<Option<Instant>>>, grace: Duration) -> Self {
-        Self { driver_done, grace }
+    pub(super) fn new(grace: Duration) -> Self {
+        Self { grace }
     }
 
-    fn expired(&self) -> bool {
-        self.driver_done
-            .lock()
-            .ok()
-            .and_then(|done| *done)
-            .is_some_and(|done| done.elapsed() > self.grace)
+    fn expired(&self, driver_completed_at: Option<Instant>) -> bool {
+        driver_completed_at.is_some_and(|done| done.elapsed() > self.grace)
     }
+}
+
+pub(super) struct DriverCompletion {
+    pub(super) result: io::Result<()>,
+    pub(super) completed_at: Instant,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -64,6 +64,7 @@ pub(super) fn read_raw_until_exit<W: Write, F>(
     output: &mut W,
     event_observer: &mut F,
     input_events: &Receiver<RawInputEvent>,
+    driver_completion: &Receiver<DriverCompletion>,
     input_mode: &Arc<Mutex<RawInputMode>>,
     input_generation: &UserPtyInputGeneration,
     last_winsize: &mut Winsize,
@@ -71,7 +72,7 @@ pub(super) fn read_raw_until_exit<W: Write, F>(
     recovery_request_file: &Path,
     handoff_request_file: &Path,
     watchdog: Option<&RawActionWatchdog>,
-) -> io::Result<()>
+) -> io::Result<bool>
 where
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
 {
@@ -83,6 +84,8 @@ where
     let mut pending_terminal_restore = PendingTerminalRecovery::default();
     let mut pending_prompt_restore = None;
     let mut input_readiness = RawInputReadinessProbe::from_env();
+    let mut driver_completed_at = None;
+    let mut eof_shutdown = None;
     // #1932 F4: ask the outer terminal to report modifier-carrying editing
     // keys (modifyOtherKeys level 1, e.g. Shift+Enter -> CSI 27;2;13~).
     // Written on the ordered output path after startup rendering settled;
@@ -99,13 +102,22 @@ where
             thread::sleep(Duration::from_millis(10));
             continue;
         }
-        drain_raw_input_events(
+        if drain_raw_input_events(
             input_events,
             parser,
             output,
             prompt,
             &mut native_candidate_echoed_len,
             &mut prompt_replay,
+        )? {
+            request_eof_shutdown(master, terminal, child, &mut eof_shutdown)?;
+        }
+        poll_driver_completion(
+            driver_completion,
+            master,
+            terminal,
+            child,
+            &mut driver_completed_at,
         )?;
         let mut observer_action = merge_pending_prompt_restore(
             observe_with_input_mode_lock(event_observer, &parser.events, output, input_mode)?,
@@ -153,14 +165,16 @@ where
                     // display cuts produced by that write's echo are
                     // handled: re-drain here, the top-of-loop drain alone
                     // loses that ordering inside this read loop (#1932).
-                    drain_raw_input_events(
+                    if drain_raw_input_events(
                         input_events,
                         parser,
                         output,
                         prompt,
                         &mut native_candidate_echoed_len,
                         &mut prompt_replay,
-                    )?;
+                    )? {
+                        request_eof_shutdown(master, terminal, child, &mut eof_shutdown)?;
+                    }
                     for (cut, cut_kind) in parser.drain_intervention_display_cuts() {
                         let cut = cut.min(parser.display.len());
                         // Only a real prompt boundary (precmd) confirms the
@@ -284,6 +298,9 @@ where
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
                 Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
                 Err(_) if child.try_wait()?.is_some() => {
+                    if !advance_eof_shutdown(&mut eof_shutdown)? {
+                        break;
+                    }
                     release_held_shell_output(
                         event_observer,
                         &parser.events,
@@ -292,13 +309,17 @@ where
                         &mut display_start,
                         &mut prompt_replay,
                     )?;
-                    return Ok(());
+                    return Ok(eof_shutdown.is_some());
                 }
                 Err(err) => return Err(err),
             }
         }
 
         if child.try_wait()?.is_some() {
+            if !advance_eof_shutdown(&mut eof_shutdown)? {
+                thread::sleep(Duration::from_millis(10));
+                continue;
+            }
             release_held_shell_output(
                 event_observer,
                 &parser.events,
@@ -307,10 +328,11 @@ where
                 &mut display_start,
                 &mut prompt_replay,
             )?;
-            return Ok(());
+            return Ok(eof_shutdown.is_some());
         }
+        advance_eof_shutdown(&mut eof_shutdown)?;
         if let Some(watchdog) = watchdog {
-            if watchdog.expired() {
+            if watchdog.expired(driver_completed_at) {
                 child.kill()?;
                 child.wait()?;
                 return Err(io::Error::new(
@@ -328,13 +350,22 @@ where
             thread::sleep(Duration::from_millis(10));
             continue;
         }
-        drain_raw_input_events(
+        if drain_raw_input_events(
             input_events,
             parser,
             output,
             prompt,
             &mut native_candidate_echoed_len,
             &mut prompt_replay,
+        )? {
+            request_eof_shutdown(master, terminal, child, &mut eof_shutdown)?;
+        }
+        poll_driver_completion(
+            driver_completion,
+            master,
+            terminal,
+            child,
+            &mut driver_completed_at,
         )?;
         observer_action = merge_pending_prompt_restore(
             observe_with_input_mode_lock(event_observer, &parser.events, output, input_mode)?,
@@ -384,6 +415,35 @@ where
         );
         thread::sleep(Duration::from_millis(10));
     }
+}
+
+fn poll_driver_completion(
+    receiver: &Receiver<DriverCompletion>,
+    master: &File,
+    terminal: &File,
+    child: &mut Child,
+    completed_at: &mut Option<Instant>,
+) -> io::Result<()> {
+    let Ok(completion) = receiver.try_recv() else {
+        return Ok(());
+    };
+    *completed_at = Some(completion.completed_at);
+    if let Err(error) = completion.result {
+        shutdown_and_reap_child(master, terminal, child);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn shutdown_and_reap_child(master: &File, terminal: &File, child: &mut Child) {
+    let mut shutdown = None;
+    if request_eof_shutdown(master, terminal, child, &mut shutdown).is_ok() {
+        while let Ok(false) = advance_eof_shutdown(&mut shutdown) {
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn latest_capture_submission_generation(events: &[ShellEvent]) -> Option<u64> {
@@ -590,3 +650,4 @@ fn mark_pending_prompt_replayed(parser: &OscParser, prompt: &[u8], display_start
 #[cfg(test)]
 #[path = "raw_relay_tests.rs"]
 mod tests;
+use eof_shutdown::{advance_eof_shutdown, request_eof_shutdown, EofShutdown};

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/eof_shutdown.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/eof_shutdown.rs
@@ -1,0 +1,68 @@
+use std::fs::File;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::process::Child;
+use std::time::{Duration, Instant};
+
+use nix::libc;
+
+use crate::raw_input::{
+    foreground_process_group_for_fds, process_group_exists, signal_process_group_id,
+};
+
+pub(super) struct EofShutdown {
+    deadline: Instant,
+    process_groups: Vec<i32>,
+    kill_sent: bool,
+}
+
+pub(super) fn request_eof_shutdown(
+    master: &File,
+    terminal: &File,
+    child: &Child,
+    shutdown: &mut Option<EofShutdown>,
+) -> io::Result<()> {
+    if shutdown.is_some() {
+        return Ok(());
+    }
+    let shell_group = child.id() as i32;
+    let mut process_groups =
+        foreground_process_group_for_fds(master.as_raw_fd(), terminal.as_raw_fd())
+            .into_iter()
+            .collect::<Vec<_>>();
+    if !process_groups.contains(&shell_group) {
+        process_groups.push(shell_group);
+    }
+    for process_group in &process_groups {
+        signal_process_group_id(*process_group, libc::SIGHUP)?;
+    }
+    *shutdown = Some(EofShutdown {
+        deadline: Instant::now() + Duration::from_millis(250),
+        process_groups,
+        kill_sent: false,
+    });
+    Ok(())
+}
+
+pub(super) fn advance_eof_shutdown(shutdown: &mut Option<EofShutdown>) -> io::Result<bool> {
+    let Some(shutdown) = shutdown else {
+        return Ok(true);
+    };
+    if shutdown
+        .process_groups
+        .iter()
+        .all(|process_group| !process_group_exists(*process_group))
+    {
+        return Ok(true);
+    }
+    if Instant::now() < shutdown.deadline {
+        return Ok(false);
+    }
+    if !shutdown.kill_sent {
+        for process_group in &shutdown.process_groups {
+            signal_process_group_id(*process_group, libc::SIGKILL)?;
+        }
+        shutdown.kill_sent = true;
+    }
+    Ok(true)
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -62,8 +62,9 @@ pub(super) fn drain_raw_input_events<W: Write>(
     prompt: &str,
     native_candidate_echoed_len: &mut usize,
     prompt_replay: &mut PromptReplayTracker,
-) -> io::Result<()> {
+) -> io::Result<bool> {
     let native_mode = prompt.is_empty();
+    let mut eof_shutdown_requested = false;
     while let Ok(event) = input_events.try_recv() {
         match event {
             RawInputEvent::ShellInputActivity { empty } => {
@@ -77,6 +78,7 @@ pub(super) fn drain_raw_input_events<W: Write>(
             RawInputEvent::Esc => parser.push_control_event("esc"),
             RawInputEvent::SoftNewlineShortcutObserved => parser.push_soft_newline_shortcut_event(),
             RawInputEvent::MultilinePasteObserved => parser.push_multiline_paste_event(),
+            RawInputEvent::EofShutdownRequested => eof_shutdown_requested = true,
             RawInputEvent::SyntheticPromptRepaint => parser.arm_synthetic_prompt_repaint(),
             RawInputEvent::PromptDraftOpen { text } => {
                 let payload = serde_json::json!({ "text": text }).to_string();
@@ -286,5 +288,5 @@ pub(super) fn drain_raw_input_events<W: Write>(
             RawInputEvent::SessionCancel(id) => parser.push_card_event("session_cancel", &id),
         }
     }
-    Ok(())
+    Ok(eof_shutdown_requested)
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -16,10 +16,10 @@ use crate::raw_input::{
 use crate::types::ShellEvent;
 
 use super::bootstrap::{start_bash_session, start_zsh_session, PtySession};
-use super::io_loop::{read_until_streaming, wait_child};
+use super::io_loop::{read_until_streaming, wait_child_preserving_signal};
 use super::lifecycle::{build_shell_host_output, push_shell_exited_event};
 use super::model::{ShellHostConfig, ShellHostOutput};
-use super::raw_relay::{read_raw_until_exit, RawActionWatchdog};
+use super::raw_relay::{read_raw_until_exit, DriverCompletion, RawActionWatchdog};
 
 pub fn run_raw_relay_bash<R, W>(
     config: &ShellHostConfig,
@@ -320,24 +320,24 @@ where
         main_prompt_gate,
         slash_route_enabled,
     );
-    let watchdog = action_watchdog.map(|grace| {
-        let driver_done = Arc::new(Mutex::new(None));
-        let done_slot = Arc::clone(&driver_done);
-        thread::spawn(move || {
-            let _ = driver_thread.join();
-            if let Ok(mut done) = done_slot.lock() {
-                *done = Some(Instant::now());
-            }
+    let (driver_completion_sender, driver_completion_receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let result = driver_thread
+            .join()
+            .unwrap_or_else(|_| Err(io::Error::other("raw input driver panicked")));
+        let _ = driver_completion_sender.send(DriverCompletion {
+            result,
+            completed_at: Instant::now(),
         });
-        RawActionWatchdog::new(driver_done, grace)
     });
+    let watchdog = action_watchdog.map(RawActionWatchdog::new);
     let mut last_winsize = config.winsize;
     let relay_prompt = if config.native_mode {
         ""
     } else {
         &config.prompt
     };
-    read_raw_until_exit(
+    let eof_shutdown = read_raw_until_exit(
         &mut session.master,
         &session.terminal,
         &mut session.child,
@@ -345,6 +345,7 @@ where
         &mut output,
         &mut event_observer,
         &input_event_receiver,
+        &driver_completion_receiver,
         &input_mode,
         &input_generation,
         &mut last_winsize,
@@ -358,7 +359,7 @@ where
     output.write_all(&session.parser.display[display_start..])?;
     output.flush()?;
 
-    let exit_status = wait_child(&mut session.child)?;
+    let exit_status = wait_child_preserving_signal(&mut session.child, eof_shutdown)?;
     push_shell_exited_event(&mut session.parser, config, exit_status)?;
     event_observer(&session.parser.events, &mut output)?;
     output.flush()?;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/scripted.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/scripted.rs
@@ -6,10 +6,12 @@ use std::time::Duration;
 use crate::input::InputDecision;
 
 use super::bootstrap::{start_bash_session, start_zsh_session, PtySession};
-use super::io_loop::{read_until, read_until_streaming, wait_child};
+use super::io_loop::{read_until, read_until_streaming, wait_pty_foreground_bounded};
 use super::lifecycle::finish_shell_host_output;
 use super::model::{ScriptedInput, ShellHostConfig, ShellHostOutput};
 use super::osc::OscParser;
+
+const SCRIPTED_SHELL_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub fn run_scripted_bash(
     config: &ShellHostConfig,
@@ -92,7 +94,12 @@ fn run_scripted_shell(
         |_| false,
     )?;
     session.parser.flush_pending();
-    let exit_status = wait_child(&mut session.child)?;
+    let exit_status = wait_pty_foreground_bounded(
+        &session.master,
+        &session.terminal,
+        &mut session.child,
+        SCRIPTED_SHELL_EXIT_TIMEOUT,
+    )?;
     finish_shell_host_output(config, session.parser, exit_status)
 }
 
@@ -165,7 +172,12 @@ where
     output.write_all(&session.parser.display[display_start..])?;
     output.flush()?;
 
-    let exit_status = wait_child(&mut session.child)?;
+    let exit_status = wait_pty_foreground_bounded(
+        &session.master,
+        &session.terminal,
+        &mut session.child,
+        SCRIPTED_SHELL_EXIT_TIMEOUT,
+    )?;
     finish_shell_host_output(config, session.parser, exit_status)
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -198,6 +198,18 @@ mod tests {
     use super::{RemovedCommand, SlashCommand, SlashCommandSpec, SlashParseError};
 
     #[test]
+    fn routing_c4_draft_grammar_no_drift() {
+        assert!(matches!(
+            SlashCommand::parse("/draft extra"),
+            Ok(Some(SlashCommand::Draft))
+        ));
+        assert!(matches!(
+            SlashCommand::parse("/draft 'extra'"),
+            Ok(Some(SlashCommand::Draft))
+        ));
+    }
+
+    #[test]
     fn removed_decision_commands_parse_as_removed_not_unknown() {
         for command in ["/allow 1", "/approve 1", "/deny 1"] {
             match SlashCommand::parse(command) {

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -481,11 +481,11 @@ mod tests {
     }
 
     #[test]
-    fn shell_marker_exact_tokens_match_registry() {
+    fn shell_marker_exact_tokens_match_registry_routing_c4_per_shell_registry() {
         let registry = exact_slash_control_commands().collect::<BTreeSet<_>>();
-        for (shell, marker, expected_lists) in [
-            ("bash", include_str!("../shell_host/marker/bash.rs"), 2),
-            ("zsh", include_str!("../shell_host/marker/zsh.rs"), 2),
+        for (shell, marker) in [
+            ("bash", include_str!("../shell_host/marker/bash.rs")),
+            ("zsh", include_str!("../shell_host/marker/zsh.rs")),
         ] {
             let case_lines = marker
                 .lines()
@@ -501,8 +501,8 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(
                 case_lines.len(),
-                expected_lists,
-                "expected {expected_lists} {shell} slash case lists"
+                1,
+                "expected one authoritative {shell} slash case list"
             );
             for line in case_lines {
                 let tokens = line
@@ -513,5 +513,24 @@ mod tests {
                 assert_eq!(tokens, registry, "{shell} case list diverged from registry");
             }
         }
+    }
+
+    #[test]
+    fn routing_c4_zsh_stubs_match_registry() {
+        let registry = exact_slash_control_commands()
+            .map(|name| name.trim_start_matches('/'))
+            .collect::<BTreeSet<_>>();
+        let marker = include_str!("../shell_host/marker/zsh.rs");
+        let line = marker
+            .lines()
+            .map(str::trim)
+            .find(|line| line.starts_with("for _cosh_sc in "))
+            .expect("zsh slash stub loop");
+        let stubs = line
+            .trim_start_matches("for _cosh_sc in ")
+            .trim_end_matches("; do")
+            .split_whitespace()
+            .collect::<BTreeSet<_>>();
+        assert_eq!(stubs, registry, "zsh slash stubs diverged from registry");
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -483,70 +483,35 @@ mod tests {
     #[test]
     fn shell_marker_exact_tokens_match_registry() {
         let registry = exact_slash_control_commands().collect::<BTreeSet<_>>();
-        // Marker scripts live in per-shell owner files under shell_host/marker/.
-        let marker = concat!(
-            include_str!("../shell_host/marker/bash.rs"),
-            "\n",
-            include_str!("../shell_host/marker/zsh.rs")
-        );
-        let marker_tokens = marker
-            .lines()
-            .map(str::trim)
-            .filter(|line| line.starts_with('/'))
-            .flat_map(|line| line.trim_end_matches(')').split('|'))
-            .map(str::trim)
-            .filter(|token| {
-                token
-                    .as_bytes()
-                    .get(1)
-                    .is_some_and(|byte| byte.is_ascii_alphabetic())
-            })
-            .collect::<BTreeSet<_>>();
-
-        for token in &registry {
-            assert!(
-                marker_tokens.contains(token),
-                "shell marker is missing registry token {token}"
-            );
-        }
-        for token in &marker_tokens {
-            assert!(
-                registry.contains(token),
-                "shell marker has unregistered slash token {token}"
-            );
-        }
-
-        // Shell routing of exact slash submissions (issue #1718) is only
-        // safe when the shell side can intercept every routed token, so
-        // both bash case lists (_cosh_should_intercept_unknown and
-        // _cosh_is_slash_control_candidate) must each carry the full
-        // registry set, not merely the bash+zsh union checked above.
-        // Case-arm lines end with `)` and every alternative starts with
-        // `/`, which keeps slash-leading comment lines out of the match.
-        let bash_case_lines = include_str!("../shell_host/marker/bash.rs")
-            .lines()
-            .map(str::trim)
-            .filter(|line| {
-                line.ends_with(')')
-                    && line
-                        .trim_end_matches(')')
-                        .split('|')
-                        .all(|token| token.trim().starts_with('/'))
-            })
-            .filter(|line| line.contains('|'))
-            .collect::<Vec<_>>();
-        assert_eq!(
-            bash_case_lines.len(),
-            2,
-            "expected exactly the two bash slash case lists"
-        );
-        for line in bash_case_lines {
-            let tokens = line
-                .trim_end_matches(')')
-                .split('|')
+        for (shell, marker, expected_lists) in [
+            ("bash", include_str!("../shell_host/marker/bash.rs"), 2),
+            ("zsh", include_str!("../shell_host/marker/zsh.rs"), 2),
+        ] {
+            let case_lines = marker
+                .lines()
                 .map(str::trim)
-                .collect::<BTreeSet<_>>();
-            assert_eq!(tokens, registry, "bash case list diverged from registry");
+                .filter(|line| {
+                    line.ends_with(')')
+                        && line
+                            .trim_end_matches(')')
+                            .split('|')
+                            .all(|token| token.trim().starts_with('/'))
+                })
+                .filter(|line| line.contains('|'))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                case_lines.len(),
+                expected_lists,
+                "expected {expected_lists} {shell} slash case lists"
+            );
+            for line in case_lines {
+                let tokens = line
+                    .trim_end_matches(')')
+                    .split('|')
+                    .map(str::trim)
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(tokens, registry, "{shell} case list diverged from registry");
+            }
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
@@ -154,6 +154,9 @@ fn raw_cli_agent_marker_invokes_adapter_without_failed_command() {
 
 #[test]
 fn raw_cli_zh_natural_language_intercept_skips_redundant_notice() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
     let output = run_raw_cli_with_args_env_and_delayed_input(
         "fake",
         &[],
@@ -359,6 +362,9 @@ fn raw_cli_zsh_shell_marker_agent_response_does_not_duplicate_prompt() {
 
 #[test]
 fn raw_cli_bash_shell_marker_agent_response_does_not_duplicate_prompt() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
     let home = temp_shell_home("agent-shell-marker-bash");
     fs::write(home.join(".bashrc"), "PS1='BPROMPT> '\n").unwrap();
     let home_str = home.to_string_lossy().to_string();
@@ -419,6 +425,9 @@ fn raw_cli_empty_enter_and_ctrl_c_do_not_start_agent() {
 
 #[test]
 fn raw_cli_empty_enter_after_agent_response_does_not_retrigger() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
@@ -445,6 +454,9 @@ fn raw_cli_empty_enter_after_agent_response_does_not_retrigger() {
 
 #[test]
 fn raw_cli_non_ascii_agent_input_echoes_before_intercept() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
@@ -454,8 +466,12 @@ fn raw_cli_non_ascii_agent_input_echoes_before_intercept() {
             (b"exit\n".to_vec(), Duration::from_millis(300)),
         ],
     );
+    let normalized = strip_ansi_escape(&output);
 
-    assert!(output.contains("cosh-osc$ \u{4f60}\u{597d}"), "{output}");
+    assert!(
+        normalized.contains("cosh-osc$ \u{4f60}\u{597d}"),
+        "{output}"
+    );
     assert_eq!(
         count_occurrences(&output, "\n\u{4f60}\u{597d}"),
         0,
@@ -470,7 +486,10 @@ fn raw_cli_non_ascii_agent_input_echoes_before_intercept() {
 }
 
 #[test]
-fn raw_cli_non_ascii_candidate_input_supports_backspace() {
+fn raw_cli_non_ascii_shell_input_supports_backspace() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
@@ -481,8 +500,17 @@ fn raw_cli_non_ascii_candidate_input_supports_backspace() {
             (b"exit\n".to_vec(), Duration::from_millis(300)),
         ],
     );
+    let normalized = strip_ansi_escape(&output);
+    let response_pos = normalized
+        .find("Received shell prompt request")
+        .expect("agent response");
+    let echo = &normalized[..response_pos];
 
-    assert!(output.contains("cosh-osc$ \u{4f60}\u{5417}"), "{output}");
+    assert!(echo.contains("cosh-osc$"), "{output}");
+    assert!(
+        echo.contains('\u{4f60}') && echo.contains('\u{5417}'),
+        "{output}"
+    );
     assert!(
         output.contains("Received shell prompt request: \u{4f60}\u{5417}"),
         "{output}"
@@ -495,14 +523,12 @@ fn raw_cli_non_ascii_candidate_input_supports_backspace() {
 }
 
 #[test]
-fn raw_cli_soft_newline_shortcut_composes_multiline_prompt() {
-    // #1721 matrix #4/#15: Shift+Enter (CSI-u) inserts a soft newline inside
-    // the natural-language draft; Enter submits one multi-line prompt.
+fn routing_c3_explicit_draft_soft_newline_composes_multiline_prompt() {
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
             (
-                "\u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}"
+                "?? \u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}"
                     .as_bytes()
                     .to_vec(),
                 Duration::ZERO,
@@ -536,12 +562,11 @@ fn raw_cli_soft_newline_shortcut_composes_multiline_prompt() {
 }
 
 #[test]
-fn raw_cli_bracketed_paste_newlines_do_not_submit_early() {
-    // #1721 matrix #7: pasted newlines stay soft; the whole paste submits as
-    // one prompt only when the user presses Enter.
+fn routing_c3_explicit_draft_bracketed_paste_newlines_do_not_submit_early() {
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
+            (b"?? ".to_vec(), Duration::ZERO),
             (
                 {
                     let mut paste = b"\x1b[200~".to_vec();
@@ -572,10 +597,10 @@ fn raw_cli_bracketed_paste_newlines_do_not_submit_early() {
 }
 
 #[test]
-fn raw_cli_split_paste_opener_composes_in_card() {
-    // #1721 #1721: the bracketed-paste opener itself may
-    // split across PTY reads at line start; the partial delimiter is held
-    // at the relay entry so no payload line ever executes in bash.
+fn routing_c3_wrapped_paste_split_opener_stays_shell_owned() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
@@ -583,40 +608,34 @@ fn raw_cli_split_paste_opener_composes_in_card() {
             (
                 {
                     let mut tail = b"00~".to_vec();
-                    tail.extend_from_slice(
-                        "\u{5206}\u{6790}\u{8d1f}\u{8f7d}\r\n\u{7ed9}\u{51fa}\u{5efa}\u{8bae}"
-                            .as_bytes(),
-                    );
+                    tail.extend_from_slice(b"printf SPLIT_PASTE_OK");
                     tail.extend_from_slice(b"\x1b[201~");
                     tail
                 },
-                Duration::from_millis(400),
+                Duration::from_millis(10),
             ),
-            (b"\x1b".to_vec(), Duration::from_millis(500)),
-            (b"exit\n".to_vec(), Duration::from_millis(400)),
+            (b"\n".to_vec(), Duration::from_millis(100)),
+            (b"exit\n".to_vec(), Duration::from_millis(300)),
         ],
     );
 
     assert!(
-        output.contains("Prompt draft"),
-        "split opener paste must open the draft card: {output}"
+        output.contains("SPLIT_PASTE_OK"),
+        "split opener paste must execute through the shell: {output}"
     );
     assert!(
-        !output.contains("command not found"),
-        "no payload line may execute in bash: {output}"
+        !output.contains("Prompt draft"),
+        "ordinary paste must not open an Agent draft: {output}"
     );
 }
 
 #[test]
-fn raw_cli_soft_newline_draft_shows_composition_hint() {
-    // #1721 matrix #17 (D13): the first soft newline upgrades the draft into
-    // the prompt card; the card frame and its footer replace the old inline
-    // hint. Esc cancels and freezes the card (D15).
+fn routing_c3_explicit_draft_shows_composition_hint() {
     let output = run_raw_cli_with_delayed_input(
         "fake",
         vec![
             (
-                "\u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}"
+                "?? \u{8bf7}\u{5e2e}\u{6211}\u{5206}\u{6790}"
                     .as_bytes()
                     .to_vec(),
                 Duration::ZERO,

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/mode.rs
@@ -95,7 +95,7 @@ fn raw_cli_zsh_native_pasted_mode_slash_does_not_reach_shell() {
 }
 
 #[test]
-fn raw_cli_pasted_trust_confirm_sets_trust_mode() {
+fn raw_cli_pasted_trust_confirm_sets_trust_mode_after_enter() {
     let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
         "fake",
         &[],
@@ -104,7 +104,7 @@ fn raw_cli_pasted_trust_confirm_sets_trust_mode() {
         &[
             (
                 "cosh-osc$ ",
-                b"\x1b[200~/mode approval trust confirm\n\x1b[201~",
+                b"\x1b[200~/mode approval trust confirm\n\x1b[201~\n",
             ),
             ("Mode set to trust.", b""),
             ("cosh-osc$ ", b"/help\n"),

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
@@ -77,11 +77,30 @@ fn shell_host_run_guard() -> MutexGuard<'static, ()> {
 
 fn shell_host_test_config(config: &ShellHostConfig) -> ShellHostConfig {
     let mut config = config.clone();
+    if !config.env_overrides.iter().any(|(key, _)| key == "INPUTRC") {
+        config = with_raw_byte_readline(config);
+    }
     if !config.env_overrides.iter().any(|(key, _)| key == "HOME") {
         config.env_overrides.push((
             "HOME".to_string(),
             config.work_dir.join("home").display().to_string(),
         ));
+    }
+    for (key, value) in [
+        ("HISTIGNORE", ""),
+        ("HISTSIZE", "1000"),
+        ("HISTFILESIZE", "1000"),
+        ("PROMPT_COMMAND", ""),
+    ] {
+        if !config
+            .env_overrides
+            .iter()
+            .any(|(existing, _)| existing == key)
+        {
+            config
+                .env_overrides
+                .push((key.to_string(), value.to_string()));
+        }
     }
     config
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/handoff.rs
@@ -847,7 +847,7 @@ fn raw_relay_zsh_user_typed_pager_assignments_are_not_a_handoff() {
 }
 
 #[test]
-fn raw_relay_approved_handoff_wrapper_does_not_leak_to_output() {
+fn routing_c3_provider_no_regression_approved_handoff_does_not_leak() {
     if Command::new("bash").arg("--version").output().is_err() {
         return;
     }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
@@ -193,22 +193,16 @@ fn long_ascii_input_avoids_per_byte_subprocess_cost() {
 }
 
 #[test]
-fn max_non_ascii_input_avoids_per_byte_subprocess_cost() {
+fn max_non_ascii_input_needs_no_byte_subprocess() {
     let input = "é".repeat(2048);
     for shell in ["bash", "zsh"] {
         if !shell_available(shell) {
             continue;
         }
-        let started = Instant::now();
         assert_eq!(
-            classify(shell, &input, &input).as_deref(),
+            classify_with_setup(shell, &input, &input, "PATH=/nonexistent").as_deref(),
             Some("ambiguous"),
             "{shell}"
-        );
-        assert!(
-            started.elapsed() < Duration::from_secs(1),
-            "{shell}: {:?}",
-            started.elapsed()
         );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
@@ -212,6 +212,10 @@ fn strong_natural_language_matrix_is_consistent() {
             "\u{5e2e}\u{6211}\u{770b} ./\u{65e5}\u{5fd7}",
             "\u{5e2e}\u{6211}\u{770b}",
         ),
+        (
+            "\u{5e2e}\u{6211}\u{770b} ./*.log",
+            "\u{5e2e}\u{6211}\u{770b}",
+        ),
         ("review ./report.log", "review"),
     ] {
         assert_bash_zsh(input, top_token, "natural_language");
@@ -277,10 +281,6 @@ fn command_veto_matrix_is_consistent() {
         ),
         (
             "\u{5e2e}\u{6211}\u{770b} \"$PATH\"",
-            "\u{5e2e}\u{6211}\u{770b}",
-        ),
-        (
-            "\u{5e2e}\u{6211}\u{770b} ./*.log",
             "\u{5e2e}\u{6211}\u{770b}",
         ),
         ("review --all", "review"),
@@ -430,8 +430,8 @@ fn missing_path_context_keeps_conservative_vetoes() {
         ("打开./config.toml | cat", "打开./config.toml", "command"),
         // option token still vetoes
         ("./run.sh --all", "./run.sh", "command"),
-        // assignment token still vetoes
-        ("打开./x FOO=bar", "打开./x", "command"),
+        // Han-leading assignment syntax is Tier A.
+        ("打开./x FOO=bar", "打开./x", "natural_language"),
     ] {
         assert_bash_zsh_missing_path(input, top_token, expected);
     }
@@ -455,6 +455,68 @@ fn missing_path_context_invalid_utf8_stays_unsafe() {
             "{shell}"
         );
     }
+}
+
+#[test]
+fn routing_c1_classifier_han_tier_matrix() {
+    for (input, top_token, expected) in [
+        (
+            "使用 git log --since=\"1 day ago\" --format=\"%h %s (%an, %ar)\" 总结",
+            "使用",
+            "natural_language",
+        ),
+        (
+            "解释 --all FOO=bar ./*.log {a,b} ~/x",
+            "解释",
+            "natural_language",
+        ),
+        ("解释一下 (quoted) 的含义", "解释一下", "command"),
+        (
+            "解释一下 \"(quoted)\" 的含义",
+            "解释一下",
+            "natural_language",
+        ),
+        ("你还好吗？ 我想问问", "你还好吗？", "natural_language"),
+        ("解释 ps aux | grep java", "解释", "command"),
+        ("解释 true && touch x", "解释", "command"),
+        ("解释 false || touch x", "解释", "command"),
+        ("解释 \"$HOME\"", "解释", "command"),
+        ("解释 'a>b'", "解释", "command"),
+        ("解释 $((1 + 1))", "解释", "command"),
+        ("解释 <(printf x)", "解释", "command"),
+        ("解释 `printf x`", "解释", "command"),
+        ("解释 \\", "解释", "command"),
+        ("解释 \"unterminated", "解释", "command"),
+        ("解释\t内容", "解释", "command"),
+    ] {
+        assert_bash_zsh(input, top_token, expected);
+    }
+}
+
+#[test]
+fn routing_c1_classifier_validates_full_utf8_before_han() {
+    let mut bytes = "解释".as_bytes().to_vec();
+    bytes.push(0xff);
+    let input = OsString::from_vec(bytes);
+    for shell in ["bash", "zsh"] {
+        if !shell_available(shell) {
+            continue;
+        }
+        assert_eq!(
+            classify(shell, &input, "解释").as_deref(),
+            Some("unsafe"),
+            "{shell}"
+        );
+    }
+}
+
+#[test]
+fn routing_c1_missing_path_allows_han_tier_a() {
+    assert_bash_zsh_missing_path(
+        "打开./不存在 --dry-run \"x (preview)\"",
+        "打开./不存在",
+        "natural_language",
+    );
 }
 
 // ENOENT-proof walk (issue #1919 review): dangling symlinks and

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
@@ -67,6 +67,66 @@ fn classify_with_context(
     Some(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+fn literal_first_word_matches(shell: &str, input: &str, attempt: &str, command: &str) -> bool {
+    let mut process = Process::new(shell);
+    if shell == "bash" {
+        process.args(["--noprofile", "--norc"]);
+    } else {
+        process.arg("-f");
+    }
+    let script = format!(
+        "{}\n_cosh_literal_first_word_matches \"$1\" \"$2\" \"$3\"",
+        shell_intent_helpers(),
+    );
+    process
+        .args(["-c", &script, "cosh-literal-test", input, attempt, command])
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[test]
+fn routing_c2_matcher_table_covers_supported_quote_removal_subset() {
+    let accepted = [
+        (
+            "子曰\"三人行必有我师\"",
+            "子曰\"三人行必有我师\"",
+            "子曰三人行必有我师",
+        ),
+        ("子曰\" 三人行必有我师\"", "子曰\"", "子曰 三人行必有我师"),
+        ("'子曰 三人行'后续", "'子曰", "子曰 三人行后续"),
+        ("\"子 曰\"x", "\"子", "子 曰x"),
+        ("子曰'\"'后续", "子曰'\"'后续", "子曰\"后续"),
+        ("\"\"子曰", "\"\"子曰", "子曰"),
+        ("子曰?", "子曰?", "子曰?"),
+        ("   解释", "解释", "解释"),
+    ];
+    let rejected = [
+        ("\"\"", "\"\"", ""),
+        ("'子曰", "'子曰", "子曰"),
+        (r"子曰\ x", r"子曰\", "子曰 x"),
+        (r#"子曰"$HOME""#, r#"子曰"$HOME""#, "子曰/tmp"),
+        ("子曰$(id)", "子曰$(id)", "子曰uid"),
+        ("子曰*", "子曰*", "子曰a"),
+    ];
+    for shell in ["bash", "zsh"] {
+        if !shell_available(shell) {
+            continue;
+        }
+        for (input, attempt, command) in accepted {
+            assert!(
+                literal_first_word_matches(shell, input, attempt, command),
+                "{shell}: accepted {input:?}"
+            );
+        }
+        for (input, attempt, command) in rejected {
+            assert!(
+                !literal_first_word_matches(shell, input, attempt, command),
+                "{shell}: rejected {input:?}"
+            );
+        }
+    }
+}
+
 #[test]
 fn classification_is_locale_independent() {
     for shell in ["bash", "zsh"] {

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
@@ -484,12 +484,13 @@ fn path_provably_missing_requires_enoent_proof() {
     use crate::unique_suffix;
     use std::os::unix::fs::PermissionsExt;
 
-    let base = std::env::temp_dir().join(format!(
+    let requested_base = std::env::temp_dir().join(format!(
         "cosh-path-proof-{}-{}",
         std::process::id(),
         unique_suffix()
     ));
-    std::fs::create_dir_all(&base).expect("base dir");
+    std::fs::create_dir_all(&requested_base).expect("base dir");
+    let base = requested_base.canonicalize().expect("canonical base dir");
     let existing = base.join("existing.txt");
     std::fs::write(&existing, "x\n").expect("existing file");
     let dangling = base.join("dangling-link");

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1826,6 +1826,10 @@ fn shell_host_bash_stale_history_guard_still_intercepts_deduped_repeats() {
     if Command::new("bash").arg("--version").output().is_err() {
         return;
     }
+    if !bash_supports_command_not_found_handler() {
+        eprintln!("SKIP: bash command_not_found_handle capability is unavailable");
+        return;
+    }
 
     let work_dir = std::env::temp_dir().join(format!(
         "cosh-shell-bash-histdedup-test-{}-{}",

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1925,6 +1925,256 @@ fn shell_host_bash_missing_path_natural_language_intercepts() {
     );
 }
 
+#[test]
+fn routing_c1_cnf_han_tier_a_routes_to_agent() {
+    for shell in ["bash", "zsh"] {
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c1-cnf-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let mut config = ShellHostConfig::new(format!("routing-c1-cnf-{shell}"), &work_dir);
+        config.native_mode = false;
+        let mut inputs = vec![
+            "使用 git log --since=\"1 day ago\" --format=\"%h %s (%an, %ar)\" 总结",
+            "你还好吗？ 我想问问",
+        ];
+        if shell == "bash" {
+            inputs.push("你还好吗? 我想问问");
+        }
+        let steps = inputs
+            .iter()
+            .map(|input| ScriptedInput::user_line(*input))
+            .collect::<Vec<_>>();
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &steps)
+        } else {
+            run_scripted_zsh(&config, &steps)
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        for input in inputs {
+            assert!(
+                output.events.iter().any(|event| {
+                    event.kind == ShellEventKind::UserInputIntercepted
+                        && event.input.as_deref() == Some(input)
+                        && event.component.as_deref() == Some("natural_language")
+                }),
+                "{shell}: {input:?}: {:?}\n{}",
+                output.events,
+                String::from_utf8_lossy(&output.terminal_output)
+            );
+        }
+    }
+}
+
+#[test]
+fn routing_c1_zsh_ascii_question_unmatched_routes_to_agent() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    let input = "你还好吗? 我想问问";
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-routing-c1-zsh-question-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c1-zsh-question", &work_dir);
+    let output =
+        run_scripted_zsh(&config, &[ScriptedInput::user_line(input)]).expect("scripted zsh");
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some(input)
+            && event.component.as_deref() == Some("natural_language")
+    }));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn routing_c1_missing_path_han_tier_a_routes_to_agent() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
+    let input = "打开./不存在 --dry-run \"x (preview)\"";
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-routing-c1-missing-path-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config = ShellHostConfig::new("routing-c1-missing-path", &work_dir);
+    config.native_mode = false;
+    let output =
+        run_scripted_bash(&config, &[ScriptedInput::user_line(input)]).expect("scripted bash");
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some(input)
+            && event.component.as_deref() == Some("natural_language")
+    }));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn routing_c1_stale_history_repeated_han_prompt_routes_twice() {
+    if !bash_supports_command_not_found_handler() {
+        return;
+    }
+    let input = "解释 git log --format=\"%h (%an)\"";
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-routing-c1-stale-history-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    std::fs::write(home_dir.join(".bashrc"), "HISTCONTROL=ignoredups\n").expect("bashrc");
+    let mut config = ShellHostConfig::new("routing-c1-stale-history", &work_dir)
+        .with_env("HOME", home_dir.display().to_string());
+    config.native_mode = false;
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line(input),
+            ScriptedInput::user_line(input),
+        ],
+    )
+    .expect("scripted bash");
+    let intercepts = output
+        .events
+        .iter()
+        .filter(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some(input)
+                && event.component.as_deref() == Some("natural_language")
+        })
+        .count();
+    assert_eq!(intercepts, 2, "{:?}", output.events);
+}
+
+#[test]
+fn routing_c1_tier_b_side_effect_stays_native() {
+    for shell in ["bash", "zsh"] {
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c1-tier-b-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        let side = work_dir.join("side-effect");
+        let input = format!("解释 \"$(touch {})\"", shell_arg(&side));
+        let config = ShellHostConfig::new(format!("routing-c1-tier-b-{shell}"), &work_dir);
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &[ScriptedInput::user_line(input.clone())])
+        } else {
+            run_scripted_zsh(&config, &[ScriptedInput::user_line(input.clone())])
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        assert!(side.exists(), "{shell}: command substitution did not run");
+        assert!(!output.events.iter().any(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some(input.as_str())
+        }));
+    }
+}
+
+#[test]
+fn routing_c1_zsh_glob_qualifier_stays_native() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-routing-c1-zsh-glob-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+    std::fs::write(work_dir.join("entry"), "x\n").expect("glob entry");
+    let side = work_dir.join("glob-side-effect");
+    let input = format!("解释 *(e:'touch {}':)", side.display());
+    let config = ShellHostConfig::new("routing-c1-zsh-glob", &work_dir);
+    let output = run_scripted_zsh(&config, &[ScriptedInput::user_line(input.clone())])
+        .expect("scripted zsh");
+    assert!(side.exists(), "glob qualifier did not run");
+    assert!(!output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some(input.as_str())
+    }));
+}
+
+#[test]
+fn routing_c1_valid_han_command_stays_native() {
+    for shell in ["bash", "zsh"] {
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c1-valid-han-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let bin_dir = work_dir.join("bin");
+        let home_dir = work_dir.join("home");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        std::fs::create_dir_all(&home_dir).expect("home dir");
+        let executable = bin_dir.join("解释");
+        std::fs::write(
+            &executable,
+            "#!/bin/sh\nprintf '__han_exec__:%s\\n' \"$1\"\n",
+        )
+        .expect("han executable");
+        make_executable(&executable);
+        let path = format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let rc = "解释函数() { printf '__han_function__:%s\\n' \"$1\"; }\n\
+                  alias 解释别名=\"printf '__han_alias__:%s\\n'\"\n";
+        std::fs::write(
+            home_dir.join(if shell == "bash" { ".bashrc" } else { ".zshrc" }),
+            rc,
+        )
+        .expect("shell rc");
+        let mut config = ShellHostConfig::new(format!("routing-c1-valid-han-{shell}"), &work_dir)
+            .with_env("PATH", path)
+            .with_env("HOME", home_dir.display().to_string());
+        if shell == "zsh" {
+            config = config.with_env("COSH_ZDOTDIR_ORIG", home_dir.display().to_string());
+        }
+        let inputs = ["解释 ok", "解释函数 ok", "解释别名 ok"];
+        let steps = inputs
+            .iter()
+            .map(|input| ScriptedInput::user_line(*input))
+            .collect::<Vec<_>>();
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &steps)
+        } else {
+            run_scripted_zsh(&config, &steps)
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        let terminal = String::from_utf8_lossy(&output.terminal_output);
+        for marker in ["__han_exec__:ok", "__han_function__:ok", "__han_alias__:ok"] {
+            assert!(terminal.contains(marker), "{shell}: {marker}: {terminal}");
+        }
+        for input in inputs {
+            assert!(!output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.input.as_deref() == Some(input)
+            }));
+        }
+    }
+}
+
 // Issue #1919 fail-closed counterproofs: the missing-path branch must never
 // fire for existing paths (I1/D6), plain-English typo paths (I2/D3), or
 // secret-bearing input (I3) — bash native behavior stays byte-identical.

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -2004,6 +2004,88 @@ fn routing_c1_cnf_han_tier_a_routes_to_agent() {
 }
 
 #[test]
+fn isolated_bash_ignores_inherited_prompt_and_history_filters() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+    let supports_command_not_found = bash_supports_command_not_found_handler();
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-isolated-prompt-command-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+    let inherited_inputrc = work_dir.join("inherited-inputrc");
+    std::fs::write(
+        &inherited_inputrc,
+        "set input-meta off\nset convert-meta on\nset output-meta off\n",
+    )
+    .expect("inherited inputrc");
+    let inherited_marker = work_dir.join("inherited-prompt-command-ran");
+    let mut config = ShellHostConfig::new("isolated-prompt-command", &work_dir)
+        .with_env(
+            "PROMPT_COMMAND",
+            format!("printf inherited > {}", shell_arg(&inherited_marker)),
+        )
+        .with_env("HISTIGNORE", "*")
+        .with_env("HISTSIZE", "0")
+        .with_env("HISTFILESIZE", "0")
+        .with_env("INPUTRC", inherited_inputrc.display().to_string());
+    config.native_mode = false;
+    let input = "解释 inherited history filter";
+
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line(
+                "printf '__cosh_hist_limits__%s:%s\\n' \"$HISTSIZE\" \"$HISTFILESIZE\"",
+            ),
+            ScriptedInput::user_line(input),
+        ],
+    )
+    .expect("isolated scripted bash");
+
+    assert!(!inherited_marker.exists());
+    assert!(
+        String::from_utf8_lossy(&output.terminal_output).contains("__cosh_hist_limits__1000:1000")
+    );
+    if supports_command_not_found {
+        assert!(output.events.iter().any(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some(input)
+                && event.component.as_deref() == Some("natural_language")
+        }));
+    }
+}
+
+#[test]
+fn isolated_zsh_preserves_inputrc_override() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-isolated-zsh-inputrc-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let inputrc = work_dir.join("custom-inputrc");
+    let mut config = ShellHostConfig::new("isolated-zsh-inputrc", &work_dir)
+        .with_env("INPUTRC", inputrc.display().to_string());
+    config.native_mode = false;
+
+    let output = run_scripted_zsh(
+        &config,
+        &[ScriptedInput::user_line(
+            "printf '__cosh_inputrc__%s\\n' \"$INPUTRC\"",
+        )],
+    )
+    .expect("isolated scripted zsh");
+
+    assert!(String::from_utf8_lossy(&output.terminal_output)
+        .contains(&format!("__cosh_inputrc__{}", inputrc.display())));
+}
+
+#[test]
 fn routing_c1_zsh_ascii_question_unmatched_routes_to_agent() {
     if Command::new("zsh").arg("--version").output().is_err() {
         return;

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -2175,6 +2175,323 @@ fn routing_c1_valid_han_command_stays_native() {
     }
 }
 
+fn assert_routing_c2_quote_cnf(shell: &str) {
+    if shell == "bash" && !bash_supports_command_not_found_handler() {
+        return;
+    }
+    if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    let inputs = ["'子曰 三人行'后续 请解释", "\"子 曰\"后续 请解释"];
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-routing-c2-quote-{shell}-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new(format!("routing-c2-quote-{shell}"), &work_dir);
+    let steps = inputs
+        .iter()
+        .map(|input| ScriptedInput::user_line(*input))
+        .collect::<Vec<_>>();
+    let output = if shell == "bash" {
+        run_scripted_bash(&config, &steps)
+    } else {
+        run_scripted_zsh(&config, &steps)
+    }
+    .unwrap_or_else(|error| panic!("{shell}: {error}"));
+    for input in inputs {
+        assert!(
+            output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.input.as_deref() == Some(input)
+                    && event.component.as_deref() == Some("natural_language")
+            }),
+            "{shell}: {input:?}: {:?}\n{}",
+            output.events,
+            String::from_utf8_lossy(&output.terminal_output)
+        );
+    }
+}
+
+#[test]
+fn routing_c2_bash_quote_cnf_routes_to_agent() {
+    assert_routing_c2_quote_cnf("bash");
+}
+
+#[test]
+fn routing_c2_zsh_quote_cnf_routes_to_agent() {
+    assert_routing_c2_quote_cnf("zsh");
+}
+
+#[test]
+fn routing_c2_expansion_drift_and_matched_arguments_stay_native() {
+    for shell in ["bash", "zsh"] {
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c2-drift-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let home_dir = work_dir.join("home");
+        std::fs::create_dir_all(&home_dir).expect("home dir");
+        std::fs::write(work_dir.join("match.log"), "x\n").expect("glob match");
+        let side = work_dir.join("alias-side");
+        let rc = format!("alias 解释='解释; touch {}'\n", side.display());
+        std::fs::write(
+            home_dir.join(if shell == "bash" { ".bashrc" } else { ".zshrc" }),
+            rc,
+        )
+        .expect("shell rc");
+        let mut config = ShellHostConfig::new(format!("routing-c2-drift-{shell}"), &work_dir)
+            .with_env("HOME", home_dir.display().to_string());
+        if shell == "zsh" {
+            config = config.with_env("COSH_ZDOTDIR_ORIG", home_dir.display().to_string());
+        }
+        let alias_input = "解释";
+        let glob_input = "说明 *.log";
+        let cd_input = format!("cd {}", shell_arg(&work_dir));
+        let output = if shell == "bash" {
+            run_scripted_bash(
+                &config,
+                &[
+                    ScriptedInput::user_line(cd_input.clone()),
+                    ScriptedInput::user_line(alias_input),
+                    ScriptedInput::user_line(glob_input),
+                ],
+            )
+        } else {
+            run_scripted_zsh(
+                &config,
+                &[
+                    ScriptedInput::user_line(cd_input),
+                    ScriptedInput::user_line(alias_input),
+                    ScriptedInput::user_line(glob_input),
+                ],
+            )
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        assert!(side.exists(), "{shell}: alias side effect missing");
+        for input in [alias_input, glob_input] {
+            assert!(
+                !output.events.iter().any(|event| {
+                    event.kind == ShellEventKind::UserInputIntercepted
+                        && event.input.as_deref() == Some(input)
+                }),
+                "{shell}: {input}: {:?}",
+                output.events
+            );
+        }
+    }
+}
+
+#[test]
+fn routing_c2_nested_provenance_marks_only_the_outer_missing_command() {
+    let input = "解释 \"$(解释)\"";
+    for shell in ["bash", "zsh"] {
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c2-nested-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let config = ShellHostConfig::new(format!("routing-c2-nested-{shell}"), &work_dir);
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &[ScriptedInput::user_line(input)])
+        } else {
+            run_scripted_zsh(&config, &[ScriptedInput::user_line(input)])
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        let proven = output
+            .events
+            .iter()
+            .filter(|event| {
+                event
+                    .routing
+                    .as_ref()
+                    .is_some_and(|routing| routing.top_level_missing && routing.proven)
+            })
+            .count();
+        assert_eq!(proven, 1, "{shell}: {:?}", output.events);
+        assert!(!output.events.iter().any(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some(input)
+        }));
+    }
+}
+
+#[test]
+fn routing_c2_nested_provenance_rejects_same_token_from_shell_function() {
+    for shell in ["bash", "zsh"] {
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c2-function-nested-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let home_dir = work_dir.join("home");
+        std::fs::create_dir_all(&home_dir).expect("home dir");
+        let rc = if shell == "bash" {
+            "解释() { unset -f 解释; 解释; }\n"
+        } else {
+            "解释() { unfunction 解释; 解释; }\n"
+        };
+        std::fs::write(
+            home_dir.join(if shell == "bash" { ".bashrc" } else { ".zshrc" }),
+            rc,
+        )
+        .expect("shell rc");
+        let mut config =
+            ShellHostConfig::new(format!("routing-c2-function-nested-{shell}"), &work_dir)
+                .with_env("HOME", home_dir.display().to_string());
+        if shell == "zsh" {
+            config = config.with_env("COSH_ZDOTDIR_ORIG", home_dir.display().to_string());
+        }
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &[ScriptedInput::user_line("解释")])
+        } else {
+            run_scripted_zsh(&config, &[ScriptedInput::user_line("解释")])
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        assert!(
+            !output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    || event
+                        .routing
+                        .as_ref()
+                        .is_some_and(|routing| routing.top_level_missing && routing.proven)
+            }),
+            "{shell}: {:?}",
+            output.events
+        );
+    }
+}
+
+#[test]
+fn routing_c2_delegate_unsupported_escape_and_matched_glob() {
+    for shell in ["bash", "zsh"] {
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c2-unsupported-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        std::fs::write(work_dir.join("中文a"), "x\n").expect("glob match");
+        let inputs = [r"解释\ 一下", "中文?"];
+        let config = ShellHostConfig::new(format!("routing-c2-unsupported-{shell}"), &work_dir);
+        let mut steps = vec![ScriptedInput::user_line(format!(
+            "cd {}",
+            shell_arg(&work_dir)
+        ))];
+        steps.extend(inputs.iter().map(|input| ScriptedInput::user_line(*input)));
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &steps)
+        } else {
+            run_scripted_zsh(&config, &steps)
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        for input in inputs {
+            assert!(
+                !output.events.iter().any(|event| {
+                    event.kind == ShellEventKind::UserInputIntercepted
+                        && event.input.as_deref() == Some(input)
+                }),
+                "{shell}: {input}: {:?}",
+                output.events
+            );
+        }
+    }
+}
+
+#[test]
+fn routing_c2_valid_quoted_command_and_inner_whitespace_keep_their_owners() {
+    for shell in ["bash", "zsh"] {
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c2-valid-quoted-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let bin_dir = work_dir.join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let executable = bin_dir.join("中文 命令");
+        std::fs::write(
+            &executable,
+            "#!/bin/sh\nprintf '__quoted_exec__:%s\\n' \"$1\"\n",
+        )
+        .expect("quoted executable");
+        make_executable(&executable);
+        let path = format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let config = ShellHostConfig::new(format!("routing-c2-valid-quoted-{shell}"), &work_dir)
+            .with_env("PATH", path);
+        let native = "\"中文 命令\" ok";
+        let natural = "解释  一下";
+        let output = if shell == "bash" {
+            run_scripted_bash(
+                &config,
+                &[
+                    ScriptedInput::user_line(native),
+                    ScriptedInput::user_line(natural),
+                ],
+            )
+        } else {
+            run_scripted_zsh(
+                &config,
+                &[
+                    ScriptedInput::user_line(native),
+                    ScriptedInput::user_line(natural),
+                ],
+            )
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        assert!(
+            String::from_utf8_lossy(&output.terminal_output).contains("__quoted_exec__:ok"),
+            "{shell}: {}",
+            String::from_utf8_lossy(&output.terminal_output)
+        );
+        assert!(!output.events.iter().any(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some(native)
+        }));
+        if shell == "zsh" || bash_supports_command_not_found_handler() {
+            assert!(
+                output.events.iter().any(|event| {
+                    event.kind == ShellEventKind::UserInputIntercepted
+                        && event.input.as_deref() == Some(natural)
+                }),
+                "{shell}: {:?}",
+                output.events
+            );
+        }
+    }
+}
+
 // Issue #1919 fail-closed counterproofs: the missing-path branch must never
 // fire for existing paths (I1/D6), plain-English typo paths (I2/D3), or
 // secret-bearing input (I3) — bash native behavior stays byte-identical.

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1159,6 +1159,36 @@ fn shell_host_zsh_adapter_emits_shared_command_events() {
 }
 
 #[test]
+fn routing_c4_zsh_stubs_intercept_bypass_only_commands() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c4-zsh-stubs-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c4-zsh-stubs", &work_dir);
+    let inputs = ["/draft", "/resume", "/session"];
+    let steps = inputs
+        .iter()
+        .map(|input| ScriptedInput::user_line(*input))
+        .collect::<Vec<_>>();
+    let output = run_scripted_zsh(&config, &steps).expect("scripted zsh slash stubs");
+
+    for input in inputs {
+        assert!(output.events.iter().any(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some(input)
+                && event.component.as_deref() == Some("slash")
+        }));
+        assert!(!output.events.iter().any(|event| {
+            event.kind == ShellEventKind::CommandStarted && event.command.as_deref() == Some(input)
+        }));
+    }
+}
+
+#[test]
 fn shell_host_zsh_later_preexec_hook_fails_closed_for_path_generation() {
     if Command::new("zsh").arg("--version").output().is_err() {
         return;

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -43,7 +43,7 @@ fn raw_relay_bash_invalid_utf8_never_enters_event_provenance() {
 }
 
 #[test]
-fn raw_relay_zsh_adapter_uses_shared_event_contract() {
+fn routing_c4_zsh_rust_route_uses_shared_event_contract() {
     if Command::new("zsh").arg("--version").output().is_err() {
         return;
     }
@@ -98,6 +98,33 @@ fn raw_relay_zsh_adapter_uses_shared_event_contract() {
     assert!(ledger.blocks.iter().any(|block| {
         block.command.contains("/path/that/does/not/exist") && block.exit_code != 0
     }));
+}
+
+#[test]
+fn routing_c4_draft_grammar_no_drift_preserves_raw_arguments() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c4-draft-grammar-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c4-draft-grammar", &work_dir);
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::line("/draft extra"),
+            RawRelayAction::line("/draft 'extra'"),
+        ],
+        Vec::new(),
+    )
+    .expect("draft grammar routing");
+
+    for input in ["/draft extra", "/draft 'extra'"] {
+        assert!(output.events.iter().any(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.input.as_deref() == Some(input)
+                && event.component.as_deref() == Some("slash")
+        }));
+    }
 }
 
 #[test]
@@ -275,7 +302,7 @@ fn raw_relay_bash_up_recalls_intercepted_slash_command() {
 }
 
 #[test]
-fn raw_relay_bash_routed_slash_enters_native_history_file() {
+fn routing_c4_bash_route_enters_native_history_file() {
     let root = std::env::temp_dir().join(format!(
         "cosh-shell-bash-1718-histfile-{}-{}",
         std::process::id(),
@@ -301,7 +328,7 @@ fn raw_relay_bash_routed_slash_enters_native_history_file() {
         vec![
             RawRelayAction::wait(Duration::from_millis(200)),
             RawRelayAction::line("/skills detail xlsx"),
-            RawRelayAction::wait(Duration::from_millis(600)),
+            RawRelayAction::wait(Duration::from_millis(1200)),
             RawRelayAction::line("exit"),
         ],
         &mut rendered,
@@ -386,7 +413,7 @@ fn raw_relay_bash_slash_route_switch_off_keeps_rust_intercept() {
 }
 
 #[test]
-fn raw_relay_bash_routed_slash_with_secret_never_persists_in_history() {
+fn routing_c4_history_privacy_secret_slash_never_persists() {
     let root = std::env::temp_dir().join(format!(
         "cosh-shell-bash-1718-secret-{}-{}",
         std::process::id(),

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -164,7 +164,7 @@ fn raw_relay_zsh_buffers_fragmented_intercept_candidates() {
 }
 
 #[test]
-fn raw_relay_bash_intercepts_fragmented_slash_while_typing() {
+fn routing_c3_valid_slash_intercepts_fragmented_input() {
     let work_dir = std::env::temp_dir().join(format!(
         "cosh-shell-slash-completion-test-{}-{}",
         std::process::id(),
@@ -1045,4 +1045,395 @@ fn raw_relay_capture_owned_input_overflow_is_visible_and_discarded() {
         .events
         .iter()
         .any(|event| event.message.as_deref() == Some("capture_overflow")));
+}
+
+#[test]
+fn routing_c3_typed_passthrough_keeps_cjk_shell_owned() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-typed-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-typed", &work_dir);
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash(
+        &config,
+        std::io::Cursor::new("printf '%s\\n' 中文\n".as_bytes().to_vec()),
+        &mut rendered,
+    )
+    .expect("typed passthrough");
+
+    assert!(String::from_utf8_lossy(&rendered).contains("中文"));
+    assert!(!output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event
+                .input
+                .as_deref()
+                .is_some_and(|input| input.contains("中文"))
+    }));
+}
+
+#[test]
+fn routing_c3_wrapped_paste_stays_shell_owned() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-wrapped-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-wrapped", &work_dir);
+    let input = b"\x1b[200~printf WRAPPED_PASTE\x1b[201~\n".to_vec();
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash(&config, std::io::Cursor::new(input), &mut rendered)
+        .expect("wrapped paste");
+
+    assert!(String::from_utf8_lossy(&rendered).contains("WRAPPED_PASTE"));
+    assert!(!output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.component.as_deref() == Some("natural_language")
+    }));
+}
+
+#[test]
+fn routing_c3_unwrapped_paste_uses_shell_newline_semantics() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-unwrapped-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-unwrapped", &work_dir);
+    let mut rendered = Vec::new();
+    run_raw_relay_bash(
+        &config,
+        std::io::Cursor::new(b"echo FIRST_LINE\necho SECOND_LINE\n".to_vec()),
+        &mut rendered,
+    )
+    .expect("unwrapped multiline input");
+
+    let rendered = String::from_utf8_lossy(&rendered);
+    assert!(rendered.contains("FIRST_LINE"), "{rendered}");
+    assert!(rendered.contains("SECOND_LINE"), "{rendered}");
+}
+
+#[test]
+fn routing_c3_mirror_dirty_eof_never_appends_exit() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-mirror-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let side_effect = work_dir.join("must-not-exist");
+    let config = ShellHostConfig::new("routing-c3-mirror", &work_dir);
+    let input = format!("touch {}\x1b[D", shell_arg(&side_effect)).into_bytes();
+    let output = run_raw_relay_bash(&config, std::io::Cursor::new(input), Vec::new())
+        .expect("dirty mirror shutdown");
+
+    assert!(!side_effect.exists());
+    assert_eq!(output.exit_status, Some(129));
+}
+
+#[test]
+fn routing_c3_paste_active_eof_never_executes_or_appends_exit() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-paste-eof-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-paste-eof", &work_dir);
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![RawRelayAction::write(b"\x1b[200~echo should-not-run\n")],
+        Vec::new(),
+    )
+    .expect("paste-active EOF shutdown");
+
+    assert_ne!(output.exit_status, Some(0));
+    assert!(!output.events.iter().any(|event| {
+        event
+            .command
+            .as_deref()
+            .is_some_and(|command| command.contains("should-not-run") || command == "exit")
+    }));
+}
+
+#[test]
+fn routing_c3_mirror_oversize_eof_never_appends_exit() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-oversize-eof-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-oversize-eof", &work_dir);
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![RawRelayAction::write(vec![b'x'; 4097])],
+        Vec::new(),
+    )
+    .expect("oversize mirror EOF shutdown");
+
+    assert_ne!(output.exit_status, Some(0));
+    assert!(!output
+        .events
+        .iter()
+        .any(|event| { event.command.as_deref() == Some("exit") }));
+}
+
+#[test]
+fn routing_c3_eof_partial_line_has_no_synthetic_pty_write() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-partial-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let side_effect = work_dir.join("partial-side-effect");
+    let config = ShellHostConfig::new("routing-c3-partial", &work_dir);
+    let input = format!("touch {}", shell_arg(&side_effect)).into_bytes();
+    let output = run_raw_relay_bash(&config, std::io::Cursor::new(input), Vec::new())
+        .expect("partial EOF shutdown");
+
+    assert!(!side_effect.exists());
+    assert_eq!(output.exit_status, Some(129));
+}
+
+#[test]
+fn routing_c3_eof_session_shutdown_is_bounded_in_zsh() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-zsh-eof-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-zsh-eof", &work_dir);
+    let started = Instant::now();
+    let output = run_raw_relay_zsh_with_output_control(
+        &config,
+        std::io::Cursor::new(b"echo ZSH_PARTIAL".to_vec()),
+        Vec::new(),
+        |_, _| Ok(RawObserverAction::Continue),
+    )
+    .expect("zsh EOF shutdown");
+
+    assert!(started.elapsed() < Duration::from_secs(5));
+    assert_ne!(output.exit_status, Some(0));
+}
+
+#[test]
+fn routing_c3_eof_submitted_no_drift_waits_for_command() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-submitted-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-submitted", &work_dir);
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash(
+        &config,
+        std::io::Cursor::new(b"sleep 0.2; echo FULL_LINE_DONE\n".to_vec()),
+        &mut rendered,
+    )
+    .expect("submitted command then EOF");
+
+    assert!(String::from_utf8_lossy(&rendered).contains("FULL_LINE_DONE"));
+    assert_eq!(output.exit_status, Some(0));
+}
+
+struct RoutingC3ErrorReader;
+
+impl Read for RoutingC3ErrorReader {
+    fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "routing-c3-reader-error",
+        ))
+    }
+}
+
+struct RoutingC3BytesThenErrorReader {
+    bytes: Option<Vec<u8>>,
+}
+
+impl Read for RoutingC3BytesThenErrorReader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if let Some(bytes) = self.bytes.take() {
+            let length = bytes.len().min(buffer.len());
+            buffer[..length].copy_from_slice(&bytes[..length]);
+            return Ok(length);
+        }
+        std::thread::sleep(Duration::from_millis(200));
+        Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "routing-c3-reader-error",
+        ))
+    }
+}
+
+#[test]
+fn routing_c3_eof_error_preserves_reader_error() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-reader-error-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-reader-error", &work_dir);
+    let error = run_raw_relay_bash(&config, RoutingC3ErrorReader, Vec::new())
+        .expect_err("reader error must propagate");
+
+    assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(error.to_string(), "routing-c3-reader-error");
+}
+
+#[test]
+fn routing_c3_driver_result_is_not_silently_discarded() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-driver-result-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-driver-result", &work_dir);
+    let error = run_raw_relay_bash(
+        &config,
+        RoutingC3BytesThenErrorReader {
+            bytes: Some(b"echo DRIVER_PREFIX_DONE\n".to_vec()),
+        },
+        Vec::new(),
+    )
+    .expect_err("driver result must reach host after relayed bytes");
+
+    assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
+}
+
+#[test]
+fn routing_c3_signal_status_reaches_all_consumers() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-signal-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-signal", &work_dir);
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::line("sleep 30"),
+            RawRelayAction::wait(Duration::from_millis(150)),
+            RawRelayAction::write(b"partial"),
+        ],
+        Vec::new(),
+    )
+    .expect("signal status relay");
+
+    assert_eq!(output.exit_status, Some(129));
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::ShellExited && event.exit_code == Some(129)
+    }));
+    assert!(output.events.iter().any(|event| {
+        matches!(
+            event.kind,
+            ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed
+        ) && event.command.as_deref() == Some("sleep 30")
+            && event.exit_code == Some(129)
+    }));
+}
+
+#[test]
+fn routing_c3_signal_status_kill_reaches_all_consumers() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-kill-signal-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-kill-signal", &work_dir);
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::line("trap '' HUP; sleep 30"),
+            RawRelayAction::wait(Duration::from_millis(150)),
+            RawRelayAction::write(b"partial"),
+        ],
+        Vec::new(),
+    )
+    .expect("kill status relay");
+
+    assert_eq!(output.exit_status, Some(137));
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::ShellExited && event.exit_code == Some(137)
+    }));
+    assert!(output.events.iter().any(|event| {
+        matches!(
+            event.kind,
+            ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed
+        ) && event.command.as_deref() == Some("trap '' HUP; sleep 30")
+            && event.exit_code == Some(137)
+    }));
+}
+
+#[test]
+fn routing_c3_eof_session_shutdown_kills_hup_ignoring_foreground_group() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-foreground-cleanup-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+    let pid_file = work_dir.join("foreground.pid");
+    let command = format!(
+        "bash -c 'trap \"\" HUP; echo $$ > {}; while :; do sleep 1; done'",
+        pid_file.display()
+    );
+    let config = ShellHostConfig::new("routing-c3-foreground-cleanup", &work_dir);
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::line(command),
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::write(b"partial"),
+        ],
+        Vec::new(),
+    )
+    .expect("foreground cleanup relay");
+
+    assert_ne!(output.exit_status, Some(0));
+    let pid = std::fs::read_to_string(&pid_file)
+        .expect("foreground pid file")
+        .trim()
+        .parse::<i32>()
+        .expect("foreground pid");
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while Instant::now() < deadline {
+        #[cfg(target_os = "linux")]
+        if std::fs::read_to_string(format!("/proc/{pid}/stat"))
+            .ok()
+            .and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .map(|(_, suffix)| suffix.starts_with('Z'))
+            })
+            == Some(true)
+        {
+            return;
+        }
+        let result = unsafe { nix::libc::kill(pid, 0) };
+        if result < 0 && io::Error::last_os_error().raw_os_error() == Some(nix::libc::ESRCH) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("foreground process {pid} survived EOF shutdown");
+}
+
+#[test]
+fn routing_c3_explicit_draft_remains_the_only_multiline_agent_entry() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-c3-draft-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("routing-c3-draft", &work_dir);
+    let output = run_raw_relay_bash(&config, std::io::Cursor::new(b"??\n".to_vec()), Vec::new())
+        .expect("explicit draft");
+
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.component.as_deref() == Some("prompt_draft")
+            && event.message.as_deref() == Some("open")
+    }));
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -238,9 +238,9 @@ fn raw_relay_bash_up_recalls_intercepted_slash_command() {
         vec![
             RawRelayAction::wait(Duration::from_millis(200)),
             RawRelayAction::line("/skills detail xlsx"),
-            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::wait(Duration::from_millis(600)),
             RawRelayAction::write(b"\x1b[A".to_vec()),
-            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::wait(Duration::from_millis(200)),
             RawRelayAction::write(b"\n".to_vec()),
             RawRelayAction::wait(Duration::from_millis(300)),
             RawRelayAction::line("exit"),
@@ -301,7 +301,7 @@ fn raw_relay_bash_routed_slash_enters_native_history_file() {
         vec![
             RawRelayAction::wait(Duration::from_millis(200)),
             RawRelayAction::line("/skills detail xlsx"),
-            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::wait(Duration::from_millis(600)),
             RawRelayAction::line("exit"),
         ],
         &mut rendered,

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
@@ -1,6 +1,60 @@
 use super::*;
 
 #[test]
+fn scripted_shell_exit_timeout_kills_foreground_group() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-scripted-exit-timeout-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let work_dir = root.join("work");
+    let descendant_pid_file = root.join("descendant.pid");
+    std::fs::create_dir_all(&root).expect("timeout test root");
+    let mut config = ShellHostConfig::new("scripted-exit-timeout", &work_dir);
+    config.native_mode = false;
+    let started = Instant::now();
+    let override_exit = format!(
+        "exit() {{ sh -c 'trap \"\" HUP TERM; printf \"%s\\n\" \"$$\" > {}; while :; do sleep 60; done'; }}",
+        shell_arg(&descendant_pid_file)
+    );
+
+    let error = run_scripted_bash(&config, &[ScriptedInput::command(override_exit)])
+        .expect_err("scripted shell that ignores exit must time out");
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert!(started.elapsed() < Duration::from_secs(8));
+    let descendant_pid = std::fs::read_to_string(&descendant_pid_file)
+        .expect("descendant pid")
+        .trim()
+        .parse::<i32>()
+        .expect("numeric descendant pid");
+    for _ in 0..20 {
+        #[cfg(target_os = "linux")]
+        let is_zombie = std::fs::read_to_string(format!("/proc/{descendant_pid}/stat"))
+            .ok()
+            .and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .map(|(_, suffix)| suffix.starts_with('Z'))
+            })
+            == Some(true);
+        #[cfg(not(target_os = "linux"))]
+        let is_zombie = false;
+        let result = unsafe { nix::libc::kill(descendant_pid, 0) };
+        let is_gone =
+            result < 0 && io::Error::last_os_error().raw_os_error() == Some(nix::libc::ESRCH);
+        if is_zombie || is_gone {
+            let _ = std::fs::remove_dir_all(&root);
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    unsafe {
+        nix::libc::kill(descendant_pid, nix::libc::SIGKILL);
+    }
+    panic!("scripted shell descendant {descendant_pid} survived timeout");
+}
+
+#[test]
 fn transparent_bash_preserves_user_stty_modes() {
     if Command::new("bash").arg("--version").output().is_err() {
         return;


### PR DESCRIPTION
## Summary

- classify safely owned Han-leading Tier-A prompts as natural language while keeping pipe/list/redirection/expansion and unquoted parentheses native
- prove quoted command-word ownership with a bounded literal matcher plus shell-specific expansion and nested-callback evidence
- remove the language-specific CJK/paste candidate path so ordinary input remains Shell-owned; retain explicit `??`, `/draft`, paste safety, and Shift/Alt+Enter
- make partial-line EOF fail closed without appending `exit`, propagate driver failures and signal status, and align Bash/Zsh slash registries

## Root cause

The Han check ran after command-veto rules, and quote removal made the saved raw command word differ from Bash/Zsh CNF tokens. Separately, the raw relay treated high-byte input as a CJK candidate and replayed it later, creating a second ownership/editing path with paste and EOF hazards.

Self-hosted CI also inherited Bash history/prompt policy and Readline `INPUTRC`. A hostile inherited inputrc can transform UTF-8 bytes before Cosh receives the line. Isolated Bash now owns a UTF-8-safe inputrc; native Bash and Zsh continue to preserve user configuration.

## Commit and rollback boundaries

1. C0 `20450f31` - lock the selector-aware routing baseline
2. C1 `200616d0` - Han Tier-A intent and Tier-B structure safety
3. C2 `21a05d81` - literal identity and CNF ownership proof
4. C3 `d943bfec` - explicit raw ownership and bounded EOF shutdown
5. C4 `afb49bc4` - slash registry and Zsh bypass alignment
6. Evidence `30433b90` - canonical routing acceptance case
7. CI isolation `72903458` - bounded sessions and inherited-environment isolation

## Intentional behavior changes

- ordinary CJK/non-ASCII typing now reaches the PTY immediately
- ordinary wrapped paste stays Shell-owned; pasted commands require the Shell's normal explicit Enter
- Cosh no longer auto-opens Draft solely because pasted or typed input is CJK
- a non-clean stdin EOF sends no synthetic PTY text and shuts down the session process group with bounded HUP/KILL escalation

## Validation

- current-head preflight: commit lint, fmt, workspace all-target clippy `-D warnings`, layout, and test inventory passed with no upstream drift
- previous product head `836fb9e4`: pull-request run `30524952623` passed `Test cosh-ng`, fast checks, release, PR lint, and CLA; failures converged 8 -> 4 -> 0 while isolating Readline and native harness ownership
- current head `72903458`: automatic pull-request run `30526624899` passed `Test cosh-ng`, fast checks, release, PR lint, and CLA after rebasing latest `main`
- Container exact regressions passed for the original eight routing failures and the four native bad-INPUTRC cases; evidence verification passed and temporary environments were cleaned
- independent implementation review found no Critical/Important code findings; all inline review threads are resolved

Canonical Bash and Zsh real-PTY acceptance passed for #1990 and both #1992 points, with `evidence verify` passing. These runs use the real `cosh-core` adapter without provider credentials, so they are correctly classified as `scripted-pty`, not real-provider evidence.

| Point | Bash | Zsh |
|---|---|---|
| #1990 Han Tier-A + ASCII quote | PASS | PASS |
| #1992 unmatched ASCII `?` in the first command word | PASS | PASS |
| #1992 ASCII quoted first word with inner space | PASS | PASS |

Bash canonical run: `20260730T082047Z-27460abd`, exit 0, 3/3 acceptance points, verified evidence. GIFs are embedded directly in the PR acceptance comment using immutable asset commit `423d465fdace689c5e0bb3a2658196cb46ac74ac`.

## Scope

Related #1990

Related #1992

This intentionally does not claim Agent routing for #1990 Tier-B/expansion inputs or #1992 matched-glob inputs; those remain Shell-owned by the fail-closed contract. It supersedes the narrower routing approach in #2004 without closing that PR automatically.
