### PR TITLE
fix(sight): skip message parse for non-LLM paths

### DIFF
--- a/src/agentsight/src/analyzer/message/mod.rs
+++ b/src/agentsight/src/analyzer/message/mod.rs
@@ -119,7 +119,10 @@ impl MessageParser {
             return Some(parsed);
         }
 
-        log::warn!("Path '{path}' does not match any known LLM API endpoint");
+        // The analyzer pre-filters non-LLM paths before calling in, so
+        // reaching this point is unexpected but harmless — keep it at debug
+        // as a last-resort diagnostic rather than a per-request alert.
+        log::debug!("Path '{path}' does not match any known LLM API endpoint");
         None
     }
 

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -547,6 +547,14 @@ impl Analyzer {
 
     /// Extract parsed API message from HTTP request/response bodies
     fn extract_message_from_http(&self, result: &AggregatedResult) -> Option<AnalysisResult> {
+        // eBPF capture feeds every HTTPS connection through this pipeline, so
+        // non-LLM traffic (e.g. MCP server requests) lands here too.
+        // parse_by_path would reject it anyway, but only after logging a
+        // per-request diagnostic; filter up front to keep such traffic out of
+        // the message parse path entirely.
+        if !Self::should_parse_message(result) {
+            return None;
+        }
         match result {
             AggregatedResult::HttpComplete(pair) => {
                 let req_body = pair.request.json_body();
@@ -584,6 +592,33 @@ impl Analyzer {
             AggregatedResult::ResponseOnly { .. }
             | AggregatedResult::ProcessComplete(_)
             | AggregatedResult::Http2Frames { .. } => None,
+        }
+    }
+
+    /// Whether the aggregated result's request path belongs to a known LLM
+    /// provider and is therefore worth message parsing.
+    ///
+    /// Unlike `GenAIBuilder::build_llm_call`, no `is_sse` exception is needed
+    /// here: this predicate is exactly the OR of the per-provider
+    /// `matches_path` checks that gate `parse_by_path` itself, so any SSE
+    /// stream it rejects could never have produced a parsed message. The
+    /// genai SSE fallback consumes the `HttpRecord` built elsewhere in
+    /// `analyze_aggregated` and is unaffected by this filter.
+    fn should_parse_message(result: &AggregatedResult) -> bool {
+        match result {
+            AggregatedResult::HttpComplete(pair) | AggregatedResult::SseComplete(pair) => {
+                MessageParser::is_llm_api_path(&pair.request.path)
+            }
+            AggregatedResult::RequestOnly { request, .. } => {
+                MessageParser::is_llm_api_path(&request.path)
+            }
+            AggregatedResult::Http2StreamComplete(stream) => {
+                MessageParser::is_llm_api_path(&stream.path())
+            }
+            // Variants without a request path never reach message parsing.
+            AggregatedResult::ResponseOnly { .. }
+            | AggregatedResult::ProcessComplete(_)
+            | AggregatedResult::Http2Frames { .. } => false,
         }
     }
 
@@ -1597,6 +1632,38 @@ mod tests {
             }
             other => panic!("expected SysomMessage with response, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_should_parse_message_rejects_non_llm_path() {
+        // MCP servers stream JSON-RPC over percent-encoded paths like the one
+        // below. The discriminating point is the pre-filter branch itself:
+        // parse_by_path returned None for such paths even before the filter
+        // existed, so only a direct assertion on should_parse_message can
+        // fail if the filter is removed.
+        let analyzer = Analyzer::new();
+        let request_body = br#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#;
+        let chunk = serde_json::json!({"jsonrpc": "2.0", "id": 1, "result": {}});
+        let stream = build_sse_http2_stream(
+            "/@modelcontextprotocol%2fserver-everything",
+            request_body,
+            &chunk,
+        );
+        let agg = AggregatedResult::Http2StreamComplete(stream);
+
+        assert!(!Analyzer::should_parse_message(&agg));
+        assert!(analyzer.extract_message_from_http(&agg).is_none());
+
+        // Positive control: the same filter must pass LLM paths (SSE
+        // included), otherwise it would silently drop provider traffic.
+        let llm_stream = build_sse_http2_stream(
+            "/v1/chat/completions",
+            br#"{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}"#,
+            &serde_json::json!({"id": "chatcmpl-1"}),
+        );
+        assert!(Analyzer::should_parse_message(
+            &AggregatedResult::Http2StreamComplete(llm_stream)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description

MCP server traffic captured by the eBPF probes flows through the same analysis pipeline as LLM provider traffic, so every MCP request reached the message parser and emitted a `warn` log about an unknown path (#2041). This change gates `extract_message_from_http` with a new `should_parse_message` pre-filter and demotes the leftover fallback `warn` to `debug`, since unknown paths are routine traffic rather than anomalies. Key decision: the filter reuses the same path predicate (`MessageParser::is_llm_api_path`) that already gates `parse_by_path` and the genai builder, instead of hardcoding MCP-specific strings or adding a config knob — so the filter can never disagree with the parser it protects.

## Related Issue

closes #2041

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Verified on a Linux 6.6 environment with rustc 1.89.0 (matches CI); the local dev box cannot compile `libbpf-sys` due to GCC 4.8.5, so all verification was run there:

- `cargo fmt --all --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test` — 1284 unit + 85 integration + 2 doc tests passed
- New discriminating unit test `test_should_parse_message_rejects_non_llm_path`, reverse-verified: it fails when the pre-filter is removed, and includes a positive control asserting LLM paths (SSE included) still pass the filter.

## Additional Notes

No config or behavior change for LLM provider traffic: the pre-filter is exactly the OR of the per-provider `matches_path` checks that already gate `parse_by_path`, so any request it rejects could never have produced a parsed message.
