### PR TITLE
fix(cosh-ng): [shell] use zsh preexec $3 for drift

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -481,7 +481,12 @@ command_not_found_handler() {
 }
 _cosh_preexec_marker() {
   local command="$1"
-  local expanded_command="${2:-$1}"
+  # zsh passes the abbreviated, size-limited form in $2 and the full text of
+  # the command being executed in $3. Long inputs truncate $2, so comparing
+  # against it produces a false expansion-drift signal that misroutes long
+  # natural-language prompts to the native command-not-found path (#2053).
+  # Prefer $3; keep $2/$1 as defensive fallbacks for hosts that omit it.
+  local expanded_command="${3:-${2:-$1}}"
   local canonical_command="${(j: :)${(z)command}}"
   local expansion_drift=0
   [[ "$canonical_command" != "$expanded_command" ]] && expansion_drift=1

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -2402,6 +2402,74 @@ fn routing_c2_expansion_drift_and_matched_arguments_stay_native() {
 }
 
 #[test]
+fn routing_c2_long_mixed_language_prompts_route_to_agent() {
+    // Issue #2053: zsh preexec abbreviates its second argument for long
+    // inputs; comparing the canonicalized command against it produced a
+    // false expansion-drift signal that pushed long CJK/ASCII prompts to
+    // the native command-not-found path instead of the Agent. Cover both
+    // sides of the abbreviated-text boundary plus a Chinese/English space
+    // variation, and keep bash as the consistency control.
+    let inputs = [
+        // Above the abbreviation boundary (the original user report).
+        "刚才没有恢复，不过 macOS 显示管理器认为屏幕在线",
+        // Space removed at the Chinese/English boundary.
+        "刚才没有恢复，不过macOS 显示管理器认为屏幕在线",
+        // Below the abbreviation boundary.
+        "刚才没有恢复 请解释",
+    ];
+    for shell in ["bash", "zsh"] {
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+        if shell == "zsh" && Command::new("zsh").arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-routing-c2-long-nl-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let config = ShellHostConfig::new(format!("routing-c2-long-nl-{shell}"), &work_dir);
+        let steps = inputs
+            .iter()
+            .map(|input| ScriptedInput::user_line(*input))
+            .collect::<Vec<_>>();
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &steps)
+        } else {
+            run_scripted_zsh(&config, &steps)
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        let terminal = String::from_utf8_lossy(&output.terminal_output);
+        for input in inputs {
+            let first_word = input.split_whitespace().next().expect("first word");
+            assert!(
+                !terminal.contains(&format!("command not found: {first_word}")),
+                "{shell}: {input:?} hit native command-not-found: {terminal}"
+            );
+            assert!(
+                output.events.iter().any(|event| {
+                    event.kind == ShellEventKind::UserInputIntercepted
+                        && event.input.as_deref() == Some(input)
+                        && event.component.as_deref() == Some("natural_language")
+                }),
+                "{shell}: {input:?}: {:?}\n{terminal}",
+                output.events
+            );
+            assert!(
+                !output.events.iter().any(|event| {
+                    event.kind == ShellEventKind::CommandFailed
+                        && event.command.as_deref() == Some(input)
+                        && event.exit_code == Some(127)
+                }),
+                "{shell}: {input:?} failed with exit 127: {:?}\n{terminal}",
+                output.events
+            );
+        }
+    }
+}
+
+#[test]
 fn routing_c2_nested_provenance_marks_only_the_outer_missing_command() {
     let input = "解释 \"$(解释)\"";
     for shell in ["bash", "zsh"] {


### PR DESCRIPTION
## Summary

In zsh, longer natural-language prompts mixing CJK text and ASCII words
were executed as shell commands (`zsh: command not found: <first word>`)
instead of being intercepted and routed to the Agent, while bash routed
the same lines correctly. The behavior was sensitive to input length and
token boundaries: adding or removing a space could flip the result.

Root cause: `_cosh_preexec_marker` compared the canonicalized input
against zsh preexec's **second** argument, which zsh documents as an
abbreviated, size-limited form. Long inputs truncate it, so the
comparison always produced a false `expansion_drift=1`, and the
command-not-found handler took the conservative delegation path before
natural-language classification.

## Changes

- `shell_host/marker/zsh.rs` `_cosh_preexec_marker`: compare against
  `${3:-${2:-$1}}` — zsh preexec's third argument carries the full text
  of the command being executed; the previous arguments remain as
  defensive fallbacks (hosts omitting `$3` keep pre-fix behavior).
- `tests/shell_host/marker.rs`: add
  `routing_c2_long_mixed_language_prompts_route_to_agent`, a scripted
  PTY regression covering both sides of zsh's abbreviated-text boundary
  plus a Chinese/English space variation, with bash as the consistency
  control.

Genuine expansion drift (aliases), command substitution, glob
expansion, nested command-not-found provenance and user-defined
`command_not_found_handler` ownership keep their existing behavior,
anchored by the existing `routing_c2` tests.

## Tests

- New: `routing_c2_long_mixed_language_prompts_route_to_agent`
  (FAIL on base → PASS with fix; verified both directions).
- `cargo test -p cosh-shell --test shell_host` full suite: 151 passed /
  0 failed (serial, clean container, zsh 5.9).
- `cargo test -p cosh-shell --lib` (1175) and `--bin cosh-shell` (2202),
  `--test logic` (8), `--test protocol` (62): all green.
- `cargo clippy -p cosh-shell --all-targets`, `cargo fmt --check`: clean.
- Gates: `check-layout.sh`, `check-test-inventory.sh`,
  `check-han-nl-routing-stage.sh C2`: all pass.

## Verification

- End-to-end FAIL→PASS on the original reproduction path: real
  `cosh-shell --shell zsh --isolated` binary + real PTY + cosh-core on
  PATH, prompt `刚才没有恢复，不过 macOS 显示管理器认为屏幕在线`
  (Linux x86_64, AnolisOS 23.4 container, zsh 5.9):
  - Before: `zsh: command not found: 刚才没有恢复，不过`; bash control
    routed to Agent (`defect_reproduced=true`, repro exit 1).
  - After: zsh intercepts and routes to the Agent, zero
    `command not found` occurrences; bash control unchanged
    (`defect_reproduced=false`, repro exit 0).
- Mechanism probe on zsh 5.9: for the 27-char prompt, preexec `$2` is
  truncated to 16 chars (after `刚才没有恢复，不过 macOS `), `$3`
  carries the full 27 chars; drift compares $2→1 (false positive),
  $3→0.
- Not run (excluded scope): macOS zsh validation — no macOS environment
  available; the deterministic Linux reproduction uses zsh 5.9 (same
  version as current macOS default) and the mechanism is OS-independent.
  Left for reviewers / follow-up per the issue's acceptance criteria.
- Host-side parallel-run flakes observed in `relay`/`termios`/
  `question`/`evidence` tests reproduce identically on unmodified
  `origin/main` and are unrelated to this diff (marker/zsh single
  point); serial runs are fully green.

## Evidence

Reproduction and acceptance captures (real binary, real PTY, cosh-core
adapter with real LLM provider responses — DashScope-authenticated
turns; AnolisOS 23.4 container, zsh 5.9, 120x36; assets pinned at
commit `4b6673b8` on the fork's `pr-2073-assets` branch):

| | zsh | bash (control) |
|---|---|---|
| **Before (base)** | ![baseline zsh command not found](https://raw.githubusercontent.com/SunnyQjm/anolisa/4b6673b8c997b6c6ff14b4c36a879a72162120aa/baseline-zsh-cnf.png) | ![baseline bash agent](https://raw.githubusercontent.com/SunnyQjm/anolisa/4b6673b8c997b6c6ff14b4c36a879a72162120aa/baseline-bash-agent.png) |
| **After (this PR)** | ![fixed zsh agent](https://raw.githubusercontent.com/SunnyQjm/anolisa/4b6673b8c997b6c6ff14b4c36a879a72162120aa/fixed-zsh-agent.png) | ![fixed bash agent](https://raw.githubusercontent.com/SunnyQjm/anolisa/4b6673b8c997b6c6ff14b4c36a879a72162120aa/fixed-bash-agent.png) |

Cast replays: [baseline-zsh.cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/4b6673b8c997b6c6ff14b4c36a879a72162120aa/baseline-zsh.cast) ·
[fixed-zsh.cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/4b6673b8c997b6c6ff14b4c36a879a72162120aa/fixed-zsh.cast)

Closes #2053
