### PR TITLE
chore(anolisa): bump version to 0.2.15

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-07-30
+
+### Added
+
+- Interactive `anolisa install`, `anolisa install --all`, and
+  `anolisa uninstall` now display phase-based activity during long-running
+  planning and execution. ANSI-capable terminals animate the current phase,
+  while limited interactive terminals print static phase lines
+  ([#2036](https://github.com/alibaba/anolisa/pull/2036)).
+
+### Changed
+
+- Human-readable failures now use conventional `error:` and `hint:` labels
+  without exposing machine codes. `--json` retains structured error codes, and
+  exit statuses remain unchanged.
+- Update notifications now quote the recommended `sudo anolisa upgrade` and
+  `anolisa update --check` commands so their boundaries are clear.
+
 ## [0.2.14] - 2026-07-29
 
 ### Fixed
@@ -721,6 +739,22 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.15] - 2026-07-30
+
+### 新增
+
+- 交互式 `anolisa install`、`anolisa install --all` 和 `anolisa uninstall`
+  现会在耗时的规划与执行阶段显示分阶段进度。支持 ANSI 的终端会动态显示当前阶段，
+  能力受限的交互式终端则输出静态阶段提示
+  ([#2036](https://github.com/alibaba/anolisa/pull/2036))。
+
+### 变更
+
+- 面向用户的失败信息现采用常规的 `error:` 和 `hint:` 标签，不再显示机器错误码；
+  `--json` 仍保留结构化错误码，退出状态保持不变。
+- 更新通知现会为建议运行的 `sudo anolisa upgrade` 和 `anolisa update --check`
+  命令加上引号，使命令边界更加清晰。
 
 ## [0.2.14] - 2026-07-29
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,12 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Jul 29 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Thu Jul 30 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Interactive install and uninstall commands now report phase-based activity.
+- Human errors now use conventional labels while JSON retains machine codes.
+- Update notices now quote their recommended commands.
+
+* Wed Jul 29 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.14-1
 - Status and doctor now detect managed file mode and capability drift.
 - Repair now restores declared metadata without granting unconfirmed capabilities.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.14",
-    "@anolisa/cli-linux-arm64": "0.2.14",
-    "@anolisa/cli-darwin-arm64": "0.2.14"
+    "@anolisa/cli-linux-x64": "0.2.15",
+    "@anolisa/cli-linux-arm64": "0.2.15",
+    "@anolisa/cli-darwin-arm64": "0.2.15"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

Synchronizes ANOLISA CLI release metadata across Cargo, npm platform packages, and RPM at 0.2.15. Curates bilingual release notes from the changes merged since 0.2.14, highlighting phase-based install and uninstall activity, conventional human error labels that retain JSON machine codes, and clearer quoted update commands from #2036. The version-bump commit adds no runtime behavior; it establishes one consistent release boundary across distributions.

## Related Issue

no-issue: routine ANOLISA CLI release metadata synchronization; runtime behavior is tracked by #2036

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Run from `src/anolisa`:

```text
cargo fmt --all -- --check
cargo check --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --workspace --locked
cargo doc --workspace --no-deps --locked
node --test npm/tests/platforms.test.js
node npm/scripts/package-npm.js --validate
target/debug/anolisa --version
```

The release audit reports consistent metadata at 0.2.15, `target/debug/anolisa --version` prints `anolisa 0.2.15`, and `git diff --check` passes.

## Additional Notes

All release validation commands passed before the atomic version-bump commit was created.