### PR TITLE
fix(cosh-ng): drop stale shell handoff text

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/activity/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/activity/runtime_tests.rs
@@ -2204,7 +2204,7 @@ fn shell_handoff_activity_ignores_stale_same_command_block_before_request() {
         id: "cmd-stale".to_string(),
         session_id: "session-1".to_string(),
         command: "df -h".to_string(),
-        origin: Default::default(),
+        origin: CommandOrigin::ProviderTool,
         cwd: "/tmp".to_string(),
         end_cwd: "/tmp".to_string(),
         started_at_ms: 100,
@@ -2225,6 +2225,114 @@ fn shell_handoff_activity_ignores_stale_same_command_block_before_request() {
     assert!(ids.is_empty(), "{ids:?}");
     assert!(state.activity.rows.is_empty(), "{:?}", state.activity.rows);
     assert!(state.control.shell_handoff().pending_front().is_some());
+}
+
+#[test]
+fn repeated_shell_handoff_uses_the_unhandled_current_block() {
+    let mut state = InlineState::default();
+    let first_request = ShellHandoffRequest::new(
+        "./changing_metric.sh",
+        "$ ./changing_metric.sh",
+        "approved_provider_shell_tool",
+        "user",
+        "req-1",
+        "run-1",
+        1_100,
+    )
+    .expect("first handoff request");
+    state
+        .control
+        .shell_handoff_mut()
+        .enqueue_approved_request(first_request);
+    state
+        .control
+        .shell_handoff_mut()
+        .emit_next_approved(0)
+        .expect("emit first handoff");
+    let first_block = CommandBlock {
+        id: "cmd-1".to_string(),
+        session_id: "session-1".to_string(),
+        command: "./changing_metric.sh".to_string(),
+        origin: CommandOrigin::ProviderTool,
+        cwd: "/tmp".to_string(),
+        end_cwd: "/tmp".to_string(),
+        started_at_ms: 1_000,
+        ended_at_ms: 1_000,
+        duration_ms: 0,
+        exit_code: 0,
+        status: CommandStatus::Completed,
+        output: OutputRefs {
+            terminal_output_ref: Some("/tmp/output-1001.txt".to_string()),
+            terminal_output_bytes: 20,
+        },
+        shell_environment_generation: None,
+        audit_identity: None,
+    };
+    assert_eq!(
+        record_approved_shell_handoff_blocks(&mut state, std::slice::from_ref(&first_block)),
+        vec!["handoff-1"]
+    );
+
+    let second_request = ShellHandoffRequest::new(
+        "./changing_metric.sh",
+        "$ ./changing_metric.sh",
+        "approved_provider_shell_tool",
+        "user",
+        "req-2",
+        "run-2",
+        1_500,
+    )
+    .expect("second handoff request");
+    state
+        .control
+        .shell_handoff_mut()
+        .enqueue_approved_request(second_request);
+    state
+        .control
+        .shell_handoff_mut()
+        .emit_next_approved(0)
+        .expect("emit second handoff");
+    let second_block = CommandBlock {
+        id: "cmd-2".to_string(),
+        session_id: "session-1".to_string(),
+        command: "./changing_metric.sh".to_string(),
+        origin: CommandOrigin::ProviderTool,
+        cwd: "/tmp".to_string(),
+        end_cwd: "/tmp".to_string(),
+        started_at_ms: 1_000,
+        ended_at_ms: 1_000,
+        duration_ms: 0,
+        exit_code: 0,
+        status: CommandStatus::Completed,
+        output: OutputRefs {
+            terminal_output_ref: Some("/tmp/output-1002.txt".to_string()),
+            terminal_output_bytes: 20,
+        },
+        shell_environment_generation: None,
+        audit_identity: None,
+    };
+
+    assert_eq!(
+        record_approved_shell_handoff_blocks(&mut state, &[first_block, second_block]),
+        vec!["handoff-2"]
+    );
+    let row = state
+        .activity
+        .rows
+        .iter()
+        .find(|row| row.id == "handoff-2")
+        .expect("second handoff row");
+    assert!(
+        row.detail.contains("command_block: cmd-2"),
+        "{}",
+        row.detail
+    );
+    assert!(
+        row.detail
+            .contains("output_id: terminal-output://session-1/cmd-2"),
+        "{}",
+        row.detail
+    );
 }
 
 fn untracked_test_event(kind: ShellEventKind, command_id: Option<&str>) -> ShellEvent {
@@ -2523,13 +2631,27 @@ fn untracked_shell_handoffs_share_prompt_boundary_when_emitted_in_same_cycle() {
             .expect("handoff row");
         assert_eq!(row.status, "completed_untracked");
     }
+    // Both closures produced recoverable evidence, and neither is lost: claims
+    // are handed out one per idle boundary, so two successive claims each yield
+    // exactly one.
     assert_eq!(
         state
             .evidence
             .claim_pending_shell_handoff_continuations()
             .len(),
-        2
+        1
     );
+    assert_eq!(
+        state
+            .evidence
+            .claim_pending_shell_handoff_continuations()
+            .len(),
+        1
+    );
+    assert!(state
+        .evidence
+        .claim_pending_shell_handoff_continuations()
+        .is_empty());
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/activity/shell_handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/activity/shell_handoff.rs
@@ -148,10 +148,10 @@ pub(crate) fn record_approved_shell_handoff_blocks(
     let mut ids = Vec::new();
     while let Some(handoff) = state.control.shell_handoff().pending_front() {
         let request = handoff.request();
-        let Some(block) = blocks
-            .iter()
-            .find(|block| shell_handoff_block_matches_request(block, request))
-        else {
+        let Some(block) = blocks.iter().find(|block| {
+            !state.analyzed_blocks.contains(&block.id)
+                && shell_handoff_block_matches_request(block, request)
+        }) else {
             break;
         };
 
@@ -246,7 +246,11 @@ fn shell_handoff_block_matches_request(
     block: &CommandBlock,
     request: &ShellHandoffRequest,
 ) -> bool {
-    block.command == request.command && block.origin == expected_handoff_origin(request)
+    // Shell markers are second-granular, so compare representable seconds.
+    let started_at_or_after_request = block.started_at_ms / 1_000 >= request.created_at_ms / 1_000;
+    block.command == request.command
+        && block.origin == expected_handoff_origin(request)
+        && started_at_or_after_request
 }
 
 fn expected_handoff_origin(request: &ShellHandoffRequest) -> CommandOrigin {

--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -30,7 +30,19 @@ pub(crate) fn finish_active_agent_run<W: Write>(
     cleanup_question_for_terminal_owner(state, output, &active_run.request.id)?;
     active_run.status_animation.clear(output)?;
     if !active_run.held_events.is_empty() {
-        if state_has_pending_interaction(state) || has_queued_run_before_held_text(state) {
+        if state
+            .control
+            .shell_handoff()
+            .has_active_handoff_for_run(&active_run.request.id)
+        {
+            // This run ended while its own foreground shell handoff was still
+            // outstanding, so its text cannot be based on the real command
+            // result. Drop it instead of rendering or transferring it; the
+            // shell-evidence continuation regenerates the answer once the result
+            // lands. Scoped to this run: another run's in-flight handoff says
+            // nothing about whether this text is stale.
+            active_run.held_events.clear();
+        } else if state_has_pending_interaction(state) || has_queued_run_before_held_text(state) {
             state
                 .agent_run
                 .held_events
@@ -274,6 +286,8 @@ fn trim_queued_requests_after_provider_timeout(state: &mut InlineState) -> usize
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
     use crate::agent::run::{PendingAgentRequest, PendingRequestClass};
     use crate::runtime::state::InlineState;
@@ -322,6 +336,95 @@ mod tests {
             selectable_after_event_index: None,
             before_held_text: false,
         }
+    }
+
+    // A provider that ends its turn while its own Bash handoff is still running
+    // produced that text without the command's result, so finishing the run must
+    // drop it instead of rendering it or moving it to the shell-wide hold. The
+    // shell-evidence continuation regenerates the answer.
+    #[test]
+    fn finish_drops_held_text_while_its_own_shell_handoff_is_still_outstanding() {
+        let (rendered, state) = finish_run_with_handoff_owned_by("run-1");
+
+        assert!(!rendered.contains("STALE ANSWER"), "{rendered}");
+        assert!(state.agent_run.held_events.is_empty());
+    }
+
+    // The drop is scoped to the run that owns the handoff: text from a run whose
+    // own work is complete must still be shown even while some other run's
+    // handoff is in flight.
+    #[test]
+    fn finish_keeps_held_text_when_another_run_owns_the_outstanding_handoff() {
+        let (rendered, _state) = finish_run_with_handoff_owned_by("unrelated-run");
+
+        assert!(rendered.contains("STALE ANSWER"), "{rendered}");
+    }
+
+    // Finishes an active `run-1` holding one text delta, with an approved handoff
+    // owned by `handoff_run_id` still outstanding. Returns what was rendered plus
+    // the resulting state.
+    fn finish_run_with_handoff_owned_by(handoff_run_id: &str) -> (String, InlineState) {
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut state = InlineState::default();
+        let run_request = request("run-1");
+        let handle = adapter.start_cancellable(run_request.clone(), CoshApprovalMode::Recommend);
+        let renderer = RatatuiInlineRenderer::for_terminal();
+        let mut active_run = ActiveAgentRun {
+            request: run_request,
+            origin: AgentRunOrigin::Standard,
+            handle,
+            provider_name: "fake",
+            language: Language::EnUs,
+            renderer: renderer.clone(),
+            status_animation: renderer.status_animation(),
+            markdown_stream: renderer.stream_markdown_agent(),
+            governed_events: Vec::new(),
+            deferred_events: Vec::new(),
+            held_events: Vec::new(),
+            cosh_request_filter: crate::evidence::stream::CoshRequestStreamFilter::default(),
+            pending_cosh_requests: Vec::new(),
+            pending_cosh_request_audits: Vec::new(),
+            rendered_governed_event_count: 0,
+            selectable_after_event_index: None,
+            started_at: Instant::now(),
+            last_activity_at: Instant::now(),
+            last_heartbeat_at: Instant::now(),
+            current_phase: String::new(),
+            current_message: String::new(),
+            has_visible_text_delta: false,
+            completed: true,
+            host_completed_tool_ids: Vec::new(),
+            pending_hook_notifications: Vec::new(),
+        };
+        active_run.held_events.push(GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::DisplayOnly,
+            event: AgentEvent::TextDelta {
+                run_id: "run-1".to_string(),
+                text: "STALE ANSWER".to_string(),
+            },
+            reason: "held".to_string(),
+            display_text: "STALE ANSWER".to_string(),
+            auto_execute: false,
+        });
+        state.agent_run.active = Some(active_run);
+        state.control.shell_handoff_mut().enqueue_approved_request(
+            ShellHandoffRequest::new(
+                "df -h",
+                "$ df -h",
+                "provider-tool-call",
+                "agent",
+                "req-1",
+                handoff_run_id,
+                1,
+            )
+            .expect("handoff"),
+        );
+        let mut output = Vec::new();
+
+        finish_active_agent_run(&mut state, &mut output, &adapter).expect("finish run");
+
+        (String::from_utf8_lossy(&output).to_string(), state)
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -211,15 +211,7 @@ fn render_inline_guidance_from_batch<W: Write>(
         output,
         event_index_base,
     )?;
-    let card_capture_pending = pending_card_capture(state).is_some();
-    let activity_actions = ActivityConsumer::consume(
-        events,
-        &ledger.blocks,
-        adapter,
-        state,
-        output,
-        card_capture_pending,
-    )?;
+    let activity_actions = ActivityConsumer::consume(events, &ledger.blocks, state, output)?;
     RuntimeDispatcher::apply_actions(activity_actions, state);
     let findings = findings_from_blocks(&ledger.blocks);
     record_blocks_followed_by_user_input(events, &ledger.blocks, state);
@@ -333,10 +325,55 @@ fn render_inline_guidance_from_batch<W: Write>(
         poll_active_agent_run(state, output, adapter)?;
     }
     flush_held_agent_events(state, output)?;
+    // Shell-evidence recovery is scheduled only after this batch's final agent
+    // poll. Claiming it earlier sees a run that is about to finish inside that
+    // poll as still active, which skips the pending continuation for this batch;
+    // it would then only be picked up if some later shell event triggered
+    // another one.
+    start_pending_shell_handoff_continuations(adapter, state, output)?;
     poll_background_compaction(state, output, adapter, false)?;
     render_soft_newline_tip(events, state, output)?;
     render_owned_shell_prompt(state, output)?;
 
+    Ok(())
+}
+
+/// Starts the shell-evidence continuation whose delivery to the owning provider
+/// run failed. Reuses the existing `PendingRecovery` claim, so a given approval
+/// recovers at most once.
+///
+/// Claiming is a one-way move (`PendingRecovery` -> `RecoveryQueued`, plus a
+/// dedup entry keyed by approval id), so it must not happen unless the run can
+/// actually start: a pending or active compaction makes
+/// `start_agent_run_with_origin` drop this `InternalBestEffort` request, which
+/// would leave the evidence claimed and unrecoverable. Hence the gate check
+/// before claiming, and — because starting a run polls the provider and can
+/// itself surface a compaction recommendation — at most one recovery per
+/// boundary. Any remaining recoveries are claimed at the next idle boundary.
+fn start_pending_shell_handoff_continuations<W: Write>(
+    adapter: &AdapterInstance,
+    state: &mut InlineState,
+    output: &mut W,
+) -> std::io::Result<()> {
+    if state.agent_run.active.is_some()
+        || pending_card_capture(state).is_some()
+        || crate::slash::session::compaction_pending_or_active(state)
+    {
+        return Ok(());
+    }
+    for (request, origin) in shell_handoff_continuation_requests(state) {
+        // Shell-handoff continuations are automatic conversation resumptions,
+        // not fresh user requests.
+        start_agent_run_with_origin(
+            &request,
+            origin,
+            AgentStartIntent::InternalBestEffort,
+            adapter,
+            state,
+            output,
+            None,
+        )?;
+    }
     Ok(())
 }
 
@@ -512,34 +549,20 @@ impl ActivityConsumer {
     pub(crate) fn consume<W: Write>(
         events: &[ShellEvent],
         blocks: &[CommandBlock],
-        adapter: &AdapterInstance,
         state: &mut InlineState,
         output: &mut W,
-        card_capture_pending: bool,
     ) -> std::io::Result<Vec<RuntimeAction>> {
         let mut handoff_activity_ids = record_approved_shell_handoff_blocks(state, blocks);
         // Fallback: close emitted handoffs that reached a prompt boundary
         // without ever producing command tracking (lost preexec marker).
         handoff_activity_ids.extend(close_untracked_shell_handoffs(state, events));
         render_activity_rows(state, &handoff_activity_ids, output)?;
-        if !card_capture_pending && state.agent_run.active.is_none() {
-            for (request, origin) in shell_handoff_continuation_requests(state) {
-                // Shell-handoff continuations are automatic conversation
-                // resumptions, not fresh user requests.
-                start_agent_run_with_origin(
-                    &request,
-                    origin,
-                    AgentStartIntent::InternalBestEffort,
-                    adapter,
-                    state,
-                    output,
-                    None,
-                )?;
-            }
-        }
         Ok(Vec::new())
     }
 }
+
+#[cfg(test)]
+mod recovery_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher/recovery_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher/recovery_tests.rs
@@ -1,0 +1,131 @@
+use super::*;
+use crate::runtime::evidence_state::{RuntimeShellCommandCompleted, ShellEvidenceDelivery};
+use crate::runtime::prelude::{
+    AgentRunOrigin, CommandStatus, FakeAgentAdapter, OutputRefs, ShellHandoffRequest,
+};
+
+// Claiming a recovery is a one-way move, so it must not happen while a
+// compaction would drop the resulting internal run: the evidence has to stay
+// claimable for a later boundary instead of being silently consumed.
+#[test]
+fn pending_compaction_does_not_consume_the_shell_evidence_recovery_claim() {
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState::default();
+    record_pending_recovery_evidence(&mut state, "req-1");
+    crate::slash::session::note_compaction_recommendation(
+        &mut state,
+        "3f2b7c14-8a1d-4c6e-9f05-2b6d8e7a1c43:1:1:100:100",
+    );
+    assert!(crate::slash::session::compaction_pending_or_active(&state));
+    let mut output = Vec::new();
+
+    start_pending_shell_handoff_continuations(&adapter, &mut state, &mut output)
+        .expect("guarded scheduling");
+
+    assert!(
+        state.agent_run.active.is_none(),
+        "no internal run may start while compaction is pending"
+    );
+    assert_eq!(
+        state
+            .evidence
+            .claim_pending_shell_handoff_continuations()
+            .len(),
+        1,
+        "recovery must still be claimable once compaction clears"
+    );
+}
+
+#[test]
+fn shell_evidence_recovery_starts_at_an_idle_boundary_without_compaction() {
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState::default();
+    record_pending_recovery_evidence(&mut state, "req-1");
+    let mut output = Vec::new();
+
+    start_pending_shell_handoff_continuations(&adapter, &mut state, &mut output)
+        .expect("scheduling");
+
+    // The fake adapter can finish the run inside the start path, so the
+    // consumed claim — not a still-active run — is what proves the recovery
+    // continuation was started.
+    assert!(state
+        .evidence
+        .claim_pending_shell_handoff_continuations()
+        .is_empty());
+    assert!(!output.is_empty(), "recovery run should render output");
+}
+
+// Starting a recovery polls the provider, which can itself surface a
+// compaction recommendation that would drop any further internal run. A
+// claim cannot be rolled back, so only one recovery may be claimed per
+// boundary and the rest must still be claimable afterwards.
+#[test]
+fn only_one_shell_evidence_recovery_is_claimed_per_idle_boundary() {
+    let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+    let mut state = InlineState::default();
+    record_pending_recovery_evidence(&mut state, "req-1");
+    record_pending_recovery_evidence(&mut state, "req-2");
+    let mut output = Vec::new();
+
+    start_pending_shell_handoff_continuations(&adapter, &mut state, &mut output)
+        .expect("scheduling");
+
+    assert_eq!(
+        state
+            .evidence
+            .claim_pending_shell_handoff_continuations()
+            .len(),
+        1,
+        "the second recovery must survive this boundary unclaimed"
+    );
+}
+
+// Records one completed shell handoff whose result never reached the
+// provider, i.e. exactly the state a recovery continuation is claimed from.
+fn record_pending_recovery_evidence(state: &mut InlineState, approval_id: &str) {
+    let mut handoff = ShellHandoffRequest::new(
+        "df -h",
+        "$ df -h",
+        "provider-tool-call",
+        "agent",
+        approval_id,
+        "run-1",
+        1,
+    )
+    .expect("handoff");
+    handoff.request_id = Some("ctrl-1".to_string());
+    handoff.tool_use_id = Some("toolu-1".to_string());
+    let block = CommandBlock {
+        id: "cmd-1".to_string(),
+        session_id: "shell-session".to_string(),
+        command: "df -h".to_string(),
+        origin: Default::default(),
+        cwd: "/repo".to_string(),
+        end_cwd: "/repo".to_string(),
+        started_at_ms: 1,
+        ended_at_ms: 2,
+        duration_ms: 1,
+        exit_code: 0,
+        status: CommandStatus::Completed,
+        output: OutputRefs {
+            terminal_output_ref: None,
+            terminal_output_bytes: 0,
+        },
+        shell_environment_generation: None,
+        audit_identity: None,
+    };
+    let mut evidence = RuntimeShellCommandCompleted::from_shell_handoff(
+        &handoff,
+        &block,
+        "completed",
+        AgentRunOrigin::Standard,
+    );
+    evidence.apply_provider_result_delivery(ShellEvidenceDelivery {
+        delivered: false,
+        status: "provider_run_not_active",
+        recovery_reason: Some("provider run was not active when shell completed"),
+        provider_preview_complete: false,
+    });
+    state.evidence.record_shell_command_completed(evidence);
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery.rs
@@ -1,8 +1,8 @@
 use crate::runtime::approval_state::RuntimeApprovalRequest;
 use crate::runtime::prelude::{
-    redact_provider_command_text, AgentContextBinding, AgentMode, AgentRequest, AgentRunOrigin,
-    ApprovalDecision, ApprovalResponse, CommandBlock, CommandStatus, HostExecutedShellMetadata,
-    HostExecutedShellResult, OutputRefs, ShellHandoffRequest,
+    redact_provider_command_text, AgentContextBinding, AgentEvent, AgentMode, AgentRequest,
+    AgentRunOrigin, ApprovalDecision, ApprovalResponse, CommandBlock, CommandStatus,
+    HostExecutedShellMetadata, HostExecutedShellResult, OutputRefs, ShellHandoffRequest,
 };
 use crate::runtime::state::InlineState;
 
@@ -29,6 +29,7 @@ pub(crate) fn record_shell_handoff_completion(
         .unwrap_or_default();
     let mut evidence =
         RuntimeShellCommandCompleted::from_shell_handoff(handoff, block, status, origin);
+    discard_text_held_before_shell_result(state, &handoff.run_id);
     let delivery = deliver_host_executed_shell_result_if_supported(state, handoff, &evidence);
     if delivery.delivered {
         state.agent_run.native_prompt_after_run = true;
@@ -56,6 +57,25 @@ pub(crate) fn record_shell_handoff_completion(
         .evidence
         .record_shell_command_completed(evidence.clone());
     evidence
+}
+
+/// Drops the text `run_id` streamed before this shell result existed.
+///
+/// Such text cannot be based on the command's result, so it must never reach the
+/// terminal — whether it is still held by the owning run or was moved to the
+/// shell-wide hold when that run ended behind the approval card. Text the
+/// provider generates after the result is delivered arrives later and is
+/// unaffected; a failed delivery recovers through the shell-evidence
+/// continuation instead.
+fn discard_text_held_before_shell_result(state: &mut InlineState, run_id: &str) {
+    if let Some(active_run) = state.agent_run.active.as_mut() {
+        if active_run.request.id == run_id {
+            active_run.held_events.clear();
+        }
+    }
+    state.agent_run.held_events.retain(|event| {
+        !matches!(&event.event, AgentEvent::TextDelta { run_id: event_run_id, .. } if event_run_id == run_id)
+    });
 }
 
 pub(crate) fn shell_handoff_continuation_requests(

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_delivery_tests.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use crate::runtime::prelude::{
-    AgentEvent, AgentRunHandle, AgentRunOrigin, AgentRunPoll, CoshApprovalMode, CoshCoreAdapter,
-    Language, OutputRefs, RatatuiInlineRenderer,
+    AgentRunHandle, AgentRunOrigin, AgentRunPoll, CoshApprovalMode, CoshCoreAdapter,
+    GovernanceDecision, GovernancePolicyDecision, GovernedEvent, Language, OutputRefs,
+    RatatuiInlineRenderer,
 };
 
 use crate::adapter::serialize_host_executed_shell_result;
@@ -608,6 +609,51 @@ fn closed_cosh_core_control_handle(request: &AgentRequest) -> AgentRunHandle {
     }
     std::thread::sleep(Duration::from_millis(200));
     handle
+}
+
+#[test]
+fn discarding_pre_result_text_only_drops_the_owning_run() {
+    let request = test_request();
+    let handle = closed_cosh_core_control_handle(&request);
+    let mut active_run = test_active_run(request, handle);
+    active_run.held_events.push(held_text("run-1", "stale"));
+    let mut state = InlineState::default();
+    state.agent_run.active = Some(active_run);
+    state.agent_run.held_events = vec![
+        held_text("run-1", "stale after the run ended"),
+        held_text("other-run", "unrelated text"),
+    ];
+
+    discard_text_held_before_shell_result(&mut state, "run-1");
+
+    assert!(state
+        .agent_run
+        .active
+        .as_ref()
+        .expect("active run")
+        .held_events
+        .is_empty());
+    let remaining = state
+        .agent_run
+        .held_events
+        .iter()
+        .map(|event| event.display_text.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(remaining, ["unrelated text"]);
+}
+
+fn held_text(run_id: &str, text: &str) -> GovernedEvent {
+    GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::TextDelta {
+            run_id: run_id.to_string(),
+            text: text.to_string(),
+        },
+        reason: "held".to_string(),
+        display_text: text.to_string(),
+        auto_execute: false,
+    }
 }
 
 fn test_active_run(request: AgentRequest, handle: AgentRunHandle) -> ActiveAgentRun {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_state.rs
@@ -18,6 +18,16 @@ impl EvidenceState {
         self.shell_command_completed.push(evidence);
     }
 
+    /// Claims **at most one** pending recovery, oldest first.
+    ///
+    /// A claim is irreversible — the evidence moves to `RecoveryQueued` and its
+    /// approval id enters the dedup set — so a caller may only claim what it can
+    /// start immediately. Starting one continuation polls the provider, which can
+    /// surface a compaction recommendation; every further internal run would then
+    /// be dropped by the start gate while already counting as claimed, losing
+    /// that recovery for good. One per idle boundary keeps claim and start
+    /// atomic; remaining recoveries are picked up at the next boundary. Same
+    /// contract as [`Self::claim_stalled_provider_shell_handoff_continuations`].
     pub(crate) fn claim_pending_shell_handoff_continuations(
         &mut self,
     ) -> Vec<RuntimeShellCommandCompleted> {
@@ -37,6 +47,7 @@ impl EvidenceState {
             }
             evidence.continuation_state = ShellEvidenceContinuationState::RecoveryQueued;
             requests.push(evidence.clone());
+            break;
         }
         requests
     }
@@ -268,6 +279,33 @@ mod tests {
 
         let second = state.claim_pending_shell_handoff_continuations();
         assert!(second.is_empty());
+    }
+
+    // Two handoffs can complete in one dispatch batch. Claiming both at once
+    // would gamble the second on a start path that may already be closed by the
+    // time it runs, and a lost claim can never be retried — so each boundary
+    // takes exactly one and the rest stay claimable.
+    #[test]
+    fn evidence_state_claims_one_pending_continuation_per_boundary() {
+        let mut state = EvidenceState::default();
+        for approval_id in ["req-1", "req-2"] {
+            state.record_shell_command_completed(shell_evidence(
+                Some(approval_id),
+                false,
+                "provider_run_not_active",
+                Some("provider run was not active"),
+            ));
+        }
+
+        let first = state.claim_pending_shell_handoff_continuations();
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].approval_id.as_deref(), Some("req-1"));
+
+        let second = state.claim_pending_shell_handoff_continuations();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].approval_id.as_deref(), Some("req-2"));
+
+        assert!(state.claim_pending_shell_handoff_continuations().is_empty());
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/shell_handoff_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/shell_handoff_state.rs
@@ -44,6 +44,18 @@ impl ShellHandoffState {
         !self.approved.is_empty() || !self.pending.is_empty()
     }
 
+    /// Whether `run_id` still owns an approved-but-unfinished handoff.
+    ///
+    /// Callers that decide whether a specific run's output can already reflect
+    /// its command result must use this rather than [`Self::has_active_handoff`]:
+    /// a handoff belonging to some other run says nothing about this one.
+    pub(crate) fn has_active_handoff_for_run(&self, run_id: &str) -> bool {
+        self.approved
+            .iter()
+            .chain(self.pending.iter())
+            .any(|handoff| handoff.request.run_id == run_id)
+    }
+
     pub(crate) fn mark_timeout_interrupt_if_elapsed(&mut self, timeout: Duration) -> bool {
         let Some(handoff) = self.pending.front_mut() else {
             return false;

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/mod.rs
@@ -3,5 +3,6 @@ use super::*;
 mod continuation;
 mod fallback;
 mod foreground;
+mod preemptive_text;
 mod recovery;
 mod send_to_shell;

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/preemptive_text.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/preemptive_text.rs
@@ -1,0 +1,237 @@
+use super::*;
+
+// Raising the shell-evidence idle timeout far above the test's own schedule
+// makes the stalled-provider fallback unreachable, so a recovery that still
+// happens can only have come from the evidence-delivery boundary.
+const NO_IDLE_FALLBACK: (&str, &str) = ("COSH_SHELL_EVIDENCE_IDLE_TIMEOUT_SECS", "600");
+
+// The provider answered in the same turn as the Bash tool request and ended the
+// turn before the foreground shell result existed. That text is based on prompt
+// history, not on this command, so it must never reach the terminal; the answer
+// must come from the shell-evidence continuation instead, and not from the
+// stalled-provider idle fallback.
+#[test]
+fn raw_cli_preemptive_provider_text_is_dropped_and_recovered_from_shell_evidence() {
+    let home = temp_shell_home("cosh-core-preemptive-stale-text");
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let cosh_core_path = bin_dir.join("cosh-core");
+    write_executable(
+        &cosh_core_path,
+        r#"#!/bin/sh
+read -r init
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true}}}}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-core-preempt","model":"cosh-core-test"}'
+read -r user_message
+case "$user_message" in
+  *ShellCommandCompleted*)
+    printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-preempt","message":{"content":[{"type":"text","text":"Token total reported by this run: FRESH_SENTINEL."}]}}'
+    printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-preempt","is_error":false,"result":"done"}'
+    exit 0
+    ;;
+  *cosh-core-provider-preempts-shell-result*)
+    printf '%s\n' '{"type":"control_request","request_id":"ctrl-preempt","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"sleep 1; echo FRESH_SENTINEL"},"tool_use_id":"toolu-preempt"}}'
+    printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-preempt","message":{"content":[{"type":"text","text":"Token total reported by this run: STALE_SENTINEL."}]}}'
+    printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-preempt","is_error":false,"result":"done"}'
+    exit 0
+    ;;
+esac
+printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-preempt","is_error":false,"result":"ignored"}'
+"#,
+    );
+    let home_str = home.to_string_lossy().to_string();
+    let cosh_core_path_str = cosh_core_path.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "cosh-core",
+        &[],
+        &[
+            ("HOME", &home_str),
+            ("COSH_CORE_PATH", &cosh_core_path_str),
+            NO_IDLE_FALLBACK,
+        ],
+        vec![
+            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+            (
+                b"?? cosh-core-provider-preempts-shell-result\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"\n".to_vec(), Duration::from_millis(2_000)),
+            (b"exit 0\n".to_vec(), Duration::from_millis(4_000)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(output.contains("Approved req-1"), "{output}");
+    assert!(output.contains("Bash tool sent to shell"), "{output}");
+    assert!(
+        output.contains("$ sleep 1; echo FRESH_SENTINEL"),
+        "{output}"
+    );
+    // The pre-result answer is never rendered, in any form.
+    assert!(!output.contains("STALE_SENTINEL"), "{output}");
+    // The answer the user sees was generated after the evidence landed, and the
+    // recovery ran exactly once.
+    assert_eq!(
+        count_occurrences(&output, "Token total reported by this run: FRESH_SENTINEL."),
+        1,
+        "{output}"
+    );
+    assert_ordered(
+        &output,
+        &[
+            "Bash tool sent to shell",
+            "Token total reported by this run: FRESH_SENTINEL.",
+        ],
+    );
+    assert!(!output.contains("Agent timed out:"), "{output}");
+}
+
+// Same preemptive answer, but emitted while the foreground command is still
+// running, so the text is held by the still-active run rather than by the
+// shell-wide hold. It must be dropped there too, and the answer must still come
+// from the shell-evidence continuation.
+#[test]
+fn raw_cli_preemptive_provider_text_during_command_is_dropped_and_recovered() {
+    let home = temp_shell_home("cosh-core-preemptive-late-finish");
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let cosh_core_path = bin_dir.join("cosh-core");
+    write_executable(
+        &cosh_core_path,
+        r#"#!/bin/sh
+read -r init
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true}}}}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-core-late-finish","model":"cosh-core-test"}'
+read -r user_message
+case "$user_message" in
+  *ShellCommandCompleted*)
+    printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-late-finish","message":{"content":[{"type":"text","text":"Token total reported by this run: FRESH_SENTINEL."}]}}'
+    printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-late-finish","is_error":false,"result":"done"}'
+    exit 0
+    ;;
+  *cosh-core-provider-preempts-during-command*)
+    printf '%s\n' '{"type":"control_request","request_id":"ctrl-late","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"sleep 5; echo FRESH_SENTINEL"},"tool_use_id":"toolu-late"}}'
+    # Answer from prompt history early in the foreground command, then end the
+    # turn without ever consuming the host-executed result. The command outlasts
+    # this by ~4s, so the stale text always precedes the shell result.
+    sleep 1
+    printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-late-finish","message":{"content":[{"type":"text","text":"Token total reported by this run: STALE_SENTINEL."}]}}'
+    printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-late-finish","is_error":false,"result":"done"}'
+    exit 0
+    ;;
+esac
+printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-late-finish","is_error":false,"result":"ignored"}'
+"#,
+    );
+    let home_str = home.to_string_lossy().to_string();
+    let cosh_core_path_str = cosh_core_path.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "cosh-core",
+        &[],
+        &[
+            ("HOME", &home_str),
+            ("COSH_CORE_PATH", &cosh_core_path_str),
+            NO_IDLE_FALLBACK,
+        ],
+        vec![
+            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+            (
+                b"?? cosh-core-provider-preempts-during-command\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"\n".to_vec(), Duration::from_millis(1_000)),
+            (b"exit 0\n".to_vec(), Duration::from_millis(10_000)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(output.contains("Approved req-1"), "{output}");
+    assert!(output.contains("Bash tool sent to shell"), "{output}");
+    assert!(!output.contains("STALE_SENTINEL"), "{output}");
+    assert_eq!(
+        count_occurrences(&output, "Token total reported by this run: FRESH_SENTINEL."),
+        1,
+        "{output}"
+    );
+    assert!(!output.contains("Agent timed out:"), "{output}");
+}
+
+// The normal same-turn flow is untouched: preamble text emitted before the Bash
+// tool request and the final text emitted after the host-executed result both
+// survive, and no recovery turn is started.
+#[test]
+fn raw_cli_same_turn_host_executed_result_keeps_preamble_and_final_text() {
+    let home = temp_shell_home("cosh-core-same-turn-preamble");
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let cosh_core_path = bin_dir.join("cosh-core");
+    write_executable(
+        &cosh_core_path,
+        r#"#!/bin/sh
+read -r init
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true}}}}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-core-same-turn","model":"cosh-core-test"}'
+read -r user_message
+case "$user_message" in
+  *cosh-core-provider-same-turn-preamble*)
+    printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-same-turn","message":{"content":[{"type":"text","text":"PREAMBLE_SENTINEL let me run the command."}]}}'
+    printf '%s\n' '{"type":"control_request","request_id":"ctrl-same-turn","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"sleep 1; echo SAME_TURN_OUTPUT"},"tool_use_id":"toolu-same-turn"}}'
+    if IFS= read -r response; then
+      case "$response" in
+        *'"behavior":"host_executed_shell"'*SAME_TURN_OUTPUT*)
+          printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-same-turn","message":{"content":[{"type":"text","text":"FINAL_SENTINEL the command printed SAME_TURN_OUTPUT."}]}}'
+          printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-same-turn","is_error":false,"result":"done"}'
+          exit 0
+          ;;
+      esac
+    fi
+    printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-same-turn","is_error":true,"result":"missing same-turn host_executed_shell result"}'
+    exit 1
+    ;;
+esac
+printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-same-turn","is_error":false,"result":"ignored"}'
+"#,
+    );
+    let home_str = home.to_string_lossy().to_string();
+    let cosh_core_path_str = cosh_core_path.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "cosh-core",
+        &[],
+        &[("HOME", &home_str), ("COSH_CORE_PATH", &cosh_core_path_str)],
+        vec![
+            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+            (
+                b"?? cosh-core-provider-same-turn-preamble\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"\n".to_vec(), Duration::from_millis(2_000)),
+            (b"exit 0\n".to_vec(), Duration::from_millis(6_000)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(output.contains("Approved req-1"), "{output}");
+    assert!(output.contains("Bash tool sent to shell"), "{output}");
+    assert!(
+        output.contains("PREAMBLE_SENTINEL let me run the command."),
+        "{output}"
+    );
+    assert!(
+        output.contains("FINAL_SENTINEL the command printed SAME_TURN_OUTPUT."),
+        "{output}"
+    );
+    assert!(
+        output.contains("provider_result_delivery_status: delivered")
+            || !output.contains("provider_result_delivery_status:"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("missing same-turn host_executed_shell result"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("Using a fresh provider turn for shell evidence recovery."),
+        "{output}"
+    );
+    assert!(!output.contains("Agent timed out:"), "{output}");
+}


### PR DESCRIPTION
## Description

Drop provider text generated before a foreground shell result when the provider
turn finishes early, then start a shell-evidence continuation at the next safe
idle boundary. Recovery cleanup and claims are scoped to the owning run and
serialized so concurrent handoffs cannot lose evidence. Repeated identical
commands now bind to the current unhandled command block instead of reusing an
older result.

## Related Issue

closes #2048

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cosh-shell --lib`
- `cargo test -p cosh-shell --test raw_cli provider_handoff::preemptive_text`
- `cargo test -p cosh-shell --bin cosh-shell`
  - 2,184 passed and 1 ignored; one known concurrent mock-binary
    `Text file busy` flake passed on isolated rerun.
- `crates/cosh-shell/scripts/check-layout.sh`
- `./scripts/check-test-inventory.sh`
- Sanitized live no-tool baseline: one expected result marker, no errors.
- Manual terminal regression at `fad9f231943e53b8c4856a849a1eb79d2870bec0`:
  repeated identical commands returned the current output on both runs.

## Additional Notes

No provider-adapter, timeout, or skill-example changes are included.
