### PR TITLE
chore(ci): centralize repository governance metadata

### DIFF
--- a/.github/components.json
+++ b/.github/components.json
@@ -1,0 +1,275 @@
+{
+  "schema_version": 1,
+  "defaults": {
+    "issue_triagers": [
+      "kongche-jbw"
+    ]
+  },
+  "components": [
+    {
+      "id": "anolisa",
+      "display_name": "ANOLISA CLI",
+      "aliases": [
+        "anolisa-cli"
+      ],
+      "issue_option": "anolisa",
+      "path_prefixes": [
+        "src/anolisa/"
+      ],
+      "label": "component:anolisa",
+      "commit_scope": "anolisa",
+      "commit_scope_aliases": [],
+      "release_tag_prefix": "anolisa/v",
+      "ci_key": "anolisa",
+      "issue_triagers": [
+        "kongche-jbw",
+        "ikunkun-sys"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "cosh",
+      "display_name": "Cosh",
+      "aliases": [
+        "copilot-shell"
+      ],
+      "issue_option": "cosh",
+      "path_prefixes": [
+        "src/copilot-shell/"
+      ],
+      "label": "component:cosh",
+      "commit_scope": "cosh",
+      "commit_scope_aliases": [
+        "copilot-shell"
+      ],
+      "release_tag_prefix": "cosh/v",
+      "ci_key": "copilot_shell",
+      "issue_triagers": [
+        "kongche-jbw",
+        "samchu-zsl"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "cosh-ng",
+      "display_name": "Cosh NG",
+      "aliases": [],
+      "issue_option": "cosh-ng",
+      "path_prefixes": [
+        "src/cosh-ng/"
+      ],
+      "label": "component:cosh-ng",
+      "commit_scope": "cosh-ng",
+      "commit_scope_aliases": [],
+      "release_tag_prefix": "cosh-ng/v",
+      "ci_key": "cosh_ng",
+      "issue_triagers": [
+        "KaiLongZhou",
+        "SunnyQjm"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "sec-core",
+      "display_name": "Agent Security Core",
+      "aliases": [
+        "agent-sec-core"
+      ],
+      "issue_option": "sec-core",
+      "path_prefixes": [
+        "src/agent-sec-core/"
+      ],
+      "label": "component:sec-core",
+      "commit_scope": "sec-core",
+      "commit_scope_aliases": [
+        "agent-sec-core"
+      ],
+      "release_tag_prefix": "sec-core/v",
+      "ci_key": "agent_sec_core",
+      "issue_triagers": [
+        "edonyzpc",
+        "kid9",
+        "RemindD"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "skill",
+      "display_name": "OS Skills",
+      "aliases": [
+        "os-skills"
+      ],
+      "issue_option": "skill",
+      "path_prefixes": [
+        "src/os-skills/"
+      ],
+      "label": "component:skill",
+      "commit_scope": "skill",
+      "commit_scope_aliases": [
+        "os-skills"
+      ],
+      "release_tag_prefix": "skill/v",
+      "ci_key": null,
+      "issue_triagers": [
+        "Ziqi002"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "sight",
+      "display_name": "AgentSight",
+      "aliases": [
+        "agentsight"
+      ],
+      "issue_option": "sight",
+      "path_prefixes": [
+        "src/agentsight/"
+      ],
+      "label": "component:sight",
+      "commit_scope": "sight",
+      "commit_scope_aliases": [
+        "agentsight"
+      ],
+      "release_tag_prefix": "sight/v",
+      "ci_key": "agentsight",
+      "issue_triagers": [
+        "chengshuyi",
+        "jfeng18"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "tokenless",
+      "display_name": "Tokenless",
+      "aliases": [],
+      "issue_option": "tokenless",
+      "path_prefixes": [
+        "src/tokenless/"
+      ],
+      "label": "component:tokenless",
+      "commit_scope": "tokenless",
+      "commit_scope_aliases": [],
+      "release_tag_prefix": "tokenless/v",
+      "ci_key": "tokenless",
+      "issue_triagers": [
+        "Forrest-ly",
+        "shiloong",
+        "ikunkun-sys"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "ckpt",
+      "display_name": "Workspace Checkpoint",
+      "aliases": [
+        "ws-ckpt"
+      ],
+      "issue_option": "ckpt",
+      "path_prefixes": [
+        "src/ws-ckpt/"
+      ],
+      "label": "component:ckpt",
+      "commit_scope": "ckpt",
+      "commit_scope_aliases": [
+        "ws-ckpt"
+      ],
+      "release_tag_prefix": "ckpt/v",
+      "ci_key": "ws_ckpt",
+      "issue_triagers": [
+        "Ziqi002"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "memory",
+      "display_name": "Agent Memory",
+      "aliases": [
+        "agent-memory"
+      ],
+      "issue_option": "memory",
+      "path_prefixes": [
+        "src/agent-memory/"
+      ],
+      "label": "component:memory",
+      "commit_scope": "memory",
+      "commit_scope_aliases": [
+        "agent-memory"
+      ],
+      "release_tag_prefix": "memory/v",
+      "ci_key": "agent_memory",
+      "issue_triagers": [
+        "shiloong",
+        "ikunkun-sys"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "skillfs",
+      "display_name": "SkillFS",
+      "aliases": [],
+      "issue_option": "skillfs",
+      "path_prefixes": [
+        "src/skillfs/"
+      ],
+      "label": "component:skillfs",
+      "commit_scope": "skillfs",
+      "commit_scope_aliases": [],
+      "release_tag_prefix": "skillfs/v",
+      "ci_key": "skillfs",
+      "issue_triagers": [
+        "kongche-jbw"
+      ],
+      "status": "active"
+    },
+    {
+      "id": "ktuner",
+      "display_name": "KTuner",
+      "aliases": [],
+      "issue_option": null,
+      "path_prefixes": [
+        "src/ktuner/"
+      ],
+      "label": "component:ktuner",
+      "commit_scope": "ktuner",
+      "commit_scope_aliases": [],
+      "release_tag_prefix": null,
+      "ci_key": "ktuner",
+      "issue_triagers": [],
+      "status": "incubating"
+    },
+    {
+      "id": "blaze",
+      "display_name": "Blaze",
+      "aliases": [],
+      "issue_option": null,
+      "path_prefixes": [
+        "src/blaze/"
+      ],
+      "label": "component:blaze",
+      "commit_scope": "blaze",
+      "commit_scope_aliases": [],
+      "release_tag_prefix": null,
+      "ci_key": "blaze",
+      "issue_triagers": [],
+      "status": "incubating"
+    },
+    {
+      "id": "osbase",
+      "display_name": "OS Base",
+      "aliases": [],
+      "issue_option": null,
+      "path_prefixes": [
+        "src/osbase/"
+      ],
+      "label": "component:osbase",
+      "commit_scope": null,
+      "commit_scope_aliases": [],
+      "release_tag_prefix": null,
+      "ci_key": null,
+      "issue_triagers": [
+        "casparant"
+      ],
+      "status": "internal"
+    }
+  ]
+}

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "labels": [
+    {
+      "name": "status:needs-triage",
+      "color": "fbca04",
+      "description": "Awaiting initial maintainer triage"
+    },
+    {
+      "name": "status:needs-info",
+      "color": "d4c5f9",
+      "description": "More information is needed from the reporter"
+    },
+    {
+      "name": "status:accepted",
+      "color": "0e8a16",
+      "description": "Accepted and ready to be worked on"
+    },
+    {
+      "name": "status:in-progress",
+      "color": "1d76db",
+      "description": "Someone is actively working on this"
+    },
+    {
+      "name": "status:blocked",
+      "color": "b60205",
+      "description": "Blocked by another decision or dependency"
+    },
+    {
+      "name": "status:duplicate",
+      "color": "cfd3d7",
+      "description": "Duplicate of another issue"
+    },
+    {
+      "name": "status:declined",
+      "color": "eeeeee",
+      "description": "Not planned or outside the current project scope"
+    },
+    {
+      "name": "priority:p0",
+      "color": "b60205",
+      "description": "Critical and urgent"
+    },
+    {
+      "name": "priority:p1",
+      "color": "d93f0b",
+      "description": "High priority"
+    },
+    {
+      "name": "priority:p2",
+      "color": "fbca04",
+      "description": "Normal priority"
+    },
+    {
+      "name": "priority:p3",
+      "color": "c2e0c6",
+      "description": "Low priority"
+    },
+    {
+      "name": "risk:security",
+      "color": "b60205",
+      "description": "Security-sensitive change"
+    },
+    {
+      "name": "risk:privileged",
+      "color": "d93f0b",
+      "description": "Touches privileged or elevated operations"
+    },
+    {
+      "name": "risk:breaking",
+      "color": "e99695",
+      "description": "May break a public interface or workflow"
+    },
+    {
+      "name": "risk:cross-component",
+      "color": "5319e7",
+      "description": "Changes contracts across multiple components"
+    }
+  ]
+}

--- a/.github/scripts/test_validate_repository_metadata.py
+++ b/.github/scripts/test_validate_repository_metadata.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Regression tests for repository governance metadata validation."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Callable
+
+SOURCE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class RepositoryMetadataValidationTest(unittest.TestCase):
+    """Run the validator against isolated metadata mutations."""
+
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name) / "repository"
+        shutil.copytree(SOURCE_ROOT / ".github", self.root / ".github")
+        self.validator = self.root / ".github/scripts/validate-repository-metadata.py"
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def run_validator(self) -> subprocess.CompletedProcess[str]:
+        """Execute the copied validator and capture its diagnostics."""
+        return subprocess.run(
+            ["python3", str(self.validator)],
+            cwd=self.root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def mutate_components(self, mutation: Callable[[dict[str, Any]], None]) -> None:
+        """Apply one test mutation to the copied component metadata."""
+        path = self.root / ".github/components.json"
+        document = json.loads(path.read_text(encoding="utf-8"))
+        mutation(document)
+        path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+
+    def assert_validation_error(self, expected: str) -> str:
+        """Require validation failure containing the expected diagnostic."""
+        result = self.run_validator()
+        output = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0, output)
+        self.assertIn(expected, output)
+        return output
+
+    def test_committed_metadata_is_valid(self) -> None:
+        result = self.run_validator()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_removed_component_leaves_no_silent_downstream_references(self) -> None:
+        self.mutate_components(
+            lambda document: document.__setitem__(
+                "components",
+                [component for component in document["components"] if component["id"] != "cosh"],
+            )
+        )
+        output = self.assert_validation_error("unknown component scope 'cosh'")
+        self.assertIn("unknown component option 'cosh'", output)
+        self.assertIn("unknown component annotation component:cosh", output)
+        self.assertIn("unknown component scope component:cosh", output)
+
+    def test_question_form_must_contain_every_component_option(self) -> None:
+        path = self.root / ".github/ISSUE_TEMPLATE/question.yml"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("        - sight\n", "", 1),
+            encoding="utf-8",
+        )
+        self.assert_validation_error("question.yml: missing component option 'sight'")
+
+    def test_issue_form_option_parsing_accepts_different_indentation(self) -> None:
+        path = self.root / ".github/ISSUE_TEMPLATE/question.yml"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "        - sight\n", "          - sight\n", 1
+            ),
+            encoding="utf-8",
+        )
+        result = self.run_validator()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_unknown_component_status_is_rejected(self) -> None:
+        def change_status(document: dict[str, Any]) -> None:
+            document["components"][0]["status"] = "actve"
+
+        self.mutate_components(change_status)
+        self.assert_validation_error("anolisa: unknown status 'actve'")
+
+    def test_each_public_path_requires_its_codeowners_mapping(self) -> None:
+        path = self.root / ".github/CODEOWNERS"
+        lines = [
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if "/src/blaze/" not in line
+        ]
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        self.assert_validation_error(
+            "CODEOWNERS: /src/blaze/ does not map to component:blaze"
+        )
+
+    def test_undeclared_path_leaves_no_codeowners_mapping(self) -> None:
+        path = self.root / ".github/CODEOWNERS"
+        path.write_text(
+            path.read_text(encoding="utf-8")
+            + "/src/legacy-blaze/ @casparant # auto-label: component:blaze\n",
+            encoding="utf-8",
+        )
+        self.assert_validation_error(
+            "CODEOWNERS: /src/legacy-blaze/ is not declared by blaze path prefixes"
+        )
+
+    def test_complete_codeowners_annotation_is_validated(self) -> None:
+        path = self.root / ".github/CODEOWNERS"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "# auto-label: component:cosh",
+                "# auto-label: component:cosh!",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        self.assert_validation_error(
+            "CODEOWNERS: unknown component annotation component:cosh!"
+        )
+
+    def test_issue_options_must_be_unique(self) -> None:
+        def duplicate_issue_option(document: dict[str, Any]) -> None:
+            document["components"][1]["issue_option"] = document["components"][0][
+                "issue_option"
+            ]
+
+        self.mutate_components(duplicate_issue_option)
+        self.assert_validation_error("duplicate issue option: anolisa")
+
+    def test_component_aliases_must_not_shadow_component_ids(self) -> None:
+        def shadow_component_id(document: dict[str, Any]) -> None:
+            document["components"][1]["aliases"].append("anolisa")
+
+        self.mutate_components(shadow_component_id)
+        self.assert_validation_error("duplicate component identifier: anolisa")
+
+    def test_component_scopes_must_not_use_reserved_scopes(self) -> None:
+        def use_reserved_scope(document: dict[str, Any]) -> None:
+            document["components"][1]["commit_scope_aliases"].append("docs")
+
+        self.mutate_components(use_reserved_scope)
+        self.assert_validation_error(
+            "component commit scope conflicts with reserved scope: 'docs'"
+        )
+
+    def test_issue_options_must_not_use_fallback_options(self) -> None:
+        def use_fallback_option(document: dict[str, Any]) -> None:
+            document["components"][1]["issue_option"] = "other"
+
+        self.mutate_components(use_fallback_option)
+        for form_name in ("bug_report.yml", "feature_request.yml", "question.yml"):
+            path = self.root / ".github/ISSUE_TEMPLATE" / form_name
+            path.write_text(
+                path.read_text(encoding="utf-8").replace("        - cosh\n", "", 1),
+                encoding="utf-8",
+            )
+        self.assert_validation_error(
+            "component issue option conflicts with fallback option: 'other'"
+        )
+
+    def test_commit_scopes_and_aliases_must_be_globally_unique(self) -> None:
+        def duplicate_commit_scope(document: dict[str, Any]) -> None:
+            document["components"][1]["commit_scope_aliases"].append(
+                document["components"][0]["commit_scope"]
+            )
+
+        self.mutate_components(duplicate_commit_scope)
+        self.assert_validation_error("duplicate commit scope: anolisa")
+
+    def test_ci_keys_must_be_unique(self) -> None:
+        def duplicate_ci_key(document: dict[str, Any]) -> None:
+            document["components"][1]["ci_key"] = document["components"][0]["ci_key"]
+
+        self.mutate_components(duplicate_ci_key)
+        self.assert_validation_error("duplicate CI key: anolisa")
+
+    def test_ci_keys_must_match_the_workflow_contract(self) -> None:
+        def change_ci_key(document: dict[str, Any]) -> None:
+            document["components"][0]["ci_key"] = "not_a_real_ci_output"
+
+        self.mutate_components(change_ci_key)
+        self.assert_validation_error(
+            "ci.yaml: missing declared output for component CI key 'not_a_real_ci_output'"
+        )
+
+    def test_ci_keys_must_route_to_their_components(self) -> None:
+        def swap_ci_keys(document: dict[str, Any]) -> None:
+            first, second = document["components"][:2]
+            first["ci_key"], second["ci_key"] = second["ci_key"], first["ci_key"]
+
+        self.mutate_components(swap_ci_keys)
+        self.assert_validation_error(
+            "ci.yaml: anolisa CI key 'copilot_shell' routes through ['anolisa']"
+        )
+
+    def test_ci_consumers_in_comments_are_ignored(self) -> None:
+        path = self.root / ".github/workflows/ci.yaml"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "    if: needs.detect-changes.outputs.anolisa == 'true'",
+                "    # if: needs.detect-changes.outputs.anolisa == 'true'\n"
+                "    if: false",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        self.assert_validation_error(
+            "ci.yaml: missing consumed output for component CI key 'anolisa'"
+        )
+
+    def test_ci_path_routes_in_comments_are_ignored(self) -> None:
+        path = self.root / ".github/workflows/ci.yaml"
+        old_route = (
+            '          if echo "$CHANGED" | grep -q "^src/anolisa/"; then\n'
+            "            ANOLISA=true\n"
+            "          fi"
+        )
+        commented_route = (
+            '          # if echo "$CHANGED" | grep -q "^src/anolisa/"; '
+            "then ANOLISA=true"
+        )
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(old_route, commented_route, 1),
+            encoding="utf-8",
+        )
+        self.assert_validation_error(
+            "ci.yaml: anolisa path 'src/anolisa/' has no change route"
+        )
+
+    def test_ci_routes_reject_undeclared_path_alternatives(self) -> None:
+        path = self.root / ".github/workflows/ci.yaml"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                'grep -q "^src/blaze/"',
+                'grep -qE "^src/(legacy-blaze|blaze)/"',
+                1,
+            ),
+            encoding="utf-8",
+        )
+        self.assert_validation_error(
+            "ci.yaml: route pattern '^src/(legacy-blaze|blaze)/' "
+            "is not an exact declared component path"
+        )
+
+    def test_release_prefixes_must_match_the_workflow_contract(self) -> None:
+        def change_release_prefix(document: dict[str, Any]) -> None:
+            document["components"][0]["release_tag_prefix"] = "not-a-real-prefix/v"
+
+        self.mutate_components(change_release_prefix)
+        self.assert_validation_error(
+            "release.yaml: missing trigger prefix for component release prefix "
+            "'not-a-real-prefix/v'"
+        )
+
+    def test_release_prefixes_must_route_to_their_components(self) -> None:
+        def swap_release_prefixes(document: dict[str, Any]) -> None:
+            first, second = document["components"][:2]
+            first["release_tag_prefix"], second["release_tag_prefix"] = (
+                second["release_tag_prefix"],
+                first["release_tag_prefix"],
+            )
+
+        self.mutate_components(swap_release_prefixes)
+        self.assert_validation_error(
+            "release.yaml: anolisa prefix 'cosh/v' parses as 'copilot-shell'"
+        )
+
+    def test_public_component_requires_specific_or_default_triagers(self) -> None:
+        def remove_fallback(document: dict[str, Any]) -> None:
+            document["defaults"]["issue_triagers"] = []
+
+        self.mutate_components(remove_fallback)
+        self.assert_validation_error("ktuner: public components need an effective issue triager")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/validate-repository-metadata.py
+++ b/.github/scripts/validate-repository-metadata.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Validate repository governance metadata using only the Python standard library."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+GITHUB = ROOT / ".github"
+
+errors: list[str] = []
+warnings: list[str] = []
+
+VALID_STATUSES = {"active", "incubating", "internal"}
+NON_COMPONENT_SCOPES = {"chore", "ci", "deps", "docs"}
+ISSUE_FORMS = ("bug_report.yml", "feature_request.yml", "question.yml")
+ISSUE_FORM_FALLBACK_OPTIONS = {"project-wide", "not sure", "other"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        errors.append(f"missing required file: {path.relative_to(ROOT)}")
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON in {path.relative_to(ROOT)}: {exc}")
+    return {}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def duplicates(values: list[str]) -> set[str]:
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for value in values:
+        if value in seen:
+            dupes.add(value)
+        seen.add(value)
+    return dupes
+
+
+def issue_form_component_options(path: Path) -> list[str]:
+    """Return the component dropdown values without depending on fixed indentation."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        errors.append(f"missing issue form: {path.relative_to(ROOT)}")
+        return []
+
+    component_line = next(
+        (index for index, line in enumerate(lines) if re.fullmatch(r"\s*id:\s*component\s*", line)),
+        None,
+    )
+    if component_line is None:
+        errors.append(f"{path.name}: missing component field")
+        return []
+
+    options_line = next(
+        (
+            index
+            for index in range(component_line + 1, len(lines))
+            if re.fullmatch(r"\s*options:\s*", lines[index])
+        ),
+        None,
+    )
+    if options_line is None:
+        errors.append(f"{path.name}: component field is missing options")
+        return []
+
+    options_indent = len(lines[options_line]) - len(lines[options_line].lstrip())
+    options: list[str] = []
+    for line in lines[options_line + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= options_indent:
+            break
+        match = re.fullmatch(r"\s*-\s*(.+?)\s*", line)
+        if not match:
+            continue
+        value = re.sub(r"\s+#.*$", "", match.group(1)).strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        options.append(value)
+    if not options:
+        errors.append(f"{path.name}: component field has no options")
+    return options
+
+
+components_doc = load_json(GITHUB / "components.json")
+labels_doc = load_json(GITHUB / "labels.json")
+maintainers_doc = load_json(GITHUB / "maintainers.json")
+commitlint_doc = load_json(GITHUB / "commitlint.config.json")
+
+components = components_doc.get("components", [])
+component_defaults = components_doc.get("defaults", {})
+require(components_doc.get("schema_version") == 1, ".github/components.json schema_version must be 1")
+require(isinstance(components, list) and components, ".github/components.json must define components")
+require(isinstance(component_defaults, dict), ".github/components.json defaults must be an object")
+
+default_triagers = (
+    component_defaults.get("issue_triagers", []) if isinstance(component_defaults, dict) else []
+)
+require(isinstance(default_triagers, list), "components defaults issue_triagers must be a list")
+if isinstance(default_triagers, list):
+    require(
+        all(isinstance(value, str) and value for value in default_triagers),
+        "components defaults issue_triagers entries must be non-empty strings",
+    )
+    for duplicate in sorted(duplicates(default_triagers)):
+        errors.append(f"duplicate components default issue_triagers entry: {duplicate}")
+else:
+    default_triagers = []
+
+required_keys = {
+    "id",
+    "display_name",
+    "aliases",
+    "issue_option",
+    "path_prefixes",
+    "label",
+    "commit_scope",
+    "commit_scope_aliases",
+    "release_tag_prefix",
+    "ci_key",
+    "issue_triagers",
+    "status",
+}
+
+for index, component in enumerate(components):
+    if not isinstance(component, dict):
+        errors.append(f"components[{index}] must be an object")
+        continue
+    missing = sorted(required_keys - component.keys())
+    if missing:
+        errors.append(f"component {component.get('id', index)!r} is missing keys: {', '.join(missing)}")
+        continue
+
+    component_id = component["id"]
+    require(bool(re.fullmatch(r"[a-z0-9][a-z0-9-]*", component_id)), f"invalid component id: {component_id}")
+    require(component["label"] == f"component:{component_id}", f"{component_id}: label must be component:{component_id}")
+    require(isinstance(component["aliases"], list), f"{component_id}: aliases must be a list")
+    aliases = component["aliases"] if isinstance(component["aliases"], list) else []
+    require(
+        all(
+            isinstance(value, str) and re.fullmatch(r"[a-z0-9][a-z0-9-]*", value)
+            for value in aliases
+        ),
+        f"{component_id}: aliases must be non-empty lowercase identifiers",
+    )
+    require(isinstance(component["path_prefixes"], list) and component["path_prefixes"], f"{component_id}: path_prefixes must not be empty")
+    require(isinstance(component["commit_scope_aliases"], list), f"{component_id}: commit_scope_aliases must be a list")
+    require(isinstance(component["issue_triagers"], list), f"{component_id}: issue_triagers must be a list")
+    require(
+        component["status"] in VALID_STATUSES,
+        f"{component_id}: unknown status {component['status']!r}",
+    )
+
+    triagers = component["issue_triagers"] if isinstance(component["issue_triagers"], list) else []
+    require(
+        all(isinstance(value, str) and value for value in triagers),
+        f"{component_id}: issue_triagers entries must be non-empty strings",
+    )
+    for duplicate in sorted(duplicates(triagers)):
+        errors.append(f"{component_id}: duplicate issue_triager {duplicate!r}")
+
+    for prefix in component["path_prefixes"]:
+        require(prefix.startswith("src/") and prefix.endswith("/"), f"{component_id}: invalid path prefix {prefix!r}")
+
+    if component["status"] == "active":
+        require(bool(component["issue_option"]), f"{component_id}: active components need an issue_option")
+        require(bool(component["commit_scope"]), f"{component_id}: active components need a commit_scope")
+        require(bool(component["release_tag_prefix"]), f"{component_id}: active components need a release_tag_prefix")
+    if component["status"] != "internal":
+        require(
+            bool(triagers or default_triagers),
+            f"{component_id}: public components need an effective issue triager",
+        )
+
+component_identifiers = [
+    identifier
+    for component in components
+    if isinstance(component, dict)
+    for identifier in [
+        component.get("id", ""),
+        *(component.get("aliases", []) if isinstance(component.get("aliases"), list) else []),
+    ]
+]
+labels = [c.get("label", "") for c in components if isinstance(c, dict)]
+paths = [p for c in components if isinstance(c, dict) for p in c.get("path_prefixes", [])]
+issue_options = [
+    c.get("issue_option")
+    for c in components
+    if isinstance(c, dict) and c.get("issue_option")
+]
+commit_scopes = [
+    scope
+    for component in components
+    if isinstance(component, dict)
+    for scope in [component.get("commit_scope"), *component.get("commit_scope_aliases", [])]
+    if scope
+]
+release_prefixes = [
+    c.get("release_tag_prefix")
+    for c in components
+    if isinstance(c, dict) and c.get("release_tag_prefix")
+]
+ci_keys = [
+    c.get("ci_key") for c in components if isinstance(c, dict) and c.get("ci_key")
+]
+for field, values in (
+    ("component identifier", component_identifiers),
+    ("component label", labels),
+    ("path prefix", paths),
+    ("issue option", issue_options),
+    ("commit scope", commit_scopes),
+    ("release tag prefix", release_prefixes),
+    ("CI key", ci_keys),
+):
+    for duplicate in sorted(duplicates(values)):
+        errors.append(f"duplicate {field}: {duplicate}")
+
+scope_rule = commitlint_doc.get("rules", {}).get("scope-enum", [])
+commitlint_scopes = set()
+if isinstance(scope_rule, list) and len(scope_rule) >= 3 and isinstance(scope_rule[2], list):
+    commitlint_scopes = set(scope_rule[2])
+else:
+    errors.append("unable to read scope-enum from .github/commitlint.config.json")
+
+for component in components:
+    scope = component.get("commit_scope")
+    if scope and scope not in commitlint_scopes:
+        errors.append(f"{component['id']}: commit scope {scope!r} is missing from commitlint.config.json")
+
+component_scopes = set(commit_scopes)
+for scope in sorted(component_scopes & NON_COMPONENT_SCOPES):
+    errors.append(f"component commit scope conflicts with reserved scope: {scope!r}")
+for scope in sorted(commitlint_scopes - component_scopes - NON_COMPONENT_SCOPES):
+    errors.append(f"commitlint.config.json: unknown component scope {scope!r}")
+
+expected_form_options = {
+    component.get("issue_option") for component in components if component.get("issue_option")
+}
+for option in sorted(expected_form_options & ISSUE_FORM_FALLBACK_OPTIONS):
+    errors.append(f"component issue option conflicts with fallback option: {option!r}")
+for form_name in ISSUE_FORMS:
+    form_path = GITHUB / "ISSUE_TEMPLATE" / form_name
+    form_options = issue_form_component_options(form_path)
+    for duplicate in sorted(duplicates(form_options)):
+        errors.append(f"{form_name}: duplicate component option {duplicate!r}")
+    for option in sorted(expected_form_options - set(form_options)):
+        errors.append(f"{form_name}: missing component option {option!r}")
+    unknown_options = set(form_options) - expected_form_options - ISSUE_FORM_FALLBACK_OPTIONS
+    for option in sorted(unknown_options):
+        errors.append(f"{form_name}: unknown component option {option!r}")
+
+codeowners_path = GITHUB / "CODEOWNERS"
+try:
+    codeowners_text = codeowners_path.read_text(encoding="utf-8")
+except FileNotFoundError:
+    errors.append("missing .github/CODEOWNERS")
+    codeowners_text = ""
+
+codeowner_mappings: dict[str, set[str]] = {}
+for line in codeowners_text.splitlines():
+    annotation = re.search(r"#\s*auto-label:\s*(component:\S+)", line)
+    if not annotation or line.lstrip().startswith("#"):
+        continue
+    pattern = line.split(maxsplit=1)[0]
+    codeowner_mappings.setdefault(annotation.group(1), set()).add(pattern)
+
+component_labels = set(labels)
+for label in sorted(set(codeowner_mappings) - component_labels):
+    errors.append(f"CODEOWNERS: unknown component annotation {label}")
+components_by_label = {
+    component.get("label"): component for component in components if isinstance(component, dict)
+}
+for label, mapped_patterns in codeowner_mappings.items():
+    component = components_by_label.get(label)
+    if not component:
+        continue
+    declared_patterns = [f"/{prefix}" for prefix in component.get("path_prefixes", [])]
+    for mapped_pattern in sorted(mapped_patterns):
+        if not any(mapped_pattern.startswith(prefix) for prefix in declared_patterns):
+            errors.append(
+                f"CODEOWNERS: {mapped_pattern} is not declared by {component['id']} path prefixes"
+            )
+for component in components:
+    if component.get("status") == "internal":
+        continue
+    for prefix in component.get("path_prefixes", []):
+        pattern = f"/{prefix}"
+        if pattern not in codeowner_mappings.get(component["label"], set()):
+            errors.append(f"CODEOWNERS: {pattern} does not map to {component['label']}")
+
+maintainer_labels = {
+    scope.get("label")
+    for scope in maintainers_doc.get("scopes", [])
+    if isinstance(scope, dict)
+}
+for label in sorted(
+    label for label in maintainer_labels - component_labels if str(label).startswith("component:")
+):
+    errors.append(f"maintainers.json: unknown component scope {label}")
+for component in components:
+    if component.get("status") == "active" and component["label"] not in maintainer_labels:
+        errors.append(f"maintainers.json: missing scope for {component['label']}")
+
+ci_workflow_path = GITHUB / "workflows/ci.yaml"
+try:
+    ci_workflow_text = ci_workflow_path.read_text(encoding="utf-8")
+except FileNotFoundError:
+    errors.append("missing .github/workflows/ci.yaml")
+    ci_workflow_text = ""
+
+ci_job = re.search(
+    r"(?ms)^  detect-changes:\s*$\n(?P<body>.*?)(?=^  [a-z0-9-]+:\s*$)",
+    ci_workflow_text,
+)
+if not ci_job:
+    errors.append("ci.yaml: unable to read detect-changes job")
+else:
+    ci_job_text = ci_job.group("body")
+    ci_output_pairs = re.findall(
+        r'(?m)^\s*echo "([a-z0-9_]+)=\$([A-Z0-9_]+)"\s*>>\s*\$GITHUB_OUTPUT\s*$',
+        ci_job_text,
+    )
+    ci_contracts = {
+        "declared output": set(
+            re.findall(
+                r"(?m)^      ([a-z0-9_]+):\s*\$\{\{\s*steps\.changes\.outputs\.\1\s*\}\}\s*$",
+                ci_job_text,
+            )
+        ),
+        "emitted output": {key for key, _ in ci_output_pairs},
+        "consumed output": set(
+            re.findall(
+                r"(?m)^[ \t]*if:[ \t]*needs\.detect-changes\.outputs\.([a-z0-9_]+)"
+                r"[ \t]*==[ \t]*['\"]true['\"][ \t]*$",
+                ci_workflow_text,
+            )
+        ),
+    }
+    expected_ci_keys = set(ci_keys)
+    for contract, workflow_keys in ci_contracts.items():
+        for key in sorted(expected_ci_keys - workflow_keys):
+            errors.append(f"ci.yaml: missing {contract} for component CI key {key!r}")
+        for key in sorted(workflow_keys - expected_ci_keys):
+            errors.append(f"ci.yaml: unknown {contract} {key!r}")
+
+    ci_path_routes = re.findall(
+        r'(?m)^[ \t]*if echo "\$CHANGED" \| grep -qE? "([^"]+)"; then[ \t]*$'
+        r"\n[ \t]+([A-Z0-9_]+)=true[ \t]*$",
+        ci_job_text,
+    )
+    declared_ci_route_patterns = {
+        f"^{prefix}"
+        for component in components
+        if component.get("ci_key")
+        for prefix in component.get("path_prefixes", [])
+    }
+    for pattern, _ in ci_path_routes:
+        if pattern not in declared_ci_route_patterns:
+            errors.append(
+                f"ci.yaml: route pattern {pattern!r} is not an exact declared component path"
+            )
+    for component in components:
+        ci_key = component.get("ci_key")
+        if not ci_key:
+            continue
+        route_variables: set[str] = set()
+        for prefix in component.get("path_prefixes", []):
+            matching_variables = {
+                variable for pattern, variable in ci_path_routes if pattern == f"^{prefix}"
+            }
+            if not matching_variables:
+                errors.append(f"ci.yaml: {component['id']} path {prefix!r} has no change route")
+            route_variables.update(matching_variables)
+        if len(route_variables) != 1:
+            errors.append(
+                f"ci.yaml: {component['id']} paths route through "
+                f"{sorted(route_variables)!r} instead of one output"
+            )
+            continue
+        route_variable = next(iter(route_variables))
+        routed_keys = sorted(key for key, variable in ci_output_pairs if variable == route_variable)
+        if routed_keys != [ci_key]:
+            errors.append(
+                f"ci.yaml: {component['id']} CI key {ci_key!r} routes through "
+                f"{routed_keys!r}"
+            )
+
+release_workflow_path = GITHUB / "workflows/release.yaml"
+try:
+    release_workflow_text = release_workflow_path.read_text(encoding="utf-8")
+except FileNotFoundError:
+    errors.append("missing .github/workflows/release.yaml")
+    release_workflow_text = ""
+
+if release_workflow_text:
+    parsed_release_routes = dict(
+        re.findall(
+            r'(?m)^\s*([a-z0-9-]+)\)\s+COMPONENT="([^"]+)"\s*;;\s*$',
+            release_workflow_text,
+        )
+    )
+    published_release_routes = dict(
+        re.findall(
+            r'(?m)^\s*([a-z0-9-]+)\)\s+PREFIX="([a-z0-9-]+/v)"',
+            release_workflow_text,
+        )
+    )
+    release_contracts = {
+        "trigger prefix": set(
+            re.findall(
+                r"(?m)^\s*-\s*['\"]([a-z0-9-]+/v)\*['\"]\s*$",
+                release_workflow_text,
+            )
+        ),
+        "parsed prefix": {f"{scope}/v" for scope in parsed_release_routes},
+        "published prefix": set(published_release_routes.values()),
+    }
+    expected_release_prefixes = set(release_prefixes)
+    for contract, workflow_prefixes in release_contracts.items():
+        for prefix in sorted(expected_release_prefixes - workflow_prefixes):
+            errors.append(
+                f"release.yaml: missing {contract} for component release prefix {prefix!r}"
+            )
+        for prefix in sorted(workflow_prefixes - expected_release_prefixes):
+            errors.append(f"release.yaml: unknown {contract} {prefix!r}")
+
+    for component in components:
+        release_prefix = component.get("release_tag_prefix")
+        if not release_prefix:
+            continue
+        source_directories = {
+            match.group(1)
+            for prefix in component.get("path_prefixes", [])
+            if (match := re.fullmatch(r"src/([^/]+)/", prefix))
+        }
+        if len(source_directories) != 1:
+            errors.append(
+                f"{component['id']}: release metadata needs one source directory"
+            )
+            continue
+        source_directory = next(iter(source_directories))
+        release_scope = release_prefix.removesuffix("/v")
+        if parsed_release_routes.get(release_scope) != source_directory:
+            errors.append(
+                f"release.yaml: {component['id']} prefix {release_prefix!r} parses as "
+                f"{parsed_release_routes.get(release_scope)!r}"
+            )
+        if published_release_routes.get(source_directory) != release_prefix:
+            errors.append(
+                f"release.yaml: {component['id']} publishes with "
+                f"{published_release_routes.get(source_directory)!r} instead of "
+                f"{release_prefix!r}"
+            )
+
+label_entries = labels_doc.get("labels", [])
+require(labels_doc.get("schema_version") == 1, ".github/labels.json schema_version must be 1")
+require(isinstance(label_entries, list), ".github/labels.json labels must be a list")
+label_names = [entry.get("name", "") for entry in label_entries if isinstance(entry, dict)]
+for duplicate in sorted(duplicates(label_names)):
+    errors.append(f"duplicate label definition: {duplicate}")
+for entry in label_entries:
+    if not isinstance(entry, dict):
+        errors.append("labels.json entries must be objects")
+        continue
+    require(bool(entry.get("name")), "labels.json entry missing name")
+    require(bool(re.fullmatch(r"[0-9a-fA-F]{6}", str(entry.get("color", "")))), f"{entry.get('name')}: color must be six hex digits")
+    require(bool(entry.get("description")), f"{entry.get('name')}: description must not be empty")
+
+print(f"Validated {len(components)} components and {len(label_entries)} governance labels.")
+for warning in warnings:
+    print(f"WARNING: {warning}", file=sys.stderr)
+if errors:
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    sys.exit(1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
           SKILLFS=false
           COSH_NG=false
           KTUNER=false
-          ANVIL=false
+          BLAZE=false
 
           # Path-based detection
           if echo "$CHANGED" | grep -q "^src/copilot-shell/"; then
@@ -152,8 +152,8 @@ jobs:
           if echo "$CHANGED" | grep -q "^src/ktuner/"; then
             KTUNER=true
           fi
-          if echo "$CHANGED" | grep -qE "^src/(anvil|blaze)/"; then
-            ANVIL=true
+          if echo "$CHANGED" | grep -q "^src/blaze/"; then
+            BLAZE=true
           fi
 
           # Manual override via workflow_dispatch
@@ -188,7 +188,7 @@ jobs:
             KTUNER=true
           fi
           if [[ "${{ inputs.run_blaze }}" == "true" ]]; then
-            ANVIL=true
+            BLAZE=true
           fi
 
           echo "copilot_shell=$COPILOT_SHELL" >> $GITHUB_OUTPUT
@@ -201,7 +201,7 @@ jobs:
           echo "skillfs=$SKILLFS" >> $GITHUB_OUTPUT
           echo "cosh_ng=$COSH_NG" >> $GITHUB_OUTPUT
           echo "ktuner=$KTUNER" >> $GITHUB_OUTPUT
-          echo "blaze=$ANVIL" >> $GITHUB_OUTPUT
+          echo "blaze=$BLAZE" >> $GITHUB_OUTPUT
 
           echo "### Change Detection Results" >> $GITHUB_STEP_SUMMARY
           echo "| Component | Changed |" >> $GITHUB_STEP_SUMMARY
@@ -216,7 +216,7 @@ jobs:
           echo "| SkillFS | $SKILLFS |" >> $GITHUB_STEP_SUMMARY
           echo "| cosh-ng | $COSH_NG |" >> $GITHUB_STEP_SUMMARY
           echo "| ktuner | $KTUNER |" >> $GITHUB_STEP_SUMMARY
-          echo "| blaze | $ANVIL |" >> $GITHUB_STEP_SUMMARY
+          echo "| blaze | $BLAZE |" >> $GITHUB_STEP_SUMMARY
 
   # =========================================================================
   # Step 2: Validate component version metadata

--- a/.github/workflows/prelint.yml
+++ b/.github/workflows/prelint.yml
@@ -1,10 +1,8 @@
 ###############################################################################
-# PR Lint gate — Commit Message + PR Title + Branch Name + Issue Link
+# PR metadata checks
 #
-# Jobs:
-#   commit-lint  — requires checkout; runs independently
-#   pr-checks    — all github-script checks consolidated into one runner
-#                  (PR title, branch name, linked issue)
+# Commit messages are a hard gate. PR title, branch name, and issue linkage are
+# advisory so external contributors receive guidance without being blocked.
 ###############################################################################
 
 name: 🔍 PR Lint
@@ -12,16 +10,13 @@ name: 🔍 PR Lint
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    branches: [main, 'feature/**', 'release/**']
+    branches: [main, "feature/**", "release/**"]
 
 permissions:
   contents: read
   pull-requests: read
 
 jobs:
-  # =========================================================================
-  # Job 1: Commit Message Lint
-  # =========================================================================
   commit-lint:
     name: 📝 Commit Message Lint
     runs-on: anolisa-k8s-general-ci-x64
@@ -35,176 +30,132 @@ jobs:
         with:
           configFile: .github/commitlint.config.json
 
-  # =========================================================================
-  # Job 2: PR Checks (title + branch name + linked issue + merge hint)
-  # All steps run with continue-on-error so every check is always reported
-  # in one pass — contributors see all warnings at once, not one at a time.
-  # None of these checks block the PR (warnings only); only commit scope
-  # enforcement (commitlint) is a hard error.
-  # =========================================================================
+      - name: Explain how to fix commit messages
+        if: failure()
+        env:
+          DOCS_REVISION: ${{ github.event.pull_request.head.sha }}
+        run: |
+          docs_url="https://github.com/${GITHUB_REPOSITORY}/blob/${DOCS_REVISION}"
+          {
+            printf '%s\n' '## Commit message check failed' ''
+            printf '%s\n' \
+              'Each commit must use `type(scope): imperative description`.' \
+              'Example: `fix(cosh): handle empty configuration`' ''
+            printf '%s\n' 'To update the latest commit:' '```bash' \
+              'git commit --amend' 'git push --force-with-lease' '```' ''
+            printf '%s\n' 'To update an older commit, select `reword` in:' \
+              '```bash' 'git rebase -i HEAD~N' \
+              'git push --force-with-lease' '```' ''
+            printf '%s\n' \
+              "- [English contribution guide](${docs_url}/CONTRIBUTING.md#commit-messages)" \
+              "- [中文贡献指南](${docs_url}/CONTRIBUTING_zh.md#commit-规范)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   pr-checks:
     name: 🔍 PR Checks
     runs-on: anolisa-k8s-general-ci-x64
     steps:
-      # -----------------------------------------------------------------------
-      # Step 1: PR Title Validation (warning only)
-      # -----------------------------------------------------------------------
-      - name: 📋 Validate PR title
-        continue-on-error: true
+      - name: Checkout governance metadata
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/components.json
+          sparse-checkout-cone-mode: false
+
+      - name: Validate PR metadata
         uses: actions/github-script@v7
         with:
           script: |
-            const title = context.payload.pull_request.title;
-            console.log(`PR Title: "${title}"`);
+            const fs = require('fs');
+            const metadata = JSON.parse(
+              fs.readFileSync('.github/components.json', 'utf8')
+            );
 
-            // Conventional Commits pattern: type(scope): description
-            // Optional ! for breaking changes
-            const pattern = /^(feat|fix|refactor|perf|docs|chore|test|ci|build|style|revert)(\(.+\))!?: .+/;
+            const componentScopes = metadata.components
+              .flatMap((component) => [
+                component.commit_scope,
+                ...(component.commit_scope_aliases || []),
+              ])
+              .filter(Boolean);
+            const validScopes = [
+              ...new Set([...componentScopes, 'deps', 'ci', 'docs', 'chore']),
+            ].sort();
 
-            if (!pattern.test(title)) {
-              core.warning(
-                `PR title does not follow Conventional Commits format.\n` +
-                `Expected: type(scope): description\n` +
-                `Examples: feat(cosh): add json output\n` +
-                `          fix(sec-core): handle sandbox escape\n` +
-                `Valid types: feat, fix, refactor, perf, docs, chore, test, ci, build, style, revert\n` +
-                `Valid scopes: cosh, sec-core, skill, sight, tokenless, ckpt, memory, anolisa, skillfs, ktuner, blaze, deps, ci, docs, chore\n` +
-                `See CONTRIBUTING.md or AGENT.md for details.`
+            const warnings = [];
+            const pr = context.payload.pull_request;
+            const title = pr.title || '';
+            const branch = pr.head.ref || '';
+            const body = pr.body || '';
+
+            const titleMatch = title.match(
+              /^(feat|fix|refactor|perf|docs|chore|test|ci|build|style|revert)(\(([^)]+)\))!?: .+/
+            );
+            if (!titleMatch) {
+              warnings.push(
+                'PR title should use `type(scope): description`, for example ' +
+                '`feat(tokenless): add adapter diagnostics`.'
               );
-              return;
+            } else if (!validScopes.includes(titleMatch[3])) {
+              warnings.push(
+                `PR title scope "${titleMatch[3]}" is not recognized. ` +
+                `Recommended scopes: ${validScopes.join(', ')}.`
+              );
             }
 
-            // Validate scope (also accept legacy long names for forward compatibility)
-            const scopeMatch = title.match(/^\w+(\([^)]+\))/);
-            if (scopeMatch) {
-              const scope = scopeMatch[1].slice(1, -1);
-              const validScopes = [
-                'cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt', 'memory', 'anolisa', 'skillfs', 'ktuner', 'blaze',
-                'agent-sec-core', 'agentsight', 'os-skills', 'ws-ckpt', 'agent-memory', // legacy aliases
-                'deps', 'ci', 'docs', 'chore'
-              ];
-              if (!validScopes.includes(scope)) {
-                core.warning(
-                  `Scope "${scope}" in PR title is not in the recommended list.\n` +
-                  `Recommended scopes: ${validScopes.join(', ')}\n` +
-                  `See CONTRIBUTING.md for the scope-to-path mapping.`
-                );
-                return;
-              }
-            }
-
-            console.log('✅ PR title format is valid');
-
-      # -----------------------------------------------------------------------
-      # Step 2: Branch Name Validation (warning only, non-blocking for forks)
-      # -----------------------------------------------------------------------
-      - name: 🌿 Validate branch name
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const branch = context.payload.pull_request.head.ref;
-            const baseBranch = context.payload.pull_request.base.ref;
-            console.log(`Head branch: "${branch}"`);
-            console.log(`Base branch: "${baseBranch}"`);
-
-            // Whitelist: these branches are always allowed
-            const whitelist = [
+            const alwaysAllowed = [
               /^main$/,
               /^dependabot\/.+/,
               /^renovate\/.+/,
               /^revert-.+/,
-              /^chore\/changelog-.+/,  // created by changelog.yml workflow
+              /^agent\/[a-z0-9][a-z0-9._-]*$/,
+              /^chore\/changelog-.+/,
             ];
+            const scopePattern = validScopes
+              .map((scope) => scope.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+              .join('|');
+            const namedPatterns = [
+              new RegExp(`^feature/(${scopePattern})/[a-z0-9][a-z0-9._-]*$`),
+              new RegExp(`^feature/(${scopePattern})/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*$`),
+              new RegExp(`^fix/(${scopePattern})/[a-z0-9][a-z0-9._-]*$`),
+              new RegExp(`^hotfix/(${scopePattern})/[a-z0-9][a-z0-9._-]*$`),
+              new RegExp(`^release/(${scopePattern})/v\\d+\\.\\d+$`),
+            ];
+            if (
+              !alwaysAllowed.some((pattern) => pattern.test(branch)) &&
+              !namedPatterns.some((pattern) => pattern.test(branch))
+            ) {
+              warnings.push(
+                `Branch "${branch}" does not follow the recommended naming ` +
+                'pattern. Fork contributors may ignore this advisory.'
+              );
+            }
 
-            for (const pattern of whitelist) {
-              if (pattern.test(branch)) {
-                console.log(`✅ Branch "${branch}" is whitelisted`);
-                return;
+            const closingKeyword =
+              /\b(closes|fixes|resolves|close|fix|resolve)\s+#\d+/i;
+            const exemption = body.match(/no-issue\s*:\s*(.+)/i);
+            if (!closingKeyword.test(body) && !exemption?.[1]?.trim()) {
+              warnings.push(
+                'Link an issue with `closes #123`, or add ' +
+                '`no-issue: <brief reason>` for a genuinely trivial change.'
+              );
+            }
+
+            if (warnings.length === 0) {
+              core.notice('PR metadata follows the recommended conventions.');
+            } else {
+              for (const warning of warnings) {
+                core.warning(warning);
               }
             }
 
-            // Valid scopes — short names preferred; legacy long names accepted for forward compatibility
-            const validScopes = ['cosh', 'sec-core', 'skill', 'sight', 'tokenless', 'ckpt', 'memory', 'anolisa', 'skillfs', 'ktuner', 'blaze', 'agent-sec-core', 'agentsight', 'os-skills', 'ws-ckpt', 'agent-memory', 'ci', 'docs', 'deps'];
-            const scopePattern = validScopes.join('|');
-
-            // Valid branch patterns per development spec
-            const validPatterns = [
-              // feature/<scope>/<desc>
-              new RegExp(`^feature/(${scopePattern})/[a-z0-9][a-z0-9._-]*$`),
-              // feature/<scope>/<feature-name>/<task> (collaborative track)
-              new RegExp(`^feature/(${scopePattern})/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*$`),
-              // fix/<scope>/<desc>
-              new RegExp(`^fix/(${scopePattern})/[a-z0-9][a-z0-9._-]*$`),
-              // release/<scope>/vX.Y
-              new RegExp(`^release/(${scopePattern})/v\\d+\\.\\d+$`),
-              // hotfix/<scope>/<desc>
-              new RegExp(`^hotfix/(${scopePattern})/[a-z0-9][a-z0-9._-]*$`),
-            ];
-
-            const isValid = validPatterns.some(p => p.test(branch));
-
-            if (!isValid) {
-              core.warning(
-                `Branch "${branch}" does not match the recommended naming convention (non-blocking).\n` +
-                `Recommended formats:\n` +
-                `  feature/<scope>/<short-desc>  e.g. feature/cosh/json-output\n` +
-                `  fix/<scope>/<short-desc>      e.g. fix/sec-core/sandbox-escape\n` +
-                `  hotfix/<scope>/<short-desc>   e.g. hotfix/skill/broken-load\n` +
-                `Valid scopes: ${validScopes.join(', ')}\n` +
-                `Fork contributors may use any branch name freely.`
-              );
-              return;
-            }
-
-            console.log('✅ Branch name is valid');
-
-      # -----------------------------------------------------------------------
-      # Step 3: Linked Issue Check (warning only)
-      # -----------------------------------------------------------------------
-      - name: 🔗 Check linked issue
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = context.payload.pull_request.body || '';
-
-            // Accept standard GitHub closing keywords linking to an issue number
-            const closingKeywords = /\b(closes|fixes|resolves|close|fix|resolve)\s+#\d+/i;
-
-            // Accept explicit exemption: no-issue: <reason>
-            const noIssueExemption = /no-issue\s*:/i;
-
-            if (closingKeywords.test(body)) {
-              const match = body.match(/(?:closes|fixes|resolves|close|fix|resolve)\s+#(\d+)/i);
-              console.log(`✅ PR is linked to issue #${match[1]}`);
-              return;
-            }
-
-            if (noIssueExemption.test(body)) {
-              const exemptMatch = body.match(/no-issue\s*:\s*(.+)/i);
-              console.log(`✅ Issue link exempted: ${exemptMatch?.[1]?.trim() || '(no reason given)'}`);
-              return;
-            }
-
-            core.warning(
-              `This PR does not reference a linked issue.\n` +
-              `Add one of the following to your PR description:\n` +
-              `  closes #<number>  /  fixes #<number>  /  resolves #<number>\n` +
-              `If there is genuinely no applicable issue, add:\n` +
-              `  no-issue: <brief reason>\n` +
-              `Create an issue first: https://github.com/alibaba/anolisa/issues/new`
-            );
-
-      # -----------------------------------------------------------------------
-      # Step 4: Summary — always runs, prints consolidated status
-      # -----------------------------------------------------------------------
-      - name: 📊 PR Checks Summary
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            console.log('=== PR Checks Summary ===');
-            console.log('All checks completed. Any warnings above are non-blocking suggestions.');
-            console.log('The only hard error that blocks merging is a missing commit scope.');
-            console.log('See CONTRIBUTING.md or AGENT.md for guidance on commit messages and PR conventions.');
+            await core.summary
+              .addHeading('PR metadata guidance', 3)
+              .addRaw(
+                warnings.length === 0
+                  ? 'No metadata warnings.'
+                  : warnings.map((warning) => `- ${warning}`).join('\n')
+              )
+              .addRaw(
+                '\n\nThese checks are advisory. Commit message lint remains the hard gate. ' +
+                'See CONTRIBUTING.md and AGENTS.md.'
+              )
+              .write();

--- a/.github/workflows/qoder-review.yml
+++ b/.github/workflows/qoder-review.yml
@@ -842,7 +842,7 @@ jobs:
             if grep -qE '^src/os-skills/' "$files_file"; then [[ "$component" == "general" ]] && component="os-skills"; fi
             if grep -qE '^src/copilot-shell/' "$files_file"; then [[ "$component" == "general" ]] && component="copilot-shell"; fi
             if grep -qE '^src/cosh-ng/' "$files_file"; then [[ "$component" == "general" ]] && component="cosh-ng"; fi
-            if grep -qE '^src/(anvil|blaze)/' "$files_file"; then [[ "$component" == "general" ]] && component="blaze"; fi
+            if grep -qE '^src/blaze/' "$files_file"; then [[ "$component" == "general" ]] && component="blaze"; fi
             if grep -qE '^src/ktuner/' "$files_file"; then [[ "$component" == "general" ]] && component="ktuner"; fi
           else
             add_component_context "$component"

--- a/.github/workflows/repository-metadata.yml
+++ b/.github/workflows/repository-metadata.yml
@@ -1,0 +1,55 @@
+name: Repository Metadata
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/components.json"
+      - ".github/labels.json"
+      - ".github/CODEOWNERS"
+      - ".github/maintainers.json"
+      - ".github/commitlint.config.json"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/scripts/validate-repository-metadata.py"
+      - ".github/scripts/test_validate_repository_metadata.py"
+      - ".github/workflows/ci.yaml"
+      - ".github/workflows/prelint.yml"
+      - ".github/workflows/release.yaml"
+      - ".github/workflows/repository-metadata.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/components.json"
+      - ".github/labels.json"
+      - ".github/CODEOWNERS"
+      - ".github/maintainers.json"
+      - ".github/commitlint.config.json"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/scripts/validate-repository-metadata.py"
+      - ".github/scripts/test_validate_repository_metadata.py"
+      - ".github/workflows/ci.yaml"
+      - ".github/workflows/prelint.yml"
+      - ".github/workflows/release.yaml"
+      - ".github/workflows/repository-metadata.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-metadata-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate governance metadata
+    runs-on: anolisa-k8s-general-ci-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate component, label, and routing metadata
+        run: |
+          python3 -m unittest discover \
+            -s .github/scripts \
+            -p 'test_validate_repository_metadata.py'
+          python3 .github/scripts/validate-repository-metadata.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 We welcome contributions! This document covers the basics of contributing to the project.
 
-> **Done coding?** Ask your AI assistant: *"Read AGENT.md and help me generate a commit message and PR description."*
+> **Done coding?** Ask your AI assistant: *"Read AGENTS.md and help me generate a commit message and PR description."*
 
 ## Development Environment
 
@@ -110,6 +110,7 @@ docs(docs): update installation guide
 | Scope | Covers |
 |-------|--------|
 | `cosh` | `src/copilot-shell/` |
+| `cosh-ng` | `src/cosh-ng/` |
 | `sec-core` | `src/agent-sec-core/` |
 | `skill` | `src/os-skills/` |
 | `sight` | `src/agentsight/` |
@@ -118,10 +119,28 @@ docs(docs): update installation guide
 | `memory` | `src/agent-memory/` |
 | `anolisa` | `src/anolisa/` |
 | `skillfs` | `src/skillfs/` |
+| `ktuner` | `src/ktuner/` |
+| `blaze` | `src/blaze/` |
 | `ci` | `.github/workflows/` |
 | `docs` | `docs/` or documentation updates |
 | `deps` | Dependency version bumps (lock files) |
 | `chore` | Other maintenance (config, scripts, tooling) |
+
+If **Commit Message Lint** rejects an existing commit, update the message and
+publish the rewritten branch safely:
+
+```bash
+# Update the latest commit.
+git commit --amend
+git push --force-with-lease
+
+# Update one of the last N commits: select "reword" for the target commit.
+git rebase -i HEAD~N
+git push --force-with-lease
+```
+
+Do not use plain `git push --force`; `--force-with-lease` refuses to overwrite
+remote work that you have not seen.
 
 ### Branch Naming
 
@@ -142,7 +161,7 @@ When you open a PR, the following checks run automatically:
 | Check | Level | How to fix |
 |-------|-------|------------|
 | Commit scope missing | **Error** (blocks merge) | Add `(scope)` to every commit message, e.g. `fix(cosh): ...` |
-| Commit scope not in allowed list | Warning | Use one of the scopes above: `cosh`, `sec-core`, `skill`, `sight`, `tokenless`, `ckpt`, `memory`, `anolisa`, `skillfs`, `ci`, `docs`, `deps`, `chore` |
+| Commit scope not in allowed list | Warning | Use one of the scopes in the table above |
 | PR title format | Warning | Follow `type(scope): description` — same as commit messages |
 | Branch name convention | Warning | Follow `feature/<scope>/<desc>` — not required for forks |
 | PR not linked to an issue | Warning | Add `closes #<n>` to your PR description, or `no-issue: <reason>` |

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -109,6 +109,7 @@ docs(docs): update installation guide
 | Scope | 覆盖范围 |
 |-------|---------|
 | `cosh` | `src/copilot-shell/` |
+| `cosh-ng` | `src/cosh-ng/` |
 | `sec-core` | `src/agent-sec-core/` |
 | `skill` | `src/os-skills/` |
 | `sight` | `src/agentsight/` |
@@ -117,10 +118,28 @@ docs(docs): update installation guide
 | `memory` | `src/agent-memory/` |
 | `anolisa` | `src/anolisa/` |
 | `skillfs` | `src/skillfs/` |
+| `ktuner` | `src/ktuner/` |
+| `blaze` | `src/blaze/` |
 | `ci` | `.github/workflows/` |
 | `docs` | `docs/` 或文档更新 |
 | `deps` | 依赖版本升级（lock 文件） |
 | `chore` | 其他维护（配置、脚本、工具） |
+
+如果 **Commit Message Lint** 拒绝已有提交，请修改 commit message，并安全地
+推送改写后的分支：
+
+```bash
+# 修改最新提交。
+git commit --amend
+git push --force-with-lease
+
+# 修改最近 N 个提交中的一个：将目标 commit 标记为 "reword"。
+git rebase -i HEAD~N
+git push --force-with-lease
+```
+
+不要使用普通的 `git push --force`；`--force-with-lease` 会在远端出现本地未知
+提交时拒绝覆盖。
 
 ### 分支命名
 

--- a/specs/component-onboarding.md
+++ b/specs/component-onboarding.md
@@ -21,7 +21,7 @@ Before code enters `src/`, the following decisions MUST be finalized:
 | Decision | Example | Used in |
 |----------|---------|---------|
 | **Positioning statement** — one sentence + 2–4 expanding sentences | "Per-host sandbox daemon that manages sandbox instance lifecycles via HTTP API." | README §4.4 opening, root README table, AGENTS.md §1 |
-| **Scope name** — short identifier for commits, branches, and CI | `anvil`, `ktuner` | commitlint, prelint, ci.yaml, AGENTS.md §6 |
+| **Scope name** — short identifier for commits, branches, and CI | `blaze`, `ktuner` | commitlint, prelint, ci.yaml, AGENTS.md §6 |
 | **Tech stack** | Rust / Python / TypeScript / Shell | AGENTS.md §1 platform column |
 | **Target platform** | Linux only / Linux + macOS / All | AGENTS.md §1, CI runner selection |
 | **Component form** | daemon / CLI tool / library / skill | Determines conditional deliverables (§3) |


### PR DESCRIPTION
## Why

Component names, commit scopes, issue options, routing labels, CI keys, and
release prefixes need one reviewed source of truth. Keeping these rules in
separate workflows allows repository governance to drift.

## What Changed

- add `.github/components.json` as the reviewed component metadata inventory
- define component owners through `issue_triagers`
- add and validate the planned governance label taxonomy
- validate component uniqueness, Issue Form options, CODEOWNERS annotations,
  maintainer mappings, component status values, and effective triager fallback
- enforce bidirectional consistency so removed components cannot leave stale
  commit scopes, Issue Form options, CODEOWNERS labels, or maintainer scopes
- validate every public component path against its CODEOWNERS label mapping
- make PR scope guidance consume the shared component metadata

## User / Agent Impact

No product runtime behavior changes. Repository automation can validate Codex
component decisions without hard-coded component or owner lists.

## Related Issue

no-issue: repository governance groundwork approved as part of the community
workflow cleanup

## Risk and Compatibility

- [ ] Public CLI/API/config changed
- [ ] Privileged/security-sensitive path changed
- [x] Cross-workflow metadata contract added

This PR does not change existing Issue automation by itself. PR #2066 consumes
the metadata only after this PR is merged.

## Validation

- `python3 .github/scripts/validate-repository-metadata.py`
- governance metadata regression suite — 21 passed
- `git diff --check up/main...HEAD`
- local validation: 13 components and 15 governance labels

## Rollout and Rollback

Merge this PR before #2066. Reverting it removes the metadata contract and must
be paired with pausing the external Issue triage dispatcher.
