### PR TITLE
feat(skillfs): support container sidecars

### DIFF
--- a/docs/user-guide/en/README.md
+++ b/docs/user-guide/en/README.md
@@ -70,6 +70,7 @@ ANOLISA provides a complete server-side runtime for AI Agent workloads. Componen
 |----------|-----------|-------------|
 | [Workspace Checkpoints](runtime/ws-ckpt.md) | ws-ckpt | Instant snapshot/rollback via btrfs COW |
 | [Skill Filesystem](runtime/skillfs.md) | skillfs | FUSE virtual views with progressive disclosure |
+| [SkillFS Kubernetes Sidecar](runtime/skillfs-kubernetes-sidecar.md) | skillfs | Running SkillFS as a FUSE sidecar in Kubernetes |
 
 ---
 

--- a/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
@@ -1,0 +1,121 @@
+# Run SkillFS as a Kubernetes Sidecar
+
+[中文版](../../zh/runtime/skillfs-kubernetes-sidecar.md)
+
+Run SkillFS beside a Kubernetes workload so the workload reads the SkillFS
+view without mounting the physical skill source. The SkillFS container owns the
+FUSE mount; the workload stays non-privileged and receives the propagated view.
+
+## Prerequisites
+
+- Kubernetes 1.29 or later.
+- Linux nodes with `/dev/fuse`.
+- Permission to run the SkillFS sidecar as privileged.
+- `docker buildx` and `kubectl`.
+- A registry that the cluster can pull from.
+
+## Build and push the image
+
+Build for the target node architecture:
+
+```bash
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+export PLATFORM=linux/amd64
+
+docker buildx build \
+  --platform "$PLATFORM" \
+  -f src/skillfs/container/Dockerfile \
+  -t "$IMAGE" \
+  --push \
+  src/skillfs
+```
+
+Use `linux/arm64` for ARM64 nodes.
+
+## Deploy
+
+The example uses a ConfigMap-backed skill source. Replace it with a PVC for
+persistent workloads.
+
+```bash
+export NS=skillfs-container-example
+
+kubectl apply -f src/skillfs/deploy/kubernetes/00-namespace.yaml
+kubectl apply -f src/skillfs/deploy/kubernetes/10-example-configmap.yaml
+sed "s|skillfs-sidecar:dev|$IMAGE|g" \
+  src/skillfs/deploy/kubernetes/20-pod.yaml | kubectl apply -f -
+
+kubectl -n "$NS" wait \
+  --for=condition=Ready pod/skillfs-sidecar-example \
+  --timeout=300s
+```
+
+## Verify the mounted view
+
+Read the view from the non-privileged workload container:
+
+```bash
+export POD=skillfs-sidecar-example
+export VIEW=/var/lib/skillfs/shared/mount/skills
+
+kubectl -n "$NS" exec "$POD" -c agent -- ls -1 "$VIEW"
+kubectl -n "$NS" exec "$POD" -c agent -- \
+  cat "$VIEW/skillfs-container-example/SKILL.md"
+kubectl -n "$NS" exec "$POD" -c agent -- \
+  cat "$VIEW/skill-discover/SKILL.md"
+kubectl -n "$NS" exec "$POD" -c agent -- \
+  cat "$VIEW/skillfs-container-reserve/SKILL.md"
+```
+
+The listing must contain `skillfs-container-example` and `skill-discover`, but
+not `skillfs-container-reserve`. The `skill-discover` output must contain the
+`reserve` view and the absolute path used by the last command. Secondary
+skills are hidden from directory listings, while their advertised paths remain
+readable.
+
+## Verify sidecar restart
+
+```bash
+kubectl -n "$NS" exec "$POD" -c skillfs -- \
+  /bin/bash -c 'kill -TERM 1'
+kubectl -n "$NS" wait \
+  --for=condition=Ready pod/skillfs-sidecar-example \
+  --timeout=300s
+```
+
+Run the mounted-view commands again after the Pod returns to Ready.
+
+## Use your own workload
+
+Edit `src/skillfs/deploy/kubernetes/20-pod.yaml`:
+
+1. replace `skill-source` with your PVC;
+2. remove the example ConfigMap and `seed-example` init container;
+3. set `SKILLFS_PROBE_FILE` to a stable file in the mounted view;
+4. replace the `agent` image and command;
+5. keep `Bidirectional` on the SkillFS mount and `HostToContainer` on the
+   workload mount.
+
+The workload readiness probe should read meaningful SkillFS content, not only
+check the directory or run `skillfs --version`.
+
+## Troubleshoot
+
+```bash
+kubectl -n "$NS" describe pod "$POD"
+kubectl -n "$NS" logs "$POD" -c skillfs
+kubectl -n "$NS" logs "$POD" -c skillfs --previous
+kubectl -n "$NS" get events --sort-by=.lastTimestamp
+```
+
+Common causes are blocked privileged containers, missing `/dev/fuse`, incorrect
+mount propagation, an unreadable probe file, or a read-only source volume.
+
+## Cleanup
+
+```bash
+kubectl delete namespace "$NS" --wait=true
+```
+
+`emptyDir` does not survive Pod recreation. Use a PVC when skill changes must
+persist across Pods.

--- a/docs/user-guide/zh/README.md
+++ b/docs/user-guide/zh/README.md
@@ -70,6 +70,7 @@ ANOLISA 为 AI Agent 提供完整的服务端运行时能力。通过 `anolisa` 
 |------|------|------|
 | [工作区快照](runtime/ws-ckpt.md) | ws-ckpt | 秒级快照创建/回滚，基于 btrfs COW |
 | [技能文件系统](runtime/skillfs.md) | skillfs | FUSE 虚拟视图、渐进披露 |
+| [SkillFS Kubernetes Sidecar](runtime/skillfs-kubernetes-sidecar.md) | skillfs | 在 Kubernetes 中以 FUSE Sidecar 运行 SkillFS |
 
 ---
 

--- a/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
@@ -1,0 +1,118 @@
+# 在 Kubernetes 上以 Sidecar 运行 SkillFS
+
+[English](../../en/runtime/skillfs-kubernetes-sidecar.md)
+
+将 SkillFS 与 Kubernetes 工作负载部署在同一个 Pod 内。SkillFS 容器负责 FUSE
+mount，工作负载保持非特权，只读取传播后的 SkillFS view，不直接挂载物理 Skill
+source。
+
+## 前提条件
+
+- Kubernetes 1.29 或更高版本。
+- Linux 节点提供 `/dev/fuse`。
+- 允许 SkillFS Sidecar 以特权容器运行。
+- 可使用 `docker buildx` 和 `kubectl`。
+- 集群能够拉取目标 registry 中的镜像。
+
+## 构建并推送镜像
+
+请为目标节点架构构建镜像：
+
+```bash
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+export PLATFORM=linux/amd64
+
+docker buildx build \
+  --platform "$PLATFORM" \
+  -f src/skillfs/container/Dockerfile \
+  -t "$IMAGE" \
+  --push \
+  src/skillfs
+```
+
+ARM64 节点使用 `linux/arm64`。
+
+## 部署
+
+示例使用 ConfigMap 提供 Skill source。持久化部署应替换为 PVC。
+
+```bash
+export NS=skillfs-container-example
+
+kubectl apply -f src/skillfs/deploy/kubernetes/00-namespace.yaml
+kubectl apply -f src/skillfs/deploy/kubernetes/10-example-configmap.yaml
+sed "s|skillfs-sidecar:dev|$IMAGE|g" \
+  src/skillfs/deploy/kubernetes/20-pod.yaml | kubectl apply -f -
+
+kubectl -n "$NS" wait \
+  --for=condition=Ready pod/skillfs-sidecar-example \
+  --timeout=300s
+```
+
+## 验证挂载视图
+
+从非特权工作负载容器读取 SkillFS view：
+
+```bash
+export POD=skillfs-sidecar-example
+export VIEW=/var/lib/skillfs/shared/mount/skills
+
+kubectl -n "$NS" exec "$POD" -c agent -- ls -1 "$VIEW"
+kubectl -n "$NS" exec "$POD" -c agent -- \
+  cat "$VIEW/skillfs-container-example/SKILL.md"
+kubectl -n "$NS" exec "$POD" -c agent -- \
+  cat "$VIEW/skill-discover/SKILL.md"
+kubectl -n "$NS" exec "$POD" -c agent -- \
+  cat "$VIEW/skillfs-container-reserve/SKILL.md"
+```
+
+目录应包含 `skillfs-container-example` 和 `skill-discover`，但不应直接包含
+`skillfs-container-reserve`。`skill-discover` 输出应包含 `reserve` view 和
+最后一条命令使用的绝对路径。Secondary skill 不出现在目录列表中，但可以通过
+其中提供的路径读取。
+
+## 验证 Sidecar 重启
+
+```bash
+kubectl -n "$NS" exec "$POD" -c skillfs -- \
+  /bin/bash -c 'kill -TERM 1'
+kubectl -n "$NS" wait \
+  --for=condition=Ready pod/skillfs-sidecar-example \
+  --timeout=300s
+```
+
+Pod 恢复 Ready 后，重新执行挂载视图验证命令。
+
+## 使用自己的工作负载
+
+修改 `src/skillfs/deploy/kubernetes/20-pod.yaml`：
+
+1. 将 `skill-source` 替换为自己的 PVC；
+2. 删除示例 ConfigMap 和 `seed-example` init container；
+3. 将 `SKILLFS_PROBE_FILE` 设置为挂载视图中的稳定文件；
+4. 替换 `agent` 镜像和命令；
+5. 保留 SkillFS mount 的 `Bidirectional` 和工作负载 mount 的
+   `HostToContainer`。
+
+工作负载 readiness probe 应读取有意义的 SkillFS 内容，不应只检查目录存在或运行
+`skillfs --version`。
+
+## 故障排查
+
+```bash
+kubectl -n "$NS" describe pod "$POD"
+kubectl -n "$NS" logs "$POD" -c skillfs
+kubectl -n "$NS" logs "$POD" -c skillfs --previous
+kubectl -n "$NS" get events --sort-by=.lastTimestamp
+```
+
+常见原因包括特权容器被策略阻止、`/dev/fuse` 缺失、mount propagation 配置错误、
+probe 文件不可读或 source volume 为只读。
+
+## 清理
+
+```bash
+kubectl delete namespace "$NS" --wait=true
+```
+
+`emptyDir` 无法跨 Pod 保留内容。Skill 变更需要持久化时请使用 PVC。

--- a/src/skillfs/.dockerignore
+++ b/src/skillfs/.dockerignore
@@ -1,0 +1,19 @@
+# Keep the SkillFS sidecar build context small and free of host artifacts, so
+# the image contents depend only on tracked sources plus Cargo.lock.
+target/
+**/target/
+.git/
+.gitignore
+
+# Local scratch that must never reach the image.
+*.log
+*.tmp
+tmp/
+mnt/
+mount/
+
+# Documentation and container-unrelated assets are not needed by the build.
+docs/
+website/
+POSIX_FS_REFERENCES.md
+POSIX_FS_TEST_MATRIX.csv

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -16,7 +16,7 @@ mounted filesystem while ordinary skill files remain backed by the source tree.
 - Uses `skillfs-views.toml` to choose the default view and secondary views.
 - Shows default-view skills directly in the mounted agent view.
 - Always exposes the virtual `skill-discover` skill so agents can discover
-  skills from secondary views and their source paths.
+  skills from secondary views and open their advertised paths.
 - Compiles `SKILL.md` on read, including conditional blocks and command
   normalization.
 - Passes ordinary files and subdirectories through to the physical source tree.
@@ -194,7 +194,7 @@ After mounting:
 
 - `/skills` shows skills from the default view.
 - `skill-discover/SKILL.md` lists skills from secondary views and their
-  `source_path`.
+  readable `source_path` values.
 
 ## `SKILL.md` Format
 
@@ -396,6 +396,8 @@ crates/
   skillfs-core/   parser, store, views, compiler, env, watcher
   skillfs-fuse/   FUSE filesystem and POSIX passthrough layer
   skillfs-cli/    mount / stop / classify / validate / list
+container/        sidecar image: Dockerfile, entrypoint, preflight, mount probe
+deploy/kubernetes/  Kubernetes sidecar manifests and example skill source
 docs/specs/       implementation specifications
 docs/security/    external decision and runtime activation docs
 docs/testing/     POSIX acceptance and external harness docs
@@ -411,11 +413,33 @@ scripts/          build.sh, test.sh, and optional POSIX harness
   - Creates a temporary skill source directory and `skillfs-views.toml`.
   - Verifies that the FUSE mount starts.
   - Verifies that `/skills` exposes default-view skills.
-  - Verifies that `skill-discover` lists secondary views and `source_path`.
+  - Verifies that `skill-discover` paths open secondary skills.
   - Verifies passthrough reads for physical files inside a skill directory.
   - Verifies clean unmount through `SIGTERM`.
 - [scripts/posix/run_pjdfstest.sh](scripts/posix/run_pjdfstest.sh)
   - Optional external POSIX harness; normal `cargo test` does not depend on it.
+
+## Kubernetes Sidecar
+
+SkillFS can expose its FUSE view to a non-privileged workload from a privileged
+sidecar. This requires Kubernetes 1.29+, `/dev/fuse`, and permission to run the
+sidecar as privileged.
+
+```bash
+cd src/skillfs
+IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+docker build -f container/Dockerfile -t "$IMAGE" .
+docker push "$IMAGE"
+kubectl apply -f deploy/kubernetes/00-namespace.yaml
+kubectl apply -f deploy/kubernetes/10-example-configmap.yaml
+sed "s|skillfs-sidecar:dev|$IMAGE|g" deploy/kubernetes/20-pod.yaml |
+  kubectl apply -f -
+```
+
+See the
+[Kubernetes sidecar user guide](../../docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md)
+([中文](../../docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md)) for
+deployment, `skill-discover` verification, troubleshooting, and cleanup.
 
 ## Test Coverage
 
@@ -532,6 +556,8 @@ Related security surfaces:
 
 ## Documentation
 
+- [Kubernetes sidecar deployment guide](../../docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md) -
+  Build, deploy, verify, and clean up SkillFS in Kubernetes.
 - [docs/specs/skillfs-spec.md](docs/specs/skillfs-spec.md) - Architecture,
   runtime consistency boundaries, and deployment scenarios.
 - [docs/specs/core-spec.md](docs/specs/core-spec.md) - `skillfs-core`

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -16,7 +16,7 @@ SkillFS 是面向 agent skill 的本地 FUSE 文件系统。它解析 `SKILL.md`
 - 通过 `skillfs-views.toml` 选择默认 view 和 secondary views。
 - 在挂载后的 agent 视图中直接显示默认 view 的 skills。
 - 始终暴露虚拟 `skill-discover` skill，让 agent 能发现 secondary views 中的
-  skills 及其 source paths。
+  skills，并打开其中提供的路径。
 - 读取 `SKILL.md` 时执行条件块编译和命令归一化。
 - 将普通文件和子目录透传到底层物理 source 树。
 - 支持 normal mount 和 in-place mount。
@@ -179,7 +179,7 @@ skills = ["apple-notes", "blogwatcher"]
 
 - `/skills` 显示 default view 中的 skills。
 - `skill-discover/SKILL.md` 列出 secondary views 中的 skills 及其
-  `source_path`。
+  可读 `source_path`。
 
 ## `SKILL.md` 格式
 
@@ -357,6 +357,8 @@ crates/
   skillfs-core/   parser, store, views, compiler, env, watcher
   skillfs-fuse/   FUSE 文件系统与 POSIX passthrough 层
   skillfs-cli/    mount / stop / classify / validate / list
+container/        Sidecar 镜像：Dockerfile、entrypoint、preflight、mount probe
+deploy/kubernetes/  Kubernetes Sidecar manifest 与示例 Skill source
 docs/specs/       实现规格
 docs/security/    external decision 与 runtime activation 文档
 docs/testing/     POSIX 验收与 external harness 文档
@@ -372,11 +374,31 @@ scripts/          build.sh、test.sh 与可选 POSIX harness
   - 创建临时 skill source 目录和 `skillfs-views.toml`。
   - 验证 FUSE mount 启动成功。
   - 验证 `/skills` 暴露 default-view skills。
-  - 验证 `skill-discover` 列出 secondary views 和 `source_path`。
+  - 验证 `skill-discover` 提供的路径可读取 secondary skills。
   - 验证 skill 目录中物理文件的 passthrough read。
   - 验证通过 `SIGTERM` 干净卸载。
 - [scripts/posix/run_pjdfstest.sh](scripts/posix/run_pjdfstest.sh)
   - 可选 external POSIX harness；普通 `cargo test` 不依赖它。
+
+## Kubernetes Sidecar
+
+SkillFS 可以通过特权 Sidecar 向非特权工作负载提供 FUSE view。部署需要
+Kubernetes 1.29+、`/dev/fuse`，并允许 Sidecar 使用特权模式。
+
+```bash
+cd src/skillfs
+IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+docker build -f container/Dockerfile -t "$IMAGE" .
+docker push "$IMAGE"
+kubectl apply -f deploy/kubernetes/00-namespace.yaml
+kubectl apply -f deploy/kubernetes/10-example-configmap.yaml
+sed "s|skillfs-sidecar:dev|$IMAGE|g" deploy/kubernetes/20-pod.yaml |
+  kubectl apply -f -
+```
+
+部署、`skill-discover` 验证、故障排查和清理见
+[Kubernetes Sidecar 用户指南](../../docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md)
+（[English](../../docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md)）。
 
 ## 测试覆盖
 
@@ -480,6 +502,8 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 
 ## 文档
 
+- [Kubernetes Sidecar 部署指南](../../docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md) -
+  在 Kubernetes 中构建、部署、验证和清理 SkillFS。
 - [docs/specs/skillfs-spec.md](docs/specs/skillfs-spec.md) - 架构、运行时一致性边界和部署场景。
 - [docs/specs/core-spec.md](docs/specs/core-spec.md) - `skillfs-core` 实现。
 - [docs/specs/fuse-spec.md](docs/specs/fuse-spec.md) - `skillfs-fuse` 实现。

--- a/src/skillfs/container/Dockerfile
+++ b/src/skillfs/container/Dockerfile
@@ -1,0 +1,147 @@
+# Dedicated SkillFS FUSE sidecar image.
+#
+# This image runs ONE process: `skillfs mount ... --foreground --allow-other`.
+# It deliberately does not include or start any other ANOLISA service, and it
+# does not depend on systemd or the SkillFS managed-mount supervisor.
+#
+# Build context: the `src/skillfs` component directory.
+#   docker build -f container/Dockerfile .
+
+# ---------------------------------------------------------------------------
+# Stage 1 — builder
+# ---------------------------------------------------------------------------
+# The builder and the runtime share the same base image so the produced binary
+# links against the runtime glibc and fuse3 ABI. Do not swap one side only.
+ARG BASE_IMAGE=debian:bookworm-slim
+
+FROM ${BASE_IMAGE} AS builder
+
+# Cargo.toml pins rust-version = "1.86" and edition = "2024". The toolchain is
+# installed explicitly rather than taken from the distro repo so the build does
+# not silently move to whatever rust version the base image ships this month.
+ARG RUST_VERSION=1.86.0
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        make \
+        binutils \
+        pkg-config \
+        libfuse3-dev \
+        curl \
+        ca-certificates; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    export RUSTUP_DIST_SERVER="${RUSTUP_DIST_SERVER}"; \
+    export RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT}"; \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path --profile minimal \
+            --default-toolchain "${RUST_VERSION}"; \
+    rustc --version; \
+    cargo --version
+
+WORKDIR /build
+
+# Copy the whole component. `.dockerignore` keeps `target/` and local mount
+# scratch out of the context so the image does not embed host build artifacts.
+COPY . /build
+
+# `--locked` makes the dependency set exactly Cargo.lock, which is what makes
+# repeated builds of the same commit produce the same dependency tree.
+RUN set -eux; \
+    RUSTFLAGS="-C opt-level=3 -C codegen-units=1" \
+        cargo build --release --locked -p skillfs; \
+    strip target/release/skillfs; \
+    target/release/skillfs --version
+
+# ---------------------------------------------------------------------------
+# Stage 2 — runtime
+# ---------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS runtime
+
+ARG VERSION=unknown
+ARG REVISION=unknown
+ARG SOURCE_URL=https://github.com/alibaba/anolisa
+
+# fuse3 provides the fusermount3 helper and the libfuse3 runtime the fuser crate
+# links against. The rest are the exact utilities the entrypoint, preflight, and
+# probe scripts use; they are named explicitly rather than assumed from the base
+# image, so a slimmer base cannot silently break startup:
+#
+#   bash                  all three scripts
+#   coreutils             stat, realpath, id, timeout, wc, install, sleep, head
+#   grep, gawk, sed       fuse.conf and /proc/self/mountinfo parsing
+#   findutils             the example seeding step in the reference manifest
+#   util-linux            umount, for residual-mount cleanup
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        fuse3 \
+        bash \
+        coreutils \
+        grep \
+        gawk \
+        sed \
+        findutils \
+        util-linux; \
+    rm -rf /var/lib/apt/lists/*
+
+# `--allow-other` requires user_allow_other in /etc/fuse.conf. The sidecar runs
+# as root today, where libfuse skips the check, but the flag is written
+# unconditionally so a future non-root sidecar UID does not silently regress,
+# and so the preflight check has something real to assert.
+RUN set -eux; \
+    touch /etc/fuse.conf; \
+    if ! grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf; then \
+        printf 'user_allow_other\n' >> /etc/fuse.conf; \
+    fi; \
+    chmod 0644 /etc/fuse.conf; \
+    grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf
+
+COPY --from=builder /build/target/release/skillfs /usr/local/bin/skillfs
+COPY container/entrypoint.sh /usr/local/bin/skillfs-sidecar-entrypoint
+COPY container/preflight.sh /usr/local/bin/skillfs-preflight
+COPY container/mount-probe.sh /usr/local/bin/skillfs-mount-probe
+
+RUN set -eux; \
+    chmod 0755 /usr/local/bin/skillfs \
+        /usr/local/bin/skillfs-sidecar-entrypoint \
+        /usr/local/bin/skillfs-preflight \
+        /usr/local/bin/skillfs-mount-probe; \
+    skillfs --version
+
+# Defaults match src/skillfs/deploy/kubernetes. Override per deployment.
+#
+# SKILLFS_MOUNTPOINT is a *subdirectory* of the shared volume, not the volume
+# root: mount propagation carries a mount created inside the shared volume, and
+# over-mounting the volume root itself is not the supported topology.
+#
+# SKILLFS_PROBE_FILE is relative to the mountpoint. SkillFS exposes the view
+# under `<mountpoint>/skills/<skill-name>/`, so the probe path includes `skills/`.
+ENV SKILLFS_SOURCE=/var/lib/skillfs/source \
+    SKILLFS_MOUNTPOINT=/var/lib/skillfs/shared/mount \
+    SKILLFS_DISCOVER_ROOT=/var/lib/skillfs/shared/mount/skills \
+    SKILLFS_EXTRA_ARGS="" \
+    SKILLFS_PROBE_FILE=skills/skillfs-container-example/SKILL.md \
+    SKILLFS_PROBE_TIMEOUT=5 \
+    RUST_LOG=info
+
+LABEL org.opencontainers.image.title="SkillFS FUSE sidecar" \
+      org.opencontainers.image.description="SkillFS foreground FUSE mount sidecar for Kubernetes" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.source="${SOURCE_URL}" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="The Anolisa Authors"
+
+# The entrypoint runs preflight and then `exec`s skillfs, so skillfs becomes
+# PID 1 and receives SIGTERM directly from the kubelet.
+ENTRYPOINT ["/usr/local/bin/skillfs-sidecar-entrypoint"]

--- a/src/skillfs/container/entrypoint.sh
+++ b/src/skillfs/container/entrypoint.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# SkillFS sidecar entrypoint.
+#
+# Runs the preflight checks, then `exec`s SkillFS so the FUSE process replaces
+# this shell as PID 1. That is what makes the kubelet's SIGTERM land directly on
+# SkillFS, which unmounts cleanly on its way out.
+#
+# There is deliberately no `sleep infinity`, no retry loop, and no trap that
+# keeps the container alive after SkillFS exits: a dead mount must surface as a
+# container restart, not as a healthy container serving nothing.
+#
+# Configuration (environment):
+#   SKILLFS_SOURCE      absolute path to the writable skill source root
+#   SKILLFS_MOUNTPOINT  absolute path where the FUSE view is exposed
+#   SKILLFS_DISCOVER_ROOT  reader-visible skills root advertised by discover
+#   SKILLFS_EXTRA_ARGS  extra `skillfs mount` arguments, whitespace separated
+#   SKILLFS_SKIP_PREFLIGHT  set to 1 to skip preflight (debugging only)
+#   RUST_LOG            SkillFS log filter, defaults to info
+#
+# Any argument passed to the container image is treated as a full command and
+# executed instead of the mount, which keeps `kubectl debug`-style overrides
+# possible without a second image.
+
+set -uo pipefail
+
+log() {
+	printf '[skillfs-entrypoint] %s\n' "$*" >&2
+}
+
+# Escape hatch for debugging: `command: ["/usr/local/bin/skillfs-sidecar-entrypoint"]`
+# plus `args: ["sleep", "3600"]` runs that command instead of the mount.
+if (($# > 0)); then
+	log "explicit command override, exec: $*"
+	exec "$@"
+fi
+
+SKILLFS_BIN="${SKILLFS_BIN:-/usr/local/bin/skillfs}"
+SOURCE_DIR="${SKILLFS_SOURCE:-}"
+MOUNTPOINT="${SKILLFS_MOUNTPOINT:-}"
+DISCOVER_ROOT="${SKILLFS_DISCOVER_ROOT:-}"
+EXTRA_ARGS="${SKILLFS_EXTRA_ARGS:-}"
+export RUST_LOG="${RUST_LOG:-info}"
+
+if [[ ! -x "$SKILLFS_BIN" ]]; then
+	log "FAIL: SkillFS binary '$SKILLFS_BIN' is missing or not executable"
+	exit 127
+fi
+
+log "skillfs version: $("$SKILLFS_BIN" --version 2>&1 | head -1)"
+log "uid=$(id -u) gid=$(id -g) source=${SOURCE_DIR:-<unset>} mountpoint=${MOUNTPOINT:-<unset>}"
+
+if [[ "${SKILLFS_SKIP_PREFLIGHT:-0}" == "1" ]]; then
+	log "WARNING: SKILLFS_SKIP_PREFLIGHT=1, skipping prerequisite validation"
+else
+	/usr/local/bin/skillfs-preflight
+	preflight_status=$?
+	if ((preflight_status != 0)); then
+		log "FAIL: preflight exited $preflight_status; not starting the mount"
+		exit "$preflight_status"
+	fi
+fi
+
+# Word splitting on SKILLFS_EXTRA_ARGS is intentional: the value is an argument
+# list, not a single argument.
+declare -a extra=()
+if [[ -n "$EXTRA_ARGS" ]]; then
+	read -r -a extra <<<"$EXTRA_ARGS"
+fi
+
+# `--foreground` keeps SkillFS as the container's main process so kubelet owns
+# restart; `--managed` and its detached supervisor must not be used here.
+# `--allow-other` is what lets the Agent container's UID reach the propagated
+# view. Both flags are fixed by the sidecar contract and are not configurable
+# through SKILLFS_EXTRA_ARGS.
+declare -a cmd=(
+	"$SKILLFS_BIN" mount "$SOURCE_DIR" "$MOUNTPOINT"
+	--foreground
+	--allow-other
+)
+if [[ -n "$DISCOVER_ROOT" ]]; then
+	cmd+=(--skill-discover-root "$DISCOVER_ROOT")
+fi
+if ((${#extra[@]} > 0)); then
+	cmd+=("${extra[@]}")
+fi
+
+log "exec: ${cmd[*]}"
+exec "${cmd[@]}"

--- a/src/skillfs/container/mount-probe.sh
+++ b/src/skillfs/container/mount-probe.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# SkillFS mount health probe for the sidecar container.
+#
+# `skillfs --version` is deliberately NOT a health signal: the binary answers
+# it while the FUSE session is absent, hung, or disconnected. This probe asserts
+# the two properties the Agent container actually depends on:
+#
+#   1. the mountpoint is present in /proc/self/mountinfo with a fuse filesystem
+#      type, and
+#   2. a configured probe file is openable and readable through the FUSE view,
+#      within a bounded time.
+#
+# The read is wrapped in `timeout` so a wedged FUSE session fails the probe
+# instead of blocking the kubelet's exec until the probe timeout kills it with
+# an ambiguous result.
+#
+# Usage:
+#   skillfs-mount-probe [--mode startup|readiness|liveness] [--timeout SECONDS]
+#                       [--mountpoint PATH] [--file RELATIVE_PATH]
+#
+# Configuration (environment, overridden by the flags above):
+#   SKILLFS_MOUNTPOINT    mountpoint to check (required)
+#   SKILLFS_PROBE_FILE    probe path relative to the mountpoint (required)
+#   SKILLFS_PROBE_TIMEOUT per-read timeout in seconds (default 5)
+#
+# Exit codes:
+#   0  the mount is present and the probe file is readable
+#   1  invalid probe configuration
+#   2  the mountpoint is not a live fuse mount
+#   3  the probe file could not be read through the FUSE view
+
+set -uo pipefail
+
+MODE="readiness"
+MOUNTPOINT="${SKILLFS_MOUNTPOINT:-}"
+PROBE_FILE="${SKILLFS_PROBE_FILE:-}"
+PROBE_TIMEOUT="${SKILLFS_PROBE_TIMEOUT:-5}"
+
+readonly EX_CONFIG=1
+readonly EX_NO_MOUNT=2
+readonly EX_UNREADABLE=3
+
+log() {
+	printf '[skillfs-probe/%s] %s\n' "$MODE" "$*" >&2
+}
+
+die() {
+	local code="$1"
+	shift
+	printf '[skillfs-probe/%s] FAIL(%s): %s\n' "$MODE" "$code" "$*" >&2
+	exit "$code"
+}
+
+while (($# > 0)); do
+	case "$1" in
+	--mode)
+		MODE="${2:-}"
+		shift 2
+		;;
+	--timeout)
+		PROBE_TIMEOUT="${2:-}"
+		shift 2
+		;;
+	--mountpoint)
+		MOUNTPOINT="${2:-}"
+		shift 2
+		;;
+	--file)
+		PROBE_FILE="${2:-}"
+		shift 2
+		;;
+	--startup | --readiness | --liveness)
+		MODE="${1#--}"
+		shift
+		;;
+	*)
+		die "$EX_CONFIG" "unknown argument '$1'"
+		;;
+	esac
+done
+
+case "$MODE" in
+startup | readiness | liveness) ;;
+*) die "$EX_CONFIG" "unknown mode '$MODE' (expected startup, readiness, or liveness)" ;;
+esac
+
+[[ -n "$MOUNTPOINT" ]] ||
+	die "$EX_CONFIG" "no mountpoint: set SKILLFS_MOUNTPOINT or pass --mountpoint"
+[[ -n "$PROBE_FILE" ]] ||
+	die "$EX_CONFIG" "no probe file: set SKILLFS_PROBE_FILE or pass --file (a path relative to the mountpoint)"
+[[ "$PROBE_TIMEOUT" =~ ^[0-9]+$ && "$PROBE_TIMEOUT" -gt 0 ]] ||
+	die "$EX_CONFIG" "invalid timeout '$PROBE_TIMEOUT' (expected a positive integer number of seconds)"
+
+# --- 1. the mountpoint must be a live fuse mount -----------------------------
+#
+# mountinfo field 5 is the mount point and field 9 the filesystem type. Matching
+# the type as well as the path prevents a bare shared-volume directory from
+# passing as a successful SkillFS mount.
+mount_fstype="$(awk -v target="$MOUNTPOINT" '
+	$5 == target {
+		for (i = 7; i <= NF; i++) {
+			if ($i == "-") { print $(i + 1); exit }
+		}
+	}
+' /proc/self/mountinfo 2>/dev/null)"
+
+if [[ -z "$mount_fstype" ]]; then
+	die "$EX_NO_MOUNT" "'$MOUNTPOINT' is not present in /proc/self/mountinfo; the SkillFS FUSE session has not been established (or has already been torn down)"
+fi
+if [[ "$mount_fstype" != fuse* ]]; then
+	die "$EX_NO_MOUNT" "'$MOUNTPOINT' is mounted with filesystem type '$mount_fstype', not a fuse filesystem; something other than SkillFS owns this path"
+fi
+
+# --- 2. the probe file must be readable through the FUSE view ----------------
+probe_path="$MOUNTPOINT/${PROBE_FILE#/}"
+
+read_output="$(timeout "$PROBE_TIMEOUT" cat -- "$probe_path" 2>&1 >/dev/null)"
+read_status=$?
+
+if ((read_status == 124)); then
+	die "$EX_UNREADABLE" "reading '$probe_path' did not complete within ${PROBE_TIMEOUT}s; the FUSE session ('$mount_fstype' on '$MOUNTPOINT') is not answering requests"
+fi
+if ((read_status != 0)); then
+	die "$EX_UNREADABLE" "reading '$probe_path' failed (exit $read_status): ${read_output:-no error output}"
+fi
+
+# A zero-byte read means the mount answered but the probe file is empty, which is
+# not a usable view for the Agent container either.
+byte_count_output="$(timeout "$PROBE_TIMEOUT" wc -c -- "$probe_path" 2>&1)"
+byte_count_status=$?
+
+if ((byte_count_status == 124)); then
+	die "$EX_UNREADABLE" "counting bytes in '$probe_path' did not complete within ${PROBE_TIMEOUT}s; the FUSE session ('$mount_fstype' on '$MOUNTPOINT') is not answering requests"
+fi
+if ((byte_count_status != 0)); then
+	die "$EX_UNREADABLE" "counting bytes in '$probe_path' failed (exit $byte_count_status): ${byte_count_output:-no error output}"
+fi
+
+read -r byte_count _ <<<"$byte_count_output"
+if [[ ! "$byte_count" =~ ^[0-9]+$ ]]; then
+	die "$EX_UNREADABLE" "counting bytes in '$probe_path' returned an invalid result: ${byte_count_output:-no output}"
+fi
+if ((byte_count == 0)); then
+	die "$EX_UNREADABLE" "'$probe_path' is readable through the FUSE view but returned 0 bytes; the probe file is empty"
+fi
+
+log "ok: $mount_fstype on $MOUNTPOINT, read $byte_count bytes from $probe_path"

--- a/src/skillfs/container/preflight.sh
+++ b/src/skillfs/container/preflight.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+#
+# SkillFS sidecar preflight.
+#
+# Validates every prerequisite the foreground FUSE mount needs before the
+# entrypoint `exec`s SkillFS, so a broken Pod fails during container startup
+# with a specific diagnostic instead of a generic mount error.
+#
+# Configuration (environment):
+#   SKILLFS_SOURCE            absolute path to the writable skill source root
+#   SKILLFS_MOUNTPOINT        absolute path where the FUSE view is exposed
+#   SKILLFS_FUSE_DEVICE       FUSE character device (default /dev/fuse)
+#   SKILLFS_FUSE_CONF         libfuse config file (default /etc/fuse.conf)
+#   SKILLFS_RESIDUAL_UNMOUNT  1 (default) to clear a stale mount, 0 to only report
+#
+# Exit codes are stable so operators can identify the failed prerequisite:
+#   0   all prerequisites satisfied
+#   10  invalid or missing configuration
+#   11  FUSE device missing, wrong type, or not openable
+#   12  fusermount3 helper missing or not executable
+#   13  source root missing, not a directory, or not readable/writable
+#   14  mountpoint missing, not a directory, or not usable
+#   15  fuse.conf does not permit allow_other
+#   16  mountpoint carries a residual mount that could not be cleared
+
+set -uo pipefail
+
+readonly EX_CONFIG=10
+readonly EX_FUSE_DEVICE=11
+readonly EX_FUSERMOUNT=12
+readonly EX_SOURCE=13
+readonly EX_MOUNTPOINT=14
+readonly EX_FUSE_CONF=15
+readonly EX_RESIDUAL_MOUNT=16
+
+SOURCE_DIR="${SKILLFS_SOURCE:-}"
+MOUNTPOINT="${SKILLFS_MOUNTPOINT:-}"
+FUSE_DEVICE="${SKILLFS_FUSE_DEVICE:-/dev/fuse}"
+FUSE_CONF="${SKILLFS_FUSE_CONF:-/etc/fuse.conf}"
+RESIDUAL_UNMOUNT="${SKILLFS_RESIDUAL_UNMOUNT:-1}"
+
+log() {
+	printf '[skillfs-preflight] %s\n' "$*" >&2
+}
+
+# Emit an actionable failure and exit with the caller-supplied stable code.
+# Every call must name the concrete device, file, path, permission, or setting
+# that is missing — "preflight failed" alone is not a usable diagnostic.
+die() {
+	local code="$1"
+	shift
+	printf '[skillfs-preflight] FAIL(%s): %s\n' "$code" "$*" >&2
+	exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# Mount table helpers
+# ---------------------------------------------------------------------------
+
+# Print the mount table lines whose mount point is exactly $1.
+#
+# /proc/self/mountinfo field 5 is the mount point and field 9 the filesystem
+# type. It is preferred over /proc/mounts because it also lists the propagation
+# flags this deployment depends on.
+mountinfo_lines_for() {
+	local target="$1"
+	awk -v target="$target" '
+		{
+			# Fields: id parent major:minor root mountpoint opts... - fstype src super
+			if ($5 == target) { print $0 }
+		}
+	' /proc/self/mountinfo 2>/dev/null
+}
+
+is_mounted() {
+	[[ -n "$(mountinfo_lines_for "$1")" ]]
+}
+
+# Print the filesystem type of the mount at $1, or nothing if it is not mounted.
+#
+# In mountinfo the optional fields sit between the mount options and a literal
+# "-" separator, so the filesystem type is the field after that separator rather
+# than a fixed column.
+mount_fstype_for() {
+	local target="$1"
+	awk -v target="$target" '
+		$5 == target {
+			for (i = 7; i <= NF; i++) {
+				if ($i == "-") { print $(i + 1); exit }
+			}
+		}
+	' /proc/self/mountinfo 2>/dev/null
+}
+
+# Report whether the mountpoint is a dead FUSE endpoint. `stat` on a mountpoint
+# whose FUSE daemon is gone fails with ENOTCONN, which is exactly the state a
+# restarted sidecar inherits through a Bidirectional shared volume.
+is_disconnected_endpoint() {
+	local target="$1"
+	local err
+	err="$(stat -c '%i' "$target" 2>&1 >/dev/null)"
+	[[ "$err" == *"Transport endpoint is not connected"* || "$err" == *ENOTCONN* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+check_config() {
+	if [[ -z "$SOURCE_DIR" ]]; then
+		die "$EX_CONFIG" "SKILLFS_SOURCE is unset or empty; set it to the absolute path of the skill source root"
+	fi
+	if [[ -z "$MOUNTPOINT" ]]; then
+		die "$EX_CONFIG" "SKILLFS_MOUNTPOINT is unset or empty; set it to the absolute path where the FUSE view is exposed"
+	fi
+	if [[ "$SOURCE_DIR" != /* ]]; then
+		die "$EX_CONFIG" "SKILLFS_SOURCE must be an absolute path, got '$SOURCE_DIR'"
+	fi
+	if [[ "$MOUNTPOINT" != /* ]]; then
+		die "$EX_CONFIG" "SKILLFS_MOUNTPOINT must be an absolute path, got '$MOUNTPOINT'"
+	fi
+	# An in-place mount is a supported SkillFS mode but not the sidecar
+	# topology: the Agent container must see the FUSE view without the
+	# physical source being exposed on the same path.
+	if [[ "$(realpath -m -- "$SOURCE_DIR")" == "$(realpath -m -- "$MOUNTPOINT")" ]]; then
+		die "$EX_CONFIG" "SKILLFS_SOURCE and SKILLFS_MOUNTPOINT resolve to the same path ('$SOURCE_DIR'); the sidecar topology requires distinct volumes"
+	fi
+	log "config source=$SOURCE_DIR mountpoint=$MOUNTPOINT"
+}
+
+check_fuse_device() {
+	if [[ ! -e "$FUSE_DEVICE" ]]; then
+		die "$EX_FUSE_DEVICE" "FUSE device '$FUSE_DEVICE' does not exist; the Pod must map the device (securityContext.privileged plus a hostPath/CharDevice volume for '$FUSE_DEVICE')"
+	fi
+	if [[ ! -c "$FUSE_DEVICE" ]]; then
+		die "$EX_FUSE_DEVICE" "FUSE device '$FUSE_DEVICE' exists but is not a character device; check the volume type (expected CharDevice)"
+	fi
+	# Existence is not enough: a device node can be present while the
+	# container lacks the device cgroup permission to open it. The open runs in
+	# a subshell so a redirection failure cannot terminate this script and the
+	# descriptor is released immediately.
+	if ! (: <>"$FUSE_DEVICE") 2>/dev/null; then
+		die "$EX_FUSE_DEVICE" "FUSE device '$FUSE_DEVICE' cannot be opened read-write by uid $(id -u); the container needs privileged (or an explicit device allowance) on this cluster"
+	fi
+	log "fuse device $FUSE_DEVICE is present and openable"
+}
+
+check_fusermount() {
+	local helper
+	helper="$(command -v fusermount3 2>/dev/null)"
+	if [[ -z "$helper" ]]; then
+		die "$EX_FUSERMOUNT" "'fusermount3' not found in PATH ($PATH); install the fuse3 package in the sidecar image"
+	fi
+	if [[ ! -x "$helper" ]]; then
+		die "$EX_FUSERMOUNT" "'$helper' is not executable; fix the fuse3 package installation or the image file mode"
+	fi
+	log "fusermount3 helper at $helper"
+}
+
+check_source() {
+	if [[ ! -e "$SOURCE_DIR" ]]; then
+		die "$EX_SOURCE" "source root '$SOURCE_DIR' does not exist; seed it with an init container or a pre-populated volume"
+	fi
+	if [[ ! -d "$SOURCE_DIR" ]]; then
+		die "$EX_SOURCE" "source root '$SOURCE_DIR' exists but is not a directory"
+	fi
+	if [[ ! -r "$SOURCE_DIR" || ! -x "$SOURCE_DIR" ]]; then
+		die "$EX_SOURCE" "source root '$SOURCE_DIR' is not readable/traversable by uid $(id -u) gid $(id -g) (mode $(stat -c '%a owner %u:%g' "$SOURCE_DIR" 2>/dev/null))"
+	fi
+	# Write-passthrough is part of the delivered contract, so a read-only
+	# source volume has to fail here rather than at the first Agent write.
+	if [[ ! -w "$SOURCE_DIR" ]]; then
+		die "$EX_SOURCE" "source root '$SOURCE_DIR' is not writable by uid $(id -u) gid $(id -g) (mode $(stat -c '%a owner %u:%g' "$SOURCE_DIR" 2>/dev/null)); SkillFS write passthrough requires a writable source volume"
+	fi
+	# `mktemp` is used rather than a predictable name with `: > file`, because a
+	# shell redirection follows an existing symlink and would truncate whatever
+	# it points at. `mktemp` creates with O_CREAT|O_EXCL on a random name, so it
+	# fails instead of writing through a planted link.
+	local probe
+	if ! probe="$(mktemp "$SOURCE_DIR/.skillfs-preflight-write-check.XXXXXXXX" 2>/dev/null)"; then
+		die "$EX_SOURCE" "source root '$SOURCE_DIR' rejected a test file creation; the volume may be mounted read-only (check volumeMounts[].readOnly) or be out of space"
+	fi
+	rm -f -- "$probe"
+	log "source root $SOURCE_DIR is readable and writable"
+}
+
+check_mountpoint() {
+	# Residual-mount handling runs first: on a disconnected FUSE endpoint every
+	# `test` on the path fails with ENOTCONN, so `-e` and `mkdir` would both
+	# misreport the real problem.
+	check_residual_mount
+	if [[ ! -e "$MOUNTPOINT" ]]; then
+		# Create it rather than fail: the shared emptyDir starts empty and
+		# the mountpoint subdirectory is ours to own.
+		if ! mkdir -p -- "$MOUNTPOINT" 2>/dev/null; then
+			die "$EX_MOUNTPOINT" "mountpoint '$MOUNTPOINT' does not exist and could not be created by uid $(id -u); pre-create it in the shared volume or grant write permission on its parent"
+		fi
+		log "created mountpoint $MOUNTPOINT"
+	fi
+	if [[ ! -d "$MOUNTPOINT" ]]; then
+		die "$EX_MOUNTPOINT" "mountpoint '$MOUNTPOINT' exists but is not a directory"
+	fi
+	if [[ ! -r "$MOUNTPOINT" || ! -x "$MOUNTPOINT" ]]; then
+		die "$EX_MOUNTPOINT" "mountpoint '$MOUNTPOINT' is not readable/traversable by uid $(id -u) gid $(id -g) (mode $(stat -c '%a owner %u:%g' "$MOUNTPOINT" 2>/dev/null))"
+	fi
+	log "mountpoint $MOUNTPOINT is usable"
+}
+
+# Clear a mount left behind by a previous SkillFS process on the same shared
+# volume. Bidirectional propagation means a killed sidecar can leave either a
+# live mount or a disconnected endpoint visible to the replacement container.
+#
+# This runs in a privileged container that can unmount anything it can see, so it
+# is deliberately narrow: only a FUSE filesystem at exactly the configured
+# mountpoint is ever unmounted. A misconfigured SKILLFS_MOUNTPOINT pointing at a
+# shared-volume root, a projected volume, or any other legitimate mount must fail
+# the container, not get silently torn down.
+check_residual_mount() {
+	local disconnected=0
+	if is_disconnected_endpoint "$MOUNTPOINT"; then
+		disconnected=1
+	fi
+	if ! is_mounted "$MOUNTPOINT" && ((disconnected == 0)); then
+		return 0
+	fi
+
+	local detail fstype
+	detail="$(mountinfo_lines_for "$MOUNTPOINT" | head -1)"
+	fstype="$(mount_fstype_for "$MOUNTPOINT")"
+	log "residual mount detected on '$MOUNTPOINT' (fstype='${fstype:-unknown}' disconnected=$disconnected): ${detail:-<not in mountinfo>}"
+
+	# Refuse anything that is not FUSE. A disconnected endpoint that is no longer
+	# in mountinfo is accepted, because only a dead FUSE mount produces ENOTCONN.
+	if [[ -n "$fstype" && "$fstype" != fuse* ]]; then
+		die "$EX_RESIDUAL_MOUNT" "refusing to unmount '$MOUNTPOINT': it carries a '$fstype' filesystem, not a FUSE mount. SkillFS only ever clears its own residual FUSE mounts. Check SKILLFS_MOUNTPOINT — it must be a dedicated subdirectory of the shared volume, not the volume root or another volume's mount path. Offending entry: $detail"
+	fi
+	if [[ -z "$fstype" ]] && ((disconnected == 0)); then
+		die "$EX_RESIDUAL_MOUNT" "mountpoint '$MOUNTPOINT' appears mounted but its filesystem type could not be determined from /proc/self/mountinfo; refusing to unmount an unidentified filesystem. Offending entry: $detail"
+	fi
+
+	if [[ "$RESIDUAL_UNMOUNT" != "1" ]]; then
+		die "$EX_RESIDUAL_MOUNT" "mountpoint '$MOUNTPOINT' already carries a residual FUSE mount and SKILLFS_RESIDUAL_UNMOUNT=0 disables cleanup: ${detail:-disconnected FUSE endpoint}"
+	fi
+
+	local attempt
+	for attempt in 1 2 3 4 5 6 7 8 9 10; do
+		# `umount -l` is the last resort and is only reached for a path already
+		# confirmed to be FUSE (or a dead FUSE endpoint) above.
+		fusermount3 -u -- "$MOUNTPOINT" >/dev/null 2>&1 ||
+			fusermount3 -u -z -- "$MOUNTPOINT" >/dev/null 2>&1 ||
+			umount -l -- "$MOUNTPOINT" >/dev/null 2>&1 ||
+			true
+		if ! is_mounted "$MOUNTPOINT" && ! is_disconnected_endpoint "$MOUNTPOINT"; then
+			log "cleared residual mount on '$MOUNTPOINT' after $attempt attempt(s)"
+			return 0
+		fi
+		# A different filesystem appearing mid-loop means something else is
+		# managing this path; stop rather than keep unmounting.
+		fstype="$(mount_fstype_for "$MOUNTPOINT")"
+		if [[ -n "$fstype" && "$fstype" != fuse* ]]; then
+			die "$EX_RESIDUAL_MOUNT" "'$MOUNTPOINT' now carries a '$fstype' filesystem after $attempt cleanup attempt(s); stopping instead of unmounting a non-FUSE filesystem"
+		fi
+		sleep 0.3
+	done
+
+	detail="$(mountinfo_lines_for "$MOUNTPOINT" | head -1)"
+	die "$EX_RESIDUAL_MOUNT" "could not clear the residual FUSE mount on '$MOUNTPOINT' after 10 attempts (fusermount3 -u, -u -z, umount -l all failed): ${detail:-disconnected FUSE endpoint}"
+}
+
+check_fuse_conf() {
+	if [[ ! -e "$FUSE_CONF" ]]; then
+		die "$EX_FUSE_CONF" "libfuse config '$FUSE_CONF' does not exist; '--allow-other' requires a 'user_allow_other' line (the sidecar image ships one, so an empty path means a volume or ConfigMap overrode it)"
+	fi
+	if [[ ! -r "$FUSE_CONF" ]]; then
+		die "$EX_FUSE_CONF" "libfuse config '$FUSE_CONF' is not readable by uid $(id -u) (mode $(stat -c '%a owner %u:%g' "$FUSE_CONF" 2>/dev/null))"
+	fi
+	# libfuse requires the option on a line of its own, with no value.
+	if ! grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' "$FUSE_CONF"; then
+		die "$EX_FUSE_CONF" "libfuse config '$FUSE_CONF' has no 'user_allow_other' line on its own; '--allow-other' would be refused for a non-root mounter, so cross-container access by a different Agent UID cannot be guaranteed"
+	fi
+	log "$FUSE_CONF permits allow_other"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	log "starting preflight as uid=$(id -u) gid=$(id -g)"
+	check_config
+	check_fuse_device
+	check_fusermount
+	check_fuse_conf
+	check_source
+	check_mountpoint
+	log "all prerequisites satisfied"
+}
+
+main "$@"

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -188,6 +188,13 @@ enum Commands {
         #[arg(long, help_heading = help_text::HEADING_MOUNT)]
         allow_other: bool,
 
+        /// Root visible to readers for paths advertised by skill-discover.
+        ///
+        /// Set this to the mounted skills directory when readers cannot access
+        /// the physical source path, such as a separate workload container.
+        #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_MOUNT)]
+        skill_discover_root: Option<PathBuf>,
+
         /// Keep SkillFS in the foreground; useful for tests and systemd.
         #[arg(long, help_heading = help_text::HEADING_PROCESS)]
         foreground: bool,
@@ -536,6 +543,7 @@ async fn run(
             source,
             mountpoint,
             allow_other,
+            skill_discover_root,
             foreground,
             managed,
             pid_file,
@@ -559,6 +567,17 @@ async fn run(
             trusted_peer_gid,
             skill_layout,
         } => {
+            if let Some(root) = &skill_discover_root {
+                if !root.is_absolute() {
+                    let result = Err(format!(
+                        "--skill-discover-root must be absolute, got '{}'",
+                        root.display()
+                    )
+                    .into());
+                    finish_sls(guard, err_reason(&result));
+                    return result;
+                }
+            }
             if managed {
                 // Managed mode: spawn a detached supervisor and return once
                 // the mount is ready. The supervisor re-invokes this binary
@@ -576,6 +595,7 @@ async fn run(
                 source,
                 mountpoint,
                 allow_other,
+                skill_discover_root,
                 foreground,
                 pid_file,
                 audit_log,
@@ -804,6 +824,7 @@ async fn cmd_mount(
     source: PathBuf,
     mountpoint: PathBuf,
     allow_other: bool,
+    skill_discover_root: Option<PathBuf>,
     foreground: bool,
     pid_file: Option<PathBuf>,
     audit_log: Option<PathBuf>,
@@ -2465,6 +2486,7 @@ async fn cmd_mount(
                 skill_layout,
                 os_adapter: os_adapter_stage,
                 directive_enabled,
+                skill_discover_root,
             },
         )
     });

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -80,6 +80,34 @@ fn empty_source() -> tempfile::TempDir {
     dir
 }
 
+#[test]
+fn relative_skill_discover_root_fails_before_mount() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--skill-discover-root",
+            "relative/skills",
+        ])
+        .output()
+        .expect("invoke skillfs");
+
+    assert!(!out.status.success(), "relative root must be rejected");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("--skill-discover-root must be absolute"),
+        "expected absolute-path error, got: {combined}"
+    );
+    assert!(!is_mounted(mount.path()), "validation must run before FUSE");
+}
+
 /// Connect to a control socket, send `ping`, and return the one-line
 /// response. Proves the server is alive; the response is either a `pong`
 /// or a `permission_denied` (the test binary may fail peer verification),

--- a/src/skillfs/crates/skillfs-fuse/src/fs/discover.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/discover.rs
@@ -13,8 +13,9 @@ impl SkillFs {
     ///
     /// When views are configured, the body lists every secondary view as a
     /// section with a table of `name | description | source_path` rows.
-    /// The `source_path` is the real physical path to each skill's SKILL.md,
-    /// enabling the AI to open it directly via `read_file`.
+    /// By default, `source_path` points to each physical `SKILL.md`. A
+    /// configured reader-visible root instead maps every path into the FUSE
+    /// view so a reader in another mount namespace can open it directly.
     ///
     /// When no views config is present, falls back to a simple listing of all
     /// skills in the store.
@@ -35,12 +36,18 @@ impl SkillFs {
                 .filter(|name| store.get(name).is_some())
                 .collect();
 
-            // Collect all source paths to find a common prefix.
+            // Physical paths use a common prefix to keep the table compact.
+            // Reader-visible paths stay absolute because the consumer may
+            // have no access to the physical source mount namespace.
             let all_paths: Vec<std::path::PathBuf> = hidden_names
                 .iter()
                 .filter_map(|name| store.get(name).map(|e| e.source_path.clone()))
                 .collect();
-            let common_prefix = find_common_path_prefix(&all_paths);
+            let common_prefix = if self.skill_discover_root.is_none() {
+                find_common_path_prefix(&all_paths)
+            } else {
+                None
+            };
 
             let frontmatter = format!(
                 "---\nname: skill-discover\ndescription: 'Hidden skills: {}'\nversion: 0.1.0\ntags: [meta, discovery]\nenabled: true\n---\n",
@@ -49,8 +56,12 @@ impl SkillFs {
 
             let mut body = String::from("\n# Secondary Skill Views\n\n");
 
-            // Show base path hint once so individual paths stay short.
-            if let Some(ref prefix) = common_prefix {
+            if self.skill_discover_root.is_some() {
+                body.push_str(
+                    "The `source_path` values below are absolute paths in the readable SkillFS \
+view. Use `read_file` on any path to read the skill and learn how to use it.\n\n",
+                );
+            } else if let Some(ref prefix) = common_prefix {
                 body.push_str(&format!(
                     "Base path: `{}`\n\nPaths below are relative to the base path. \
 Use `read_file` on any `source_path` to read the skill and learn how to use it.\n\n",
@@ -80,13 +91,17 @@ Use `read_file` on any `source_path` to read the skill and learn how to use it.\
                             .unwrap_or("")
                             .trim()
                             .replace('|', r"\|");
-                        let display_path = match &common_prefix {
-                            Some(prefix) => entry
-                                .source_path
-                                .strip_prefix(prefix)
-                                .map(|p| p.display().to_string())
-                                .unwrap_or_else(|_| entry.source_path.display().to_string()),
-                            None => entry.source_path.display().to_string(),
+                        let display_path = if let Some(root) = &self.skill_discover_root {
+                            root.join(skill_name).join("SKILL.md").display().to_string()
+                        } else {
+                            match &common_prefix {
+                                Some(prefix) => entry
+                                    .source_path
+                                    .strip_prefix(prefix)
+                                    .map(|p| p.display().to_string())
+                                    .unwrap_or_else(|_| entry.source_path.display().to_string()),
+                                None => entry.source_path.display().to_string(),
+                            }
                         };
                         body.push_str(&format!(
                             "| {} | {} | {} |\n",
@@ -141,5 +156,91 @@ enabled: true
 ",
             body
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+
+    use super::SkillFs;
+
+    fn write_skill(source: &Path, name: &str) {
+        let dir = source.join(name);
+        std::fs::create_dir_all(&dir).expect("create skill directory");
+        std::fs::write(
+            dir.join("SKILL.md"),
+            format!(
+                "---\nname: {name}\ndescription: Test skill.\nversion: 1.0.0\n\
+                 enabled: true\n---\n\n# Test\n"
+            ),
+        )
+        .expect("write SKILL.md");
+    }
+
+    fn discover_fixture() -> (tempfile::TempDir, SkillFs) {
+        let source = tempfile::tempdir().expect("source tempdir");
+        write_skill(source.path(), "primary");
+        write_skill(source.path(), "reserve");
+        std::fs::write(
+            source.path().join("skillfs-views.toml"),
+            r#"[[view]]
+name = "default"
+default = true
+skills = ["primary"]
+
+[[view]]
+name = "reserve"
+default = false
+skills = ["reserve"]
+"#,
+        )
+        .expect("write views config");
+
+        let mut store = SkillStore::new();
+        let errors = store.load_from_directory(source.path(), &ParseConfig::default());
+        assert!(errors.is_empty(), "load errors: {errors:?}");
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+        let fs = SkillFs::new(
+            source.path().join("mount"),
+            source.path().to_path_buf(),
+            shared,
+            false,
+        );
+        (source, fs)
+    }
+
+    #[test]
+    fn default_discover_paths_remain_physical_and_relative() {
+        let (source, fs) = discover_fixture();
+        let content = fs.get_skill_discover_content();
+
+        assert!(
+            content.contains(&format!(
+                "Base path: `{}`",
+                source.path().join("reserve").display()
+            )),
+            "expected physical source base, got:\n{content}"
+        );
+        assert!(content.contains("| reserve | Test skill. | SKILL.md |"));
+    }
+
+    #[test]
+    fn discover_root_emits_reader_visible_absolute_paths() {
+        let (source, fs) = discover_fixture();
+        let content = fs
+            .with_skill_discover_root("/workload/skills".into())
+            .get_skill_discover_content();
+
+        assert!(content.contains("| reserve | Test skill. | /workload/skills/reserve/SKILL.md |"));
+        assert!(!content.contains("Base path:"));
+        assert!(
+            !content.contains(&source.path().display().to_string()),
+            "physical source path leaked into reader-visible output: {content}"
+        );
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -61,6 +61,9 @@ pub struct SkillFs {
     transform_pipeline: TransformPipeline,
     /// View configuration loaded from skillfs-views.toml (if present).
     views_config: Option<ViewsConfig>,
+    /// Optional reader-visible root for paths emitted by `skill-discover`.
+    /// `None` keeps the physical source-path output used by local mounts.
+    skill_discover_root: Option<PathBuf>,
     /// Pre-opened fd to source dir (in-place mode). Bypasses the FUSE mount
     /// layer so file reads still reach the real inode after over-mounting.
     source_dirfd: Option<std::fs::File>,
@@ -219,6 +222,7 @@ impl SkillFs {
             inodes: InodeManager::new(),
             transform_pipeline,
             views_config,
+            skill_discover_root: None,
             source_dirfd,
             in_place,
             skill_layout: SkillLayout::Flat,
@@ -270,6 +274,17 @@ impl SkillFs {
     /// Override the Skill Security event sink. Default is [`NoopEventSink`].
     pub fn with_event_sink(mut self, sink: Arc<dyn SkillEventSink>) -> Self {
         self.event_sink = sink;
+        self
+    }
+
+    /// Advertise secondary skills through a reader-visible view root.
+    ///
+    /// Each `skill-discover` `source_path` becomes
+    /// `<root>/<skill-name>/SKILL.md`. This is useful when readers share the
+    /// FUSE view but cannot access the physical source directory. Without this
+    /// override, `skill-discover` retains its physical-path output.
+    pub fn with_skill_discover_root(mut self, root: PathBuf) -> Self {
+        self.skill_discover_root = Some(root);
         self
     }
 

--- a/src/skillfs/crates/skillfs-fuse/src/lib.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/lib.rs
@@ -3,8 +3,9 @@
 //! Exposes skills as a virtual filesystem. The default view (from
 //! \`skillfs-views.toml\`) is shown directly under \`/skills/\`. Secondary
 //! views are accessible via the always-visible \`skill-discover\` virtual
-//! skill, which lists their real source paths so the AI can open them
-//! directly.
+//! skill, which lists readable paths for opening them directly. Paths point
+//! to the physical source by default and can be mapped into a shared FUSE view
+//! for readers in another mount namespace.
 #![allow(clippy::too_many_arguments)]
 
 use std::path::PathBuf;
@@ -52,6 +53,8 @@ pub enum FuseError {
     UnmountFailed(String),
     #[error("invalid mount point: {0}")]
     InvalidMountPoint(String),
+    #[error("invalid skill-discover root: {0}")]
+    InvalidSkillDiscoverRoot(String),
     #[error("permission denied: {0}")]
     PermissionDenied(String),
     #[error("io error: {0}")]
@@ -250,6 +253,30 @@ mod tests {
     #[test]
     fn test_parse_path_root() {
         assert_eq!(parse_path(Path::new("/"), false), PathType::Root);
+    }
+
+    #[test]
+    fn configured_mount_rejects_relative_skill_discover_root() {
+        let source = tempfile::tempdir().expect("source tempdir");
+        let mountpoint = tempfile::tempdir().expect("mountpoint tempdir");
+        let store = std::sync::Arc::new(parking_lot::RwLock::new(
+            skillfs_core::store::SkillStore::new(),
+        ));
+
+        let error = mount_configured(
+            mountpoint.path(),
+            source.path(),
+            store,
+            MountOptions::default(),
+            false,
+            MountConfig {
+                skill_discover_root: Some("relative/skills".into()),
+                ..MountConfig::default()
+            },
+        )
+        .expect_err("relative discover root must fail before FUSE");
+
+        assert!(matches!(error, FuseError::InvalidSkillDiscoverRoot(_)));
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/mount.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/mount.rs
@@ -6,7 +6,7 @@
 //! which accept a [`MountConfig`] struct. The legacy per-feature
 //! functions are deprecated but remain for backward compatibility.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,6 +48,12 @@ pub struct MountConfig {
     /// Directive/compiler stage toggle. `None` keeps the default (enabled);
     /// `Some(false)` disables directive compilation for `SKILL.md` reads.
     pub directive_enabled: Option<bool>,
+    /// Workload-visible root used for paths emitted by `skill-discover`.
+    ///
+    /// `None` preserves the default physical source paths. Set this when the
+    /// reader runs in a different mount namespace and can only access the
+    /// SkillFS view, for example `<mountpoint>/skills` in a sidecar workload.
+    pub skill_discover_root: Option<PathBuf>,
 }
 
 /// Mount the SkillFS FUSE filesystem (blocking) with a unified
@@ -81,6 +87,7 @@ pub fn mount_configured(
         config.skill_layout,
         config.os_adapter,
         config.directive_enabled,
+        config.skill_discover_root,
     )
 }
 
@@ -121,6 +128,7 @@ pub fn mount_background_configured(
             config.skill_layout,
             config.os_adapter,
             config.directive_enabled,
+            config.skill_discover_root,
         ) {
             error!(error = %e, "background mount failed");
         }
@@ -160,8 +168,18 @@ fn mount_inner(
     skill_layout: Option<SkillLayout>,
     os_adapter: Option<OsAdapterStage>,
     directive_enabled: Option<bool>,
+    skill_discover_root: Option<PathBuf>,
 ) -> Result<(), FuseError> {
     info!(mountpoint = %mountpoint.display(), source = %source.display(), in_place, "mounting SkillFS");
+
+    if let Some(root) = &skill_discover_root {
+        if !root.is_absolute() {
+            return Err(FuseError::InvalidSkillDiscoverRoot(format!(
+                "path must be absolute, got '{}'",
+                root.display()
+            )));
+        }
+    }
 
     if !mountpoint.exists() {
         return Err(FuseError::InvalidMountPoint(
@@ -209,6 +227,9 @@ fn mount_inner(
         in_place,
         TransformPipeline::empty(),
     );
+    if let Some(root) = skill_discover_root {
+        fs = fs.with_skill_discover_root(root);
+    }
     if let Some(sink) = event_sink {
         fs = fs.with_event_sink(sink);
     }
@@ -325,7 +346,7 @@ pub fn mount(
 ) -> Result<(), FuseError> {
     mount_inner(
         mountpoint, source, store, options, in_place, None, None, None, None, None, None, None,
-        None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None,
     )
 }
 
@@ -355,7 +376,7 @@ pub fn mount_with_security(
 ) -> Result<(), FuseError> {
     mount_inner(
         mountpoint, source, store, options, in_place, event_sink, policy, None, None, None, None,
-        None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None,
     )
 }
 
@@ -390,6 +411,7 @@ pub fn mount_with_security_and_active_resolver(
         event_sink,
         policy,
         active_resolver,
+        None,
         None,
         None,
         None,
@@ -448,6 +470,7 @@ pub fn mount_with_security_active_resolver_and_demo_refresh(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -490,6 +513,7 @@ pub fn mount_with_security_active_resolver_demo_refresh_and_trusted_writer(
         refresh_controller,
         None,
         trusted_writer,
+        None,
         None,
         None,
         None,
@@ -658,6 +682,7 @@ pub fn mount_background_with_security_active_resolver_demo_refresh_and_trusted_w
             refresh_controller,
             None,
             trusted_writer,
+            None,
             None,
             None,
             None,

--- a/src/skillfs/deploy/kubernetes/00-namespace.yaml
+++ b/src/skillfs/deploy/kubernetes/00-namespace.yaml
@@ -1,0 +1,10 @@
+# Dedicated namespace for the SkillFS sidecar example.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skillfs-container-example
+  labels:
+    app.kubernetes.io/name: skillfs
+    app.kubernetes.io/component: fuse-sidecar
+    app.kubernetes.io/part-of: anolisa
+    skillfs.anolisa.io/purpose: sidecar-example

--- a/src/skillfs/deploy/kubernetes/10-example-configmap.yaml
+++ b/src/skillfs/deploy/kubernetes/10-example-configmap.yaml
@@ -1,0 +1,105 @@
+# Deterministic skill source for the SkillFS container sidecar example.
+#
+# The ConfigMap holds only the example content. It is never mounted as the
+# SkillFS source: a ConfigMap volume is read-only and SkillFS requires a
+# writable source root for write passthrough. The init container copies these
+# files into the writable source volume instead (see 20-pod.yaml).
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skillfs-example-source
+  labels:
+    app.kubernetes.io/name: skillfs
+    app.kubernetes.io/component: fuse-sidecar
+    skillfs.anolisa.io/purpose: sidecar-example
+data:
+  # ---------------------------------------------------------------------------
+  # View configuration.
+  #
+  # `default = true` decides what the Agent container sees directly at the
+  # mount root; the secondary view proves that view filtering still applies
+  # across the container boundary rather than the mount exposing the raw source.
+  # ---------------------------------------------------------------------------
+  skillfs-views.toml: |
+    [[view]]
+    name = "default"
+    default = true
+    description = "Skills exposed directly to the workload container"
+    skills = ["skillfs-container-example"]
+
+    [[view]]
+    name = "reserve"
+    default = false
+    description = "Skills reachable only through skill-discover"
+    skills = ["skillfs-container-reserve"]
+
+  # ---------------------------------------------------------------------------
+  # Default-view skill.
+  #
+  # The conditional block is what makes the transform observable: on Linux the
+  # compiled read must contain SKILLFS_TRANSFORM_LINUX and must NOT contain
+  # SKILLFS_TRANSFORM_OTHER or the `@if` directive lines, while the physical
+  # source file on the sidecar still contains all three. Comparing the two is a
+  # byte-level proof that the Agent reads through the transform pipeline.
+  # ---------------------------------------------------------------------------
+  SKILL.md: |
+    ---
+    name: skillfs-container-example
+    description: Example skill served through the SkillFS container sidecar
+    version: 1.0.0
+    tags: [example, kubernetes, sidecar]
+    enabled: true
+    ---
+
+    # SkillFS Container Example
+
+    This skill demonstrates the SkillFS FUSE sidecar on Kubernetes.
+
+    SKILLFS_EXAMPLE_ID=container-sidecar-v1
+
+    <!-- @if os == linux -->
+    SKILLFS_TRANSFORM_LINUX
+    <!-- @else -->
+    SKILLFS_TRANSFORM_OTHER
+    <!-- @endif -->
+
+    ## Parameters
+
+    - `target` (string, required): Path checked by the workload
+
+    ## Returns
+
+    - `status` (string, required): Literal `ok` when the mount is healthy
+
+  # ---------------------------------------------------------------------------
+  # Ordinary passthrough file inside the default-view skill. Reads must return
+  # these bytes unchanged, unlike SKILL.md.
+  # ---------------------------------------------------------------------------
+  reference.md: |
+    # Passthrough Reference
+
+    SKILLFS_PASSTHROUGH_MARKER=container-sidecar-v1
+
+    Ordinary files are served straight from the physical source tree. The
+    directive syntax below must survive verbatim, because only SKILL.md goes
+    through the transform pipeline:
+
+    <!-- @if os == linux -->
+    not-compiled
+    <!-- @endif -->
+
+  # ---------------------------------------------------------------------------
+  # Secondary-view skill. Must NOT appear at the mount root.
+  # ---------------------------------------------------------------------------
+  reserve-SKILL.md: |
+    ---
+    name: skillfs-container-reserve
+    description: Secondary-view skill that must not appear at the mount root
+    version: 1.0.0
+    enabled: true
+    ---
+
+    # SkillFS Secondary View Example
+
+    SKILLFS_RESERVE_MARKER=container-sidecar-v1

--- a/src/skillfs/deploy/kubernetes/20-pod.yaml
+++ b/src/skillfs/deploy/kubernetes/20-pod.yaml
@@ -1,0 +1,335 @@
+# SkillFS FUSE sidecar reference Pod for Kubernetes 1.29 or later.
+#
+# DEPLOYMENT PREREQUISITES — read before applying:
+#
+#   1. The cluster must already permit privileged containers in this namespace.
+#      The SkillFS sidecar needs `privileged: true` to open /dev/fuse and to use
+#      `mountPropagation: Bidirectional`. This is a cluster policy decision
+#      made by the cluster administrator.
+#
+#   2. The namespace must permit the `/dev/fuse` hostPath volume below.
+#
+#   3. Kubernetes >= 1.29 is required, because the SkillFS container is a native
+#      sidecar (`initContainers[].restartPolicy: Always`). See SIDECAR FORM.
+#
+#   If a prerequisite is missing, the Pod is rejected at admission — see the
+#   deployment guide for the exact policy to request and how to capture the
+#   admission error.
+#
+# TOPOLOGY
+#
+#   volume: skill-example   ConfigMap, read-only, example content only
+#   volume: skill-source    emptyDir, writable physical source root
+#   volume: skill-shared    emptyDir (Memory), carries the propagated FUSE mount
+#   volume: fuse-device     hostPath /dev/fuse (CharDevice)
+#
+#   initContainer seed-example               regular init container
+#     └── copies skill-example -> skill-source        (no FUSE, no privilege)
+#
+#   initContainer skillfs (restartPolicy: Always)     NATIVE SIDECAR
+#                                            PRIVILEGED — the only such container
+#     ├── /dev/fuse                          from fuse-device
+#     ├── /var/lib/skillfs/source            from skill-source (physical source)
+#     └── /var/lib/skillfs/shared            from skill-shared, Bidirectional
+#         └── mount/                         FUSE mount created here
+#
+#   container agent                          NON-PRIVILEGED, uid 10001
+#     └── /var/lib/skillfs/shared            from skill-shared, HostToContainer
+#         └── mount/skills/...               propagated SkillFS view
+#
+#   The agent does NOT mount skill-source, so the physical source tree is not
+#   reachable from the workload container.
+#
+#   The FUSE mount is created at `<shared volume>/mount`, a subdirectory of the
+#   propagated volume, rather than over the volume root. Mount propagation
+#   carries mounts made *inside* the shared volume; over-mounting the volume
+#   root is not the supported arrangement.
+#
+# SIDECAR FORM — why a native sidecar
+#
+#   SkillFS is declared as a native sidecar: an entry in `initContainers` with
+#   `restartPolicy: Always`. This is not cosmetic. It buys two guarantees a plain
+#   `containers` entry cannot provide:
+#
+#     - A real start barrier. The kubelet does not start the next init container
+#       or any main container until this sidecar's startupProbe succeeds, so the
+#       agent cannot begin initializing against a mountpoint that has no FUSE
+#       mount yet. With a plain sidecar the containers start concurrently and
+#       only Pod *readiness* is gated — which does nothing for a workload that
+#       reads skills during its own startup.
+#
+#     - Correct shutdown ordering. Native sidecars are terminated only after the
+#       main containers exit, so SkillFS keeps serving the view until the agent
+#       is gone. With a plain sidecar both receive SIGTERM together and the agent
+#       can be left reading a dead FUSE endpoint.
+#
+#   Native sidecars require Kubernetes >= 1.29 (the SidecarContainers feature is
+#   enabled by default from 1.29 and GA in 1.33). Only this one form is
+#   maintained by this example.
+#
+#   For a cluster below 1.29, move this entry into `containers` and remove its
+#   `restartPolicy`. Understand that doing so gives up both guarantees above; the
+#   agent readiness probe is then the only gate, and it protects Pod readiness
+#   only.
+#
+# The `skillfs.anolisa.io/*` and `app.kubernetes.io/*` labels are
+# informational.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skillfs-sidecar-example
+  labels:
+    app.kubernetes.io/name: skillfs
+    app.kubernetes.io/component: fuse-sidecar
+    app.kubernetes.io/part-of: anolisa
+    skillfs.anolisa.io/purpose: sidecar-example
+spec:
+  # A sidecar restart does not recreate the Pod, so the source emptyDir
+  # survives a remount.
+  restartPolicy: Always
+  # Enough time for SkillFS to answer SIGTERM, drain the FUSE session, and
+  # unmount before the kubelet escalates to SIGKILL and leaves a stale mount.
+  # This budget covers the agent shutting down first, then the sidecar.
+  terminationGracePeriodSeconds: 30
+
+  initContainers:
+    # -----------------------------------------------------------------------
+    # Example seeding — a regular init container, runs to completion first.
+    # -----------------------------------------------------------------------
+    # The ConfigMap cannot be the source directly: ConfigMap volumes are
+    # read-only and SkillFS requires a writable source root for write
+    # passthrough.
+    #
+    # Runs as root only to set predictable ownership and modes on the seeded
+    # tree; it needs no privilege, no FUSE device, and no propagation.
+    - name: seed-example
+      image: skillfs-sidecar:dev
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          src=/etc/skillfs-example
+          dst=/var/lib/skillfs/source
+          echo "[seed-example] seeding $dst from $src"
+          # Start from a clean tree so a Pod restart cannot accumulate state
+          # from an earlier run and make assertions ambiguous.
+          rm -rf "$dst"/* "$dst"/.[!.]* 2>/dev/null || true
+          install -d -m 0755 "$dst/skillfs-container-example/reference"
+          install -d -m 0755 "$dst/skillfs-container-reserve"
+          install -m 0644 "$src/skillfs-views.toml"  "$dst/skillfs-views.toml"
+          install -m 0644 "$src/SKILL.md"            "$dst/skillfs-container-example/SKILL.md"
+          install -m 0644 "$src/reference.md"        "$dst/skillfs-container-example/reference/reference.md"
+          install -m 0644 "$src/reserve-SKILL.md"    "$dst/skillfs-container-reserve/SKILL.md"
+          echo "[seed-example] result:"
+          find "$dst" -printf '%M %10s %p\n' | sort
+      securityContext:
+        privileged: false
+        allowPrivilegeEscalation: false
+        runAsUser: 0
+        capabilities:
+          drop: ["ALL"]
+      volumeMounts:
+        - name: skill-example
+          mountPath: /etc/skillfs-example
+          readOnly: true
+        - name: skill-source
+          mountPath: /var/lib/skillfs/source
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 128Mi
+
+    # -----------------------------------------------------------------------
+    # SkillFS native sidecar — the ONLY privileged container in this Pod.
+    # -----------------------------------------------------------------------
+    - name: skillfs
+      image: skillfs-sidecar:dev
+      imagePullPolicy: IfNotPresent
+      # This is what makes it a sidecar rather than an init container: it keeps
+      # running for the life of the Pod, it is restarted independently, and the
+      # kubelet waits for its startupProbe before starting the agent.
+      restartPolicy: Always
+      env:
+        - name: SKILLFS_SOURCE
+          value: /var/lib/skillfs/source
+        # A subdirectory of the shared volume, never the volume root.
+        - name: SKILLFS_MOUNTPOINT
+          value: /var/lib/skillfs/shared/mount
+        # Paths advertised by skill-discover must be readable by the agent,
+        # which sees the FUSE view but not the physical source volume.
+        - name: SKILLFS_DISCOVER_ROOT
+          value: /var/lib/skillfs/shared/mount/skills
+        # Probe path, relative to the mountpoint. SkillFS exposes the view
+        # under `<mountpoint>/skills/`.
+        - name: SKILLFS_PROBE_FILE
+          value: skills/skillfs-container-example/SKILL.md
+        - name: SKILLFS_PROBE_TIMEOUT
+          value: "5"
+        - name: RUST_LOG
+          value: info
+      securityContext:
+        # Required for /dev/fuse and for Bidirectional mount propagation.
+        # Bidirectional propagation is rejected by the kubelet on a
+        # non-privileged container, so this cannot be narrowed to
+        # capabilities alone in this phase.
+        privileged: true
+        runAsUser: 0
+      volumeMounts:
+        # Declared explicitly rather than relying on a privileged container
+        # implicitly receiving the host /dev. That behavior is a container
+        # runtime detail, not a Kubernetes API guarantee.
+        - name: fuse-device
+          mountPath: /dev/fuse
+        - name: skill-source
+          mountPath: /var/lib/skillfs/source
+        - name: skill-shared
+          mountPath: /var/lib/skillfs/shared
+          # Propagates the FUSE mount created inside this volume back to the
+          # host mount namespace, from where it reaches the agent container.
+          mountPropagation: Bidirectional
+      # `skillfs --version` is deliberately not used as a health signal: it
+      # succeeds while the FUSE session is absent, hung, or disconnected. Each
+      # probe asserts the mount is in mountinfo AND the probe file reads through
+      # the FUSE view within a bounded time.
+      #
+      # For a native sidecar this startupProbe is also the start barrier: the
+      # agent is not started until it succeeds.
+      startupProbe:
+        exec:
+          command: ["/usr/local/bin/skillfs-mount-probe", "--startup"]
+        periodSeconds: 2
+        timeoutSeconds: 10
+        failureThreshold: 30
+      readinessProbe:
+        exec:
+          command: ["/usr/local/bin/skillfs-mount-probe", "--readiness"]
+        periodSeconds: 10
+        timeoutSeconds: 10
+        failureThreshold: 3
+      # Fails when the FUSE session stops answering, including the hung case
+      # where the process is still alive. The startup probe gates this one, so
+      # no initialDelaySeconds is needed.
+      livenessProbe:
+        exec:
+          command: ["/usr/local/bin/skillfs-mount-probe", "--liveness"]
+        periodSeconds: 20
+        timeoutSeconds: 10
+        failureThreshold: 3
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: "1"
+          memory: 512Mi
+
+  containers:
+    # -----------------------------------------------------------------------
+    # Agent / workload container — non-privileged, different UID.
+    # -----------------------------------------------------------------------
+    - name: agent
+      image: skillfs-sidecar:dev
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/sh", "-c", "exec sleep infinity"]
+      env:
+        - name: SKILLFS_VIEW
+          value: /var/lib/skillfs/shared/mount/skills
+      securityContext:
+        privileged: false
+        allowPrivilegeEscalation: false
+        # A different UID from the sidecar: cross-UID access through the mount
+        # is what `--allow-other` exists for, so the example uses a different
+        # identity from the sidecar.
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        capabilities:
+          drop: ["ALL"]
+      volumeMounts:
+        # Only the propagated view. skill-source is intentionally absent, so
+        # the physical source tree is not reachable from this container.
+        - name: skill-shared
+          mountPath: /var/lib/skillfs/shared
+          mountPropagation: HostToContainer
+      # Defence in depth. The native sidecar's startupProbe already guarantees
+      # the mount exists before this container starts; this probe additionally
+      # confirms the view is readable from *this* container and *this* UID, which
+      # is what catches a mount-propagation failure.
+      #
+      # `timeout` bounds the read so a wedged FUSE session fails the probe
+      # instead of hanging it. The checks prove both the transformed default
+      # skill and the synthesized skill-discover view crossed the container
+      # boundary.
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              p="$SKILLFS_VIEW/skillfs-container-example/SKILL.md"
+              d="$SKILLFS_VIEW/skill-discover/SKILL.md"
+              timeout 5 test -f "$p"
+              timeout 5 grep -q SKILLFS_TRANSFORM_LINUX "$p"
+              timeout 5 grep -q '^name: skill-discover$' "$d"
+              timeout 5 grep -q '^## reserve$' "$d"
+              r="$SKILLFS_VIEW/skillfs-container-reserve/SKILL.md"
+              timeout 5 grep -Fq "| skillfs-container-reserve |" "$d"
+              timeout 5 grep -Fq "$r" "$d"
+              ! ls -1 "$SKILLFS_VIEW" | grep -Fxq skillfs-container-reserve
+              timeout 5 grep -q '^name: skillfs-container-reserve$' "$r"
+        initialDelaySeconds: 3
+        periodSeconds: 5
+        timeoutSeconds: 10
+        failureThreshold: 24
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+
+  volumes:
+    - name: skill-example
+      configMap:
+        name: skillfs-example-source
+        defaultMode: 0444
+
+    # Physical source root. emptyDir is Pod-scoped, so it survives a sidecar
+    # container restart and keeps writes available after a remount.
+    #
+    # To persist across Pod recreation, replace this entry with a PVC:
+    #
+    #   - name: skill-source
+    #     persistentVolumeClaim:
+    #       claimName: skillfs-source
+    #
+    # Nothing else in this manifest changes; the sidecar and the init container
+    # keep the same mountPath. Note that the init container wipes the source
+    # tree on every start, so remove or guard that step before pointing this
+    # volume at a PVC holding real skills.
+    - name: skill-source
+      emptyDir: {}
+
+    # Carrier for the propagated FUSE mount. Memory-backed emptyDir is the
+    # form the Kubernetes mount-propagation documentation uses for this
+    # pattern. It only ever holds the mountpoint directory itself; skill
+    # content lives in skill-source and is served through FUSE.
+    - name: skill-shared
+      emptyDir:
+        medium: Memory
+        sizeLimit: 16Mi
+
+    # The FUSE character device. `type: CharDevice` makes the kubelet verify
+    # that the host path really is a character device instead of silently
+    # creating a directory.
+    - name: fuse-device
+      hostPath:
+        path: /dev/fuse
+        type: CharDevice

--- a/src/skillfs/deploy/kubernetes/README.md
+++ b/src/skillfs/deploy/kubernetes/README.md
@@ -1,0 +1,53 @@
+# SkillFS Kubernetes Sidecar Manifests
+
+These manifests run SkillFS as a privileged FUSE sidecar and expose its view to
+a non-privileged workload container.
+
+See the
+[Kubernetes sidecar user guide](../../../../docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md)
+([中文](../../../../docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md))
+for the complete workflow.
+
+## Prerequisites
+
+- Kubernetes 1.29 or later.
+- Privileged containers and the `/dev/fuse` hostPath are allowed.
+- The target nodes provide `/dev/fuse`.
+- The SkillFS image is available to the cluster.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `00-namespace.yaml` | Isolated example namespace |
+| `10-example-configmap.yaml` | Example default and secondary skills |
+| `20-pod.yaml` | SkillFS sidecar and workload Pod |
+
+## Deploy
+
+```bash
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+export NS=skillfs-container-example
+
+kubectl apply -f 00-namespace.yaml
+kubectl apply -f 10-example-configmap.yaml
+sed "s|skillfs-sidecar:dev|$IMAGE|g" 20-pod.yaml | kubectl apply -f -
+kubectl -n "$NS" wait \
+  --for=condition=Ready pod/skillfs-sidecar-example \
+  --timeout=300s
+```
+
+The workload readiness probe reads the transformed default skill and the
+virtual `skill-discover/SKILL.md`. It also opens a secondary skill through the
+path advertised by `skill-discover`. Secondary skills stay out of the directory
+listing but remain readable through their advertised paths.
+
+## Use your own skills
+
+Before using the manifest for a workload:
+
+1. replace `skill-source` with a PVC;
+2. remove the example ConfigMap and `seed-example` init container;
+3. update `SKILLFS_PROBE_FILE`;
+4. replace the `agent` image and command;
+5. keep the shared-volume mount propagation settings unchanged.

--- a/src/skillfs/docs/specs/fuse-spec.md
+++ b/src/skillfs/docs/specs/fuse-spec.md
@@ -96,7 +96,11 @@ in-place mount 模式：
 ### 4.2 `skill-discover`
 
 - 当存在 secondary views 时，`skill-discover/SKILL.md` 会列出这些 view 中的技能。
-- 列表里包含 `source_path`，供上层 agent 直接打开真实文件。
+- 列表里包含 `source_path`，供上层 agent 直接打开技能。
+- 默认输出物理 source path。设置 `--skill-discover-root` 后，输出改为
+  `<root>/<skill-name>/SKILL.md`，用于只共享 FUSE view 的独立 mount namespace。
+- Secondary skill 不出现在 `/skills` 的目录枚举中，但配置为 view root 的路径
+  仍可直接 lookup 和读取。
 - 当没有 views 配置时，`skill-discover` 退化为简单的全部技能列表。
 
 ### 4.3 Write Path

--- a/src/skillfs/docs/specs/skillfs-spec.md
+++ b/src/skillfs/docs/specs/skillfs-spec.md
@@ -66,6 +66,8 @@ physical skills directory
 2. FUSE 根据 views 决定 `/skills` 或 in-place 根目录中哪些技能可见。
 3. `skill-discover` 始终可见，用于暴露 secondary views。
 4. in-place 模式会预打开 source dir fd，并通过 `/proc/self/fd/{n}` 访问底层真实目录。
+5. `--skill-discover-root` 可将 discover 路径映射到 reader 可见的 FUSE view；
+   未设置时保留物理 source path。
 
 ### 3.3 Read
 
@@ -136,6 +138,8 @@ flowchart TD
 - 默认 view 技能集合。
 - secondary views 技能集合。
 - `skill-discover` 展示内容。
+- 可选的 `--skill-discover-root` 决定 discover 输出物理 source path，还是
+  reader 可见的 FUSE view path。
 
 注意：当前 store 同步不会自动修改或热重载 `skillfs-views.toml`；views 仍然是挂载时加载的配置快照。
 

--- a/src/skillfs/scripts/test.sh
+++ b/src/skillfs/scripts/test.sh
@@ -197,7 +197,7 @@ EOF
 cat > "$SOURCE_DIR/tertiary-skill/SKILL.md" <<'EOF'
 ---
 name: tertiary-skill
-description: Another hidden skill to keep source_path relative to the source root.
+description: Another skill in the secondary view.
 version: 1.0.0
 tags: [secondary]
 enabled: true
@@ -227,6 +227,7 @@ printf 'passthrough-ok\n' > "$SOURCE_DIR/primary-skill/assets/info.txt"
 info "启动 FUSE 挂载"
 "$BIN" mount "$SOURCE_DIR" "$MOUNT_DIR" \
 	--foreground \
+	--skill-discover-root "$MOUNT_DIR/skills" \
 	--pid-file "$PID_FILE" \
 	--log-file "$LOG_FILE" \
 	>/dev/null 2>&1 &
@@ -256,7 +257,10 @@ assert_contains "$DISCOVER_MD" "## other" "discover 包含 secondary view 章节
 assert_contains "$DISCOVER_MD" "secondary-skill" "discover 列出隐藏技能"
 assert_contains "$DISCOVER_MD" "tertiary-skill" "discover 列出全部 secondary 技能"
 assert_contains "$DISCOVER_MD" "| name | description | source_path |" "discover 暴露 source_path 列"
-assert_contains "$DISCOVER_MD" "secondary-skill/SKILL.md" "discover source_path 相对路径正确"
+DISCOVERED_SECONDARY="$MOUNT_DIR/skills/secondary-skill/SKILL.md"
+assert_contains "$DISCOVER_MD" "$DISCOVERED_SECONDARY" "discover 输出可读挂载路径"
+SECONDARY_MD="$(cat "$DISCOVERED_SECONDARY")"
+assert_contains "$SECONDARY_MD" "name: secondary-skill" "discover 路径可直接读取隐藏技能"
 
 info "发送 SIGTERM 触发卸载"
 kill -TERM "$(cat "$PID_FILE")" >/dev/null 2>&1 || kill -TERM "$MOUNT_PID" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Description

Add a reusable Kubernetes sidecar deployment path for SkillFS. SkillFS runs as
a dedicated privileged FUSE sidecar and propagates its mounted view to a
non-privileged workload that cannot access the physical skill source. The
container adapter maps `skill-discover` paths into the workload-visible FUSE
view so secondary skills remain absent from directory listings but readable
through their advertised paths.

## Related Issue

closes #2028

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] CI/CD or build changes

## Scope

- [x] `skillfs` (SkillFS)

## Checklist

- [x] My code follows the project code style
- [x] I have added tests that prove the feature works
- [x] I have updated the documentation accordingly
- [x] SkillFS format, clippy, and workspace tests pass
- [x] Lock files are up to date

## Testing

Validated at revision `3991ae886fdc787896f48ae4265960223c8ec258`:

- Kubernetes live acceptance: `37/37`
- Kubernetes server-side schema validation: `3/3`
- `skill-discover` keeps the secondary skill out of `ls` while advertising an
  absolute FUSE path that the workload can read directly
- workload readiness reaches Ready with the discovery contract checked
- sidecar restart count advances from `0` to `1`; discovery content and
  write-through data remain available after restart
- reference passthrough behavior uses the previously validated baseline and was
  not counted again in the `37/37` result
- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`
- `cargo +1.86.0 doc --workspace --no-deps`
- `scripts/test.sh`, including a real FUSE discovery-path read
- documentation naming and bilingual tree parity checks

The image was built successfully with the supported build-source overrides and
used for the Kubernetes validation. A build using the default Docker Hub path
was not completed because the registry handshake timed out, so this PR does not
claim that the default external build path passed.

## Additional Notes

The SkillFS sidecar requires privileged access for `/dev/fuse` and
bidirectional mount propagation. The workload remains non-privileged, uses a
different UID, and only mounts the propagated SkillFS view.
