### PR TITLE
feat(tokenless): add shared database directory

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
@@ -164,10 +164,19 @@ Each config field can be overridden via environment variables:
 - `TOKENLESS_STATS_ENABLED` — override `stats_enabled`
 - `TOKENLESS_SLS_ENABLED` — override `sls_enabled`
 - `TOKENLESS_COMPRESSION_ENABLED` — override `compression_enabled`
+- `TOKENLESS_DATA_DIR` — directory containing `stats.db` and `stash.db`
 
-### Statistics Database
+### Local Databases
 
-Local statistics are stored in `~/.tokenless/stats.db`.
+Local statistics and reversible-compression data default to
+`~/.tokenless/stats.db` and `~/.tokenless/stash.db`. To relocate both:
+
+```bash
+export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
+```
+
+The value must be an absolute path under the real user home. Per-file
+`TOKENLESS_STATS_DB` and `TOKENLESS_STASH_DB` overrides take precedence.
 
 ---
 

--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -477,12 +477,24 @@ Priority: **env > config.json > default** (per toggle, independent). Empty value
 | `TOKENLESS_STATS_ENABLED` | Override `stats_enabled` | — |
 | `TOKENLESS_SLS_ENABLED` | Override `sls_enabled` | — |
 | `TOKENLESS_COMPRESSION_ENABLED` | Override `compression_enabled` (dry-run toggle) | — |
+| `TOKENLESS_DATA_DIR` | Directory containing `stats.db` and `stash.db` | Absolute path under the real user home |
 | `TOKENLESS_STATS_DB` | Custom stats DB path | Must be under the user's home dir, else ignored + warned |
+| `TOKENLESS_STASH_DB` | Custom stash DB path | Must be under the user's home dir, else ignored + warned |
 | `TOKENLESS_SLS_PATH` | Custom SLS JSONL path | Must be under `/var/log/` or `/tmp/`, else fallback |
 | `TOKENLESS_TOOL_READY_SPEC` | Custom tool-ready-spec path | Must pass trust-path check |
 | `TOKENLESS_ENV_FIX_SCRIPT` | Custom env-fix script path | Must pass trust-path check |
 | `TOKENLESS_PACKAGE_MANAGER` | Override package-manager detection (dnf/yum/apt/apk) | Testing |
 | `TOKENLESS_AGENT_ID` | Agent identity injected by hooks | Set automatically by cosh-extension.json |
+
+Database path priority is:
+
+- Stats: `TOKENLESS_STATS_DB` > `TOKENLESS_DATA_DIR/stats.db` > `~/.tokenless/stats.db`
+- Stash: `--stash-db` > `TOKENLESS_STASH_DB` > `TOKENLESS_DATA_DIR/stash.db` > `~/.tokenless/stash.db`
+
+An empty value is treated as unset. `TOKENLESS_DATA_DIR` may name a directory
+that does not exist yet; Tokenless creates it after validating its nearest
+existing ancestor. It does not relocate `~/.tokenless/config.json` or the SLS
+JSONL output.
 
 ### OpenClaw plugin config (`openclaw.plugin.json`)
 
@@ -536,7 +548,7 @@ tokenless env-check --all --checklist
 | `JSON parse error` | Invalid JSON; validate with `jq . < input.json` |
 | Original emitted + stderr notice | No compression savings (`after >= before`); normal; not recorded |
 | dry-run notice | `TOKENLESS_COMPRESSION_ENABLED=0` or config `compression_enabled=false`; original emitted, prediction recorded |
-| `Failed to open database` | `~/.tokenless/` not writable, or `TOKENLESS_STATS_DB` rejected as outside home |
+| `Failed to open database` | Selected data directory not writable, or a database path override was rejected as outside home |
 | SLS JSONL not generated | Confirm `TOKENLESS_SLS_ENABLED` is not `0`; `TOKENLESS_SLS_PATH` must be under `/var/log/` or `/tmp/`; file must be pre-created by the anolisa SLS component |
 | cosh hook not firing | Confirm `cosh-extension.json` exists in `COSH_EXTENSION_DIR`; restart copilot-shell |
 | `jq not installed` | `dnf install jq` / `apt install jq` |
@@ -634,7 +646,7 @@ All hooks receive `TOKENLESS_AGENT_ID=copilot-shell`. Auxiliary files: `hook_uti
 ### Security model
 
 - **Unforgeable identity source**: home dir resolved via `getpwuid_r(getuid())` (passwd), **not** `$HOME`/`dirs::home_dir()` (user-controllable).
-- **Database path validation**: `TOKENLESS_STATS_DB` must canonicalize under the user's real home dir, else ignored + warned; empty home → `/dev/null/.tokenless/stats.db` (safe failure).
+- **Database path validation**: `TOKENLESS_DATA_DIR`, `TOKENLESS_STATS_DB`, and `TOKENLESS_STASH_DB` must resolve under the user's real home dir, else they are ignored + warned; empty home → stats writes fail safely and stash is disabled.
 - **SLS path validation**: `TOKENLESS_SLS_PATH` must be under `/var/log/` or `/tmp/` with no `..`; canonicalized check prevents symlink escape.
 - **Tool Ready trust path**: system prefixes (`/usr/share`, `/usr/libexec`, `/usr/lib/anolisa`, `/usr/local/share`) trusted unconditionally; other paths validate file/parent-dir ownership (current_uid or root) and reject world-writable bits. The shell equivalent in `tool_ready_hook.sh` is kept in sync.
 - **Config file permissions**: `~/.tokenless/config.json` is chmod 0600 after write.

--- a/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
@@ -163,10 +163,19 @@ Total         21,392         56.1%
 - `TOKENLESS_STATS_ENABLED` — 覆盖 `stats_enabled`
 - `TOKENLESS_SLS_ENABLED` — 覆盖 `sls_enabled`
 - `TOKENLESS_COMPRESSION_ENABLED` — 覆盖 `compression_enabled`
+- `TOKENLESS_DATA_DIR` — 存放 `stats.db` 和 `stash.db` 的目录
 
-### 统计数据库
+### 本地数据库
 
-本地统计数据存储于 `~/.tokenless/stats.db`。
+本地统计数据和可逆压缩数据默认分别存储于 `~/.tokenless/stats.db` 和
+`~/.tokenless/stash.db`。如需同时迁移两者：
+
+```bash
+export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
+```
+
+该值必须是位于真实用户 home 下的绝对路径。单文件覆盖项
+`TOKENLESS_STATS_DB` 和 `TOKENLESS_STASH_DB` 的优先级更高。
 
 ---
 

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -472,12 +472,23 @@ RTK 源码由 justfile 从 GitHub 克隆（`v0.43.0`）并应用 tokenless 专�
 | `TOKENLESS_STATS_ENABLED` | 覆盖 `stats_enabled` | — |
 | `TOKENLESS_SLS_ENABLED` | 覆盖 `sls_enabled` | — |
 | `TOKENLESS_COMPRESSION_ENABLED` | 覆盖 `compression_enabled`（dry-run 开关） | — |
+| `TOKENLESS_DATA_DIR` | 存放 `stats.db` 和 `stash.db` 的目录 | 须为真实用户 home 下的绝对路径 |
 | `TOKENLESS_STATS_DB` | 自定义统计数据库路径 | 须位于用户 home 下，否则忽略并告警 |
+| `TOKENLESS_STASH_DB` | 自定义 stash 数据库路径 | 须位于用户 home 下，否则忽略并告警 |
 | `TOKENLESS_SLS_PATH` | 自定义 SLS JSONL 路径 | 须位于 `/var/log/` 或 `/tmp/` 下，否则回退默认 |
 | `TOKENLESS_TOOL_READY_SPEC` | 自定义 tool-ready-spec 路径 | 须通过信任路径校验 |
 | `TOKENLESS_ENV_FIX_SCRIPT` | 自定义 env-fix 脚本路径 | 须通过信任路径校验 |
 | `TOKENLESS_PACKAGE_MANAGER` | 覆盖包管理器探测（dnf/yum/apt/apk） | 测试用 |
 | `TOKENLESS_AGENT_ID` | hook 注入的 agent 标识 | 由 cosh-extension.json 自动设置 |
+
+数据库路径优先级如下：
+
+- 统计库：`TOKENLESS_STATS_DB` > `TOKENLESS_DATA_DIR/stats.db` > `~/.tokenless/stats.db`
+- stash 库：`--stash-db` > `TOKENLESS_STASH_DB` > `TOKENLESS_DATA_DIR/stash.db` > `~/.tokenless/stash.db`
+
+空值视为未设置。`TOKENLESS_DATA_DIR` 可以指向尚不存在的目录；Tokenless
+会先校验其最近的已存在父目录，再创建目标目录。该变量不会迁移
+`~/.tokenless/config.json` 或 SLS JSONL 输出。
 
 ### OpenClaw 插件配置（`openclaw.plugin.json`）
 
@@ -531,7 +542,7 @@ tokenless env-check --all --checklist
 | `JSON parse error` | 输入非合法 JSON；先用 `jq . < input.json` 校验 |
 | 压缩后输出原文 + stderr 提示 | 压缩无收益（`after >= before`），属正常；该次不记录统计 |
 | dry-run 模式提示 | `TOKENLESS_COMPRESSION_ENABLED=0` 或 config `compression_enabled=false`；输出原文但记录预测值 |
-| `Failed to open database` | `~/.tokenless/` 不可写或 `TOKENLESS_STATS_DB` 路径在 home 之外被拒 |
+| `Failed to open database` | 选定的数据目录不可写，或数据库路径覆盖项因位于 home 之外而被拒 |
 | SLS JSONL 未生成 | 确认 `TOKENLESS_SLS_ENABLED` 未设为 `0`；`TOKENLESS_SLS_PATH` 须在 `/var/log/` 或 `/tmp/` 下；文件须由 anolisa SLS 组件预建 |
 | cosh Hook 不触发 | 确认 `COSH_EXTENSION_DIR` 存在 `cosh-extension.json`；重启 copilot-shell |
 | `jq not installed` | `dnf install jq` / `apt install jq` |
@@ -629,7 +640,7 @@ make adapter-scan         # 查看已注册适配器能力
 ### 安全模型
 
 - **不可伪造的身份源**：home 目录通过 `getpwuid_r(getuid())` 查询 passwd，**不信任** `$HOME`/`dirs::home_dir()`（可被任意改写）。
-- **数据库路径校验**：`TOKENLESS_STATS_DB` 必须规范解析后位于用户真实 home 下，否则忽略并告警；home 为空时写入 `/dev/null/.tokenless/stats.db`（安全失败）。
+- **数据库路径校验**：`TOKENLESS_DATA_DIR`、`TOKENLESS_STATS_DB` 和 `TOKENLESS_STASH_DB` 必须解析到用户真实 home 下，否则忽略并告警；home 为空时统计写入安全失败并禁用 stash。
 - **SLS 路径校验**：`TOKENLESS_SLS_PATH` 必须位于 `/var/log/` 或 `/tmp/` 前缀下且不含 `..`；canonicalize 后校验防符号链接逃逸。
 - **Tool Ready 信任路径**：系统前缀（`/usr/share`、`/usr/libexec`、`/usr/lib/anolisa`、`/usr/local/share`）直接信任；其他路径校验文件/父目录 owner（须为 current_uid 或 root）且非 world-writable。`tool_ready_hook.sh` 中的 shell 实现保持同步。
 - **配置文件权限**：`~/.tokenless/config.json` 写入后 chmod 0600。

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -199,6 +199,20 @@ stored output/input content matches exactly, avoiding duplicate intermediate
 token counts. See the [user manual](../../docs/user-guide/en/token-saving/tokenless/user-manual.md#statistics--measurement)
 for options and measurement limits.
 
+### Database location
+
+Tokenless stores statistics and reversible-compression data in
+`~/.tokenless/stats.db` and `~/.tokenless/stash.db`. Set one directory for both:
+
+```bash
+export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
+```
+
+The directory must be an absolute path under the real user home. The existing
+`TOKENLESS_STATS_DB`, `TOKENLESS_STASH_DB`, and `--stash-db` overrides take
+precedence when only one database needs a custom path. Configuration remains
+at `~/.tokenless/config.json`.
+
 ## copilot-shell Hooks
 
 The adapter provides hooks that are auto-discovered by copilot-shell via the cosh extension manifest:

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -96,6 +96,20 @@ diff。只有相邻 active 阶段的输出与输入内容完全一致时才会�
 从而避免重复计算中间阶段的 Token。完整选项和度量限制见
 [用户手册](../../docs/user-guide/zh/token-saving/tokenless/user-manual.md#统计与效果度量)。
 
+## 数据库位置
+
+Tokenless 默认将统计数据和可逆压缩数据分别存储在
+`~/.tokenless/stats.db` 与 `~/.tokenless/stash.db`。可为两个数据库统一
+指定目录：
+
+```bash
+export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
+```
+
+该目录必须是位于真实用户 home 下的绝对路径。若只需自定义一个数据库，
+现有的 `TOKENLESS_STATS_DB`、`TOKENLESS_STASH_DB` 和 `--stash-db` 覆盖项
+优先级更高。配置文件仍位于 `~/.tokenless/config.json`。
+
 ## 架构
 
 - `crates/tokenless-schema/` — 核心库：SchemaCompressor + ResponseCompressor

--- a/src/tokenless/adapters/tokenless/codex/README.md
+++ b/src/tokenless/adapters/tokenless/codex/README.md
@@ -96,7 +96,13 @@ Configuration is managed through the `tokenless` CLI's environment and config fi
 | `TOKENLESS_AGENT_ID` | `codex` | Agent identifier for statistics |
 | `TOKENLESS_BIN` | (auto-detected) | Path to tokenless binary |
 | `TOKENLESS_STATS_ENABLED` | `1` | Enable statistics recording |
+| `TOKENLESS_DATA_DIR` | `~/.tokenless` | Directory for `stats.db` and `stash.db` |
 | `TOKENLESS_STATS_DB` | `~/.tokenless/stats.db` | Statistics database path |
+| `TOKENLESS_STASH_DB` | `~/.tokenless/stash.db` | Reversible stash database path |
+
+`TOKENLESS_STATS_DB` and `TOKENLESS_STASH_DB` take precedence over
+`TOKENLESS_DATA_DIR`. Custom database paths must remain under the real user
+home.
 
 ### View Statistics
 

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -52,7 +52,8 @@ enum Commands {
         /// flag makes truncation lossy (the pre-stash behavior).
         #[arg(long)]
         no_stash: bool,
-        /// Override the stash database path (default ~/.tokenless/stash.db).
+        /// Override the stash database path. Defaults to
+        /// $TOKENLESS_DATA_DIR/stash.db or ~/.tokenless/stash.db.
         /// Resolved under the trusted home directory; rejected if outside.
         #[arg(long)]
         stash_db: Option<String>,
@@ -84,7 +85,8 @@ enum Commands {
         /// flag makes truncation lossy (the pre-stash behavior).
         #[arg(long)]
         no_stash: bool,
-        /// Override the stash database path (default ~/.tokenless/stash.db).
+        /// Override the stash database path. Defaults to
+        /// $TOKENLESS_DATA_DIR/stash.db or ~/.tokenless/stash.db.
         /// Resolved under the trusted home directory; rejected if outside.
         #[arg(long)]
         stash_db: Option<String>,
@@ -95,7 +97,8 @@ enum Commands {
     Retrieve {
         /// The stash hash, or a line containing a `<<tokenless:HASH>>` marker.
         hash: String,
-        /// Override the stash database path (default ~/.tokenless/stash.db).
+        /// Override the stash database path. Defaults to
+        /// $TOKENLESS_DATA_DIR/stash.db or ~/.tokenless/stash.db.
         #[arg(long)]
         stash_db: Option<String>,
     },
@@ -311,13 +314,106 @@ pub fn get_home_dir() -> String {
     tokenless_stats::get_home_dir()
 }
 
+/// Validate a custom tokenless data directory against the user's home.
+///
+/// Unlike database file overrides, the directory may not exist yet. The
+/// nearest existing ancestor is canonicalized so a symlink cannot redirect
+/// the eventual directory outside the trusted home. Validation and later
+/// directory creation are separate filesystem operations, so callers must
+/// not treat this check as protection from concurrent path replacement.
+fn validate_data_dir_path(env_path: &str, home: &str) -> Result<String, String> {
+    if home.is_empty() {
+        return Err("no trusted home directory available".to_string());
+    }
+
+    let canonical_home = std::path::Path::new(home)
+        .canonicalize()
+        .map_err(|e| format!("home directory '{}' cannot be resolved: {}", home, e))?;
+    let candidate = std::path::Path::new(env_path);
+    if !candidate.is_absolute() {
+        return Err(format!("path '{}' is not absolute", env_path));
+    }
+    if candidate
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(format!("path '{}' contains parent traversal", env_path));
+    }
+    if candidate.exists() && !candidate.is_dir() {
+        return Err(format!("path '{}' is not a directory", env_path));
+    }
+
+    let mut existing_ancestor = candidate;
+    while !existing_ancestor.exists() {
+        existing_ancestor = existing_ancestor
+            .parent()
+            .ok_or_else(|| format!("path '{}' has no existing ancestor to validate", env_path))?;
+    }
+    let resolved_ancestor = existing_ancestor
+        .canonicalize()
+        .map_err(|e| format!("path '{}' cannot be resolved: {}", env_path, e))?;
+    if !resolved_ancestor.starts_with(&canonical_home) {
+        return Err(format!(
+            "path '{}' is outside home directory '{}'",
+            env_path, home
+        ));
+    }
+
+    Ok(env_path.to_string())
+}
+
+/// Resolve the directory containing tokenless SQLite databases.
+///
+/// `TOKENLESS_DATA_DIR` affects `stats.db` and `stash.db` only. Invalid
+/// overrides are ignored in favor of the existing `~/.tokenless` default.
+/// Returns an error when no trusted home anchor exists.
+fn get_data_dir(home: &str) -> Result<String, String> {
+    if home.is_empty() {
+        return Err("no trusted home directory available".to_string());
+    }
+
+    let data_dir = match std::env::var("TOKENLESS_DATA_DIR") {
+        Ok(env_path) if !env_path.is_empty() => match validate_data_dir_path(&env_path, home) {
+            Ok(path) => path,
+            Err(reason) => {
+                eprintln!("[tokenless] ignoring TOKENLESS_DATA_DIR: {}", reason);
+                format!("{}/.tokenless", home)
+            }
+        },
+        _ => format!("{}/.tokenless", home),
+    };
+    Ok(data_dir)
+}
+
+// Lazily snapshot path inputs for one command so stats and stash share the
+// same passwd lookup and data-directory validation without global caching.
+#[derive(Default)]
+struct DatabasePathResolver {
+    home: std::sync::OnceLock<String>,
+    data_dir: std::sync::OnceLock<Result<String, String>>,
+}
+
+impl DatabasePathResolver {
+    fn home(&self) -> &str {
+        self.home.get_or_init(get_home_dir)
+    }
+
+    fn data_dir(&self) -> Result<&str, &str> {
+        self.data_dir
+            .get_or_init(|| get_data_dir(self.home()))
+            .as_ref()
+            .map(String::as_str)
+            .map_err(String::as_str)
+    }
+}
+
 /// Resolve the database path. When `TOKENLESS_STATS_DB` is set, the path
 /// is validated to ensure it resides under the user's home directory;
-/// otherwise the env var is ignored and the default path is used. This
-/// prevents an attacker from redirecting the database to a system-critical
-/// location (e.g. `/etc/evil.db`).
-fn get_db_path() -> String {
-    let home = get_home_dir();
+/// otherwise `TOKENLESS_DATA_DIR` and then the default data directory are
+/// used. This prevents an attacker from redirecting the database to a
+/// system-critical location (e.g. `/etc/evil.db`).
+fn get_db_path_with(paths: &DatabasePathResolver) -> String {
+    let home = paths.home();
     // When no trusted home is available (empty string from passwd lookup
     // failure), return a path that will safely fail on open/create rather
     // than silently writing to / or CWD.
@@ -326,13 +422,23 @@ fn get_db_path() -> String {
         return "/dev/null/.tokenless/stats.db".to_string();
     }
     match std::env::var("TOKENLESS_STATS_DB") {
-        Ok(env_path) if !env_path.is_empty() => match validate_db_path(&env_path, &home) {
+        Ok(env_path) if !env_path.is_empty() => match validate_db_path(&env_path, home) {
             Ok(path) => return path,
             Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STATS_DB: {}", reason),
         },
         _ => {}
     }
-    format!("{}/.tokenless/stats.db", home)
+    let data_dir = match paths.data_dir() {
+        Ok(path) => path,
+        Err(reason) => {
+            eprintln!("[tokenless] {} — stats DB writes disabled", reason);
+            return "/dev/null/.tokenless/stats.db".to_string();
+        }
+    };
+    std::path::Path::new(&data_dir)
+        .join("stats.db")
+        .to_string_lossy()
+        .into_owned()
 }
 
 /// Validate a TOKENLESS_STATS_DB candidate against the user's home directory.
@@ -384,8 +490,7 @@ fn validate_db_path(env_path: &str, home: &str) -> Result<String, String> {
     }
 }
 
-fn ensure_db_dir() -> Result<(), (String, i32)> {
-    let db_path = get_db_path();
+fn ensure_db_dir(db_path: &str) -> Result<(), (String, i32)> {
     if let Some(parent) = std::path::Path::new(&db_path).parent() {
         fs::create_dir_all(parent)
             .map_err(|e| (format!("Failed to create database directory: {}", e), 1))?;
@@ -394,8 +499,13 @@ fn ensure_db_dir() -> Result<(), (String, i32)> {
 }
 
 fn open_recorder() -> Result<StatsRecorder, (String, i32)> {
-    ensure_db_dir()?;
-    StatsRecorder::new(get_db_path()).map_err(|e| (format!("Failed to open database: {}", e), 1))
+    open_recorder_with(&DatabasePathResolver::default())
+}
+
+fn open_recorder_with(paths: &DatabasePathResolver) -> Result<StatsRecorder, (String, i32)> {
+    let db_path = get_db_path_with(paths);
+    ensure_db_dir(&db_path)?;
+    StatsRecorder::new(db_path).map_err(|e| (format!("Failed to open database: {}", e), 1))
 }
 
 /// Resolve the stash database path under the trusted home directory.
@@ -406,8 +516,11 @@ fn open_recorder() -> Result<StatsRecorder, (String, i32)> {
 /// `None` when no trusted home anchor exists or an override is rejected —
 /// callers fail open (no stash, lossy truncation) rather than writing state
 /// to an untrusted location.
-fn get_stash_db_path(override_path: Option<&str>) -> Option<String> {
-    let home = get_home_dir();
+fn get_stash_db_path_with(
+    paths: &DatabasePathResolver,
+    override_path: Option<&str>,
+) -> Option<String> {
+    let home = paths.home();
     if home.is_empty() {
         eprintln!("[tokenless] no home directory available — stash disabled");
         return None;
@@ -417,28 +530,46 @@ fn get_stash_db_path(override_path: Option<&str>) -> Option<String> {
     // default under the trusted home (rather than silently disabling the
     // stash), so a typo doesn't quietly drop reversibility.
     if let Some(p) = override_path.filter(|s| !s.is_empty()) {
-        match validate_db_path(p, &home) {
+        match validate_db_path(p, home) {
             Ok(valid) => return Some(valid),
             Err(reason) => eprintln!("[tokenless] rejecting --stash-db {}: {}", p, reason),
         }
     }
-    match std::env::var("TOKENLESS_STASH_DB") {
-        Ok(env_path) if !env_path.is_empty() => match validate_db_path(&env_path, &home) {
-            Ok(path) => Some(path),
-            Err(reason) => {
-                eprintln!("[tokenless] ignoring TOKENLESS_STASH_DB: {}", reason);
-                Some(format!("{}/.tokenless/stash.db", home))
-            }
-        },
-        _ => Some(format!("{}/.tokenless/stash.db", home)),
+    if let Ok(env_path) = std::env::var("TOKENLESS_STASH_DB")
+        && !env_path.is_empty()
+    {
+        match validate_db_path(&env_path, home) {
+            Ok(path) => return Some(path),
+            Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STASH_DB: {}", reason),
+        }
     }
+    let data_dir = match paths.data_dir() {
+        Ok(path) => path,
+        Err(reason) => {
+            eprintln!("[tokenless] {} — stash disabled", reason);
+            return None;
+        }
+    };
+    Some(
+        std::path::Path::new(&data_dir)
+            .join("stash.db")
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 /// Open a stash store, returning the specific failure cause. Used by
 /// user-initiated paths (`retrieve`) where a generic "unavailable" message
 /// would hide the real reason (no home, path rejected, corrupt DB, …).
 fn open_stash_store_or_err(override_path: Option<&str>) -> Result<Arc<dyn StashStore>, String> {
-    let path = get_stash_db_path(override_path)
+    open_stash_store_or_err_with(&DatabasePathResolver::default(), override_path)
+}
+
+fn open_stash_store_or_err_with(
+    paths: &DatabasePathResolver,
+    override_path: Option<&str>,
+) -> Result<Arc<dyn StashStore>, String> {
+    let path = get_stash_db_path_with(paths, override_path)
         .ok_or_else(|| "no trusted home directory available for stash db".to_string())?;
     if let Some(parent) = std::path::Path::new(&path).parent() {
         fs::create_dir_all(parent)
@@ -453,7 +584,14 @@ fn open_stash_store_or_err(override_path: Option<&str>) -> Result<Arc<dyn StashS
 /// proceeds without stash (lossy truncation) when the home anchor is missing,
 /// the parent directory cannot be created, or the database cannot be opened.
 fn open_stash_store(override_path: Option<&str>) -> Option<Arc<dyn StashStore>> {
-    match open_stash_store_or_err(override_path) {
+    open_stash_store_with(&DatabasePathResolver::default(), override_path)
+}
+
+fn open_stash_store_with(
+    paths: &DatabasePathResolver,
+    override_path: Option<&str>,
+) -> Option<Arc<dyn StashStore>> {
+    match open_stash_store_or_err_with(paths, override_path) {
         Ok(store) => Some(store),
         Err(e) => {
             eprintln!("[tokenless] stash disabled: {}", e);
@@ -488,11 +626,12 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             // markers never reach the LLM (the original input is emitted),
             // orphaning them.
             let config = TokenlessConfig::load();
+            let database_paths = DatabasePathResolver::default();
             let compression_on = config.is_compression_enabled();
             let stash = if no_stash || !compression_on {
                 None
             } else {
-                open_stash_store(stash_db.as_deref())
+                open_stash_store_with(&database_paths, stash_db.as_deref())
             };
             let mut compressor = SchemaCompressor::new();
             if let Some(ref store) = stash {
@@ -538,6 +677,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
 
             record_compression_stats(
                 &config,
+                &database_paths,
                 OperationType::CompressSchema,
                 agent_id,
                 session_id,
@@ -581,11 +721,12 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             // markers never reach the LLM (the original input is emitted),
             // orphaning them.
             let config = TokenlessConfig::load();
+            let database_paths = DatabasePathResolver::default();
             let compression_on = config.is_compression_enabled();
             let stash = if no_stash || !compression_on {
                 None
             } else {
-                open_stash_store(stash_db.as_deref())
+                open_stash_store_with(&database_paths, stash_db.as_deref())
             };
             if let Some(ref store) = stash {
                 compressor = compressor.with_stash_store(store.clone());
@@ -639,6 +780,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
 
             record_compression_stats(
                 &config,
+                &database_paths,
                 OperationType::CompressResponse,
                 agent_id,
                 session_id,
@@ -916,8 +1058,10 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             // Recorded `after` = the predicted TOON result (or original when
             // TOON did not reduce size), so dry-run captures the prediction.
             let record_after = if no_savings { input.clone() } else { output };
+            let database_paths = DatabasePathResolver::default();
             record_compression_stats(
                 &config,
+                &database_paths,
                 OperationType::CompressToon,
                 agent_id,
                 session_id,
@@ -1006,6 +1150,7 @@ fn warn_mode_mismatch(label: &str, records: &[StatsRecord], expected: Compressio
 #[allow(clippy::too_many_arguments)]
 fn record_compression_stats(
     config: &TokenlessConfig,
+    database_paths: &DatabasePathResolver,
     op: OperationType,
     agent_id: Option<String>,
     session_id: Option<String>,
@@ -1060,7 +1205,7 @@ fn record_compression_stats(
 
     // SQLite stats recording — gated by stats_enabled
     if config.is_stats_enabled()
-        && let Ok(recorder) = open_recorder()
+        && let Ok(recorder) = open_recorder_with(database_paths)
     {
         let _ = recorder.record(&record);
     }

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -2,6 +2,13 @@ use std::sync::Mutex;
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
+fn default_path_resolver(home: &str) -> DatabasePathResolver {
+    DatabasePathResolver {
+        home: std::sync::OnceLock::from(home.to_string()),
+        data_dir: std::sync::OnceLock::from(Ok(format!("{home}/.tokenless"))),
+    }
+}
+
 struct TempDbGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     test_dir: String,
@@ -180,6 +187,79 @@ fn validate_db_path_rejects_parent_dir_bypass_with_nonexistent_parent() {
 }
 
 #[test]
+fn validate_data_dir_path_accepts_nonexistent_descendant() {
+    let home = temp_subdir("data-dir-home");
+    let candidate = home.join("nested/data");
+    let result =
+        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap();
+    assert_eq!(result, candidate.to_str().unwrap());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn get_data_dir_rejects_empty_home() {
+    let err = get_data_dir("").unwrap_err();
+    assert!(err.contains("no trusted home"));
+}
+
+#[test]
+fn validate_data_dir_path_rejects_outside_home() {
+    let home = temp_subdir("data-dir-outside-home");
+    let outside = temp_subdir("data-dir-outside-candidate");
+    let err =
+        validate_data_dir_path(outside.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
+    assert!(err.contains("outside home"));
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&outside).ok();
+}
+
+#[test]
+fn validate_data_dir_path_rejects_relative_path() {
+    let home = temp_subdir("data-dir-relative");
+    let err = validate_data_dir_path("relative/data", home.to_str().unwrap()).unwrap_err();
+    assert!(err.contains("not absolute"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn validate_data_dir_path_rejects_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let home = temp_subdir("data-dir-symlink-home");
+    let outside = temp_subdir("data-dir-symlink-outside");
+    let link = home.join("redirect");
+    symlink(&outside, &link).unwrap();
+    let candidate = link.join("data");
+    let err =
+        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
+    assert!(err.contains("outside home"));
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&outside).ok();
+}
+
+#[test]
+fn validate_data_dir_path_rejects_parent_traversal() {
+    let home = temp_subdir("data-dir-traversal");
+    let candidate = home.join("nested/../data");
+    let err =
+        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
+    assert!(err.contains("parent traversal"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn validate_data_dir_path_rejects_existing_file() {
+    let home = temp_subdir("data-dir-file");
+    let candidate = home.join("not-a-directory");
+    std::fs::write(&candidate, "").unwrap();
+    let err =
+        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
+    assert!(err.contains("not a directory"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn read_input_from_file() {
     let dir = tempfile::tempdir().unwrap();
     let f = dir.path().join("input.json");
@@ -252,7 +332,7 @@ fn get_stash_db_path_default() {
     if home.is_empty() {
         return;
     }
-    let path = get_stash_db_path(None);
+    let path = get_stash_db_path_with(&default_path_resolver(&home), None);
     assert!(path.is_some());
     assert!(path.unwrap().contains(".tokenless/stash.db"));
 }
@@ -262,7 +342,10 @@ fn get_stash_db_path_with_valid_override() {
     let guard = match TempDbGuard::new() { Some(g) => g, None => return };
     // Use the temp stash path as an explicit override; get_stash_db_path
     // validates it (under home via TempDbGuard) and returns it directly.
-    let result = get_stash_db_path(Some(guard.stash_db_path()));
+    let result = get_stash_db_path_with(
+        &DatabasePathResolver::default(),
+        Some(guard.stash_db_path()),
+    );
     assert_eq!(result, Some(guard.stash_db_path().to_string()));
 }
 
@@ -288,7 +371,7 @@ fn ensure_db_dir_creates_parent() {
 
     // ensure_db_dir is idempotent — calling it when the dir already exists
     // (which it does for most test envs) succeeds.
-    let result = ensure_db_dir();
+    let result = ensure_db_dir(&get_db_path_with(&DatabasePathResolver::default()));
     // With TempDbGuard the stats DB path points to a temp dir, so this succeeds.
     assert!(result.is_ok());
 }
@@ -303,6 +386,7 @@ fn record_compression_stats_skips_when_both_disabled() {
     // Should return immediately without touching DB
     record_compression_stats(
         &config,
+        &DatabasePathResolver::default(),
         OperationType::CompressSchema,
         Some("test".to_string()),
         None,
@@ -322,6 +406,7 @@ fn record_compression_stats_skips_when_no_savings() {
     // after is larger than before → no savings → skip
     record_compression_stats(
         &config,
+        &DatabasePathResolver::default(),
         OperationType::CompressSchema,
         Some("test".to_string()),
         None,
@@ -343,6 +428,7 @@ fn record_compression_stats_records_when_savings_exist() {
     let short_after = "y".repeat(50);
     record_compression_stats(
         &config,
+        &DatabasePathResolver::default(),
         OperationType::CompressSchema,
         Some("test-agent".to_string()),
         Some("session-1".to_string()),
@@ -364,6 +450,7 @@ fn record_compression_stats_records_dryrun_mode() {
     let short_after = "y".repeat(50);
     record_compression_stats(
         &config,
+        &DatabasePathResolver::default(),
         OperationType::CompressResponse,
         None,
         None,
@@ -380,7 +467,7 @@ fn record_compression_stats_records_dryrun_mode() {
 #[test]
 fn get_db_path_returns_valid_path() {
     let _guard = match TempDbGuard::new() { Some(g) => g, None => return };
-    let db_path = get_db_path();
+    let db_path = get_db_path_with(&DatabasePathResolver::default());
     assert!(db_path.contains("stats.db"));
 }
 
@@ -1009,7 +1096,7 @@ fn get_stash_db_path_returns_valid() {
     if home.is_empty() {
         return;
     }
-    let path = get_stash_db_path(None);
+    let path = get_stash_db_path_with(&default_path_resolver(&home), None);
     assert!(path.is_some());
     assert!(path.unwrap().contains(".tokenless/stash.db"));
 }
@@ -1021,7 +1108,10 @@ fn get_stash_db_path_with_bad_override() {
     if home.is_empty() {
         return;
     }
-    let path = get_stash_db_path(Some("/nonexistent/deep/dir/stash.db"));
+    let path = get_stash_db_path_with(
+        &default_path_resolver(&home),
+        Some("/nonexistent/deep/dir/stash.db"),
+    );
     // Bad override is rejected, falls back to default
     assert!(path.is_some());
     assert!(path.unwrap().contains(".tokenless/stash.db"));
@@ -1085,6 +1175,7 @@ fn record_compression_stats_sls_only_path() {
     let short_after = "y".repeat(50);
     record_compression_stats(
         &config,
+        &DatabasePathResolver::default(),
         OperationType::CompressResponse,
         Some("sls-test".to_string()),
         Some("sls-session".to_string()),
@@ -1106,6 +1197,7 @@ fn record_compression_stats_full_path() {
     let short_after = "w".repeat(100);
     record_compression_stats(
         &config,
+        &DatabasePathResolver::default(),
         OperationType::CompressSchema,
         Some("full-agent".to_string()),
         Some("full-session".to_string()),
@@ -1124,6 +1216,7 @@ fn record_compression_stats_no_savings() {
     let config = TokenlessConfig { stats_enabled: true, ..Default::default() };
     record_compression_stats(
         &config,
+        &DatabasePathResolver::default(),
         OperationType::CompressResponse,
         None,
         None,

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -65,6 +65,121 @@ impl Drop for TempStatsDb {
     }
 }
 
+struct TempDataDir {
+    root: std::path::PathBuf,
+    data_dir: std::path::PathBuf,
+}
+
+impl TempDataDir {
+    fn new() -> Option<Self> {
+        let home = get_home_dir();
+        if home.is_empty() {
+            return None;
+        }
+        let unique = format!(
+            ".tokenless-data-dir-integration-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?
+                .as_nanos()
+        );
+        let root = std::path::PathBuf::from(home).join(unique);
+        std::fs::create_dir_all(&root).ok()?;
+        let data_dir = root.join("databases");
+        Some(Self { root, data_dir })
+    }
+
+    fn command(&self) -> Command {
+        let mut command = tokenless_bin();
+        command
+            .env("TOKENLESS_DATA_DIR", &self.data_dir)
+            .env_remove("TOKENLESS_STATS_DB")
+            .env_remove("TOKENLESS_STASH_DB");
+        command
+    }
+}
+
+impl Drop for TempDataDir {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.root).ok();
+    }
+}
+
+#[test]
+fn data_dir_env_routes_stats_and_stash_databases() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+
+    let stats_output = fixture
+        .command()
+        .args(["stats", "summary"])
+        .output()
+        .unwrap();
+    assert!(
+        stats_output.status.success(),
+        "stats command failed: {}",
+        String::from_utf8_lossy(&stats_output.stderr)
+    );
+    assert!(fixture.data_dir.join("stats.db").is_file());
+
+    let stash_output = fixture
+        .command()
+        .args(["retrieve", "abcdef0123456789abcdef01"])
+        .output()
+        .unwrap();
+    assert!(!stash_output.status.success());
+    assert!(fixture.data_dir.join("stash.db").is_file());
+}
+
+#[test]
+fn stats_db_env_takes_precedence_over_data_dir() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let explicit_dir = fixture.root.join("explicit");
+    std::fs::create_dir_all(&explicit_dir).unwrap();
+    let explicit_db = explicit_dir.join("stats.db");
+
+    let output = fixture
+        .command()
+        .env("TOKENLESS_STATS_DB", &explicit_db)
+        .args(["stats", "summary"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stats command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(explicit_db.is_file());
+    assert!(!fixture.data_dir.join("stats.db").exists());
+}
+
+#[test]
+fn stash_db_env_takes_precedence_over_data_dir() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let explicit_dir = fixture.root.join("explicit");
+    std::fs::create_dir_all(&explicit_dir).unwrap();
+    let explicit_db = explicit_dir.join("stash.db");
+
+    let output = fixture
+        .command()
+        .env("TOKENLESS_STASH_DB", &explicit_db)
+        .args(["retrieve", "abcdef0123456789abcdef01"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(explicit_db.is_file());
+    assert!(!fixture.data_dir.join("stash.db").exists());
+}
+
 #[test]
 fn compress_schema_from_stdin() {
     let schema = r#"{"function":{"name":"test","description":"A test function","parameters":{"type":"object","properties":{"x":{"type":"string","title":"Remove Me","examples":["ex1"]}}}}}"#;

--- a/src/tokenless/docs/stash-reversible-compression.md
+++ b/src/tokenless/docs/stash-reversible-compression.md
@@ -91,18 +91,22 @@ echo '[...]' | tokenless compress-response --no-stash
 tokenless retrieve <hash> --stash-db ~/.tokenless/alt-stash.db
 ```
 
-`TOKENLESS_STASH_DB` mirrors `TOKENLESS_STATS_DB` as an env override.
+`TOKENLESS_DATA_DIR` relocates both SQLite databases, producing
+`$TOKENLESS_DATA_DIR/stash.db` and `$TOKENLESS_DATA_DIR/stats.db`.
+`TOKENLESS_STASH_DB` mirrors `TOKENLESS_STATS_DB` as a higher-priority
+single-file override.
 
 ## Security model
 
 The stash db path is resolved under the **trusted home directory** — derived
 from `getpwuid_r(getuid())`, never from `$HOME` (which a parent process can
 spoof to redirect state into attacker-writable paths). An override
-(`--stash-db` or `TOKENLESS_STASH_DB`) is validated by canonicalizing both the
-home anchor and the candidate and requiring the candidate to live under the
-home; a path outside home is rejected. This mirrors the stats DB trust model
-exactly, so an attacker cannot redirect the stash to a system-critical
-location.
+(`--stash-db`, `TOKENLESS_STASH_DB`, or `TOKENLESS_DATA_DIR`) is validated
+against the canonical home anchor and must remain under that home. For a data
+directory that does not exist yet, tokenless canonicalizes the nearest existing
+ancestor before checking that boundary; a path outside home is rejected. This
+mirrors the stats DB trust model exactly, so an attacker cannot redirect the
+stash to a system-critical location.
 
 `retrieve` queries are parameterized SQL; a malformed hash simply yields "no
 payload" rather than an injection.

--- a/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
+++ b/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/tracking.rs b/src/core/tracking.rs
-index 359e4f6..c543753 100644
+index 359e4f6..0a7507b 100644
 --- a/src/core/tracking.rs
 +++ b/src/core/tracking.rs
 @@ -1358,6 +1358,9 @@ impl TimedExecution {
@@ -12,7 +12,7 @@ index 359e4f6..c543753 100644
          if let Ok(tracker) = Tracker::new() {
              let _ = tracker.record(
                  original_cmd,
-@@ -1419,6 +1422,159 @@ pub fn args_display(args: &[OsString]) -> String {
+@@ -1419,5 +1422,247 @@ pub fn args_display(args: &[OsString]) -> String {
          .join(" ")
  }
  
@@ -83,6 +83,98 @@ index 359e4f6..c543753 100644
 +        .unwrap_or(true)
 +}
 +
++#[cfg(unix)]
++#[allow(unsafe_code)] // libc is required to avoid trusting the mutable HOME environment variable.
++fn tokenless_trusted_home_dir() -> Option<std::path::PathBuf> {
++    use std::ffi::CStr;
++
++    // SAFETY: getuid is infallible. getpwuid_r receives valid pointers to a
++    // live passwd value and buffer, and cannot write beyond the given length.
++    let uid = unsafe { libc::getuid() };
++    let mut passwd: libc::passwd = unsafe { std::mem::zeroed() };
++    let mut buffer = vec![0u8; 4096];
++    let mut result: *mut libc::passwd = std::ptr::null_mut();
++    let status = unsafe {
++        libc::getpwuid_r(
++            uid,
++            &mut passwd,
++            buffer.as_mut_ptr().cast(),
++            buffer.len(),
++            &mut result,
++        )
++    };
++    if status != 0 || result.is_null() || passwd.pw_dir.is_null() {
++        return None;
++    }
++
++    // SAFETY: a successful getpwuid_r call provides a NUL-terminated pw_dir
++    // pointer backed by buffer, which remains alive for this conversion.
++    let home = unsafe { CStr::from_ptr(passwd.pw_dir) }.to_str().ok()?;
++    let path = std::path::PathBuf::from(home);
++    if home == "/" || !path.is_absolute() {
++        return None;
++    }
++    Some(path)
++}
++
++#[cfg(not(unix))]
++fn tokenless_trusted_home_dir() -> Option<std::path::PathBuf> {
++    None
++}
++
++fn tokenless_path_is_under_home(path: &std::path::Path, home: &std::path::Path) -> bool {
++    let Ok(canonical_home) = home.canonicalize() else {
++        return false;
++    };
++    let resolved = path.canonicalize().or_else(|_| {
++        path.parent()
++            .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotFound))
++            .and_then(std::path::Path::canonicalize)
++    });
++    resolved.is_ok_and(|resolved| resolved.starts_with(canonical_home))
++}
++
++fn validate_tokenless_data_dir(
++    data_dir: &str,
++    home: &std::path::Path,
++) -> Option<std::path::PathBuf> {
++    let candidate = std::path::PathBuf::from(data_dir);
++    if !candidate.is_absolute()
++        || candidate
++            .components()
++            .any(|component| matches!(component, std::path::Component::ParentDir))
++        || (candidate.exists() && !candidate.is_dir())
++    {
++        return None;
++    }
++
++    let mut existing_ancestor = candidate.as_path();
++    while !existing_ancestor.exists() {
++        existing_ancestor = existing_ancestor.parent()?;
++    }
++    tokenless_path_is_under_home(existing_ancestor, home).then_some(candidate)
++}
++
++fn resolve_tokenless_stats_db() -> Option<std::path::PathBuf> {
++    let home = tokenless_trusted_home_dir()?;
++
++    if let Some(path) = std::env::var("TOKENLESS_STATS_DB")
++        .ok()
++        .filter(|path| !path.is_empty())
++        .map(std::path::PathBuf::from)
++        .filter(|path| tokenless_path_is_under_home(path, &home))
++    {
++        return Some(path);
++    }
++
++    let data_dir = std::env::var("TOKENLESS_DATA_DIR")
++        .ok()
++        .filter(|path| !path.is_empty())
++        .and_then(|path| validate_tokenless_data_dir(&path, &home))
++        .unwrap_or_else(|| home.join(".tokenless"));
++    Some(data_dir.join("stats.db"))
++}
++
 +/// Record RTK command output compression stats to the tokenless stats database.
 +///
 +/// Fails silently so RTK output is never blocked by database errors.
@@ -100,12 +192,9 @@ index 359e4f6..c543753 100644
 +
 +    let (agent_id, session_id, tool_use_id) = resolve_tokenless_context();
 +
-+    let db_path = std::env::var("TOKENLESS_STATS_DB").unwrap_or_else(|_| {
-+        format!(
-+            "{}/.tokenless/stats.db",
-+            std::env::var("HOME").unwrap_or_else(|_| ".".to_string())
-+        )
-+    });
++    let Some(db_path) = resolve_tokenless_stats_db() else {
++        return;
++    };
 +
 +    let before_chars = raw_output.len();
 +    let after_chars = filtered_output.len();
@@ -119,7 +208,7 @@ index 359e4f6..c543753 100644
 +    }
 +
 +    let _ = (|| -> anyhow::Result<()> {
-+        if let Some(parent) = std::path::Path::new(&db_path).parent() {
++        if let Some(parent) = db_path.parent() {
 +            std::fs::create_dir_all(parent)?;
 +        }
 +        let conn = rusqlite::Connection::open(&db_path)?;
@@ -171,7 +260,40 @@ index 359e4f6..c543753 100644
 +
  #[cfg(test)]
  mod tests {
+@@ -1424 +1669,32 @@ mod tests {
      use super::*;
++
++    #[test]
++    fn tokenless_data_dir_accepts_nonexistent_descendant() {
++        let home = tempfile::tempdir().unwrap();
++        let candidate = home.path().join("nested/data");
++        let resolved =
++            validate_tokenless_data_dir(candidate.to_str().unwrap(), home.path()).unwrap();
++        assert_eq!(resolved, candidate);
++    }
++
++    #[test]
++    fn tokenless_data_dir_rejects_outside_home() {
++        let home = tempfile::tempdir().unwrap();
++        let outside = tempfile::tempdir().unwrap();
++        assert!(
++            validate_tokenless_data_dir(outside.path().to_str().unwrap(), home.path()).is_none()
++        );
++    }
++
++    #[cfg(unix)]
++    #[test]
++    fn tokenless_data_dir_rejects_symlink_escape() {
++        use std::os::unix::fs::symlink;
++
++        let home = tempfile::tempdir().unwrap();
++        let outside = tempfile::tempdir().unwrap();
++        let link = home.path().join("redirect");
++        symlink(outside.path(), &link).unwrap();
++        let candidate = link.join("data");
++        assert!(validate_tokenless_data_dir(candidate.to_str().unwrap(), home.path()).is_none());
++    }
++
 diff --git a/src/hooks/hook_check.rs b/src/hooks/hook_check.rs
 index 4dd26d8..3638321 100644
 --- a/src/hooks/hook_check.rs


### PR DESCRIPTION
## Description

Adds `TOKENLESS_DATA_DIR` so users can relocate the Tokenless statistics and reversible-stash SQLite databases with one setting while retaining `~/.tokenless` as the compatible default. Existing per-file overrides remain higher priority, and custom directories are validated against the trusted user home before creation. RTK statistics writes follow the same directory setting, while `config.json` and SLS output locations remain unchanged.

## Related Issue

closes #2037

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `make test-hooks test-integration test-adapters` with locally built Tokenless and RTK binaries plus an isolated `TOKENLESS_DATA_DIR`
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- Applied the RTK patch to v0.43.0, ran `cargo check`, and verified a real RTK command created `$TOKENLESS_DATA_DIR/stats.db`

## Additional Notes

The default database locations remain `~/.tokenless/stats.db` and `~/.tokenless/stash.db`; this change does not migrate existing data. RTK's full upstream `cargo test` target remains blocked by two pre-existing `dead_code` warnings (`FILTERS_TOML` and `TomlFilterRegistry::load`) under its deny-warnings configuration; patch application, formatting, compilation, and runtime database routing were verified separately.