### PR TITLE
fix(cosh-ng): emit JSON envelope for clap errors in cosh-cli

### DIFF
--- a/src/cosh-ng/crates/cosh-cli/src/main.rs
+++ b/src/cosh-ng/crates/cosh-cli/src/main.rs
@@ -10,6 +10,7 @@ use clap::{Parser, Subcommand};
 mod cmd;
 
 use cosh_platform::detect::Distro;
+use cosh_types::error::{CoshError, ErrorCode};
 use cosh_types::output::{CoshResponse, ResponseMeta};
 
 #[derive(Parser)]
@@ -61,7 +62,29 @@ fn main() {
         .with_target(true)
         .try_init();
 
-    let cli = Cli::parse();
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => {
+            // Help and version are clap "errors" but should behave as before:
+            // print text to stdout and exit 0.
+            if matches!(
+                e.kind(),
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+            ) {
+                let _ = e.print();
+                std::process::exit(0);
+            }
+            // All other clap errors: emit JSON envelope on stdout, exit 1.
+            let distro = Distro::detect();
+            let start = Instant::now();
+            let error = CoshError::new(ErrorCode::InvalidInput, e.to_string(), "cli")
+                .with_details(serde_json::json!({"kind": format!("{:?}", e.kind())}));
+            std::process::exit(print_failure(
+                error,
+                build_meta("cli", &distro, start, false),
+            ));
+        }
+    };
     let distro = Distro::detect();
     let start = Instant::now();
 

--- a/src/cosh-ng/crates/cosh-cli/src/main.rs
+++ b/src/cosh-ng/crates/cosh-cli/src/main.rs
@@ -75,8 +75,20 @@ fn main() {
                 std::process::exit(0);
             }
             // All other clap errors: emit JSON envelope on stdout, exit 1.
+            //
+            // stderr contract: this path stays silent. Never call `e.print()`
+            // or `e.exit()` here — both render clap's human-readable error to
+            // stderr, which would put free text beside the machine-facing
+            // envelope an agent parses on stdout. `e.to_string()` only formats.
+            // `test_clap_error_no_subcommand_emits_json_envelope` and
+            // `test_clap_error_paths_keep_stderr_empty` pin the contract.
             let distro = Distro::detect();
             let start = Instant::now();
+            // `details.kind` is a best-effort debugging hint rendered from
+            // clap's `Debug` impl, not a stable API: clap may rename or
+            // regroup `ErrorKind` variants across upgrades. Consumers must
+            // route on `error.code` (`InvalidInput`) and treat `kind` as
+            // log/triage context only.
             let error = CoshError::new(ErrorCode::InvalidInput, e.to_string(), "cli")
                 .with_details(serde_json::json!({"kind": format!("{:?}", e.kind())}));
             std::process::exit(print_failure(

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -1094,6 +1094,95 @@ fn test_invalid_subcommand_fails() {
     assert!(!output.status.success());
 }
 
+// --- Clap errors emit JSON envelope (issue #1548) ---
+
+/// Clap errors (missing required argument) must emit a JSON envelope on stdout
+/// with exit code 1, not clap's default text on stderr with exit code 2.
+#[test]
+fn test_clap_error_missing_arg_emits_json_envelope() {
+    let output = cosh_bin().args(["pkg", "install"]).output().unwrap();
+
+    // Exit code must be 1 (application error), not 2 (clap default).
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "clap errors should exit with code 1, not 2"
+    );
+
+    // stdout must contain a valid JSON envelope.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be valid JSON envelope");
+
+    assert_eq!(json["ok"], false, "envelope ok field must be false");
+    assert!(
+        !json["error"]["message"].as_str().unwrap_or("").is_empty(),
+        "error message must not be empty"
+    );
+    assert_eq!(
+        json["error"]["subsystem"], "cli",
+        "error subsystem must be 'cli'"
+    );
+    assert_eq!(
+        json["meta"]["subsystem"], "cli",
+        "meta subsystem must be 'cli'"
+    );
+}
+
+/// Clap errors (unrecognized subcommand) must emit a JSON envelope on stdout.
+#[test]
+fn test_clap_error_invalid_subcommand_emits_json_envelope() {
+    let output = cosh_bin().arg("nonexistent-subcommand").output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be valid JSON envelope");
+
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("nonexistent-subcommand"),
+        "error message should mention the invalid subcommand"
+    );
+}
+
+/// Clap errors (no subcommand) must emit a JSON envelope on stdout.
+#[test]
+fn test_clap_error_no_subcommand_emits_json_envelope() {
+    let output = cosh_bin().output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be valid JSON envelope");
+
+    assert_eq!(json["ok"], false);
+    assert!(
+        !json["error"]["message"].as_str().unwrap_or("").is_empty(),
+        "error message must not be empty"
+    );
+}
+
+/// --help and --version must still print text to stdout and exit 0
+/// (not a JSON envelope).
+#[test]
+fn test_help_still_prints_text_not_json() {
+    let output = cosh_bin().arg("--help").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Help text should not be a JSON envelope.
+    assert!(
+        !stdout.starts_with('{'),
+        "help output should not be a JSON envelope"
+    );
+    assert!(stdout.contains("Computable Operating System Harness"));
+}
+
 // --- Regression: issue #1551 compound command contract ---
 
 #[test]

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -1168,8 +1168,71 @@ fn test_clap_error_no_subcommand_emits_json_envelope() {
     );
 }
 
-/// --help and --version must still print text to stdout and exit 0
-/// (not a JSON envelope).
+/// Every clap error path must keep stderr empty: the JSON envelope on
+/// stdout is the only machine-facing channel, so a rendered clap error on
+/// stderr would let an agent act on free text that contradicts `ok=false`.
+#[test]
+fn test_clap_error_paths_keep_stderr_empty() {
+    for args in [
+        // MissingSubcommand
+        Vec::new(),
+        // UnknownArgument
+        vec!["--no-such-flag"],
+        // InvalidSubcommand
+        vec!["bogus"],
+        // MissingSubcommand: a subcommand without its nested action
+        vec!["pkg"],
+    ] {
+        let output = cosh_bin().args(&args).output().unwrap();
+        let label = if args.is_empty() {
+            "<no args>".to_string()
+        } else {
+            args.join(" ")
+        };
+
+        assert_eq!(output.status.code(), Some(1), "{label}: exit code");
+        assert!(
+            output.stderr.is_empty(),
+            "{label}: stderr must stay empty, got {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("{label}: stdout must be a JSON envelope");
+        assert_eq!(json["ok"], false, "{label}: envelope must report failure");
+        assert_eq!(
+            json["error"]["code"], "InvalidInput",
+            "{label}: clap errors map to InvalidInput"
+        );
+    }
+}
+
+/// `--version` is a clap "error" (DisplayVersion) that must keep the legacy
+/// text behaviour: exit 0, plain text on stdout, no JSON envelope.
+#[test]
+fn test_version_still_prints_text_not_json() {
+    let output = cosh_bin().arg("--version").output().unwrap();
+    assert!(output.status.success());
+    assert!(
+        output.stderr.is_empty(),
+        "version output should not write to stderr, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.starts_with('{'),
+        "version output should not be a JSON envelope"
+    );
+    assert!(
+        serde_json::from_str::<serde_json::Value>(stdout.trim()).is_err(),
+        "version output must not parse as JSON"
+    );
+    assert!(stdout.contains("cosh-cli"));
+}
+
+/// --help must still print text to stdout and exit 0 (not a JSON envelope).
+/// `test_version_still_prints_text_not_json` covers the DisplayVersion path.
 #[test]
 fn test_help_still_prints_text_not_json() {
     let output = cosh_bin().arg("--help").output().unwrap();


### PR DESCRIPTION
## Summary

Fix cosh-cli clap errors bypassing the JSON envelope contract (issue #1548).

Previously, `Cli::parse()` let clap handle errors internally — printing raw text to stderr and exiting with code 2. Any agent or script consuming stdout as JSON would get an empty string on clap errors, causing parse failures or false-success misjudgments.

**Changes:**
- Replace `Cli::parse()` with `Cli::try_parse()` in `main.rs`
- On clap error, `DisplayHelp`/`DisplayVersion` still print text to stdout and exit 0 (preserving existing `--help`/`--version` behaviour)
- All other clap errors are converted to `CoshResponse::failure` with `ErrorCode::InvalidInput`, serialized as JSON to stdout, and exit with code 1
- The clap error kind is included in `error.details.kind` for programmatic introspection

**Before:**
```
$ cosh-cli pkg install; echo "exit=$?"
# stdout: (empty)
# stderr: error: the following required arguments were not provided:
#         <PACKAGE>
# exit=2
```

**After:**
```json
{
  "ok": false,
  "error": {
    "code": "InvalidInput",
    "message": "error: the following required arguments were not provided:\n  <PACKAGE>\n\nUsage: cosh-cli pkg install <PACKAGE>\n\nFor more information, try '--help'.\n",
    "recoverable": false,
    "subsystem": "cli",
    "details": { "kind": "MissingRequiredArgument" }
  },
  "meta": {
    "subsystem": "cli",
    "duration_ms": 0,
    "distro": "alinux",
    "dry_run": false
  }
}
```
exit=1

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (unchanged)

## Testing

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p cosh-cli --all-targets -- -D warnings` — pass
- `cargo test -p cosh-cli` — 66 passed, 0 failed
- New tests: `test_clap_error_missing_arg_emits_json_envelope`, `test_clap_error_invalid_subcommand_emits_json_envelope`, `test_clap_error_no_subcommand_emits_json_envelope`, `test_help_still_prints_text_not_json`
- Manual verification: all three repro cases from the issue now emit JSON envelopes with exit code 1; `--help` still prints text with exit 0

Fixes #1548

