### PR TITLE
feat(cosh-ng): [core,shell] improve auth menu

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md
@@ -234,6 +234,7 @@ max_disk_bytes = 1073741824
 | `COSH_AI_PROVIDER` | Override active provider | `ai.active_provider` |
 | `COSH_OUTPUT_LANGUAGE` | Output language | `ai.output_language` |
 | `COSH_MAX_TURNS` | Maximum turns | `agent.max_turns` |
+| `COSH_SERVICE_SITE` | Built-in Coding Plan and Token Plan endpoint catalog | — |
 | `COSH_LOG` | Log level (global) | `logging.level` |
 | `RUST_LOG` | Rust log filter | — |
 | `COSH_SHELL_ADAPTER` | Shell adapter | `shell.adapter_default` |
@@ -243,6 +244,13 @@ max_disk_bytes = 1073741824
 | `ALIBABA_CLOUD_ACCESS_KEY_ID` | Alibaba Cloud AK | `ai.providers.aliyun.access_key_id` |
 | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | Alibaba Cloud SK | `ai.providers.aliyun.access_key_secret` |
 | `DASHSCOPE_API_KEY` | DashScope API Key | Provider resolution chain |
+
+`COSH_SERVICE_SITE` accepts `china`/`cn` and
+`international`/`intl`/`global`. An unset or unrecognized value uses the
+China catalog. It changes the built-in endpoints offered by `/auth`; it does
+not rewrite saved provider URLs. Legacy OpenAI-compatible plan providers are
+restored to a plan-specific edit form only when their endpoint matches the
+selected catalog, ignoring a trailing slash.
 
 ## Log Level Priority
 

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md
@@ -217,6 +217,7 @@ max_disk_bytes = 1073741824
 | `COSH_AI_PROVIDER` | 覆盖活跃提供商 | `ai.active_provider` |
 | `COSH_OUTPUT_LANGUAGE` | 输出语言 | `ai.output_language` |
 | `COSH_MAX_TURNS` | 最大轮次 | `agent.max_turns` |
+| `COSH_SERVICE_SITE` | Coding Plan 和 Token Plan 的内置 endpoint 目录 | — |
 | `COSH_LOG` | 日志级别（全局） | `logging.level` |
 | `RUST_LOG` | Rust 日志过滤 | — |
 | `COSH_SHELL_ADAPTER` | Shell 适配器 | `shell.adapter_default` |
@@ -226,6 +227,12 @@ max_disk_bytes = 1073741824
 | `ALIBABA_CLOUD_ACCESS_KEY_ID` | 阿里云 AK | `ai.providers.aliyun.access_key_id` |
 | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | 阿里云 SK | `ai.providers.aliyun.access_key_secret` |
 | `DASHSCOPE_API_KEY` | DashScope API Key | provider 解析链 |
+
+`COSH_SERVICE_SITE` 支持 `china`/`cn` 和
+`international`/`intl`/`global`。未设置或无法识别时使用中国站目录。该变量只
+改变 `/auth` 提供的内置 endpoint，不会改写已保存的 provider URL。旧版
+OpenAI-compatible Plan provider 仅在 endpoint 与当前站点目录匹配时恢复为 Plan
+专用编辑表单，匹配时忽略末尾斜杠。
 
 ## 日志级别优先级
 

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -100,6 +100,13 @@ the same provider conversation. Override the budget with `agent.max_turns` or
 `COSH_MAX_TURNS`; see the
 [configuration guide](../../docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md#agent-turn-budget).
 
+The `/auth` picker includes Coding Plan and Token Plan. Their built-in
+endpoints default to the China service site; set
+`COSH_SERVICE_SITE=international` for the international endpoint catalog.
+See the
+[configuration guide](../../docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md#environment-variable-overrides)
+for accepted aliases and fallback behavior.
+
 Core and Shell also write a redacted, versioned audit timeline under
 `$XDG_STATE_HOME/cosh/audit` or `~/.local/state/cosh/audit`. The existing
 SLS/metrics export is unchanged. See the

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -94,6 +94,11 @@ shell 会请求批准，并在同一个 provider 对话中追加同等预算。�
 `agent.max_turns` 或 `COSH_MAX_TURNS` 覆盖该预算，详见
 [配置指南](../../docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md#agent-轮次预算)。
 
+`/auth` 选择器包含 Coding Plan 和 Token Plan。内置 endpoint 默认使用中国站；
+国际站设置 `COSH_SERVICE_SITE=international` 后使用国际站 endpoint 目录。
+可选别名和 fallback 行为见
+[配置指南](../../docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md#环境变量覆盖)。
+
 Core 和 Shell 还会把脱敏、版本化的审计时间线写入
 `$XDG_STATE_HOME/cosh/audit` 或 `~/.local/state/cosh/audit`。既有
 SLS/metrics 导出保持不变。配置、保留、追踪和事故导出方法见

--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -15,69 +15,10 @@ use validation::{validate_auth_response, validate_base_url};
 pub fn builtin_auth_providers() -> Vec<AuthProvider> {
     vec![
         AuthProvider {
-            id: "dashscope".to_string(),
-            label: "DashScope (百炼)".to_string(),
-            fields: vec![
-                AuthField {
-                    name: "api_key".to_string(),
-                    label: "API Key".to_string(),
-                    hint: Some(
-                        "获取地址: https://bailian.console.aliyun.com/?tab=model#/api-key"
-                            .to_string(),
-                    ),
-                    secret: true,
-                    required: true,
-                    placeholder: None,
-                },
-                AuthField {
-                    name: "model".to_string(),
-                    label: "Model".to_string(),
-                    hint: Some("默认: qwen3.7-plus, e.g. qwen3.7-max, deepseek-v4-pro".to_string()),
-                    secret: false,
-                    required: false,
-                    placeholder: Some("qwen3.7-plus".to_string()),
-                },
-            ],
-            builtin_base_url: Some("https://dashscope.aliyuncs.com/compatible-mode/v1".to_string()),
-            builtin_provider_type: "dashscope".to_string(),
-            builtin_default_model: Some("qwen3.7-plus".to_string()),
-        },
-        AuthProvider {
-            id: "openai_compat".to_string(),
-            label: "OpenAI Compatible".to_string(),
-            fields: vec![
-                AuthField {
-                    name: "base_url".to_string(),
-                    label: "Base URL".to_string(),
-                    hint: Some("例如: https://api.openai.com/v1".to_string()),
-                    secret: false,
-                    required: true,
-                    placeholder: Some("https://api.openai.com/v1".to_string()),
-                },
-                AuthField {
-                    name: "api_key".to_string(),
-                    label: "API Key".to_string(),
-                    hint: Some("sk-...".to_string()),
-                    secret: true,
-                    required: true,
-                    placeholder: None,
-                },
-                AuthField {
-                    name: "model".to_string(),
-                    label: "Model".to_string(),
-                    hint: Some("e.g. qwen3.7-max, deepseek-v4-pro".to_string()),
-                    secret: false,
-                    required: true,
-                    placeholder: None,
-                },
-            ],
-            builtin_base_url: None,
-            builtin_provider_type: "openai".to_string(),
-            builtin_default_model: None,
-        },
-        AuthProvider {
             id: "aliyun".to_string(),
             label: "Aliyun Authentication".to_string(),
+            description: Some("Free with limited quota".to_string()),
+            description_zh_cn: Some("提供有限的免费额度".to_string()),
             fields: vec![
                 AuthField {
                     name: "access_key_id".to_string(),
@@ -107,6 +48,71 @@ pub fn builtin_auth_providers() -> Vec<AuthProvider> {
             builtin_base_url: None,
             builtin_provider_type: "aliyun".to_string(),
             builtin_default_model: Some("qwen3.7-plus".to_string()),
+        },
+        AuthProvider {
+            id: "dashscope".to_string(),
+            label: "DashScope (百炼)".to_string(),
+            description: Some("Connect with an existing Bailian API key".to_string()),
+            description_zh_cn: Some("使用现有的百炼 API Key".to_string()),
+            fields: vec![
+                AuthField {
+                    name: "api_key".to_string(),
+                    label: "API Key".to_string(),
+                    hint: Some(
+                        "获取地址: https://bailian.console.aliyun.com/?tab=model#/api-key"
+                            .to_string(),
+                    ),
+                    secret: true,
+                    required: true,
+                    placeholder: None,
+                },
+                AuthField {
+                    name: "model".to_string(),
+                    label: "Model".to_string(),
+                    hint: Some("默认: qwen3.7-plus, e.g. qwen3.7-max, deepseek-v4-pro".to_string()),
+                    secret: false,
+                    required: false,
+                    placeholder: Some("qwen3.7-plus".to_string()),
+                },
+            ],
+            builtin_base_url: Some("https://dashscope.aliyuncs.com/compatible-mode/v1".to_string()),
+            builtin_provider_type: "dashscope".to_string(),
+            builtin_default_model: Some("qwen3.7-plus".to_string()),
+        },
+        AuthProvider {
+            id: "openai_compat".to_string(),
+            label: "OpenAI Compatible".to_string(),
+            description: Some("Use an existing OpenAI-compatible Base URL and API key".to_string()),
+            description_zh_cn: Some("使用现有的 OpenAI 兼容 Base URL 和 API Key".to_string()),
+            fields: vec![
+                AuthField {
+                    name: "base_url".to_string(),
+                    label: "Base URL".to_string(),
+                    hint: Some("例如: https://api.openai.com/v1".to_string()),
+                    secret: false,
+                    required: true,
+                    placeholder: Some("https://api.openai.com/v1".to_string()),
+                },
+                AuthField {
+                    name: "api_key".to_string(),
+                    label: "API Key".to_string(),
+                    hint: Some("sk-...".to_string()),
+                    secret: true,
+                    required: true,
+                    placeholder: None,
+                },
+                AuthField {
+                    name: "model".to_string(),
+                    label: "Model".to_string(),
+                    hint: Some("e.g. qwen3.7-max, deepseek-v4-pro".to_string()),
+                    secret: false,
+                    required: true,
+                    placeholder: None,
+                },
+            ],
+            builtin_base_url: None,
+            builtin_provider_type: "openai".to_string(),
+            builtin_default_model: None,
         },
     ]
 }
@@ -303,15 +309,18 @@ mod tests {
     fn builtin_providers_have_correct_ids() {
         let providers = builtin_auth_providers();
         assert_eq!(providers.len(), 3);
-        assert_eq!(providers[0].id, "dashscope");
-        assert_eq!(providers[1].id, "openai_compat");
-        assert_eq!(providers[2].id, "aliyun");
+        assert_eq!(providers[0].id, "aliyun");
+        assert_eq!(providers[1].id, "dashscope");
+        assert_eq!(providers[2].id, "openai_compat");
     }
 
     #[test]
     fn dashscope_has_builtin_base_url() {
         let providers = builtin_auth_providers();
-        let ds = &providers[0];
+        let ds = providers
+            .iter()
+            .find(|provider| provider.id == "dashscope")
+            .unwrap();
         assert!(ds.builtin_base_url.is_some());
         assert_eq!(ds.fields.len(), 2);
         assert_eq!(ds.fields[0].name, "api_key");
@@ -321,7 +330,10 @@ mod tests {
     #[test]
     fn openai_compat_has_no_builtin_base_url() {
         let providers = builtin_auth_providers();
-        let oc = &providers[1];
+        let oc = providers
+            .iter()
+            .find(|provider| provider.id == "openai_compat")
+            .unwrap();
         assert!(oc.builtin_base_url.is_none());
         assert_eq!(oc.fields.len(), 3);
         assert_eq!(oc.fields[0].name, "base_url");

--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -11,8 +11,110 @@ pub(crate) use exchange::request_validated_auth;
 pub(crate) use validation::AuthConfigValidationError;
 use validation::{validate_auth_response, validate_base_url};
 
+const DEFAULT_PLAN_MODEL: &str = "qwen3.7-plus";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceSite {
+    China,
+    International,
+}
+
+impl ServiceSite {
+    fn from_env() -> Self {
+        std::env::var("COSH_SERVICE_SITE")
+            .ok()
+            .and_then(|value| Self::parse(&value))
+            .unwrap_or(Self::China)
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "china" | "cn" => Some(Self::China),
+            "international" | "intl" | "global" => Some(Self::International),
+            _ => None,
+        }
+    }
+}
+
+struct PlanEndpoint {
+    base_url: &'static str,
+    api_key_url: &'static str,
+}
+
+fn coding_plan_endpoint(site: ServiceSite) -> PlanEndpoint {
+    match site {
+        ServiceSite::China => PlanEndpoint {
+            base_url: "https://coding.dashscope.aliyuncs.com/v1",
+            api_key_url:
+                "https://bailian.console.aliyun.com/?tab=coding-plan#/efm/coding-plan-detail",
+        },
+        ServiceSite::International => PlanEndpoint {
+            base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
+            api_key_url:
+                "https://modelstudio.console.alibabacloud.com/?tab=dashboard#/efm/coding_plan",
+        },
+    }
+}
+
+fn token_plan_endpoint(site: ServiceSite) -> PlanEndpoint {
+    match site {
+        ServiceSite::China => PlanEndpoint {
+            base_url: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            api_key_url:
+                "https://bailian.console.aliyun.com/?tab=plan#/efm/subscription/token-plan",
+        },
+        ServiceSite::International => PlanEndpoint {
+            base_url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+            api_key_url: "https://www.alibabacloud.com/help/en/model-studio/token-plan-quickstart",
+        },
+    }
+}
+
+fn plan_auth_provider(
+    id: &str,
+    label: &str,
+    description: &str,
+    description_zh_cn: &str,
+    endpoint: PlanEndpoint,
+) -> AuthProvider {
+    AuthProvider {
+        id: id.to_string(),
+        label: label.to_string(),
+        description: Some(description.to_string()),
+        description_zh_cn: Some(description_zh_cn.to_string()),
+        fields: vec![
+            AuthField {
+                name: "api_key".to_string(),
+                label: "API Key".to_string(),
+                hint: Some(format!(
+                    "Plan keys start with sk-sp-. Get yours: {}",
+                    endpoint.api_key_url
+                )),
+                secret: true,
+                required: true,
+                placeholder: None,
+            },
+            AuthField {
+                name: "model".to_string(),
+                label: "Model".to_string(),
+                hint: Some(format!("Default: {DEFAULT_PLAN_MODEL}")),
+                secret: false,
+                required: false,
+                placeholder: Some(DEFAULT_PLAN_MODEL.to_string()),
+            },
+        ],
+        builtin_base_url: Some(endpoint.base_url.to_string()),
+        builtin_provider_type: id.to_string(),
+        builtin_default_model: Some(DEFAULT_PLAN_MODEL.to_string()),
+    }
+}
+
 /// Returns the builtin provider templates for the auth UI.
 pub fn builtin_auth_providers() -> Vec<AuthProvider> {
+    builtin_auth_providers_for_site(ServiceSite::from_env())
+}
+
+fn builtin_auth_providers_for_site(site: ServiceSite) -> Vec<AuthProvider> {
     vec![
         AuthProvider {
             id: "aliyun".to_string(),
@@ -49,6 +151,20 @@ pub fn builtin_auth_providers() -> Vec<AuthProvider> {
             builtin_provider_type: "aliyun".to_string(),
             builtin_default_model: Some("qwen3.7-plus".to_string()),
         },
+        plan_auth_provider(
+            "coding_plan",
+            "Coding Plan",
+            "For individual developers • Weekly quota included",
+            "面向个人开发者 • 包含每周额度",
+            coding_plan_endpoint(site),
+        ),
+        plan_auth_provider(
+            "token_plan",
+            "Token Plan",
+            "For teams and companies • Usage-based billing with dedicated capacity",
+            "面向团队和企业 • 按用量计费，提供专属容量",
+            token_plan_endpoint(site),
+        ),
         AuthProvider {
             id: "dashscope".to_string(),
             label: "DashScope (百炼)".to_string(),
@@ -308,10 +424,85 @@ mod tests {
     #[test]
     fn builtin_providers_have_correct_ids() {
         let providers = builtin_auth_providers();
-        assert_eq!(providers.len(), 3);
+        assert_eq!(providers.len(), 5);
         assert_eq!(providers[0].id, "aliyun");
-        assert_eq!(providers[1].id, "dashscope");
-        assert_eq!(providers[2].id, "openai_compat");
+        assert_eq!(providers[1].id, "coding_plan");
+        assert_eq!(providers[2].id, "token_plan");
+        assert_eq!(providers[3].id, "dashscope");
+        assert_eq!(providers[4].id, "openai_compat");
+    }
+
+    #[test]
+    fn plan_endpoints_match_service_site() {
+        let coding_cn = coding_plan_endpoint(ServiceSite::China);
+        let coding_intl = coding_plan_endpoint(ServiceSite::International);
+        let token_cn = token_plan_endpoint(ServiceSite::China);
+        let token_intl = token_plan_endpoint(ServiceSite::International);
+
+        assert_eq!(
+            coding_cn.base_url,
+            "https://coding.dashscope.aliyuncs.com/v1"
+        );
+        assert_eq!(
+            coding_intl.base_url,
+            "https://coding-intl.dashscope.aliyuncs.com/v1"
+        );
+        assert_eq!(
+            token_cn.base_url,
+            "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+        );
+        assert_eq!(
+            token_intl.base_url,
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+        );
+    }
+
+    #[test]
+    fn international_site_builds_plan_templates_with_international_urls() {
+        let providers = builtin_auth_providers_for_site(ServiceSite::International);
+        let coding_plan = providers
+            .iter()
+            .find(|provider| provider.id == "coding_plan")
+            .unwrap();
+        let token_plan = providers
+            .iter()
+            .find(|provider| provider.id == "token_plan")
+            .unwrap();
+
+        assert_eq!(
+            coding_plan.builtin_base_url.as_deref(),
+            Some("https://coding-intl.dashscope.aliyuncs.com/v1")
+        );
+        assert_eq!(
+            coding_plan.description_zh_cn.as_deref(),
+            Some("面向个人开发者 • 包含每周额度")
+        );
+        assert_eq!(
+            coding_plan.description.as_deref(),
+            Some("For individual developers • Weekly quota included")
+        );
+        assert_eq!(
+            token_plan.builtin_base_url.as_deref(),
+            Some("https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1")
+        );
+        assert_eq!(
+            token_plan.description.as_deref(),
+            Some("For teams and companies • Usage-based billing with dedicated capacity")
+        );
+        assert_eq!(
+            token_plan.description_zh_cn.as_deref(),
+            Some("面向团队和企业 • 按用量计费，提供专属容量")
+        );
+    }
+
+    #[test]
+    fn service_site_accepts_packaging_aliases() {
+        assert_eq!(ServiceSite::parse("cn"), Some(ServiceSite::China));
+        assert_eq!(
+            ServiceSite::parse("global"),
+            Some(ServiceSite::International)
+        );
+        assert_eq!(ServiceSite::parse("unknown"), None);
     }
 
     #[test]
@@ -361,6 +552,27 @@ mod tests {
         );
         assert_eq!(p.provider_type.as_deref(), Some("dashscope"));
         assert_eq!(p.model.as_deref(), Some("qwen3.7-plus"));
+    }
+
+    #[test]
+    fn apply_coding_plan_credentials_uses_preset_endpoint() {
+        let mut config = CoreConfig::default();
+        let response = AuthResponse {
+            provider_id: "coding-plan".to_string(),
+            provider_type: Some("coding_plan".to_string()),
+            values: HashMap::from([("api_key".to_string(), "sk-sp-test".to_string())]),
+            persist: true,
+        };
+
+        apply_auth_credentials(&mut config, &response).unwrap();
+
+        let provider = config.ai.providers.get("coding-plan").unwrap();
+        assert_eq!(provider.provider_type.as_deref(), Some("coding_plan"));
+        assert_eq!(
+            provider.base_url.as_deref(),
+            Some("https://coding.dashscope.aliyuncs.com/v1")
+        );
+        assert_eq!(provider.model.as_deref(), Some(DEFAULT_PLAN_MODEL));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -34,6 +34,12 @@ pub struct AuthField {
 pub struct AuthProvider {
     pub id: String,
     pub label: String,
+    /// Short guidance shown under the provider label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Simplified Chinese guidance shown when the shell uses zh-CN.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description_zh_cn: Option<String>,
     pub fields: Vec<AuthField>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub builtin_base_url: Option<String>,

--- a/src/cosh-ng/crates/cosh-core/src/provider/profile.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/profile.rs
@@ -87,7 +87,7 @@ impl ProviderProfile for DeepSeekProfile {
 
 pub fn profile_from_name(name: &str) -> Box<dyn ProviderProfile> {
     match name {
-        "dashscope" => Box::new(DashScopeProfile),
+        "dashscope" | "coding_plan" | "token_plan" => Box::new(DashScopeProfile),
         "openai" => Box::new(OpenAIProfile),
         "deepseek" => Box::new(DeepSeekProfile),
         _ => Box::new(GenericProfile),
@@ -144,6 +144,8 @@ mod tests {
     #[test]
     fn profile_from_name_routing() {
         assert_eq!(profile_from_name("dashscope").name(), "dashscope");
+        assert_eq!(profile_from_name("coding_plan").name(), "dashscope");
+        assert_eq!(profile_from_name("token_plan").name(), "dashscope");
         assert_eq!(profile_from_name("openai").name(), "openai");
         assert_eq!(profile_from_name("deepseek").name(), "deepseek");
         assert_eq!(profile_from_name("unknown").name(), "generic");

--- a/src/cosh-ng/crates/cosh-core/src/registry/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry/auth.rs
@@ -17,6 +17,8 @@ pub(super) fn handle_auth(
                         "id": provider.id,
                         "provider_type": provider.id,
                         "label": provider.label,
+                        "description": provider.description,
+                        "description_zh_cn": provider.description_zh_cn,
                         "fields": provider.fields,
                         "builtin_base_url": provider.builtin_base_url,
                         "builtin_default_model": provider.builtin_default_model,

--- a/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
@@ -124,6 +124,20 @@ fn bare_registry_reports_env_only_auth_as_satisfied() {
 }
 
 #[test]
+fn registry_auth_state_includes_localized_provider_guidance() {
+    let resp = run_registry_request("auth", "state", Value::Null);
+    let templates = resp["data"]["templates"]
+        .as_array()
+        .expect("auth templates");
+    let dashscope = templates
+        .iter()
+        .find(|provider| provider["id"] == "dashscope")
+        .expect("DashScope template");
+
+    assert_eq!(dashscope["description_zh_cn"], "使用现有的百炼 API Key");
+}
+
+#[test]
 fn bare_registry_does_not_discover_project_skills() {
     let home = tempfile::tempdir().expect("temp home");
     let project = tempfile::tempdir().expect("temp project");

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
@@ -96,6 +96,12 @@ impl ShellOutputDirection {
 pub struct AuthProviderInfo {
     pub id: String,
     pub label: String,
+    /// Short guidance shown under the provider label.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Simplified Chinese guidance supplied by the provider registry.
+    #[serde(default)]
+    pub description_zh_cn: Option<String>,
     pub fields: Vec<AuthFieldInfo>,
 }
 
@@ -437,6 +443,14 @@ pub fn parse_control_request(line: &str) -> Option<ControlRequest> {
                         .filter_map(|item| {
                             let id = item.get("id")?.as_str()?.to_string();
                             let label = item.get("label")?.as_str()?.to_string();
+                            let description = item
+                                .get("description")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string);
+                            let description_zh_cn = item
+                                .get("description_zh_cn")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string);
                             let fields = item
                                 .get("fields")
                                 .and_then(|v| v.as_array())
@@ -473,7 +487,13 @@ pub fn parse_control_request(line: &str) -> Option<ControlRequest> {
                                         .collect()
                                 })
                                 .unwrap_or_default();
-                            Some(AuthProviderInfo { id, label, fields })
+                            Some(AuthProviderInfo {
+                                id,
+                                label,
+                                description,
+                                description_zh_cn,
+                                fields,
+                            })
                         })
                         .collect()
                 })

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
@@ -6,8 +6,10 @@ use std::time::{Duration, Instant};
 use crate::tools::is_shell_tool_name;
 use crate::types::{AgentEvent, QuestionSelectionMode};
 
+mod auth;
 mod serialization;
 
+use auth::parse_auth_provider;
 pub use serialization::{
     serialize_answer, serialize_auth_response, serialize_claude_allow, serialize_co_allow,
     serialize_deny, serialize_host_executed_shell_result, serialize_initialize,
@@ -102,6 +104,9 @@ pub struct AuthProviderInfo {
     /// Simplified Chinese guidance supplied by the provider registry.
     #[serde(default)]
     pub description_zh_cn: Option<String>,
+    /// Fixed endpoint used to recognize preset-backed saved providers.
+    #[serde(default)]
+    pub builtin_base_url: Option<String>,
     pub fields: Vec<AuthFieldInfo>,
 }
 
@@ -438,65 +443,7 @@ pub fn parse_control_request(line: &str) -> Option<ControlRequest> {
             let providers = request
                 .get("providers")
                 .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|item| {
-                            let id = item.get("id")?.as_str()?.to_string();
-                            let label = item.get("label")?.as_str()?.to_string();
-                            let description = item
-                                .get("description")
-                                .and_then(|value| value.as_str())
-                                .map(str::to_string);
-                            let description_zh_cn = item
-                                .get("description_zh_cn")
-                                .and_then(|value| value.as_str())
-                                .map(str::to_string);
-                            let fields = item
-                                .get("fields")
-                                .and_then(|v| v.as_array())
-                                .map(|farr| {
-                                    farr.iter()
-                                        .filter_map(|f| {
-                                            let name = f.get("name")?.as_str()?.to_string();
-                                            let label = f.get("label")?.as_str()?.to_string();
-                                            let hint = f
-                                                .get("hint")
-                                                .and_then(|v| v.as_str())
-                                                .map(|s| s.to_string());
-                                            let secret = f
-                                                .get("secret")
-                                                .and_then(|v| v.as_bool())
-                                                .unwrap_or(false);
-                                            let required = f
-                                                .get("required")
-                                                .and_then(|v| v.as_bool())
-                                                .unwrap_or(true);
-                                            let placeholder = f
-                                                .get("placeholder")
-                                                .and_then(|v| v.as_str())
-                                                .map(|s| s.to_string());
-                                            Some(AuthFieldInfo {
-                                                name,
-                                                label,
-                                                hint,
-                                                secret,
-                                                required,
-                                                placeholder,
-                                            })
-                                        })
-                                        .collect()
-                                })
-                                .unwrap_or_default();
-                            Some(AuthProviderInfo {
-                                id,
-                                label,
-                                description,
-                                description_zh_cn,
-                                fields,
-                            })
-                        })
-                        .collect()
-                })
+                .map(|arr| arr.iter().filter_map(parse_auth_provider).collect())
                 .unwrap_or_default();
             Some(ControlRequest::AuthRequired {
                 request_id,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/auth.rs
@@ -1,0 +1,45 @@
+use serde_json::Value;
+
+use super::{AuthFieldInfo, AuthProviderInfo};
+
+pub(super) fn parse_auth_provider(item: &Value) -> Option<AuthProviderInfo> {
+    let id = item.get("id")?.as_str()?.to_string();
+    let label = item.get("label")?.as_str()?.to_string();
+    let description = optional_string(item, "description");
+    let description_zh_cn = optional_string(item, "description_zh_cn");
+    let builtin_base_url = optional_string(item, "builtin_base_url");
+    let fields = item
+        .get("fields")
+        .and_then(Value::as_array)
+        .map(|fields| fields.iter().filter_map(parse_auth_field).collect())
+        .unwrap_or_default();
+    Some(AuthProviderInfo {
+        id,
+        label,
+        description,
+        description_zh_cn,
+        builtin_base_url,
+        fields,
+    })
+}
+
+fn parse_auth_field(field: &Value) -> Option<AuthFieldInfo> {
+    Some(AuthFieldInfo {
+        name: field.get("name")?.as_str()?.to_string(),
+        label: field.get("label")?.as_str()?.to_string(),
+        hint: optional_string(field, "hint"),
+        secret: field
+            .get("secret")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        required: field
+            .get("required")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        placeholder: optional_string(field, "placeholder"),
+    })
+}
+
+fn optional_string(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).map(str::to_string)
+}

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
@@ -838,7 +838,7 @@ fn serialize_user_message_format() {
 
 #[test]
 fn parse_auth_required() {
-    let line = r#"{"type":"control_request","request_id":"auth-init","request":{"subtype":"auth_required","reason":"not_configured","providers":[{"id":"dashscope","label":"DashScope","fields":[{"name":"api_key","label":"API Key","hint":"get from console","secret":true,"required":true}]},{"id":"openai_compat","label":"OpenAI","fields":[{"name":"base_url","label":"Base URL","secret":false,"required":true,"placeholder":"https://api.openai.com/v1"},{"name":"api_key","label":"Key","secret":true,"required":true}]}]}}"#;
+    let line = r#"{"type":"control_request","request_id":"auth-init","request":{"subtype":"auth_required","reason":"not_configured","providers":[{"id":"dashscope","label":"DashScope","description":"Use a Bailian API key","description_zh_cn":"使用百炼 API Key","fields":[{"name":"api_key","label":"API Key","hint":"get from console","secret":true,"required":true}]},{"id":"openai_compat","label":"OpenAI","fields":[{"name":"base_url","label":"Base URL","secret":false,"required":true,"placeholder":"https://api.openai.com/v1"},{"name":"api_key","label":"Key","secret":true,"required":true}]}]}}"#;
     let req = parse_control_request(line).expect("should parse auth_required");
     match req {
         ControlRequest::AuthRequired {
@@ -853,6 +853,14 @@ fn parse_auth_required() {
             assert_eq!(providers.len(), 2);
             assert_eq!(providers[0].id, "dashscope");
             assert_eq!(providers[0].label, "DashScope");
+            assert_eq!(
+                providers[0].description.as_deref(),
+                Some("Use a Bailian API key")
+            );
+            assert_eq!(
+                providers[0].description_zh_cn.as_deref(),
+                Some("使用百炼 API Key")
+            );
             assert_eq!(providers[0].fields.len(), 1);
             assert_eq!(providers[0].fields[0].name, "api_key");
             assert!(providers[0].fields[0].secret);
@@ -862,6 +870,8 @@ fn parse_auth_required() {
                 Some("get from console")
             );
             assert_eq!(providers[1].id, "openai_compat");
+            assert!(providers[1].description.is_none());
+            assert!(providers[1].description_zh_cn.is_none());
             assert_eq!(providers[1].fields.len(), 2);
             assert_eq!(
                 providers[1].fields[0].placeholder.as_deref(),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
@@ -838,7 +838,7 @@ fn serialize_user_message_format() {
 
 #[test]
 fn parse_auth_required() {
-    let line = r#"{"type":"control_request","request_id":"auth-init","request":{"subtype":"auth_required","reason":"not_configured","providers":[{"id":"dashscope","label":"DashScope","description":"Use a Bailian API key","description_zh_cn":"使用百炼 API Key","fields":[{"name":"api_key","label":"API Key","hint":"get from console","secret":true,"required":true}]},{"id":"openai_compat","label":"OpenAI","fields":[{"name":"base_url","label":"Base URL","secret":false,"required":true,"placeholder":"https://api.openai.com/v1"},{"name":"api_key","label":"Key","secret":true,"required":true}]}]}}"#;
+    let line = r#"{"type":"control_request","request_id":"auth-init","request":{"subtype":"auth_required","reason":"not_configured","providers":[{"id":"dashscope","label":"DashScope","description":"Use a Bailian API key","description_zh_cn":"使用百炼 API Key","builtin_base_url":"https://dashscope.example/v1","fields":[{"name":"api_key","label":"API Key","hint":"get from console","secret":true,"required":true}]},{"id":"openai_compat","label":"OpenAI","fields":[{"name":"base_url","label":"Base URL","secret":false,"required":true,"placeholder":"https://api.openai.com/v1"},{"name":"api_key","label":"Key","secret":true,"required":true}]}]}}"#;
     let req = parse_control_request(line).expect("should parse auth_required");
     match req {
         ControlRequest::AuthRequired {
@@ -861,6 +861,10 @@ fn parse_auth_required() {
                 providers[0].description_zh_cn.as_deref(),
                 Some("使用百炼 API Key")
             );
+            assert_eq!(
+                providers[0].builtin_base_url.as_deref(),
+                Some("https://dashscope.example/v1")
+            );
             assert_eq!(providers[0].fields.len(), 1);
             assert_eq!(providers[0].fields[0].name, "api_key");
             assert!(providers[0].fields[0].secret);
@@ -872,6 +876,7 @@ fn parse_auth_required() {
             assert_eq!(providers[1].id, "openai_compat");
             assert!(providers[1].description.is_none());
             assert!(providers[1].description_zh_cn.is_none());
+            assert!(providers[1].builtin_base_url.is_none());
             assert_eq!(providers[1].fields.len(), 2);
             assert_eq!(
                 providers[1].fields[0].placeholder.as_deref(),

--- a/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/capture.rs
@@ -33,6 +33,7 @@ pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCaptur
         AuthPhase::ManagingProviders => Some(RawInputCapture::Question {
             id: auth_capture_id(auth),
             option_count: management_entry_count(&auth.sysom, auth.existing_providers.len()),
+            selected: auth.selected_provider,
             allow_free_text: false,
             multiple: false,
             secret: false,
@@ -48,6 +49,7 @@ pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCaptur
             Some(RawInputCapture::Question {
                 id: auth_capture_id(auth),
                 option_count,
+                selected: auth.selected_provider,
                 allow_free_text: false,
                 multiple: false,
                 secret: false,
@@ -56,6 +58,7 @@ pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCaptur
         AuthPhase::ConfirmDelete { .. } => Some(RawInputCapture::Question {
             id: auth_capture_id(auth),
             option_count: DELETE_CONFIRM_OPTION_COUNT,
+            selected: auth.selected_provider,
             allow_free_text: false,
             multiple: false,
             secret: false,
@@ -63,6 +66,7 @@ pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCaptur
         AuthPhase::SelectingProvider => Some(RawInputCapture::Question {
             id: auth_capture_id(auth),
             option_count: auth.providers.len(),
+            selected: auth.selected_provider,
             allow_free_text: false,
             multiple: false,
             secret: false,
@@ -82,6 +86,7 @@ pub(crate) fn pending_auth_capture(state: &InlineState) -> Option<RawInputCaptur
         AuthPhase::AliyunEcsChallenge { .. } => Some(RawInputCapture::Question {
             id: auth_capture_id(auth),
             option_count: 1,
+            selected: 0,
             allow_free_text: false,
             multiple: false,
             secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
@@ -22,6 +22,8 @@ fn openai_compat_template() -> AuthProviderInfo {
     AuthProviderInfo {
         id: "openai_compat".to_string(),
         label: "OpenAI Compatible".to_string(),
+        description: None,
+        description_zh_cn: None,
         fields: vec![
             field("provider_id", false),
             field("base_url", false),

--- a/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/navigation/tests.rs
@@ -24,6 +24,7 @@ fn openai_compat_template() -> AuthProviderInfo {
         label: "OpenAI Compatible".to_string(),
         description: None,
         description_zh_cn: None,
+        builtin_base_url: None,
         fields: vec![
             field("provider_id", false),
             field("base_url", false),

--- a/src/cosh-ng/crates/cosh-shell/src/auth/prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/prompt.rs
@@ -3,13 +3,15 @@
 use std::io::{self, Write};
 
 use crate::runtime::prelude::{
-    QuestionInputFeedback, QuestionPanelModel, QuestionSelectionMode, RatatuiInlineRenderer,
+    I18n, MessageId, QuestionInputFeedback, QuestionPanelModel, QuestionSelectionMode,
+    RatatuiInlineRenderer,
 };
 use crate::runtime::state::InlineState;
 
 use super::capture::auth_capture_id;
 use super::delete_confirm::render_delete_confirmation;
 use super::menu::{existing_provider_label, management_options};
+use super::provider_display::provider_option;
 use super::provider_management::provider_action_options;
 use super::runtime::AuthPhase;
 
@@ -21,6 +23,7 @@ pub(super) fn render_current_auth_panel<W: Write>(
         return Ok(());
     };
     let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+    let i18n = I18n::new(state.language);
     let panel_id = auth_capture_id(auth);
 
     match auth.phase {
@@ -79,11 +82,11 @@ pub(super) fn render_current_auth_panel<W: Write>(
             let options: Vec<String> = auth
                 .providers
                 .iter()
-                .map(|provider| provider.label.clone())
+                .map(|provider| provider_option(provider, state.language))
                 .collect();
             let model = QuestionPanelModel {
                 id: &panel_id,
-                question: "\u{1f511} Authentication Required \u{2014} Select your AI provider:",
+                question: i18n.t(MessageId::AuthSelectProviderQuestion),
                 options: &options,
                 selected_option: auth.selected_provider,
                 selected_options: &[],

--- a/src/cosh-ng/crates/cosh-shell/src/auth/provider_display.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/provider_display.rs
@@ -34,6 +34,7 @@ mod tests {
             label: id.to_string(),
             description: description.map(str::to_string),
             description_zh_cn: None,
+            builtin_base_url: None,
             fields: Vec::new(),
         }
     }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/provider_display.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/provider_display.rs
@@ -1,14 +1,84 @@
+use crate::config::Language;
 use crate::runtime::prelude::AuthProviderInfo;
+use crate::ui::OPTION_DETAIL_SEPARATOR;
 
-pub(crate) fn auth_required_providers_for_display(
-    providers: &[AuthProviderInfo],
-) -> Vec<AuthProviderInfo> {
+pub(crate) fn auth_providers_for_display(providers: &[AuthProviderInfo]) -> Vec<AuthProviderInfo> {
     let mut providers = providers.to_vec();
-    for provider in &mut providers {
-        if provider.id == "aliyun" && !provider.label.contains("免费可用") {
-            provider.label = format!("{} (免费可用)", provider.label);
-        }
-    }
     providers.sort_by_key(|provider| if provider.id == "aliyun" { 0 } else { 1 });
     providers
+}
+
+pub(crate) fn provider_option(provider: &AuthProviderInfo, language: Language) -> String {
+    let description = match language {
+        Language::EnUs => provider.description.as_deref(),
+        Language::ZhCn => provider
+            .description_zh_cn
+            .as_deref()
+            .or(provider.description.as_deref()),
+    };
+    match description {
+        Some(description) => {
+            format!("{}{OPTION_DETAIL_SEPARATOR}{description}", provider.label)
+        }
+        None => provider.label.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(id: &str, description: Option<&str>) -> AuthProviderInfo {
+        AuthProviderInfo {
+            id: id.to_string(),
+            label: id.to_string(),
+            description: description.map(str::to_string),
+            description_zh_cn: None,
+            fields: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn normalizes_legacy_provider_order() {
+        let providers = vec![
+            provider("dashscope", None),
+            provider("openai_compat", None),
+            provider("aliyun", None),
+        ];
+
+        let ids = auth_providers_for_display(&providers)
+            .into_iter()
+            .map(|provider| provider.id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["aliyun", "dashscope", "openai_compat"]);
+    }
+
+    #[test]
+    fn renders_description_on_an_indented_line() {
+        assert_eq!(
+            provider_option(
+                &provider(
+                    "Coding Plan",
+                    Some("For individual developers • Weekly quota included")
+                ),
+                Language::EnUs
+            ),
+            "Coding Plan\n    For individual developers • Weekly quota included"
+        );
+    }
+
+    #[test]
+    fn prefers_chinese_description_for_zh_cn() {
+        let mut provider = provider(
+            "Token Plan",
+            Some("For teams and companies • Usage-based billing with dedicated capacity"),
+        );
+        provider.description_zh_cn = Some("面向团队和企业 • 按用量计费，提供专属容量".to_string());
+
+        assert_eq!(
+            provider_option(&provider, Language::ZhCn),
+            "Token Plan\n    面向团队和企业 • 按用量计费，提供专属容量"
+        );
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/provider_management.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/provider_management.rs
@@ -79,6 +79,8 @@ fn secret_mask(len: usize) -> String {
 fn label_for_provider_type(provider_type: &str) -> &'static str {
     match provider_type {
         "dashscope" => "DashScope (\u{767e}\u{70bc})",
+        "coding_plan" => "Coding Plan",
+        "token_plan" => "Token Plan",
         "aliyun" => "Aliyun Authentication",
         _ => "OpenAI Compatible",
     }
@@ -111,6 +113,31 @@ impl From<CoreSavedProvider> for ExistingProvider {
     }
 }
 
+fn restore_plan_template(provider: &mut ExistingProvider, templates: &[AuthProviderInfo]) {
+    if !matches!(
+        provider.provider_type.as_str(),
+        "openai_compat" | "openai" | "generic" | "dashscope"
+    ) {
+        return;
+    }
+    let Some(base_url) = provider.base_url.as_deref() else {
+        return;
+    };
+    let Some(template) = templates.iter().find(|template| {
+        matches!(template.id.as_str(), "coding_plan" | "token_plan")
+            && template
+                .builtin_base_url
+                .as_deref()
+                .is_some_and(|template_url| {
+                    template_url.trim_end_matches('/') == base_url.trim_end_matches('/')
+                })
+    }) else {
+        return;
+    };
+    provider.provider_type.clone_from(&template.id);
+    provider.label = label_for_provider_type(&template.id).to_string();
+}
+
 pub(super) fn load_core_auth_state(cosh_core: &CoshCoreAdapter) -> Result<CoreAuthState, String> {
     let value = cosh_core.registry_query("auth", "state", Value::Null)?;
     let state: RegistryAuthState =
@@ -118,7 +145,11 @@ pub(super) fn load_core_auth_state(cosh_core: &CoshCoreAdapter) -> Result<CoreAu
     let mut existing_providers: Vec<ExistingProvider> = state
         .saved_providers
         .into_iter()
-        .map(ExistingProvider::from)
+        .map(|provider| {
+            let mut provider = ExistingProvider::from(provider);
+            restore_plan_template(&mut provider, &state.templates);
+            provider
+        })
         .collect();
     existing_providers.sort_by(|left, right| {
         right
@@ -236,7 +267,58 @@ pub(super) fn provider_action_choice(
 
 #[cfg(test)]
 mod tests {
-    use super::{provider_action_choice, provider_action_options, ProviderAction};
+    use super::{
+        label_for_provider_type, provider_action_choice, provider_action_options,
+        restore_plan_template, ExistingProvider, ProviderAction,
+    };
+    use crate::runtime::prelude::AuthProviderInfo;
+
+    #[test]
+    fn labels_plan_provider_types() {
+        assert_eq!(label_for_provider_type("coding_plan"), "Coding Plan");
+        assert_eq!(label_for_provider_type("token_plan"), "Token Plan");
+    }
+
+    #[test]
+    fn restores_plan_only_for_the_selected_site_endpoint() {
+        let templates = vec![AuthProviderInfo {
+            id: "coding_plan".to_string(),
+            label: "Coding Plan".to_string(),
+            description: None,
+            description_zh_cn: None,
+            builtin_base_url: Some("https://coding.dashscope.aliyuncs.com/v1".to_string()),
+            fields: Vec::new(),
+        }];
+        let mut china = existing_openai_provider("https://coding.dashscope.aliyuncs.com/v1/");
+        let mut international =
+            existing_openai_provider("https://coding-intl.dashscope.aliyuncs.com/v1");
+
+        restore_plan_template(&mut china, &templates);
+        restore_plan_template(&mut international, &templates);
+
+        assert_eq!(china.provider_type, "coding_plan");
+        assert_eq!(china.label, "Coding Plan");
+        assert_eq!(international.provider_type, "openai");
+        assert_eq!(international.label, "OpenAI Compatible");
+    }
+
+    fn existing_openai_provider(base_url: &str) -> ExistingProvider {
+        ExistingProvider {
+            name: "legacy".to_string(),
+            provider_type: "openai".to_string(),
+            label: "OpenAI Compatible".to_string(),
+            model: "qwen3.7-plus".to_string(),
+            is_active: false,
+            editable: true,
+            source: "user".to_string(),
+            base_url: Some(base_url.to_string()),
+            api_key_mask: None,
+            access_key_id_mask: None,
+            access_key_secret_mask: None,
+            security_token_mask: None,
+            auth_source: None,
+        }
+    }
 
     #[test]
     fn user_provider_actions_include_delete() {

--- a/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/required.rs
@@ -8,7 +8,7 @@ use crate::runtime::state::InlineState;
 
 use super::menu::SysomMenu;
 use super::prompt::render_current_auth_panel;
-use super::provider_display::auth_required_providers_for_display;
+use super::provider_display::auth_providers_for_display;
 use super::runtime::{AuthBackend, AuthPhase, RuntimeAuthState};
 
 pub(crate) fn record_auth_required(
@@ -35,7 +35,7 @@ pub(crate) fn record_auth_required(
                 id: id.clone(),
                 request_id: request_id.clone(),
                 phase: AuthPhase::SelectingProvider,
-                providers: auth_required_providers_for_display(providers),
+                providers: auth_providers_for_display(providers),
                 selected_provider: 0,
                 current_field: 0,
                 collected_values: HashMap::new(),

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -461,10 +461,11 @@ fn handle_auth_answer<W: std::io::Write>(
                     let template_idx = auth
                         .providers
                         .iter()
-                        .position(|p| match provider_type {
-                            "dashscope" => p.id == "dashscope",
-                            "aliyun" => p.id == "aliyun",
-                            _ => p.id == "openai_compat",
+                        .position(|provider| provider.id == provider_type)
+                        .or_else(|| {
+                            auth.providers
+                                .iter()
+                                .position(|provider| provider.id == "openai_compat")
                         })
                         .unwrap_or(0);
 

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -17,6 +17,7 @@ use crate::auth::menu::{
 };
 use crate::auth::navigation::{step_back, BackOutcome};
 use crate::auth::prompt::{clear_active_auth_panel, render_current_auth_panel};
+use crate::auth::provider_display::auth_providers_for_display;
 use crate::auth::provider_management::{
     core_auth_activate, core_auth_configure, load_core_auth_state, provider_action_choice,
     ExistingProvider, ProviderAction,
@@ -169,7 +170,8 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
         }
     };
 
-    let providers = providers_with_provider_id_field(core_state.templates);
+    let providers =
+        auth_providers_for_display(&providers_with_provider_id_field(core_state.templates));
     let request_id = format!(
         "slash-auth-{}",
         std::time::SystemTime::now()

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -25,6 +25,7 @@ fn template(id: &str) -> AuthProviderInfo {
         label: id.to_string(),
         description: None,
         description_zh_cn: None,
+        builtin_base_url: None,
         fields: Vec::new(),
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -23,6 +23,8 @@ fn template(id: &str) -> AuthProviderInfo {
     AuthProviderInfo {
         id: id.to_string(),
         label: id.to_string(),
+        description: None,
+        description_zh_cn: None,
         fields: Vec::new(),
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -3,13 +3,15 @@ use super::runtime::*;
 use super::validation::{record_field_edit, record_field_submission, FieldSubmission};
 use crate::runtime::prelude::{
     AgentEvent, AuthFieldInfo, AuthProviderInfo, GovernanceDecision, GovernancePolicyDecision,
-    GovernedEvent, InlineState, RawInputCapture,
+    GovernedEvent, InlineState, Language, RawInputCapture,
 };
 
 fn provider(id: &str, label: &str) -> AuthProviderInfo {
     AuthProviderInfo {
         id: id.into(),
         label: label.into(),
+        description: None,
+        description_zh_cn: None,
         fields: Vec::new(),
     }
 }
@@ -61,7 +63,7 @@ fn retry_auth_request_surfaces_validation_error() {
 
 #[test]
 fn record_auth_required_promotes_aliyun_from_legacy_order() {
-    // cosh-core's control protocol still emits the legacy provider order.
+    // Keep new shells compatible with older cosh-core provider ordering.
     let legacy = vec![
         provider("dashscope", "DashScope (百炼)"),
         provider("openai_compat", "OpenAI Compatible"),
@@ -75,7 +77,29 @@ fn record_auth_required_promotes_aliyun_from_legacy_order() {
     let ids: Vec<&str> = stored.providers.iter().map(|p| p.id.as_str()).collect();
     // Aliyun promoted to front; other providers keep their original relative order.
     assert_eq!(ids, ["aliyun", "dashscope", "openai_compat"]);
-    assert!(stored.providers[0].label.contains("免费可用"));
+    assert_eq!(stored.providers[0].label, "Aliyun Authentication");
+}
+
+#[test]
+fn zh_cn_auth_picker_localizes_title_and_provider_guidance() {
+    let mut coding_plan = provider("coding_plan", "Coding Plan");
+    coding_plan.description = Some("For individual developers • Weekly quota included".to_string());
+    coding_plan.description_zh_cn = Some("面向个人开发者 • 包含每周额度".to_string());
+    let mut state = InlineState {
+        language: Language::ZhCn,
+        ..InlineState::default()
+    };
+    let ids = record_auth_required(&mut state, &[governed_auth_required(vec![coding_plan])]);
+    let mut output = Vec::new();
+
+    render_auth_panel(&mut state, &ids, &mut output).expect("render zh-CN auth picker");
+
+    let output = String::from_utf8(output).expect("utf8 auth panel");
+    assert!(output.contains("需要认证"), "{output}");
+    assert!(output.contains("选择 AI 服务"), "{output}");
+    assert!(output.contains("面向个人开发者 • 包含每周额度"), "{output}");
+    assert!(!output.contains("Authentication Required"), "{output}");
+    assert!(!output.contains("For individual developers"), "{output}");
 }
 
 #[test]
@@ -96,6 +120,24 @@ fn pending_auth_capture_marks_secret_fields() {
     assert!(matches!(
         pending_auth_capture(&state),
         Some(RawInputCapture::TextQuestion { secret: true, .. })
+    ));
+}
+
+#[test]
+fn pending_auth_capture_keeps_the_picker_selection() {
+    let providers = vec![
+        provider("aliyun", "Aliyun Authentication"),
+        provider("coding_plan", "Coding Plan"),
+        provider("token_plan", "Token Plan"),
+        provider("dashscope", "DashScope"),
+    ];
+    let mut state = InlineState::default();
+    record_auth_required(&mut state, &[governed_auth_required(providers)]);
+    state.auth.state.as_mut().unwrap().selected_provider = 2;
+
+    assert!(matches!(
+        pending_auth_capture(&state),
+        Some(RawInputCapture::Question { selected: 2, .. })
     ));
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -12,6 +12,7 @@ fn provider(id: &str, label: &str) -> AuthProviderInfo {
         label: label.into(),
         description: None,
         description_zh_cn: None,
+        builtin_base_url: None,
         fields: Vec::new(),
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en.rs
@@ -3,6 +3,7 @@ use super::MessageId;
 mod activity;
 mod agent;
 mod approval;
+mod auth;
 mod config;
 mod debug;
 mod health;
@@ -32,5 +33,6 @@ pub(super) fn message(id: MessageId) -> &'static str {
         .or_else(|| question::message(id))
         .or_else(|| approval::message(id))
         .or_else(|| session::message(id))
+        .or_else(|| auth::message(id))
         .expect("missing en-US translation")
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/auth.rs
@@ -1,0 +1,10 @@
+use super::MessageId;
+
+pub(super) fn message(id: MessageId) -> Option<&'static str> {
+    match id {
+        MessageId::AuthSelectProviderQuestion => {
+            Some("\u{1f511} Authentication Required \u{2014} Select your AI provider:")
+        }
+        _ => None,
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -28,6 +28,8 @@ mod question;
 mod approval;
 #[macro_use]
 mod session;
+#[macro_use]
+mod auth;
 
 macro_rules! define_message_id {
     ($($id:ident,)*) => {
@@ -96,4 +98,5 @@ collect_message_ids!([
     approval_turn_extension_ids,
     capture_notice_ids,
     agent_recovery_reason_ids,
+    auth_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/auth.rs
@@ -1,0 +1,9 @@
+macro_rules! auth_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            AuthSelectProviderQuestion,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -51,6 +51,7 @@ mod tests {
         "activity",
         "agent",
         "approval",
+        "auth",
         "config",
         "debug",
         "health",
@@ -144,7 +145,7 @@ mod tests {
             846
         );
         // The #1913 capture-notice segment remains pinned ahead of the
-        // appended shell-recovery reason message.
+        // appended shell-recovery reason and auth messages.
         assert_eq!(MessageId::CaptureInputRejectedTitle as usize, 847);
         assert_eq!(MessageId::CaptureInputRejectedBody as usize, 848);
         assert_eq!(
@@ -152,8 +153,16 @@ mod tests {
             MessageId::CaptureInputRejectedBody as usize + 1
         );
         assert_eq!(
-            MessageId::AgentRecoveryTriggerLine as usize,
+            MessageId::AuthSelectProviderQuestion as usize,
+            MessageId::AgentRecoveryTriggerLine as usize + 1
+        );
+        assert_eq!(
+            MessageId::AuthSelectProviderQuestion as usize,
             MessageId::ALL.len() - 1
+        );
+        assert_eq!(
+            MessageId::AgentRecoveryTriggerLine as usize,
+            MessageId::ALL.len() - 2
         );
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh.rs
@@ -3,6 +3,7 @@ use super::MessageId;
 mod activity;
 mod agent;
 mod approval;
+mod auth;
 mod config;
 mod debug;
 mod health;
@@ -32,5 +33,6 @@ pub(super) fn message(id: MessageId) -> &'static str {
         .or_else(|| question::message(id))
         .or_else(|| approval::message(id))
         .or_else(|| session::message(id))
+        .or_else(|| auth::message(id))
         .unwrap_or_else(|| super::en::message(id))
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/auth.rs
@@ -1,0 +1,8 @@
+use super::MessageId;
+
+pub(super) fn message(id: MessageId) -> Option<&'static str> {
+    match id {
+        MessageId::AuthSelectProviderQuestion => Some("\u{1f511} 需要认证 \u{2014} 选择 AI 服务："),
+        _ => None,
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/question/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/question/runtime.rs
@@ -48,6 +48,7 @@ pub(crate) fn pending_question_capture(state: &InlineState) -> Option<RawInputCa
             return Some(RawInputCapture::Question {
                 id: question.id.clone(),
                 option_count: question.options.len(),
+                selected: question.selected_option,
                 allow_free_text: question.allow_free_text,
                 multiple: question.selection_mode == QuestionSelectionMode::Multiple,
                 secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -111,6 +111,7 @@ mod tests {
         RawInputCapture::Question {
             id: "question-1".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -3,10 +3,10 @@ use super::{RawInputCapture, RawInputEvent, CTRL_C};
 use crate::question::choices::toggle_question_option;
 
 use events::{
-    approval_event_for_action, cancel_event, capture_action_set, card_answer_event,
-    empty_question_submission, is_csi_final_byte, is_removed_question_answer_slash,
-    is_removed_question_answer_slash_fragment, question_choice_count, releases_capture,
-    selected_options_answer,
+    approval_event_for_action, cancel_event, capture_action_set, capture_initial_selection,
+    card_answer_event, empty_question_submission, is_csi_final_byte,
+    is_removed_question_answer_slash, is_removed_question_answer_slash_fragment,
+    question_choice_count, releases_capture, selected_options_answer,
 };
 // capture_bridge shares events::releases_capture with the consume loop (#1932).
 pub(in crate::raw_input) mod events;
@@ -75,6 +75,7 @@ impl CardInputState {
                 allow_free_text,
                 multiple,
                 secret,
+                ..
             } => CardInputKind::Question {
                 id: id.clone(),
                 option_count: *option_count,
@@ -157,29 +158,7 @@ impl CardInputState {
                     return;
                 }
             }
-            let selected = match capture {
-                RawInputCapture::Mode {
-                    selected,
-                    option_count,
-                    ..
-                }
-                | RawInputCapture::Config {
-                    selected,
-                    option_count,
-                    ..
-                }
-                | RawInputCapture::ConfigLanguage {
-                    selected,
-                    option_count,
-                    ..
-                }
-                | RawInputCapture::Session {
-                    selected,
-                    option_count,
-                    ..
-                } => (*selected).min(option_count.saturating_sub(1)),
-                _ => 0,
-            };
+            let selected = capture_initial_selection(capture);
             self.active_kind = Some(kind);
             self.selected = selected;
             self.free_text = match capture {
@@ -547,6 +526,7 @@ impl CardInputState {
                 allow_free_text,
                 multiple,
                 secret,
+                ..
             } => {
                 let answer = self.free_text.trim();
                 if is_removed_question_answer_slash(answer) {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/events.rs
@@ -128,3 +128,32 @@ pub(super) fn question_choice_count(capture: &RawInputCapture) -> usize {
         | RawInputCapture::PromptDraft { .. } => 0,
     }
 }
+
+pub(super) fn capture_initial_selection(capture: &RawInputCapture) -> usize {
+    match capture {
+        RawInputCapture::Question { selected, .. } => {
+            (*selected).min(question_choice_count(capture).saturating_sub(1))
+        }
+        RawInputCapture::Mode {
+            selected,
+            option_count,
+            ..
+        }
+        | RawInputCapture::Config {
+            selected,
+            option_count,
+            ..
+        }
+        | RawInputCapture::ConfigLanguage {
+            selected,
+            option_count,
+            ..
+        }
+        | RawInputCapture::Session {
+            selected,
+            option_count,
+            ..
+        } => (*selected).min(option_count.saturating_sub(1)),
+        _ => 0,
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -5,6 +5,7 @@ fn submitted_capture_preserves_same_read_suffix() {
     let capture = RawInputCapture::Question {
         id: "question-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -26,6 +27,7 @@ fn question_capture_custom_option_waits_for_text_before_submit() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 2,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -55,6 +57,7 @@ fn question_capture_clears_free_text_after_submit() {
     let capture = RawInputCapture::Question {
         id: "q-clear".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -98,6 +101,7 @@ fn question_capture_emits_one_submission_per_input_batch() {
     let capture = RawInputCapture::Question {
         id: "q-burst".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -125,6 +129,7 @@ fn question_capture_custom_option_empty_submit_emits_attempt() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 2,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -147,6 +152,7 @@ fn question_capture_multiple_empty_submit_emits_attempt() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 2,
+        selected: 0,
         allow_free_text: true,
         multiple: true,
         secret: false,
@@ -165,6 +171,7 @@ fn question_capture_strips_bracketed_paste_wrappers() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -192,6 +199,7 @@ fn secret_question_capture_marks_input_as_sensitive() {
     let capture = RawInputCapture::Question {
         id: "auth-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: true,
@@ -219,6 +227,7 @@ fn question_capture_strips_split_bracketed_paste_wrappers() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -247,6 +256,7 @@ fn question_capture_buffers_split_utf8_input() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -279,6 +289,7 @@ fn question_capture_ignores_tilde_control_sequences() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -301,6 +312,7 @@ fn question_capture_ignores_removed_answer_slash() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 2,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -340,6 +352,7 @@ fn question_capture_still_submits_selected_option() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 2,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -357,10 +370,33 @@ fn question_capture_still_submits_selected_option() {
 }
 
 #[test]
+fn question_capture_uses_initial_selected_option() {
+    let capture = RawInputCapture::Question {
+        id: "q-restored".to_string(),
+        option_count: 5,
+        selected: 2,
+        allow_free_text: false,
+        multiple: false,
+        secret: false,
+    };
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    assert_eq!(
+        state.consume(&capture, b"\x1b[B\n"),
+        vec![
+            RawInputEvent::CardFocus("q-restored".to_string(), 3),
+            RawInputEvent::CardAnswer("4".to_string())
+        ]
+    );
+}
+
+#[test]
 fn question_capture_multiple_toggles_options_and_submits_indices() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 3,
+        selected: 0,
         allow_free_text: true,
         multiple: true,
         secret: false,
@@ -384,6 +420,7 @@ fn question_capture_multiple_marks_custom_only_answer() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 3,
+        selected: 0,
         allow_free_text: true,
         multiple: true,
         secret: false,
@@ -402,6 +439,7 @@ fn question_capture_multiple_preserves_checked_options_with_custom_answer() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 3,
+        selected: 0,
         allow_free_text: true,
         multiple: true,
         secret: false,
@@ -745,6 +783,7 @@ fn question_capture_ctrl_c_and_escape_cancel_question() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 2,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -774,6 +813,7 @@ fn question_capture_ctrl_c_stops_consuming_and_returns_the_rest() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 2,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -825,6 +865,7 @@ fn text_question(id: &str, secret: bool) -> RawInputCapture {
     RawInputCapture::Question {
         id: id.to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -194,6 +194,7 @@ pub enum RawInputCapture {
     Question {
         id: String,
         option_count: usize,
+        selected: usize,
         allow_free_text: bool,
         multiple: bool,
         secret: bool,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -331,6 +331,7 @@ fn submitted_capture_discards_a_later_owned_read_when_the_chain_ends() {
     let first = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -338,6 +339,7 @@ fn submitted_capture_discards_a_later_owned_read_when_the_chain_ends() {
     let second = RawInputCapture::Question {
         id: "q-2".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -428,6 +430,7 @@ fn input_obtained_before_capture_replacement_does_not_enter_the_new_capture() {
     let first = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -435,6 +438,7 @@ fn input_obtained_before_capture_replacement_does_not_enter_the_new_capture() {
     let second = RawInputCapture::Question {
         id: "q-2".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -532,6 +536,7 @@ fn input_obtained_after_capture_install_enters_the_new_capture() {
     let capture = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -624,6 +629,7 @@ fn passthrough_owned_input_does_not_enter_a_later_capture() {
             &RawObserverAction::CaptureInput(RawInputCapture::Question {
                 id: "q-1".to_string(),
                 option_count: 0,
+                selected: 0,
                 allow_free_text: true,
                 multiple: false,
                 secret: false,
@@ -686,6 +692,7 @@ fn delay_owned_escape_does_not_reach_a_later_capture_or_shell() {
         &RawObserverAction::CaptureInput(RawInputCapture::Question {
             id: "q-1".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,
@@ -720,6 +727,7 @@ fn capture_owned_input_does_not_enter_later_passthrough() {
         capture: RawInputCapture::Question {
             id: "q-1".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,
@@ -1072,6 +1080,7 @@ fn stale_generation_reads_are_discarded_without_affecting_the_next_capture() {
         capture: RawInputCapture::Question {
             id: "q-2".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,
@@ -1133,6 +1142,7 @@ fn active_capture_eof_drains_the_generation_without_input() {
         capture: RawInputCapture::Question {
             id: "q-1".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,
@@ -1689,6 +1699,7 @@ fn selection_pending_escape_does_not_cancel_a_new_capture() {
         capture: RawInputCapture::Question {
             id: "q-1".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,
@@ -1768,6 +1779,7 @@ fn selection_split_shift_tab_suffix_does_not_enter_a_new_capture() {
         capture: RawInputCapture::Question {
             id: "q-1".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
@@ -45,6 +45,7 @@ fn question_capture(id: &str) -> RawInputCapture {
     RawInputCapture::Question {
         id: id.to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
@@ -23,6 +23,7 @@ fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
     let previous = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -30,6 +31,7 @@ fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
     let next = RawInputCapture::Question {
         id: "q-2".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
@@ -83,6 +83,7 @@ fn relay_uses_the_validated_mode_snapshot() {
         capture: RawInputCapture::Question {
             id: "later-capture".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,
@@ -203,6 +204,7 @@ fn delayed_ghost_suffix_keeps_capture_generation_across_replacement() {
     let previous = RawInputCapture::Question {
         id: "q-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -210,6 +212,7 @@ fn delayed_ghost_suffix_keeps_capture_generation_across_replacement() {
     let next = RawInputCapture::Question {
         id: "q-2".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -313,6 +316,7 @@ fn ghost_suffix_does_not_consume_input_from_a_new_capture_generation() {
         capture: RawInputCapture::Question {
             id: "q-2".to_string(),
             option_count: 0,
+            selected: 0,
             allow_free_text: true,
             multiple: false,
             secret: false,
@@ -379,6 +383,7 @@ fn delay_escape_does_not_cancel_a_later_capture() {
     let capture = RawInputCapture::Question {
         id: "new-question".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/question.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests/question.rs
@@ -415,12 +415,16 @@ fn question_panel_multiple_empty_feedback_replaces_heading() {
 #[test]
 fn question_panel_write_preserves_ratatui_styles_for_terminal_output() {
     let renderer = RatatuiInlineRenderer {
-        width: 100,
+        width: 60,
         plain: false,
         styled: true,
         language: crate::Language::EnUs,
     };
-    let options = vec!["Approve".to_string(), "Deny".to_string()];
+    let options = vec![
+        "Approve\n    For teams and companies • Usage-based billing with dedicated capacity"
+            .to_string(),
+        "Deny\nsecond line".to_string(),
+    ];
     let mut output = Vec::new();
 
     renderer
@@ -446,6 +450,13 @@ fn question_panel_write_preserves_ratatui_styles_for_terminal_output() {
     assert!(clean.contains("Agent question"), "{clean}");
     assert!(!clean.contains("Agent question q-1"), "{clean}");
     assert!(clean.contains("[2]"), "{clean}");
+
+    let gray_detail_rows = text
+        .lines()
+        .filter(|line| line.contains("\u{1b}[0;90m      "))
+        .count();
+    assert_eq!(gray_detail_rows, 2, "{text:?}");
+    assert!(!text.contains("\u{1b}[0;90m      second line"), "{text:?}");
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/ui/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/public.rs
@@ -6,4 +6,5 @@ mod question;
 mod renderer;
 
 pub(crate) use agent_render::*;
+pub(crate) use question::OPTION_DETAIL_SEPARATOR;
 pub(crate) use renderer::render_transcript;

--- a/src/cosh-ng/crates/cosh-shell/src/ui/question.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/question.rs
@@ -28,6 +28,9 @@ pub use cursor::QuestionCursorPlacement;
 mod styles;
 use styles::{option_heading_style, option_marker_style, render_custom_option_lines};
 
+/// Separates an option label from secondary text rendered in dark gray.
+pub(crate) const OPTION_DETAIL_SEPARATOR: &str = "\n    ";
+
 #[derive(Debug, Clone)]
 pub struct QuestionPanelModel<'a> {
     pub id: &'a str,
@@ -468,11 +471,17 @@ fn render_wrapped_option(
     prefix_style: Style,
     width: usize,
 ) -> Vec<Line<'static>> {
+    let detail_start = text
+        .split_once(OPTION_DETAIL_SEPARATOR)
+        .map(|(label, _)| wrap_option_text(prefix, label, width).len());
+    let detail_style = Style::default().fg(Color::DarkGray);
     wrap_option_text(prefix, text, width)
         .into_iter()
         .enumerate()
         .map(|(idx, line)| {
-            if idx == 0 {
+            if detail_start.is_some_and(|start| idx >= start) {
+                Line::from(Span::styled(line, detail_style))
+            } else if idx == 0 {
                 let prefix_len = prefix.len().min(line.len());
                 let (prefix, rest) = line.split_at(prefix_len);
                 Line::from(vec![

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
@@ -133,7 +133,7 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"auth-inline","mod
 printf '%s\n' '{"type":"result","subtype":"success","session_id":"auth-inline","is_error":false,"result":"done"}'
 "#;
 
-/// The builtin template order cosh-core reports: DashScope, OpenAI Compatible, Aliyun.
+/// Legacy cosh-core template order used to verify shell-side compatibility.
 const AUTH_TEMPLATES: &str = r#"[{"id":"dashscope","label":"DashScope (百炼)","fields":[{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]},{"id":"openai_compat","label":"OpenAI Compatible","fields":[{"name":"base_url","label":"Base URL","hint":null,"secret":false,"required":true,"placeholder":null},{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":true,"placeholder":null}]},{"id":"aliyun","label":"Aliyun Authentication","fields":[{"name":"access_key_id","label":"Access Key ID","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"access_key_secret","label":"Access Key Secret","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]}]"#;
 
 const SAVED_NONE: &str = "[]";
@@ -279,9 +279,9 @@ fn raw_cli_auth_ecs_promotes_configured_ram_role_provider() {
     assert_eq!(action_count(&requests, "delete"), 0, "{requests}");
 }
 
-/// A non-ECS host keeps the template picker and its `dashscope, openai_compat, aliyun` order.
+/// A non-ECS host uses the same Aliyun-first order as an active-run auth request.
 #[test]
-fn raw_cli_auth_non_ecs_without_saved_providers_keeps_template_order() {
+fn raw_cli_auth_non_ecs_without_saved_providers_normalizes_template_order() {
     let (output, requests) = run_auth_menu_flow(
         "auth-non-ecs-no-saved",
         SAVED_NONE,
@@ -293,9 +293,9 @@ fn raw_cli_auth_non_ecs_without_saved_providers_keeps_template_order() {
     );
 
     let compact = compact_terminal_words(&output);
-    assert!(compact.contains("> [1] DashScope"), "{output}");
-    assert!(compact.contains("[2] OpenAI Compatible"), "{output}");
-    assert!(compact.contains("[3] Aliyun Authentication"), "{output}");
+    assert!(compact.contains("> [1] Aliyun Authentication"), "{output}");
+    assert!(compact.contains("[2] DashScope"), "{output}");
+    assert!(compact.contains("[3] OpenAI Compatible"), "{output}");
     assert!(!compact.contains("SysOM"), "{output}");
     assert!(!compact.contains("Provider Management"), "{output}");
     assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
@@ -427,7 +427,7 @@ fn raw_cli_auth_esc_walks_back_through_the_form_before_cancelling() {
         MANUAL_PREPARE,
         &[
             ("cosh-osc$", b"/auth\n".as_slice()),
-            ("Authentication Required", b"\x1b[C\n".as_slice()),
+            ("Authentication Required", b"\x1b[C\x1b[C\n".as_slice()),
             ("Enter Provider ID", b"qwen-prod\n".as_slice()),
             ("Enter Base URL", b"https://example.invalid/v1\n".as_slice()),
             // ESC on API Key returns to Base URL, which still carries the value just submitted.
@@ -451,13 +451,35 @@ fn raw_cli_auth_esc_walks_back_through_the_form_before_cancelling() {
         "stepping back lost the submitted Provider ID: {output}"
     );
     // The picker reopens on the template the form belonged to.
-    assert!(compact.contains("> [2] OpenAI Compatible"), "{output}");
+    assert!(compact.contains("> [3] OpenAI Compatible"), "{output}");
     // Only the last ESC cancels; the three before it are back-navigation.
     assert_eq!(
         count_occurrences(&compact, "Auth cancelled"),
         1,
         "an intermediate ESC cancelled the flow: {output}"
     );
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+}
+
+#[test]
+fn raw_cli_auth_esc_preserves_picker_focus_for_the_next_arrow() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-esc-picker-focus",
+        SAVED_NONE,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("Authentication Required", b"\x1b[C\x1b[C\n".as_slice()),
+            ("Enter Provider ID", b"\x1b".as_slice()),
+            ("Authentication Required", b"\x1b[B".as_slice()),
+            ("> [4] DashScope", b"\x1b".as_slice()),
+            ("Auth cancelled", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("> [3] Token Plan"), "{output}");
+    assert!(compact.contains("> [4] DashScope"), "{output}");
     assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
 }
 
@@ -471,7 +493,7 @@ fn raw_cli_auth_ctrl_c_mid_form_abandons_the_flow() {
         MANUAL_PREPARE,
         &[
             ("cosh-osc$", b"/auth\n".as_slice()),
-            ("Authentication Required", b"\x1b[C\n".as_slice()),
+            ("Authentication Required", b"\x1b[C\x1b[C\n".as_slice()),
             ("Enter Provider ID", b"qwen-prod\n".as_slice()),
             ("Enter Base URL", b"\x03".as_slice()),
             ("Auth cancelled", b"".as_slice()),
@@ -530,7 +552,7 @@ fn raw_cli_auth_non_ecs_aliyun_falls_back_to_manual_keys() {
         MANUAL_PREPARE,
         &[
             ("cosh-osc$", b"/auth\n".as_slice()),
-            ("Authentication Required", b"\x1b[C\x1b[C\n".as_slice()),
+            ("Authentication Required", b"\n".as_slice()),
             ("Enter Provider ID", b"aliyun-manual\n".as_slice()),
             ("Enter Access Key ID", b"AK-TEST-VALUE\n".as_slice()),
             ("Enter Access Key Secret", b"".as_slice()),

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
@@ -133,12 +133,13 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"auth-inline","mod
 printf '%s\n' '{"type":"result","subtype":"success","session_id":"auth-inline","is_error":false,"result":"done"}'
 "#;
 
-/// Legacy cosh-core template order used to verify shell-side compatibility.
-const AUTH_TEMPLATES: &str = r#"[{"id":"dashscope","label":"DashScope (百炼)","fields":[{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]},{"id":"openai_compat","label":"OpenAI Compatible","fields":[{"name":"base_url","label":"Base URL","hint":null,"secret":false,"required":true,"placeholder":null},{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":true,"placeholder":null}]},{"id":"aliyun","label":"Aliyun Authentication","fields":[{"name":"access_key_id","label":"Access Key ID","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"access_key_secret","label":"Access Key Secret","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]}]"#;
+const AUTH_TEMPLATES: &str = r#"[{"id":"aliyun","label":"Aliyun Authentication","description":"Free with limited quota","fields":[{"name":"access_key_id","label":"Access Key ID","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"access_key_secret","label":"Access Key Secret","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]},{"id":"coding_plan","label":"Coding Plan","description":"For individual developers • Weekly quota included","builtin_base_url":"https://coding.dashscope.aliyuncs.com/v1","fields":[{"name":"api_key","label":"API Key","hint":"Plan keys start with sk-sp-.","secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]},{"id":"token_plan","label":"Token Plan","description":"For teams and companies • Usage-based billing with dedicated capacity","builtin_base_url":"https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1","fields":[{"name":"api_key","label":"API Key","hint":"Plan keys start with sk-sp-.","secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]},{"id":"dashscope","label":"DashScope (百炼)","description":"Connect with an existing Bailian API key","builtin_base_url":"https://dashscope.aliyuncs.com/compatible-mode/v1","fields":[{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":false,"placeholder":"qwen3.7-plus"}]},{"id":"openai_compat","label":"OpenAI Compatible","description":"Use an existing OpenAI-compatible Base URL and API key","fields":[{"name":"base_url","label":"Base URL","hint":null,"secret":false,"required":true,"placeholder":null},{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":true,"placeholder":null}]}]"#;
 
 const SAVED_NONE: &str = "[]";
 
 const SAVED_DASHSCOPE: &str = r#"[{"provider_id":"qwen-prod","provider_type":"dashscope","source":"user","editable":true,"auth_source":null,"model":"qwen3.7-plus","base_url":null,"api_key_len":8,"active":true}]"#;
+
+const SAVED_CODING_PLAN: &str = r#"[{"provider_id":"coding-prod","provider_type":"openai","source":"user","editable":true,"auth_source":null,"model":"qwen3.7-plus","base_url":"https://coding.dashscope.aliyuncs.com/v1","api_key_len":12,"active":true}]"#;
 
 /// A saved SysOM setup is the `aliyun` provider with `auth_source=ecs_ram_role`.
 const SAVED_DASHSCOPE_AND_ECS: &str = r#"[{"provider_id":"qwen-prod","provider_type":"dashscope","source":"user","editable":true,"auth_source":null,"model":"qwen3.7-plus","base_url":null,"api_key_len":8,"active":true},{"provider_id":"sysom-trial","provider_type":"aliyun","source":"user","editable":true,"auth_source":"ecs_ram_role","model":"qwen3.7-plus","base_url":null,"active":false}]"#;
@@ -279,9 +280,9 @@ fn raw_cli_auth_ecs_promotes_configured_ram_role_provider() {
     assert_eq!(action_count(&requests, "delete"), 0, "{requests}");
 }
 
-/// A non-ECS host uses the same Aliyun-first order as an active-run auth request.
+/// A non-ECS host shows the plan-oriented provider menu with guidance.
 #[test]
-fn raw_cli_auth_non_ecs_without_saved_providers_normalizes_template_order() {
+fn raw_cli_auth_non_ecs_without_saved_providers_shows_plan_entries() {
     let (output, requests) = run_auth_menu_flow(
         "auth-non-ecs-no-saved",
         SAVED_NONE,
@@ -294,8 +295,19 @@ fn raw_cli_auth_non_ecs_without_saved_providers_normalizes_template_order() {
 
     let compact = compact_terminal_words(&output);
     assert!(compact.contains("> [1] Aliyun Authentication"), "{output}");
-    assert!(compact.contains("[2] DashScope"), "{output}");
-    assert!(compact.contains("[3] OpenAI Compatible"), "{output}");
+    assert!(compact.contains("[2] Coding Plan"), "{output}");
+    assert!(compact.contains("[3] Token Plan"), "{output}");
+    assert!(compact.contains("[4] DashScope"), "{output}");
+    assert!(compact.contains("[5] OpenAI Compatible"), "{output}");
+    assert!(compact.contains("Free with limited quota"), "{output}");
+    assert!(
+        compact.contains("For individual developers • Weekly quota included"),
+        "{output}"
+    );
+    assert!(
+        compact.contains("For teams and companies • Usage-based billing with dedicated capacity"),
+        "{output}"
+    );
     assert!(!compact.contains("SysOM"), "{output}");
     assert!(!compact.contains("Provider Management"), "{output}");
     assert_eq!(action_count(&requests, "prepare"), 1, "{requests}");
@@ -324,6 +336,30 @@ fn raw_cli_auth_non_ecs_keeps_saved_providers_then_add_new() {
     // Edit still pre-fills the masked API key and offers to keep it.
     assert!(compact.contains("Edit API Key"), "{output}");
     assert!(compact.contains("Enter to keep current value"), "{output}");
+    assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
+}
+
+#[test]
+fn raw_cli_auth_edits_coding_plan_with_its_original_template() {
+    let (output, requests) = run_auth_menu_flow(
+        "auth-edit-coding-plan",
+        SAVED_CODING_PLAN,
+        MANUAL_PREPARE,
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("coding-prod", b"\n".as_slice()),
+            ("Edit configuration", b"\n".as_slice()),
+            ("Edit API Key", b"".as_slice()),
+        ],
+    );
+
+    let compact = compact_terminal_words(&output);
+    assert!(compact.contains("Coding Plan"), "{output}");
+    assert!(compact.contains("Edit API Key"), "{output}");
+    assert!(
+        !compact.contains("Edit Base URL"),
+        "plan edit fell back to the OpenAI-compatible template: {output}"
+    );
     assert_eq!(action_count(&requests, "configure"), 0, "{requests}");
 }
 
@@ -427,7 +463,10 @@ fn raw_cli_auth_esc_walks_back_through_the_form_before_cancelling() {
         MANUAL_PREPARE,
         &[
             ("cosh-osc$", b"/auth\n".as_slice()),
-            ("Authentication Required", b"\x1b[C\x1b[C\n".as_slice()),
+            (
+                "Authentication Required",
+                b"\x1b[C\x1b[C\x1b[C\x1b[C\n".as_slice(),
+            ),
             ("Enter Provider ID", b"qwen-prod\n".as_slice()),
             ("Enter Base URL", b"https://example.invalid/v1\n".as_slice()),
             // ESC on API Key returns to Base URL, which still carries the value just submitted.
@@ -451,7 +490,7 @@ fn raw_cli_auth_esc_walks_back_through_the_form_before_cancelling() {
         "stepping back lost the submitted Provider ID: {output}"
     );
     // The picker reopens on the template the form belonged to.
-    assert!(compact.contains("> [3] OpenAI Compatible"), "{output}");
+    assert!(compact.contains("> [5] OpenAI Compatible"), "{output}");
     // Only the last ESC cancels; the three before it are back-navigation.
     assert_eq!(
         count_occurrences(&compact, "Auth cancelled"),
@@ -493,7 +532,10 @@ fn raw_cli_auth_ctrl_c_mid_form_abandons_the_flow() {
         MANUAL_PREPARE,
         &[
             ("cosh-osc$", b"/auth\n".as_slice()),
-            ("Authentication Required", b"\x1b[C\x1b[C\n".as_slice()),
+            (
+                "Authentication Required",
+                b"\x1b[C\x1b[C\x1b[C\x1b[C\n".as_slice(),
+            ),
             ("Enter Provider ID", b"qwen-prod\n".as_slice()),
             ("Enter Base URL", b"\x03".as_slice()),
             ("Auth cancelled", b"".as_slice()),

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -745,6 +745,7 @@ fn raw_relay_capture_ack_replays_same_read_multiline_suffix() {
     let capture = RawInputCapture::Question {
         id: "question-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -811,6 +812,7 @@ fn raw_relay_capture_chain_discards_old_generation_suffix() {
     let first = RawInputCapture::Question {
         id: "question-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -818,6 +820,7 @@ fn raw_relay_capture_chain_discards_old_generation_suffix() {
     let second = RawInputCapture::Question {
         id: "question-2".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -880,6 +883,7 @@ fn raw_relay_capture_target_gone_discards_old_suffix_then_installs_new_target() 
     let first = RawInputCapture::Question {
         id: "question-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -887,6 +891,7 @@ fn raw_relay_capture_target_gone_discards_old_suffix_then_installs_new_target() 
     let second = RawInputCapture::Question {
         id: "question-2".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -894,6 +899,7 @@ fn raw_relay_capture_target_gone_discards_old_suffix_then_installs_new_target() 
     let third = RawInputCapture::Question {
         id: "question-3".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -981,6 +987,7 @@ fn raw_relay_capture_eof_discards_old_generation_suffix() {
     let first = RawInputCapture::Question {
         id: "question-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -988,6 +995,7 @@ fn raw_relay_capture_eof_discards_old_generation_suffix() {
     let second = RawInputCapture::Question {
         id: "question-2".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,
@@ -1042,6 +1050,7 @@ fn raw_relay_capture_owned_input_overflow_is_visible_and_discarded() {
     let capture = RawInputCapture::Question {
         id: "question-1".to_string(),
         option_count: 0,
+        selected: 0,
         allow_free_text: true,
         multiple: false,
         secret: false,


### PR DESCRIPTION
## Description

Aligns the cosh-ng authentication picker with copilot-shell and exposes
Coding Plan and Token Plan as first-level provider choices. Provider guidance
is localized for Chinese and English sites, uses the existing dark-gray
secondary style, and selects China or international plan endpoints from a
shared site-aware catalog. ESC navigation now preserves the restored provider
focus, so the next arrow key moves from the visible selection.

## Related Issue

closes #2050

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test --package cosh-shell --lib`
- `cargo test --package cosh-shell --test logic`
- `cargo test --package cosh-shell --test protocol`
- `cargo test --package cosh-shell --test raw_cli auth::raw_cli_auth_esc_preserves_picker_focus_for_the_next_arrow -- --exact`
- `cargo test --package cosh-shell --test raw_cli auth::raw_cli_auth_esc_walks_back_through_the_form_before_cancelling -- --exact`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --locked --release --package cosh-core --package cosh-shell`
- `cargo doc --workspace --no-deps`
- `crates/cosh-shell/scripts/check-layout.sh`
- Real SysOM role authentication smoke test on an isolated ECS workspace

## Additional Notes

The complete parallel `shell_host` run had one timing-sensitive timeout
assertion exceed eight seconds; its exact isolated rerun passed in 5.44
seconds. Automated PTY coverage includes the Token Plan -> ESC -> Down
regression. Final post-fix manual UI verification is not recorded in this PR.
