### PR TITLE
fix(anolisa): relax rpm probe on deb-family hosts

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -50,9 +50,9 @@ use super::{COMMAND, InstallArgs};
 // shared guards it mirrors.
 use super::io_util::now_iso8601;
 use super::{
-    PlannedComponent, PlannedRoute, handle_one, handle_one_with_planned_components, host_backends,
-    plan_component, quarantined, require_configured_rpm_backend, revalidate_native_absence,
-    step_label,
+    PlannedComponent, PlannedRoute, RpmdbProbe, handle_one, handle_one_with_planned_components,
+    host_backends, plan_component, quarantined, require_configured_rpm_backend,
+    revalidate_native_absence, step_label,
 };
 // ── --all support ───────────────────────────────────────────────────
 
@@ -143,8 +143,12 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
             names.len()
         ));
         let per_args = per_component_args(name, &args);
+        let env = anolisa_env::EnvService::detect();
+        let rpmdb = RpmdbProbe::for_host(&env);
         let candidate = host_backends(name, &per_args, &suppressed_ctx)
-            .and_then(|(query, txn)| plan_component(name, &per_args, &suppressed_ctx, &query, &txn))
+            .and_then(|(query, txn)| {
+                plan_component(name, &per_args, &suppressed_ctx, &env, &rpmdb, &query, &txn)
+            })
             .ok()
             .and_then(|planned| {
                 merged_package(&planned).map(|package| MergedItem {
@@ -560,9 +564,14 @@ fn execute_merged_group_with_deps(
             ));
             continue;
         }
-        if let Err(err) =
-            revalidate_native_absence(Some(&item.package), &provider, &now, target, BATCH_COMMAND)
-        {
+        if let Err(err) = revalidate_native_absence(
+            Some(&item.package),
+            &provider,
+            &now,
+            target,
+            BATCH_COMMAND,
+            None,
+        ) {
             items.push(failed_item(&item.name, err.reason().to_string()));
             continue;
         }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -8,7 +8,7 @@
 //! executor with a [`StoreRecordSink`]. No lifecycle policy lives here.
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anolisa_core::executor::{DelegatedExecutionTarget, execute_delegated_steps};
 use anolisa_core::facts::{
@@ -70,10 +70,14 @@ pub(crate) fn handle_one(
 ) -> Result<InstallOutcome, CliError> {
     let mut activity = install_activity(&component, ctx);
     let (query, txn) = host_backends(&component, &args, ctx)?;
+    let env = anolisa_env::EnvService::detect();
+    let rpmdb = RpmdbProbe::for_host(&env);
     install_component_with_deps_and_planned(
         &component,
         &args,
         ctx,
+        &env,
+        &rpmdb,
         &query,
         &txn,
         privilege::is_root(),
@@ -92,10 +96,14 @@ pub(crate) fn handle_one_with_planned_components(
 ) -> Result<InstallOutcome, CliError> {
     let mut activity = install_activity(&component, ctx);
     let (query, txn) = host_backends(&component, &args, ctx)?;
+    let env = anolisa_env::EnvService::detect();
+    let rpmdb = RpmdbProbe::for_host(&env);
     install_component_with_deps_and_planned(
         &component,
         &args,
         ctx,
+        &env,
+        &rpmdb,
         &query,
         &txn,
         privilege::is_root(),
@@ -291,11 +299,41 @@ pub(crate) fn install_component_with_deps(
     txn: &dyn PackageTransaction,
     is_root: bool,
 ) -> Result<InstallOutcome, CliError> {
+    let env = anolisa_env::EnvService::detect();
+    install_component_with_deps_and_env(
+        input,
+        args,
+        ctx,
+        &env,
+        &RpmdbProbe::absent(),
+        query,
+        txn,
+        is_root,
+    )
+}
+
+/// Test variant with the host facts injected, so family-sensitive branches
+/// (deb degrade, rpm fail-closed, unknown fail-closed) are covered
+/// deterministically instead of depending on the runner's /etc/os-release.
+#[cfg(test)]
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn install_component_with_deps_and_env(
+    input: &str,
+    args: &InstallArgs,
+    ctx: &CliContext,
+    env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+) -> Result<InstallOutcome, CliError> {
     let mut activity = install_activity(input, ctx);
     install_component_with_deps_and_planned(
         input,
         args,
         ctx,
+        env,
+        rpmdb,
         query,
         txn,
         is_root,
@@ -311,17 +349,21 @@ fn install_component_with_deps_and_planned(
     input: &str,
     args: &InstallArgs,
     ctx: &CliContext,
+    env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
     planned_components: &HashSet<String>,
     reporter: &mut dyn ProgressReporter,
 ) -> Result<InstallOutcome, CliError> {
-    let planned = plan_component(input, args, ctx, query, txn)?;
+    let planned = plan_component(input, args, ctx, env, rpmdb, query, txn)?;
     execute_planned(
         planned,
         args,
         ctx,
+        env,
+        rpmdb,
         query,
         txn,
         is_root,
@@ -338,6 +380,8 @@ pub(crate) fn plan_component(
     input: &str,
     args: &InstallArgs,
     ctx: &CliContext,
+    env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
 ) -> Result<PlannedComponent, CliError> {
@@ -350,7 +394,6 @@ pub(crate) fn plan_component(
         InstallMode::User => InstallationScope::User { uid },
     };
     let now = now_iso8601();
-    let env = anolisa_env::EnvService::detect();
     let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
 
     // Resolve identity across all visible roots, but bind install planning to
@@ -442,7 +485,8 @@ pub(crate) fn plan_component(
                 InstallationScope::System => Some(system_probe_package(
                     args,
                     &layout,
-                    &env,
+                    env,
+                    rpmdb,
                     &repo_config,
                     &component,
                     query,
@@ -474,7 +518,7 @@ pub(crate) fn plan_component(
                 let fresh = resolve_fresh_delegated(
                     args,
                     &layout,
-                    &env,
+                    env,
                     &repo_config,
                     &component,
                     query,
@@ -498,23 +542,48 @@ pub(crate) fn plan_component(
     };
     // A missing rpm/dnf binary is a hard error whenever a probe was needed:
     // without it the host cannot prove the component is not an unobserved
-    // system RPM, and a raw install over one could corrupt it (I3).
-    let facts = assemble_facts(
+    // system RPM, and a raw install over one could corrupt it (I3). The one
+    // exception is the raw family on a host whose package authority is not
+    // RPM — there is no rpmdb to protect, so the facts degrade to NotProbed.
+    // The package identity is kept: the executor's locked recheck re-probes
+    // it and applies the same CommandMissing policy, so tooling (and an RPM)
+    // appearing between planning and placement is still caught.
+    let facts = match assemble_facts(
         &observe_request,
         &store,
         Some(&provider),
         &layout,
         &journal_dir,
-    )
-    .map_err(|err| match err {
-        FactsError::Probe(ProviderError::Query(PackageQueryError::CommandMissing {
+    ) {
+        Ok(facts) => facts,
+        Err(FactsError::Probe(ProviderError::Query(PackageQueryError::CommandMissing {
             command: bin,
-        })) => rpm_tooling_missing_error(&command, &bin, &component),
-        err => CliError::Runtime {
-            command: command.clone(),
-            reason: err.to_string(),
-        },
-    })?;
+        }))) => {
+            if family != "raw" || missing_rpm_tooling_is_fatal(env, rpmdb) {
+                return Err(rpm_tooling_missing_error(&command, &bin, &component));
+            }
+            let observe_request = ObserveRequest {
+                kind: ObjectKind::Component,
+                name: &component,
+                scope,
+                native_package: None,
+                observed_at: &now,
+                verify_owned_files: false,
+            };
+            assemble_facts(&observe_request, &store, None, &layout, &journal_dir).map_err(
+                |err| CliError::Runtime {
+                    command: command.clone(),
+                    reason: err.to_string(),
+                },
+            )?
+        }
+        Err(err) => {
+            return Err(CliError::Runtime {
+                command: command.clone(),
+                reason: err.to_string(),
+            });
+        }
+    };
 
     let request = InstallRequest {
         target,
@@ -574,6 +643,8 @@ fn execute_planned(
     planned: PlannedComponent,
     args: &InstallArgs,
     ctx: &CliContext,
+    env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
@@ -593,7 +664,6 @@ fn execute_planned(
         route,
     } = planned;
     let layout = common::resolve_layout(ctx);
-    let env = anolisa_env::EnvService::detect();
     let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
     let state_path = layout.state_dir.join("installed.toml");
     let journal_dir = rpm_install::journal_dir(&layout);
@@ -629,7 +699,7 @@ fn execute_planned(
                 args,
                 ctx,
                 &layout,
-                &env,
+                env,
                 &repo_config,
                 ResolvedInstallIdentity {
                     component: component.clone(),
@@ -725,6 +795,7 @@ fn execute_planned(
             validated,
             raw_pin.as_ref(),
             native_package.as_deref(),
+            (!missing_rpm_tooling_is_fatal(env, rpmdb)).then_some(rpmdb),
             &provider,
             &command,
             reporter,
@@ -875,34 +946,131 @@ fn resolve_owned_artifact(
     .map_err(|err| err.with_command(command))
 }
 
+/// Whether missing rpm/dnf tooling is fatal for the system-RPM presence
+/// probe (planner rule I3).
+///
+/// The probe protects unobserved system RPMs, which can only exist where
+/// RPM is the host's package authority. When rpm tooling is present the
+/// probe always runs; this only decides what a missing binary means. A
+/// host whose `/etc/os-release` `ID`/`ID_LIKE` classifies as deb-family
+/// normally has no rpmdb to protect, so the probe degrades to NotProbed
+/// instead of demanding rpm/dnf the distro does not ship — unless an rpmdb
+/// exists on disk (RPMs were installed before the rpm binary went away),
+/// in which case there is a database to protect and the family inference
+/// yields to the filesystem evidence. Rpm-family and unrecognized hosts
+/// keep the hard error, so a genuinely rpm-based host with broken tooling
+/// still fails closed.
+pub(crate) fn missing_rpm_tooling_is_fatal(
+    env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
+) -> bool {
+    anolisa_env::package_family(env.os_id.as_deref(), env.os_id_like.as_deref()).as_deref()
+        != Some("deb")
+        || rpmdb.rpmdb_exists()
+}
+
+/// Where filesystem evidence of a host rpmdb is probed.
+///
+/// The probe targets the databases the host's `PackageQuery` would answer
+/// from — never the ANOLISA install layout: a `--prefix` relocates where
+/// components are placed, not where the host keeps its rpmdb. Beyond the
+/// two system locations, Debian's own rpm package defaults `%_dbpath` to
+/// `~/.rpmdb`, so the invoking user's home is probed as well. Deliberately
+/// file-based: the check must work exactly when the rpm binary does not.
+pub(crate) struct RpmdbProbe {
+    /// Host filesystem root holding `var/lib/rpm` and
+    /// `usr/lib/sysimage/rpm`; `/` in production.
+    system_root: PathBuf,
+    /// Home directory probed for Debian's `~/.rpmdb` default dbpath.
+    home: Option<PathBuf>,
+}
+
+impl RpmdbProbe {
+    /// Production probe: the real host root plus the invoking user's home.
+    pub(crate) fn for_host(env: &anolisa_env::EnvFacts) -> Self {
+        Self {
+            system_root: PathBuf::from("/"),
+            home: Some(env.home.clone()),
+        }
+    }
+
+    /// Probe against isolated roots, so tests never read the runner's
+    /// real rpmdb (or the developer's `~/.rpmdb`).
+    #[cfg(test)]
+    pub(crate) fn with_roots(system_root: PathBuf, home: Option<PathBuf>) -> Self {
+        Self { system_root, home }
+    }
+
+    /// Probe that never finds a database, for tests that assert behavior
+    /// on hosts without any rpmdb regardless of the runner's filesystem.
+    #[cfg(test)]
+    pub(crate) fn absent() -> Self {
+        Self {
+            system_root: PathBuf::from("/nonexistent-rpmdb-root"),
+            home: None,
+        }
+    }
+
+    /// Whether any known rpmdb location holds a database file, covering
+    /// the bdb, ndb, and sqlite backends.
+    fn rpmdb_exists(&self) -> bool {
+        let dirs = [
+            Some(self.system_root.join("var/lib/rpm")),
+            Some(self.system_root.join("usr/lib/sysimage/rpm")),
+            self.home.as_ref().map(|home| home.join(".rpmdb")),
+        ];
+        dirs.into_iter().flatten().any(|db| {
+            ["rpmdb.sqlite", "Packages", "Packages.db"]
+                .iter()
+                .any(|file| db.join(file).exists())
+        })
+    }
+}
+
 /// RPM package name a raw install probes for the planner's I3 rule.
+///
+/// When candidate resolution cannot settle on a single package — rpm
+/// tooling is missing on a host whose package authority is not RPM, or the
+/// candidates are not unique — an explicit `--package` override is already
+/// the known probe identity and wins over the component-name fallback, so
+/// the executor's locked recheck re-probes the exact RPM the user named.
+#[expect(clippy::too_many_arguments)]
 fn system_probe_package(
     args: &InstallArgs,
     layout: &FsLayout,
     env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
     repo_config: &RepoConfig,
     component: &str,
     query: &dyn PackageQuery,
     command: &str,
 ) -> Result<String, CliError> {
+    let fallback = || {
+        args.package
+            .clone()
+            .unwrap_or_else(|| component.to_string())
+    };
     let component_index = load_optional_component_index(layout, env, repo_config);
-    let candidates = rpm_package_candidates_with_index(
+    let candidates = match rpm_package_candidates_with_index(
         args.package.as_deref(),
         repo_config.backends.get("rpm"),
         component_index.as_ref(),
         query,
         component,
         ResolutionUse::Install,
-    )
-    .map_err(|err| match err {
-        PackageQueryError::CommandMissing { command: bin } => {
-            rpm_tooling_missing_error(command, &bin, component)
+    ) {
+        Ok(candidates) => candidates,
+        Err(PackageQueryError::CommandMissing { command: bin }) => {
+            if missing_rpm_tooling_is_fatal(env, rpmdb) {
+                return Err(rpm_tooling_missing_error(command, &bin, component));
+            }
+            return Ok(fallback());
         }
-        err => pkg_query_err(err, command),
-    })?;
+        Err(err) => return Err(pkg_query_err(err, command)),
+    };
     Ok(match candidates.as_slice() {
         [single] => single.package.clone(),
-        _ => component.to_string(),
+        _ => fallback(),
     })
 }
 
@@ -1058,6 +1226,7 @@ fn install_owned(
     validated: ValidatedInstall,
     raw_pin: Option<&RawPin>,
     native_package: Option<&str>,
+    degraded_rpmdb: Option<&RpmdbProbe>,
     provider: &DelegatedProvider,
     command: &str,
     reporter: &mut dyn ProgressReporter,
@@ -1086,7 +1255,14 @@ fn install_owned(
             ),
         });
     }
-    revalidate_native_absence(native_package, provider, now, target, command)?;
+    revalidate_native_absence(
+        native_package,
+        provider,
+        now,
+        target,
+        command,
+        degraded_rpmdb,
+    )?;
 
     let evidence = JournalEvidence::new(journal_dir, &store.operations);
     let mut journal_gate = LockedJournalGate::load(&_lock, evidence, command)?;
@@ -1213,7 +1389,7 @@ fn install_delegated(
             ),
         });
     }
-    revalidate_native_absence(Some(package), provider, now, target, command)?;
+    revalidate_native_absence(Some(package), provider, now, target, command, None)?;
 
     let evidence = JournalEvidence::new(journal_dir, &store.operations);
     let mut journal_gate = LockedJournalGate::load(&_lock, evidence, command)?;
@@ -1304,16 +1480,36 @@ fn install_delegated(
     Ok(InstallOutcome::Installed)
 }
 
+/// Locked recheck that the native package is still absent before mutation.
+///
+/// Presence evidence is never muted — when the probe can run and reports
+/// the package, the install refuses regardless of the host family.
+///
+/// `degraded` selects the CommandMissing policy: `None` keeps the hard
+/// error, while `Some(probe)` is the deb-family degrade. The degraded
+/// verdict is a planning-time snapshot, so it is re-verified against the
+/// filesystem under the lock: if an rpmdb has appeared since — an external
+/// process installed RPMs, whether or not this process can see the rpm
+/// binary, and whether or not the probe identity matches what that process
+/// installed — the vacuous-probe justification is gone and the install
+/// refuses. A retry re-plans against the now-present database with full
+/// candidate resolution.
 pub(crate) fn revalidate_native_absence(
     package: Option<&str>,
     provider: &DelegatedProvider,
     now: &str,
     target: &str,
     command: &str,
+    degraded: Option<&RpmdbProbe>,
 ) -> Result<(), CliError> {
     let Some(package) = package else {
         return Ok(());
     };
+    if let Some(rpmdb) = degraded
+        && rpmdb.rpmdb_exists()
+    {
+        return Err(rpmdb_appeared_error(command, target));
+    }
     match provider.observe(package, now) {
         Ok(NativeProbe::Absent) => Ok(()),
         Ok(NativeProbe::Present { .. } | NativeProbe::MultipleVersions { .. }) => {
@@ -1329,12 +1525,28 @@ pub(crate) fn revalidate_native_absence(
             reason: format!("locked system-RPM probe for '{package}' did not run"),
         }),
         Err(ProviderError::Query(PackageQueryError::CommandMissing { command: bin })) => {
-            Err(rpm_tooling_missing_error(command, &bin, target))
+            match degraded {
+                None => Err(rpm_tooling_missing_error(command, &bin, target)),
+                Some(rpmdb) if rpmdb.rpmdb_exists() => Err(rpmdb_appeared_error(command, target)),
+                Some(_) => Ok(()),
+            }
         }
         Err(err) => Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!("locked rpm query failed for '{package}': {err}"),
         }),
+    }
+}
+
+/// Refusal when the locked recheck finds rpmdb evidence that was absent at
+/// planning time: the raw placement stops before any mutation and the retry
+/// re-runs the presence probe against the database.
+fn rpmdb_appeared_error(command: &str, target: &str) -> CliError {
+    CliError::InvalidArgument {
+        command: command.to_string(),
+        reason: format!(
+            "an rpm database appeared while '{target}' was being resolved; nothing was changed — retry `anolisa install {target}` so the system-RPM presence check runs against it"
+        ),
     }
 }
 
@@ -1750,6 +1962,177 @@ mod tests {
     }
 
     #[test]
+    fn missing_rpm_tooling_fatality_follows_host_package_family() {
+        let rpmdb = RpmdbProbe::absent();
+        let env = |id: Option<&str>, id_like: Option<&str>| anolisa_env::EnvFacts {
+            os_id: id.map(str::to_string),
+            os_id_like: id_like.map(str::to_string),
+            ..linux_env()
+        };
+        // rpm-family hosts must treat missing rpm/dnf as a hard I3 error.
+        assert!(missing_rpm_tooling_is_fatal(
+            &env(Some("alinux"), None),
+            &rpmdb
+        ));
+        assert!(missing_rpm_tooling_is_fatal(
+            &env(Some("fedora"), None),
+            &rpmdb
+        ));
+        // deb-family hosts have no rpmdb; the probe degrades to NotProbed.
+        assert!(!missing_rpm_tooling_is_fatal(
+            &env(Some("ubuntu"), None),
+            &rpmdb
+        ));
+        // A derivative declaring deb lineage via ID_LIKE also degrades.
+        assert!(!missing_rpm_tooling_is_fatal(
+            &env(Some("zorin"), Some("ubuntu debian")),
+            &rpmdb
+        ));
+        // Unrecognized or undetected hosts fail closed.
+        assert!(missing_rpm_tooling_is_fatal(
+            &env(Some("alpine"), Some("musl")),
+            &rpmdb
+        ));
+        assert!(missing_rpm_tooling_is_fatal(&env(None, None), &rpmdb));
+    }
+
+    #[test]
+    fn rpmdb_on_disk_overrides_the_deb_family_relaxation() {
+        // A deb-family host that installed RPMs before losing the rpm
+        // binary still owns a database the raw path could corrupt: the
+        // on-disk rpmdb evidence must win over the family inference, for
+        // every db backend and both host system locations.
+        let deb_env = anolisa_env::EnvFacts {
+            os_id: Some("ubuntu".to_string()),
+            os_id_like: Some("debian".to_string()),
+            ..linux_env()
+        };
+        for (dir, file) in [
+            ("var/lib/rpm", "rpmdb.sqlite"),
+            ("var/lib/rpm", "Packages"),
+            ("var/lib/rpm", "Packages.db"),
+            ("usr/lib/sysimage/rpm", "rpmdb.sqlite"),
+        ] {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let rpmdb = RpmdbProbe::with_roots(tmp.path().to_path_buf(), None);
+            assert!(
+                !missing_rpm_tooling_is_fatal(&deb_env, &rpmdb),
+                "without an rpmdb the deb-family host degrades"
+            );
+            let db = tmp.path().join(dir);
+            std::fs::create_dir_all(&db).expect("rpmdb dir");
+            std::fs::write(db.join(file), b"").expect("rpmdb file");
+            assert!(
+                missing_rpm_tooling_is_fatal(&deb_env, &rpmdb),
+                "{dir}/{file} must force the hard error"
+            );
+        }
+    }
+
+    #[test]
+    fn debian_default_home_dbpath_also_counts_as_rpmdb_evidence() {
+        // Debian's own rpm package defaults %_dbpath to ~/.rpmdb, so a
+        // database in the invoking user's home is host evidence too.
+        let deb_env = anolisa_env::EnvFacts {
+            os_id: Some("debian".to_string()),
+            os_id_like: None,
+            ..linux_env()
+        };
+        let system = tempfile::tempdir().expect("system root");
+        let home = tempfile::tempdir().expect("home");
+        let rpmdb =
+            RpmdbProbe::with_roots(system.path().to_path_buf(), Some(home.path().to_path_buf()));
+        assert!(
+            !missing_rpm_tooling_is_fatal(&deb_env, &rpmdb),
+            "no database anywhere degrades"
+        );
+        let db = home.path().join(".rpmdb");
+        std::fs::create_dir_all(&db).expect("home rpmdb dir");
+        std::fs::write(db.join("Packages"), b"").expect("home rpmdb file");
+        assert!(
+            missing_rpm_tooling_is_fatal(&deb_env, &rpmdb),
+            "~/.rpmdb must force the hard error"
+        );
+    }
+
+    #[test]
+    fn rpmdb_evidence_ignores_the_install_prefix() {
+        // A --prefix relocates where components are placed, not where the
+        // host keeps its rpmdb: a database inside the install prefix is
+        // ANOLISA's own tree, while the host probe roots stay clean — the
+        // degrade must follow the host, not the layout.
+        let deb_env = anolisa_env::EnvFacts {
+            os_id: Some("ubuntu".to_string()),
+            os_id_like: Some("debian".to_string()),
+            ..linux_env()
+        };
+        let host_root = tempfile::tempdir().expect("host root");
+        let prefix = tempfile::tempdir().expect("install prefix");
+        let inside_prefix = prefix.path().join("var/lib/rpm");
+        std::fs::create_dir_all(&inside_prefix).expect("prefix rpm dir");
+        std::fs::write(inside_prefix.join("rpmdb.sqlite"), b"").expect("prefix file");
+        let rpmdb = RpmdbProbe::with_roots(host_root.path().to_path_buf(), None);
+        assert!(
+            !missing_rpm_tooling_is_fatal(&deb_env, &rpmdb),
+            "a file under the install prefix is not host rpmdb evidence"
+        );
+        // Conversely a host database keeps the hard error no matter what
+        // prefix the install targets.
+        let host_db = host_root.path().join("var/lib/rpm");
+        std::fs::create_dir_all(&host_db).expect("host rpm dir");
+        std::fs::write(host_db.join("rpmdb.sqlite"), b"").expect("host file");
+        assert!(
+            missing_rpm_tooling_is_fatal(&deb_env, &rpmdb),
+            "host rpmdb evidence is independent of the install prefix"
+        );
+    }
+
+    #[test]
+    fn locked_recheck_refuses_on_rpmdb_evidence_even_when_probe_reports_absent() {
+        // The essence of the planning-degrade races: under the lock the
+        // probe may answer Absent for a stale or fallback identity (e.g. a
+        // differently named provider was installed meanwhile), or still
+        // fail with CommandMissing while another process grew a database.
+        // With the degraded policy, on-disk rpmdb evidence must refuse
+        // regardless of what the per-package query reports.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let rpmdb = RpmdbProbe::with_roots(tmp.path().to_path_buf(), None);
+        let db = tmp.path().join("var/lib/rpm");
+        std::fs::create_dir_all(&db).expect("rpmdb dir");
+        std::fs::write(db.join("rpmdb.sqlite"), b"").expect("rpmdb file");
+        // The default FakeQuery reports every package as absent.
+        let q = FakeQuery::default();
+        let provider = DelegatedProvider::new(&q, &NoTxn);
+
+        let err = revalidate_native_absence(
+            Some("copilot-shell"),
+            &provider,
+            "2026-01-01T00:00:00Z",
+            "copilot-shell",
+            COMMAND,
+            Some(&rpmdb),
+        )
+        .expect_err("rpmdb evidence must refuse under the degraded policy");
+        assert!(
+            err.reason().contains("rpm database appeared"),
+            "got: {}",
+            err.reason()
+        );
+
+        // The same evidence with the fatal policy defers to the probe: the
+        // absent answer from working tooling is authoritative there.
+        revalidate_native_absence(
+            Some("copilot-shell"),
+            &provider,
+            "2026-01-01T00:00:00Z",
+            "copilot-shell",
+            COMMAND,
+            None,
+        )
+        .expect("the fatal policy trusts the probe answer");
+    }
+
+    #[test]
     fn delegated_install_reports_execution_and_finalization() {
         let (_tmp, mut ctx) = system_ctx_with_configured_rpm_repo(false);
         ctx.quiet = true;
@@ -1766,6 +2149,8 @@ mod tests {
             "copilot-shell",
             &install_args,
             &ctx,
+            &linux_env(),
+            &RpmdbProbe::absent(),
             &fake,
             &fake,
             true,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -660,6 +660,33 @@ pub fn handle_one_with_query(
     install_component_with_deps(&component, &args, ctx, query, &txn, false)
 }
 
+/// [`handle_one_with_query`] with injected host facts, for tests pinning
+/// package-family-sensitive behavior (deb degrade vs rpm/unknown fail
+/// closed) independently of the runner's real /etc/os-release.
+pub fn handle_one_with_query_env(
+    component: String,
+    args: InstallArgs,
+    ctx: &CliContext,
+    env: &anolisa_env::EnvFacts,
+    query: &dyn PackageQuery,
+) -> Result<InstallOutcome, CliError> {
+    handle_one_with_query_env_rpmdb(component, args, ctx, env, &RpmdbProbe::absent(), query)
+}
+
+/// Variant with the host rpmdb evidence probe injected, for tests staging
+/// database files under isolated roots instead of the runner's real host.
+pub fn handle_one_with_query_env_rpmdb(
+    component: String,
+    args: InstallArgs,
+    ctx: &CliContext,
+    env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
+    query: &dyn PackageQuery,
+) -> Result<InstallOutcome, CliError> {
+    let txn = NoTxn;
+    install_component_with_deps_and_env(&component, &args, ctx, env, rpmdb, query, &txn, false)
+}
+
 /// Load the v5 store the pipeline writes, for post-install assertions.
 pub fn load_store(ctx: &CliContext) -> anolisa_core::state_store::StateStore {
     let layout = common::resolve_layout(ctx);
@@ -687,6 +714,15 @@ pub struct FakeInstaller {
     pub lock_probe: Option<PathBuf>,
     pub lock_was_held: Cell<bool>,
     package_appears_under_lock_path: Option<PathBuf>,
+    /// Lock path after which rpm tooling (and the external RPM) exists: every
+    /// query fails with `CommandMissing` until the install lock is held, then
+    /// behaves as if the package was installed while tooling was appearing.
+    tooling_appears_under_lock_path: Option<PathBuf>,
+    /// `(lock, rpmdb file)` simulating an external process that installs
+    /// RPMs with a binary this process cannot see: queries always fail with
+    /// `CommandMissing`, but once the install lock is held the rpmdb file
+    /// is written before the failure is returned.
+    rpmdb_appears_under_lock: Option<(PathBuf, PathBuf)>,
     /// Optional installed.toml path replaced with a directory after dnf.
     pub block_state_save: Option<PathBuf>,
     pending_race: Option<(PathBuf, PathBuf, String)>,
@@ -708,6 +744,8 @@ impl FakeInstaller {
             lock_probe: None,
             lock_was_held: Cell::new(false),
             package_appears_under_lock_path: None,
+            tooling_appears_under_lock_path: None,
+            rpmdb_appears_under_lock: None,
             block_state_save: None,
             pending_race: None,
             pending_race_injected: Cell::new(false),
@@ -740,6 +778,41 @@ impl FakeInstaller {
     pub fn package_appears_under_lock(mut self, path: PathBuf) -> Self {
         self.package_appears_under_lock_path = Some(path);
         self
+    }
+    /// Simulate a host without rpm tooling at planning time that gains both
+    /// the tooling and an external RPM before the install lock is taken.
+    pub fn tooling_appears_under_lock(mut self, path: PathBuf) -> Self {
+        self.tooling_appears_under_lock_path = Some(path);
+        self
+    }
+    /// Simulate an rpmdb growing behind this process's back: rpm tooling
+    /// stays invisible to every query, but under the install lock the
+    /// database file appears on disk.
+    pub fn rpmdb_appears_under_lock(mut self, lock: PathBuf, rpmdb_file: PathBuf) -> Self {
+        self.rpmdb_appears_under_lock = Some((lock, rpmdb_file));
+        self
+    }
+    /// `CommandMissing` while the install lock is free in the
+    /// tooling-appears-under-lock mode; `None` otherwise.
+    fn tooling_still_missing(&self) -> Option<PackageQueryError> {
+        if let Some((lock, rpmdb_file)) = &self.rpmdb_appears_under_lock {
+            if matches!(InstallLock::acquire(lock), Err(LockError::Held { .. })) {
+                std::fs::create_dir_all(rpmdb_file.parent().expect("rpmdb dir"))
+                    .expect("create rpmdb dir");
+                std::fs::write(rpmdb_file, b"").expect("write rpmdb file");
+            }
+            return Some(PackageQueryError::CommandMissing {
+                command: "rpm".to_string(),
+            });
+        }
+        let path = self.tooling_appears_under_lock_path.as_ref()?;
+        if matches!(InstallLock::acquire(path), Err(LockError::Held { .. })) {
+            None
+        } else {
+            Some(PackageQueryError::CommandMissing {
+                command: "rpm".to_string(),
+            })
+        }
     }
     pub fn failing_state_save(mut self, path: PathBuf) -> Self {
         self.block_state_save = Some(path);
@@ -780,8 +853,14 @@ impl FakeInstaller {
 impl PackageQuery for FakeInstaller {
     fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
         self.maybe_inject_pending_journal();
+        if let Some(err) = self.tooling_still_missing() {
+            return Err(err);
+        }
         if package != self.package {
             return Ok(None);
+        }
+        if self.tooling_appears_under_lock_path.is_some() {
+            *self.installed.borrow_mut() = Some(self.installs_to.clone());
         }
         if let Some(path) = &self.package_appears_under_lock_path
             && matches!(InstallLock::acquire(path), Err(LockError::Held { .. }))
@@ -806,6 +885,9 @@ impl PackageQuery for FakeInstaller {
     }
 
     fn what_provides_installed(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        if let Some(err) = self.tooling_still_missing() {
+            return Err(err);
+        }
         if capability == self.component_capability() && self.installed.borrow().is_some() {
             Ok(vec![self.package.clone()])
         } else {
@@ -814,6 +896,9 @@ impl PackageQuery for FakeInstaller {
     }
 
     fn what_provides_available(&self, capability: &str) -> Result<Vec<String>, PackageQueryError> {
+        if let Some(err) = self.tooling_still_missing() {
+            return Err(err);
+        }
         if capability == self.component_capability() {
             Ok(vec![self.package.clone()])
         } else {
@@ -1126,6 +1211,7 @@ pub fn linux_env() -> anolisa_env::EnvFacts {
         kernel: Some("5.10.0".to_string()),
         pkg_base: Some("alinux4".to_string()),
         os_id: Some("alinux".to_string()),
+        os_id_like: None,
         os_version: Some("4".to_string()),
         btf: Some(true),
         cap_bpf: Some(true),
@@ -1133,6 +1219,44 @@ pub fn linux_env() -> anolisa_env::EnvFacts {
         user: "root".to_string(),
         uid: 0,
         home: PathBuf::from("/root"),
+    }
+}
+
+/// Host facts for a deb-family host (Ubuntu), with `os`/`arch` matching the
+/// running machine so raw artifact entries built by the repo fixtures still
+/// resolve. Injected into planning to cover the rpm-tooling degrade branch
+/// deterministically on any CI runner.
+pub fn deb_host_env() -> anolisa_env::EnvFacts {
+    anolisa_env::EnvFacts {
+        pkg_base: None,
+        os_id: Some("ubuntu".to_string()),
+        os_id_like: Some("debian".to_string()),
+        os_version: Some("24.04".to_string()),
+        ..anolisa_env::EnvService::detect()
+    }
+}
+
+/// Host facts for an rpm-family host (alinux), `os`/`arch` matching the
+/// running machine. The fail-closed counterpart of [`deb_host_env`].
+pub fn rpm_host_env() -> anolisa_env::EnvFacts {
+    anolisa_env::EnvFacts {
+        pkg_base: Some("alinux4".to_string()),
+        os_id: Some("alinux".to_string()),
+        os_id_like: None,
+        os_version: Some("4".to_string()),
+        ..anolisa_env::EnvService::detect()
+    }
+}
+
+/// Host facts for a distro outside the known rpm/deb families; missing rpm
+/// tooling must fail closed here.
+pub fn unknown_host_env() -> anolisa_env::EnvFacts {
+    anolisa_env::EnvFacts {
+        pkg_base: None,
+        os_id: Some("alpine".to_string()),
+        os_id_like: Some("musl".to_string()),
+        os_version: None,
+        ..anolisa_env::EnvService::detect()
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -348,6 +348,198 @@ fn system_raw_install_rechecks_native_absence_under_lock() {
 }
 
 #[test]
+fn deb_host_raw_install_rechecks_native_absence_under_lock() {
+    // The deb-family relaxation covers a missing rpm binary only. With
+    // working tooling on a deb-family host the planning probe resolves a
+    // native package, so an RPM appearing between planning and placement
+    // must still trip the locked recheck — the family never mutes obtained
+    // presence evidence.
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let fake = FakeInstaller::new(
+        "agentsight",
+        pkg_info("agentsight", "0.2.0", Some("1.al8"), "x86_64"),
+    )
+    .package_appears_under_lock(layout.lock_file.clone());
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+
+    let err = install_component_with_deps_and_env(
+        "agentsight",
+        &a,
+        &ctx,
+        &deb_host_env(),
+        &RpmdbProbe::absent(),
+        &fake,
+        &NoTxn,
+        true,
+    )
+    .expect_err("an external RPM appearing before raw placement must block install");
+
+    assert!(err.reason().contains("appeared"), "got: {}", err.reason());
+    assert!(
+        load_v5_store(&layout)
+            .find(ObjectKind::Component, "agentsight")
+            .is_none(),
+        "a refused race must not claim an owned record"
+    );
+}
+
+#[test]
+fn deb_host_tooling_appearing_under_lock_still_refuses() {
+    // The race the planning degrade must not hide: rpm tooling is missing
+    // while the deb-family plan resolves (CommandMissing degrades to
+    // NotProbed), then tooling plus an external same-named RPM appear
+    // before raw placement. The probe identity survives planning, so the
+    // locked recheck re-probes, obtains presence evidence, and refuses.
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let fake = FakeInstaller::new(
+        "agentsight",
+        pkg_info("agentsight", "0.2.0", Some("1.al8"), "x86_64"),
+    )
+    .tooling_appears_under_lock(layout.lock_file.clone());
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+
+    let err = install_component_with_deps_and_env(
+        "agentsight",
+        &a,
+        &ctx,
+        &deb_host_env(),
+        &RpmdbProbe::absent(),
+        &fake,
+        &NoTxn,
+        true,
+    )
+    .expect_err("presence evidence gained under the lock must block the raw install");
+
+    assert!(err.reason().contains("appeared"), "got: {}", err.reason());
+    assert!(
+        load_v5_store(&layout)
+            .find(ObjectKind::Component, "agentsight")
+            .is_none(),
+        "a refused race must not claim an owned record"
+    );
+}
+
+#[test]
+fn deb_host_rpmdb_growing_under_lock_still_refuses() {
+    // The degraded CommandMissing policy is a planning-time snapshot: an
+    // external process may install RPMs with a binary this process cannot
+    // see (absolute path outside PATH), so its queries keep failing while
+    // an rpmdb grows on disk. The locked recheck must re-verify the
+    // filesystem evidence instead of trusting the captured verdict.
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    // The rpmdb grows under the host probe root, deliberately separate
+    // from the install prefix: evidence follows the host, not the layout.
+    let host_root = tmp.path().join("host");
+    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix.clone()));
+    let rpmdb = RpmdbProbe::with_roots(host_root.clone(), None);
+    let fake = FakeInstaller::new(
+        "agentsight",
+        pkg_info("agentsight", "0.2.0", Some("1.al8"), "x86_64"),
+    )
+    .rpmdb_appears_under_lock(
+        layout.lock_file.clone(),
+        host_root.join("var/lib/rpm/rpmdb.sqlite"),
+    );
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+
+    let err = install_component_with_deps_and_env(
+        "agentsight",
+        &a,
+        &ctx,
+        &deb_host_env(),
+        &rpmdb,
+        &fake,
+        &NoTxn,
+        true,
+    )
+    .expect_err("an rpmdb appearing under the lock must block the raw install");
+
+    assert!(
+        err.reason().contains("rpm database appeared"),
+        "got: {}",
+        err.reason()
+    );
+    assert!(
+        load_v5_store(&layout)
+            .find(ObjectKind::Component, "agentsight")
+            .is_none(),
+        "a refused race must not claim an owned record"
+    );
+}
+
+#[test]
+fn deb_host_package_override_survives_planning_degrade() {
+    // Same race as above but with an explicit `--package` naming an RPM
+    // that differs from the component: the override is already the known
+    // probe identity, so the CommandMissing degrade must not collapse it
+    // to the component name. The locked recheck then probes the RPM the
+    // user named, sees it appeared with the tooling, and refuses.
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    // The raw index is keyed by the backend-native package name, so the
+    // override needs an alternate publication of the same artifact under
+    // `custom-rpm` for the pre-lock artifact resolution to succeed.
+    let index_path = tmp.path().join("repo/v1/index.toml");
+    let index = std::fs::read_to_string(&index_path).expect("read index");
+    let alternate = index
+        .split("[[entries]]")
+        .nth(1)
+        .expect("fixture entry")
+        .replace("component = \"agentsight\"", "component = \"custom-rpm\"");
+    std::fs::write(index_path, format!("{index}\n[[entries]]{alternate}"))
+        .expect("write alternate publication");
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let fake = FakeInstaller::new(
+        "custom-rpm",
+        pkg_info("custom-rpm", "0.2.0", Some("1.al8"), "x86_64"),
+    )
+    .tooling_appears_under_lock(layout.lock_file.clone());
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+    a.package = Some("custom-rpm".to_string());
+
+    let err = install_component_with_deps_and_env(
+        "agentsight",
+        &a,
+        &ctx,
+        &deb_host_env(),
+        &RpmdbProbe::absent(),
+        &fake,
+        &NoTxn,
+        true,
+    )
+    .expect_err("the overridden RPM appearing under the lock must block the raw install");
+
+    assert!(
+        err.reason().contains("'custom-rpm' appeared"),
+        "the recheck must probe the --package identity, got: {}",
+        err.reason()
+    );
+    assert!(
+        load_v5_store(&layout)
+            .find(ObjectKind::Component, "agentsight")
+            .is_none(),
+        "a refused race must not claim an owned record"
+    );
+}
+
+#[test]
 fn prepare_raw_execution_resolves_declared_capabilities() {
     let tmp = tempdir().expect("tmpdir");
     let prefix = tmp.path().join("sys");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -662,16 +662,25 @@ fn delegated_install_requires_configured_rpm_backend() {
 
 #[test]
 fn system_install_without_rpm_tooling_warns_and_exits() {
-    // System scope, fresh state: with rpm/dnf absent the probe cannot prove
-    // the component is not an unobserved system RPM (I3), so install refuses
-    // rather than silently placing raw files over one.
+    // Rpm-family host, system scope, fresh state: with rpm/dnf absent the
+    // probe cannot prove the component is not an unobserved system RPM
+    // (I3), so install refuses rather than silently placing raw files over
+    // one. The injected env pins the rpm family regardless of the runner;
+    // the deb-family degrade is asserted in
+    // `deb_host_missing_rpm_tooling_does_not_block_raw_install`.
     let (_tmp, ctx) = system_ctx_with_raw_repo(false);
     let q = FakeQuery {
         command_missing: true,
         ..Default::default()
     };
-    let err = handle_one_with_query("copilot-shell".to_string(), args("copilot-shell"), &ctx, &q)
-        .expect_err("missing rpm/dnf must abort, not fall back to raw");
+    let err = handle_one_with_query_env(
+        "copilot-shell".to_string(),
+        args("copilot-shell"),
+        &ctx,
+        &rpm_host_env(),
+        &q,
+    )
+    .expect_err("missing rpm/dnf must abort, not fall back to raw");
     assert_eq!(err.code(), "EXECUTION_FAILED");
     assert!(
         err.reason().contains("not found on PATH"),
@@ -688,7 +697,141 @@ fn system_install_without_rpm_tooling_warns_and_exits() {
 }
 
 #[test]
+fn unknown_host_missing_rpm_tooling_fails_closed() {
+    // A distro outside the known rpm/deb families cannot prove it has no
+    // rpmdb, so missing tooling keeps the hard I3 error.
+    let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+    let q = FakeQuery {
+        command_missing: true,
+        ..Default::default()
+    };
+    let err = handle_one_with_query_env(
+        "copilot-shell".to_string(),
+        args("copilot-shell"),
+        &ctx,
+        &unknown_host_env(),
+        &q,
+    )
+    .expect_err("an unclassified host must fail closed");
+    assert_eq!(err.code(), "EXECUTION_FAILED");
+    assert!(
+        err.reason().contains("not found on PATH"),
+        "got: {}",
+        err.reason()
+    );
+}
+
+#[test]
+fn deb_host_missing_rpm_tooling_does_not_block_raw_install() {
+    // A deb-family host (e.g. Ubuntu) has no rpmdb, so when rpm/dnf is
+    // missing the I3 presence probe degrades to NotProbed instead of
+    // blocking the raw install. The injected env pins the deb family
+    // regardless of the runner; rpm-family hosts assert the hard error in
+    // `system_install_without_rpm_tooling_warns_and_exits`.
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+    let ctx = ctx_with_prefix(false, Some(prefix));
+    let q = FakeQuery {
+        command_missing: true,
+        ..Default::default()
+    };
+
+    handle_one_with_query_env("agentsight".to_string(), a, &ctx, &deb_host_env(), &q)
+        .expect("raw install must not require rpm tooling on a deb-family host");
+
+    assert!(
+        load_store(&ctx)
+            .find(ObjectKind::Component, "agentsight")
+            .is_some(),
+        "raw install must be recorded"
+    );
+}
+
+#[test]
+fn deb_host_with_leftover_rpmdb_still_fails_closed() {
+    // The deb-family relaxation is an inference, not evidence: a host that
+    // installed RPMs before the rpm binary went away still owns a database
+    // the raw path could corrupt. An rpmdb on disk must keep the missing
+    // tooling fatal even though ID/ID_LIKE classify the host as deb.
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    // The database lives under the host probe root, not the install
+    // prefix: host evidence must gate the degrade wherever ANOLISA is
+    // asked to place its own files.
+    let host_root = tmp.path().join("host");
+    let db = host_root.join("var/lib/rpm");
+    std::fs::create_dir_all(&db).expect("rpmdb dir");
+    std::fs::write(db.join("rpmdb.sqlite"), b"").expect("rpmdb file");
+    let rpmdb = RpmdbProbe::with_roots(host_root, None);
+    let repo_url = write_local_repo(&tmp.path().join("repo"));
+    let mut a = args("agentsight");
+    a.repo = Some(repo_url);
+    let ctx = ctx_with_prefix(false, Some(prefix));
+    let q = FakeQuery {
+        command_missing: true,
+        ..Default::default()
+    };
+
+    let err = handle_one_with_query_env_rpmdb(
+        "agentsight".to_string(),
+        a,
+        &ctx,
+        &deb_host_env(),
+        &rpmdb,
+        &q,
+    )
+    .expect_err("an on-disk rpmdb must keep missing rpm tooling fatal");
+
+    assert!(
+        err.reason().contains("not found on PATH"),
+        "got: {}",
+        err.reason()
+    );
+    assert!(
+        load_store(&ctx)
+            .find(ObjectKind::Component, "agentsight")
+            .is_none(),
+        "the refused install must not write any state"
+    );
+}
+
+#[test]
+fn deb_host_present_system_rpm_still_points_at_adopt() {
+    // The deb-family relaxation only covers an unusable probe. When rpm
+    // tooling exists and reports the package as installed, the presence
+    // evidence must keep driving the I3 refusal even on a deb-family host.
+    let (_tmp, ctx) = system_ctx_with_raw_repo(false);
+    let q = FakeQuery {
+        installed: vec![(
+            "copilot-shell".to_string(),
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        )],
+        ..Default::default()
+    };
+    let err = handle_one_with_query_env(
+        "copilot-shell".to_string(),
+        args("copilot-shell"),
+        &ctx,
+        &deb_host_env(),
+        &q,
+    )
+    .expect_err("obtained RPM presence evidence must refuse on any host");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(
+        err.reason().contains("adopt copilot-shell"),
+        "must point at adopt: {}",
+        err.reason()
+    );
+}
+
+#[test]
 fn explicit_rpm_without_tooling_warns_and_exits() {
+    // The deb-family degrade is raw-only: an explicit `--backend rpm`
+    // cannot run without the native tooling on any host, so the deb env is
+    // injected here to pin the strictest combination.
     let (_tmp, ctx) = system_ctx_with_raw_repo(false);
     let q = FakeQuery {
         command_missing: true,
@@ -696,7 +839,7 @@ fn explicit_rpm_without_tooling_warns_and_exits() {
     };
     let mut a = args("copilot-shell");
     a.backend = Some("rpm".to_string());
-    let err = handle_one_with_query("copilot-shell".to_string(), a, &ctx, &q)
+    let err = handle_one_with_query_env("copilot-shell".to_string(), a, &ctx, &deb_host_env(), &q)
         .expect_err("missing rpm/dnf must abort");
     assert_eq!(err.code(), "EXECUTION_FAILED");
     assert!(

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -951,6 +951,7 @@ base_url = "file://{}"
             kernel: None,
             pkg_base: None,
             os_id: None,
+            os_id_like: None,
             os_version: None,
             btf: None,
             cap_bpf: None,

--- a/src/anolisa/crates/anolisa-core/src/capability.rs
+++ b/src/anolisa/crates/anolisa-core/src/capability.rs
@@ -794,6 +794,7 @@ mod tests {
             kernel: None,
             pkg_base: None,
             os_id: None,
+            os_id_like: None,
             os_version: None,
             btf: None,
             cap_bpf: None,

--- a/src/anolisa/crates/anolisa-core/src/osbase_install.rs
+++ b/src/anolisa/crates/anolisa-core/src/osbase_install.rs
@@ -1180,6 +1180,7 @@ mod tests {
             kernel: Some("6.6.30".to_string()),
             pkg_base: None,
             os_id: Some("alinux".to_string()),
+            os_id_like: None,
             os_version: Some("4".to_string()),
             btf: None,
             cap_bpf: None,

--- a/src/anolisa/crates/anolisa-core/src/service.rs
+++ b/src/anolisa/crates/anolisa-core/src/service.rs
@@ -1127,6 +1127,7 @@ mod tests {
             kernel: None,
             pkg_base: None,
             os_id: None,
+            os_id_like: None,
             os_version: None,
             btf: None,
             cap_bpf: None,

--- a/src/anolisa/crates/anolisa-env/src/lib.rs
+++ b/src/anolisa/crates/anolisa-env/src/lib.rs
@@ -43,6 +43,12 @@ pub struct EnvFacts {
     /// `"ubuntu"`, `"debian"`, `"anolis"`). `None` on non-Linux hosts
     /// or when `/etc/os-release` is missing / unreadable.
     pub os_id: Option<String>,
+    /// Raw `ID_LIKE` field from `/etc/os-release` (e.g. `"debian"`,
+    /// `"rhel fedora"`). `None` when unavailable. Defaulted on
+    /// deserialization so snapshots written before this field existed
+    /// keep loading.
+    #[serde(default)]
+    pub os_id_like: Option<String>,
     /// Raw `VERSION_ID` field from `/etc/os-release` (e.g. `"4"`,
     /// `"24.04"`, `"12"`). `None` when unavailable.
     pub os_version: Option<String>,
@@ -76,6 +82,9 @@ pub struct EnvFacts {
 pub struct OsReleaseInfo {
     /// Raw `ID` field (e.g. `"alinux"`, `"ubuntu"`, `"anolis"`).
     pub id: Option<String>,
+    /// Raw `ID_LIKE` field (e.g. `"debian"`, `"rhel fedora"`), used to
+    /// classify derivatives whose `ID` is not individually known.
+    pub id_like: Option<String>,
     /// Raw `VERSION_ID` field (e.g. `"4"`, `"24.04"`, `"23"`).
     pub version_id: Option<String>,
     /// Anolis-family package base hint (`"anolis23"`, `"anolis8"`,
@@ -116,6 +125,7 @@ impl EnvService {
             kernel,
             pkg_base: os_release.pkg_base,
             os_id: os_release.id,
+            os_id_like: os_release.id_like,
             os_version: os_release.version_id,
             btf,
             cap_bpf,
@@ -210,6 +220,7 @@ pub fn parse_os_release(content: &str) -> OsReleaseInfo {
 
     OsReleaseInfo {
         id,
+        id_like,
         version_id,
         pkg_base,
     }
@@ -230,6 +241,22 @@ pub fn pkg_base_from_id(id: &str) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// Classify the host package family (`"rpm"` / `"deb"`) from the raw
+/// `/etc/os-release` `ID` and `ID_LIKE` fields.
+///
+/// `ID` wins when it is individually known; otherwise every whitespace
+/// token of `ID_LIKE` is tried in order, so derivatives that declare
+/// their lineage (e.g. `ID=pop`, `ID_LIKE="ubuntu debian"`) classify
+/// without being listed by name. Returns `None` when neither field
+/// names a known rpm/deb family member — callers must treat that as
+/// "unknown", not as a third family.
+pub fn package_family(id: Option<&str>, id_like: Option<&str>) -> Option<String> {
+    if let Some(family) = id.and_then(pkg_base_from_id) {
+        return Some(family);
+    }
+    id_like?.split_whitespace().find_map(pkg_base_from_id)
 }
 
 fn version_major(version_id: &str) -> Option<String> {
@@ -500,6 +527,44 @@ mod tests {
         assert!(pkg_base_from_id("arch").is_none());
         assert!(pkg_base_from_id("gentoo").is_none());
         assert!(pkg_base_from_id("").is_none());
+    }
+
+    #[test]
+    fn parse_os_release_keeps_id_like() {
+        let content = "ID=pop\nID_LIKE=\"ubuntu debian\"\n";
+        let info = parse_os_release(content);
+        assert_eq!(info.id.as_deref(), Some("pop"));
+        assert_eq!(info.id_like.as_deref(), Some("ubuntu debian"));
+    }
+
+    #[test]
+    fn package_family_prefers_known_id() {
+        assert_eq!(
+            package_family(Some("alinux"), Some("debian")).as_deref(),
+            Some("rpm"),
+            "a known ID must not be overridden by ID_LIKE",
+        );
+        assert_eq!(package_family(Some("ubuntu"), None).as_deref(), Some("deb"));
+    }
+
+    #[test]
+    fn package_family_falls_back_to_id_like_tokens() {
+        // A derivative unknown by name classifies through its lineage.
+        assert_eq!(
+            package_family(Some("zorin"), Some("ubuntu debian")).as_deref(),
+            Some("deb"),
+        );
+        assert_eq!(
+            package_family(Some("openeuler"), Some("rhel fedora")).as_deref(),
+            Some("rpm"),
+        );
+    }
+
+    #[test]
+    fn package_family_unknown_everywhere_is_none() {
+        assert!(package_family(Some("arch"), None).is_none());
+        assert!(package_family(Some("alpine"), Some("musl")).is_none());
+        assert!(package_family(None, None).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

`anolisa install` refused raw-backend installs on hosts without RPM tooling (e.g. Ubuntu), failing with `rpm not found on PATH` even though the raw backend does not need rpm/dnf. The failure came from the planner's I3 system-RPM presence probe, which ran unconditionally for fresh raw system-scope installs.

The fix separates "the probe cannot run" from "the probe found evidence": the probe still runs whenever rpm tooling is present, and any `Present`/`MultipleVersions` evidence keeps driving the I3 refusal and the locked recheck on every host. Only a missing rpm binary is reinterpreted through the host package family — now formally exposed as `anolisa_env::package_family` over `/etc/os-release` `ID` + `ID_LIKE`, so derivatives declaring deb lineage classify without name lists. Deb-family hosts degrade to `NotProbed`; rpm-family and unrecognized hosts (Alpine, Arch, ...) keep failing closed. Host facts are injected into install planning (`plan_component`), so the family-sensitive branches are covered deterministically in tests instead of depending on the runner's real os-release.

## Related Issue

no-issue: user-reported runtime bug fixed directly

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `anolisa` (anolisa-cli)

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo doc --workspace --no-deps` all pass
- `cargo test --workspace` passes; the review's six-case matrix is covered deterministically via injected `EnvFacts` on a single runner:
  - deb + `CommandMissing` → raw install succeeds (`deb_host_missing_rpm_tooling_does_not_block_raw_install`)
  - deb + installed RPM evidence → refuses, points at adopt (`deb_host_present_system_rpm_still_points_at_adopt`)
  - deb + RPM appears under lock → refuses (`deb_host_raw_install_rechecks_native_absence_under_lock`)
  - rpm-family + `CommandMissing` → fail closed (`system_install_without_rpm_tooling_warns_and_exits`)
  - unknown + `CommandMissing` → fail closed (`unknown_host_missing_rpm_tooling_fails_closed`)
  - explicit `--backend rpm` + `CommandMissing` → still fails (`explicit_rpm_without_tooling_warns_and_exits`, pinned to a deb env)
- `anolisa_env::package_family` unit tests cover ID priority, ID_LIKE token fallback, and unknown classification

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly (CHANGELOG `[Unreleased]`)
