### PR TITLE
fix(cosh-ng): [shell] fd dup redirect is not write

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
@@ -3,11 +3,17 @@ use super::command_risk::CommandShape;
 /// Non-persistent output-suppression sink allowlist (issue #1667
 /// implementation boundaries): a `[N]>` / `[N]>>` redirection is treated
 /// as output suppression instead of a filesystem write only when the
-/// target is an unquoted, non-expanded literal from this table. Every
-/// other form (regular files, quoted or expanded targets, `2>&1`, `&>`)
-/// keeps the fail-closed RedirectionWrite high-risk path. Extending this
-/// table requires revisiting the issue #1667 boundaries and the
-/// decision-matrix tests in `command_risk_tests.rs`.
+/// target is an unquoted, non-expanded literal from this table. The fd
+/// words `[N]>&1` / `[N]>&2` (duplication onto the conventional output
+/// targets) and `[N]>&-` (close) are exempted by policy as descriptor
+/// operations, not filesystem writes; see the fd word probe in
+/// `parse_command` for the policy rationale (issue #2054, spec
+/// `shell-fd-dup-redirection-risk`). Every other form (regular files,
+/// quoted or expanded targets, other numeric targets, `&>`, `>&file`,
+/// bash's move form `[N]>&M-`) keeps the fail-closed RedirectionWrite
+/// high-risk path. Extending this table requires revisiting the issue
+/// #1667 boundaries and the decision-matrix tests in
+/// `command_risk_tests.rs`.
 const SAFE_OUTPUT_SINKS: &[&str] = &["/dev/null"];
 
 #[derive(Debug, Clone)]
@@ -121,6 +127,99 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                     && token.bytes().all(|byte| byte.is_ascii_digit());
                 if !fd_candidate {
                     push_token(&mut tokens, &mut token, &mut token_quoted);
+                }
+                // Fd word probe (issue #2054, spec
+                // `shell-fd-dup-redirection-risk`). Policy: exempt only
+                // the conventional output targets — `[N]>&1` / `[N]>&2`
+                // duplication and `[N]>&-` close. Rebinding fd 1/2 to a
+                // file (`exec 2>out`) is possible in the persistent
+                // foreground shell, but that rebinding command is itself
+                // fail-closed High (user-approved first), and once
+                // rebound the file receives output from commands with no
+                // redirection syntax at all, so this lexical classifier
+                // cannot defend that state either way. Auxiliary fds
+                // (`>&3`, `2>&10`) stay fail-closed: their bindings are
+                // only reachable through explicit fd syntax, where
+                // lexical rejection is effective. The source prefix must
+                // be a single digit (zsh treats only a lone digit as an
+                // fd; `tee 10>&1` passes `10` as an argument), and
+                // bash's move form `[N]>&M-` is excluded (zsh parses it
+                // as a redirection to a file named `M-`). Non-consuming
+                // and fail-closed: every rejected form falls through
+                // byte-for-byte to the pre-existing path. Full trade-off
+                // record: spec `shell-fd-dup-redirection-risk`
+                // design.md (matrix + invariant I0).
+                let single_digit_prefix = !fd_candidate || token.len() == 1;
+                if !guarded && single_digit_prefix && chars.peek().is_some_and(|next| *next == '&')
+                {
+                    let mut dup_lookahead = chars.clone();
+                    dup_lookahead.next();
+                    let mut dup_consumed = 1usize;
+                    let mut target_digit: Option<char> = None;
+                    if dup_lookahead
+                        .peek()
+                        .is_some_and(|next| next.is_ascii_digit())
+                    {
+                        target_digit = dup_lookahead.next();
+                        dup_consumed += 1;
+                    }
+                    // Only fd 1 and fd 2 are safe duplication targets; a
+                    // second digit (`2>&10`) or any other digit (`>&3`)
+                    // rejects the elision.
+                    let has_digit = matches!(target_digit, Some('1') | Some('2'))
+                        && !dup_lookahead
+                            .peek()
+                            .is_some_and(|next| next.is_ascii_digit());
+                    let mut has_dash = false;
+                    if target_digit.is_none()
+                        && dup_lookahead.peek().is_some_and(|next| *next == '-')
+                    {
+                        dup_lookahead.next();
+                        dup_consumed += 1;
+                        has_dash = true;
+                    }
+                    // Keep the workspace Rust 1.74 MSRV; `Option::is_none_or`
+                    // is newer.
+                    #[allow(clippy::unnecessary_map_or)]
+                    let boundary_ok = dup_lookahead.peek().map_or(true, |next| {
+                        // Word boundary = whitespace or a POSIX operator
+                        // character. `{`/`}` are NOT operators in the
+                        // redirection-word position: both bash and zsh
+                        // parse `: >&1{` as a redirection to a file named
+                        // `1{`, so they must reject
+                        // the elision and fail closed.
+                        matches!(
+                            next,
+                            ' ' | '\t' | '\n' | ';' | '|' | '&' | '<' | '>' | '(' | ')'
+                        )
+                    });
+                    if (has_digit || has_dash) && boundary_ok {
+                        for _ in 0..dup_consumed {
+                            chars.next();
+                        }
+                        // Close forms (`[N]>&-`) suppress the stream from
+                        // the user's point of view only when they close an
+                        // output stream: the bare default (stdout), fd 1,
+                        // or fd 2. Closing stdin or an auxiliary fd
+                        // (`0>&-`, `3>&-`) leaves the visible output
+                        // untouched (verified in bash and zsh), so those
+                        // stay annotation-free like duplications.
+                        let closes_output_stream =
+                            has_dash && (!fd_candidate || token == "1" || token == "2");
+                        if fd_candidate {
+                            // The IO_NUMBER prefix (the `2` in `2>&1`)
+                            // belongs to the redirection syntax, not argv.
+                            token.clear();
+                            token_quoted = false;
+                        }
+                        // Output-closing forms join the issue #1667
+                        // null-sink channel (`output-suppressed` reason +
+                        // auto-allow fallback).
+                        if closes_output_stream {
+                            null_redirections += 1;
+                        }
+                        continue;
+                    }
                 }
                 // Non-consuming lookahead: on rejection fall back to a path
                 // that is byte-for-byte identical to the pre-fix behavior.

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -651,7 +651,9 @@ fn complex_shapes_with_null_redirection_keep_pre_fix_classification() {
     }
 
     // Lexical fail-closed forms outside the strippable set (design v3 §1).
-    for command in ["ls >| out.txt", "echo hi >&2", "ls > /dev/nul*"] {
+    // `echo hi >&2` moved to the fd-duplication elision cases (issue
+    // #2054, spec shell-fd-dup-redirection-risk).
+    for command in ["ls >| out.txt", "ls > /dev/nul*"] {
         let assessment = ask(command);
         assert_eq!(assessment.impact, RiskImpact::High, "{command}");
         assert!(
@@ -684,20 +686,17 @@ fn redirection_fail_closed_paths_stay_high() {
         );
     }
 
-    // V-M9: fd duplication and `&>` are out of scope, behavior unchanged.
-    for command in ["ls 2>&1", "ls &>/dev/null"] {
-        let assessment = ask(command);
-        assert_eq!(assessment.impact, RiskImpact::High, "{command}");
-        assert!(
-            assessment.reasons.contains(&"redirection-write"),
-            "{command}: {:?}",
-            assessment.reasons
-        );
-        assert!(
-            !assessment.reasons.contains(&"output-suppressed"),
-            "{command}"
-        );
-    }
+    // V-M9 (re-anchored by issue #2054): `&>` merges both streams into a
+    // file and stays High; `ls 2>&1` moved to the fd-duplication elision
+    // cases (spec shell-fd-dup-redirection-risk).
+    let amp_merge = ask("ls &>/dev/null");
+    assert_eq!(amp_merge.impact, RiskImpact::High);
+    assert!(
+        amp_merge.reasons.contains(&"redirection-write"),
+        "{:?}",
+        amp_merge.reasons
+    );
+    assert!(!amp_merge.reasons.contains(&"output-suppressed"));
 }
 
 #[test]
@@ -749,4 +748,198 @@ fn adjacent_words_before_null_redirection_use_default_fd() {
         "quoted argument must be preserved, got {:?}",
         parsed.stages
     );
+}
+
+#[test]
+fn fd_duplication_is_not_redirection_write() {
+    // V-F1/V-F2/V-F4 (spec shell-fd-dup-redirection-risk,
+    // issue #2054): `[N]>&1` / `[N]>&2` duplicate onto the
+    // conventional stdout/stderr streams without touching the
+    // filesystem in bash or zsh, and keep the stream visible, so the
+    // command keeps the risk of its remaining real shape with no
+    // suppression annotation. The trailing-space form exercises the
+    // word boundary at end of input.
+    for command in [
+        "ls 2>&1",
+        "ls 2>&1 ",
+        "cat f 2>&1",
+        "cosh --version 2>&1",
+        "echo hi >&2",
+        "ls 1>&2",
+        // Closing stdin or an auxiliary fd leaves visible output
+        // untouched (verified in bash and zsh), so these carry no
+        // suppression annotation either.
+        "ls 0>&-",
+        "ls 3>&-",
+    ] {
+        let assessment = ask(command);
+        assert_ne!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            !assessment.reasons.contains(&"redirection-write"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+        assert!(
+            !assessment.reasons.contains(&"output-suppressed"),
+            "{command}: fd duplication is not output suppression"
+        );
+    }
+
+    // V-F5: close
+    // forms that hit an output stream (bare default, fd 1, fd 2)
+    // suppress user-visible output, so they join the issue #1667
+    // null-sink channel: still not a write, but annotated
+    // `output-suppressed` and never auto-allowed.
+    for command in ["ls 2>&-", "ls 1>&-", "ls >&-"] {
+        let assessment = ask(command);
+        assert_ne!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            !assessment.reasons.contains(&"redirection-write"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+        assert!(
+            assessment.reasons.contains(&"output-suppressed"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+        let auto_policy = auto(command);
+        assert_eq!(
+            auto_policy.execution,
+            ExecutionDecision::AskUser,
+            "{command}"
+        );
+        assert!(auto_policy.auto_allow.is_none(), "{command}");
+    }
+
+    // I3: redirection syntax (IO_NUMBER prefix and `&M[-]` word) must not
+    // leak into argv, and ordinary arguments must be preserved.
+    let parsed = super::command_risk_parser::parse_command("ls 2>&1");
+    assert_eq!(parsed.shape, CommandShape::Simple);
+    assert_eq!(parsed.stages, vec![vec!["ls".to_string()]]);
+    let hi = super::command_risk_parser::parse_command("echo hi >&2");
+    assert_eq!(hi.shape, CommandShape::Simple);
+    assert_eq!(hi.stages, vec![vec!["echo".to_string(), "hi".to_string()]]);
+    let multi_digit = super::command_risk_parser::parse_command("ls 2>&1");
+    assert_eq!(multi_digit.shape, CommandShape::Simple);
+    assert_eq!(multi_digit.stages, vec![vec!["ls".to_string()]]);
+    // Multi-digit source prefixes fail closed AND keep the word as an
+    // ordinary argument, matching zsh which passes `10` to the command
+    //.
+    let multi_src = super::command_risk_parser::parse_command("tee 10>&1");
+    assert!(
+        multi_src.stages[0].contains(&"10".to_string()),
+        "zsh passes 10 as an argument, got {:?}",
+        multi_src.stages
+    );
+}
+
+#[test]
+fn fd_duplication_compound_and_pipeline_keep_segment_assessment() {
+    // V-F3: the issue #2054 field shape is assessed per segment via the
+    // issue #1785 aggregation path instead of failing closed to High.
+    let compound = ask("rtk ls -la /usr/share/x 2>&1 && echo --- && rtk ls -la /tmp/y 2>&1");
+    assert_eq!(compound.shape, CommandShape::AndOrList);
+    assert_ne!(compound.impact, RiskImpact::High, "{:?}", compound.reasons);
+    assert!(!compound.reasons.contains(&"redirection-write"));
+    assert_eq!(compound.execution, ExecutionDecision::AskUser);
+
+    // Boundary directly after the duplication word (no separating space).
+    let adjacent = ask("ls 2>&1&&echo ok");
+    assert_eq!(adjacent.shape, CommandShape::AndOrList);
+    assert_ne!(adjacent.impact, RiskImpact::High, "{:?}", adjacent.reasons);
+
+    // V-F8: pipeline stages keep their own assessment.
+    let piped = ask("ls 2>&1 | grep x");
+    assert_eq!(piped.shape, CommandShape::Pipeline);
+    assert_ne!(piped.impact, RiskImpact::High, "{:?}", piped.reasons);
+
+    // High-risk remaining commands are never masked by fd duplication.
+    let delete = ask("rm -rf /tmp/x 2>&1");
+    assert_eq!(delete.impact, RiskImpact::High);
+    assert!(delete.reasons.contains(&"filesystem-delete"));
+}
+
+#[test]
+fn fd_duplication_lookalikes_fail_closed_to_high() {
+    // M9-M13: anything but a strict cross-shell `[N]>&digits` /
+    // `[N]>&-` word up to a word boundary keeps the pre-fix
+    // RedirectionWrite path, so every blind spot stays conservative.
+    // Bash's move form `2>&1-` fails closed too: zsh parses it as a
+    // real redirection to a file named `1-`. `{`/`}` are not operators in the
+    // redirection-word position (both shells write a file named `1{`
+    // for `>&1{`), so they are not word boundaries either.
+    for command in [
+        "ls 2>&1x",
+        "ls 2>&x",
+        "ls 2>&$FD",
+        "ls 2>&\"1\"",
+        "ls 2>&\\1",
+        "ls 2>&1-",
+        "ls >&1{",
+        "ls >&1}",
+        "ls >&-{",
+        // Multi-digit SOURCE prefixes are shell-divergent: zsh only
+        // treats a lone digit before the operator as an fd, so
+        // `tee 10>&1` keeps `10` as an argument and creates a file
+        // named `10`.
+        "tee 10>&1",
+        "ls 10>&-",
+        // Arbitrary numeric TARGETS are state-dependent in the
+        // persistent foreground shell: after `exec 3>out`, both bash
+        // and zsh write `printf x >&3` into the file `out`; same for
+        // `2>&10` once fd 10 is bound.
+        "printf payload >&3",
+        "ls 2>&10",
+        "ls 2>&3",
+        // The fd 1/2 exemption's precondition: rebinding
+        // stdout/stderr requires an `exec [N]>file` style command,
+        // which is itself fail-closed High and user-approved before
+        // any `>&2` elision could matter.
+        "exec 2>out",
+        "exec 1>out",
+        "ls >&file",
+        "ls 2>&file",
+        "ls &>f",
+        "ls &>>f",
+        "ls &>&1",
+        "ls 2>& 1",
+        "ls 2>>&1",
+    ] {
+        let assessment = ask(command);
+        assert_eq!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            assessment.reasons.contains(&"redirection-write"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+    }
+}
+
+#[test]
+fn fd_duplication_execution_boundary_stays_closed() {
+    // I2/R3.2: fd duplication never widens auto-execution; the hard
+    // gates keep rejecting the raw `>` byte in the original command.
+    assert!(can_run_approved_bash_tool("ls 2>&1").is_err());
+    assert!(validate_guarded_diagnostic("ps aux --sort=-%mem 2>&1").is_err());
+    assert!(validate_readonly_pipeline("ps aux 2>&1 | head -1").is_err());
+
+    let auto_policy = auto("ls 2>&1");
+    assert_eq!(auto_policy.execution, ExecutionDecision::AskUser);
+    assert!(auto_policy.auto_allow.is_none());
+}
+
+#[test]
+fn fd_duplication_and_null_suppression_compose_independently() {
+    // M16: both elisions apply on one command, still not a write.
+    let mixed = ask("ls 2>&1 >/dev/null");
+    assert_ne!(mixed.impact, RiskImpact::High, "{:?}", mixed.reasons);
+    assert!(!mixed.reasons.contains(&"redirection-write"));
+    assert!(mixed.reasons.contains(&"output-suppressed"));
+
+    // M15: the issue #1667 null-suppression path is untouched, and fd
+    // duplication alone never contributes an output-suppressed reason.
+    let null_only = ask("df -h 2>/dev/null");
+    assert!(null_only.reasons.contains(&"output-suppressed"));
+    assert!(!null_only.reasons.contains(&"redirection-write"));
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -824,8 +824,7 @@ fn fd_duplication_is_not_redirection_write() {
     assert_eq!(multi_digit.shape, CommandShape::Simple);
     assert_eq!(multi_digit.stages, vec![vec!["ls".to_string()]]);
     // Multi-digit source prefixes fail closed AND keep the word as an
-    // ordinary argument, matching zsh which passes `10` to the command
-    //.
+    // ordinary argument, matching zsh which passes `10` to the command.
     let multi_src = super::command_risk_parser::parse_command("tee 10>&1");
     assert!(
         multi_src.stages[0].contains(&"10".to_string()),

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 646
+check_overlap_ceiling cosh-shell cosh-shell 651
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
# Summary

`2>&1`-style fd duplication is parsed with an empty redirection target, misses the `/dev/null` allowlist, and fails closed to the `RedirectionWrite` shape, so every read-only command carrying `2>&1` is reported as **high risk / write redirection** on the approval card and requires a manual Allow (issue #2054; boundary inherited from issue #1667, whose spec explicitly deferred fd duplication to a follow-up).

This PR exempts by policy the **conventional output targets** — `[N]>&1` / `[N]>&2` (duplication) and `[N]>&-` (close) — from the write-redirection escalation. The command then keeps the risk of its real remaining shape (e.g. `ls 2>&1` → medium AskUser instead of high). The policy rationale (review rounds 6–8): rebinding fd 1/2 (`exec 2>out`) is possible in the persistent foreground shell, but that rebinding command is itself fail-closed High and user-approved first, and once rebound the file receives output from commands with no redirection syntax at all — a lexical classifier cannot defend that state either way. Arbitrary numeric targets (`>&3`, `2>&10`) stay fail-closed: their bindings are only reachable through explicit fd syntax, where lexical rejection is effective. Bash's move form `[N]>&M-` is not elided either: zsh has no move syntax and really writes a file named `M-` (review round 2).

# Changes

- `crates/cosh-shell/src/tools/command_risk_parser.rs`: fd word probe at the head of the `'>'` arm.
  - Recognition requires **all** of: not `&>`-led (`amp_redirect_guard`), not `>>`, a single-digit-or-absent source prefix (zsh treats only a lone digit as an fd — `tee 10>&1` passes `10` as an argument and creates a file named `10`, review round 5), `&` followed by exactly `1`, `2`, or `-` (conventional output targets only, review round 6), and a word boundary right after. The boundary set is whitespace plus POSIX operator characters (`;|&<>()`) only — `{`/`}` are not operators in the redirection-word position (both bash and zsh write a file named `1{` for `>&1{`, review round 3) and are not boundaries. Anything else falls through **byte-for-byte** to the pre-existing fail-closed path, so every blind spot stays conservative (mis-conservative, never mis-permissive).
  - On recognition the IO_NUMBER prefix (`2` in `2>&1`) and the fd word are consumed as redirection syntax (no argv leakage) and the shape is not raised. Duplications add no reason; closes of an **output stream** (bare default, fd 1, fd 2) hide user-visible output and join the issue #1667 null-sink channel (`output-suppressed`, never auto-allowed; review round 1), while `0>&-`/`3>&-` keep visible output untouched and elide without annotation (review round 4).
- `crates/cosh-shell/src/tools/command_risk_tests.rs`: decision-matrix tests (elision positives incl. `>&2`, trailing-space `ls 2>&1 `, `0>&-`/`3>&-`; suppression-annotated closes `2>&-`/`1>&-`/`>&-`; fail-closed lookalikes incl. `2>&1x`, `2>&$FD`, `2>&1-`, `>&1{`, `>&1}`, `>&-{`, `tee 10>&1`, `10>&-`, `printf payload >&3`, `2>&10`, `2>&3`, `>&file`, `&>&1`, `2>& 1`, `2>>&1`), invariant tests (argv preservation incl. zsh-semantics `10`, `&&` boundary, high-risk tails never masked), and execution-boundary anchors (three auto-allow hard gates keep rejecting the raw `>`; `ls 2>&1` is never AutoAllow).
  - Re-anchored: V-M9 `ls 2>&1` moved to the elision cases (`ls &>/dev/null` stays High); design v3 §1 `echo hi >&2` moved likewise (`ls >| out.txt`, `ls > /dev/nul*` unchanged).
- `scripts/check-test-inventory.sh`: cosh-shell exact lib/bin overlap ceiling 646 → 651 (five new tests in the shared tools module; measured via `cargo test -- --list` on both targets).

# Tests

- New: `fd_duplication_is_not_redirection_write`, `fd_duplication_compound_and_pipeline_keep_segment_assessment`, `fd_duplication_lookalikes_fail_closed_to_high`, `fd_duplication_execution_boundary_stays_closed`, `fd_duplication_and_null_suppression_compose_independently`.
- Review-round regressions: `2>&1-` (zsh writes `1-`), `>&1{`/`>&1}`/`>&-{` (`{}` not a boundary; both shells write `1{`), close forms annotated `output-suppressed`, trailing-space boundary case.
- FAIL→PASS: pre-fix probe on base `e8a9b8ff` asserts `ask("ls 2>&1")` is not High → FAILED; same assertions pass post-fix (now the permanent regression tests above).

# Verification

- Focused (macOS host, worktree): `cargo test -p cosh-shell --lib` 1179 passed / 0 failed; `--bin cosh-shell` 2205 passed / 0 failed / 1 ignored (pre-existing); `cargo clippy -p cosh-shell --all-targets` clean; `cargo fmt --check` clean.
- CI gates run locally: `check-layout.sh` pass, `check-test-inventory.sh` pass (ceiling updated to measured 651).
- Real-machine acceptance (alinux3 arm64 container, real `cosh-shell raw` + real `cosh-core` headless + real provider): agent-dispatched `ls -la /tmp 2>&1` now surfaces an approval card reading **`Bash · 中风险`** with the command verbatim and no write-redirection reason; after Allow the command executes (exit 0) and the turn completes. Scripted-PTY case green, evidence verify passed.
- Excluded scope (not run): full workspace tests on linux; the raw_cli signal-semantics suite fails identically on base and on this branch in the local container backend (no init/zombie reaping; A/B verified) and defers to GitHub CI as the authority.

# Evidence

Real-machine acceptance (alinux3 arm64 container, real cosh-core adapter over a real PTY, scripted case FDDUP-APPR-001; screenshots derived from the sanitized cast of this branch's binaries):

**Approval card after the fix — `Bash · 中风险` (medium), command verbatim, no write-redirection reason** (before the fix this exact shape rendered `Bash · high risk` + `Risk: write redirection`, see issue #2054):

![approval card medium risk](https://raw.githubusercontent.com/SunnyQjm/anolisa/6aeac18b6bd632d843f614512dc23203f9aa8561/approval-card-risk-line.png)

**Final state — command approved, executed (exit 0), agent summarized, session exited cleanly:**

![final state](https://raw.githubusercontent.com/SunnyQjm/anolisa/6aeac18b6bd632d843f614512dc23203f9aa8561/fd-dup-final.png)

Closes #2054
