### PR TITLE
fix(cosh-ng): [shell] guard pagers on agent handoff commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -292,6 +292,76 @@ _cosh_replace_handoff_history() {
   builtin history -s "$_COSH_HANDOFF_HISTORY_COMMAND" 2>/dev/null || true
   unset _COSH_HANDOFF_HISTORY_NO _COSH_HANDOFF_HISTORY_COMMAND 2>/dev/null || true
 }
+# Agent handoff commands run on the foreground TTY, so pager-capable tools
+# (git log, systemctl, man) would drop into interactive less and the precmd
+# marker — and with it the agent turn — could not close until a human
+# pressed q (issue #1988). While an agent-approved handoff command is
+# running, force the pager family to cat via exported env. Rust side drops
+# a sidecar marker file next to the handoff request file for agent-approved
+# handoffs only; user `send_to_shell` handoffs (explicitly interactive) and
+# user-typed commands never arm the guard. Restore is exact: original
+# value, export attribute, and unset state all round-trip. Every step is
+# fail-safe (guard failure means pagers behave as before the fix).
+# GIT_PAGER outranks core.pager which outranks PAGER, so PAGER alone is
+# not enough for git; SYSTEMD_PAGER/MANPAGER shadow PAGER the same way.
+# Note: changes a handoff command itself makes to these variables do not
+# persist; the guard restores the pre-handoff environment exactly at the
+# next prompt.
+_COSH_PAGER_GUARD_VARS='GIT_PAGER PAGER SYSTEMD_PAGER MANPAGER'
+_COSH_PAGER_GUARD_ARMED=0
+_cosh_handoff_pager_guard_requested() {
+  [[ -n "${COSH_HANDOFF_REQUEST_FILE:-}" && -f "${COSH_HANDOFF_REQUEST_FILE}.pager-guard" ]]
+}
+_cosh_clear_handoff_pager_guard_marker() {
+  if [[ -n "${COSH_HANDOFF_REQUEST_FILE:-}" && -f "${COSH_HANDOFF_REQUEST_FILE}.pager-guard" ]]; then
+    rm -f -- "${COSH_HANDOFF_REQUEST_FILE}.pager-guard" 2>/dev/null || true
+  fi
+}
+_cosh_arm_handoff_pager_guard() {
+  if [[ "${_COSH_PAGER_GUARD_ARMED:-0}" == 1 ]]; then
+    return 0
+  fi
+  _cosh_handoff_pager_guard_requested || return 0
+  local var decl
+  for var in $_COSH_PAGER_GUARD_VARS; do
+    if decl="$(declare -p "$var" 2>/dev/null)"; then
+      if [[ "$decl" == "declare -x"* ]]; then
+        printf -v "_COSH_PG_STATE_$var" '%s' exported
+      else
+        printf -v "_COSH_PG_STATE_$var" '%s' set
+      fi
+      printf -v "_COSH_PG_VALUE_$var" '%s' "${!var}"
+    else
+      printf -v "_COSH_PG_STATE_$var" '%s' unset
+    fi
+    export "$var=cat" 2>/dev/null || true
+  done
+  _COSH_PAGER_GUARD_ARMED=1
+}
+_cosh_restore_handoff_pager_guard() {
+  if [[ "${_COSH_PAGER_GUARD_ARMED:-0}" != 1 ]]; then
+    return 0
+  fi
+  local var state_var value_var
+  for var in $_COSH_PAGER_GUARD_VARS; do
+    state_var="_COSH_PG_STATE_$var"
+    value_var="_COSH_PG_VALUE_$var"
+    case "${!state_var:-unset}" in
+      exported)
+        export "$var=${!value_var}" 2>/dev/null || true
+        ;;
+      set)
+        printf -v "$var" '%s' "${!value_var}"
+        export -n "$var" 2>/dev/null || true
+        ;;
+      *)
+        unset "$var" 2>/dev/null || true
+        ;;
+    esac
+    unset "$state_var" "$value_var" 2>/dev/null || true
+  done
+  _COSH_PAGER_GUARD_ARMED=0
+}
 _cosh_begin_attempt() {
   local input="$1"
   local top_token="$2"
@@ -569,8 +639,10 @@ _cosh_preexec_marker() {
         display_command="$(_cosh_unwrap_handoff_command "$command")"
         _COSH_HANDOFF_ACTIVE=1
         _COSH_HANDOFF_HISTORY_NO="$history_no"
+        _cosh_arm_handoff_pager_guard
       elif _cosh_is_pending_handoff_command "$command"; then
         _COSH_HANDOFF_ACTIVE=1
+        _cosh_arm_handoff_pager_guard
       else
         _cosh_clear_handoff_request
         unset _COSH_HANDOFF_ACTIVE 2>/dev/null || true
@@ -630,6 +702,8 @@ _cosh_precmd_marker() {
   _cosh_apply_internal_recovery
   _cosh_replace_handoff_history
   _cosh_clear_handoff_request
+  _cosh_clear_handoff_pager_guard_marker
+  _cosh_restore_handoff_pager_guard
   unset _COSH_HANDOFF_ACTIVE 2>/dev/null || true
   _COSH_ATTEMPT_ACTIVE=0
   _cosh_emit_marker "precmd" "" "$status" false

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -245,6 +245,67 @@ _cosh_add_handoff_history() {
   print -sr -- "$_COSH_HANDOFF_HISTORY_COMMAND" 2>/dev/null || true
   unset _COSH_HANDOFF_HISTORY_COMMAND 2>/dev/null || true
 }
+# Pager guard for agent-approved handoff commands (issue #1988); see the
+# bash marker for the full rationale. Armed only when the Rust side left
+# the sidecar marker file, restored exactly at the next prompt. Fail-safe:
+# any failure leaves pagers behaving as before the fix. Note: changes a
+# handoff command itself makes to these variables do not persist; the
+# guard restores the pre-handoff environment exactly at the next prompt.
+_COSH_PAGER_GUARD_VARS='GIT_PAGER PAGER SYSTEMD_PAGER MANPAGER'
+_COSH_PAGER_GUARD_ARMED=0
+_cosh_handoff_pager_guard_requested() {
+  [[ -n "${COSH_HANDOFF_REQUEST_FILE:-}" && -f "${COSH_HANDOFF_REQUEST_FILE}.pager-guard" ]]
+}
+_cosh_clear_handoff_pager_guard_marker() {
+  if [[ -n "${COSH_HANDOFF_REQUEST_FILE:-}" && -f "${COSH_HANDOFF_REQUEST_FILE}.pager-guard" ]]; then
+    rm -f -- "${COSH_HANDOFF_REQUEST_FILE}.pager-guard" 2>/dev/null || true
+  fi
+}
+_cosh_arm_handoff_pager_guard() {
+  if [[ "${_COSH_PAGER_GUARD_ARMED:-0}" == 1 ]]; then
+    return 0
+  fi
+  _cosh_handoff_pager_guard_requested || return 0
+  local var
+  for var in ${=_COSH_PAGER_GUARD_VARS}; do
+    if [[ -n "${parameters[$var]-}" ]]; then
+      if [[ "${parameters[$var]-}" == *export* ]]; then
+        typeset -g "_COSH_PG_STATE_$var=exported"
+      else
+        typeset -g "_COSH_PG_STATE_$var=set"
+      fi
+      typeset -g "_COSH_PG_VALUE_$var=${(P)var}"
+    else
+      typeset -g "_COSH_PG_STATE_$var=unset"
+    fi
+    export "$var=cat" 2>/dev/null || true
+  done
+  _COSH_PAGER_GUARD_ARMED=1
+}
+_cosh_restore_handoff_pager_guard() {
+  if [[ "${_COSH_PAGER_GUARD_ARMED:-0}" != 1 ]]; then
+    return 0
+  fi
+  local var state_var value_var
+  for var in ${=_COSH_PAGER_GUARD_VARS}; do
+    state_var="_COSH_PG_STATE_$var"
+    value_var="_COSH_PG_VALUE_$var"
+    case "${(P)state_var:-unset}" in
+      exported)
+        export "$var=${(P)value_var}" 2>/dev/null || true
+        ;;
+      set)
+        typeset -g "$var=${(P)value_var}"
+        typeset +x "$var" 2>/dev/null || true
+        ;;
+      *)
+        unset "$var" 2>/dev/null || true
+        ;;
+    esac
+    unset "$state_var" "$value_var" 2>/dev/null || true
+  done
+  _COSH_PAGER_GUARD_ARMED=0
+}
 _cosh_begin_attempt() {
   local input="$1"
   local top_token="$2"
@@ -373,12 +434,14 @@ _cosh_preexec_marker() {
   if _cosh_is_handoff_wrapper "$command"; then
     display_command="$(_cosh_unwrap_handoff_command "$command")"
     _COSH_HANDOFF_ACTIVE=1
+    _cosh_arm_handoff_pager_guard
     if _cosh_command_has_secret "$display_command"; then
       display_command="<redacted sensitive command>"
     fi
     _COSH_HANDOFF_HISTORY_COMMAND="$display_command"
   elif _cosh_is_pending_handoff_command "$command"; then
     _COSH_HANDOFF_ACTIVE=1
+    _cosh_arm_handoff_pager_guard
   else
     _cosh_clear_handoff_request
     unset _COSH_HANDOFF_ACTIVE 2>/dev/null || true
@@ -410,6 +473,8 @@ _cosh_precmd_marker() {
   _cosh_apply_internal_recovery
   _cosh_add_handoff_history
   _cosh_clear_handoff_request
+  _cosh_clear_handoff_pager_guard_marker
+  _cosh_restore_handoff_pager_guard
   unset _COSH_HANDOFF_ACTIVE 2>/dev/null || true
   _COSH_ATTEMPT_ACTIVE=0
   _cosh_emit_marker "precmd" "" "$exit_status" false

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::{self, Write};
 use std::os::fd::AsRawFd;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use nix::libc;
@@ -18,6 +18,28 @@ use super::{mark_pending_prompt_replayed, write_pending_display, write_prompt_gh
 
 fn write_handoff_request(path: &Path, command: &str) -> io::Result<()> {
     std::fs::write(path, command.as_bytes())
+}
+
+/// Sidecar marker consumed by `_cosh_arm_handoff_pager_guard` in the bash
+/// marker script: present only for agent-approved handoffs, so pagers are
+/// forced to `cat` there while user-driven `send_to_shell` handoffs (the
+/// user explicitly chose interactive foreground execution) keep native
+/// pager behavior (issue #1988).
+pub(crate) fn pager_guard_marker_path(handoff_request_file: &Path) -> PathBuf {
+    let mut path = handoff_request_file.as_os_str().to_os_string();
+    path.push(".pager-guard");
+    PathBuf::from(path)
+}
+
+fn sync_pager_guard_marker(handoff_request_file: &Path, request: &ShellHandoffRequest) {
+    let guard = pager_guard_marker_path(handoff_request_file);
+    // Fail-quiet on both sides: a missing marker only means the pager
+    // guard stays disarmed and pagers behave as before the fix.
+    if request.source == "send_to_shell" {
+        let _ = std::fs::remove_file(&guard);
+    } else {
+        let _ = std::fs::write(&guard, b"");
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -147,8 +169,10 @@ fn emit_to_pty<W: Write>(
     pending_terminal_restore.record_intervention_start(terminal_fd);
     parser.register_pending_handoff_origin(&request);
     write_handoff_request(handoff_request_file, &request.command)?;
+    sync_pager_guard_marker(handoff_request_file, &request);
     if let Err(err) = write_all_pty(master, &bytes) {
         let _ = std::fs::remove_file(handoff_request_file);
+        let _ = std::fs::remove_file(pager_guard_marker_path(handoff_request_file));
         return Err(err);
     }
     Ok(())

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/handoff.rs
@@ -279,3 +279,201 @@ fn raw_relay_zsh_history_records_original_handoff_command() {
         "{terminal}"
     );
 }
+
+fn pager_guard_handoff_request(command: &str, source: &str) -> ShellHandoffRequest {
+    ShellHandoffRequest::new(
+        command,
+        format!("$ {command}"),
+        source,
+        "user",
+        "approval-pg",
+        "run-pg",
+        1,
+    )
+    .expect("handoff request")
+}
+
+// Issue #1988: agent-approved handoff commands run with the pager family
+// forced to cat so pager-capable tools cannot stall the turn on the
+// foreground TTY; the guard must restore the user's environment exactly
+// afterwards and must not touch user-initiated executions.
+#[test]
+fn raw_relay_bash_pager_guard_exports_cat_for_agent_handoff_and_restores() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-pager-guard-restore-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config = ShellHostConfig::new("pager-guard-restore-test", &work_dir);
+    config
+        .env_overrides
+        .push(("GIT_PAGER".to_string(), "less".to_string()));
+    let mut emitted = false;
+    let command =
+        "printf 'during=%s,%s,%s,%s\\n' \"${GIT_PAGER-unset}\" \"${PAGER-unset}\" \"${SYSTEMD_PAGER-unset}\" \"${MANPAGER-unset}\"";
+    let output = run_raw_relay_bash_with_actions_output_control(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(700)),
+            RawRelayAction::line(
+                "printf 'after=%s,%s\\n' \"${GIT_PAGER-unset}\" \"${PAGER-unset}\"",
+            ),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::line("exit"),
+        ],
+        Vec::new(),
+        move |_, _| {
+            if emitted {
+                return Ok(RawObserverAction::Continue);
+            }
+            emitted = true;
+            Ok(RawObserverAction::EmitToPty(pager_guard_handoff_request(
+                command,
+                "approved_provider_shell_tool",
+            )))
+        },
+    )
+    .expect("raw relay pager guard restore");
+
+    let ledger = ledger_from_output(&output);
+    let command_output = ledger_output_refs_text(&ledger);
+    assert!(
+        command_output.contains("during=cat,cat,cat,cat"),
+        "{command_output}"
+    );
+    assert!(
+        command_output.contains("after=less,unset"),
+        "{command_output}"
+    );
+}
+
+#[test]
+fn raw_relay_bash_pager_guard_covers_compound_handoff_command() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-pager-guard-compound-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("pager-guard-compound-test", &work_dir);
+    let mut emitted = false;
+    let command = "true && printf 'compound=%s\\n' \"${GIT_PAGER-unset}\"";
+    let output = run_raw_relay_bash_with_actions_output_control(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(700)),
+            RawRelayAction::line("exit"),
+        ],
+        Vec::new(),
+        move |_, _| {
+            if emitted {
+                return Ok(RawObserverAction::Continue);
+            }
+            emitted = true;
+            Ok(RawObserverAction::EmitToPty(pager_guard_handoff_request(
+                command,
+                "approved_provider_shell_tool",
+            )))
+        },
+    )
+    .expect("raw relay pager guard compound");
+
+    let ledger = ledger_from_output(&output);
+    let command_output = ledger_output_refs_text(&ledger);
+    assert!(command_output.contains("compound=cat"), "{command_output}");
+}
+
+#[test]
+fn raw_relay_bash_pager_guard_skips_user_send_to_shell_handoff() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-pager-guard-send-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("pager-guard-send-test", &work_dir);
+    let mut emitted = false;
+    let command = "printf 'send=%s\\n' \"${GIT_PAGER-unset}\"";
+    let output = run_raw_relay_bash_with_actions_output_control(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(700)),
+            RawRelayAction::line("exit"),
+        ],
+        Vec::new(),
+        move |_, _| {
+            if emitted {
+                return Ok(RawObserverAction::Continue);
+            }
+            emitted = true;
+            Ok(RawObserverAction::EmitToPty(pager_guard_handoff_request(
+                command,
+                "send_to_shell",
+            )))
+        },
+    )
+    .expect("raw relay pager guard send_to_shell");
+
+    let ledger = ledger_from_output(&output);
+    let command_output = ledger_output_refs_text(&ledger);
+    assert!(command_output.contains("send=unset"), "{command_output}");
+}
+
+#[test]
+fn raw_relay_zsh_pager_guard_exports_cat_for_agent_handoff_and_restores() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-zsh-pager-guard-test-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config = ShellHostConfig::new("zsh-pager-guard-test", &work_dir);
+    config.native_mode = false;
+    config
+        .env_overrides
+        .push(("GIT_PAGER".to_string(), "less".to_string()));
+    let input = DelayedInput::new(vec![
+        (
+            b"printf 'after=%s,%s\\n' \"${GIT_PAGER-unset}\" \"${PAGER-unset}\"\n".to_vec(),
+            Duration::from_millis(900),
+        ),
+        (b"exit\n".to_vec(), Duration::from_millis(300)),
+    ]);
+    let mut emitted = false;
+    let command = "printf 'during=%s,%s\\n' \"${GIT_PAGER-unset}\" \"${PAGER-unset}\"";
+    let output = run_raw_relay_zsh_with_output_control(&config, input, Vec::new(), move |_, _| {
+        if emitted {
+            return Ok(RawObserverAction::Continue);
+        }
+        emitted = true;
+        Ok(RawObserverAction::EmitToPty(pager_guard_handoff_request(
+            command,
+            "approved_provider_shell_tool",
+        )))
+    })
+    .expect("raw zsh relay pager guard");
+
+    let ledger = ledger_from_output(&output);
+    let command_output = ledger_output_refs_text(&ledger);
+    assert!(
+        command_output.contains("during=cat,cat"),
+        "{command_output}"
+    );
+    assert!(
+        command_output.contains("after=less,unset"),
+        "{command_output}"
+    );
+}


### PR DESCRIPTION
## Summary

Agent-approved shell handoffs run on the foreground bash TTY. Commands whose
output exceeds one screen (`git log`, `systemctl`, `man`) drop into
interactive `less`: the precmd marker never fires, the turn cannot close,
and the session looks stuck until a human presses `q` (#1988).

This PR adds a pager guard scoped to the agent-approved handoff lifecycle:
while such a command runs, the shell markers export
`GIT_PAGER/PAGER/SYSTEMD_PAGER/MANPAGER=cat`, and restore the exact previous
state (value, export attribute, unset) at the next prompt.

Key properties:
- **Zero intrusion**: user-typed commands and user-driven `send_to_shell`
  handoffs (explicitly interactive) never arm the guard — native pager
  behavior is untouched. The guard arms only when the Rust emit path drops a
  `.pager-guard` sidecar next to the handoff request file.
- **Compound-command coverage**: env scoping happens in the DEBUG trap /
  preexec hook, so `cd x && git log` and loop bodies inherit the guard. A
  command-text prefix rewrite was rejected: `GIT_PAGER=cat for ...` is a
  bash syntax error and `VAR=x cmd1 && cmd2` leaves cmd2 unguarded.
- **Fail-safe**: every guard step degrades to pre-fix pager behavior on
  failure (missing sidecar, readonly vars, etc.).
- Covers both bash and zsh markers.

Closes #1988

## Changes

- `crates/cosh-shell/src/shell_host/marker/bash.rs`: arm/restore pager guard
  around the two handoff-tagged preexec branches; restore + sidecar cleanup
  in precmd.
- `crates/cosh-shell/src/shell_host/marker/zsh.rs`: symmetric guard using
  zsh `parameters` / `${(P)}` state round-trip.
- `crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs`: write the
  `.pager-guard` sidecar for agent-approved handoffs, remove it for
  `send_to_shell`; clean up on PTY write failure.
- `crates/cosh-shell/tests/shell_host/handoff.rs`: 4 new integration tests
  (cat override during agent handoff + exact restore incl. export attribute;
  compound command coverage; `send_to_shell` untouched; zsh mirror).

## Tests

- New: `raw_relay_bash_pager_guard_exports_cat_for_agent_handoff_and_restores`,
  `raw_relay_bash_pager_guard_covers_compound_handoff_command`,
  `raw_relay_bash_pager_guard_skips_user_send_to_shell_handoff`,
  `raw_relay_zsh_pager_guard_exports_cat_for_agent_handoff_and_restores`
  (4/4 green, alinux3 arm64 container, bash 4.4 + zsh).

## Verification

Focused green (alinux3 arm64 container):
- `cargo test -p cosh-shell --lib` (1144 passed)
- `cargo test -p cosh-shell --bin cosh-shell` (2151 passed)
- `cargo test -p cosh-shell --test shell_host pager_guard` (4 passed)
- `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`
- gates: `check-layout.sh`, `check-test-inventory.sh`

Known pre-existing failures (identical on unmodified base a065b407 in the
same container, not introduced here): shell_host
`heavy::raw_relay_host_shows_isolated_sudo_prompt_and_keeps_shell_usable`,
`termios::cosh_owned_timeout_recovery_restores_pty_without_visible_command`,
`termios::transparent_ctrl_backslash_is_not_synthesized_from_ctrl_c`;
raw_cli `heavy::raw_cli_host_executed_fullscreen_timeout_defers_notice_until_exit_alt_screen`,
`heavy::raw_cli_host_executed_password_prompt_timeout_defers_notice_until_prompt`.

Excluded scope (not run): full raw_cli suite beyond host_executed filter,
other workspace crates' test suites.

Real-machine FAIL→PASS on real PTY + real cosh-core (default approval mode,
approval card approved via Enter, synthesized repo with 80 commits in the
last day):
- FAIL (base): handoff `git log --since="1 day ago" --oneline ...` stalls at
  the less `:` prompt (quiet ≥12s at t=27.6s); turn only proceeds after a
  manual `q`.
- PASS (fixed): same driver — no pager stall, full output visible
  (`repro commit 000` tail on screen), turn completes at t=17.6s with no
  human key.
- Control (fixed binary): user-typed `git log` still pages natively and
  stops at `:` (zero-intrusion counterproof).

## Evidence

Casts/screenshots: assets pending upload to fork branch (will be linked by
commit SHA).
