### PR TITLE
fix(sight): encrypt optimization config api key

### DIFF
--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -6,6 +6,7 @@
 pub mod auth;
 mod handlers;
 pub mod optimize;
+mod secret;
 mod token_savings;
 
 use std::path::PathBuf;

--- a/src/agentsight/src/server/optimize.rs
+++ b/src/agentsight/src/server/optimize.rs
@@ -2,8 +2,10 @@
 //! `agentsight-opt` accuracy/perf/cost analyzers.
 //!
 //! LLM credentials are configured at runtime from the Dashboard settings page
-//! and persisted to `optimization_config.json` next to the databases. Analysis
-//! results are persisted per session via `agentsight-opt-store`.
+//! and persisted to `optimization_config.json` next to the databases. The API
+//! key is sealed with machine-bound encryption (see [`super::secret`]) before
+//! it reaches disk. Analysis results are persisted per session via
+//! `agentsight-opt-store`.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -18,11 +20,20 @@ use agentsight_trajectory_collector::{TrajectoryRecord, TrajectoryStore};
 use uuid::Uuid;
 
 use super::AppState;
+use super::secret;
 use crate::storage::sqlite::GenAISqliteStore;
 
 const CONFIG_FILE_NAME: &str = "optimization_config.json";
 const DB_FILE_NAME: &str = "optimization.db";
 const TRAJECTORIES_DIR_NAME: &str = "opt-trajectories";
+
+/// Directory holding the config file — where the sealing salt lives too.
+fn config_dir(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf()
+}
 
 // ─── LLM configuration ───────────────────────────────────────────────────────
 
@@ -38,18 +49,48 @@ pub struct OptLlmConfig {
 }
 
 impl OptLlmConfig {
-    fn load(path: &Path) -> Self {
-        match std::fs::read_to_string(path) {
+    /// Load from disk, unsealing the API key.
+    ///
+    /// The second value is true when the file held a legacy plaintext key
+    /// that must be resealed so the plaintext leaves the disk.
+    fn load(path: &Path) -> (Self, bool) {
+        let mut config: Self = match std::fs::read_to_string(path) {
             Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-            Err(_) => Self::default(),
+            Err(_) => return (Self::default(), false),
+        };
+        let mut needs_reseal = false;
+        if let Some(stored) = config.api_key.take() {
+            if secret::is_sealed(&stored) {
+                match secret::unseal(&stored, &config_dir(path)) {
+                    Some(plain) => config.api_key = Some(plain),
+                    // Salt or machine-id changed (e.g. config copied from
+                    // another host) — treat as unconfigured, never as a key.
+                    None => log::warn!(
+                        "Cannot decrypt the stored optimization API key; \
+                         re-enter it in the dashboard settings"
+                    ),
+                }
+            } else {
+                // Pre-encryption config: keep the key usable and reseal at
+                // startup so the plaintext copy is overwritten.
+                config.api_key = Some(stored);
+                needs_reseal = true;
+            }
         }
+        (config, needs_reseal)
     }
 
     fn save(&self, path: &Path) -> std::io::Result<()> {
-        let json =
-            serde_json::to_string_pretty(self).map_err(|e| std::io::Error::other(e.to_string()))?;
+        // Never persist the API key as plaintext — 0o600 does not survive
+        // backups, snapshots, or root compromise (see super::secret).
+        let mut on_disk = self.clone();
+        if let Some(ref key) = on_disk.api_key {
+            on_disk.api_key = Some(secret::seal(key, &config_dir(path))?);
+        }
+        let json = serde_json::to_string_pretty(&on_disk)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         std::fs::write(path, json)?;
-        // Config contains an API key — restrict to owner.
+        // Defense in depth: keep the sealed config owner-only as well.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -110,7 +151,15 @@ impl OptimizeState {
     /// Initialize from the storage base directory (where the .db files live).
     pub fn init(base_dir: &Path) -> Arc<Self> {
         let config_path = base_dir.join(CONFIG_FILE_NAME);
-        let config = OptLlmConfig::load(&config_path);
+        let (config, needs_reseal) = OptLlmConfig::load(&config_path);
+        if needs_reseal {
+            // One-shot migration of pre-encryption configs: rewrite the file
+            // so the plaintext API key no longer exists on disk.
+            match config.save(&config_path) {
+                Ok(()) => log::info!("Migrated optimization API key to encrypted storage"),
+                Err(e) => log::warn!("Failed to encrypt stored optimization API key: {e}"),
+            }
+        }
         let store = match OptimizationStore::new_with_path(&base_dir.join(DB_FILE_NAME)) {
             Ok(s) => Some(s),
             Err(e) => {
@@ -832,6 +881,75 @@ mod tests {
 
         assert_eq!(config.effective_api_key().as_deref(), Some("short"));
         assert_eq!(config.masked_api_key().as_deref(), Some("••••••"));
+    }
+
+    /// The API key must reach disk sealed (issue: plaintext key protected
+    /// only by 0o600 leaks via backups/snapshots/root compromise).
+    #[test]
+    fn save_seals_api_key_and_load_restores_it() {
+        let dir = tmp_dir("sealed-config");
+        let path = dir.join(CONFIG_FILE_NAME);
+        let config = OptLlmConfig {
+            api_key: Some("sk-super-secret-key".into()),
+            base_url: Some("http://localhost/v1".into()),
+            model: Some("test-model".into()),
+        };
+        config.save(&path).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("sk-super-secret-key"), "plaintext on disk");
+        assert!(raw.contains("enc:v1:"), "api_key must be sealed");
+        // Non-sensitive fields stay readable for debugging.
+        assert!(raw.contains("http://localhost/v1"));
+
+        let (loaded, needs_reseal) = OptLlmConfig::load(&path);
+        assert!(!needs_reseal);
+        assert_eq!(loaded.api_key.as_deref(), Some("sk-super-secret-key"));
+        assert_eq!(loaded.model.as_deref(), Some("test-model"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Legacy plaintext configs stay usable and are flagged for resealing.
+    #[test]
+    fn load_flags_legacy_plaintext_key_for_reseal() {
+        let dir = tmp_dir("legacy-config");
+        let path = dir.join(CONFIG_FILE_NAME);
+        std::fs::write(&path, r#"{"api_key":"sk-legacy-plain","model":"m"}"#).unwrap();
+
+        let (loaded, needs_reseal) = OptLlmConfig::load(&path);
+        assert!(needs_reseal);
+        assert_eq!(loaded.api_key.as_deref(), Some("sk-legacy-plain"));
+
+        // The migration path: saving removes the plaintext copy.
+        loaded.save(&path).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("sk-legacy-plain"));
+        let (reloaded, needs_reseal) = OptLlmConfig::load(&path);
+        assert!(!needs_reseal);
+        assert_eq!(reloaded.api_key.as_deref(), Some("sk-legacy-plain"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An undecryptable envelope (foreign host / lost salt) must degrade to
+    /// "not configured" instead of surfacing ciphertext as an API key.
+    #[test]
+    fn load_drops_undecryptable_key() {
+        let dir = tmp_dir("undecryptable-config");
+        let path = dir.join(CONFIG_FILE_NAME);
+        std::fs::write(
+            &path,
+            r#"{"api_key":"enc:v1:AAAAAAAAAAAAAAAA:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","model":"m"}"#,
+        )
+        .unwrap();
+
+        let (loaded, needs_reseal) = OptLlmConfig::load(&path);
+        assert!(!needs_reseal);
+        assert_eq!(loaded.api_key, None);
+        assert_eq!(loaded.model.as_deref(), Some("m"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/agentsight/src/server/secret.rs
+++ b/src/agentsight/src/server/secret.rs
@@ -1,0 +1,236 @@
+//! Machine-bound reversible encryption for dashboard-managed secrets.
+//!
+//! Secrets entered on the dashboard settings page (LLM API keys) must never
+//! reach disk as plaintext — file permissions alone do not survive backups,
+//! image snapshots, or root-level compromise. Values are sealed with
+//! AES-256-GCM using a key derived from the host machine-id plus a
+//! per-install random salt (stored next to the config with mode 0o400), so a
+//! copied config file cannot be decrypted off-host.
+//!
+//! Linux-only by construction: the parent `server` module is cfg-gated in
+//! lib.rs and `openssl` is a Linux-only dependency of this crate. The macOS
+//! local viewer keeps its own plaintext config by design (per-user directory,
+//! non-root) and must not reuse this module.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use openssl::rand::rand_bytes;
+use openssl::symm::{Cipher, decrypt_aead, encrypt_aead};
+use sha2::{Digest, Sha256};
+
+/// Envelope prefix marking a sealed value; bump the version on format changes.
+const SEALED_PREFIX: &str = "enc:v1:";
+/// Per-install salt file name, created next to the config file.
+const SALT_FILE_NAME: &str = ".secret_salt";
+const SALT_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
+/// Domain separation for key derivation and GCM authentication.
+const KEY_CONTEXT: &[u8] = b"agentsight.optimization_config.v1";
+
+/// Returns whether `value` carries the sealed-envelope prefix.
+pub fn is_sealed(value: &str) -> bool {
+    value.starts_with(SEALED_PREFIX)
+}
+
+/// Encrypt `plaintext` into an `enc:v1:<b64 nonce>:<b64 ciphertext+tag>`
+/// envelope bound to this host. Creates the salt file on first use.
+///
+/// # Errors
+///
+/// Fails when the salt file cannot be created or read, or when the OpenSSL
+/// primitives reject the operation.
+pub fn seal(plaintext: &str, base_dir: &Path) -> io::Result<String> {
+    let key = derive_key(base_dir, true)?;
+    let mut nonce = [0u8; NONCE_LEN];
+    rand_bytes(&mut nonce).map_err(crypto_err)?;
+    let mut tag = [0u8; TAG_LEN];
+    let mut ciphertext = encrypt_aead(
+        Cipher::aes_256_gcm(),
+        &key,
+        Some(&nonce),
+        KEY_CONTEXT,
+        plaintext.as_bytes(),
+        &mut tag,
+    )
+    .map_err(crypto_err)?;
+    ciphertext.extend_from_slice(&tag);
+    Ok(format!(
+        "{SEALED_PREFIX}{}:{}",
+        BASE64.encode(nonce),
+        BASE64.encode(&ciphertext)
+    ))
+}
+
+/// Decrypt a sealed envelope produced by [`seal`].
+///
+/// Returns `None` when the envelope is malformed, the salt file is missing,
+/// or the value was sealed on another host — callers should treat that as
+/// "not configured" and ask the user to re-enter the secret.
+pub fn unseal(value: &str, base_dir: &Path) -> Option<String> {
+    let rest = value.strip_prefix(SEALED_PREFIX)?;
+    let (nonce_b64, ct_b64) = rest.split_once(':')?;
+    let nonce = BASE64.decode(nonce_b64).ok()?;
+    let data = BASE64.decode(ct_b64).ok()?;
+    if nonce.len() != NONCE_LEN || data.len() < TAG_LEN {
+        return None;
+    }
+    let (ciphertext, tag) = data.split_at(data.len() - TAG_LEN);
+    let key = derive_key(base_dir, false).ok()?;
+    let plain = decrypt_aead(
+        Cipher::aes_256_gcm(),
+        &key,
+        Some(&nonce),
+        KEY_CONTEXT,
+        ciphertext,
+        tag,
+    )
+    .ok()?;
+    String::from_utf8(plain).ok()
+}
+
+fn crypto_err(e: openssl::error::ErrorStack) -> io::Error {
+    io::Error::other(e.to_string())
+}
+
+/// Derive the AES-256 key: SHA-256(context ‖ machine-id ‖ salt).
+///
+/// The machine-id binds ciphertexts to the host; the salt keeps the key
+/// unpredictable even where /etc/machine-id is world-readable, and is the
+/// sole key material in environments without a machine-id (containers).
+fn derive_key(base_dir: &Path, create_salt: bool) -> io::Result<[u8; 32]> {
+    let salt = load_or_create_salt(&base_dir.join(SALT_FILE_NAME), create_salt)?;
+    let mut hasher = Sha256::new();
+    hasher.update(KEY_CONTEXT);
+    match machine_id() {
+        Some(id) => hasher.update(id.as_bytes()),
+        // Surface the degraded binding mode so operators can tell
+        // machine-bound and salt-only installs apart when auditing.
+        None => log::info!(
+            "machine-id unavailable; optimization secret key derives from the per-install salt only"
+        ),
+    }
+    hasher.update(&salt);
+    Ok(hasher.finalize().into())
+}
+
+/// Read the per-install salt, generating it with mode 0o400 when absent and
+/// `create` is set. Refusing to create during decryption ensures a config
+/// copied without its salt file never silently "decrypts" to garbage keys.
+fn load_or_create_salt(path: &PathBuf, create: bool) -> io::Result<Vec<u8>> {
+    match std::fs::read(path) {
+        Ok(salt) if salt.len() == SALT_LEN => Ok(salt),
+        Ok(_) => Err(io::Error::other(format!(
+            "corrupt salt file {} (expected {SALT_LEN} bytes)",
+            path.display()
+        ))),
+        Err(e) if e.kind() == io::ErrorKind::NotFound && create => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let mut salt = vec![0u8; SALT_LEN];
+            rand_bytes(&mut salt).map_err(crypto_err)?;
+            std::fs::write(path, &salt)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o400))?;
+            }
+            Ok(salt)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Host identity per machine-id(5); `None` in containers or minimal images,
+/// where the per-install salt alone still keeps keys out of plaintext.
+fn machine_id() -> Option<String> {
+    for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"] {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            let id = content.trim();
+            if !id.is_empty() {
+                return Some(id.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("opt-secret-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn seal_unseal_roundtrip() {
+        let dir = tmp_dir("roundtrip");
+        let sealed = seal("sk-test-1234567890", &dir).unwrap();
+        assert!(is_sealed(&sealed));
+        assert!(!sealed.contains("sk-test"));
+        assert_eq!(unseal(&sealed, &dir).as_deref(), Some("sk-test-1234567890"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unseal_fails_with_foreign_salt() {
+        let dir_a = tmp_dir("salt-a");
+        let dir_b = tmp_dir("salt-b");
+        let sealed = seal("sk-secret", &dir_a).unwrap();
+        // Simulate a config copied to another install: same envelope, other salt.
+        seal("warm-up", &dir_b).unwrap();
+        assert_eq!(unseal(&sealed, &dir_b), None);
+        let _ = std::fs::remove_dir_all(&dir_a);
+        let _ = std::fs::remove_dir_all(&dir_b);
+    }
+
+    #[test]
+    fn unseal_fails_when_salt_missing_or_tampered() {
+        let dir = tmp_dir("tamper");
+        let sealed = seal("sk-secret", &dir).unwrap();
+
+        // Flip one ciphertext character — GCM authentication must reject it.
+        let mut chars: Vec<char> = sealed.chars().collect();
+        let last = chars.len() - 1;
+        chars[last] = if chars[last] == 'A' { 'B' } else { 'A' };
+        let tampered: String = chars.into_iter().collect();
+        assert_eq!(unseal(&tampered, &dir), None);
+
+        // Losing the salt must fail decryption, not regenerate a new salt.
+        std::fs::remove_file(dir.join(SALT_FILE_NAME)).unwrap();
+        assert_eq!(unseal(&sealed, &dir), None);
+        assert!(!dir.join(SALT_FILE_NAME).exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rejects_malformed_envelopes() {
+        let dir = tmp_dir("malformed");
+        for bad in ["plain-key", "enc:v1:", "enc:v1:notb64", "enc:v1:AAAA:!!"] {
+            assert_eq!(unseal(bad, &dir), None, "must reject {bad:?}");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn salt_file_is_owner_read_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tmp_dir("perm");
+        seal("sk-secret", &dir).unwrap();
+        let mode = std::fs::metadata(dir.join(SALT_FILE_NAME))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o400);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Description

The dashboard settings page persisted the optimization LLM API key as plaintext JSON in `/var/log/sysak/.agentsight/optimization_config.json`, guarded only by `chmod 0o600` — which does not survive backups, image snapshots, or root-level compromise. This PR seals the `api_key` field with AES-256-GCM before it reaches disk (issue direction B). The key derives from `SHA-256(context || machine-id || per-install salt)`: the machine-id binds ciphertexts to the host so a copied config cannot be decrypted elsewhere, and the 0o400 salt file keeps the key unpredictable where `/etc/machine-id` is world-readable (sole key material in containers without one). Legacy plaintext configs are resealed once at startup; undecryptable envelopes degrade to "not configured" instead of surfacing ciphertext as a key.

Key implementation decisions:

- **Machine-bound encryption over OS keyring**: agentsight runs as a root systemd service where session keyrings are unreliable; this approach reuses existing deps (`openssl`, `sha2`, `base64`) with zero new crates.
- **Salt is never created on the decrypt path**: a config copied without its salt file fails closed rather than silently regenerating a key.
- **No API contract change**: `GET/POST /api/optimize/config` still return the masked key; the in-memory config keeps plaintext for `LlmClient` construction.

## Related Issue

closes #1952

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked` (1256 lib + integration tests, all pass), `cargo doc --no-deps --locked` — all run in `src/agentsight/`.
- New unit tests (8) cover: seal/unseal roundtrip, foreign-salt rejection (config copied to another install), GCM tamper rejection, missing-salt fail-closed behavior, malformed envelope rejection, salt file 0o400 permission, sealed persistence roundtrip (no plaintext on disk, non-sensitive fields stay readable), legacy plaintext migration flag + reseal, and undecryptable-key degradation to unconfigured.

## Additional Notes

- Trade-off: a config restored onto another host (or after machine-id/salt loss) requires re-entering the key in the dashboard — intended fail-closed behavior.
- The macOS local viewer (`src/local/server/optimize.rs`) keeps its own plaintext copy under the user's directory; it is out of scope here since `openssl` is a Linux-only dependency and that path is not the root-run `/var/log/sysak` scenario from the issue. Can be tracked separately if desired.
- Issue direction C (unified anolisa secret store) remains a longer-term effort; this PR keeps the sealing logic in a private `server::secret` module so it can be lifted out later.
