### PR TITLE
fix(cosh-ng): [shell] resume shell-handoff fallback within the same provider session

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
@@ -433,6 +433,54 @@ fn prepare_invocation_does_not_resume_across_cwd_scope() {
     assert!(!inv.args.contains(&"prev-sess".to_string()));
 }
 
+// The same-session retry fallback (T2) carries no
+// "disable provider resume" hint, so it must resume the active session;
+// the final fresh safety net (T3) carries the hint and must not.
+#[test]
+fn prepare_invocation_same_session_retry_fallback_resumes_active_session() {
+    let adapter = CoshCoreAdapter::new("cosh-core", false);
+    *adapter.session.lock().unwrap() =
+        SessionRuntimeState::with_active("prev-sess", test_workspace_scope());
+    let mut request = test_request();
+    request.context_hints = vec![
+        "analysis-only continuation after foreground shell handoff".to_string(),
+        "shell handoff recovery owner: req-1/<none>/toolu-1".to_string(),
+        "same-session retry for shell handoff fallback".to_string(),
+    ];
+    let inv = adapter.prepare_invocation(&request, CoshApprovalMode::Auto);
+    assert!(inv.args.contains(&"--resume".to_string()), "{:?}", inv.args);
+    assert!(
+        inv.args.contains(&"prev-sess".to_string()),
+        "{:?}",
+        inv.args
+    );
+}
+
+#[test]
+fn prepare_invocation_fresh_fallback_disables_resume() {
+    let adapter = CoshCoreAdapter::new("cosh-core", false);
+    *adapter.session.lock().unwrap() =
+        SessionRuntimeState::with_active("prev-sess", test_workspace_scope());
+    let mut request = test_request();
+    request.context_hints = vec![
+        "analysis-only continuation after foreground shell handoff".to_string(),
+        "shell handoff recovery owner: req-1/<none>/toolu-1".to_string(),
+        "same-session retry for shell handoff fallback".to_string(),
+        "disable provider resume for shell handoff fallback".to_string(),
+    ];
+    let inv = adapter.prepare_invocation(&request, CoshApprovalMode::Auto);
+    assert!(
+        !inv.args.contains(&"--resume".to_string()),
+        "{:?}",
+        inv.args
+    );
+    assert!(
+        !inv.args.contains(&"prev-sess".to_string()),
+        "{:?}",
+        inv.args
+    );
+}
+
 #[test]
 fn prepare_invocation_ignores_failed_selected_session() {
     let adapter = test_adapter();

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake.rs
@@ -138,7 +138,25 @@ impl AgentAdapter for FakeAgentAdapter {
                         max_turns: None,
                     }]);
                 }
+                // Times out for the T1 continuation only, so the T2
+                // same-session retry succeeds (T2-success presentation path).
+                // Checked before the plain "trigger resume timeout" branch
+                // because that trigger is a substring of this one.
+                if input.contains("trigger resume timeout once")
+                    && !request.context_hints.iter().any(|hint| {
+                        hint.contains("disable provider resume")
+                            || hint.contains("same-session retry")
+                    })
+                {
+                    return Ok(vec![AgentEvent::AgentFailed {
+                        run_id,
+                        error: "Agent timed out: No provider response within 20s".to_string(),
+                        error_code: Some(PROVIDER_TIMEOUT_ERROR_CODE.to_string()),
+                        max_turns: None,
+                    }]);
+                }
                 if input.contains("trigger resume timeout")
+                    && !input.contains("trigger resume timeout once")
                     && !request
                         .context_hints
                         .iter()

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/qwen.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/qwen.rs
@@ -515,6 +515,29 @@ mod tests {
         assert!(!inv.args.contains(&"prev-sess".to_string()));
     }
 
+    // The same-session retry fallback (T2) does not carry the
+    // disable hint, so qwen keeps resuming the previous session like
+    // cosh-core does.
+    #[test]
+    fn mode_flags_same_session_retry_fallback_keeps_session_resume() {
+        let adapter = QwenCliAdapter {
+            program: "qwen".to_string(),
+            allow_model_call: false,
+            session_id: Arc::new(Mutex::new(Some("prev-sess".to_string()))),
+        };
+        let mut request = test_request();
+        request
+            .context_hints
+            .push("same-session retry for shell handoff fallback".to_string());
+        let inv = adapter.prepare_invocation(&request, CoshApprovalMode::Auto);
+        assert!(inv.args.contains(&"--resume".to_string()), "{:?}", inv.args);
+        assert!(
+            inv.args.contains(&"prev-sess".to_string()),
+            "{:?}",
+            inv.args
+        );
+    }
+
     #[test]
     fn qwen_process_args_append_prompt_flag() {
         let args = qwen_args_with_prompt(&PreparedInvocation {

--- a/src/cosh-ng/crates/cosh-shell/src/agent/continuation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/continuation.rs
@@ -6,6 +6,11 @@ use crate::types::PROVIDER_TIMEOUT_ERROR_CODE;
 const SHELL_HANDOFF_CONTINUATION_HINT: &str = crate::types::SHELL_HANDOFF_CONTINUATION_HINT;
 const SHELL_HANDOFF_RECOVERY_OWNER_HINT: &str = "shell handoff recovery owner:";
 const DISABLE_PROVIDER_RESUME_HINT: &str = "disable provider resume for shell handoff fallback";
+// First fallback tier (T2) for provider timeouts: retry within the same
+// provider session so the committed history and the provider session uuid
+// survive. Must not contain the "disable provider resume"
+// substring the adapters gate on.
+const SHELL_HANDOFF_SAME_SESSION_RETRY_HINT: &str = "same-session retry for shell handoff fallback";
 const SHELL_HANDOFF_FALLBACK_REASON_HINT: &str = "shell handoff fallback reason:";
 const RESUME_FAILED_REASON: &str = "resume_failed";
 const PROVIDER_TIMEOUT_REASON: &str = "provider_timeout";
@@ -95,6 +100,52 @@ pub(crate) fn render_fresh_turn_recovery_notice<W: Write>(
         )
 }
 
+/// A same-session retry (T2) keeps provider continuity, so the fresh-turn
+/// recovery panel copy would be wrong for it; emit the trigger reason plus
+/// one lightweight retry line. The reason must render here too because a
+/// successful T2 never reaches the T3 panel.
+pub(crate) fn render_same_session_retry_notice<W: Write>(
+    state: &InlineState,
+    reason: &str,
+    output: &mut W,
+) -> std::io::Result<()> {
+    writeln!(
+        output,
+        "{}",
+        state
+            .i18n()
+            .format(MessageId::AgentRecoveryTriggerLine, &[("reason", reason)])
+    )?;
+    writeln!(
+        output,
+        "{}",
+        state.i18n().t(MessageId::AgentRecoverySameSessionRetryLine)
+    )
+}
+
+/// Renders the recovery notice matching the fallback tier: the fresh-turn
+/// panel only for a true fresh turn (T3), the trigger-reason and retry
+/// status lines for the same-session retry (T2).
+pub(crate) fn render_fallback_recovery_notice<W: Write>(
+    state: &InlineState,
+    fallback: &AgentRequest,
+    reason: &str,
+    output: &mut W,
+) -> std::io::Result<()> {
+    if fallback_request_is_fresh_turn(fallback) {
+        render_fresh_turn_recovery_notice(state, output, reason)
+    } else {
+        render_same_session_retry_notice(state, reason, output)
+    }
+}
+
+pub(crate) fn fallback_request_is_fresh_turn(request: &AgentRequest) -> bool {
+    request
+        .context_hints
+        .iter()
+        .any(|hint| hint.contains(DISABLE_PROVIDER_RESUME_HINT))
+}
+
 pub(crate) fn shell_handoff_resume_fallback_request(
     active_run: &ActiveAgentRun,
 ) -> Option<(AgentRequest, AgentRunOrigin, &'static str)> {
@@ -121,6 +172,11 @@ fn shell_handoff_resume_fallback_request_for_reason(
     if !run_request_is_shell_handoff_recovery_continuation(&active_run.request) {
         return None;
     }
+    // Tier chain: T1 continuation -> T2 same-session retry ->
+    // T3 fresh safety net -> stop. Hints only ever accumulate, so the chain
+    // is monotonic and capped at three turns. A rejected resume
+    // (resume_failed) skips T2: retrying the same session would fail the
+    // same way, so it goes straight to the fresh safety net.
     if active_run
         .request
         .context_hints
@@ -129,13 +185,31 @@ fn shell_handoff_resume_fallback_request_for_reason(
     {
         return None;
     }
+    let retried_same_session = active_run
+        .request
+        .context_hints
+        .iter()
+        .any(|hint| hint.contains(SHELL_HANDOFF_SAME_SESSION_RETRY_HINT));
 
     let mut request = active_run.request.clone();
-    request.id = format!("{}-fresh", request.id);
-    request.command_block.id = format!("{}-fresh", request.command_block.id);
-    request
-        .context_hints
-        .push(DISABLE_PROVIDER_RESUME_HINT.to_string());
+    if reason == PROVIDER_TIMEOUT_REASON && !retried_same_session {
+        // T2: retry within the same provider session, keeping the committed
+        // history and the provider session uuid.
+        request.id = format!("{}-retry", request.id);
+        request.command_block.id = format!("{}-retry", request.command_block.id);
+        request
+            .context_hints
+            .push(SHELL_HANDOFF_SAME_SESSION_RETRY_HINT.to_string());
+    } else {
+        // T3: the same-session retry stalled too (or the resume itself was
+        // rejected); fall back to a fresh provider turn so the user still
+        // gets an answer.
+        request.id = format!("{}-fresh", request.id);
+        request.command_block.id = format!("{}-fresh", request.command_block.id);
+        request
+            .context_hints
+            .push(DISABLE_PROVIDER_RESUME_HINT.to_string());
+    }
     request
         .context_hints
         .push(format!("{SHELL_HANDOFF_FALLBACK_REASON_HINT} {reason}"));
@@ -286,6 +360,81 @@ mod tests {
             .context_hints
             .iter()
             .any(|hint| hint == "shell handoff fallback reason: provider_timeout"));
+    }
+
+    // A provider timeout escalates through a same-session retry
+    // (T2, resume stays enabled) before the fresh safety net (T3) disables
+    // resume; the chain stops after T3. A rejected resume (resume_failed,
+    // covered above) skips T2 and goes straight to T3.
+    #[test]
+    fn shell_handoff_provider_timeout_escalates_through_retry_then_fresh() {
+        fn timeout_event(run_id: &str) -> GovernedEvent {
+            GovernedEvent {
+                decision: GovernanceDecision::Display,
+                policy_decision: GovernancePolicyDecision::AuditOnly,
+                event: AgentEvent::AgentFailed {
+                    run_id: run_id.to_string(),
+                    error: "watchdog expired".to_string(),
+                    error_code: Some(PROVIDER_TIMEOUT_ERROR_CODE.to_string()),
+                    max_turns: None,
+                },
+                reason: "failed".to_string(),
+                display_text: "failed".to_string(),
+                auto_execute: false,
+            }
+        }
+
+        let mut request = test_request();
+        request.context_hints = vec![
+            SHELL_HANDOFF_CONTINUATION_HINT.to_string(),
+            format!("{SHELL_HANDOFF_RECOVERY_OWNER_HINT} req-1/toolu-1"),
+        ];
+        let mut active_run = test_active_run(request);
+        active_run.governed_events.push(timeout_event("run-1"));
+
+        // T2: same-session retry keeps provider resume enabled.
+        let (retry, _origin, reason) =
+            shell_handoff_resume_fallback_request(&active_run).expect("retry request");
+        assert_eq!(reason, PROVIDER_TIMEOUT_REASON);
+        assert_eq!(retry.id, "request-1-retry");
+        assert_eq!(retry.command_block.id, "block-1-retry");
+        assert!(!fallback_request_is_fresh_turn(&retry));
+        assert!(retry
+            .context_hints
+            .iter()
+            .any(|hint| hint.contains(SHELL_HANDOFF_SAME_SESSION_RETRY_HINT)));
+
+        // T3: the retry timed out too; the fresh safety net disables resume.
+        let mut retry_run = test_active_run(retry);
+        retry_run.governed_events.push(timeout_event("run-2"));
+        let (fresh, _origin, _reason) =
+            shell_handoff_resume_fallback_request(&retry_run).expect("fresh request");
+        assert_eq!(fresh.id, "request-1-retry-fresh");
+        assert!(fallback_request_is_fresh_turn(&fresh));
+
+        // Chain cap: no fallback beyond the fresh safety net.
+        let mut exhausted = test_active_run(fresh);
+        exhausted.governed_events.push(timeout_event("run-3"));
+        assert!(shell_handoff_resume_fallback_request(&exhausted).is_none());
+    }
+
+    // The adapters (cosh_core.rs, qwen.rs, claude.rs) gate provider resume on
+    // the literal substring "disable provider resume" rather than on these
+    // constants. Anchor the cross-module contract so renaming either hint
+    // cannot silently flip the T2/T3 resume behavior.
+    #[test]
+    fn fallback_hints_keep_the_adapter_resume_gating_contract() {
+        const ADAPTER_RESUME_GATE_SUBSTRING: &str = "disable provider resume";
+        assert!(DISABLE_PROVIDER_RESUME_HINT.contains(ADAPTER_RESUME_GATE_SUBSTRING));
+        assert!(!SHELL_HANDOFF_SAME_SESSION_RETRY_HINT.contains(ADAPTER_RESUME_GATE_SUBSTRING));
+
+        let mut request = test_request();
+        request.context_hints = vec![SHELL_HANDOFF_SAME_SESSION_RETRY_HINT.to_string()];
+        assert!(!fallback_request_is_fresh_turn(&request));
+        request
+            .context_hints
+            .push(DISABLE_PROVIDER_RESUME_HINT.to_string());
+        assert!(fallback_request_is_fresh_turn(&request));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -1,5 +1,5 @@
 use crate::agent::continuation::{
-    render_fresh_turn_recovery_notice, shell_handoff_recovery_approval_id,
+    render_fallback_recovery_notice, shell_handoff_recovery_approval_id,
     shell_handoff_resume_fallback_request,
 };
 use crate::agent::events::{
@@ -64,8 +64,9 @@ pub(crate) fn finish_active_agent_run<W: Write>(
             state.evidence.mark_recovery_reason(approval_id, reason);
         }
         render_recovery_context_before_notice(state, &active_run, output, adapter)?;
-        render_fresh_turn_recovery_notice(state, output, reason)?;
-        // Failed provider resume is retried once as an internal fresh fallback.
+        render_fallback_recovery_notice(state, &fallback, reason, output)?;
+        // Failed provider resume escalates through the tier chain: a
+        // same-session retry first, then one fresh fallback.
         start_agent_run_with_origin(
             &fallback,
             origin,

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
@@ -10,6 +10,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         }
         MessageId::AgentRecoveryContinuityBody => "Provider session continuity may be degraded.",
         MessageId::AgentRecoveryTriggerLine => "Recovery trigger: {reason}",
+        MessageId::AgentRecoverySameSessionRetryLine => {
+            "Provider turn stalled; retrying with session history..."
+        }
         MessageId::AgentStatusTitle => "Agent",
         MessageId::AgentStillWorking => "Still working... {elapsed}s · {detail}",
         MessageId::AgentStatusFooter => "Ctrl+C cancels · [Cancel]",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -99,4 +99,5 @@ collect_message_ids!([
     capture_notice_ids,
     agent_recovery_reason_ids,
     auth_ids,
+    agent_recovery_retry_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
@@ -127,3 +127,15 @@ macro_rules! agent_recovery_reason_ids {
         );
     };
 }
+
+// #2031 trailing segment: appended after every earlier segment so
+// pre-existing discriminants never shift.
+macro_rules! agent_recovery_retry_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            AgentRecoverySameSessionRetryLine,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -152,16 +152,22 @@ mod tests {
             MessageId::AgentRecoveryTriggerLine as usize,
             MessageId::CaptureInputRejectedBody as usize + 1
         );
+        // The #2031 recovery-retry segment is the current tail; the tail
+        // ownership assertions move with each appended segment.
         assert_eq!(
             MessageId::AuthSelectProviderQuestion as usize,
             MessageId::AgentRecoveryTriggerLine as usize + 1
         );
         assert_eq!(
-            MessageId::AuthSelectProviderQuestion as usize,
+            MessageId::AgentRecoverySameSessionRetryLine as usize,
+            MessageId::AuthSelectProviderQuestion as usize + 1
+        );
+        assert_eq!(
+            MessageId::AgentRecoverySameSessionRetryLine as usize,
             MessageId::ALL.len() - 1
         );
         assert_eq!(
-            MessageId::AgentRecoveryTriggerLine as usize,
+            MessageId::AuthSelectProviderQuestion as usize,
             MessageId::ALL.len() - 2
         );
     }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
@@ -8,6 +8,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AgentRecoveryFreshTurnBody => "正在使用新的 provider 轮次恢复 shell evidence。",
         MessageId::AgentRecoveryContinuityBody => "Provider 会话连续性可能降低。",
         MessageId::AgentRecoveryTriggerLine => "恢复触发原因：{reason}",
+        MessageId::AgentRecoverySameSessionRetryLine => "Provider 轮次无响应，正带会话历史重试...",
         MessageId::AgentStatusTitle => "Agent",
         MessageId::AgentStillWorking => "仍在处理... {elapsed}s · {detail}",
         MessageId::AgentStatusFooter => "Ctrl+C 取消 · [Cancel]",

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/recovery.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/recovery.rs
@@ -43,6 +43,98 @@ fn raw_cli_shell_handoff_resume_timeout_retries_without_timeout_card() {
     );
 }
 
+// The first fallback turn (T2) retries within the same provider
+// session, so the "Agent recovery" fresh-turn panel (whose copy claims a
+// fresh provider turn and degraded continuity) must not be shown for it;
+// T2 renders the trigger-reason and retry status lines instead. The fake
+// adapter keeps timing out until resume is disabled, so the chain escalates
+// to the final fresh safety net (T3), which renders the panel exactly once,
+// after the T2 lines.
+#[test]
+fn raw_cli_shell_handoff_fallback_chain_renders_retry_line_then_single_panel() {
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[("COSH_SHELL_LANG", "en-US")],
+        vec![
+            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+            (
+                b"?? provider resume timeout shell trigger resume timeout\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"\n".to_vec(), Duration::from_millis(2_000)),
+            (b"exit 0\n".to_vec(), Duration::from_millis(6_000)),
+        ],
+    );
+
+    // T2 renders the trigger reason plus the same-session retry line before
+    // any panel (a successful T2 never reaches the T3 panel, so the reason
+    // must already be visible here).
+    assert_ordered(
+        &output,
+        &[
+            "Recovery trigger: provider_timeout",
+            "Provider turn stalled; retrying with session history...",
+            "Using a fresh provider turn for shell evidence recovery.",
+        ],
+    );
+    // The fresh-turn panel appears exactly once (T3 only, never for T2).
+    assert_eq!(
+        count_occurrences(
+            &output,
+            "Using a fresh provider turn for shell evidence recovery."
+        ),
+        1,
+        "{output}"
+    );
+    assert_eq!(
+        count_occurrences(&output, "Provider session continuity may be degraded."),
+        1,
+        "{output}"
+    );
+}
+
+// When the T2 same-session retry succeeds,
+// the chain never reaches the T3 panel, so the recovery trigger reason must
+// already be part of the T2 notice; the fresh-turn panel must not render.
+#[test]
+fn raw_cli_shell_handoff_retry_success_shows_reason_without_panel() {
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &[],
+        &[("COSH_SHELL_LANG", "en-US")],
+        vec![
+            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+            (
+                b"?? provider resume timeout shell trigger resume timeout once\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"\n".to_vec(), Duration::from_millis(2_000)),
+            (b"exit 0\n".to_vec(), Duration::from_millis(6_000)),
+        ],
+    );
+
+    // T1 times out once; T2 succeeds with the reason line + retry line.
+    assert_ordered(
+        &output,
+        &[
+            "Recovery trigger: provider_timeout",
+            "Provider turn stalled; retrying with session history...",
+            "Command result analysis for req-1: foreground shell evidence received",
+        ],
+    );
+    // The T3 fresh-turn panel copy must never appear on the success path.
+    assert!(
+        !output.contains("Using a fresh provider turn for shell evidence recovery."),
+        "{output}"
+    );
+    assert!(
+        !output.contains("Provider session continuity may be degraded."),
+        "{output}"
+    );
+    assert!(!output.contains("Agent timed out:"), "{output}");
+}
+
 #[test]
 fn raw_cli_shell_handoff_resume_timeout_renders_structured_context_before_recovery_notice() {
     let output = run_raw_cli_with_args_env_and_delayed_input(
@@ -87,9 +179,12 @@ fn raw_cli_shell_handoff_resume_timeout_renders_structured_context_before_recove
         1,
         "{output}"
     );
+    // The trigger reason renders once in the T2 same-session retry notice
+    // and once inside the T3 fresh-turn panel (a successful T2 must already
+    // show the reason, so the full chain shows it twice).
     assert_eq!(
         count_occurrences(&output, "Recovery trigger: provider_timeout"),
-        1,
+        2,
         "{output}"
     );
     assert!(!output.contains("Agent timed out:"), "{output}");


### PR DESCRIPTION
## Summary

Fixes #2031: one user conversation was split across two provider sessions when the shell-evidence continuation turn stalled. The fallback turn used to disable provider resume immediately, so the original session recorded an interrupted zero-token call while the real answer landed in a brand-new session — the sight dashboard showed "0 input tokens / no agent reply".

This PR splits "do not resume" from "do not retry", grafted onto the reason-based fallback trigger from #2072 (merged):

```
provider_timeout:
  T1 continuation (--resume)  stalls
    -> T2 same-session retry (--resume, committed history kept)  stalls again
      -> T3 fresh safety net (disable provider resume, old behavior)  -> stop
resume_failed:
  skips T2 (retrying a rejected session would fail identically)
    -> straight to the T3 fresh safety net  -> stop
```

Hints only ever accumulate (`SHELL_HANDOFF_SAME_SESSION_RETRY_HINT`, then `DISABLE_PROVIDER_RESUME_HINT`), so the chain is monotonic and capped. The "Agent recovery" panel (whose copy claims a fresh turn and degraded continuity) now renders only for T3 where it is true; T2 renders the `Recovery trigger: {reason}` line (same message the T3 panel embeds — a successful T2 never reaches the panel, so the reason must already be visible here) followed by the retry status line (`AgentRecoverySameSessionRetryLine`, en/zh).

The observer-side grouping gaps (agentsight `.json`/`.jsonl` mapper mismatch, pid-anchored grouping) are tracked separately in #2059; the two are companions — this PR restores provider-side continuity and gives the observer a single stable session uuid to anchor on.

## Changes

- `agent/continuation.rs`: tier gating inside the #2072 reason-based `shell_handoff_resume_fallback_request_for_reason` (`provider_timeout` without a T2 marker -> same-session retry `-retry`; with marker -> fresh `-fresh`; `resume_failed` -> fresh directly); tier-aware `render_fallback_recovery_notice` (T2: trigger-reason line + retry line; T3: the panel, which embeds the reason line).
- `agent/finish.rs`: the single post-#2072 trigger path renders by tier.
- i18n: new `MessageId::AgentRecoverySameSessionRetryLine` appended as a trailing segment (`agent_recovery_retry_ids`) after the #2072 `agent_recovery_reason_ids` segment, so existing discriminants never shift; tail-ownership assertions moved with the segment.
- `adapter/cosh_core_tests.rs` / `adapter/qwen.rs`: adapters need no logic change (T2 carries no "disable provider resume" substring and naturally resumes); added invocation tests pinning T2 -> `--resume <active>` and T3 -> no resume on both adapters, plus a cross-module contract anchor (`fallback_hints_keep_the_adapter_resume_gating_contract`) since adapters gate on the literal substring.
- `adapter/fake.rs`: new `trigger resume timeout once` scenario — times out only for the T1 continuation (gated on the absence of both the retry and disable hints) so the T2-success presentation path is testable.
- `tests/raw_cli/provider_handoff/recovery.rs`: chain-presentation case (T2 reason + retry lines render before a single T3 panel) and the T2-success case (reason line renders, panel never does).

### Test anchoring (on top of the #2072 suite)

| Anchor | Semantics |
| --- | --- |
| `shell_handoff_resume_fallback_retries_once_without_resume` (upstream, kept) | `resume_failed` still goes straight to fresh |
| `shell_handoff_provider_timeout_escalates_through_retry_then_fresh` (new) | timeout chain T1->T2->T3->stop + cap |
| `shell_handoff_first_fallback_keeps_provider_resume` (new) | S2 FAIL baseline, red before this fix |
| `fallback_hints_keep_the_adapter_resume_gating_contract` (new) | adapter literal-substring gating cannot drift |
| `raw_cli_shell_handoff_fallback_chain_renders_retry_line_then_single_panel` (new) | T2 reason + retry lines, exactly one panel |
| `raw_cli_shell_handoff_retry_success_shows_reason_without_panel` (new) | successful T2 shows the trigger reason, no panel |

## Tests

- `cargo test -p cosh-shell --bins`: 2215 tests, 0 failed (known parallel flakes in the registry/hooks family, green on single-run).
- `cargo test -p cosh-shell --test raw_cli provider_handoff`: 30 tests green (recovery module serial 6/6; parallel PTY-echo flakes pass on single-run; main shows the same family).
- `cargo clippy -p cosh-shell --all-targets -- -D warnings`, `cargo fmt --check`: green.
- Gates: `check-layout.sh`, `check-test-inventory.sh`: green.

## Evidence

**Historical real-machine evidence (pre-graft)**: the run below was recorded against the pre-graft implementation, whose T2 was triggered by the since-removed 15s first-text timeout — it demonstrates the same-session T2 *outcome* (single provider session uuid, 7-message chain vs. the split baseline), but does **not** exercise the current structured `AgentFailed(provider_timeout)` trigger path. The current trigger path is pinned by the raw CLI cases above (assets pinned to fork commit `ac924a31`):

| pre-graft branch (same-session retry, single session) | baseline main (recovery panel, split sessions) |
| --- | --- |
| ![fixed](https://raw.githubusercontent.com/SunnyQjm/anolisa/ac924a310a47f00af701fa235660c495109c8049/fixed-final.png) | ![baseline](https://raw.githubusercontent.com/SunnyQjm/anolisa/ac924a310a47f00af701fa235660c495109c8049/baseline-final.png) |

- casts: [fixed.cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/ac924a310a47f00af701fa235660c495109c8049/fixed.cast) · [baseline.cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/ac924a310a47f00af701fa235660c495109c8049/baseline.cast)
- full transcripts, session json copies, driver/proxy scripts archived in the workspace evidence bundle `artifacts/cosh-2031-real-accept-20260731/`.

Companion observer-side issue: #2059.
