### PR TITLE
feat(cosh-ng): [shell] add CompoundReadonlyExecutor route for auto-allow of readonly compound commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_compound.rs
@@ -1,7 +1,8 @@
 use super::command_risk::{
     assess_pipeline, assess_simple_command, insert_structural_reason, is_high_risk_explanation,
-    AssessmentConfidence, AssessmentPolicy, CommandAssessment, CommandShape, ExecutionDecision,
-    InteractionRequirement, OutputExposure, OutputStability, RiskImpact, SideEffectClass,
+    AssessmentConfidence, AssessmentPolicy, AutoAllowEvidence, CommandAssessment, CommandShape,
+    ExecutionDecision, InteractionRequirement, OutputExposure, OutputStability, RiskImpact,
+    SideEffectClass,
 };
 use super::command_risk_build::{
     dedupe_reasons, max_output_exposure, max_output_stability, min_confidence,
@@ -41,8 +42,13 @@ pub(super) fn compound_segments(parsed: &ParsedCommand) -> Option<Vec<Vec<Vec<St
 /// run`, `awk system()`, `curl | sh`) and escalated benign arguments
 /// (`echo rm>/dev/null && true`).
 ///
-/// The compound execution boundary is unchanged: always `AskUser`, never
-/// auto-allow. Only the assessment precision is improved.
+/// When `policy.compound_readonly_executor` is set, all segments carry
+/// per-segment `AutoAllowEvidence`, none contains a shell builtin with
+/// cross-segment state effects (`cd`, `export`, env assignments), and
+/// none requires TTY interaction, the assessment is upgraded to
+/// `AutoAllow` with `AutoAllowEvidence::CompoundReadonlyExecutor`.
+/// Aggregated `Low` impact alone is insufficient; every segment must
+/// individually qualify (issue #1882).
 pub(super) fn assess_stripped_compound(
     command: &str,
     shape: CommandShape,
@@ -56,6 +62,7 @@ pub(super) fn assess_stripped_compound(
     let mut output_exposure = OutputExposure::Normal;
     let mut side_effects: Vec<SideEffectClass> = Vec::new();
     let mut reasons: Vec<&'static str> = Vec::new();
+    let mut all_segments_auto_allow = true;
 
     for segment in segments {
         let segment_text = segment
@@ -89,6 +96,11 @@ pub(super) fn assess_stripped_compound(
             }
         }
         reasons.extend(assessed.reasons);
+        // Track whether this segment individually carries auto-allow evidence
+        // and does not contain state-mutating shell constructs.
+        if assessed.auto_allow.is_none() || segment_has_state_mutating_builtin(segment) {
+            all_segments_auto_allow = false;
+        }
     }
 
     let mut reasons = dedupe_reasons(reasons);
@@ -103,6 +115,34 @@ pub(super) fn assess_stripped_compound(
             reasons.insert(0, primary);
         }
     }
+
+    // When every segment individually qualifies for auto-allow and no
+    // segment contains state-mutating builtins or TTY requirements, the
+    // compound can be run through CompoundReadonlyExecutor without a shell.
+    let compound_auto_allow = policy.compound_readonly_executor
+        && all_segments_auto_allow
+        && !segments.is_empty()
+        && interaction == InteractionRequirement::None
+        && impact == RiskImpact::Low;
+
+    if compound_auto_allow {
+        reasons.insert(0, "compound-readonly-executor");
+        return CommandAssessment {
+            source: policy.source,
+            command: command.to_string(),
+            shape,
+            execution: ExecutionDecision::AutoAllow,
+            impact,
+            confidence: min_confidence(confidence, AssessmentConfidence::High),
+            interaction,
+            output_stability,
+            output_exposure,
+            side_effects,
+            reasons,
+            auto_allow: Some(AutoAllowEvidence::CompoundReadonlyExecutor),
+        };
+    }
+
     insert_structural_reason(
         &mut reasons,
         match shape {
@@ -164,4 +204,32 @@ fn max_interaction(
     } else {
         left
     }
+}
+
+/// Returns `true` if the segment's first stage contains a shell builtin
+/// or construct that mutates session state consumed by later segments:
+/// `cd` (working directory), `export`/`unset` (environment), or a bare
+/// env-assignment token (shell variable). These constructs require a real
+/// shell interpreter and must never be routed through CompoundReadonlyExecutor.
+fn segment_has_state_mutating_builtin(segment: &[Vec<String>]) -> bool {
+    let Some(first_stage) = segment.first() else {
+        return false;
+    };
+    let Some(program) = first_stage.first() else {
+        return false;
+    };
+    // Shell builtins that mutate session state visible to subsequent segments.
+    if matches!(program.as_str(), "cd" | "export" | "unset" | "source" | ".") {
+        return true;
+    }
+    // A bare env-assignment (e.g. `FOO=bar`) in command position is a shell
+    // variable assignment, not an env-prefix for a program invocation. The
+    // parser records it as the first token of a Simple stage; detect it by
+    // the presence of `=` in the program name (env-prefix assignments are
+    // only valid immediately before a command, and the parser puts them
+    // before the program token in the same stage).
+    if program.contains('=') {
+        return true;
+    }
+    false
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_model.rs
@@ -84,6 +84,7 @@ pub enum AutoAllowEvidence {
     DirectReadonlyBroker,
     GuardedDiagnostic,
     ReadonlyPipelineExecutor,
+    CompoundReadonlyExecutor,
 }
 
 impl AutoAllowEvidence {
@@ -92,6 +93,7 @@ impl AutoAllowEvidence {
             Self::DirectReadonlyBroker => "bounded-readonly",
             Self::GuardedDiagnostic => "safe-diagnostic-family",
             Self::ReadonlyPipelineExecutor => "readonly-pipeline-executor",
+            Self::CompoundReadonlyExecutor => "compound-readonly-executor",
         }
     }
 }
@@ -207,6 +209,7 @@ pub struct AssessmentPolicy {
     pub auto_mode: bool,
     pub guarded_diagnostic_executor: bool,
     pub readonly_pipeline_executor: bool,
+    pub compound_readonly_executor: bool,
 }
 
 impl AssessmentPolicy {
@@ -216,6 +219,7 @@ impl AssessmentPolicy {
             auto_mode: false,
             guarded_diagnostic_executor: false,
             readonly_pipeline_executor: false,
+            compound_readonly_executor: false,
         }
     }
 
@@ -225,6 +229,7 @@ impl AssessmentPolicy {
             auto_mode: true,
             guarded_diagnostic_executor: true,
             readonly_pipeline_executor: false,
+            compound_readonly_executor: false,
         }
     }
 
@@ -234,6 +239,7 @@ impl AssessmentPolicy {
             auto_mode: true,
             guarded_diagnostic_executor: false,
             readonly_pipeline_executor: false,
+            compound_readonly_executor: false,
         }
     }
 
@@ -243,6 +249,17 @@ impl AssessmentPolicy {
             auto_mode: true,
             guarded_diagnostic_executor: false,
             readonly_pipeline_executor: true,
+            compound_readonly_executor: false,
+        }
+    }
+
+    pub fn auto_with_compound_readonly(source: AssessmentSource) -> Self {
+        Self {
+            source,
+            auto_mode: true,
+            guarded_diagnostic_executor: false,
+            readonly_pipeline_executor: false,
+            compound_readonly_executor: true,
         }
     }
 }
@@ -251,6 +268,7 @@ impl AssessmentPolicy {
 pub struct AutoExecutionPolicy {
     pub guarded_diagnostic_executor: bool,
     pub readonly_pipeline_executor: bool,
+    pub compound_readonly_executor: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -259,6 +277,7 @@ pub enum AutoExecutionRoute {
     DirectReadonlyBroker,
     GuardedDiagnosticExecutor,
     ReadonlyPipelineExecutor,
+    CompoundReadonlyExecutor,
     Block,
 }
 
@@ -267,6 +286,7 @@ impl AutoExecutionPolicy {
         Self {
             guarded_diagnostic_executor: false,
             readonly_pipeline_executor: false,
+            compound_readonly_executor: false,
         }
     }
 
@@ -276,6 +296,7 @@ impl AutoExecutionPolicy {
             auto_mode: true,
             guarded_diagnostic_executor: self.guarded_diagnostic_executor,
             readonly_pipeline_executor: self.readonly_pipeline_executor,
+            compound_readonly_executor: self.compound_readonly_executor,
         }
     }
 
@@ -294,6 +315,11 @@ impl AutoExecutionPolicy {
                 if self.readonly_pipeline_executor =>
             {
                 AutoExecutionRoute::ReadonlyPipelineExecutor
+            }
+            Some(AutoAllowEvidence::CompoundReadonlyExecutor)
+                if self.compound_readonly_executor =>
+            {
+                AutoExecutionRoute::CompoundReadonlyExecutor
             }
             _ => AutoExecutionRoute::AskUser,
         }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -14,6 +14,13 @@ fn ask(command: &str) -> CommandAssessment {
     )
 }
 
+fn compound_auto(command: &str) -> CommandAssessment {
+    assess_shell_command(
+        command,
+        AssessmentPolicy::auto_with_compound_readonly(AssessmentSource::ProviderShellTool),
+    )
+}
+
 #[test]
 fn command_risk_assessment_direct_readonly_and_diagnostics() {
     for command in [
@@ -748,5 +755,129 @@ fn adjacent_words_before_null_redirection_use_default_fd() {
         parsed.stages[0].contains(&"2".to_string()),
         "quoted argument must be preserved, got {:?}",
         parsed.stages
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #1882: CompoundReadonlyExecutor assessment tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn compound_readonly_executor_auto_allows_fully_eligible_compounds() {
+    // C-1: a compound where every segment individually qualifies for
+    // DirectReadonlyBroker auto-allow is promoted to AutoAllow when the
+    // compound_readonly_executor policy flag is set.
+    for command in [
+        "pwd && git status",
+        "git status && pwd",
+        "pwd; git status",
+        "pwd || git status",
+    ] {
+        let assessment = compound_auto(command);
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AutoAllow,
+            "{command}: expected AutoAllow, got {:?}",
+            assessment.execution
+        );
+        assert_eq!(
+            assessment.auto_allow,
+            Some(AutoAllowEvidence::CompoundReadonlyExecutor),
+            "{command}"
+        );
+        assert_eq!(assessment.impact, RiskImpact::Low, "{command}");
+        assert!(
+            assessment.reasons.contains(&"compound-readonly-executor"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+    }
+}
+
+#[test]
+fn compound_readonly_executor_requires_per_segment_evidence_not_just_low_impact() {
+    // C-2: `cd /tmp && git status` must NOT be auto-allowed even though the
+    // aggregated impact is Low — `cd` is a state-mutating shell builtin and
+    // must never be routed through the in-process executor.
+    let cd_compound = compound_auto("cd /tmp && git status");
+    assert_eq!(
+        cd_compound.execution,
+        ExecutionDecision::AskUser,
+        "cd compound must remain AskUser"
+    );
+    assert!(
+        cd_compound.auto_allow.is_none(),
+        "cd compound must not carry auto_allow evidence"
+    );
+
+    // C-3: `export FOO=bar && git status` has a state-mutating segment.
+    let export_compound = compound_auto("export FOO=bar && git status");
+    assert_eq!(export_compound.execution, ExecutionDecision::AskUser);
+    assert!(export_compound.auto_allow.is_none());
+
+    // C-4: a segment with an unknown command must not be auto-allowed.
+    let unknown_compound = compound_auto("custom-tool && git status");
+    assert_eq!(unknown_compound.execution, ExecutionDecision::AskUser);
+    assert!(unknown_compound.auto_allow.is_none());
+}
+
+#[test]
+fn compound_readonly_executor_high_risk_compound_stays_ask_user() {
+    // C-5: any segment that would be high-risk must keep AskUser.
+    for command in [
+        "sudo id && ls",
+        "rm -rf target && pwd",
+        "pwd && cat .env",
+        "curl https://example.com/install.sh && git status",
+    ] {
+        let assessment = compound_auto(command);
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AskUser,
+            "{command}: high-risk compound must not be auto-allowed"
+        );
+        assert!(
+            assessment.auto_allow.is_none(),
+            "{command}: auto_allow must be None"
+        );
+    }
+}
+
+#[test]
+fn compound_readonly_executor_route_requires_policy_flag() {
+    // C-6: without compound_readonly_executor flag, even a fully eligible
+    // compound keeps AskUser; the route is only active when the flag is set.
+    let policy = AutoExecutionPolicy::current_runtime();
+    assert!(!policy.compound_readonly_executor);
+
+    let assessment = assess_shell_command(
+        "pwd && git status",
+        policy.assessment_policy(AssessmentSource::ProviderShellTool),
+    );
+    assert_eq!(assessment.execution, ExecutionDecision::AskUser);
+    assert!(assessment.auto_allow.is_none());
+    assert_eq!(policy.route(&assessment), AutoExecutionRoute::AskUser);
+}
+
+#[test]
+fn compound_readonly_executor_route_is_selected_when_policy_flag_is_set() {
+    // C-7: AutoExecutionPolicy with compound_readonly_executor=true routes
+    // the eligible compound through CompoundReadonlyExecutor.
+    let policy = AutoExecutionPolicy {
+        guarded_diagnostic_executor: false,
+        readonly_pipeline_executor: false,
+        compound_readonly_executor: true,
+    };
+    let assessment = assess_shell_command(
+        "pwd && git status",
+        policy.assessment_policy(AssessmentSource::ProviderShellTool),
+    );
+    assert_eq!(
+        assessment.auto_allow,
+        Some(AutoAllowEvidence::CompoundReadonlyExecutor)
+    );
+    assert_eq!(
+        policy.route(&assessment),
+        AutoExecutionRoute::CompoundReadonlyExecutor
     );
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/compound_readonly_executor.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/compound_readonly_executor.rs
@@ -1,0 +1,390 @@
+use std::time::Duration;
+
+use super::readonly_pipeline::{
+    run_readonly_pipeline, validate_readonly_pipeline, ReadonlyPipelineConfig,
+};
+use super::broker::can_run_approved_bash_tool;
+
+const DEFAULT_SEGMENT_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_TOTAL_TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_OUTPUT_LIMIT_BYTES: usize = 64 * 1024;
+const DEFAULT_OUTPUT_LIMIT_LINES: usize = 1000;
+
+/// Configuration for the CompoundReadonlyExecutor.
+#[derive(Debug, Clone)]
+pub struct CompoundReadonlyConfig {
+    pub segment_timeout: Duration,
+    pub total_timeout: Duration,
+    pub output_limit_bytes: usize,
+    pub output_limit_lines: usize,
+}
+
+impl Default for CompoundReadonlyConfig {
+    fn default() -> Self {
+        Self {
+            segment_timeout: DEFAULT_SEGMENT_TIMEOUT,
+            total_timeout: DEFAULT_TOTAL_TIMEOUT,
+            output_limit_bytes: DEFAULT_OUTPUT_LIMIT_BYTES,
+            output_limit_lines: DEFAULT_OUTPUT_LIMIT_LINES,
+        }
+    }
+}
+
+/// The combined output from all segments of a compound command, joined
+/// by a newline separator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompoundReadonlyOutput {
+    /// Exit code of the last segment that ran.
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompoundReadonlyError {
+    pub reason: &'static str,
+    pub detail: String,
+}
+
+/// Describes the connector that joins two consecutive segments in a compound
+/// command. Used to implement `&&` / `||` short-circuit semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentConnector {
+    /// `;` or newline — always run the next segment regardless of exit code.
+    Sequence,
+    /// `&&` — run the next segment only when the current exit code is 0.
+    And,
+    /// `||` — run the next segment only when the current exit code is non-zero.
+    Or,
+}
+
+/// A validated plan produced by [`validate_compound_readonly`].
+#[derive(Debug, Clone)]
+pub struct CompoundReadonlyPlan {
+    /// Segments in order, each paired with the connector that precedes it
+    /// (the first segment has no predecessor, so `None`).
+    pub segments: Vec<(Option<SegmentConnector>, Vec<Vec<String>>)>,
+}
+
+/// Validates a compound command for execution through the
+/// CompoundReadonlyExecutor. Returns `Err` if any segment is not
+/// individually eligible for auto-allow or if a state-mutating builtin
+/// is present.
+///
+/// The validation deliberately reuses the existing per-route validators
+/// (`can_run_approved_bash_tool`, `validate_readonly_pipeline`) so the
+/// executor cannot be widened without simultaneously widening the
+/// underlying validators.
+pub fn validate_compound_readonly(
+    _command: &str,
+    parsed_segments: &[Vec<Vec<String>>],
+    connectors: &[SegmentConnector],
+) -> Result<CompoundReadonlyPlan, CompoundReadonlyError> {
+    if parsed_segments.is_empty() {
+        return Err(error("empty-compound", "compound command has no segments"));
+    }
+    if connectors.len() != parsed_segments.len().saturating_sub(1) {
+        return Err(error(
+            "connector-mismatch",
+            "connector count does not match segment count",
+        ));
+    }
+
+    let mut plan_segments = Vec::new();
+    for (index, segment) in parsed_segments.iter().enumerate() {
+        validate_segment_eligibility(segment)?;
+        let connector = if index == 0 {
+            None
+        } else {
+            Some(connectors[index - 1])
+        };
+        plan_segments.push((connector, segment.clone()));
+    }
+
+    Ok(CompoundReadonlyPlan {
+        segments: plan_segments,
+    })
+}
+
+/// Validates that a single compound segment is eligible for CompoundReadonlyExecutor.
+/// A segment is eligible when it is individually auto-allowable through the
+/// DirectReadonlyBroker or ReadonlyPipelineExecutor routes, and contains no
+/// state-mutating shell builtins.
+fn validate_segment_eligibility(
+    segment: &[Vec<String>],
+) -> Result<(), CompoundReadonlyError> {
+    let Some(first_stage) = segment.first() else {
+        return Err(error("empty-segment", "compound segment is empty"));
+    };
+    let Some(program) = first_stage.first() else {
+        return Err(error("empty-stage", "segment stage is empty"));
+    };
+
+    // Reject state-mutating shell builtins (cd, export, unset, source, .).
+    if matches!(program.as_str(), "cd" | "export" | "unset" | "source" | ".") {
+        return Err(error(
+            "state-mutating-builtin",
+            program.clone(),
+        ));
+    }
+    // Reject bare env-assignments in command position.
+    if program.contains('=') {
+        return Err(error("env-assignment-in-command", program.clone()));
+    }
+
+    if segment.len() > 1 {
+        // Pipeline segment — validate through readonly pipeline executor.
+        let segment_text = segment
+            .iter()
+            .map(|stage| stage.join(" "))
+            .collect::<Vec<_>>()
+            .join(" | ");
+        validate_readonly_pipeline(&segment_text)
+            .map_err(|e| error("segment-not-readonly-pipeline", e.detail))?;
+    } else {
+        // Simple segment — validate through direct readonly broker.
+        let segment_text = first_stage.join(" ");
+        can_run_approved_bash_tool(&segment_text)
+            .map_err(|e| error("segment-not-direct-readonly", e))?;
+    }
+    Ok(())
+}
+
+/// Executes a validated compound command plan. Each segment is run through
+/// its appropriate executor (`DirectReadonlyBroker` for simple commands,
+/// `ReadonlyPipelineExecutor` for pipelines). `&&` / `||` short-circuit
+/// semantics are implemented in-process without invoking a shell.
+///
+/// The final stdout is the concatenation of each segment's stdout, separated
+/// by a blank line when multiple segments produce output.
+pub fn run_compound_readonly(
+    plan: &CompoundReadonlyPlan,
+    config: &CompoundReadonlyConfig,
+) -> Result<CompoundReadonlyOutput, CompoundReadonlyError> {
+    let deadline = std::time::Instant::now() + config.total_timeout;
+    let mut combined_stdout = String::new();
+    let mut combined_stderr = String::new();
+    let mut last_exit_code: Option<i32> = None;
+
+    for (connector, segment) in &plan.segments {
+        if std::time::Instant::now() >= deadline {
+            return Err(error("compound-timeout", "compound command timed out"));
+        }
+
+        // Short-circuit evaluation: skip segment if connector condition is unmet.
+        if let Some(conn) = connector {
+            match (conn, last_exit_code) {
+                (SegmentConnector::And, Some(code)) if code != 0 => continue,
+                (SegmentConnector::Or, Some(code)) if code == 0 => continue,
+                _ => {}
+            }
+        }
+
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let seg_timeout = config.segment_timeout.min(remaining);
+
+        let (stdout, stderr, exit_code) = if segment.len() > 1 {
+            // Pipeline segment.
+            let segment_text = segment
+                .iter()
+                .map(|stage| stage.join(" "))
+                .collect::<Vec<_>>()
+                .join(" | ");
+            let pipeline_config = ReadonlyPipelineConfig {
+                stage_timeout: seg_timeout,
+                total_timeout: seg_timeout,
+                output_limit_bytes: config.output_limit_bytes,
+                output_limit_lines: config.output_limit_lines,
+            };
+            let output = run_readonly_pipeline(&segment_text, &pipeline_config)
+                .map_err(|e| error("segment-pipeline-failed", e.detail))?;
+            (output.stdout, output.stderr, output.exit_code)
+        } else {
+            // Simple segment — run via DirectReadonlyBroker.
+            let stage = &segment[0];
+            run_direct_readonly_segment(stage, seg_timeout, config.output_limit_bytes)?
+        };
+
+        if !combined_stdout.is_empty() && !stdout.is_empty() {
+            combined_stdout.push('\n');
+        }
+        combined_stdout.push_str(&stdout);
+        if !combined_stderr.is_empty() && !stderr.is_empty() {
+            combined_stderr.push('\n');
+        }
+        combined_stderr.push_str(&stderr);
+        last_exit_code = exit_code;
+    }
+
+    Ok(CompoundReadonlyOutput {
+        exit_code: last_exit_code,
+        stdout: combined_stdout,
+        stderr: combined_stderr,
+    })
+}
+
+/// Runs a simple (non-pipeline) segment through the direct readonly broker:
+/// spawns the program without a shell, with a timeout, and returns
+/// (stdout, stderr, exit_code).
+fn run_direct_readonly_segment(
+    argv: &[String],
+    timeout: Duration,
+    output_limit_bytes: usize,
+) -> Result<(String, String, Option<i32>), CompoundReadonlyError> {
+    use std::fs::File;
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+    let Some(program) = argv.first() else {
+        return Err(error("empty-stage", "empty argv"));
+    };
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let pid = std::process::id();
+    let stdout_path = PathBuf::from(std::env::temp_dir()).join(format!(
+        "cosh-compound-direct-{pid}-{nanos}-stdout"
+    ));
+    let stderr_path = PathBuf::from(std::env::temp_dir()).join(format!(
+        "cosh-compound-direct-{pid}-{nanos}-stderr"
+    ));
+
+    let stdout_file = File::create(&stdout_path)
+        .map_err(|e| error("executor-io", format!("create stdout: {e}")))?;
+    let stderr_file = File::create(&stderr_path)
+        .map_err(|e| error("executor-io", format!("create stderr: {e}")))?;
+
+    let mut child = Command::new(program)
+        .args(&argv[1..])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .map_err(|e| error("executor-spawn", format!("{program}: {e}")))?;
+
+    let deadline = Instant::now() + timeout;
+    let exit_code = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status.code(),
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = std::fs::remove_file(&stdout_path);
+                let _ = std::fs::remove_file(&stderr_path);
+                return Err(error("segment-timeout", argv.join(" ")));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(e) => {
+                let _ = std::fs::remove_file(&stdout_path);
+                let _ = std::fs::remove_file(&stderr_path);
+                return Err(error("executor-wait", e.to_string()));
+            }
+        }
+    };
+
+    let read_output = |path: &PathBuf| -> Result<String, CompoundReadonlyError> {
+        let bytes = std::fs::read(path).map_err(|e| error("executor-io", e.to_string()))?;
+        let truncated = &bytes[..bytes.len().min(output_limit_bytes)];
+        let mut text = String::from_utf8_lossy(truncated).to_string();
+        if bytes.len() > output_limit_bytes {
+            text.push_str("\n<truncated>");
+        }
+        Ok(super::strip_ansi(&text))
+    };
+
+    let stdout = read_output(&stdout_path)?;
+    let stderr = read_output(&stderr_path)?;
+    let _ = std::fs::remove_file(&stdout_path);
+    let _ = std::fs::remove_file(&stderr_path);
+    Ok((stdout, stderr, exit_code))
+}
+
+fn error(reason: &'static str, detail: impl Into<String>) -> CompoundReadonlyError {
+    CompoundReadonlyError {
+        reason,
+        detail: detail.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compound_readonly_validates_all_direct_readonly_segments() {
+        // Both segments qualify via DirectReadonlyBroker.
+        let segments = vec![
+            vec![vec!["pwd".to_string()]],
+            vec![vec!["git".to_string(), "status".to_string()]],
+        ];
+        let connectors = vec![SegmentConnector::And];
+        let plan = validate_compound_readonly("pwd && git status", &segments, &connectors)
+            .expect("valid compound");
+        assert_eq!(plan.segments.len(), 2);
+        assert_eq!(plan.segments[0].0, None);
+        assert_eq!(plan.segments[1].0, Some(SegmentConnector::And));
+    }
+
+    #[test]
+    fn compound_readonly_rejects_cd_segment() {
+        let segments = vec![
+            vec![vec!["cd".to_string(), "/tmp".to_string()]],
+            vec![vec!["git".to_string(), "status".to_string()]],
+        ];
+        let connectors = vec![SegmentConnector::And];
+        let err = validate_compound_readonly("cd /tmp && git status", &segments, &connectors)
+            .expect_err("cd must be rejected");
+        assert_eq!(err.reason, "state-mutating-builtin");
+    }
+
+    #[test]
+    fn compound_readonly_rejects_export_segment() {
+        let segments = vec![
+            vec![vec!["export".to_string(), "FOO=bar".to_string()]],
+            vec![vec!["git".to_string(), "status".to_string()]],
+        ];
+        let connectors = vec![SegmentConnector::And];
+        let err = validate_compound_readonly("export FOO=bar && git status", &segments, &connectors)
+            .expect_err("export must be rejected");
+        assert_eq!(err.reason, "state-mutating-builtin");
+    }
+
+    #[test]
+    fn compound_readonly_rejects_unknown_command_segment() {
+        let segments = vec![
+            vec![vec!["custom-tool".to_string()]],
+            vec![vec!["git".to_string(), "status".to_string()]],
+        ];
+        let connectors = vec![SegmentConnector::And];
+        let err =
+            validate_compound_readonly("custom-tool && git status", &segments, &connectors)
+                .expect_err("unknown command must be rejected");
+        assert_eq!(err.reason, "segment-not-direct-readonly");
+    }
+
+    #[test]
+    fn compound_readonly_executes_and_short_circuits() {
+        // `pwd && git status`: both segments should run (pwd exits 0).
+        let segments = vec![
+            vec![vec!["pwd".to_string()]],
+            vec![vec!["git".to_string(), "status".to_string(), "--short".to_string()]],
+        ];
+        let connectors = vec![SegmentConnector::And];
+        let plan = validate_compound_readonly("pwd && git status --short", &segments, &connectors)
+            .expect("valid plan");
+        let output = run_compound_readonly(&plan, &CompoundReadonlyConfig::default())
+            .expect("execution succeeded");
+        assert!(
+            output.exit_code.is_some(),
+            "exit code should be set"
+        );
+        // pwd output should be present.
+        assert!(
+            !output.stdout.is_empty(),
+            "stdout should contain pwd output"
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
@@ -7,6 +7,7 @@ mod command_risk_model;
 mod command_risk_parser;
 #[cfg(test)]
 mod command_risk_tests;
+pub(crate) mod compound_readonly_executor;
 pub mod display;
 pub(crate) mod guarded_diagnostic;
 pub(crate) mod readonly_pipeline;
@@ -68,6 +69,10 @@ pub use command_risk::{
     AutoExecutionRoute, CommandAssessment, CommandShape, ExecutionDecision, InteractionRequirement,
     OutputExposure, OutputStability as CommandRiskOutputStability, ReadonlyEvidence, RiskImpact,
     RiskReason, SideEffectClass,
+};
+pub use compound_readonly_executor::{
+    run_compound_readonly, validate_compound_readonly, CompoundReadonlyConfig,
+    CompoundReadonlyError, CompoundReadonlyOutput, CompoundReadonlyPlan, SegmentConnector,
 };
 pub use guarded_diagnostic::{
     run_guarded_diagnostic, validate_guarded_diagnostic, GuardedDiagnosticConfig,


### PR DESCRIPTION
## Summary

- Implements `CompoundReadonlyExecutor`, a new fourth `AutoExecutionRoute` that enables auto-execution of fully readonly compound commands (`&&`/`||`/`;`/newline separated) in auto mode without invoking a shell (issue #1882 design candidate 1).
- All segments must individually carry `AutoAllowEvidence` (per-segment assessment from #1785 is a prerequisite); aggregated `Low` impact alone is insufficient.
- State-mutating shell builtins (`cd`, `export`, `unset`, `source`, `.`, bare env-assignments) are excluded, so `cd /tmp && git status` still requires `AskUser`.
- The executor interprets `&&`/`||`/`;` short-circuit semantics in-process via the new `compound_readonly_executor.rs` module, dispatching each segment through the existing `DirectReadonlyBroker` or `ReadonlyPipelineExecutor` validators.
- The `compound_readonly_executor` flag in `AutoExecutionPolicy::current_runtime()` is `false`; the route is implemented but not active in the current runtime, matching the issue's requirement to land it as an independent capability extension without changing the existing auto-allow surface.

## Changes

- `command_risk_model.rs`: Add `AutoAllowEvidence::CompoundReadonlyExecutor`, `AutoExecutionRoute::CompoundReadonlyExecutor`, `compound_readonly_executor` field to `AssessmentPolicy`/`AutoExecutionPolicy`, and `AssessmentPolicy::auto_with_compound_readonly` constructor.
- `command_risk_compound.rs`: Update `assess_stripped_compound` to compute compound auto-allow evidence when the policy flag is set.
- `compound_readonly_executor.rs` (new): `validate_compound_readonly` / `run_compound_readonly` with full `&&`/`||`/`;` short-circuit semantics, per-route validation, and segment execution without shell.
- `command_risk_tests.rs`: Add 7 new tests covering auto-allow eligibility, `cd`/`export`/unknown-command rejection, high-risk blocking, policy-flag gating, and route selection.

## Test plan

- [x] All pre-existing `cosh-shell` tests pass (1154/1154 unit tests; the 1 pre-existing failure in `activity::runtime_tests::activity_tool_output_details_show_internal_output_ref_in_debug` is unrelated to this change and exists on `main` before this patch).
- [x] New tests: `compound_readonly_executor_auto_allows_fully_eligible_compounds`, `compound_readonly_executor_requires_per_segment_evidence_not_just_low_impact`, `compound_readonly_executor_high_risk_compound_stays_ask_user`, `compound_readonly_executor_route_requires_policy_flag`, `compound_readonly_executor_route_is_selected_when_policy_flag_is_set`.
- [x] Executor integration test: `compound_readonly_executes_and_short_circuits` verifies real execution of `pwd && git status --short`.

Related to ANO-1252