### PR TITLE
chore(chore): simplify community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,56 +1,73 @@
 name: Bug Report
-description: Report a bug to help us improve
-title: "bug: "
-labels: ["bug"]
+description: Report something that is not working
+labels: ["type:bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Please prefix the title with `[component]`, e.g. `[cosh] bug: login fails`.
+        Thanks for reporting a problem. A short, reproducible report is enough.
+        Please remove tokens, keys, private addresses, and other sensitive data.
 
-        **Tip:** Run `anolisa bug` to auto-generate diagnostic info, then paste the output into the "Diagnostic Output" field below.
   - type: dropdown
     id: component
     attributes:
       label: Component
-      description: Which component is affected?
+      description: Choose the closest area. Select "not sure" when the boundary is unclear.
       options:
         - anolisa
-        - cosh
-        - cosh-ng
-        - sec-core
-        - skill
-        - sight
         - tokenless
-        - ckpt
-        - memory
+        - cosh-ng
+        - cosh
         - skillfs
+        - sight
+        - sec-core
+        - memory
+        - ckpt
+        - skill
+        - project-wide
+        - not sure
         - other
     validations:
       required: true
+
   - type: textarea
-    id: description
+    id: problem
     attributes:
       label: What happened?
-      description: Describe the bug and how to reproduce it.
+      description: Briefly include the command or operation, the result, and what you expected.
       placeholder: |
-        Bug description:
+        I ran:
+          anolisa ...
 
-        Steps to reproduce:
-        1. Run `anolisa ...`
-        2. Observe ...
+        What happened:
+          ...
 
-        Expected behavior:
+        What I expected:
+          ...
     validations:
       required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: A minimal example is enough. Skip details that are not relevant.
+      placeholder: |
+        1. Install or configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
   - type: textarea
     id: diagnostics
     attributes:
-      label: Diagnostic Output
-      description: Paste the output of `anolisa bug` (or `anolisa bug --capability <name>`).
+      label: Diagnostic output
+      description: Optional. Run `anolisa bug` and remove any secrets or private addresses.
       render: shell
+
   - type: textarea
     id: additional
     attributes:
-      label: Additional Context
-      description: Screenshots, config snippets, or anything else that helps.
+      label: Anything else?
+      description: Optional logs, screenshots, configuration, or context.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,9 @@ blank_issues_enabled: false
 
 contact_links:
   - name: 📖 Documentation / 文档
-    url: https://github.com/alibaba/anolisa/tree/main/docs
-    about: |
-      Check documentation before opening an issue.
+    url: https://agentic-os.sh/docs
+    about: Check the documentation before opening an issue.
+
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/alibaba/anolisa/security/advisories/new
+    about: Report vulnerabilities privately. Do not include security details in a public issue.

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,0 +1,26 @@
+name: Documentation Issue
+description: Report incorrect, missing, unclear, or outdated documentation
+labels: ["type:documentation", "scope:documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Paste a URL, file path, or section name.
+      placeholder: https://agentic-os.sh/docs/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or unclear?
+      description: A short explanation is enough.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      description: Optional. Describe the wording, example, or missing content that would help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,55 +1,55 @@
 name: Feature Request
-description: Suggest an idea for this project
-title: "feat: "
-labels: ["enhancement"]
+description: Suggest an improvement
+labels: ["type:enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        > [!IMPORTANT]
-        > Thanks for suggesting a new feature!
-        > Select the affected component below — the title will be prefixed automatically.
+        Start with the problem and the outcome you need. An implementation proposal is optional.
+
   - type: dropdown
     id: component
     attributes:
       label: Component
-      description: Which component does this feature relate to?
+      description: Choose the closest area. Select "not sure" when the boundary is unclear.
       options:
-        - cosh
-        - cosh-ng
-        - sec-core
-        - skill
-        - sight
-        - tokenless
-        - ckpt
-        - memory
         - anolisa
+        - tokenless
+        - cosh-ng
+        - cosh
         - skillfs
+        - sight
+        - sec-core
+        - memory
+        - ckpt
+        - skill
+        - project-wide
+        - not sure
         - other
     validations:
       required: true
+
   - type: textarea
     id: problem
     attributes:
-      label: Problem Statement
-      description: Is your feature request related to a problem? Please describe.
-      placeholder: I'm always frustrated when...
+      label: What problem are you trying to solve?
+      placeholder: |
+        Today, when I ...
+        I have to ...
+        This is difficult because ...
     validations:
       required: true
+
   - type: textarea
-    id: solution
+    id: outcome
     attributes:
-      label: Proposed Solution
-      description: Describe the solution you'd like.
+      label: What would a useful outcome look like?
+      description: Describe the user or Agent experience rather than the internal implementation.
     validations:
       required: true
+
   - type: textarea
-    id: alternatives
+    id: approach
     attributes:
-      label: Alternatives Considered
-      description: Describe any alternative solutions or features you've considered.
-  - type: textarea
-    id: context
-    attributes:
-      label: Additional Context
-      description: Add any other context, mockups, or screenshots about the feature request here.
+      label: Possible approach
+      description: Optional. Share an implementation idea or workaround if you already have one.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,39 +1,44 @@
 name: Question
-description: Ask a question about the project
-title: "docs: "
-labels: ["question"]
+description: Ask for help using or understanding ANOLISA
+labels: ["type:question"]
 body:
   - type: markdown
     attributes:
       value: |
-        Have a question? Please fill in the details below.
-        For general questions about ANOLISA, you can also check the [documentation](../docs/).
+        Ask a focused question and tell us what you have already tried.
+        Questions remain available here until GitHub Discussions is enabled.
+
   - type: dropdown
     id: component
     attributes:
       label: Component
-      description: Which component does your question relate to?
       options:
-        - cosh
-        - cosh-ng
-        - sec-core
-        - skill
-        - sight
-        - tokenless
-        - ckpt
-        - memory
         - anolisa
+        - tokenless
+        - cosh-ng
+        - cosh
         - skillfs
+        - sight
+        - sec-core
+        - memory
+        - ckpt
+        - skill
+        - project-wide
+        - not sure
         - other
+    validations:
+      required: true
+
   - type: textarea
     id: question
     attributes:
-      label: Your Question
-      description: Please describe your question in detail.
+      label: What do you need help with?
+      description: Include the goal, the command or workflow, and where you became blocked.
     validations:
       required: true
+
   - type: textarea
     id: context
     attributes:
-      label: Context
-      description: What have you already tried? What documentation have you read?
+      label: What have you tried?
+      description: Optional commands, documentation links, logs, or screenshots.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,76 +1,33 @@
-## Description
+## Why
 
-<!-- Provide a clear and concise description of the changes. Include motivation and context. -->
+<!-- What problem does this change solve? Why is it needed now? -->
 
-## Related Issue
+## What changed
 
-<!--
-  REQUIRED: Every PR must be linked to an existing issue.
-  Use one of the closing keywords so the issue closes automatically on merge:
+<!-- Keep this focused on one logical change. -->
 
-    closes #<number>
-    fixes #<number>
-    resolves #<number>
+## Related issue
 
-  If this is a trivial typo / doc-only fix with no issue, write:
-    no-issue: <reason>
--->
+<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
+For a genuinely trivial change, use `no-issue: <brief reason>`. -->
 
-closes #
+## User / Agent impact
 
-## Type of Change
+<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->
 
-<!-- Check all that apply. -->
+## Risk and compatibility
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Refactoring (no functional change)
-- [ ] Performance improvement
-- [ ] CI/CD or build changes
+- [ ] Public CLI, API, configuration, or documented behavior changed
+- [ ] Privileged or security-sensitive behavior changed
+- [ ] Cross-component contract changed
+- [ ] Migration or rollback guidance is needed
 
-## Scope
+<!-- Explain any checked item, or write "Low risk" when none apply. -->
 
-<!-- Which sub-project does this PR affect? -->
+## Validation
 
-- [ ] `cosh` (copilot-shell)
-- [ ] `cosh-ng` (cosh-ng)
-- [ ] `sec-core` (agent-sec-core)
-- [ ] `skill` (os-skills)
-- [ ] `sight` (agentsight)
-- [ ] `tokenless` (tokenless)
-- [ ] `ckpt` (ws-ckpt)
-- [ ] `memory` (agent-memory)
-- [ ] `anolisa` (anolisa-cli)
-- [ ] `skillfs` (SkillFS)
-- [ ] `blaze` (blaze)
-- [ ] Multiple / Project-wide
+<!-- List the relevant tests, commands, environments, or manual checks. -->
 
-## Checklist
+## Documentation and rollback
 
-<!-- Check all that apply. -->
-
-- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
-- [ ] My code follows the project's code style
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have updated the documentation accordingly
-- [ ] For `cosh`: Lint passes, type check passes, and tests pass
-- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
-- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
-- [ ] For `sec-core` (Python): Ruff format and pytest pass
-- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
-- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
-- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
-- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
-- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
-- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
-- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)
-
-## Testing
-
-<!-- Describe the tests you ran and how to reproduce them. -->
-
-## Additional Notes
-
-<!-- Any additional information, screenshots, or context. -->
+<!-- What documentation changed? How can this be reverted or disabled? -->


### PR DESCRIPTION
## Why

The current Issue and PR templates ask contributors to understand internal
component structure and complete long checklists before starting a conversation.
Community intake should collect only the information maintainers need to begin
triage.

## What changed

- reduce Bug and Feature forms to three required inputs
- add `project-wide` and `not sure` component choices
- keep diagnostics, implementation ideas, and extra context optional
- add focused Documentation and Question forms
- add documentation and private security contact routes
- replace the component-wide PR checklist with an impact-oriented template
- align Issue Forms with the repository's `type:*` label taxonomy

## Related issue

no-issue: community intake simplification approved as repository workflow cleanup

## User / Agent impact

New contributors can open a useful Issue in roughly a minute without knowing
the repository's internal architecture. Maintainers retain enough information
for initial triage and can request advanced details when needed.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

Only GitHub community intake behavior changes. Existing Issues and PRs remain
valid, and reverting the template commit restores the previous forms.

## Validation

- parsed every Issue Form as YAML
- `bash scripts/docs-lint.sh`
- `git diff --check up/main...HEAD`

## Documentation and rollback

The templates are the affected workflow documentation. Reverting the single
commit restores the previous intake experience.