### PR TITLE
fix(sight): extract cache tokens and user query for cosh-ng/DashScope

### DIFF
--- a/src/agentsight/src/analyzer/token/mod.rs
+++ b/src/agentsight/src/analyzer/token/mod.rs
@@ -165,13 +165,27 @@ pub fn extract_usage_object(
         }
     };
 
-    // Extract cache tokens (Anthropic-specific)
+    // Extract cache tokens.
+    //
+    // Anthropic reports two separate counters: `cache_creation_input_tokens`
+    // (write) and `cache_read_input_tokens` (hit).
+    //
+    // OpenAI nests cache hits under `prompt_tokens_details.cached_tokens`;
+    // DashScope may surface them at the top level as `cached_tokens`.
+    // Both are read-only hits — there is no separate write counter.
     let cache_creation_input_tokens = usage
         .get("cache_creation_input_tokens")
         .and_then(|v| v.as_u64());
     let cache_read_input_tokens = usage
         .get("cache_read_input_tokens")
-        .and_then(|v| v.as_u64());
+        .and_then(|v| v.as_u64())
+        .or_else(|| {
+            usage
+                .get("prompt_tokens_details")
+                .and_then(|d| d.get("cached_tokens"))
+                .and_then(|v| v.as_u64())
+        })
+        .or_else(|| usage.get("cached_tokens").and_then(|v| v.as_u64()));
 
     // Extract model name
     let model = full_json

--- a/src/agentsight/src/analyzer/token/parser.rs
+++ b/src/agentsight/src/analyzer/token/parser.rs
@@ -293,6 +293,57 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_openai_usage_with_cached_tokens() {
+        // OpenAI nests cache hits under prompt_tokens_details.cached_tokens.
+        let parser = TokenParser::new();
+        let data = r#"{
+            "id": "chatcmpl-456",
+            "model": "gpt-4o",
+            "usage": {
+                "prompt_tokens": 10000,
+                "completion_tokens": 50,
+                "total_tokens": 10050,
+                "prompt_tokens_details": {
+                    "cached_tokens": 8500
+                }
+            }
+        }"#;
+
+        let event = create_test_event(data);
+        let usage = parser.parse_event(&event).expect("should parse");
+        assert_eq!(usage.input_tokens, 10000);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_input_tokens, Some(8500));
+        assert_eq!(usage.cache_creation_input_tokens, None);
+        assert_eq!(usage.provider, LLMProvider::OpenAI);
+    }
+
+    #[test]
+    fn test_parse_dashscope_usage_with_cached_tokens() {
+        // DashScope may surface cached_tokens at the top level of the usage
+        // object instead of nesting under prompt_tokens_details.
+        let parser = TokenParser::new();
+        let data = r#"{
+            "id": "chatcmpl-789",
+            "model": "qwen3.5-plus",
+            "usage": {
+                "prompt_tokens": 9800,
+                "completion_tokens": 120,
+                "total_tokens": 9920,
+                "cached_tokens": 9000
+            }
+        }"#;
+
+        let event = create_test_event(data);
+        let usage = parser.parse_event(&event).expect("should parse");
+        assert_eq!(usage.input_tokens, 9800);
+        assert_eq!(usage.output_tokens, 120);
+        assert_eq!(usage.cache_read_input_tokens, Some(9000));
+        assert_eq!(usage.cache_creation_input_tokens, None);
+        assert_eq!(usage.provider, LLMProvider::OpenAI);
+    }
+
+    #[test]
     fn test_skip_done_marker() {
         let parser = TokenParser::new();
 

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -445,7 +445,18 @@ impl GenAIBuilder {
 
     /// 去除 user message 中的 metadata 前缀，只保留用户实际输入的文本
     ///
-    /// OpenClaw 等 Agent 会在 user message 前面加上元数据，格式如：
+    /// 支持的 Agent prompt 模板格式：
+    ///
+    /// **cosh-ng**: user_input 标记行
+    /// ```text
+    /// Handle this natural-language shell prompt request ...
+    /// ...
+    /// user_input: 查看一下系统状态
+    ///
+    /// runtime_frame:
+    /// ```
+    ///
+    /// **OpenClaw**: 时间戳方括号
     /// ```text
     /// Sender (untrusted metadata):
     /// ```json
@@ -455,7 +466,21 @@ impl GenAIBuilder {
     /// [Tue 2026-03-31 17:19 GMT+8] 用户实际输入
     /// ```
     pub(super) fn strip_user_query_prefix(text: &str) -> String {
-        // 查找最后一个 [timestamp] 模式，取其后的内容
+        // cosh-ng: find a line starting with "user_input:" (after trimming)
+        // and extract its value. This line-by-line approach tolerates template
+        // adjustments such as indentation changes, missing leading newlines,
+        // or extra whitespace around the marker.
+        for line in text.lines() {
+            let trimmed = line.trim_start();
+            if let Some(value) = trimmed.strip_prefix("user_input:") {
+                let extracted = value.trim();
+                if !extracted.is_empty() {
+                    return extracted.to_string();
+                }
+            }
+        }
+
+        // OpenClaw: 查找最后一个 [timestamp] 模式，取其后的内容
         // 格式: [Day YYYY-MM-DD HH:MM TZ] 或 [Day, DD Mon YYYY HH:MM:SS TZ]
         if let Some(pos) = text.rfind(']') {
             // 确认 ] 前面有对应的 [
@@ -756,6 +781,28 @@ mod tests {
     fn test_strip_user_query_prefix_with_timestamp() {
         let text = "Sender (untrusted metadata):\n```json\n{}\n```\n\n[Tue 2026-03-31 17:19 GMT+8] hello world";
         assert_eq!(GenAIBuilder::strip_user_query_prefix(text), "hello world");
+    }
+
+    #[test]
+    fn test_strip_user_query_prefix_cosh_ng_user_input() {
+        let text = "Handle this natural-language shell prompt request for a Shell-first assistant.\n\
+                     Decide based on user intent:\n\
+                     - If the user wants to DO something...\n\n\
+                     user_input: 查看一下系统状态\n\n\
+                     runtime_frame:\n\
+                     cwd: ~\n\n\
+                     cosh-shell Agent contract:";
+        assert_eq!(
+            GenAIBuilder::strip_user_query_prefix(text),
+            "查看一下系统状态"
+        );
+    }
+
+    #[test]
+    fn test_strip_user_query_prefix_cosh_ng_indented() {
+        // Template with indentation before user_input: marker
+        let text = "  Some preamble text\n  user_input: 检查磁盘空间\n\nruntime_frame:";
+        assert_eq!(GenAIBuilder::strip_user_query_prefix(text), "检查磁盘空间");
     }
 
     #[test]


### PR DESCRIPTION
## Description

AgentSight failed to capture two data fields for cosh-ng LLM calls using DashScope provider:

1. **cache_read_tokens**: `extract_usage_object` only parsed Anthropic-format cache fields (`cache_read_input_tokens`). Added fallbacks for OpenAI (`prompt_tokens_details.cached_tokens`) and DashScope (top-level `cached_tokens`) so cache hits are captured regardless of provider.

2. **user_query**: `strip_user_query_prefix` only handled OpenClaw timestamp markers. Added extraction for cosh-ng adapter prompt template where the real user input follows a `user_input: ` marker line, terminated by a blank line or the next section header.

Both fixes are backward-compatible: Anthropic format retains highest priority, OpenAI/DashScope serve as fallbacks; existing OpenClaw timestamp stripping remains unchanged.

## Related Issue

closes #2033

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- Deployed to test machines (8.154.45.123, 47.243.235.37) with cosh-ng traffic
- Verified `cache_read_tokens` correctly captured for DashScope calls (e.g., 6272 cached tokens on cache-hit calls)
- Verified `user_query` now shows actual user input (e.g., "查看一下系统状态") instead of the full 3677-char adapter prompt
- `cargo test --lib`: 1258 tests pass, including 3 new tests for the fixes
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

## Additional Notes

The ATIF detail page cache token display requires a separate enhancement to the trajectory store → API → Dashboard pipeline, which is tracked as a follow-up.