### PR TITLE
chore(memory): bump version to 0.2.6

### DIFF
--- a/src/agent-memory/.anolisa/component.toml
+++ b/src/agent-memory/.anolisa/component.toml
@@ -6,7 +6,7 @@
 # Installed to: %{_datadir}/anolisa/components/agent-memory/component.toml
 [component]
 name = "agent-memory"
-version = "0.2.5"
+version = "0.2.6"
 
 [[adapters]]
 framework = "openclaw"

--- a/src/agent-memory/CHANGELOG.md
+++ b/src/agent-memory/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-07-30
+
+### Fixed
+
+- **agent-memory**: Updated to v0.2.6, retries short-token LIKE searches with OR matching when strict matching finds nothing and ranks stronger keyword matches first, agents can recall relevant memories from stopword-heavy prompts instead of receiving an empty result (#2040)
+
 ## [0.2.5] - 2026-07-27
 
 ### Fixed

--- a/src/agent-memory/CHANGELOG_zh.md
+++ b/src/agent-memory/CHANGELOG_zh.md
@@ -7,6 +7,12 @@
 本文档格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 项目遵循[语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
 
+## [0.2.6] - 2026-07-30
+
+### 修复
+
+- **agent-memory**：更新到 v0.2.6，在短 token 的 LIKE 严格匹配无结果时改用 OR 匹配，并优先保留匹配更多关键词的结果，Agent 可从包含停用词的 prompt 中召回相关记忆而不再得到空结果（#2040）
+
 ## [0.2.5] - 2026-07-27
 
 ### 修复

--- a/src/agent-memory/Cargo.lock
+++ b/src/agent-memory/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-memory"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/agent-memory/Cargo.toml
+++ b/src/agent-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-memory"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 # edition 2024 stabilised in rustc 1.85; let-chains land in 1.88 so we
 # avoid them. Anolis ships 1.86, which is fine for build but won't take

--- a/src/agent-memory/adapters/agent-memory/manifest.json
+++ b/src/agent-memory/adapters/agent-memory/manifest.json
@@ -1,6 +1,6 @@
 {
   "component": "agent-memory",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "targets": {
     "openclaw": {
       "compatibleVersions": ">=5.0.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memory-anolisa",
   "name": "Anolisa Memory",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Persistent memory backed by the agent-memory MCP server with namespace isolation and openat2 sandbox. Provides BM25 search, file read/write, observe, and context assembly tools.",
   "activation": {
     "onStartup": false

--- a/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memory-anolisa-openclaw-plugin",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-memory/adapters/agent-memory/openclaw/package.json
+++ b/src/agent-memory/adapters/agent-memory/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-anolisa-openclaw-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-memory/agent-memory.spec.in
+++ b/src/agent-memory/agent-memory.spec.in
@@ -198,6 +198,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Thu Jul 30 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.2.6-1
+- fix(memory): recall partial short-token matches with OR fallback (#2040)
+
 * Mon Jul 27 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.2.5-1
 - fix(memory): improve auto-recall for long English and CJK prompts
 

--- a/src/agent-memory/config/mcp-server.json
+++ b/src/agent-memory/config/mcp-server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-memory",
   "description": "Agent memory — filesystem memory MCP server. 31 tools across three tiers: Tier A file ops (read/write/append/edit/list/grep/diff/mkdir/remove/promote + mem_session_log), Tier B structured (memory_search, memory_observe, memory_get_context, memory_task_save/resume/list/close, memory_forget, memory_consent, mem_export, mem_import), Tier C governance (mem_snapshot/mem_snapshot_list/mem_snapshot_restore/mem_log/mem_revert/mem_consolidate/mem_compact, memory_about, memory_auto_created). Optional Linux user-namespace isolation, SQLite FTS5 BM25 + vector hybrid background index, time-decay ranking, cold archival, episodic memory extraction, conflict detection, git versioning, tar.gz snapshots, cgroup v2 memory.max, and journald audit fan-out.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "command": "/usr/bin/agent-memory",
   "args": [],
   "env": {},


### PR DESCRIPTION
## Description

Bump agent-memory from 0.2.5 to 0.2.6 across Cargo, component, adapter, npm, MCP, and RPM metadata. This release packages the #2040 LIKE-search OR fallback already merged into `main`, allowing auto-recall to recover partial matches from stopword-heavy prompts. `Cargo.toml` remains the authoritative version source, and the English and Chinese changelogs record the user-visible fix.

## Related Issue

closes #2040

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [x] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `make sync-versions`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (346 tests passed)
- `git diff --check`

## Additional Notes

The version bump is the final commit on the release branch. No additional release limitations are known.
