### PR TITLE
fix(cosh): prevent shell recovery storms

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
@@ -1,5 +1,5 @@
 use crate::evidence::{provider_safe_command_fact_line, terminal_output_id};
-use crate::types::{AgentEvent, AgentRequest, QuestionSelectionMode};
+use crate::types::{AgentEvent, AgentRequest, QuestionSelectionMode, PROVIDER_TIMEOUT_ERROR_CODE};
 
 use super::{AdapterError, AgentAdapter, AgentBackendCapabilities};
 use control_protocol::emit_fake_control_protocol_stream;
@@ -134,7 +134,7 @@ impl AgentAdapter for FakeAgentAdapter {
                     return Ok(vec![AgentEvent::AgentFailed {
                         run_id,
                         error: "Agent timed out: No provider response within 20s".to_string(),
-                        error_code: None,
+                        error_code: Some(PROVIDER_TIMEOUT_ERROR_CODE.to_string()),
                         max_turns: None,
                     }]);
                 }
@@ -147,7 +147,7 @@ impl AgentAdapter for FakeAgentAdapter {
                     return Ok(vec![AgentEvent::AgentFailed {
                         run_id,
                         error: "Agent timed out: No provider response within 20s".to_string(),
-                        error_code: None,
+                        error_code: Some(PROVIDER_TIMEOUT_ERROR_CODE.to_string()),
                         max_turns: None,
                     }]);
                 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/process.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use nix::libc;
 
-use crate::types::AgentEvent;
+use crate::types::{AgentEvent, PROVIDER_TIMEOUT_ERROR_CODE};
 
 use super::{
     AdapterError, PreparedInvocation, ProviderCancellationArtifact,
@@ -245,7 +245,7 @@ pub(crate) fn run_provider_process_loop(
             let _ = sender.send(Ok(AgentEvent::AgentFailed {
                 run_id,
                 error: timeout_failure_message(provider_label, timeout, &stderr_tail.snapshot()),
-                error_code: None,
+                error_code: Some(PROVIDER_TIMEOUT_ERROR_CODE.to_string()),
                 max_turns: None,
             }));
             return ProviderRunOutcome::Failed;

--- a/src/cosh-ng/crates/cosh-shell/src/agent/continuation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/continuation.rs
@@ -1,13 +1,14 @@
-use std::time::Duration;
-
 use crate::agent::run::ActiveAgentRun;
 use crate::runtime::prelude::*;
+use crate::types::PROVIDER_TIMEOUT_ERROR_CODE;
 
 #[cfg(test)]
 const SHELL_HANDOFF_CONTINUATION_HINT: &str = crate::types::SHELL_HANDOFF_CONTINUATION_HINT;
 const SHELL_HANDOFF_RECOVERY_OWNER_HINT: &str = "shell handoff recovery owner:";
 const DISABLE_PROVIDER_RESUME_HINT: &str = "disable provider resume for shell handoff fallback";
-const SHELL_HANDOFF_FIRST_TEXT_TIMEOUT: Duration = Duration::from_secs(15);
+const SHELL_HANDOFF_FALLBACK_REASON_HINT: &str = "shell handoff fallback reason:";
+const RESUME_FAILED_REASON: &str = "resume_failed";
+const PROVIDER_TIMEOUT_REASON: &str = "provider_timeout";
 
 pub(crate) fn run_request_is_analysis_only_continuation(
     run_request: Option<&AgentRequest>,
@@ -55,10 +56,23 @@ fn run_request_is_shell_handoff_recovery_continuation(request: &AgentRequest) ->
             .any(|hint| hint.contains(SHELL_HANDOFF_RECOVERY_OWNER_HINT))
 }
 
+pub(crate) fn shell_handoff_recovery_approval_id(request: &AgentRequest) -> Option<&str> {
+    request.context_hints.iter().find_map(|hint| {
+        hint.strip_prefix(SHELL_HANDOFF_RECOVERY_OWNER_HINT)
+            .map(str::trim)
+            .and_then(|owner| owner.split('/').next())
+            .filter(|approval_id| !approval_id.is_empty())
+    })
+}
+
 pub(crate) fn render_fresh_turn_recovery_notice<W: Write>(
     state: &InlineState,
     output: &mut W,
+    reason: &str,
 ) -> std::io::Result<()> {
+    let reason_line = state
+        .i18n()
+        .format(MessageId::AgentRecoveryTriggerLine, &[("reason", reason)]);
     RatatuiInlineRenderer::for_terminal()
         .with_language(state.language)
         .write_notice_panel(
@@ -74,6 +88,7 @@ pub(crate) fn render_fresh_turn_recovery_notice<W: Write>(
                         .i18n()
                         .t(MessageId::AgentRecoveryContinuityBody)
                         .to_string(),
+                    reason_line,
                 ],
                 footer: None,
             },
@@ -82,23 +97,27 @@ pub(crate) fn render_fresh_turn_recovery_notice<W: Write>(
 
 pub(crate) fn shell_handoff_resume_fallback_request(
     active_run: &ActiveAgentRun,
-) -> Option<(AgentRequest, AgentRunOrigin)> {
-    let failed = active_run.governed_events.iter().any(|event| {
-        matches!(
-            &event.event,
-            AgentEvent::AgentFailed { .. } | AgentEvent::AgentCancelled { .. }
+) -> Option<(AgentRequest, AgentRunOrigin, &'static str)> {
+    let reason = active_run.governed_events.iter().rev().find_map(|event| {
+        let AgentEvent::AgentFailed { error_code, .. } = &event.event else {
+            return None;
+        };
+        Some(
+            if error_code.as_deref() == Some(PROVIDER_TIMEOUT_ERROR_CODE) {
+                PROVIDER_TIMEOUT_REASON
+            } else {
+                RESUME_FAILED_REASON
+            },
         )
     });
-    if !failed {
-        return None;
-    }
 
-    shell_handoff_resume_fallback_request_without_failure(active_run)
+    shell_handoff_resume_fallback_request_for_reason(active_run, reason?)
 }
 
-fn shell_handoff_resume_fallback_request_without_failure(
+fn shell_handoff_resume_fallback_request_for_reason(
     active_run: &ActiveAgentRun,
-) -> Option<(AgentRequest, AgentRunOrigin)> {
+    reason: &'static str,
+) -> Option<(AgentRequest, AgentRunOrigin, &'static str)> {
     if !run_request_is_shell_handoff_recovery_continuation(&active_run.request) {
         return None;
     }
@@ -119,20 +138,8 @@ fn shell_handoff_resume_fallback_request_without_failure(
         .push(DISABLE_PROVIDER_RESUME_HINT.to_string());
     request
         .context_hints
-        .push("fresh-turn fallback after shell handoff continuation resume failure".to_string());
-    Some((request, active_run.origin))
-}
-
-pub(crate) fn shell_handoff_first_text_fallback_request(
-    active_run: &ActiveAgentRun,
-) -> Option<(AgentRequest, AgentRunOrigin)> {
-    if active_run.has_visible_text_delta {
-        return None;
-    }
-    if active_run.started_at.elapsed() < SHELL_HANDOFF_FIRST_TEXT_TIMEOUT {
-        return None;
-    }
-    shell_handoff_resume_fallback_request_without_failure(active_run)
+        .push(format!("{SHELL_HANDOFF_FALLBACK_REASON_HINT} {reason}"));
+    Some((request, active_run.origin, reason))
 }
 
 #[cfg(test)]
@@ -171,7 +178,7 @@ mod tests {
             policy_decision: GovernancePolicyDecision::AuditOnly,
             event: AgentEvent::AgentFailed {
                 run_id: "run-1".to_string(),
-                error: "Agent timed out: resume failed".to_string(),
+                error: "provider resume session was rejected".to_string(),
                 error_code: None,
                 max_turns: None,
             },
@@ -180,15 +187,20 @@ mod tests {
             auto_execute: false,
         });
 
-        let (fallback, origin) =
+        let (fallback, origin, reason) =
             shell_handoff_resume_fallback_request(&active_run).expect("fallback request");
         assert_eq!(origin, AgentRunOrigin::InsightPrompt);
+        assert_eq!(reason, RESUME_FAILED_REASON);
         assert_eq!(fallback.id, "request-1-fresh");
         assert_eq!(fallback.command_block.id, "block-1-fresh");
         assert!(fallback
             .context_hints
             .iter()
             .any(|hint| hint.contains(DISABLE_PROVIDER_RESUME_HINT)));
+        assert!(fallback
+            .context_hints
+            .iter()
+            .any(|hint| hint == "shell handoff fallback reason: resume_failed"));
 
         let mut retry = test_active_run(fallback);
         retry.governed_events.push(GovernedEvent {
@@ -196,7 +208,7 @@ mod tests {
             policy_decision: GovernancePolicyDecision::AuditOnly,
             event: AgentEvent::AgentFailed {
                 run_id: "run-2".to_string(),
-                error: "Agent timed out again".to_string(),
+                error: "fresh provider turn failed".to_string(),
                 error_code: None,
                 max_turns: None,
             },
@@ -208,18 +220,43 @@ mod tests {
     }
 
     #[test]
-    fn shell_handoff_resume_fallback_ignores_successful_continuation() {
+    fn shell_handoff_active_continuation_age_does_not_trigger_fallback() {
         let mut request = test_request();
         request.context_hints = vec![
             SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
             format!("{SHELL_HANDOFF_RECOVERY_OWNER_HINT} req-1/toolu-1"),
         ];
-        let active_run = test_active_run(request);
+        let mut active_run = test_active_run(request);
+        active_run.started_at = Instant::now() - std::time::Duration::from_secs(60);
+        active_run.last_activity_at = Instant::now();
         assert!(shell_handoff_resume_fallback_request(&active_run).is_none());
     }
 
     #[test]
-    fn shell_handoff_first_text_timeout_retries_without_resume() {
+    fn shell_handoff_cancel_does_not_start_fresh_fallback() {
+        let mut request = test_request();
+        request.context_hints = vec![
+            SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
+            format!("{SHELL_HANDOFF_RECOVERY_OWNER_HINT} req-1/toolu-1"),
+        ];
+        let mut active_run = test_active_run(request);
+        active_run.governed_events.push(GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::AuditOnly,
+            event: AgentEvent::AgentCancelled {
+                run_id: "run-1".to_string(),
+                reason: "user requested cancellation".to_string(),
+            },
+            reason: "cancelled".to_string(),
+            display_text: "cancelled".to_string(),
+            auto_execute: false,
+        });
+
+        assert!(shell_handoff_resume_fallback_request(&active_run).is_none());
+    }
+
+    #[test]
+    fn shell_handoff_provider_timeout_records_trigger_reason() {
         let mut request = test_request();
         request.context_hints = vec![
             SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
@@ -227,40 +264,28 @@ mod tests {
         ];
         let mut active_run = test_active_run(request);
         active_run.origin = AgentRunOrigin::AutoFailure;
-        active_run.started_at = Instant::now() - SHELL_HANDOFF_FIRST_TEXT_TIMEOUT;
+        active_run.governed_events.push(GovernedEvent {
+            decision: GovernanceDecision::Display,
+            policy_decision: GovernancePolicyDecision::AuditOnly,
+            event: AgentEvent::AgentFailed {
+                run_id: "run-1".to_string(),
+                error: "watchdog expired".to_string(),
+                error_code: Some(PROVIDER_TIMEOUT_ERROR_CODE.to_string()),
+                max_turns: None,
+            },
+            reason: "failed".to_string(),
+            display_text: "failed".to_string(),
+            auto_execute: false,
+        });
 
-        let (fallback, origin) =
-            shell_handoff_first_text_fallback_request(&active_run).expect("fallback request");
+        let (fallback, origin, reason) =
+            shell_handoff_resume_fallback_request(&active_run).expect("fallback request");
         assert_eq!(origin, AgentRunOrigin::AutoFailure);
-        assert_eq!(fallback.id, "request-1-fresh");
+        assert_eq!(reason, PROVIDER_TIMEOUT_REASON);
         assert!(fallback
             .context_hints
             .iter()
-            .any(|hint| hint.contains(DISABLE_PROVIDER_RESUME_HINT)));
-    }
-
-    #[test]
-    fn shell_handoff_first_text_timeout_ignores_visible_text() {
-        let mut request = test_request();
-        request.context_hints = vec![
-            SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
-            format!("{SHELL_HANDOFF_RECOVERY_OWNER_HINT} req-1/toolu-1"),
-        ];
-        let mut active_run = test_active_run(request);
-        active_run.started_at = Instant::now() - SHELL_HANDOFF_FIRST_TEXT_TIMEOUT;
-        active_run.has_visible_text_delta = true;
-
-        assert!(shell_handoff_first_text_fallback_request(&active_run).is_none());
-    }
-
-    #[test]
-    fn shell_handoff_first_text_timeout_requires_recovery_owner() {
-        let mut request = test_request();
-        request.context_hints = vec![SHELL_HANDOFF_CONTINUATION_HINT.to_string()];
-        let mut active_run = test_active_run(request);
-        active_run.started_at = Instant::now() - SHELL_HANDOFF_FIRST_TEXT_TIMEOUT;
-
-        assert!(shell_handoff_first_text_fallback_request(&active_run).is_none());
+            .any(|hint| hint == "shell handoff fallback reason: provider_timeout"));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -1,5 +1,6 @@
 use crate::agent::continuation::{
-    render_fresh_turn_recovery_notice, shell_handoff_resume_fallback_request,
+    render_fresh_turn_recovery_notice, shell_handoff_recovery_approval_id,
+    shell_handoff_resume_fallback_request,
 };
 use crate::agent::events::{
     flush_cosh_request_filter_into_active_run, render_agent_structured_events,
@@ -15,6 +16,7 @@ use crate::runtime::evidence_requests::{
 };
 use crate::runtime::prelude::*;
 use crate::runtime::question_terminal::cleanup_question_for_terminal_owner;
+use crate::types::PROVIDER_TIMEOUT_ERROR_CODE;
 
 pub(crate) fn finish_active_agent_run<W: Write>(
     state: &mut InlineState,
@@ -56,15 +58,14 @@ pub(crate) fn finish_active_agent_run<W: Write>(
     active_run.markdown_stream.finish(output, None)?;
     let provider_timed_out = active_run_provider_timed_out(&active_run);
     record_finished_agent_run(state, &active_run.request, &active_run.governed_events);
-    let resume_fallback = if provider_timed_out {
-        shell_handoff_resume_fallback_request(&active_run)
-    } else {
-        None
-    };
-    if let Some((fallback, origin)) = resume_fallback {
+    let resume_fallback = shell_handoff_resume_fallback_request(&active_run);
+    if let Some((fallback, origin, reason)) = resume_fallback {
+        if let Some(approval_id) = shell_handoff_recovery_approval_id(&active_run.request) {
+            state.evidence.mark_recovery_reason(approval_id, reason);
+        }
         render_recovery_context_before_notice(state, &active_run, output, adapter)?;
-        render_fresh_turn_recovery_notice(state, output)?;
-        // Provider-timeout resume is an internal fallback continuation.
+        render_fresh_turn_recovery_notice(state, output, reason)?;
+        // Failed provider resume is retried once as an internal fresh fallback.
         start_agent_run_with_origin(
             &fallback,
             origin,
@@ -250,7 +251,8 @@ fn render_recovery_context_before_notice<W: Write>(
 fn governed_event_is_provider_timeout(event: &GovernedEvent) -> bool {
     matches!(
         &event.event,
-        AgentEvent::AgentFailed { error, .. } if error.contains("Agent timed out:")
+        AgentEvent::AgentFailed { error_code, .. }
+            if error_code.as_deref() == Some(PROVIDER_TIMEOUT_ERROR_CODE)
     )
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat_tests.rs
@@ -473,6 +473,8 @@ fn question_activity_localizes_empty_question_fallback() {
 fn provider_status_activity_localizes_neutral_tokens() {
     let mut active_run = test_active_run();
     active_run.language = Language::ZhCn;
+    active_run.started_at = Instant::now() - Duration::from_secs(60);
+    active_run.last_activity_at = Instant::now() - Duration::from_secs(30);
     remember_agent_activity(
         &mut active_run,
         &[GovernedEvent {
@@ -491,6 +493,10 @@ fn provider_status_activity_localizes_neutral_tokens() {
 
     assert_eq!(active_run.current_phase, "正在思考");
     assert_eq!(active_run.current_message, "正在思考");
+    assert!(
+        active_run.last_activity_at.elapsed() < Duration::from_secs(1),
+        "status progress must refresh the provider idle clock"
+    );
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
@@ -1,9 +1,6 @@
 use std::time::Duration;
 
-use crate::agent::continuation::{
-    render_fresh_turn_recovery_notice, run_request_is_analysis_only_continuation,
-    shell_handoff_first_text_fallback_request,
-};
+use crate::agent::continuation::run_request_is_analysis_only_continuation;
 use crate::agent::events::{
     active_run_has_unrendered_interaction, render_active_agent_event,
     render_new_agent_structured_events, state_has_pending_interaction, TextHoldReason,
@@ -49,7 +46,7 @@ fn poll_active_agent_run_with_policy<W: Write>(
     suppress_heartbeat: bool,
 ) -> std::io::Result<()> {
     let mut should_finish = false;
-    let mut first_text_fallback: Option<(AgentRequest, AgentRunOrigin, Option<usize>)> = None;
+    let mut stalled_shell_recovery: Option<(AgentRequest, AgentRunOrigin, Option<usize>)> = None;
     // cosh-core emits a versioned
     // `compaction_recommended_v1:<session>:<gen>:<rev>:<hist>:<usable>` status
     // at the idle boundary of a turn, delivered just before the turn's
@@ -138,21 +135,9 @@ fn poll_active_agent_run_with_policy<W: Write>(
             Ok(AgentRunPoll::Event(event)) => event,
             Ok(AgentRunPoll::Timeout) => {
                 if let Some((fallback, origin)) = stalled_provider_shell_fallback {
-                    first_text_fallback =
+                    stalled_shell_recovery =
                         Some((fallback, origin, active_run.selectable_after_event_index));
                     break;
-                }
-                if !pending_interaction_before_poll
-                    && !queued_before_held_text
-                    && !unrendered_interaction_pending
-                {
-                    if let Some((fallback, origin)) =
-                        shell_handoff_first_text_fallback_request(active_run)
-                    {
-                        first_text_fallback =
-                            Some((fallback, origin, active_run.selectable_after_event_index));
-                        break;
-                    }
                 }
                 if pending_interaction_before_poll
                     || queued_before_held_text
@@ -403,15 +388,14 @@ fn poll_active_agent_run_with_policy<W: Write>(
         crate::slash::session::note_compaction_recommendation(state, &payload);
     }
 
-    if let Some((fallback, origin, selectable_after_event_index)) = first_text_fallback {
+    if let Some((fallback, origin, selectable_after_event_index)) = stalled_shell_recovery {
         if let Some(mut active_run) = state.agent_run.active.take() {
             active_run.handle.cancel();
             active_run.status_animation.clear(output)?;
         }
         // Turn-scope batch consent never outlives its run (issue #1773).
         state.control.trust.clear_run_batch_consent();
-        render_fresh_turn_recovery_notice(state, output)?;
-        // Fresh-turn recovery is an internal fallback continuation.
+        // Evidence-idle recovery is an internal resumable continuation.
         start_agent_run_with_origin(
             &fallback,
             origin,

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
@@ -9,6 +9,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "Using a fresh provider turn for shell evidence recovery."
         }
         MessageId::AgentRecoveryContinuityBody => "Provider session continuity may be degraded.",
+        MessageId::AgentRecoveryTriggerLine => "Recovery trigger: {reason}",
         MessageId::AgentStatusTitle => "Agent",
         MessageId::AgentStillWorking => "Still working... {elapsed}s · {detail}",
         MessageId::AgentStatusFooter => "Ctrl+C cancels · [Cancel]",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -95,4 +95,5 @@ collect_message_ids!([
     approval_foreground_interactive_ids,
     approval_turn_extension_ids,
     capture_notice_ids,
+    agent_recovery_reason_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
@@ -117,3 +117,13 @@ macro_rules! question_hardening_ids {
         );
     };
 }
+
+macro_rules! agent_recovery_reason_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            AgentRecoveryTriggerLine,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -143,17 +143,17 @@ mod tests {
             MessageId::ApprovalTurnExtensionUnavailableBody as usize,
             846
         );
-        // The #1913 capture-notice segment is the current tail; the tail
-        // ownership assertions move with each appended segment.
+        // The #1913 capture-notice segment remains pinned ahead of the
+        // appended shell-recovery reason message.
         assert_eq!(MessageId::CaptureInputRejectedTitle as usize, 847);
         assert_eq!(MessageId::CaptureInputRejectedBody as usize, 848);
         assert_eq!(
-            MessageId::CaptureInputRejectedBody as usize,
-            MessageId::ALL.len() - 1
+            MessageId::AgentRecoveryTriggerLine as usize,
+            MessageId::CaptureInputRejectedBody as usize + 1
         );
         assert_eq!(
-            MessageId::CaptureInputRejectedTitle as usize,
-            MessageId::ALL.len() - 2
+            MessageId::AgentRecoveryTriggerLine as usize,
+            MessageId::ALL.len() - 1
         );
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
@@ -7,6 +7,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AgentRecoveryTitle => "Agent 恢复",
         MessageId::AgentRecoveryFreshTurnBody => "正在使用新的 provider 轮次恢复 shell evidence。",
         MessageId::AgentRecoveryContinuityBody => "Provider 会话连续性可能降低。",
+        MessageId::AgentRecoveryTriggerLine => "恢复触发原因：{reason}",
         MessageId::AgentStatusTitle => "Agent",
         MessageId::AgentStillWorking => "仍在处理... {elapsed}s · {detail}",
         MessageId::AgentStatusFooter => "Ctrl+C 取消 · [Cancel]",

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/evidence_state.rs
@@ -73,6 +73,7 @@ impl EvidenceState {
             {
                 continue;
             }
+            evidence.recovery_reason = Some("evidence_idle_timeout");
             evidence.continuation_state = ShellEvidenceContinuationState::RecoveryQueued;
             requests.push(evidence.clone());
             break;
@@ -95,6 +96,20 @@ impl EvidenceState {
                 | ShellEvidenceContinuationState::RecoveryQueued
                 | ShellEvidenceContinuationState::Closed => {}
             }
+        }
+    }
+
+    pub(crate) fn mark_recovery_reason(&mut self, approval_id: &str, reason: &'static str) {
+        if let Some(evidence) = self
+            .shell_command_completed
+            .iter_mut()
+            .rev()
+            .find(|evidence| {
+                evidence.approval_id.as_deref() == Some(approval_id)
+                    && evidence.continuation_state == ShellEvidenceContinuationState::RecoveryQueued
+            })
+        {
+            evidence.recovery_reason = Some(reason);
         }
     }
 
@@ -402,6 +417,7 @@ mod tests {
         let first = state.claim_stalled_provider_shell_handoff_continuations();
         assert_eq!(first.len(), 1);
         assert_eq!(first[0].approval_id.as_deref(), Some("req-1"));
+        assert_eq!(first[0].recovery_reason, Some("evidence_idle_timeout"));
         assert_eq!(
             state.shell_command_completed[0].continuation_state,
             ShellEvidenceContinuationState::RecoveryQueued
@@ -414,6 +430,49 @@ mod tests {
         let second = state.claim_stalled_provider_shell_handoff_continuations();
         assert_eq!(second.len(), 1);
         assert_eq!(second[0].approval_id.as_deref(), Some("req-2"));
+    }
+
+    #[test]
+    fn recovery_paths_share_one_claim_per_evidence() {
+        let mut state = EvidenceState::default();
+        state.record_shell_command_completed(shell_evidence(
+            Some("req-1"),
+            true,
+            "delivered",
+            None,
+        ));
+
+        assert_eq!(
+            state
+                .claim_stalled_provider_shell_handoff_continuations()
+                .len(),
+            1
+        );
+        assert!(state.claim_pending_shell_handoff_continuations().is_empty());
+        assert!(state
+            .claim_stalled_provider_shell_handoff_continuations()
+            .is_empty());
+    }
+
+    #[test]
+    fn failed_resume_updates_claimed_evidence_reason() {
+        let mut state = EvidenceState::default();
+        state.record_shell_command_completed(shell_evidence(
+            Some("req-1"),
+            false,
+            "provider_run_not_active",
+            Some("provider run was not active"),
+        ));
+        assert_eq!(state.claim_pending_shell_handoff_continuations().len(), 1);
+
+        state.mark_recovery_reason("req-1", "resume_failed");
+
+        assert_eq!(
+            state
+                .latest_recovery()
+                .and_then(|item| item.recovery_reason),
+            Some("resume_failed")
+        );
     }
 
     fn shell_evidence(

--- a/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use shell_handoff::{NON_INTERACTIVE_PAGER_PREFIX, SHELL_HANDOFF_UNTRA
 
 pub const COMMAND_OUTPUT_REF_MAX_BYTES: usize = 1024 * 1024;
 pub const SESSION_OUTPUT_REF_MAX_BYTES: usize = 64 * 1024 * 1024;
+pub(crate) const PROVIDER_TIMEOUT_ERROR_CODE: &str = "provider_timeout";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/cosh-ng/crates/cosh-shell/src/types/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/public.rs
@@ -17,9 +17,9 @@ pub(crate) use implementation::{
     request_is_analysis_only_continuation, set_request_context_binding, AgentContextBinding,
     BuiltinFactRecord, BuiltinFindingFacts, EvaluatedHookFinding, HighMemoryProcessFacts,
     HookProvenance, MemoryPressureFacts, MetricsConfidence, ProcessMemoryFact,
-    ShellEnvironmentSnapshot, NON_INTERACTIVE_PAGER_PREFIX, SHELL_HANDOFF_CONTINUATION_HINT,
-    SHELL_HANDOFF_UNTRACKED_STATUS, TOOL_ARGUMENTS_STATUS_PHASE, TOOL_ARGUMENTS_STATUS_PREFIX,
-    USER_APPROVAL_MODE_HINT_PREFIX,
+    ShellEnvironmentSnapshot, NON_INTERACTIVE_PAGER_PREFIX, PROVIDER_TIMEOUT_ERROR_CODE,
+    SHELL_HANDOFF_CONTINUATION_HINT, SHELL_HANDOFF_UNTRACKED_STATUS, TOOL_ARGUMENTS_STATUS_PHASE,
+    TOOL_ARGUMENTS_STATUS_PREFIX, USER_APPROVAL_MODE_HINT_PREFIX,
 };
 
 pub(crate) use implementation::audit;

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/lifecycle.rs
@@ -350,8 +350,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
         "{output}"
     );
     assert!(
-        output.contains("latest recovery reason: provider run was not active")
-            || output.contains("latest recovery reason: provider approval channel closed"),
+        output.contains("latest recovery reason: resume_failed"),
         "{output}"
     );
     assert!(

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/recovery.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/recovery.rs
@@ -32,6 +32,10 @@ fn raw_cli_shell_handoff_resume_timeout_retries_without_timeout_card() {
         output.contains("Provider session continuity may be degraded."),
         "{output}"
     );
+    assert!(
+        output.contains("Recovery trigger: provider_timeout"),
+        "{output}"
+    );
     assert!(!output.contains("Agent timed out:"), "{output}");
     assert!(
         !output.contains("No provider response within 20s"),
@@ -83,6 +87,11 @@ fn raw_cli_shell_handoff_resume_timeout_renders_structured_context_before_recove
         1,
         "{output}"
     );
+    assert_eq!(
+        count_occurrences(&output, "Recovery trigger: provider_timeout"),
+        1,
+        "{output}"
+    );
     assert!(!output.contains("Agent timed out:"), "{output}");
     assert!(
         !output.contains("No provider response within 20s"),
@@ -130,6 +139,10 @@ fn raw_cli_shell_handoff_recovery_uses_zh_language_env() {
         "{output}"
     );
     assert!(output.contains("Provider 会话连续性可能降低。"), "{output}");
+    assert!(
+        output.contains("恢复触发原因：provider_timeout"),
+        "{output}"
+    );
     assert!(
         !output.contains("Using a fresh provider turn for shell evidence recovery."),
         "{output}"


### PR DESCRIPTION
## Description

Fixes the cosh-ng shell handoff recovery state machine so a continuation is
not cancelled merely because it has produced no visible text for 15 seconds.
The speculative first-text fallback is removed in favor of the existing
activity-aware provider watchdog, while explicit resume failures and terminal
provider timeouts still receive one fresh no-resume fallback. Evidence claims
remain the single deduplication boundary, and recovery status now distinguishes
`resume_failed`, `provider_timeout`, and `evidence_idle_timeout`.

## Related Issue

closes #2052

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `cosh-ng` (cosh-ng)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --package cosh-shell --bin cosh-shell`
  (`2203 passed`, `1 ignored`)
- Targeted raw CLI recovery and provider-native control tests
- `cargo build --workspace --release --locked`
- `crates/cosh-shell/scripts/check-layout.sh`
- `cargo test --workspace --locked`
  - The cosh-shell unit, logic, protocol, and raw CLI layers passed.
  - Two unrelated shell-host timing assertions failed only under full parallel
    load; both passed immediately when rerun individually with
    `--test-threads=1`.

Real SysOM/TUI validation used an isolated HOME and the exact candidate source
tree. A no-tool baseline passed. A bounded provider-native shell control
completed in one provider request with no recovery or timeout. The issue's
original install prompt made eight foreground provider requests without any
fresh recovery, then reached the configured max-turn gate because the requested
source path was absent on the validation host; one independent background
provider request was also recorded.

## Additional Notes

The patch intentionally does not shorten the shared provider watchdog. A truly
silent continuation can therefore wait for the provider start/idle watchdog
(defaults: 20s before first response, 90s after progress, with a 600s hard
limit). Those watchdogs are already activity-aware and apply to every provider
run; changing their defaults here would risk terminating valid slow reasoning,
hooks, authentication, or tool latency. Reintroducing a separate shell
first-text timer would recreate the competing recovery decisions that caused
this issue. Genuine evidence stalls still use
`COSH_SHELL_EVIDENCE_IDLE_TIMEOUT_SECS`, and terminal resume failures still get
at most one fresh fallback.

The live install attempt was not completed because the requested
`/usr/share/anolisa/runtime/skills/ws-ckpt` source path was absent. Validation
did not fabricate that system path because the ECS run was intentionally
isolated and non-mutating outside its dedicated workspace.

This change does not address AgentSight cached-token parsing or cross-process
session correlation. Those require separate observability and session-identity
work and are not needed to stop the recovery storm.
