### PR TITLE
fix(tokenless): resolve hermes hook_utils path

### DIFF
--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -40,11 +40,87 @@ import subprocess
 import sys
 from typing import Any
 
-# Import shared FHS constants from hook_utils.
-# realpath needed because install.sh symlinks __init__.py into
-# ~/.hermes/plugins/, and plain __file__ points to the symlink
-# path — resolving .. from there hits a nonexistent directory.
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "common", "hooks"))
+# Resolve shared hook utilities (common/hooks/) with FHS fallback paths.
+# Primary: relative path — realpath needed because install.sh symlinks
+# __init__.py into ~/.hermes/plugins/, and plain __file__ points to the
+# symlink path; resolving .. from the adapter dir hits common/hooks.
+# Fallbacks: system and user FHS paths — needed when the plugin bundle is
+# *copied* into ~/.hermes/plugins/tokenless/ (e.g. by the anolisa driver)
+# instead of symlinked, so the relative path resolves nowhere.
+#
+# Trust model (aligned with codex/scripts/rewrite-hook, bash
+# is_trusted_file, and Rust is_trusted_path): system FHS paths are
+# unconditional; user paths use passwd DB home (NOT $HOME —
+# env-controllable) with ownership and parent-dir permission checks.
+_HERE = os.path.dirname(os.path.realpath(__file__))
+
+
+def _is_trusted_dir(path: str) -> bool:
+    """Check whether a directory is trusted for Python module imports.
+
+    Callers must pass realpath-resolved paths so symlink targets are
+    validated before the trust check.
+    """
+    # System FHS prefixes are always trusted
+    for prefix in ("/usr/share/", "/usr/local/share/", "/usr/libexec/", "/usr/lib/anolisa/"):
+        if path.startswith(prefix):
+            return True
+    # Outside system prefixes: trust only if owned by current uid or root
+    # AND the parent directory is not world-writable.
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    if st.st_uid != os.getuid() and st.st_uid != 0:
+        return False
+    parent = os.path.dirname(path)
+    try:
+        pst = os.stat(parent)
+    except OSError:
+        return False
+    if pst.st_uid != os.getuid() and pst.st_uid != 0:
+        return False
+    if pst.st_mode & 0o002:  # world-writable
+        return False
+    return True
+
+
+# Resolve real home from passwd DB for user-install fallback path.
+try:
+    import pwd as _pwd
+    _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
+except (ImportError, KeyError):
+    _REAL_HOME = ""
+if not os.path.isabs(_REAL_HOME):
+    _REAL_HOME = ""
+
+_HOOK_UTILS_CANDIDATES = [
+    os.path.join(_HERE, "..", "common", "hooks"),                          # source-tree / symlink install
+    "/usr/share/anolisa/adapters/tokenless/common/hooks",                  # RPM system
+    "/usr/local/share/anolisa/adapters/tokenless/common/hooks",            # manual system
+    os.path.join(_REAL_HOME, ".local", "share",
+                 "anolisa", "adapters", "tokenless", "common", "hooks") if _REAL_HOME else "",  # user
+]
+_HOOK_UTILS_RESOLVED = ""
+for _c in _HOOK_UTILS_CANDIDATES:
+    if not _c or not os.path.isdir(_c):
+        continue
+    _real = os.path.realpath(_c)
+    if _is_trusted_dir(_real):
+        _HOOK_UTILS_RESOLVED = _real
+        sys.path.insert(0, _real)
+        break
+
+if not _HOOK_UTILS_RESOLVED:
+    _tried = "\n".join(f"  - {c}" for c in _HOOK_UTILS_CANDIDATES if c)
+    raise ImportError(
+        "tokenless: cannot locate shared hook_utils module (common/hooks/).\n"
+        "Searched (in order):\n" + _tried + "\n"
+        "Install the tokenless common hooks (anolisa install tokenless) or "
+        "re-run adapters/tokenless/hermes/scripts/install.sh from a complete "
+        "adapter tree."
+    )
+
 from hook_utils import (
     _TOKENLESS_FALLBACK,
     _TOKENLESS_LOCAL_SHARE,

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -46,46 +46,57 @@ from typing import Any
 # symlink path; resolving .. from the adapter dir hits common/hooks.
 # Fallbacks: system and user FHS paths — needed when the plugin bundle is
 # *copied* into ~/.hermes/plugins/tokenless/ (e.g. by the anolisa driver)
-# instead of symlinked, so the relative path resolves nowhere.
+# instead of symlinked, so the relative path resolves nowhere.  User-scope
+# candidates honor XDG_DATA_HOME (anolisa FsLayout::user prefers it over
+# ~/.local/share).
 #
 # Trust model (aligned with codex/scripts/rewrite-hook, bash
 # is_trusted_file, and Rust is_trusted_path): system FHS paths are
-# unconditional; user paths use passwd DB home (NOT $HOME —
-# env-controllable) with ownership and parent-dir permission checks.
+# unconditional; elsewhere the hooks directory, its parent, and the
+# hook_utils.py file itself must be owned by the current user or root and
+# must not be world-writable.  A candidate that exists but is rejected or
+# incomplete does not stop the search — later candidates are still tried,
+# and every rejection reason is kept for the final diagnostic.
 _HERE = os.path.dirname(os.path.realpath(__file__))
 
 
-def _is_trusted_dir(path: str) -> bool:
-    """Check whether a directory is trusted for Python module imports.
+def _validate_hooks_dir(path: str) -> str | None:
+    """Validate a candidate hooks directory for importing hook_utils.
 
-    Callers must pass realpath-resolved paths so symlink targets are
-    validated before the trust check.
+    Returns None when the directory is trusted and contains an importable
+    hook_utils.py, otherwise a human-readable rejection reason.
     """
-    # System FHS prefixes are always trusted
+    if not path or not os.path.isabs(path):
+        return "not an absolute path"
+    real = os.path.realpath(path)
+    if not os.path.isdir(real):
+        return "directory does not exist"
+    module = os.path.join(real, "hook_utils.py")
+    if not os.path.isfile(module):
+        return "hook_utils.py missing (incomplete or residual install)"
+    # System FHS prefixes are always trusted (checked on the realpath so a
+    # symlink pointing outside a system prefix cannot bypass the check).
     for prefix in ("/usr/share/", "/usr/local/share/", "/usr/libexec/", "/usr/lib/anolisa/"):
-        if path.startswith(prefix):
-            return True
-    # Outside system prefixes: trust only if owned by current uid or root
-    # AND the parent directory is not world-writable.
-    try:
-        st = os.stat(path)
-    except OSError:
-        return False
-    if st.st_uid != os.getuid() and st.st_uid != 0:
-        return False
-    parent = os.path.dirname(path)
-    try:
-        pst = os.stat(parent)
-    except OSError:
-        return False
-    if pst.st_uid != os.getuid() and pst.st_uid != 0:
-        return False
-    if pst.st_mode & 0o002:  # world-writable
-        return False
-    return True
+        if real.startswith(prefix):
+            return None
+    # Outside system prefixes: the hooks dir, its parent, and the module
+    # file must be owned by the current uid or root and not world-writable
+    # (mirrors bash is_trusted_file / Rust is_trusted_path).
+    uid = os.getuid()
+    for p in (real, os.path.dirname(real), module):
+        try:
+            st = os.stat(p)
+        except OSError as exc:
+            return f"stat failed for {p}: {exc}"
+        if st.st_uid != uid and st.st_uid != 0:
+            return f"{p} not owned by current user or root (uid {st.st_uid})"
+        if st.st_mode & 0o002:
+            return f"{p} is world-writable"
+    return None
 
 
-# Resolve real home from passwd DB for user-install fallback path.
+# Resolve real home from passwd DB for user-install fallback path
+# (NOT $HOME — env-controllable).
 try:
     import pwd as _pwd
     _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
@@ -98,27 +109,38 @@ _HOOK_UTILS_CANDIDATES = [
     os.path.join(_HERE, "..", "common", "hooks"),                          # source-tree / symlink install
     "/usr/share/anolisa/adapters/tokenless/common/hooks",                  # RPM system
     "/usr/local/share/anolisa/adapters/tokenless/common/hooks",            # manual system
-    os.path.join(_REAL_HOME, ".local", "share",
-                 "anolisa", "adapters", "tokenless", "common", "hooks") if _REAL_HOME else "",  # user
 ]
+# XDG user data dir first (anolisa FsLayout::user precedence), then the
+# passwd-home default. XDG_DATA_HOME is env-controllable, but candidates
+# still pass the full ownership/permission validation above.
+_xdg_data = os.environ.get("XDG_DATA_HOME", "")
+if _xdg_data and os.path.isabs(_xdg_data):
+    _HOOK_UTILS_CANDIDATES.append(
+        os.path.join(_xdg_data, "anolisa", "adapters", "tokenless", "common", "hooks"))
+if _REAL_HOME:
+    _HOOK_UTILS_CANDIDATES.append(
+        os.path.join(_REAL_HOME, ".local", "share",
+                     "anolisa", "adapters", "tokenless", "common", "hooks"))
+
 _HOOK_UTILS_RESOLVED = ""
+_rejections: list[str] = []
 for _c in _HOOK_UTILS_CANDIDATES:
-    if not _c or not os.path.isdir(_c):
-        continue
-    _real = os.path.realpath(_c)
-    if _is_trusted_dir(_real):
-        _HOOK_UTILS_RESOLVED = _real
-        sys.path.insert(0, _real)
+    _reason = _validate_hooks_dir(_c)
+    if _reason is None:
+        _HOOK_UTILS_RESOLVED = os.path.realpath(_c)
+        sys.path.insert(0, _HOOK_UTILS_RESOLVED)
         break
+    _rejections.append(f"  - {_c}: {_reason}")
 
 if not _HOOK_UTILS_RESOLVED:
-    _tried = "\n".join(f"  - {c}" for c in _HOOK_UTILS_CANDIDATES if c)
     raise ImportError(
-        "tokenless: cannot locate shared hook_utils module (common/hooks/).\n"
-        "Searched (in order):\n" + _tried + "\n"
-        "Install the tokenless common hooks (anolisa install tokenless) or "
-        "re-run adapters/tokenless/hermes/scripts/install.sh from a complete "
-        "adapter tree."
+        "tokenless: no trusted shared hook_utils module (common/hooks/) found.\n"
+        "Candidates checked (in order):\n" + "\n".join(_rejections) + "\n"
+        "Note: a candidate may be rejected by the trust policy (ownership or "
+        "permissions) even though the path exists — see the reason next to "
+        "each path. Install the tokenless common hooks (anolisa install "
+        "tokenless) or re-run adapters/tokenless/hermes/scripts/install.sh "
+        "from a complete adapter tree."
     )
 
 from hook_utils import (

--- a/src/tokenless/tests/test_hermes_plugin_import.py
+++ b/src/tokenless/tests/test_hermes_plugin_import.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Regression tests for the Hermes plugin hook_utils resolution.
+
+Covers the review findings on PR #2058:
+- P1-a: the hooks directory itself, its parent, and hook_utils.py must all
+  be rejected when world-writable or foreign-owned (not just the parent).
+- P1-b: copy-installs must honor XDG_DATA_HOME (anolisa FsLayout::user
+  prefers it over ~/.local/share).
+- P1-c: an existing-but-incomplete high-priority candidate must not stop
+  the search; later valid candidates are still tried.
+- P2: candidate list contains no empty placeholders; _validate_hooks_dir
+  rejects relative/empty paths; the ImportError mentions trust-policy
+  rejections, not just "missing".
+"""
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PLUGIN_SRC = os.path.join(_REPO_ROOT, "adapters", "tokenless", "hermes", "__init__.py")
+_HOOKS_SRC = os.path.join(_REPO_ROOT, "adapters", "tokenless", "common", "hooks")
+
+_needs_py39 = sys.version_info < (3, 9)
+
+
+def _load_plugin(path: str, name: str):
+    """Load a copy of the Hermes plugin module under a unique name."""
+    # Drop any previously imported hook_utils so each load re-resolves it.
+    sys.modules.pop("hook_utils", None)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_hooks_dir(base: str) -> str:
+    """Create a complete, trusted hooks dir under base and return its path."""
+    hooks = os.path.join(base, "anolisa", "adapters", "tokenless", "common", "hooks")
+    os.makedirs(hooks, mode=0o755)
+    for fname in ("hook_utils.py", "tool_categories.json"):
+        shutil.copy(os.path.join(_HOOKS_SRC, fname), hooks)
+    os.chmod(hooks, 0o755)
+    return hooks
+
+
+@unittest.skipIf(_needs_py39, "hermes plugin requires Python 3.9+")
+class ValidateHooksDirTest(unittest.TestCase):
+    """Unit tests for _validate_hooks_dir (loaded from the source tree)."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Source-tree import: the relative candidate resolves, so loading
+        # the real plugin file always succeeds here.
+        cls.plugin = _load_plugin(_PLUGIN_SRC, "hermes_plugin_srctree")
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="hermes-hooks-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def test_rejects_empty_and_relative_paths(self):
+        self.assertIsNotNone(self.plugin._validate_hooks_dir(""))
+        self.assertIsNotNone(self.plugin._validate_hooks_dir("relative/hooks"))
+
+    def test_rejects_missing_directory(self):
+        reason = self.plugin._validate_hooks_dir(os.path.join(self.tmp, "nope"))
+        self.assertIn("does not exist", reason)
+
+    def test_rejects_incomplete_dir_without_hook_utils(self):
+        # P1-c: uninstall residue — dir exists but hook_utils.py is gone.
+        empty = os.path.join(self.tmp, "hooks")
+        os.makedirs(empty)
+        reason = self.plugin._validate_hooks_dir(empty)
+        self.assertIn("hook_utils.py missing", reason)
+
+    def test_accepts_trusted_complete_dir(self):
+        hooks = _make_hooks_dir(self.tmp)
+        self.assertIsNone(self.plugin._validate_hooks_dir(hooks))
+
+    def test_rejects_world_writable_hooks_dir(self):
+        # P1-a: the hooks dir itself is world-writable.
+        hooks = _make_hooks_dir(self.tmp)
+        os.chmod(hooks, 0o777)
+        reason = self.plugin._validate_hooks_dir(hooks)
+        self.assertIn("world-writable", reason)
+
+    def test_rejects_world_writable_hook_utils_file(self):
+        # P1-a: hook_utils.py itself is world-writable (0666).
+        hooks = _make_hooks_dir(self.tmp)
+        os.chmod(os.path.join(hooks, "hook_utils.py"), 0o666)
+        reason = self.plugin._validate_hooks_dir(hooks)
+        self.assertIn("world-writable", reason)
+
+    def test_rejects_world_writable_parent_dir(self):
+        hooks = _make_hooks_dir(self.tmp)
+        os.chmod(os.path.dirname(hooks), 0o777)
+        reason = self.plugin._validate_hooks_dir(hooks)
+        self.assertIn("world-writable", reason)
+
+    def test_candidate_list_has_no_empty_entries(self):
+        # P2: no "" placeholder elements in the candidate list.
+        for candidate in self.plugin._HOOK_UTILS_CANDIDATES:
+            self.assertTrue(candidate, "empty candidate in _HOOK_UTILS_CANDIDATES")
+            self.assertTrue(os.path.isabs(candidate) or candidate.startswith(self.plugin._HERE))
+
+
+@unittest.skipIf(_needs_py39, "hermes plugin requires Python 3.9+")
+class CopyInstallResolutionTest(unittest.TestCase):
+    """End-to-end: plugin copied to a bare dir (anolisa driver behavior)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="hermes-copy-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        plugin_dir = os.path.join(self.tmp, "plugins", "tokenless")
+        os.makedirs(plugin_dir)
+        shutil.copy(_PLUGIN_SRC, plugin_dir)
+        self.plugin_copy = os.path.join(plugin_dir, "__init__.py")
+        self._saved_xdg = os.environ.get("XDG_DATA_HOME")
+
+    def tearDown(self):
+        if self._saved_xdg is None:
+            os.environ.pop("XDG_DATA_HOME", None)
+        else:
+            os.environ["XDG_DATA_HOME"] = self._saved_xdg
+
+    def test_resolves_via_xdg_data_home(self):
+        # P1-b: XDG_DATA_HOME layout must be honored for copy-installs.
+        xdg = os.path.join(self.tmp, "xdg-data")
+        hooks = _make_hooks_dir(xdg)
+        os.environ["XDG_DATA_HOME"] = xdg
+        plugin = _load_plugin(self.plugin_copy, "hermes_plugin_xdg")
+        self.assertEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(hooks))
+
+    def test_incomplete_xdg_candidate_does_not_mask_later_ones(self):
+        # P1-c: an existing-but-empty XDG hooks dir must be skipped, and the
+        # search must continue to later candidates instead of breaking.
+        xdg = os.path.join(self.tmp, "xdg-data")
+        empty_hooks = os.path.join(xdg, "anolisa", "adapters", "tokenless", "common", "hooks")
+        os.makedirs(empty_hooks)
+        os.environ["XDG_DATA_HOME"] = xdg
+        try:
+            plugin = _load_plugin(self.plugin_copy, "hermes_plugin_incomplete_xdg")
+        except ImportError as exc:
+            # No later candidate exists on this machine — the diagnostic must
+            # name the incomplete dir with its rejection reason (P2 wording).
+            self.assertIn("hook_utils.py missing", str(exc))
+            self.assertIn(empty_hooks, str(exc))
+        else:
+            # A later candidate (e.g. passwd-home install) won — but never
+            # the incomplete XDG dir.
+            self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(empty_hooks))
+
+    def test_import_error_mentions_trust_policy(self):
+        # P2: the diagnostic must explain that existing paths can be
+        # rejected by the trust policy, not only be "missing".
+        xdg = os.path.join(self.tmp, "xdg-data")
+        hooks = _make_hooks_dir(xdg)
+        os.chmod(hooks, 0o777)  # exists but untrusted
+        os.environ["XDG_DATA_HOME"] = xdg
+        try:
+            plugin = _load_plugin(self.plugin_copy, "hermes_plugin_untrusted_xdg")
+        except ImportError as exc:
+            self.assertIn("world-writable", str(exc))
+            self.assertIn("trust policy", str(exc))
+        else:
+            # Later candidate won; the untrusted dir must not be selected.
+            self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(hooks))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Installing the tokenless plugin into Hermes fails at import time with
`No module named 'hook_utils'` when the plugin bundle is **copied** into
`~/.hermes/plugins/tokenless/` (as the anolisa driver does) instead of
symlinked: the plugin located the shared `hook_utils` module only via a
path relative to `realpath(__file__)`, which resolves nowhere after a copy.
This PR replaces the single relative lookup with ordered candidate-path
probing (relative → `/usr/share` → `/usr/local/share` → `~/.local/share`),
reusing the same trust model as the codex adapter (system FHS prefixes
unconditional; user paths validated via passwd home + ownership +
parent-dir permission checks). If every candidate misses, the plugin now
raises an `ImportError` listing the searched paths and recovery steps
instead of the bare module error.

## Related Issue

no-issue: small self-contained adapter fix; root-caused directly from a local install failure, no tracking issue exists

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless` (tokenless)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass (N/A — Python-only change, no Rust code touched)
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `python3 -m pytest tests/test_compress_response_hook.py tests/test_compress_schema_hook.py -q` — 21 passed
- Manual: source-tree import resolves via the relative candidate (symlink-install path preserved)
- Manual: simulated copy-install (bare `__init__.py` copied into an isolated `plugins/tokenless/` dir) — previously raised `ModuleNotFoundError`, now resolves via the user-scope FHS fallback `~/.local/share/anolisa/adapters/tokenless/common/hooks`
- Edge case: with all candidates absent, the raised `ImportError` lists every searched path plus actionable recovery steps

## Additional Notes

Unlike the codex hook scripts there is intentionally no fail-open inline
fallback: the Hermes plugin needs the full shared constants set from
`hook_utils`, so a clear diagnostic failure beats silently degraded behavior.
