### PR TITLE
ci(sight): use dedicated high-memory runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -606,7 +606,7 @@ jobs:
     name: Test agentsight
     needs: detect-changes
     if: needs.detect-changes.outputs.agentsight == 'true'
-    runs-on: anolisa-k8s-general-ci-x64
+    runs-on: anolisa-agentsight-ci-x64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- route the existing AgentSight CI job to the dedicated high-memory ARC scale set
- keep all triggers, test steps, permissions, and artifact handling unchanged

## Validation

- full AgentSight CI passed on the new runner: https://github.com/alibaba/anolisa/actions/runs/30503908888/job/90749452255
- runner smoke validation passed: https://github.com/alibaba/anolisa/actions/runs/30503598090
- the runner is ephemeral, uses pod-local emptyDir storage, mounts no PVC, and does not receive a Kubernetes service-account token

## Scope

Kernel-specific scale sets for 5.10, 5.15, and 6.6 are deployed but are intentionally not wired into automatic CI in this PR. The currently ignored BPF load suite still has three consistent EPERM failures across all kernels and will be handled separately.