### PR TITLE
feat(anolisa): improve CLI interaction feedback

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -39,6 +39,7 @@ use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
+use crate::progress::{self, Activity};
 use crate::response::{CliError, render_json, render_json_with_status};
 
 use super::types::InstallOutcome;
@@ -87,8 +88,13 @@ pub(crate) struct AllSummaryPayload {
 }
 
 pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
+    let mut activity = Activity::start(
+        progress::feedback_for_stderr(ctx.json, ctx.quiet),
+        "Preparing batch installation...",
+    );
     let names = resolve_all_components(ctx, args.backend.as_deref())?;
     if names.is_empty() {
+        activity.finish();
         if !ctx.quiet && !ctx.json {
             let color = Palette::new(ctx.no_color);
             println!(
@@ -130,7 +136,12 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
     // is cheap next to a dnf run.
     let mut merged: Vec<MergedItem> = Vec::new();
     let mut per_item: Vec<String> = Vec::new();
-    for name in &names {
+    for (index, name) in names.iter().enumerate() {
+        activity.set_message(&format!(
+            "Planning {name} ({}/{})...",
+            index + 1,
+            names.len()
+        ));
         let per_args = per_component_args(name, &args);
         let candidate = host_backends(name, &per_args, &suppressed_ctx)
             .and_then(|(query, txn)| plan_component(name, &per_args, &suppressed_ctx, &query, &txn))
@@ -165,14 +176,21 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
     let mut fail_fast_tripped = false;
 
     if !merged.is_empty() {
+        let members = merged
+            .iter()
+            .map(|item| item.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if ctx.dry_run {
+            activity.set_message(&format!("Preparing install plan for {members}..."));
+        } else {
+            activity.set_message(&format!("Installing {members}..."));
+        }
         if !ctx.quiet && !ctx.json {
             let color = Palette::new(ctx.no_color);
-            let members = merged
-                .iter()
-                .map(|item| item.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
-            println!("{} {members} (one rpm transaction)", color.label("==>"));
+            progress::suspend_output(|| {
+                println!("{} {members} (one rpm transaction)", color.label("==>"))
+            });
         }
         if ctx.dry_run {
             // Each member previews its own plan in the single-component
@@ -182,10 +200,12 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
                 let labels: Vec<String> =
                     item.planned.route.steps().iter().map(step_label).collect();
                 if !ctx.quiet && !ctx.json {
-                    println!("install {} (dry-run):", item.name);
-                    for label in &labels {
-                        println!("  - {label}");
-                    }
+                    progress::suspend_output(|| {
+                        println!("install {} (dry-run):", item.name);
+                        for label in &labels {
+                            println!("  - {label}");
+                        }
+                    });
                 }
                 results.insert(
                     item.name.clone(),
@@ -214,9 +234,14 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
         if fail_fast_tripped {
             break;
         }
+        if ctx.dry_run {
+            activity.set_message(&format!("Preparing install plan for {name}..."));
+        } else {
+            activity.set_message(&format!("Installing {name}..."));
+        }
         if !ctx.quiet && !ctx.json {
             let color = Palette::new(ctx.no_color);
-            println!("{} {name}", color.label("==>"));
+            progress::suspend_output(|| println!("{} {name}", color.label("==>")));
         }
         let per_args = per_component_args(name, &args);
         match handle_one_with_planned_components(
@@ -281,6 +306,8 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
         .count();
     let failed = items.iter().filter(|i| i.status == "failed").count();
     let skipped = items.iter().filter(|i| i.status == "skipped").count();
+
+    activity.finish();
 
     if ctx.json {
         // The batch summary is the single, complete JSON response.  We
@@ -654,7 +681,7 @@ fn execute_merged_group_with_deps(
                             COMMAND,
                             ctx.packaged_data_probe(),
                         ) {
-                            eprintln!("warning: {warning}");
+                            progress::suspend_output(|| eprintln!("warning: {warning}"));
                         }
                         items.push(AllSummaryItem {
                             component: item.name.clone(),
@@ -688,7 +715,9 @@ fn execute_merged_group_with_deps(
             // Operation history is best-effort bookkeeping on top of the
             // committed records, exactly like the single-component path.
             if let Err(err) = store.save(&state_path) {
-                eprintln!("warning: failed to record operation history: {err}");
+                progress::suspend_output(|| {
+                    eprintln!("warning: failed to record operation history: {err}")
+                });
             }
             items
         }
@@ -722,10 +751,12 @@ fn execute_merged_group_with_deps(
                     .mark_failed(0, &reason)
                     .and_then(|()| journal.finish(journal_outcome))
                 {
-                    eprintln!(
-                        "warning: failed to journal the merged transaction outcome for '{}': {err}",
-                        item.name
-                    );
+                    progress::suspend_output(|| {
+                        eprintln!(
+                            "warning: failed to journal the merged transaction outcome for '{}': {err}",
+                            item.name
+                        )
+                    });
                 }
             }
             drop(store);
@@ -734,10 +765,12 @@ fn execute_merged_group_with_deps(
             if clean.is_empty() {
                 return items;
             }
-            eprintln!(
-                "warning: merged rpm transaction failed ({reason}); retrying {} component(s) individually",
-                clean.len()
-            );
+            progress::suspend_output(|| {
+                eprintln!(
+                    "warning: merged rpm transaction failed ({reason}); retrying {} component(s) individually",
+                    clean.len()
+                )
+            });
             let mut fail_fast_tripped = false;
             for name in clean {
                 if fail_fast_tripped {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -40,6 +40,7 @@ use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install;
 use crate::context::{CliContext, InstallMode};
+use crate::progress::{self, Activity, ProgressReporter};
 use crate::repo_config::{
     BackendConfig, HostVars, RepoConfig, RepoConfigError, normalize_override_url,
 };
@@ -67,8 +68,18 @@ pub(crate) fn handle_one(
     args: InstallArgs,
     ctx: &CliContext,
 ) -> Result<InstallOutcome, CliError> {
+    let mut activity = install_activity(&component, ctx);
     let (query, txn) = host_backends(&component, &args, ctx)?;
-    install_component_with_deps(&component, &args, ctx, &query, &txn, privilege::is_root())
+    install_component_with_deps_and_planned(
+        &component,
+        &args,
+        ctx,
+        &query,
+        &txn,
+        privilege::is_root(),
+        &HashSet::new(),
+        &mut activity,
+    )
 }
 
 /// Dispatch one batch member while treating earlier successful dry-run
@@ -79,6 +90,7 @@ pub(crate) fn handle_one_with_planned_components(
     ctx: &CliContext,
     planned_components: &HashSet<String>,
 ) -> Result<InstallOutcome, CliError> {
+    let mut activity = install_activity(&component, ctx);
     let (query, txn) = host_backends(&component, &args, ctx)?;
     install_component_with_deps_and_planned(
         &component,
@@ -88,6 +100,14 @@ pub(crate) fn handle_one_with_planned_components(
         &txn,
         privilege::is_root(),
         planned_components,
+        &mut activity,
+    )
+}
+
+fn install_activity(component: &str, ctx: &CliContext) -> Activity {
+    Activity::start(
+        progress::feedback_for_stderr(ctx.json, ctx.quiet),
+        &format!("Preparing to install {component}..."),
     )
 }
 
@@ -262,6 +282,7 @@ impl PlannedRoute {
 
 /// Core of [`handle_one`] with the package backends injected so tests drive
 /// every branch without a live rpmdb/dnf or real privileges.
+#[cfg(test)]
 pub(crate) fn install_component_with_deps(
     input: &str,
     args: &InstallArgs,
@@ -270,9 +291,22 @@ pub(crate) fn install_component_with_deps(
     txn: &dyn PackageTransaction,
     is_root: bool,
 ) -> Result<InstallOutcome, CliError> {
-    install_component_with_deps_and_planned(input, args, ctx, query, txn, is_root, &HashSet::new())
+    let mut activity = install_activity(input, ctx);
+    install_component_with_deps_and_planned(
+        input,
+        args,
+        ctx,
+        query,
+        txn,
+        is_root,
+        &HashSet::new(),
+        &mut activity,
+    )
 }
 
+// Tests vary each execution dependency independently; keeping them explicit
+// makes the host boundary visible instead of hiding it in an opaque test bag.
+#[expect(clippy::too_many_arguments)]
 fn install_component_with_deps_and_planned(
     input: &str,
     args: &InstallArgs,
@@ -281,9 +315,19 @@ fn install_component_with_deps_and_planned(
     txn: &dyn PackageTransaction,
     is_root: bool,
     planned_components: &HashSet<String>,
+    reporter: &mut dyn ProgressReporter,
 ) -> Result<InstallOutcome, CliError> {
     let planned = plan_component(input, args, ctx, query, txn)?;
-    execute_planned(planned, args, ctx, query, txn, is_root, planned_components)
+    execute_planned(
+        planned,
+        args,
+        ctx,
+        query,
+        txn,
+        is_root,
+        planned_components,
+        reporter,
+    )
 }
 
 /// Planning prefix of an install: resolve the component and its provider
@@ -319,7 +363,7 @@ pub(crate) fn plan_component(
     if let Some(explicit) = args.backend.as_deref()
         && let Some(warning) = RepoConfig::backend_name_deprecation_warning(explicit)
     {
-        eprintln!("warning: {warning}");
+        progress::suspend_output(|| eprintln!("warning: {warning}"));
     }
 
     let family = install_family(args, &store, &component, &repo_config);
@@ -520,9 +564,12 @@ pub(crate) fn plan_component(
     })
 }
 
-/// Execution half of [`install_component_with_deps`]: render the idempotent
+/// Execution half of [`handle_one`]: render the idempotent
 /// NoOp, place a resolved owned artifact, or run the delegated native
 /// transaction. Dry-run renders the plan and stops before any side effect.
+// Mirrors the explicit planner/executor dependency boundary above, with the
+// reporter added so terminal lifecycle remains injectable in tests.
+#[expect(clippy::too_many_arguments)]
 fn execute_planned(
     planned: PlannedComponent,
     args: &InstallArgs,
@@ -531,6 +578,7 @@ fn execute_planned(
     txn: &dyn PackageTransaction,
     is_root: bool,
     planned_components: &HashSet<String>,
+    reporter: &mut dyn ProgressReporter,
 ) -> Result<InstallOutcome, CliError> {
     let PlannedComponent {
         command,
@@ -554,6 +602,7 @@ fn execute_planned(
     // planning refusal is independent of the raw repo being reachable.
     let (steps, resolution) = match route {
         PlannedRoute::AlreadyInstalled { version } => {
+            reporter.finish();
             render_result(
                 ctx,
                 &InstallResultPayload {
@@ -575,6 +624,7 @@ fn execute_planned(
         }
         PlannedRoute::Delegated { steps } => (steps, None),
         PlannedRoute::Owned { steps } => {
+            reporter.report(&format!("Resolving {component}..."));
             let resolution = resolve_owned_artifact(
                 args,
                 ctx,
@@ -602,6 +652,7 @@ fn execute_planned(
     };
 
     if ctx.dry_run {
+        reporter.finish();
         for warning in resolution.iter().flat_map(|r| r.warnings.iter()) {
             eprintln!("warning: {warning}");
         }
@@ -653,11 +704,13 @@ fn execute_planned(
     }
 
     if let Some(resolution) = resolution {
+        reporter.report(&format!("Downloading and verifying {component}..."));
         // Download, digest check, and contract validation run before the
         // lock: they are side-effect free outside the download cache, and a
         // contract refusal (mode mismatch, component conflict, malformed
         // hooks) is an argument error, not a failed transaction.
         let validated = validate_owned_install(ctx, &layout, &store, resolution, &command)?;
+        reporter.report(&format!("Installing {component}..."));
         let provider = DelegatedProvider::new(query, txn);
         return install_owned(
             &component,
@@ -674,9 +727,11 @@ fn execute_planned(
             native_package.as_deref(),
             &provider,
             &command,
+            reporter,
         );
     }
 
+    reporter.report(&format!("Installing {component}..."));
     let provider = DelegatedProvider::new(query, txn);
     let package = native_package.unwrap_or_else(|| component.clone());
     install_delegated(
@@ -695,6 +750,7 @@ fn execute_planned(
         &repo_config,
         is_root,
         &command,
+        reporter,
     )
 }
 
@@ -1004,6 +1060,7 @@ fn install_owned(
     native_package: Option<&str>,
     provider: &DelegatedProvider,
     command: &str,
+    reporter: &mut dyn ProgressReporter,
 ) -> Result<InstallOutcome, CliError> {
     // No root pre-check for an owned install: `--prefix` may point at a
     // user-writable tree, and a genuine permission problem fails the exact
@@ -1058,6 +1115,8 @@ fn install_owned(
     let outcome =
         result.map_err(|err| owned_error_to_cli(err, target, scope, command, &retained_note))?;
 
+    reporter.report(&format!("Finalizing {target} installation..."));
+
     // Operation history is best-effort bookkeeping on top of the committed
     // record: the install already succeeded, so a history-write failure
     // degrades to a warning instead of unwinding anything.
@@ -1070,13 +1129,16 @@ fn install_owned(
         parent_operation_id: None,
     });
     if let Err(err) = store.save(state_path) {
-        eprintln!("warning: failed to record operation history: {err}");
+        progress::suspend_output(|| {
+            eprintln!("warning: failed to record operation history: {err}")
+        });
     }
 
     for warning in resolve_warnings.iter().chain(outcome.warnings.iter()) {
-        eprintln!("warning: {warning}");
+        progress::suspend_output(|| eprintln!("warning: {warning}"));
     }
 
+    reporter.finish();
     render_result(ctx, &{
         let mut payload = InstallResultPayload {
             component: target.to_string(),
@@ -1119,6 +1181,7 @@ fn install_delegated(
     repo_config: &RepoConfig,
     is_root: bool,
     command: &str,
+    reporter: &mut dyn ProgressReporter,
 ) -> Result<InstallOutcome, CliError> {
     // A fresh delegated install pulls from the configured ANOLISA RPM
     // repository; without one, dnf would resolve against arbitrary host
@@ -1188,6 +1251,8 @@ fn install_delegated(
         ),
     })?;
 
+    reporter.report(&format!("Finalizing {target} installation..."));
+
     // Operation history is best-effort bookkeeping on top of the committed
     // record, exactly like the owned path.
     store.operations.push(OperationRecord {
@@ -1199,7 +1264,9 @@ fn install_delegated(
         parent_operation_id: None,
     });
     if let Err(err) = store.save(state_path) {
-        eprintln!("warning: failed to record operation history: {err}");
+        progress::suspend_output(|| {
+            eprintln!("warning: failed to record operation history: {err}")
+        });
     }
 
     // Best-effort: snapshot the datadir component contract so adapter
@@ -1211,7 +1278,7 @@ fn install_delegated(
         command,
         ctx.packaged_data_probe(),
     ) {
-        eprintln!("warning: {warning}");
+        progress::suspend_output(|| eprintln!("warning: {warning}"));
     }
 
     let version = outcome.observation.as_ref().map(|o| o.version.clone());
@@ -1232,6 +1299,7 @@ fn install_delegated(
     if let Some(pin) = delegated_pin {
         payload = payload.with_pin(pin);
     }
+    reporter.finish();
     render_result(ctx, &payload)?;
     Ok(InstallOutcome::Installed)
 }
@@ -1662,7 +1730,63 @@ mod tests {
     use super::*;
     use crate::repo_config::RepoConfig;
     use anolisa_platform::fs_layout::FsLayout;
+    use std::cell::{Cell, RefCell};
     use tempfile::tempdir;
+
+    #[derive(Default)]
+    struct RecordingProgress {
+        messages: RefCell<Vec<String>>,
+        finished: Cell<bool>,
+    }
+
+    impl ProgressReporter for RecordingProgress {
+        fn report(&self, message: &str) {
+            self.messages.borrow_mut().push(message.to_string());
+        }
+
+        fn finish(&mut self) {
+            self.finished.set(true);
+        }
+    }
+
+    #[test]
+    fn delegated_install_reports_execution_and_finalization() {
+        let (_tmp, mut ctx) = system_ctx_with_configured_rpm_repo(false);
+        ctx.quiet = true;
+        let fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        )
+        .with_origin("anolisa");
+        let mut install_args = args("copilot-shell");
+        install_args.backend = Some("rpm".to_string());
+        let mut reporter = RecordingProgress::default();
+
+        let outcome = install_component_with_deps_and_planned(
+            "copilot-shell",
+            &install_args,
+            &ctx,
+            &fake,
+            &fake,
+            true,
+            &HashSet::new(),
+            &mut reporter,
+        )
+        .expect("delegated install");
+
+        assert_eq!(outcome, InstallOutcome::Installed);
+        assert_eq!(
+            reporter.messages.borrow().as_slice(),
+            [
+                "Installing copilot-shell...",
+                "Finalizing copilot-shell installation...",
+            ]
+        );
+        assert!(
+            reporter.finished.get(),
+            "progress must stop before the final result is rendered"
+        );
+    }
 
     #[test]
     fn pinned_payload_json_exposes_requested_resolved_repo_and_artifact() {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/io_util.rs
@@ -403,7 +403,7 @@ fn snapshot_datadir_contract_with_missing_policy(
         datadir_root: contract.datadir_root,
     };
     if let Err(msg) = publish_contract_pair(&dest, &contract.content, &provenance) {
-        eprintln!("warning: {msg}");
+        crate::progress::suspend_output(|| eprintln!("warning: {msg}"));
         warnings.push(msg);
         return ContractRefreshOutcome {
             state: ContractRefreshState::Failed,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -57,6 +57,7 @@ use crate::commands::tier1::install::RawTeardownOps;
 use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
+use crate::progress::{self, Activity, ProgressReporter};
 use crate::response::{CliError, render_json};
 
 const COMMAND: &str = "uninstall";
@@ -103,10 +104,27 @@ pub(crate) fn handle_with_deps(
     txn: &dyn PackageTransaction,
     is_root: bool,
 ) -> Result<(), CliError> {
+    let mut activity = Activity::start(
+        progress::feedback_for_stderr(ctx.json, ctx.quiet),
+        &format!("Preparing to uninstall {}...", args.component),
+    );
+    handle_with_deps_and_progress(args, ctx, query, txn, is_root, &mut activity)
+}
+
+fn handle_with_deps_and_progress(
+    args: UninstallArgs,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    reporter: &mut dyn ProgressReporter,
+) -> Result<(), CliError> {
+    reporter.report(&format!("Preparing to uninstall {}...", args.component));
     if args.purge {
+        reporter.finish();
         return handle_purge(&args, ctx);
     }
-    uninstall_component(&args, ctx, query, txn, is_root)
+    uninstall_component(&args, ctx, query, txn, is_root, reporter)
 }
 
 /// The plain-uninstall pipeline: observe, plan (rows X1–X6), execute through
@@ -117,6 +135,7 @@ fn uninstall_component(
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
+    reporter: &mut dyn ProgressReporter,
 ) -> Result<(), CliError> {
     let input = args.component.as_str();
     let command = format!("{COMMAND} {input}");
@@ -134,6 +153,7 @@ fn uninstall_component(
     let (resolved, view) = common::resolve_mutation_target(input, ctx, &scope_command)?;
     let store = view.writable.state;
     let target = resolved.as_str();
+    reporter.report(&format!("Resolving {target}..."));
 
     if store.find(ObjectKind::Component, target).is_none() {
         // A name that only matched a legacy `kind = "capability"` row was
@@ -154,7 +174,9 @@ fn uninstall_component(
     // `--force` is a wire stub; surface it on real runs so users do not
     // assume it changes behavior. Dry-run stays quiet.
     if args.force && !ctx.dry_run {
-        eprintln!("warning: --force is a spec stub today and has no behavioral effect yet");
+        progress::suspend_output(|| {
+            eprintln!("warning: --force is a spec stub today and has no behavioral effect yet");
+        });
     }
 
     // `--remove-system-package` only governs delegated records. Flag it on
@@ -168,9 +190,11 @@ fn uninstall_component(
             Some(ProviderBinding::Owned { .. })
         )
     {
-        eprintln!(
-            "warning: --remove-system-package has no effect for raw component '{target}' (there is no system RPM to remove)"
-        );
+        progress::suspend_output(|| {
+            eprintln!(
+                "warning: --remove-system-package has no effect for raw component '{target}' (there is no system RPM to remove)"
+            );
+        });
     }
 
     // The probe target comes from the record; uninstall never resolves a
@@ -264,6 +288,7 @@ fn uninstall_component(
         Ok(Plan::NoOp { .. }) => {
             // The uninstall table has no NoOp rows today; render an honest
             // "nothing to do" if the planner ever grows one.
+            reporter.finish();
             return render_result(
                 ctx,
                 target,
@@ -281,6 +306,7 @@ fn uninstall_component(
     let disposition = disposition_for(&steps, &notes);
 
     if ctx.dry_run {
+        reporter.finish();
         return render_result(
             ctx,
             target,
@@ -305,6 +331,7 @@ fn uninstall_component(
         )
     });
     if !is_delegated_plan {
+        reporter.report(&format!("Uninstalling {target}..."));
         return uninstall_owned(
             target,
             ctx,
@@ -315,6 +342,7 @@ fn uninstall_component(
             &now,
             &intent,
             &command,
+            reporter,
         );
     }
 
@@ -337,6 +365,7 @@ fn uninstall_component(
             ),
         });
     }
+    reporter.report(&format!("Uninstalling {target}..."));
 
     // Real run under the install lock, with state re-read and the adapter
     // guard re-checked inside it — a concurrent `adapter enable` must not
@@ -550,16 +579,17 @@ fn uninstall_component(
             ),
         },
     })?;
+    reporter.report(&format!("Finalizing {target} uninstall..."));
 
     // The manifest snapshot travels with the record. Best-effort: the
     // record drop is already committed.
     if let Err(err) = remove_component_manifest_snapshot(&layout, target, &command) {
-        eprintln!("warning: {err}");
+        progress::suspend_output(|| eprintln!("warning: {err}"));
     }
     if let Some(dir) = legacy_manifest_dir
         && let Err(err) = remove_manifest_snapshot_dir(&dir, &command)
     {
-        eprintln!("warning: {err}");
+        progress::suspend_output(|| eprintln!("warning: {err}"));
     }
 
     // Operation history is best-effort bookkeeping on top of the committed
@@ -573,16 +603,20 @@ fn uninstall_component(
         parent_operation_id: None,
     });
     if let Err(err) = store.save(&state_path) {
-        eprintln!("warning: failed to record operation history: {err}");
+        progress::suspend_output(|| {
+            eprintln!("warning: failed to record operation history: {err}");
+        });
     }
 
     if matches!(disposition, UninstallDisposition::AlreadyAbsent) && !ctx.json && !ctx.quiet {
         let color = Palette::new(ctx.no_color);
-        eprintln!(
-            "{} RPM package '{}' is not present in rpmdb (already removed by a manual `rpm -e`); dropping ANOLISA state only",
-            color.warn("warning:"),
-            native_package.as_deref().unwrap_or(target),
-        );
+        progress::suspend_output(|| {
+            eprintln!(
+                "{} RPM package '{}' is not present in rpmdb (already removed by a manual `rpm -e`); dropping ANOLISA state only",
+                color.warn("warning:"),
+                native_package.as_deref().unwrap_or(target),
+            );
+        });
     }
 
     append_uninstall_log(
@@ -595,6 +629,7 @@ fn uninstall_component(
         &disposition,
         native_package.as_deref(),
     );
+    reporter.finish();
 
     render_result(
         ctx,
@@ -619,6 +654,7 @@ fn uninstall_owned(
     now: &str,
     intent: &Intent,
     command: &str,
+    reporter: &mut dyn ProgressReporter,
 ) -> Result<(), CliError> {
     // No root pre-check for owned teardown: `--prefix` may point at a
     // user-writable tree, and a genuine permission problem fails the exact
@@ -741,6 +777,7 @@ fn uninstall_owned(
         execute_owned_steps(&steps, &mut ops, &mut journal)
     }
     .map_err(|err| owned_teardown_error_to_cli(err, target, scope, command))?;
+    reporter.report(&format!("Finalizing {target} uninstall..."));
 
     store.operations.push(OperationRecord {
         id: operation_id.clone(),
@@ -751,13 +788,15 @@ fn uninstall_owned(
         parent_operation_id: None,
     });
     if let Err(err) = store.save(state_path) {
-        eprintln!("warning: failed to record operation history: {err}");
+        progress::suspend_output(|| {
+            eprintln!("warning: failed to record operation history: {err}");
+        });
     }
 
     if !ctx.json && !ctx.quiet {
         let color = Palette::new(ctx.no_color);
         for warning in &outcome.warnings {
-            eprintln!("{} {warning}", color.warn("warning:"));
+            progress::suspend_output(|| eprintln!("{} {warning}", color.warn("warning:")));
         }
     }
 
@@ -771,6 +810,7 @@ fn uninstall_owned(
         &disposition,
         None,
     );
+    reporter.finish();
 
     render_result(
         ctx,
@@ -1146,7 +1186,7 @@ fn append_uninstall_log(
         details: serde_json::Value::Null,
     };
     if let Err(err) = log.append(&record) {
-        eprintln!("warning: failed to write central log: {err}");
+        progress::suspend_output(|| eprintln!("warning: failed to write central log: {err}"));
     }
 }
 
@@ -1377,6 +1417,22 @@ mod tests {
     use anolisa_platform::fs_layout::{FsLayout, InstallMode as LayoutInstallMode};
     use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
     use anolisa_platform::pkg_transaction::PackageTransactionError;
+
+    #[derive(Default)]
+    struct RecordingProgress {
+        messages: RefCell<Vec<String>>,
+        finished: bool,
+    }
+
+    impl ProgressReporter for RecordingProgress {
+        fn report(&self, message: &str) {
+            self.messages.borrow_mut().push(message.to_string());
+        }
+
+        fn finish(&mut self) {
+            self.finished = true;
+        }
+    }
 
     fn ctx_with_prefix(
         json: bool,
@@ -2202,6 +2258,49 @@ mod tests {
         is_root: bool,
     ) -> Result<(), CliError> {
         handle_with_deps(args, ctx, rpm, rpm, is_root)
+    }
+
+    #[test]
+    fn uninstall_reports_resolve_remove_and_finalize_phases() {
+        let tmp = tempdir().expect("tmpdir");
+        let ctx = ctx_with_prefix(
+            false,
+            false,
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+        );
+        seed(
+            &ctx,
+            vec![rpm_object(
+                "copilot-shell",
+                "copilot-shell",
+                Ownership::RpmObserved,
+            )],
+            Vec::new(),
+        );
+        let rpm = FakeRpm::present("copilot-shell");
+        let mut progress = RecordingProgress::default();
+
+        handle_with_deps_and_progress(
+            args_rm("copilot-shell"),
+            &ctx,
+            &rpm,
+            &rpm,
+            true,
+            &mut progress,
+        )
+        .expect("uninstall");
+
+        assert_eq!(
+            progress.messages.into_inner(),
+            [
+                "Preparing to uninstall copilot-shell...",
+                "Resolving copilot-shell...",
+                "Uninstalling copilot-shell...",
+                "Finalizing copilot-shell uninstall...",
+            ]
+        );
+        assert!(progress.finished, "progress must stop before result output");
     }
 
     /// The new `--remove-system-package` flag parses to the positional + flag.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/render.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/render.rs
@@ -72,7 +72,7 @@ pub(super) fn build_motd(report: &UpdateCheckReport) -> Option<String> {
         "ANOLISA toolchain update is available."
     };
     Some(format!(
-        "{headline}\n{}.\nRun: sudo anolisa upgrade to apply, or anolisa update --check for details",
+        "{headline}\n{}.\nRun: \"sudo anolisa upgrade\" to apply, or \"anolisa update --check\" for details",
         parts.join("; ")
     ))
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -988,8 +988,8 @@ fn update_check_motd_text_lists_upgrades_and_installs() {
     assert!(text.contains("ANOLISA toolchain update is available."));
     assert!(text.contains("1 component can be upgraded"));
     assert!(text.contains("1 new default component can be installed"));
-    assert!(text.contains("Run: sudo anolisa upgrade to apply"));
-    assert!(text.contains("anolisa update --check for details"));
+    assert!(text.contains("Run: \"sudo anolisa upgrade\" to apply"));
+    assert!(text.contains("\"anolisa update --check\" for details"));
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/main.rs
+++ b/src/anolisa/crates/anolisa-cli/src/main.rs
@@ -63,7 +63,7 @@ fn finish(exit_code: ExitCode) -> ExitCode {
 fn finish_with_error(exit_code: ExitCode, error: Option<io::Error>) -> ExitCode {
     match error {
         Some(error) => {
-            eprintln!("error[EXECUTION_FAILED]: failed writing to stdout: {error}");
+            eprintln!("error: failed writing to stdout: {error}");
             ExitCode::from(1)
         }
         None => exit_code,

--- a/src/anolisa/crates/anolisa-cli/src/progress.rs
+++ b/src/anolisa/crates/anolisa-cli/src/progress.rs
@@ -1,17 +1,17 @@
 //! Transient interactive activity feedback for long-running human-readable
 //! commands (issue #1452).
 //!
-//! Repository queries, upgrade planning, and `dnf` transactions can each block
-//! for a long time with no visible output, so a healthy run is
-//! indistinguishable from a hung process. This module provides an injectable
-//! [`ProgressReporter`] plus an [`Activity`] guard that renders feedback in one
-//! of two ways, chosen by [`feedback_mode`], without ever touching the
-//! structured stdout/JSON contract:
+//! Repository queries, install/upgrade planning, artifact preparation, and
+//! `dnf` transactions can each block for a long time with no visible output,
+//! so a healthy run is indistinguishable from a hung process. This module
+//! provides an injectable [`ProgressReporter`] plus an [`Activity`] guard that
+//! renders feedback in one of two ways, chosen by [`feedback_mode`], without
+//! ever touching the structured stdout/JSON contract:
 //!
 //! - **Animated** (interactive, ANSI-capable terminal): a background spinner on
 //!   stderr, repainted in place.
 //! - **Static** (interactive terminal that cannot animate — `TERM=dumb`, an
-//!   unknown/zero width, or a spinner thread that failed to spawn): a single
+//!   unknown/zero width, or an animation thread that failed to spawn): a single
 //!   plain stderr line per phase, no ANSI and no repaint. This keeps a feedback
 //!   channel for users the animated path cannot serve, instead of going silent
 //!   and reintroducing the "looks hung" problem.
@@ -24,7 +24,7 @@
 //!   is known and the frame fits one physical line ([`fit_line`]); otherwise the
 //!   painter falls back to a one-time static line for that message, so a frame
 //!   `clear_line` could not fully erase is never emitted.
-//! - **No competing output**: while an animated spinner is live, occasional
+//! - **No competing output**: while animated feedback is live, occasional
 //!   persistent lines (repo-config deprecation, provisioning result,
 //!   central-log warning) go through [`suspend_output`], which parks the painter
 //!   and clears the frame so the two never interleave.
@@ -51,7 +51,7 @@ use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, SigmaskHow, Signa
 /// runs on ANSI-capable terminals anyway).
 const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-/// Interval between spinner frames.
+/// Interval between animation frames.
 const TICK: Duration = Duration::from_millis(100);
 
 /// Granularity at which the painter polls the stop flags while waiting out a
@@ -66,10 +66,10 @@ const STOP_POLL: Duration = Duration::from_millis(10);
 /// last frame, which no design could safely erase while that write is stuck.
 const SIGINT_SPIN_LIMIT: u32 = 20_000_000;
 
-/// The active animated spinner's shared state, published while it is live so
+/// The active animation's shared state, published while it is live so
 /// [`suspend_output`] can coordinate with the painter from another call path.
-/// At most one spinner is live at a time in this CLI (never nested).
-static ACTIVE: Mutex<Option<Arc<SpinnerState>>> = Mutex::new(None);
+/// At most one animation is live at a time in this CLI (never nested).
+static ACTIVE: Mutex<Option<Arc<AnimationState>>> = Mutex::new(None);
 
 /// Set by the SIGINT handler to tell the painter to stop. Global (not a field)
 /// because the async-signal-safe handler cannot reach the `Arc` state.
@@ -87,6 +87,12 @@ static SIG_DONE: AtomicBool = AtomicBool::new(false);
 pub(crate) trait ProgressReporter {
     /// Replace the currently displayed activity message.
     fn report(&self, message: &str);
+
+    /// Stop transient feedback before persistent command output is rendered.
+    ///
+    /// Recording and no-op reporters do not own terminal state, so the default
+    /// implementation is intentionally empty.
+    fn finish(&mut self) {}
 }
 
 /// A [`ProgressReporter`] that discards every message.
@@ -107,7 +113,7 @@ impl ProgressReporter for NoopReporter {
 pub(crate) enum FeedbackMode {
     /// No feedback: `--json`, `--quiet`, or a non-interactive stderr.
     Disabled,
-    /// In-place stderr spinner on an ANSI-capable interactive terminal.
+    /// In-place stderr animation on an ANSI-capable interactive terminal.
     Animated,
     /// One plain stderr line per phase when the terminal cannot animate.
     Static,
@@ -155,9 +161,9 @@ fn ansi_capable_for(term: Option<&str>) -> bool {
     matches!(term, Some(t) if !t.is_empty() && t != "dumb")
 }
 
-/// Run `f`, parking the active animated spinner (if any) and clearing its frame
+/// Run `f`, parking active animated feedback (if any) and clearing its frame
 /// for the duration so a persistent line written by `f` cannot interleave with,
-/// or be erased by, spinner repaints. A no-op wrapper when no animated spinner
+/// or be erased by, animation repaints. A no-op wrapper when no animation
 /// is live (including static mode), so it is safe to route every occasional CLI
 /// line through it unconditionally.
 pub(crate) fn suspend_output<T>(f: impl FnOnce() -> T) -> T {
@@ -185,7 +191,7 @@ fn emit_static_line(message: &str) {
 ///
 /// Construct with [`Activity::start`]; the mode decides whether it animates,
 /// prints static lines, or does nothing. Dropping it tears down the animated
-/// spinner (join the worker, restore SIGINT); the other modes need no cleanup.
+/// worker (join the thread, restore SIGINT); the other modes need no cleanup.
 pub(crate) struct Activity {
     inner: ActivityInner,
 }
@@ -193,7 +199,7 @@ pub(crate) struct Activity {
 enum ActivityInner {
     Disabled,
     Static(StaticHint),
-    Animated(AnimatedSpinner),
+    Animated(AnimatedFeedback),
 }
 
 impl Activity {
@@ -206,8 +212,8 @@ impl Activity {
         let inner = match mode {
             FeedbackMode::Disabled => ActivityInner::Disabled,
             FeedbackMode::Static => ActivityInner::Static(StaticHint::new(message)),
-            FeedbackMode::Animated => match AnimatedSpinner::start(message) {
-                Some(spinner) => ActivityInner::Animated(spinner),
+            FeedbackMode::Animated => match AnimatedFeedback::start(message) {
+                Some(animation) => ActivityInner::Animated(animation),
                 None => ActivityInner::Static(StaticHint::new(message)),
             },
         };
@@ -219,19 +225,32 @@ impl Activity {
         match &self.inner {
             ActivityInner::Disabled => {}
             ActivityInner::Static(hint) => hint.report(message),
-            ActivityInner::Animated(spinner) => {
+            ActivityInner::Animated(animation) => {
                 // Avoid pausing this thread in the handler while it owns the
                 // message lock the painter may need before its final clear.
                 let _sigint_block = ScopedSigintBlock::block().ok();
-                set_shared_message(&spinner.state.message, message);
+                set_shared_message(&animation.state.message, message);
             }
         }
+    }
+
+    /// Stop feedback and clear any animated frame.
+    ///
+    /// Keeping the guard usable after this call lets command pipelines finish
+    /// it through a borrowed [`ProgressReporter`] before printing their final
+    /// result. Dropping the guard later is then a no-op.
+    pub(crate) fn finish(&mut self) {
+        self.inner = ActivityInner::Disabled;
     }
 }
 
 impl ProgressReporter for Activity {
     fn report(&self, message: &str) {
         self.set_message(message);
+    }
+
+    fn finish(&mut self) {
+        Activity::finish(self);
     }
 }
 
@@ -262,15 +281,15 @@ impl StaticHint {
 }
 
 /// Animated feedback: a background worker repaints frames on stderr.
-struct AnimatedSpinner {
-    state: Arc<SpinnerState>,
+struct AnimatedFeedback {
+    state: Arc<AnimationState>,
     handle: Option<JoinHandle<()>>,
     /// SIGINT disposition to restore on drop; `None` when the scoped handler
     /// could not be installed.
     prev_sigint: Option<SigAction>,
 }
 
-impl AnimatedSpinner {
+impl AnimatedFeedback {
     /// Spawn the painter, or `None` if the worker thread cannot be created.
     fn start(message: &str) -> Option<Self> {
         // Block before installing the handler and spawning. The painter inherits
@@ -278,11 +297,11 @@ impl AnimatedSpinner {
         // wait for its own `SIG_DONE`. Failure degrades to static feedback.
         let sigint_block = ScopedSigintBlock::block().ok()?;
 
-        // Fresh interrupt-handshake state for this spinner.
+        // Fresh interrupt-handshake state for this animation.
         SIG_STOP.store(false, Ordering::Release);
         SIG_DONE.store(false, Ordering::Release);
 
-        let state = Arc::new(SpinnerState {
+        let state = Arc::new(AnimationState {
             message: Mutex::new(message.to_string()),
             stop: AtomicBool::new(false),
             paint: Mutex::new(()),
@@ -293,7 +312,7 @@ impl AnimatedSpinner {
         let worker_state = Arc::clone(&state);
         match thread::Builder::new()
             .name("anolisa-activity".to_string())
-            .spawn(move || run_spinner(&worker_state))
+            .spawn(move || run_animation(&worker_state))
         {
             Ok(handle) => {
                 // The worker now exists with SIGINT blocked, so a pending signal
@@ -317,7 +336,7 @@ impl AnimatedSpinner {
     }
 }
 
-impl Drop for AnimatedSpinner {
+impl Drop for AnimatedFeedback {
     fn drop(&mut self) {
         self.state.stop.store(true, Ordering::Release);
         if let Some(handle) = self.handle.take() {
@@ -333,16 +352,16 @@ impl Drop for AnimatedSpinner {
     }
 }
 
-/// Shared spinner state driven by the worker thread and updated by
+/// Shared animation state driven by the worker thread and updated by
 /// [`Activity::set_message`].
-struct SpinnerState {
+struct AnimationState {
     message: Mutex<String>,
     stop: AtomicBool,
     /// Serializes terminal repaints against [`suspend_output`].
     paint: Mutex<()>,
 }
 
-impl SpinnerState {
+impl AnimationState {
     fn lock_paint(&self) -> MutexGuard<'_, ()> {
         self.paint
             .lock()
@@ -356,13 +375,13 @@ impl SpinnerState {
     }
 }
 
-/// Worker loop: repaint the spinner until a stop flag is set, then perform the
+/// Worker loop: repaint the animation until a stop flag is set, then perform the
 /// one and only final clear.
 ///
 /// The painter is the *sole* terminal writer, which is what lets the SIGINT
 /// handler stay write-free: the last thing written here is always the final
 /// clear, after which [`SIG_DONE`] is published and the thread exits.
-fn run_spinner(state: &SpinnerState) {
+fn run_animation(state: &AnimationState) {
     let term = Term::stderr();
     let mut frame = 0usize;
     let mut render_state = RenderState::default();
@@ -372,10 +391,7 @@ fn run_spinner(state: &SpinnerState) {
             let _paint = state.lock_paint();
             if !state.should_stop() {
                 let message = read_shared_message(&state.message);
-                match fit_to_width(
-                    &term,
-                    &format!("{} {message}", FRAMES[frame % FRAMES.len()]),
-                ) {
+                match spinner_line(&term, frame, &message) {
                     Some(line) => {
                         // Best-effort paint: a transient stderr write error must
                         // not abort the whole command.
@@ -461,7 +477,7 @@ impl RenderState {
 
 /// Sleep out one [`TICK`], waking early (within [`STOP_POLL`]) when a stop flag
 /// is set so shutdown latency stays low.
-fn sleep_until_stop(state: &SpinnerState) {
+fn sleep_until_stop(state: &AnimationState) {
     let mut elapsed = Duration::ZERO;
     while elapsed < TICK {
         if state.should_stop() {
@@ -478,6 +494,10 @@ fn sleep_until_stop(state: &SpinnerState) {
 /// pure decision to [`fit_line`] so it is testable without a terminal.
 fn fit_to_width(term: &Term, line: &str) -> Option<String> {
     fit_line(term.size_checked().map(|(_rows, cols)| cols), line)
+}
+
+fn spinner_line(term: &Term, frame: usize, message: &str) -> Option<String> {
+    fit_to_width(term, &format!("{} {message}", FRAMES[frame % FRAMES.len()]))
 }
 
 /// Pure width-fitting: `Some(truncated)` when `cols` is known and greater than
@@ -513,16 +533,16 @@ fn truncate_to_width(s: &str, max: usize) -> String {
     out
 }
 
-// ── global active-spinner registry ───────────────────────────────────────────
+// ── global active-animation registry ─────────────────────────────────────────
 
-fn active_state() -> Option<Arc<SpinnerState>> {
+fn active_state() -> Option<Arc<AnimationState>> {
     match ACTIVE.lock() {
         Ok(guard) => guard.clone(),
         Err(poisoned) => poisoned.into_inner().clone(),
     }
 }
 
-fn set_active(state: Option<Arc<SpinnerState>>) {
+fn set_active(state: Option<Arc<AnimationState>>) {
     match ACTIVE.lock() {
         Ok(mut guard) => *guard = state,
         Err(poisoned) => *poisoned.into_inner() = state,
@@ -576,7 +596,7 @@ extern "C" fn on_sigint(_sig: libc::c_int) {
 
 /// Install the scoped SIGINT cleanup handler, returning the previous
 /// disposition to restore later. Best-effort: a failure yields `None` and the
-/// spinner simply falls back to "leftover frame on Ctrl+C".
+/// animation simply falls back to "leftover frame on Ctrl+C".
 fn install_sigint_cleanup() -> Option<SigAction> {
     let action = SigAction::new(
         SigHandler::Handler(on_sigint),
@@ -715,7 +735,7 @@ mod tests {
     }
 
     /// A disabled activity does nothing: it never registers as the active
-    /// spinner, and `report` is a no-op.
+    /// animation, and `report` is a no-op.
     #[test]
     fn disabled_activity_is_inert() {
         let activity = Activity::start(FeedbackMode::Disabled, "Checking for updates...");
@@ -724,10 +744,10 @@ mod tests {
         activity.report("still inert");
     }
 
-    /// With no active animated spinner, `suspend_output` is a transparent
+    /// With no active animation, `suspend_output` is a transparent
     /// passthrough that runs the closure exactly once and returns its value.
     #[test]
-    fn suspend_output_without_spinner_is_passthrough() {
+    fn suspend_output_without_animation_is_passthrough() {
         let ran = RefCell::new(0);
         let value = suspend_output(|| {
             *ran.borrow_mut() += 1;

--- a/src/anolisa/crates/anolisa-cli/src/response.rs
+++ b/src/anolisa/crates/anolisa-cli/src/response.rs
@@ -344,18 +344,14 @@ pub fn render_error(ctx: &CliContext, err: &CliError) -> ExitCode {
         };
         if let Err(serialize_err) = write_json(&response) {
             eprintln!(
-                "internal: failed to serialize error envelope: {serialize_err}; original error[{}]: {}",
-                err.code(),
-                err.reason()
+                "internal: failed to serialize error envelope: {serialize_err}; original error: {} (code: {})",
+                err.reason(),
+                err.code()
             );
         }
     } else {
         let color = Palette::new(ctx.no_color);
-        eprintln!(
-            "{} {}",
-            color.err(format!("error[{}]:", err.code())),
-            err.reason()
-        );
+        eprintln!("{} {}", color.err("error:"), err.reason());
         if let Some(hint) = err.hint() {
             eprintln!("{} {}", color.warn("hint:"), hint);
         }

--- a/src/anolisa/crates/anolisa-cli/tests/broken_pipe.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/broken_pipe.rs
@@ -96,7 +96,7 @@ fn stdout_device_failure_overrides_every_success_output_path() {
 
         assert_eq!(Some(1), output.status.code(), "stderr: {diagnostic}");
         assert!(
-            diagnostic.contains("error[EXECUTION_FAILED]: failed writing to stdout:"),
+            diagnostic.contains("error: failed writing to stdout:"),
             "stderr: {diagnostic}"
         );
     }

--- a/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
@@ -76,9 +76,35 @@ fn doctor_fix_help_matches_reserved_behavior() {
     assert!(help.contains("returns `NOT_IMPLEMENTED`"));
     assert!(!help.contains("executes the fix plan"));
 
-    let fix = run(&["doctor", "--fix"]);
+    let fix = run(&["--no-color", "doctor", "--fix"]);
     assert_eq!(Some(64), fix.status.code());
-    assert!(String::from_utf8_lossy(&fix.stderr).contains("NOT_IMPLEMENTED"));
+    assert_eq!(
+        "error: command 'doctor' is not implemented\n\
+         hint: doctor is read-only in this release; rerun without --fix to inspect fix_plan suggestions\n",
+        String::from_utf8_lossy(&fix.stderr)
+    );
+}
+
+#[test]
+fn handler_errors_use_human_labels_without_exposing_machine_codes() {
+    let human = run(&["--no-color", "update"]);
+    let stderr = String::from_utf8_lossy(&human.stderr);
+
+    assert_eq!(Some(2), human.status.code());
+    assert!(human.stdout.is_empty());
+    assert!(
+        stderr.starts_with("error: specify a component to update"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("INVALID_ARGUMENT"), "stderr: {stderr}");
+
+    let json = run(&["--json", "update"]);
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("error output must remain valid JSON");
+
+    assert_eq!(Some(2), json.status.code());
+    assert!(json.stderr.is_empty());
+    assert_eq!(Some("INVALID_ARGUMENT"), envelope["error"]["code"].as_str());
 }
 
 #[cfg(target_os = "linux")]
@@ -95,8 +121,5 @@ fn help_reports_stdout_failure_when_output_device_is_full() {
 
     // Then the CLI reports the failed stdout write instead of exiting successfully.
     assert_eq!(Some(1), output.status.code());
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("error[EXECUTION_FAILED]: failed writing to stdout:")
-    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("error: failed writing to stdout:"));
 }


### PR DESCRIPTION
## Description

Human-readable CLI output previously exposed machine-oriented error codes, while install and uninstall could spend significant time resolving repositories, running package transactions, or executing lifecycle hooks without visible activity. This change keeps stable error codes in JSON envelopes but uses a conventional `error:` label for human output, quotes actionable commands in the update notice, and extends the shared `Activity` spinner to install and uninstall phases. Transient feedback is cleared before final results and suspended around persistent warnings so terminal output remains readable. JSON, quiet, and non-TTY behavior remain unchanged, and phase-based feedback avoids inventing unreliable percentages.

## Related Issue

no-issue: follow-up CLI interaction improvements requested directly; no open tracking issue exists

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `cargo check --locked`
- `cargo doc --no-deps --locked`

The CLI suite passed 754 unit tests plus all integration tests, and the full Cargo workspace test suite passed.

## Additional Notes

No user-facing flags or structured output schemas changed, so documentation updates are not required. This extends the progress-feedback design introduced for update and upgrade in #1452 to install and uninstall.
