### PR TITLE
fix(ckpt): handle external mounts in k8s sidecar scenario

### DIFF
--- a/src/ws-ckpt/docs/k8s-sidecar-deploy.md
+++ b/src/ws-ckpt/docs/k8s-sidecar-deploy.md
@@ -1,0 +1,147 @@
+# ws-ckpt K8s Sidecar 部署指南
+
+## 前置条件
+
+- 宿主机内核已加载 btrfs 模块（`modprobe btrfs && modprobe loop`）
+- 宿主机 `/dev/loop-control` 和 `/dev/loop*` 可用
+- 容器镜像包含：ws-ckpt 二进制、btrfs-progs、util-linux（losetup/mount/findmnt）、psmisc（fuser）、rsync、kmod
+
+## 构建镜像示例
+
+```bash
+# 1. 编译 ws-ckpt（需要 Rust stable >= 1.78）
+cd anolisa/src/ws-ckpt/src
+cargo build --release --workspace
+ls target/release/ws-ckpt
+
+# 2. 准备构建上下文
+mkdir -p ~/wsckpt-image
+# 拷贝编译好的二进制可执行文件
+cp target/release/ws-ckpt ~/wsckpt-image/
+
+# 3. 如果宿主机是源码编译的 btrfs-progs（dnf 无包），需要拷贝用户态工具：
+cp /usr/local/bin/btrfs /usr/local/bin/mkfs.btrfs ~/wsckpt-image/
+# 若 dnf 有 btrfs-progs 则 Dockerfile 里直接 dnf install 即可，跳过此步
+
+# 4. 写 Dockerfile
+cat > ~/wsckpt-image/Dockerfile <<'EOF'
+FROM registry.cn-hangzhou.aliyuncs.com/alinux/alinux3:latest
+
+RUN dnf install -y --setopt=tsflags=nodocs \
+      util-linux psmisc rsync kmod which findutils \
+    && dnf clean all
+
+# btrfs-progs：若 dnf 有包则换成 dnf install btrfs-progs
+COPY btrfs mkfs.btrfs /usr/local/bin/
+RUN chmod 0755 /usr/local/bin/btrfs /usr/local/bin/mkfs.btrfs \
+    && ln -sf /usr/local/bin/btrfs /usr/bin/btrfs
+
+COPY ws-ckpt /usr/local/bin/ws-ckpt
+RUN chmod 0755 /usr/local/bin/ws-ckpt
+EOF
+
+# 5. 构建 + 验证
+cd ~/wsckpt-image
+docker build -t localhost/ws-ckpt:smoke .
+docker run --rm localhost/ws-ckpt:smoke ws-ckpt --version
+docker run --rm localhost/ws-ckpt:smoke btrfs --version
+
+# 6. 导入到集群节点（以 k3s 为例；标准 k8s 推送到 registry 即可）
+docker save -o ws-ckpt-smoke.tar localhost/ws-ckpt:smoke
+sudo k3s ctr images import ws-ckpt-smoke.tar
+# 或推送到私有 registry：
+# docker tag localhost/ws-ckpt:smoke your-registry/ws-ckpt:smoke
+# docker push your-registry/ws-ckpt:smoke
+```
+
+## 部署
+
+```bash
+# 确保宿主机内核模块就绪
+sudo modprobe loop && sudo modprobe btrfs
+
+# 应用 Pod 清单（yaml 示例见 k8s-sidecar-example.yaml）
+kubectl apply -f k8s-sidecar-example.yaml
+kubectl get pod wsckpt-smoke -w          # 等待 2/2 Running
+kubectl logs wsckpt-smoke -c daemon      # 确认 bootstrap 成功
+```
+
+完整 Pod yaml 示例见 [`k8s-sidecar-example.yaml`](../k8s-sidecar-example.yaml)。
+
+## Pod 设计
+
+单 Pod 双容器，共用同一镜像：
+
+| 容器 | 角色 | 权限 |
+|------|------|------|
+| daemon | 运行 `ws-ckpt daemon`，管理 btrfs loop | privileged: true |
+| app | 业务负载，通过 UDS 调用 CLI 与 daemon 通信 | 无特权 |
+
+## 必需 Volume
+
+| 名称 | 类型 | 用途 |
+|------|------|------|
+| sock | emptyDir | UDS socket（`/run/ws-ckpt/ws-ckpt.sock`） |
+| dev | hostPath `/dev` | loop 设备访问（`/dev/loop-control`、`/dev/loop*`） |
+| ws-state | hostPath `/var/lib/ws-ckpt` | **必须持久化** — 存放 btrfs-data.img、state.json、daemon.lock。丢失此 volume = 数据丢失。 |
+| ws-ckpt-mount | hostPath（anchor 目录） | daemon 在此 overmount btrfs；daemon 侧 `mountPropagation: Bidirectional`，app 侧 `HostToContainer` |
+| data | emptyDir | workspace 父目录；workspace 使用其子目录（如 `/data/workspace`） |
+
+## 关键约束
+
+1. **`privileged: true`** — losetup/mount/mkfs.btrfs 需要。
+
+2. **hostPath `/dev` 透传** — k3s containerd 不会自动向 privileged 容器暴露宿主机 loop 设备节点，必须显式挂载。
+
+3. **`/var/lib/ws-ckpt` 必须持久化**（hostPath 或 PVC）。btrfs 镜像路径不可配置。若此目录落在容器可写层，pod 重启后 img 消失，但 orphan loop/mount 泄漏到宿主机。
+
+4. **`--mount-path` 必须指向一个两容器同路径挂载的共享 volume**（mount anchor），daemon 侧配 `mountPropagation: Bidirectional`，app 侧配 `HostToContainer`。不能使用容器 rootfs 里的普通目录，那样 overmount 只存在于 daemon 容器私有的 mount namespace 里，无法传播到 app 容器，`init` 之后 app 会拿到悬空 symlink，而 daemon 侧无任何报错。
+
+5. **workspace 必须是共享 volume 的子目录**，不能直接使用 volume 挂载点本身。`ws-ckpt init` 会对 workspace 路径执行 `rename()`，对挂载点 rename 返回 EBUSY。
+
+6. **`shareProcessNamespace: true`** — 使 `fuser -m`（rollback/recover/img-shrink 判断挂载是否空闲时调用）能看到 app 容器的进程。
+
+7. **后端自动检测**：若宿主机 `/var/lib` 在原生 btrfs 上，`auto_detect` 选择 BtrfsBase（直接操作 subvolume，无需 loop 设备）。BtrfsLoop overmount 路径仅在 ext4/xfs 宿主机上激活。两种后端均可正常工作，无需 ConfigMap 强制指定。
+
+## SIGTERM 与 Loop 设备清理
+
+**daemon 收到 SIGTERM 只退出，不执行 `umount` 或 `losetup -d`。**
+
+不做清理的后果：
+- 宿主机级 btrfs 挂载在容器死亡后持续存在
+- loop 设备保持 attached，backing path 指向已消失的容器 rootfs 内路径
+- 反复重建 pod 会累积 stacked mount 并耗尽 `/dev/loop*` 设备
+
+**缓解方案：** daemon 容器配置 `preStop` lifecycle hook：
+
+```yaml
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          umount /opt/ws-ckpt-mount 2>/dev/null || true
+          losetup -ln -O NAME,BACK-FILE | while read dev file; do
+            [ -e "$file" ] || losetup -d "$dev" 2>/dev/null
+          done
+```
+
+对于 preStop 无法执行的异常场景（OOMKill、节点故障）：daemon 下次启动时 `try_exists` 检测到 orphan loop 设备（backing file 已不存在），跳过陈尸挂载走冷路径重新 bootstrap。此场景下旧挂载中的数据不可恢复 — 持久化 `ws-state` volume 是防止此情况发生的根本保障。
+
+## 冒烟验证
+
+```bash
+# Pod 达到 2/2 Running 后：
+kubectl exec wsckpt-smoke -c app -- mkdir -p /data/workspace
+kubectl exec wsckpt-smoke -c app -- sh -c 'echo hello > /data/workspace/file.txt'
+kubectl exec wsckpt-smoke -c app -- ws-ckpt init --workspace /data/workspace
+kubectl exec wsckpt-smoke -c app -- ws-ckpt checkpoint --workspace /data/workspace --message smoke-v1
+kubectl exec wsckpt-smoke -c app -- ws-ckpt list --workspace /data/workspace
+
+# init 后 workspace 仍可正常读写（验证 symlink + btrfs 传播链完整）：
+kubectl exec wsckpt-smoke -c app -- sh -c 'echo bug6-verify-$(date +%s) > /data/workspace/verify.txt'
+kubectl exec wsckpt-smoke -c app -- cat /data/workspace/verify.txt
+kubectl exec wsckpt-smoke -c app -- ls -la /data/workspace/
+```

--- a/src/ws-ckpt/k8s-sidecar-example.yaml
+++ b/src/ws-ckpt/k8s-sidecar-example.yaml
@@ -1,0 +1,99 @@
+# ws-ckpt K8s sidecar example.
+#
+# Two containers share a pod:
+#   daemon  — privileged, runs ws-ckpt daemon (losetup + btrfs mount)
+#   app     — unprivileged workload, sees btrfs via mountPropagation
+#
+# Shared volumes:
+#   sock          — emptyDir, daemon <-> app UDS communication
+#   dev           — hostPath /dev, gives daemon access to loop devices
+#   ws-state      — hostPath, persists daemon state across pod restarts
+#   ws-ckpt-mount — hostPath anchor, daemon overmounts btrfs here;
+#                   Bidirectional propagation carries the mount to app
+#   data          — emptyDir, workspace parent directory (/data/workspace)
+#
+# Notes:
+# - shareProcessNamespace: true so fuser -m (used by rollback/recover/shrink)
+#   can see app container processes when checking mount busy state.
+# - If the host's /var/lib is on native btrfs, auto_detect picks BtrfsBase
+#   (no loop device needed); the overmount path only activates on ext4/xfs hosts.
+# - daemon does NOT umount/losetup -d on SIGTERM; preStop hook handles cleanup
+#   to prevent loop device leaks across pod restarts.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wsckpt-smoke
+  labels:
+    app: wsckpt-smoke
+spec:
+  shareProcessNamespace: true
+  restartPolicy: Never
+  volumes:
+    - name: sock
+      emptyDir: {}
+    - name: dev
+      hostPath:
+        path: /dev
+        type: Directory
+    - name: ws-state
+      hostPath:
+        path: /var/lib/ws-ckpt
+        type: DirectoryOrCreate
+    # Mount anchor: daemon overmounts btrfs here; propagation carries it to app.
+    - name: ws-ckpt-mount
+      hostPath:
+        path: /var/lib/wsckpt/mount-anchor
+        type: DirectoryOrCreate
+    - name: data                         # workspace parent dir; workspace uses subdir /data/workspace. Container rootfs dirs are private — only shared volumes align app writes with daemon operations
+      emptyDir: {}                       # avoids ws-ckpt bug (mount point rename EBUSY)
+  containers:
+    - name: daemon
+      image: localhost/ws-ckpt:smoke
+      imagePullPolicy: Never             # locally imported image, no remote pull
+      securityContext:
+        privileged: true                 # required for losetup/mount/mkfs.btrfs
+      command:
+        - ws-ckpt
+        - daemon
+        - --mount-path=/opt/ws-ckpt-mount   # must match ws-ckpt-mount volumeMount path exactly
+        - --log-level=debug
+      volumeMounts:
+        - name: sock
+          mountPath: /run/ws-ckpt
+        - name: dev
+          mountPath: /dev                # passthrough host /dev/loop-control and /dev/loop*
+        - name: ws-state
+          mountPath: /var/lib/ws-ckpt
+          mountPropagation: Bidirectional
+        - name: ws-ckpt-mount
+          mountPath: /opt/ws-ckpt-mount
+          mountPropagation: Bidirectional
+        - name: data
+          mountPath: /data
+      # Clean orphan loop devices on pod teardown. Dead containers leave
+      # host-scoped loops pointing at phantom paths (container rootfs gone but
+      # loop persists). Without this, the next pod sees a stale btrfs mount.
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - |
+                umount /opt/ws-ckpt-mount 2>/dev/null || true
+                losetup -ln -O NAME,BACK-FILE | while read dev file; do
+                  [ -e "$file" ] || losetup -d "$dev" 2>/dev/null
+                done
+    - name: app
+      image: localhost/ws-ckpt:smoke
+      imagePullPolicy: Never
+      command: ["sleep", "infinity"]
+      volumeMounts:
+        - name: sock
+          mountPath: /run/ws-ckpt        # communicates with daemon via UDS
+        - name: ws-ckpt-mount
+          mountPath: /opt/ws-ckpt-mount
+          mountPropagation: HostToContainer
+        - name: data
+          mountPath: /data               # workspace at subdir /data/workspace

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -466,29 +466,35 @@ impl StorageBackend for BtrfsLoopBackend {
 
         let mount_path_str = self.mount_path.to_string_lossy().to_string();
         let mounted = is_mounted(&mount_path_str).await?;
-        // External mount (k8s hostPath / bind-mount): overmount btrfs on top.
         let needs_mount = if mounted {
-            match is_external_mount(&mount_path_str).await {
-                Ok(true) => {
+            // Check if our img is already the one mounted here (inode-based).
+            let our_loop = find_loop_device_for(&img_path_str).await.ok();
+            let mounted_source = run_command("findmnt", &["-no", "SOURCE", &mount_path_str])
+                .await
+                .ok()
+                .map(|s| last_nonempty_line(&s).to_string());
+            match (&our_loop, &mounted_source) {
+                (Some(ours), Some(src)) if ours == src => {
+                    info!("Already mounted at {:?} (loop {})", self.mount_path, ours);
+                    false
+                }
+                _ => {
                     info!(
-                        "{} has external mount; overmounting with btrfs loop image",
-                        mount_path_str
+                        "{} mounted by {:?} but our img loop is {:?}; overmounting",
+                        mount_path_str, mounted_source, our_loop
                     );
                     true
                 }
-                Ok(false) => {
-                    info!("Already mounted at {:?}", self.mount_path);
-                    false
-                }
-                Err(e) => {
-                    warn!(
-                        "is_external_mount({}) failed: {:#}; assuming ours, skip mount",
-                        mount_path_str, e
-                    );
-                    false
-                }
             }
         } else {
+            // Detach orphan loop from a prior failed mount attempt before re-attaching.
+            if let Ok(orphan) = find_loop_device_for(&img_path_str).await {
+                warn!(
+                    "Found orphan loop {} for img (attached but not mounted); detaching",
+                    orphan
+                );
+                let _ = run_command_checked("losetup", &["-d", &orphan]).await;
+            }
             true
         };
         if needs_mount {
@@ -558,14 +564,13 @@ impl StorageBackend for BtrfsLoopBackend {
 ///
 /// Decision tree:
 ///
-/// 1. `mount_path` already mounted — look up backing via `findmnt` + `losetup`.
-///    - Backing == target: return target.
-///    - Backing == legacy: try in-place relocation (umount → rename → remount).
+/// 1. `mount_path` already mounted — classify via `losetup -j` (inode-based):
+///    - Ours (target): return target.
+///    - OursLegacy: try in-place relocation (umount → rename → remount).
 ///      Pre-rename failure (busy / cross-fs / cmd error) → fall back to legacy.
 ///      Post-rename failure (losetup/mount) → return target; bootstrap will mount.
-///    - Lookup itself failed: bail loud — guessing risks reconciling a stale
-///      target while live data still sits on legacy.
-/// 2. Cold path (mount not active):
+///    - External / Stale / probe error: fall through to cold path.
+/// 2. Cold path (mount not active or not ours):
 ///    - target exists → use target.
 ///    - target missing && legacy exists → attempt migration.
 ///      - success → use target.
@@ -580,88 +585,63 @@ pub async fn decide_effective_img_path(
     let mount_path_str = mount_path.to_string_lossy().to_string();
     match is_mounted(&mount_path_str).await {
         Ok(true) => {
-            // K8s sidecar / hostPath scenario: mount_path has an external mount
-            // (ext4, xfs, overlay, or non-loop btrfs). This is not ours — bootstrap
-            // will overmount btrfs on top via mountPropagation.
-            match is_external_mount(&mount_path_str).await {
-                Ok(true) => {
+            match classify_mount(&mount_path_str, target, legacy).await {
+                Ok(MountDisposition::Ours(loop_dev)) => {
+                    info!("Mount at {} is ours (loop {})", mount_path_str, loop_dev);
+                    return Ok(target.to_path_buf());
+                }
+                Ok(MountDisposition::OursLegacy(loop_dev)) => {
+                    info!(
+                        "Mount at {} backs legacy img; attempting live relocation",
+                        mount_path_str
+                    );
+                    match try_relocate_active_legacy_mount(
+                        &mount_path_str,
+                        legacy,
+                        target,
+                        &loop_dev,
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            info!("Live img migration complete: {:?} -> {:?}", legacy, target);
+                            return Ok(target.to_path_buf());
+                        }
+                        Err(e) => {
+                            error!(
+                                "In-place relocation from legacy {:?} -> target {:?} \
+                                 aborted: {:#}. Daemon will keep serving on legacy this \
+                                 run; migration will retry on next start once the mount \
+                                 is idle.",
+                                legacy, target, e
+                            );
+                            return Ok(legacy.to_path_buf());
+                        }
+                    }
+                }
+                Ok(MountDisposition::Stale(loop_dev)) => {
+                    warn!(
+                        "Mount at {} uses loop {} which doesn't back target or legacy; \
+                         bootstrap will overmount",
+                        mount_path_str, loop_dev
+                    );
+                    // Don't umount here — stacked mount removal can cascade via
+                    // propagation and destroy our own underlying mount. Bootstrap
+                    // will overmount on top of the stale layer safely.
+                }
+                Ok(MountDisposition::External) => {
                     info!(
                         "{} has an external (non-btrfs-loop) mount; \
                          bootstrap will overmount with our btrfs image",
                         mount_path_str
                     );
-                    // Fall through to the cold path — return target so bootstrap proceeds.
+                    // Fall through to cold path.
                 }
                 Err(e) => {
                     warn!(
-                        "is_external_mount({}) probe failed: {:#}; \
-                         falling through to cold path",
+                        "classify_mount({}) failed: {:#}; falling through to cold path",
                         mount_path_str, e
                     );
-                    // Cannot determine mount ownership; fall through safely.
-                }
-                Ok(false) => {
-                    match find_backing_file(&mount_path_str).await {
-                        Ok((loop_dev, backing)) => {
-                            // Orphan loop from a dead container: backing path only existed
-                            // inside the old container rootfs, not on this filesystem.
-                            if !tokio::fs::try_exists(&backing).await.unwrap_or(false) {
-                                warn!(
-                                    "Loop {} backs phantom path {:?} (does not exist); \
-                                     treating mount as stale — falling through to cold path",
-                                    loop_dev, backing
-                                );
-                                // Fall through to cold path like external-mount case.
-                            } else if backing == legacy {
-                                info!(
-                                    "Backing {:?} is at legacy path; \
-                                     attempting live relocation to {:?}",
-                                    legacy, target
-                                );
-                                match try_relocate_active_legacy_mount(
-                                    &mount_path_str,
-                                    legacy,
-                                    target,
-                                    &loop_dev,
-                                )
-                                .await
-                                {
-                                    Ok(()) => {
-                                        info!(
-                                            "Live img migration complete: {:?} -> {:?}",
-                                            legacy, target
-                                        );
-                                        return Ok(target.to_path_buf());
-                                    }
-                                    Err(e) => {
-                                        error!(
-                                            "In-place relocation from legacy {:?} -> target \
-                                             {:?} aborted: {:#}. Daemon will keep serving on \
-                                             legacy this run; migration will retry on next \
-                                             start once the mount is idle.",
-                                            legacy, target, e
-                                        );
-                                        return Ok(legacy.to_path_buf());
-                                    }
-                                }
-                            } else {
-                                return Ok(backing);
-                            }
-                        }
-                        Err(e) => {
-                            bail!(
-                                "{} is mounted but backing-file lookup failed ({:#}). \
-                                 Refusing to guess which img file backs the mount — \
-                                 picking the wrong file would let bootstrap reconcile a \
-                                 stale image and let the next cold start mount empty data, \
-                                 silently hiding the live workspace. Diagnose with \
-                                 `findmnt -no SOURCE {0}` and `losetup -l <loop>`, \
-                                 then restart the daemon.",
-                                mount_path_str,
-                                e
-                            );
-                        }
-                    }
                 }
             }
         }
@@ -719,30 +699,59 @@ pub async fn decide_effective_img_path(
     Ok(target.to_path_buf())
 }
 
-/// Returns true when `mount_path` is mounted but NOT by a ws-ckpt btrfs-loop
-/// (e.g. k8s hostPath bind-mount, host-level ext4/xfs/overlay pre-mount).
-/// We detect this via `findmnt -no FSTYPE`: btrfs sourced from /dev/loop* is ours;
-/// anything else is external.
+/// Mount ownership classification for `mount_path`.
+enum MountDisposition {
+    /// External mount (non-btrfs, or btrfs on a non-loop block device).
+    External,
+    /// Our btrfs-loop: the loop device backing `target` is what's mounted.
+    Ours(String),
+    /// Our btrfs-loop backing `legacy` img (needs migration).
+    OursLegacy(String),
+    /// A loop-backed btrfs mount that doesn't match target or legacy (stale).
+    Stale(String),
+}
+
+/// Classify the mount at `mount_path` using inode-based ownership detection.
 ///
-/// After an overmount, findmnt may return multiple lines (one per stacked mount).
-/// We inspect the **last** line — the topmost (most-recent) mount.
-async fn is_external_mount(mount_path: &str) -> anyhow::Result<bool> {
-    let raw = run_command("findmnt", &["-no", "FSTYPE", mount_path])
+/// Instead of reading BACK-FILE (which breaks across mount namespaces due to
+/// kernel `d_path()` rendering), we use `losetup -j <img>` which matches by
+/// st_dev+st_ino — correct regardless of which namespace the loop was created in.
+async fn classify_mount(
+    mount_path: &str,
+    target: &Path,
+    legacy: &Path,
+) -> anyhow::Result<MountDisposition> {
+    let raw = run_command("findmnt", &["-no", "FSTYPE,SOURCE", mount_path])
         .await
-        .context("findmnt FSTYPE failed")?;
-    let fstype = last_nonempty_line(&raw);
-    if fstype.is_empty() {
-        return Ok(false);
+        .context("findmnt FSTYPE,SOURCE failed")?;
+    let line = last_nonempty_line(&raw);
+    if line.is_empty() {
+        return Ok(MountDisposition::External);
     }
-    if fstype != "btrfs" {
-        return Ok(true);
+    let mut parts = line.splitn(2, char::is_whitespace);
+    let fstype = parts.next().unwrap_or("");
+    let source = parts.next().unwrap_or("").trim();
+
+    if fstype != "btrfs" || !source.starts_with("/dev/loop") {
+        return Ok(MountDisposition::External);
     }
-    // FSTYPE=btrfs — check if SOURCE is a loop device (ours) or block device (external)
-    let raw = run_command("findmnt", &["-no", "SOURCE", mount_path])
-        .await
-        .context("findmnt SOURCE failed")?;
-    let source = last_nonempty_line(&raw);
-    Ok(!source.starts_with("/dev/loop"))
+
+    // source is /dev/loopN. Check ownership via inode-based losetup -j.
+    let target_str = target.to_string_lossy();
+    if let Ok(dev) = find_loop_device_for(&target_str).await {
+        if dev == source {
+            return Ok(MountDisposition::Ours(source.to_string()));
+        }
+    }
+    let legacy_str = legacy.to_string_lossy();
+    if let Ok(dev) = find_loop_device_for(&legacy_str).await {
+        if dev == source {
+            return Ok(MountDisposition::OursLegacy(source.to_string()));
+        }
+    }
+
+    // Loop device at mount_path doesn't match target or legacy — stale.
+    Ok(MountDisposition::Stale(source.to_string()))
 }
 
 /// Extract the last non-empty line from command output.
@@ -753,31 +762,6 @@ fn last_nonempty_line(s: &str) -> &str {
         .find(|l| !l.trim().is_empty())
         .map(|l| l.trim())
         .unwrap_or("")
-}
-
-/// Resolve the loop device and its backing file for the mount at `mount_path`.
-/// Takes the topmost (last) findmnt entry to handle stacked mounts.
-async fn find_backing_file(mount_path: &str) -> anyhow::Result<(String, PathBuf)> {
-    let src = run_command("findmnt", &["-no", "SOURCE", mount_path])
-        .await
-        .context("findmnt failed")?;
-    let loop_dev = last_nonempty_line(&src).to_string();
-    if loop_dev.is_empty() {
-        bail!(
-            "findmnt returned no SOURCE for {} (raw output: {:?}). \
-             Likely a mount-namespace inconsistency or stale /proc/mounts entry.",
-            mount_path,
-            src.trim()
-        );
-    }
-    let out = run_command("losetup", &["-nl", "--output", "BACK-FILE", &loop_dev])
-        .await
-        .context("losetup -l failed")?;
-    let back = out.trim();
-    if back.is_empty() {
-        bail!("losetup returned empty BACK-FILE for {}", loop_dev);
-    }
-    Ok((loop_dev, PathBuf::from(back)))
 }
 
 /// Live-mount migration legacy → target: idle-check, umount, rename, remount.

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -468,15 +468,25 @@ impl StorageBackend for BtrfsLoopBackend {
         let mounted = is_mounted(&mount_path_str).await?;
         // External mount (k8s hostPath / bind-mount): overmount btrfs on top.
         let needs_mount = if mounted {
-            if is_external_mount(&mount_path_str).await.unwrap_or(false) {
-                info!(
-                    "{} has external mount; overmounting with btrfs loop image",
-                    mount_path_str
-                );
-                true
-            } else {
-                info!("Already mounted at {:?}", self.mount_path);
-                false
+            match is_external_mount(&mount_path_str).await {
+                Ok(true) => {
+                    info!(
+                        "{} has external mount; overmounting with btrfs loop image",
+                        mount_path_str
+                    );
+                    true
+                }
+                Ok(false) => {
+                    info!("Already mounted at {:?}", self.mount_path);
+                    false
+                }
+                Err(e) => {
+                    warn!(
+                        "is_external_mount({}) failed: {:#}; assuming ours, skip mount",
+                        mount_path_str, e
+                    );
+                    false
+                }
             }
         } else {
             true
@@ -573,71 +583,84 @@ pub async fn decide_effective_img_path(
             // K8s sidecar / hostPath scenario: mount_path has an external mount
             // (ext4, xfs, overlay, or non-loop btrfs). This is not ours — bootstrap
             // will overmount btrfs on top via mountPropagation.
-            if is_external_mount(&mount_path_str).await.unwrap_or(false) {
-                info!(
-                    "{} has an external (non-btrfs-loop) mount; \
-                     bootstrap will overmount with our btrfs image",
-                    mount_path_str
-                );
-                // Fall through to the cold path — return target so bootstrap proceeds.
-            } else {
-                match find_backing_file(&mount_path_str).await {
-                    Ok((loop_dev, backing)) => {
-                        // Orphan loop from a dead container: backing path only existed
-                        // inside the old container rootfs, not on this filesystem.
-                        if !tokio::fs::try_exists(&backing).await.unwrap_or(false) {
-                            warn!(
-                                "Loop {} backs phantom path {:?} (does not exist); \
-                                 treating mount as stale — falling through to cold path",
-                                loop_dev, backing
-                            );
-                            // Fall through to cold path like external-mount case.
-                        } else if backing == legacy {
-                            info!(
-                                "Backing {:?} is at legacy path; attempting live relocation to {:?}",
-                                legacy, target
-                            );
-                            match try_relocate_active_legacy_mount(
-                                &mount_path_str,
-                                legacy,
-                                target,
-                                &loop_dev,
-                            )
-                            .await
-                            {
-                                Ok(()) => {
-                                    info!(
-                                        "Live img migration complete: {:?} -> {:?}",
-                                        legacy, target
-                                    );
-                                    return Ok(target.to_path_buf());
+            match is_external_mount(&mount_path_str).await {
+                Ok(true) => {
+                    info!(
+                        "{} has an external (non-btrfs-loop) mount; \
+                         bootstrap will overmount with our btrfs image",
+                        mount_path_str
+                    );
+                    // Fall through to the cold path — return target so bootstrap proceeds.
+                }
+                Err(e) => {
+                    warn!(
+                        "is_external_mount({}) probe failed: {:#}; \
+                         falling through to cold path",
+                        mount_path_str, e
+                    );
+                    // Cannot determine mount ownership; fall through safely.
+                }
+                Ok(false) => {
+                    match find_backing_file(&mount_path_str).await {
+                        Ok((loop_dev, backing)) => {
+                            // Orphan loop from a dead container: backing path only existed
+                            // inside the old container rootfs, not on this filesystem.
+                            if !tokio::fs::try_exists(&backing).await.unwrap_or(false) {
+                                warn!(
+                                    "Loop {} backs phantom path {:?} (does not exist); \
+                                     treating mount as stale — falling through to cold path",
+                                    loop_dev, backing
+                                );
+                                // Fall through to cold path like external-mount case.
+                            } else if backing == legacy {
+                                info!(
+                                    "Backing {:?} is at legacy path; \
+                                     attempting live relocation to {:?}",
+                                    legacy, target
+                                );
+                                match try_relocate_active_legacy_mount(
+                                    &mount_path_str,
+                                    legacy,
+                                    target,
+                                    &loop_dev,
+                                )
+                                .await
+                                {
+                                    Ok(()) => {
+                                        info!(
+                                            "Live img migration complete: {:?} -> {:?}",
+                                            legacy, target
+                                        );
+                                        return Ok(target.to_path_buf());
+                                    }
+                                    Err(e) => {
+                                        error!(
+                                            "In-place relocation from legacy {:?} -> target \
+                                             {:?} aborted: {:#}. Daemon will keep serving on \
+                                             legacy this run; migration will retry on next \
+                                             start once the mount is idle.",
+                                            legacy, target, e
+                                        );
+                                        return Ok(legacy.to_path_buf());
+                                    }
                                 }
-                                Err(e) => {
-                                    error!(
-                                        "In-place relocation from legacy {:?} -> target {:?} \
-                                         aborted: {:#}. Daemon will keep serving on legacy this \
-                                         run; migration will retry on next start once the mount \
-                                         is idle.",
-                                        legacy, target, e
-                                    );
-                                    return Ok(legacy.to_path_buf());
-                                }
+                            } else {
+                                return Ok(backing);
                             }
-                        } else {
-                            return Ok(backing);
                         }
-                    }
-                    Err(e) => {
-                        bail!(
-                            "{} is mounted but backing-file lookup failed ({:#}). Refusing to \
-                             guess which img file backs the mount — picking the wrong file \
-                             would let bootstrap reconcile a stale image and let the next \
-                             cold start mount empty data, silently hiding the live workspace. \
-                             Diagnose with `findmnt -no SOURCE {0}` and `losetup -l <loop>`, \
-                             then restart the daemon.",
-                            mount_path_str,
-                            e
-                        );
+                        Err(e) => {
+                            bail!(
+                                "{} is mounted but backing-file lookup failed ({:#}). \
+                                 Refusing to guess which img file backs the mount — \
+                                 picking the wrong file would let bootstrap reconcile a \
+                                 stale image and let the next cold start mount empty data, \
+                                 silently hiding the live workspace. Diagnose with \
+                                 `findmnt -no SOURCE {0}` and `losetup -l <loop>`, \
+                                 then restart the daemon.",
+                                mount_path_str,
+                                e
+                            );
+                        }
                     }
                 }
             }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -465,7 +465,23 @@ impl StorageBackend for BtrfsLoopBackend {
             .context("Failed to create mount point directory")?;
 
         let mount_path_str = self.mount_path.to_string_lossy().to_string();
-        if !is_mounted(&mount_path_str).await? {
+        let mounted = is_mounted(&mount_path_str).await?;
+        // External mount (k8s hostPath / bind-mount): overmount btrfs on top.
+        let needs_mount = if mounted {
+            if is_external_mount(&mount_path_str).await.unwrap_or(false) {
+                info!(
+                    "{} has external mount; overmounting with btrfs loop image",
+                    mount_path_str
+                );
+                true
+            } else {
+                info!("Already mounted at {:?}", self.mount_path);
+                false
+            }
+        } else {
+            true
+        };
+        if needs_mount {
             let loop_device = run_command("losetup", &["--find", "--show", &img_path_str])
                 .await
                 .context("Failed to setup loop device")?;
@@ -483,8 +499,6 @@ impl StorageBackend for BtrfsLoopBackend {
                 return Err(e).context("Failed to mount btrfs image");
             }
             info!("Mounted {} at {}", loop_device, mount_path_str);
-        } else {
-            info!("Already mounted at {:?}", self.mount_path);
         }
 
         if img_existed_before {
@@ -555,51 +569,79 @@ pub async fn decide_effective_img_path(
 ) -> anyhow::Result<PathBuf> {
     let mount_path_str = mount_path.to_string_lossy().to_string();
     match is_mounted(&mount_path_str).await {
-        Ok(true) => match find_backing_file(&mount_path_str).await {
-            Ok((loop_dev, backing)) => {
-                if backing == legacy {
-                    info!(
-                        "Backing {:?} is at legacy path; attempting live relocation to {:?}",
-                        legacy, target
-                    );
-                    match try_relocate_active_legacy_mount(
-                        &mount_path_str,
-                        legacy,
-                        target,
-                        &loop_dev,
-                    )
-                    .await
-                    {
-                        Ok(()) => {
-                            info!("Live img migration complete: {:?} -> {:?}", legacy, target);
-                            return Ok(target.to_path_buf());
-                        }
-                        Err(e) => {
-                            error!(
-                                "In-place relocation from legacy {:?} -> target {:?} aborted: {:#}. \
-                                 Daemon will keep serving on legacy this run; migration will retry \
-                                 on next start once the mount is idle.",
-                                legacy, target, e
+        Ok(true) => {
+            // K8s sidecar / hostPath scenario: mount_path has an external mount
+            // (ext4, xfs, overlay, or non-loop btrfs). This is not ours — bootstrap
+            // will overmount btrfs on top via mountPropagation.
+            if is_external_mount(&mount_path_str).await.unwrap_or(false) {
+                info!(
+                    "{} has an external (non-btrfs-loop) mount; \
+                     bootstrap will overmount with our btrfs image",
+                    mount_path_str
+                );
+                // Fall through to the cold path — return target so bootstrap proceeds.
+            } else {
+                match find_backing_file(&mount_path_str).await {
+                    Ok((loop_dev, backing)) => {
+                        // Orphan loop from a dead container: backing path only existed
+                        // inside the old container rootfs, not on this filesystem.
+                        if !tokio::fs::try_exists(&backing).await.unwrap_or(false) {
+                            warn!(
+                                "Loop {} backs phantom path {:?} (does not exist); \
+                                 treating mount as stale — falling through to cold path",
+                                loop_dev, backing
                             );
-                            return Ok(legacy.to_path_buf());
+                            // Fall through to cold path like external-mount case.
+                        } else if backing == legacy {
+                            info!(
+                                "Backing {:?} is at legacy path; attempting live relocation to {:?}",
+                                legacy, target
+                            );
+                            match try_relocate_active_legacy_mount(
+                                &mount_path_str,
+                                legacy,
+                                target,
+                                &loop_dev,
+                            )
+                            .await
+                            {
+                                Ok(()) => {
+                                    info!(
+                                        "Live img migration complete: {:?} -> {:?}",
+                                        legacy, target
+                                    );
+                                    return Ok(target.to_path_buf());
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "In-place relocation from legacy {:?} -> target {:?} \
+                                         aborted: {:#}. Daemon will keep serving on legacy this \
+                                         run; migration will retry on next start once the mount \
+                                         is idle.",
+                                        legacy, target, e
+                                    );
+                                    return Ok(legacy.to_path_buf());
+                                }
+                            }
+                        } else {
+                            return Ok(backing);
                         }
                     }
+                    Err(e) => {
+                        bail!(
+                            "{} is mounted but backing-file lookup failed ({:#}). Refusing to \
+                             guess which img file backs the mount — picking the wrong file \
+                             would let bootstrap reconcile a stale image and let the next \
+                             cold start mount empty data, silently hiding the live workspace. \
+                             Diagnose with `findmnt -no SOURCE {0}` and `losetup -l <loop>`, \
+                             then restart the daemon.",
+                            mount_path_str,
+                            e
+                        );
+                    }
                 }
-                return Ok(backing);
             }
-            Err(e) => {
-                bail!(
-                    "{} is mounted but backing-file lookup failed ({:#}). Refusing to \
-                     guess which img file backs the mount — picking the wrong file \
-                     would let bootstrap reconcile a stale image and let the next \
-                     cold start mount empty data, silently hiding the live workspace. \
-                     Diagnose with `findmnt -no SOURCE {0}` and `losetup -l <loop>`, \
-                     then restart the daemon.",
-                    mount_path_str,
-                    e
-                );
-            }
-        },
+        }
         Ok(false) => {}
         Err(e) => {
             // /proc/mounts being unreadable is a degenerate state that downstream
@@ -654,12 +696,49 @@ pub async fn decide_effective_img_path(
     Ok(target.to_path_buf())
 }
 
+/// Returns true when `mount_path` is mounted but NOT by a ws-ckpt btrfs-loop
+/// (e.g. k8s hostPath bind-mount, host-level ext4/xfs/overlay pre-mount).
+/// We detect this via `findmnt -no FSTYPE`: btrfs sourced from /dev/loop* is ours;
+/// anything else is external.
+///
+/// After an overmount, findmnt may return multiple lines (one per stacked mount).
+/// We inspect the **last** line — the topmost (most-recent) mount.
+async fn is_external_mount(mount_path: &str) -> anyhow::Result<bool> {
+    let raw = run_command("findmnt", &["-no", "FSTYPE", mount_path])
+        .await
+        .context("findmnt FSTYPE failed")?;
+    let fstype = last_nonempty_line(&raw);
+    if fstype.is_empty() {
+        return Ok(false);
+    }
+    if fstype != "btrfs" {
+        return Ok(true);
+    }
+    // FSTYPE=btrfs — check if SOURCE is a loop device (ours) or block device (external)
+    let raw = run_command("findmnt", &["-no", "SOURCE", mount_path])
+        .await
+        .context("findmnt SOURCE failed")?;
+    let source = last_nonempty_line(&raw);
+    Ok(!source.starts_with("/dev/loop"))
+}
+
+/// Extract the last non-empty line from command output.
+/// Stacked mounts produce multiple findmnt lines; the last is the topmost.
+fn last_nonempty_line(s: &str) -> &str {
+    s.lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim())
+        .unwrap_or("")
+}
+
 /// Resolve the loop device and its backing file for the mount at `mount_path`.
+/// Takes the topmost (last) findmnt entry to handle stacked mounts.
 async fn find_backing_file(mount_path: &str) -> anyhow::Result<(String, PathBuf)> {
     let src = run_command("findmnt", &["-no", "SOURCE", mount_path])
         .await
         .context("findmnt failed")?;
-    let loop_dev = src.trim().to_string();
+    let loop_dev = last_nonempty_line(&src).to_string();
     if loop_dev.is_empty() {
         bail!("findmnt returned no SOURCE for {}", mount_path);
     }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -763,7 +763,12 @@ async fn find_backing_file(mount_path: &str) -> anyhow::Result<(String, PathBuf)
         .context("findmnt failed")?;
     let loop_dev = last_nonempty_line(&src).to_string();
     if loop_dev.is_empty() {
-        bail!("findmnt returned no SOURCE for {}", mount_path);
+        bail!(
+            "findmnt returned no SOURCE for {} (raw output: {:?}). \
+             Likely a mount-namespace inconsistency or stale /proc/mounts entry.",
+            mount_path,
+            src.trim()
+        );
     }
     let out = run_command("losetup", &["-nl", "--output", "BACK-FILE", &loop_dev])
         .await

--- a/src/ws-ckpt/src/crates/daemon/src/startup.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/startup.rs
@@ -109,7 +109,7 @@ async fn resolve_from_persisted(
         .await
         .context("Failed to bootstrap backend during state recovery")?;
 
-    Ok(Arc::new(
+    let state = Arc::new(
         DaemonState::rebuild_from_persisted(
             state_file,
             config.clone(),
@@ -119,7 +119,9 @@ async fn resolve_from_persisted(
         )
         .await
         .context("Failed to rebuild daemon state from persisted state.json")?,
-    ))
+    );
+    state.mark_bootstrapped();
+    Ok(state)
 }
 
 /// Fresh start: detect backend, bootstrap, optionally migrate legacy indexes.
@@ -188,6 +190,7 @@ async fn resolve_fresh(
             .context("Failed to rebuild daemon state from disk on fresh install")?,
         )
     };
+    state.mark_bootstrapped();
 
     Ok(state)
 }

--- a/src/ws-ckpt/src/crates/daemon/src/state.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/state.rs
@@ -311,6 +311,11 @@ impl DaemonState {
         Ok(())
     }
 
+    /// Seed the OnceCell after startup already called bootstrap directly.
+    pub fn mark_bootstrapped(&self) {
+        let _ = self.bootstrapped.set(());
+    }
+
     pub fn get_by_wsid(&self, ws_id: &str) -> Option<Arc<RwLock<WorkspaceState>>> {
         self.workspaces
             .get(ws_id)

--- a/src/ws-ckpt/src/crates/daemon/src/state.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/state.rs
@@ -313,7 +313,9 @@ impl DaemonState {
 
     /// Seed the OnceCell after startup already called bootstrap directly.
     pub fn mark_bootstrapped(&self) {
-        let _ = self.bootstrapped.set(());
+        if self.bootstrapped.set(()).is_err() {
+            warn!("mark_bootstrapped called but OnceCell already set; likely duplicate call");
+        }
     }
 
     pub fn get_by_wsid(&self, ws_id: &str) -> Option<Arc<RwLock<WorkspaceState>>> {


### PR DESCRIPTION
## Description

- K8s sidecar 场景下 daemon 启动时 mount_path 已被 hostPath bind 占据，find_backing_file 对非 loop 设备执行 losetup 返回空后 bail，导致 daemon 无法启动
- 新增 probe_mount() 通过单次 findmnt 区分"我们的 btrfs-loop"与"外部挂载"，外部挂载走 overmount 路径而非 fatal bail

### 问题背景

ws-ckpt daemon 在 K8s sidecar 部署时，mount_path（如 `/opt/ws-ckpt-mount`）会被 kubelet 预先 bind-mount 一个 hostPath volume。原代码假设 mount_path 只可能被 ws-ckpt 自身的 btrfs-loop 挂载，遇到非 loop 设备时 `find_backing_file` → `losetup --output BACK-FILE /dev/vda1` → 返回空 → `bail!`，daemon 直接崩溃。

### 修复方案

1. **probe_mount()**: 一次 `findmnt -no FSTYPE,SOURCE` 判定挂载归属——FSTYPE=btrfs + SOURCE=/dev/loop* 才是我们的，其余一律视为外部挂载
2. **decide_effective_img_path**: 外部挂载时跳过 find_backing_file，fall through 到冷路径返回 target img
3. **bootstrap**: 外部挂载时 needs_mount=true，正常 losetup+mount overmount btrfs 上去，配合 yaml 中 mountPropagation: Bidirectional 传播到 app 容器
4. **try_exists 校验**: find_backing_file 返回的 backing path 做存在性检查，拒绝 dead container 遗留的幽灵 loop 设备
5. **last_nonempty_line**: findmnt 在 overmount 后可能输出多行（stacked mounts），取最后一行避免 double-bootstrap EEXIST
6. **OnceCell seeding**: startup 阶段预设 bootstrapped 标记，防止 dispatcher 重复触发 bootstrap

## Related Issue

no-issue: K8s sidecar 部署场景下的首次适配，无对应 issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `memory` (agent-memory)
- [x] `ckpt` (ws-ckpt)
- [ ] Multiple / Project-wide

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

已在 k3s 环境模拟验证：hostPath bind-mount 场景下 daemon 正常启动、overmount btrfs 成功、app 容器init后仍可写入。cargo fmt/clippy/test 全部通过。

## Additional Notes
