### PR TITLE
fix(cosh-cli): route clap errors through JSON envelope contract

### DIFF
--- a/src/cosh-ng/crates/cosh-cli/src/main.rs
+++ b/src/cosh-ng/crates/cosh-cli/src/main.rs
@@ -5,11 +5,12 @@
 
 use std::time::Instant;
 
-use clap::{Parser, Subcommand};
+use clap::{error::ErrorKind, Parser, Subcommand};
 
 mod cmd;
 
 use cosh_platform::detect::Distro;
+use cosh_types::error::{CoshError, ErrorCode};
 use cosh_types::output::{CoshResponse, ResponseMeta};
 
 #[derive(Parser)]
@@ -61,9 +62,36 @@ fn main() {
         .with_target(true)
         .try_init();
 
-    let cli = Cli::parse();
-    let distro = Distro::detect();
     let start = Instant::now();
+    let distro = Distro::detect();
+
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => {
+            // --help and --version print to stdout and exit 0 — keep clap's
+            // native behaviour for these, do not wrap in the JSON envelope.
+            if matches!(
+                e.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            ) {
+                e.exit();
+            }
+            // All other clap errors (missing args, unknown subcommand, etc.)
+            // must honour the unified JSON envelope contract: emit the envelope
+            // on STDOUT and exit 1 instead of clap's default (STDERR text, exit 2).
+            let error = CoshError::new(ErrorCode::InvalidInput, e.to_string(), "cli")
+                .with_details(serde_json::json!({"kind": "clap"}));
+            let meta = ResponseMeta {
+                subsystem: "cli".to_string(),
+                duration_ms: start.elapsed().as_millis() as u64,
+                distro: Some(distro.id_str().to_string()),
+                dry_run: false,
+                warning: None,
+            };
+            let exit_code = print_failure(error, meta);
+            std::process::exit(exit_code);
+        }
+    };
 
     let exit_code = match cli.command {
         Commands::Pkg { action } => cmd::pkg::run(action, &distro, start),

--- a/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
+++ b/src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs
@@ -1722,16 +1722,50 @@ fn test_pkg_remove_rejects_shell_metachar() {
 // --- No subcommand ---
 
 /// When cosh-cli is invoked with no arguments, clap reports missing subcommand.
+/// The error must honour the unified JSON envelope contract: STDOUT contains a
+/// valid `{"ok":false,...}` envelope and the exit code is 1 (not clap's default 2).
 #[test]
 fn test_no_subcommand_fails() {
     let output = cosh_bin().output().unwrap();
-    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "InvalidInput");
+    assert_eq!(json["error"]["subsystem"], "cli");
+    assert_eq!(json["error"]["details"]["kind"], "clap");
+    assert_eq!(json["meta"]["subsystem"], "cli");
+    assert_eq!(json["meta"]["dry_run"], false);
 }
 
 #[test]
 fn test_invalid_subcommand_fails() {
     let output = cosh_bin().arg("foobar").output().unwrap();
-    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "InvalidInput");
+    assert_eq!(json["error"]["subsystem"], "cli");
+    assert_eq!(json["error"]["details"]["kind"], "clap");
+    assert_eq!(json["meta"]["subsystem"], "cli");
+}
+
+/// Missing required positional argument (e.g. `pkg install` without <PACKAGE>)
+/// must also produce the JSON envelope on STDOUT with exit 1.
+#[test]
+fn test_missing_required_arg_fails_with_envelope() {
+    let output = cosh_bin().args(["pkg", "install"]).output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "InvalidInput");
+    assert_eq!(json["error"]["details"]["kind"], "clap");
+    assert_eq!(json["meta"]["subsystem"], "cli");
 }
 
 // --- Regression: issue #1551 compound command contract ---


### PR DESCRIPTION
## 改动说明

`cosh-cli` 在 README 中声明所有命令输出统一的 JSON envelope，但 clap 层错误（缺少必填参数、未知子命令、无子命令）绕过了该契约：STDOUT 为空，STDERR 是 clap 的纯文本错误，退出码为 2。

本 PR 将 `Cli::parse()` 替换为 `Cli::try_parse()`，在 main 顶层捕获 `clap::Error`：

- `--help` / `--version`：保持 clap 原生行为（STDOUT 打印帮助/版本，exit 0）
- 其他 clap 错误：转换为 `CoshResponse::failure` envelope（`ErrorCode::InvalidInput`，`details.kind = "clap"`），输出到 STDOUT，退出码改为 1

### 改动文件

- `src/cosh-ng/crates/cosh-cli/src/main.rs` — 核心修复
- `src/cosh-ng/crates/cosh-cli/tests/cli_integration.rs` — 更新/新增测试用例验证 envelope 结构和退出码

### 测试情况

```
cargo test -p cosh-cli --test cli_integration -- test_no_subcommand_fails test_invalid_subcommand_fails test_missing_required_arg_fails_with_envelope test_help_output test_version_output
# 5 passed; 0 failed
```

全部 79 个集成测试中 77 个通过，2 个失败为 pre-existing 环境问题（`test_pkg_install_dry_run_*` 需要 root 权限执行 dnf，与本次改动无关）。

Fixes ANO-764
Related to https://github.com/alibaba/anolisa/issues/1548