### PR TITLE
fix(cosh-ng): [shell,core] fix session previews

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/cli.rs
+++ b/src/cosh-ng/crates/cosh-core/src/cli.rs
@@ -155,6 +155,11 @@ pub struct CliArgs {
     #[arg(long, hide = true)]
     pub include_partial_messages: bool,
 
+    /// Wrapper instructions persisted as a system message alongside the
+    /// single-shot prompt (sent by cosh-shell)
+    #[arg(long, value_name = "TEXT", hide = true)]
+    pub system_context: Option<String>,
+
     /// Single-shot prompt (headless mode: send one user message then exit)
     pub prompt: Option<String>,
 }

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -196,6 +196,21 @@ impl CoshCore {
         W: Write,
         R: AsyncBufReadExt + Unpin,
     {
+        self.handle_user_message_with_system_context(content, None, reader, writer)
+            .await
+    }
+
+    pub async fn handle_user_message_with_system_context<W, R>(
+        &mut self,
+        content: &str,
+        system_context: Option<&str>,
+        reader: &mut tokio::io::Lines<R>,
+        writer: &mut W,
+    ) -> Result<(), String>
+    where
+        W: Write,
+        R: AsyncBufReadExt + Unpin,
+    {
         self.bind_current_extension_snapshot();
         let _generation_pin = self.extension_generation.pin();
         // Generate a unique run_id for this agent run.
@@ -314,6 +329,11 @@ impl CoshCore {
         }
 
         self.messages.push(Message::user(content));
+
+        // After the user message so compaction keeps it inside this run's span.
+        if let Some(ctx) = system_context {
+            self.messages.push(Message::system(ctx));
+        }
 
         // Inject additional context from hooks
         if let Some(ref ctx) = prompt_result.additional_context {

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -263,6 +263,54 @@ async fn user_provided_secret_reaches_the_provider_boundary() {
     assert!(user_message.content.as_text().contains(secret));
 }
 
+#[tokio::test]
+async fn system_context_is_persisted_after_raw_user_message_and_reaches_provider() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        messages: Arc::clone(&captured),
+        ..RecordingProvider::default()
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message_with_system_context(
+        "查看当前目录下的文件",
+        Some("Handle this natural-language shell prompt request wrapper"),
+        &mut reader,
+        &mut output,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(core.messages[0].role, "user");
+    assert_eq!(core.messages[0].content.as_text(), "查看当前目录下的文件");
+    assert_eq!(core.messages[1].role, "system");
+    assert_eq!(
+        core.messages[1].content.as_text(),
+        "Handle this natural-language shell prompt request wrapper"
+    );
+
+    let messages = captured.lock().unwrap();
+    let user_index = messages
+        .iter()
+        .position(|message| message.role == "user")
+        .expect("provider user message");
+    assert_eq!(
+        messages[user_index].content.as_text(),
+        "查看当前目录下的文件"
+    );
+    assert!(messages.iter().any(|message| {
+        message.role == "system"
+            && message
+                .content
+                .as_text()
+                .contains("natural-language shell prompt request wrapper")
+    }));
+}
+
 fn find_declaration<'a>(
     declarations: &'a [crate::provider::ToolDeclaration],
     name: &str,

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -137,7 +137,12 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
         }
         let start = std::time::Instant::now();
         let turn_result = engine
-            .handle_user_message(prompt, &mut lines, &mut writer)
+            .handle_user_message_with_system_context(
+                prompt,
+                args.system_context.as_deref(),
+                &mut lines,
+                &mut writer,
+            )
             .await;
         let persist_result = session.persist(&engine);
         match combine_turn_and_persist(turn_result, persist_result) {
@@ -394,7 +399,12 @@ where
             let start = std::time::Instant::now();
 
             let turn_result = engine
-                .handle_user_message(&message.content, lines, writer)
+                .handle_user_message_with_system_context(
+                    &message.content,
+                    message.system_context.as_deref(),
+                    lines,
+                    writer,
+                )
                 .await;
             let persist_result = session.persist(engine);
             match combine_turn_and_persist(turn_result, persist_result) {

--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -83,6 +83,10 @@ pub enum InputMessage {
 pub struct UserMessageContent {
     pub role: String,
     pub content: String,
+    /// Wrapper instructions sent by cosh-shell alongside the raw user input.
+    /// Persisted as a system message so session previews keep the raw input.
+    #[serde(default)]
+    pub system_context: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -767,7 +771,24 @@ mod tests {
             } => {
                 assert_eq!(message.role, "user");
                 assert_eq!(message.content, "hello world");
+                assert_eq!(message.system_context, None);
                 assert_eq!(session_id.as_deref(), Some("default"));
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
+
+    #[test]
+    fn parse_user_message_with_system_context() {
+        let json = r#"{"type":"user","message":{"role":"user","content":"list files","system_context":"wrapper instructions"},"parent_tool_use_id":null}"#;
+        let msg: InputMessage = serde_json::from_str(json).expect("should parse user message");
+        match msg {
+            InputMessage::User { message, .. } => {
+                assert_eq!(message.content, "list files");
+                assert_eq!(
+                    message.system_context.as_deref(),
+                    Some("wrapper instructions")
+                );
             }
             _ => panic!("expected User variant"),
         }

--- a/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/store/tests.rs
@@ -318,6 +318,75 @@ fn summaries_are_newest_first_and_derive_metadata() {
 }
 
 #[test]
+fn first_prompt_uses_raw_user_input_when_wrapper_is_a_system_message() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let mut session = PersistedSession::new(
+        ProviderSessionId::new(),
+        store.workspace_scope().to_string(),
+        "mock-model".to_string(),
+        vec![
+            Message::user("查看当前目录下的文件"),
+            Message::system(
+                "Handle this natural-language shell prompt request for a Shell-first assistant.",
+            ),
+            Message::assistant("done"),
+        ],
+    );
+    store.persist(&mut session).unwrap();
+
+    let summary = store.inspect(&session.session_id).unwrap();
+
+    assert_eq!(
+        summary.first_prompt.as_deref(),
+        Some("查看当前目录下的文件")
+    );
+}
+
+#[test]
+fn first_prompt_extracts_raw_input_from_legacy_wrapper_merged_message() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let legacy_prompt =
+        "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
+        Decide based on user intent:\n\
+        history_access: Recent shell history is not included by default.\n\
+        Do not mention Claude Code, plan mode, implementation status, or internal workflow.\n\n\
+        user_input: 帮我检查 nginx 服务状态\n\
+        \n\nruntime_frame:\ncwd: /repo";
+    let mut session = PersistedSession::new(
+        ProviderSessionId::new(),
+        store.workspace_scope().to_string(),
+        "mock-model".to_string(),
+        vec![Message::user(legacy_prompt), Message::assistant("done")],
+    );
+    store.persist(&mut session).unwrap();
+
+    let summary = store.inspect(&session.session_id).unwrap();
+
+    assert_eq!(
+        summary.first_prompt.as_deref(),
+        Some("帮我检查 nginx 服务状态")
+    );
+}
+
+#[test]
+fn first_prompt_keeps_genuine_user_text_mentioning_user_input_marker() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let genuine = "please explain what\nuser_input: means in this codebase";
+    let mut session = new_session(&store, genuine);
+    store.persist(&mut session).unwrap();
+
+    let summary = store.inspect(&session.session_id).unwrap();
+
+    assert_eq!(
+        summary.first_prompt.as_deref(),
+        Some("please explain what user_input: means in this codebase")
+    );
+}
+
+#[test]
 fn summaries_bound_untrusted_model_and_mismatched_workspace_metadata() {
     let temp = tempfile::tempdir().unwrap();
     let store = store(&temp);

--- a/src/cosh-ng/crates/cosh-core/src/session/summary.rs
+++ b/src/cosh-ng/crates/cosh-core/src/session/summary.rs
@@ -18,7 +18,12 @@ pub(super) fn summary_from_session(
         .messages
         .iter()
         .filter(|message| message.role == "user")
-        .find_map(|message| bounded_message_preview(&message.content));
+        .find_map(
+            |message| match legacy_wrapper_user_input(&message.content) {
+                Some(input) => bounded_message_preview(&MessageContent::Text(input.to_string())),
+                None => bounded_message_preview(&message.content),
+            },
+        );
     SessionSummary {
         session_id: session.session_id.clone(),
         workspace_scope: bounded_summary_text(
@@ -34,6 +39,29 @@ pub(super) fn summary_from_session(
         schema_version: Some(session.schema_version),
         health,
     }
+}
+
+/// First line of the cosh-shell prompt wrapper that older shells merged into
+/// the persisted user message (before the system_context split).
+const LEGACY_WRAPPER_PREFIX: &str =
+    "Handle this natural-language shell prompt request for a Shell-first assistant.";
+const LEGACY_USER_INPUT_MARKER: &str = "\nuser_input: ";
+const LEGACY_RUNTIME_FRAME_MARKER: &str = "\n\nruntime_frame:";
+
+// Recovers the raw user input from a legacy wrapper-merged user message so
+// previews of pre-split sessions do not all show the same wrapper prefix.
+// The exact-prefix guard keeps genuine user text untouched.
+fn legacy_wrapper_user_input(content: &MessageContent) -> Option<&str> {
+    let MessageContent::Text(text) = content else {
+        return None;
+    };
+    if !text.starts_with(LEGACY_WRAPPER_PREFIX) {
+        return None;
+    }
+    let start = text.find(LEGACY_USER_INPUT_MARKER)? + LEGACY_USER_INPUT_MARKER.len();
+    let rest = &text[start..];
+    let end = rest.find(LEGACY_RUNTIME_FRAME_MARKER).unwrap_or(rest.len());
+    Some(&rest[..end])
 }
 
 /// Truncates summary metadata without splitting a UTF-8 code point.

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude.rs
@@ -136,6 +136,7 @@ impl ClaudeCodeAdapter {
             program: self.program.clone(),
             args,
             prompt: claude_prompt_from_request(request, mode),
+            system_context: None,
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
@@ -11,8 +11,8 @@ mod serialization;
 pub use serialization::{
     serialize_answer, serialize_auth_response, serialize_claude_allow, serialize_co_allow,
     serialize_deny, serialize_host_executed_shell_result, serialize_initialize,
-    serialize_shell_evidence_result, serialize_user_message, HostExecutedShellMetadata,
-    HostExecutedShellResult,
+    serialize_shell_evidence_result, serialize_user_message,
+    serialize_user_message_with_system_context, HostExecutedShellMetadata, HostExecutedShellResult,
 };
 
 const SHELL_HANDOFF_EVIDENCE_PROMPT_MARKER: &str = "ShellCommandCompleted";

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
@@ -38,11 +38,25 @@ pub fn serialize_initialize(request_id: &str) -> String {
 }
 
 pub fn serialize_user_message(content: &str, session_id: Option<&str>) -> String {
+    serialize_user_message_with_system_context(content, None, session_id)
+}
+
+/// cosh-core JSONL user message; `system_context` carries wrapper instructions
+/// so cosh-core persists the raw input as the user message. Omitted when
+/// `None` to stay byte-compatible with other providers.
+pub fn serialize_user_message_with_system_context(
+    content: &str,
+    system_context: Option<&str>,
+    session_id: Option<&str>,
+) -> String {
     let mut message = json!({
         "type": "user",
         "message": { "role": "user", "content": content },
         "parent_tool_use_id": null
     });
+    if let Some(system_context) = system_context {
+        message["message"]["system_context"] = Value::String(system_context.to_string());
+    }
     if let Some(session_id) = session_id {
         message["session_id"] = Value::String(session_id.to_string());
     }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
@@ -828,12 +828,30 @@ fn serialize_user_message_format() {
     assert_eq!(v["type"], "user");
     assert_eq!(v["message"]["role"], "user");
     assert_eq!(v["message"]["content"], "hello world");
+    assert!(v["message"].get("system_context").is_none());
     assert!(v["parent_tool_use_id"].is_null());
     assert_eq!(v["session_id"], "sess-1");
 
     let s2 = serialize_user_message("hi", None);
     let v2: Value = serde_json::from_str(&s2).unwrap();
     assert!(v2.get("session_id").is_none());
+}
+
+#[test]
+fn serialize_user_message_with_system_context_format() {
+    let s = serialize_user_message_with_system_context(
+        "查看当前目录下的文件",
+        Some("wrapper instructions"),
+        Some("sess-1"),
+    );
+    let v: Value = serde_json::from_str(&s).unwrap();
+    assert_eq!(v["message"]["content"], "查看当前目录下的文件");
+    assert_eq!(v["message"]["system_context"], "wrapper instructions");
+    assert_eq!(v["session_id"], "sess-1");
+
+    let s2 = serialize_user_message_with_system_context("hi", None, None);
+    let v2: Value = serde_json::from_str(&s2).unwrap();
+    assert!(v2["message"].get("system_context").is_none());
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
@@ -14,14 +14,16 @@ use super::cosh_core_process::{
     suppress_synthetic_completion_after_transport_failure,
 };
 use super::cosh_core_service::PersistentCoshCoreRuntime;
-use super::prompt::provider_prompt_contract_for_request_with_evidence_access;
+use super::prompt::{
+    provider_prompt_contract_for_request_with_evidence_access,
+    split_prompt_from_request_with_evidence_policy,
+};
 use super::{
-    agent_event_is_provider_progress, control_protocol, prompt_from_request_with_evidence_policy,
-    record_cancellation_pending_session, run_provider_process_loop, spawn_provider_child,
-    start_threaded_adapter_run, AdapterError, AdapterInstance, AgentAdapter,
-    AgentBackendCapabilities, AgentRunHandle, ClaudeStreamParser, FreshSessionOutcome,
-    PreparedInvocation, ProviderCancellationArtifactStore, ProviderLineProgress,
-    ProviderPromptArgMode, ProviderRunOutcome, ProviderStdinMode,
+    agent_event_is_provider_progress, control_protocol, record_cancellation_pending_session,
+    run_provider_process_loop, spawn_provider_child, start_threaded_adapter_run, AdapterError,
+    AdapterInstance, AgentAdapter, AgentBackendCapabilities, AgentRunHandle, ClaudeStreamParser,
+    FreshSessionOutcome, PreparedInvocation, ProviderCancellationArtifactStore,
+    ProviderLineProgress, ProviderPromptArgMode, ProviderRunOutcome, ProviderStdinMode,
 };
 
 pub(super) mod question_ingress;
@@ -324,10 +326,12 @@ impl CoshCoreAdapter {
             args.extend(["--resume".to_string(), session_id]);
         }
 
+        let (prompt, system_context) = cosh_core_prompt_from_request(request, mode);
         PreparedInvocation {
             program: self.program.clone(),
             args,
-            prompt: cosh_core_prompt_from_request(request, mode),
+            prompt,
+            system_context,
         }
     }
 
@@ -427,18 +431,25 @@ fn protected_session_ids_from_state(session: &SessionRuntimeState) -> Vec<String
     protected
 }
 
-fn cosh_core_prompt_from_request(request: &AgentRequest, mode: CoshApprovalMode) -> String {
+fn cosh_core_prompt_from_request(
+    request: &AgentRequest,
+    mode: CoshApprovalMode,
+) -> (String, Option<String>) {
     let access = crate::evidence::ShellEvidenceAccess::ControlProtocolTool;
-    let request_prompt = prompt_from_request_with_evidence_policy(
+    let parts = split_prompt_from_request_with_evidence_policy(
         request,
         access,
         mode != CoshApprovalMode::Recommend,
     );
-    format!(
-        "{}{}",
-        request_prompt,
-        provider_prompt_contract_for_request_with_evidence_access(request, mode, "shell", access)
-    )
+    let contract =
+        provider_prompt_contract_for_request_with_evidence_access(request, mode, "shell", access);
+    match parts.system_context {
+        Some(system_context) => (
+            parts.user_message,
+            Some(format!("{system_context}{contract}")),
+        ),
+        None => (format!("{}{}", parts.user_message, contract), None),
+    }
 }
 
 fn cosh_core_dry_run_events(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/question_writer.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core/question_writer.rs
@@ -13,6 +13,7 @@ use super::question_ingress::{protocol_error, CoreQuestionProtocolReason, CoshCo
 pub(crate) struct QuestionWriter {
     pub(crate) stdin: ChildStdin,
     pub(crate) prompt: String,
+    pub(crate) system_context: Option<String>,
     pub(crate) approval_rx: mpsc::Receiver<ApprovalResponse>,
     pub(crate) auth_rx: mpsc::Receiver<AuthResponse>,
     pub(crate) done: Arc<AtomicBool>,
@@ -34,7 +35,11 @@ impl QuestionWriter {
         let _ = writer.flush();
 
         if !self.prompt.is_empty() {
-            let user_msg = control_protocol::serialize_user_message(&self.prompt, None);
+            let user_msg = control_protocol::serialize_user_message_with_system_context(
+                &self.prompt,
+                self.system_context.as_deref(),
+                None,
+            );
             let _ = writeln!(writer, "{user_msg}");
             let _ = writer.flush();
         }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
@@ -219,6 +219,8 @@ pub(super) fn start_control_protocol_cosh_core_process(
     });
 
     let prompt = prepared.prompt.clone();
+    let system_context = prepared.system_context.clone();
+    let analysis_gate_text = prepared.analysis_gate_text();
     let pending_session_for_thread = Arc::clone(&pending_session);
     let session_scope_for_thread = session_scope;
     let cancellation_artifacts_for_thread = cancellation_artifacts.clone();
@@ -270,6 +272,7 @@ pub(super) fn start_control_protocol_cosh_core_process(
         let writer_thread = QuestionWriter {
             stdin,
             prompt: prompt_for_loop.clone(),
+            system_context,
             approval_rx,
             auth_rx,
             done: Arc::clone(&writer_done),
@@ -351,7 +354,7 @@ pub(super) fn start_control_protocol_cosh_core_process(
                                 .take_matching_control_shell(&run_id, &tool_use_id);
                             if let Some(response) =
                                 control_protocol::analysis_continuation_shell_deny_response(
-                                    &prompt_for_loop,
+                                    &analysis_gate_text,
                                     &request_id,
                                     &tool_name,
                                     &tool_input,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service.rs
@@ -420,6 +420,7 @@ fn run_turn(
         &process.stdin,
         &user_message(
             &command.prepared.prompt,
+            command.prepared.system_context.as_deref(),
             session_id.as_deref(),
             &command.session_scope,
         ),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/control.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/control.rs
@@ -31,7 +31,7 @@ pub(super) fn handle_control_request(
                 .borrow_mut()
                 .take_matching_control_shell(&command.run_id, &tool_use_id);
             if let Some(response) = control_protocol::analysis_continuation_shell_deny_response(
-                &command.prepared.prompt,
+                &command.prepared.analysis_gate_text(),
                 &request_id,
                 &tool_name,
                 &tool_input,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
@@ -389,15 +389,23 @@ pub(super) fn control_request(subtype: &str, request_id: &str, fields: Value) ->
     .to_string()
 }
 
-pub(super) fn user_message(content: &str, session_id: Option<&str>, cwd: &str) -> String {
-    serde_json::json!({
+pub(super) fn user_message(
+    content: &str,
+    system_context: Option<&str>,
+    session_id: Option<&str>,
+    cwd: &str,
+) -> String {
+    let mut message = serde_json::json!({
         "type": "user",
         "message": {"role": "user", "content": content},
         "parent_tool_use_id": null,
         "session_id": session_id.unwrap_or("default"),
         "shell_context": {"cwd": cwd, "env": {}, "last_exit_code": 0},
-    })
-    .to_string()
+    });
+    if let Some(system_context) = system_context {
+        message["message"]["system_context"] = Value::String(system_context.to_string());
+    }
+    message.to_string()
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
@@ -259,17 +259,16 @@ fn shell_handoff_continuation_keeps_strict_args_without_recommend_claim() {
     let inv = test_adapter().prepare_invocation(&request, CoshApprovalMode::Recommend);
 
     assert!(inv.args.contains(&"strict".to_string()));
-    assert!(!inv.prompt.contains("recommend mode"), "{}", inv.prompt);
+    assert_eq!(inv.prompt, "test");
+    let context = inv.system_context.expect("split system context");
+    assert!(!context.contains("recommend mode"), "{context}");
     assert!(
-        inv.prompt
-            .contains("approval mode is auto and has not changed"),
-        "{}",
-        inv.prompt
+        context.contains("approval mode is auto and has not changed"),
+        "{context}"
     );
     assert!(
-        inv.prompt.contains("Do not emit tool calls in this turn"),
-        "{}",
-        inv.prompt
+        context.contains("Do not emit tool calls in this turn"),
+        "{context}"
     );
 }
 
@@ -277,17 +276,14 @@ fn shell_handoff_continuation_keeps_strict_args_without_recommend_claim() {
 fn prepare_invocation_prompt_includes_cosh_shell_contract() {
     let inv = test_adapter().prepare_invocation(&test_request(), CoshApprovalMode::Auto);
 
-    assert!(inv
-        .prompt
-        .contains("Handle this natural-language shell prompt request"));
-    assert!(inv.prompt.contains("cosh-shell Agent contract"));
-    assert!(inv
-        .prompt
-        .contains("Always emit a provider permission request"));
-    assert!(inv.prompt.contains("State the diagnostic conclusion first"));
-    assert!(inv
-        .prompt
-        .contains("at most one primary recommendation command"));
+    assert_eq!(inv.prompt, "test");
+    let context = inv.system_context.expect("split system context");
+    assert!(context.contains("Handle this natural-language shell prompt request"));
+    assert!(context.contains("cosh-shell Agent contract"));
+    assert!(context.contains("Always emit a provider permission request"));
+    assert!(context.contains("State the diagnostic conclusion first"));
+    assert!(context.contains("at most one primary recommendation command"));
+    assert!(!context.contains("user_input:"), "{context}");
 }
 
 #[test]
@@ -316,47 +312,31 @@ fn prepare_invocation_prompt_uses_shell_output_tool_mode() {
 
     let inv = test_adapter().prepare_invocation(&request, CoshApprovalMode::Auto);
 
-    assert!(inv.prompt.contains("cosh_shell_evidence"), "{}", inv.prompt);
+    let context = inv.system_context.expect("split system context");
+    assert!(context.contains("cosh_shell_evidence"), "{context}");
+    assert!(context.contains("action=list_commands"), "{context}");
+    assert!(context.contains("action=read_output"), "{context}");
     assert!(
-        inv.prompt.contains("action=list_commands"),
-        "{}",
-        inv.prompt
-    );
-    assert!(inv.prompt.contains("action=read_output"), "{}", inv.prompt);
-    assert!(
-        inv.prompt.contains("Use current tool results first"),
-        "{}",
-        inv.prompt
+        context.contains("Use current tool results first"),
+        "{context}"
     );
     assert!(
-        inv.prompt
-            .contains("Use read_output only for older shell ledger output"),
-        "{}",
-        inv.prompt
+        context.contains("Use read_output only for older shell ledger output"),
+        "{context}"
     );
     assert!(
-        inv.prompt.contains("activity recaps or command lists"),
-        "{}",
-        inv.prompt
+        context.contains("activity recaps or command lists"),
+        "{context}"
     );
+    assert!(context.contains("output_available=false"), "{context}");
+    assert!(context.contains("output_bytes=0"), "{context}");
     assert!(
-        inv.prompt.contains("output_available=false"),
-        "{}",
-        inv.prompt
+        context.contains("call cosh_shell_evidence with action=list_commands"),
+        "{context}"
     );
-    assert!(inv.prompt.contains("output_bytes=0"), "{}", inv.prompt);
-    assert!(
-        inv.prompt
-            .contains("call cosh_shell_evidence with action=list_commands"),
-        "{}",
-        inv.prompt
-    );
+    assert!(!context.contains("```cosh-request"), "{context}");
+    assert!(!context.contains("```cosh-request\noutput"), "{context}");
     assert!(!inv.prompt.contains("```cosh-request"), "{}", inv.prompt);
-    assert!(
-        !inv.prompt.contains("```cosh-request\noutput"),
-        "{}",
-        inv.prompt
-    );
 }
 
 #[test]
@@ -371,17 +351,13 @@ fn prepare_invocation_prompt_suppresses_shell_output_requests_in_recommend_mode(
 
     let inv = test_adapter().prepare_invocation(&request, CoshApprovalMode::Recommend);
 
+    let context = inv.system_context.expect("split system context");
     assert!(
-        inv.prompt
-            .contains("do not request shell output automatically"),
-        "{}",
-        inv.prompt
+        context.contains("do not request shell output automatically"),
+        "{context}"
     );
-    assert!(
-        !inv.prompt.contains("cosh_shell_evidence"),
-        "{}",
-        inv.prompt
-    );
+    assert!(!context.contains("cosh_shell_evidence"), "{context}");
+    assert!(!context.contains("```cosh-request"), "{context}");
     assert!(!inv.prompt.contains("```cosh-request"), "{}", inv.prompt);
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
@@ -511,6 +511,9 @@ pub struct PreparedInvocation {
     pub program: String,
     pub args: Vec<String>,
     pub prompt: String,
+    /// Wrapper instructions sent separately from the raw prompt so cosh-core
+    /// persists the real user input as the user message (cosh-core only).
+    pub system_context: Option<String>,
 }
 
 impl PreparedInvocation {
@@ -519,6 +522,16 @@ impl PreparedInvocation {
         argv.extend(self.args.clone());
         argv.push("<prompt>".to_string());
         argv
+    }
+
+    /// Provider-visible text for gates that scan the outgoing turn; joins the
+    /// prompt with the split-off system context so markers spread across both
+    /// parts are still detected.
+    pub fn analysis_gate_text(&self) -> String {
+        match &self.system_context {
+            Some(system_context) => format!("{}{system_context}", self.prompt),
+            None => self.prompt.clone(),
+        }
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/process.rs
@@ -72,6 +72,9 @@ pub(crate) fn spawn_provider_child(
         match prompt_mode {
             ProviderPromptArgMode::None => {}
             ProviderPromptArgMode::TrailingArgIfNonEmpty => {
+                if let Some(system_context) = &prepared.system_context {
+                    command.arg("--system-context").arg(system_context);
+                }
                 if !prepared.prompt.is_empty() {
                     command.arg(&prepared.prompt);
                 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt.rs
@@ -31,6 +31,94 @@ pub fn prompt_from_request_with_evidence_policy(
     bound_provider_context(trigger, runtime, hook, request)
 }
 
+/// Provider prompt split into instruction context and the user-authored message.
+pub(crate) struct ProviderPromptParts {
+    /// Wrapper instructions plus runtime frame, suitable for a system-role channel.
+    /// `None` when the request variant must stay a single user message.
+    pub system_context: Option<String>,
+    /// Raw user input when split, otherwise the full combined prompt.
+    pub user_message: String,
+}
+
+/// Splits the provider prompt so the natural-language wrapper can travel as
+/// system context while the raw user input remains the persisted user message.
+/// Only the natural-language variant splits; continuation and insight variants
+/// keep the combined prompt unchanged.
+pub(crate) fn split_prompt_from_request_with_evidence_policy(
+    request: &AgentRequest,
+    access: ShellEvidenceAccess,
+    allow_output_requests: bool,
+) -> ProviderPromptParts {
+    if let Some(input) = natural_language_user_input(request, access, allow_output_requests) {
+        let body = natural_language_trigger_body(access, allow_output_requests);
+        let runtime = redact_sensitive_text(&runtime_frame_prompt(
+            request,
+            access,
+            allow_output_requests,
+        ))
+        .0;
+        let hook = redact_sensitive_text(&hook_finding_prompt(request)).0;
+        return ProviderPromptParts {
+            system_context: Some(format!("{body}{runtime}{hook}")),
+            user_message: input.to_string(),
+        };
+    }
+    ProviderPromptParts {
+        system_context: None,
+        user_message: prompt_from_request_with_evidence_policy(
+            request,
+            access,
+            allow_output_requests,
+        ),
+    }
+}
+
+// Mirrors the branch chain in `trigger_evidence_prompt`: returns the raw input
+// only when the natural-language wrapper branch would be taken.
+fn natural_language_user_input(
+    request: &AgentRequest,
+    access: ShellEvidenceAccess,
+    allow_output_requests: bool,
+) -> Option<&str> {
+    let output_access = output_access_instruction(access, allow_output_requests);
+    let input = request.user_input.as_deref()?;
+    if input.starts_with("Answer to pending Agent question:")
+        || input.starts_with("Tool result for request ")
+        || input.starts_with("Tool result for approved request ")
+        || input.starts_with("Approval result for request ")
+        || input.starts_with("ShellEvidenceExcerpt\n")
+    {
+        return None;
+    }
+    if bound_insight_prompt(request, output_access, allow_output_requests).is_some() {
+        return None;
+    }
+    Some(input)
+}
+
+fn natural_language_trigger_body(
+    access: ShellEvidenceAccess,
+    allow_output_requests: bool,
+) -> String {
+    format!(
+        "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
+         Decide based on user intent:\n\
+         - If the user wants to DO something (view files, check status, run tests, inspect system, debug), \
+         use the Bash tool directly. cosh-shell has an approval system that reviews every tool request \
+         before execution.\n\
+         - If the user wants to KNOW something (ask a question, request explanation, compare options), \
+         answer in prose with example commands in code blocks.\n\
+         Prefer one bounded read-only Bash command at a time when that is enough. \
+         If shell syntax such as pipes, redirects, or command chains materially improves the task, \
+         use it as a Bash tool request and let cosh-shell ask for confirmation when required.\n\
+         If more user input is needed, request AskUserQuestion with the visible question text \
+         and 2-4 concrete options; allow free text for an Other answer when appropriate.\n\
+         history_access: {}\n\
+         Do not mention Claude Code, plan mode, implementation status, or internal workflow.\n\n",
+        history_access_instruction(access, allow_output_requests)
+    )
+}
+
 fn bound_provider_context(
     trigger: String,
     runtime: String,
@@ -180,23 +268,8 @@ fn trigger_evidence_prompt(
             prompt
         } else {
             format!(
-                "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
-                 Decide based on user intent:\n\
-                 - If the user wants to DO something (view files, check status, run tests, inspect system, debug), \
-                 use the Bash tool directly. cosh-shell has an approval system that reviews every tool request \
-                 before execution.\n\
-                 - If the user wants to KNOW something (ask a question, request explanation, compare options), \
-                 answer in prose with example commands in code blocks.\n\
-                 Prefer one bounded read-only Bash command at a time when that is enough. \
-                 If shell syntax such as pipes, redirects, or command chains materially improves the task, \
-                 use it as a Bash tool request and let cosh-shell ask for confirmation when required.\n\
-                 If more user input is needed, request AskUserQuestion with the visible question text \
-                 and 2-4 concrete options; allow free text for an Other answer when appropriate.\n\
-                 history_access: {}\n\
-                 Do not mention Claude Code, plan mode, implementation status, or internal workflow.\n\n\
-                 user_input: {}\n\
-                 ",
-                history_access_instruction(access, allow_output_requests),
+                "{}user_input: {}\n",
+                natural_language_trigger_body(access, allow_output_requests),
                 input
             )
         }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/prompt_tests.rs
@@ -2,7 +2,7 @@ use super::prompt::{
     prompt_from_request, prompt_from_request_with_evidence_access,
     prompt_from_request_with_evidence_policy, provider_prompt_contract,
     provider_prompt_contract_for_language, provider_prompt_contract_for_request,
-    provider_prompt_contract_with_evidence_access,
+    provider_prompt_contract_with_evidence_access, split_prompt_from_request_with_evidence_policy,
 };
 use crate::evidence::ShellEvidenceAccess;
 use crate::types::{
@@ -1249,4 +1249,132 @@ fn bound_insight_prompt_does_not_treat_user_text_as_evidence_boundary() {
         "provider context bytes: {}",
         prompt.len()
     );
+}
+
+fn natural_language_request(input: &str) -> AgentRequest {
+    AgentRequest {
+        id: "agent-request-split".to_string(),
+        session_id: "session-1".to_string(),
+        command_block: command_block("input-1", input, 0, None),
+        context_blocks: vec![command_block("cmd-1", "echo split-context", 0, None)],
+        context_hints: Vec::new(),
+        user_input: Some(input.to_string()),
+        findings: Vec::new(),
+        mode: AgentMode::RecommendOnly,
+        user_confirmed: true,
+        hook_finding: None,
+        recommended_skill: None,
+    }
+}
+
+#[test]
+fn split_natural_language_prompt_separates_wrapper_from_raw_user_input() {
+    let input = "查看当前目录下的文件";
+    let request = natural_language_request(input);
+
+    let parts = split_prompt_from_request_with_evidence_policy(
+        &request,
+        ShellEvidenceAccess::FencedRequestFallback,
+        true,
+    );
+
+    assert_eq!(parts.user_message, input);
+    let system_context = parts.system_context.expect("natural language split");
+    assert!(
+        system_context.starts_with("Handle this natural-language shell prompt request"),
+        "{system_context}"
+    );
+    assert!(
+        system_context.contains("history_access:"),
+        "{system_context}"
+    );
+    assert!(
+        system_context.contains("runtime_frame:"),
+        "{system_context}"
+    );
+    assert!(system_context.contains("cwd: /repo"), "{system_context}");
+    assert!(!system_context.contains("user_input:"), "{system_context}");
+    assert!(!system_context.contains(input), "{system_context}");
+}
+
+#[test]
+fn split_continuation_variants_keep_combined_prompt_byte_identical() {
+    for input in [
+        "Answer to pending Agent question: yes",
+        "Tool result for request req-1: done",
+        "Tool result for approved request req-1: done",
+        "Approval result for request req-1: denied",
+        "ShellEvidenceExcerpt\nexcerpt-body",
+    ] {
+        let request = natural_language_request(input);
+
+        let parts = split_prompt_from_request_with_evidence_policy(
+            &request,
+            ShellEvidenceAccess::FencedRequestFallback,
+            true,
+        );
+
+        assert!(parts.system_context.is_none(), "{input}");
+        assert_eq!(
+            parts.user_message,
+            prompt_from_request_with_evidence_policy(
+                &request,
+                ShellEvidenceAccess::FencedRequestFallback,
+                true,
+            )
+        );
+    }
+}
+
+#[test]
+fn split_insight_and_failure_variants_keep_combined_prompt_byte_identical() {
+    for request in [
+        bound_failure_request("BuildOrTestFailure", None),
+        bound_failure_request("BuildOrTestFailure", Some("聚焦这一次失败")),
+        bound_failure_request("", None),
+    ] {
+        let parts = split_prompt_from_request_with_evidence_policy(
+            &request,
+            ShellEvidenceAccess::FencedRequestFallback,
+            true,
+        );
+
+        assert!(parts.system_context.is_none());
+        assert_eq!(
+            parts.user_message,
+            prompt_from_request_with_evidence_policy(
+                &request,
+                ShellEvidenceAccess::FencedRequestFallback,
+                true,
+            )
+        );
+    }
+}
+
+#[test]
+fn split_occurs_iff_combined_prompt_starts_with_natural_language_wrapper() {
+    let requests = [
+        natural_language_request("list files"),
+        natural_language_request("Answer to pending Agent question: yes"),
+        natural_language_request("ShellEvidenceExcerpt\nbody"),
+        bound_failure_request("BuildOrTestFailure", None),
+        bound_failure_request("", Some("聚焦这一次失败")),
+    ];
+    for request in requests {
+        let combined = prompt_from_request_with_evidence_policy(
+            &request,
+            ShellEvidenceAccess::FencedRequestFallback,
+            true,
+        );
+        let parts = split_prompt_from_request_with_evidence_policy(
+            &request,
+            ShellEvidenceAccess::FencedRequestFallback,
+            true,
+        );
+        assert_eq!(
+            parts.system_context.is_some(),
+            combined.starts_with("Handle this natural-language shell prompt request"),
+            "{combined}"
+        );
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/qwen.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/qwen.rs
@@ -94,6 +94,7 @@ impl QwenCliAdapter {
             program: self.program.clone(),
             args,
             prompt: qwen_prompt_from_request(request, mode),
+            system_context: None,
         }
     }
 
@@ -522,6 +523,7 @@ mod tests {
                 "Read,Grep,Glob,LS".to_string(),
             ],
             prompt: "hello prompt".to_string(),
+            system_context: None,
         });
 
         let prompt_at = args


### PR DESCRIPTION
## Description

`/session list` showed the same wrapper prefix ("Handle this natural-language shell prompt request…") for every session because cosh-shell merged its prompt wrapper and the raw user input into one persisted user message, and the 160-char `first_prompt` preview never reached the real input. This PR implements Option A from the issue: the wrapper travels through a new optional `system_context` field (JSONL) / hidden `--system-context` flag (one-shot), while the raw input stays the user message; cosh-core persists the wrapper as a system message pushed after the user message. A preview-only fallback recovers previews for sessions persisted before the split by extracting the text after the `user_input:` marker.

## Related Issue

closes #1995

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings`: 0 warnings; `cargo fmt --all -- --check`: clean
- cosh-shell: lib 1149 passed, `logic` 8 passed, `protocol` 56 passed
- cosh-core: 645/646 passed (the one failure, `expand_tilde_bare_tilde`, is a pre-existing HOME-env race that also fails on a clean tree)
- New regression tests: prompt split variants (natural-language splits; continuation/insight variants stay byte-identical), protocol parse with/without `system_context`, engine message order `[user(raw), system(ctx)]` + provider receives ctx as system role, store `first_prompt` from raw input, legacy wrapper extraction + false-positive guard
- Edge cases verified: continuation prefixes ("Tool result…", "Approval result…", question answers, evidence excerpts) never split; analysis-only deny gate still fires with markers spanning prompt and system_context; older shells (no field) unchanged via serde default

## Additional Notes

Version skew (new shell + old core) drops the wrapper for that turn only — degraded instruction-following but functional; shell and core ship in lockstep. claude/qwen adapters keep the single combined prompt.