### PR TITLE
ci(sight): verify eBPF probe loading on dedicated runner pools

### DIFF
--- a/.github/workflows/agentsight-runner-test.yml
+++ b/.github/workflows/agentsight-runner-test.yml
@@ -1,0 +1,163 @@
+name: AgentSight Full Runner Test
+
+on:
+  push:
+    branches:
+      - chore/test_sight
+    paths:
+      - 'src/agentsight/**'
+      - '.github/workflows/agentsight-runner-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  RUSTUP_DIST_SERVER: https://static.rust-lang.org
+  RUSTUP_UPDATE_ROOT: https://static.rust-lang.org/rustup
+
+concurrency:
+  group: agentsight-runner-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  standard:
+    name: Standard CI
+    runs-on: anolisa-agentsight-ci-x64
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.89.0'
+          components: 'rustfmt, clippy, llvm-tools-preview'
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/agentsight
+
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: '3.11.6'
+
+      - name: Install eBPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang llvm libbpf-dev libelf-dev elfutils libssl-dev \
+            zlib1g-dev pkg-config perl
+
+      - name: Check formatting
+        working-directory: src/agentsight
+        run: cargo fmt --all --check
+
+      - name: Check architecture boundaries
+        working-directory: src/agentsight
+        run: python3 scripts/check-arch-boundaries.py
+
+      - name: Lint
+        working-directory: src/agentsight
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Run tests with coverage
+        working-directory: src/agentsight
+        run: |
+          cargo llvm-cov --workspace --cobertura --output-path coverage.xml \
+            --ignore-filename-regex '(\.skel\.rs|target/debug/build|target/release/build|src/probes/|src/bin/|crates/agentsight-opt/src/bin/analyze\.rs|crates/agentsight-opt/src/llm/client\.rs|crates/agentsight-opt/src/(perf|cost)/llm\.rs|src/server/optimize\.rs|src/local/)'
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentsight-runner-test-coverage
+          path: src/agentsight/coverage.xml
+          retention-days: 7
+
+  ebpf:
+    name: eBPF load (${{ matrix.kernel }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - kernel: '5.10'
+            runner: anolisa-agentsight-kernel510-x64
+          - kernel: '5.15'
+            runner: anolisa-agentsight-kernel515-x64
+          - kernel: '6.6'
+            runner: anolisa-agentsight-kernel66-x64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify kernel runner
+        shell: bash
+        env:
+          EXPECTED_KERNEL: ${{ matrix.kernel }}
+        run: |
+          set -euo pipefail
+          actual_kernel=$(uname -r)
+          case "$actual_kernel" in
+            "$EXPECTED_KERNEL".*) ;;
+            *)
+              echo "Expected kernel ${EXPECTED_KERNEL}.x, got ${actual_kernel}" >&2
+              exit 1
+              ;;
+          esac
+
+          sudo -n true
+          sudo test -r /sys/kernel/btf/vmlinux
+          test ! -e /var/run/secrets/kubernetes.io/serviceaccount/token
+          echo "Kernel: ${actual_kernel}"
+          echo "Runner capabilities:"
+          sudo grep -E '^(Cap(Inh|Prm|Eff|Bnd|Amb)|NoNewPrivs|Seccomp):' \
+            /proc/self/status
+          echo "BPF sysctls:"
+          cat /proc/sys/kernel/unprivileged_bpf_disabled
+          cat /proc/sys/kernel/perf_event_paranoid
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.89.0'
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/agentsight
+          shared-key: agentsight-bpf-${{ matrix.kernel }}
+
+      - name: Install eBPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang llvm libbpf-dev libelf-dev elfutils libssl-dev \
+            zlib1g-dev pkg-config perl
+
+      - name: Load all eBPF probes
+        shell: bash
+        env:
+          RUST_BACKTRACE: '1'
+          RUST_LOG: debug
+        run: |
+          set -euo pipefail
+          cd src/agentsight
+          cargo_bin=$(command -v cargo)
+          sudo env \
+            HOME="$HOME" \
+            CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" \
+            RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" \
+            PATH="$PATH" \
+            RUST_BACKTRACE="$RUST_BACKTRACE" \
+            RUST_LOG="$RUST_LOG" \
+            CARGO_BIN="$cargo_bin" \
+            bash -c '
+              ulimit -l unlimited
+              exec "$CARGO_BIN" test --test bpf_load -- \
+                --ignored --nocapture --test-threads=1
+            '

--- a/.github/workflows/agentsight-runner-test.yml
+++ b/.github/workflows/agentsight-runner-test.yml
@@ -50,8 +50,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            clang llvm libbpf-dev libelf-dev elfutils libssl-dev \
+            clang-15 llvm-15 libbpf-dev libelf-dev elfutils libssl-dev \
             zlib1g-dev pkg-config perl
+          echo "/usr/lib/llvm-15/bin" >> "$GITHUB_PATH"
 
       - name: Check formatting
         working-directory: src/agentsight
@@ -136,8 +137,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            clang llvm libbpf-dev libelf-dev elfutils libssl-dev \
+            clang-15 llvm-15 libbpf-dev libelf-dev elfutils libssl-dev \
             zlib1g-dev pkg-config perl
+          echo "/usr/lib/llvm-15/bin" >> "$GITHUB_PATH"
 
       - name: Load all eBPF probes
         shell: bash

--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -318,7 +318,7 @@ Agent 规则配置文件路径：`/etc/agentsight/config.json`（可通过 `--co
 
 - Linux kernel >= 5.8（BTF 支持）
 - Rust >= 1.80
-- clang/llvm >= 11（eBPF 编译）
+- clang/llvm >= 15（eBPF 编译；14 及以下会优化掉长度钳制，sslsniff/tcpsniff 无法通过 verifier）
 - libbpf >= 0.8
 
 ## 14. User-Facing Documentation Guidelines

--- a/src/agentsight/docs/DEVELOPMENT.md
+++ b/src/agentsight/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@
 |------|----------|------|
 | Linux kernel | >= 5.8 | BTF 支持，eBPF 运行时 |
 | Rust | >= 1.80 | 编译 Rust 代码 |
-| clang/llvm | >= 11 | 编译 eBPF C 程序 |
+| clang/llvm | >= 15 | 编译 eBPF C 程序（14 及以下会优化掉 sslsniff/tcpsniff 的长度钳制，导致 verifier 拒绝加载）|
 | libbpf | >= 0.8 | eBPF 用户态库 |
 | Node.js | >= 16 | 前端构建 |
 | npm | >= 8 | 前端依赖管理 |

--- a/src/agentsight/tests/bpf_load.rs
+++ b/src/agentsight/tests/bpf_load.rs
@@ -9,11 +9,16 @@
 //! Each test names the probe it covers so a failure immediately identifies
 //! which BPF program the verifier rejected.
 
-use agentsight::probes::{
-    FileWatch, FileWriteProbe, Probes, ProcMon, ProcTrace, SharedMaps, SslSniff, TcpSniff, UdpDns,
+use agentsight::{
+    config,
+    probes::{
+        FileWatch, FileWriteProbe, Probes, ProcMon, ProcTrace, SharedMaps, SslSniff, TcpSniff,
+        UdpDns,
+    },
 };
 
 fn make_shared_maps() -> (ProcTrace, SharedMaps) {
+    config::set_verbose(true);
     let pt = ProcTrace::new().expect("proctrace open+load");
     let shared = SharedMaps::new(pt.rb_handle().expect("rb handle")).with_traced_processes(
         pt.traced_processes_handle()
@@ -25,12 +30,14 @@ fn make_shared_maps() -> (ProcTrace, SharedMaps) {
 #[test]
 #[ignore]
 fn proctrace_bpf_loads() {
+    config::set_verbose(true);
     ProcTrace::new().expect("proctrace BPF should load on this kernel");
 }
 
 #[test]
 #[ignore]
 fn sslsniff_bpf_loads() {
+    config::set_verbose(true);
     SslSniff::new().expect("sslsniff BPF should load on this kernel");
 }
 
@@ -72,6 +79,7 @@ fn tcpsniff_bpf_loads() {
 #[test]
 #[ignore]
 fn all_probes_load() {
+    config::set_verbose(true);
     Probes::new(&[], None, true, true, &[])
         .expect("unified Probes (all BPF programs) should load on this kernel");
 }


### PR DESCRIPTION
## Description

AgentSight 的 `tests/bpf_load.rs` 一直是 `#[ignore]` 的——主仓 `ci.yaml` 从不执行，所以没有任何一条流水线真正在内核上加载过 BPF 程序，verifier 层面的回归只能等到用户运行时才暴露。

本 PR 新增 `agentsight-runner-test.yml`，在自建 runner pool 上跑两类 job：一个标准 CI（fmt / clippy / 覆盖率测试），一个 kernel matrix（5.10 / 5.15 / 6.6）专门以 `--ignored` 执行全部 BPF 加载测试，并打开 `config::set_verbose(true)` 以便失败时能直接从 libbpf 日志读到 verifier 报错。

首轮运行立刻抓到一个真实问题：runner 默认的 clang 14 会把 `sslsniff.bpf.c` / `tcpsniff.bpf.c` 里的长度钳制屏障折叠回原始有符号 `len` 寄存器，导致 `probe_SSL_read_exit` 与 `trace_tcp_sendmsg` 被 verifier 以 `R2 min value is negative` 拒绝，三个内核全部失败。第二个 commit 把工具链钉到 clang/llvm 15 —— 15.0.7 既是 Anolis 8 的默认版本，也是 jammy universe 的版本，CI 从此与 AgentSight 实际发布的平台一致。同时把文档里 `clang/llvm >= 11` 的声明修正为 `>= 15`，因为 11 对这两个探针从来就不成立。

## Related Issue

no-issue: CI 基础设施改动，用于补上 eBPF 加载测试从未被执行的覆盖缺口

## Type of Change

- [x] CI/CD or build changes
- [x] Documentation update

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass

## Testing

- 本地（clang 15.0.7 + kernel 5.10.134-al8）：`cargo test --test bpf_load -- --ignored sslsniff_bpf_loads tcpsniff_bpf_loads` 全部通过，确认 clang 15 下这两个探针可正常加载
- workflow YAML 语法校验通过
- 待本 PR 的流水线在 5.10 / 5.15 / 6.6 三个内核上给出结果作为最终验证

## Additional Notes

钉版本而非兼容所有 clang 是一个有意的取舍：屏障写法在 clang 15+ 生效、clang 14 失效，逐版本适配成本高且难以长期保证。若后续要放宽下限，方向是把 `asm volatile` 屏障换成显式位掩码（`_n &= (u32)(TIER)`，TIER 均为 2 的幂，掩码天然给 verifier 提供上界），这样对 14/15 都成立。

libbpf-cargo 只从 `$PATH` 解析 `clang`（不调用 llvm-strip 等其他 LLVM 工具），所以把 `/usr/lib/llvm-15/bin` 写入 `$GITHUB_PATH` 就够了，`build.rs` 无需改动。