### PR TITLE
fix(tokenless): address Hermes review feedback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -812,6 +812,7 @@ jobs:
         run: |
           cd src/tokenless
           python3 tests/test_compress_response_hook.py
+          python3 tests/test_hermes_plugin_import.py
 
       - uses: actions/setup-node@v4
         with:

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -187,6 +187,7 @@ test-integration:
 	@echo "==> Testing hook integration (Python)..."
 	python3 tests/test_compress_response_hook.py
 	python3 tests/test_compress_schema_hook.py
+	python3 tests/test_hermes_plugin_import.py
 	python3 tests/test_rewrite_hook.py
 	python3 tests/test_resolve_agent_id.py
 

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -95,53 +95,62 @@ def _validate_hooks_dir(path: str) -> str | None:
     return None
 
 
-# Resolve real home from passwd DB for user-install fallback path
-# (NOT $HOME — env-controllable).
-try:
-    import pwd as _pwd
-    _REAL_HOME = _pwd.getpwuid(os.getuid()).pw_dir
-except (ImportError, KeyError):
-    _REAL_HOME = ""
-if not os.path.isabs(_REAL_HOME):
-    _REAL_HOME = ""
+def _resolve_hook_utils() -> tuple[str, list[str]]:
+    """Locate a trusted shared hooks directory and make it importable.
 
-_HOOK_UTILS_CANDIDATES = [
-    os.path.join(_HERE, "..", "common", "hooks"),                          # source-tree / symlink install
-    "/usr/share/anolisa/adapters/tokenless/common/hooks",                  # RPM system
-    "/usr/local/share/anolisa/adapters/tokenless/common/hooks",            # manual system
-]
-# XDG user data dir first (anolisa FsLayout::user precedence), then the
-# passwd-home default. XDG_DATA_HOME is env-controllable, but candidates
-# still pass the full ownership/permission validation above.
-_xdg_data = os.environ.get("XDG_DATA_HOME", "")
-if _xdg_data and os.path.isabs(_xdg_data):
-    _HOOK_UTILS_CANDIDATES.append(
-        os.path.join(_xdg_data, "anolisa", "adapters", "tokenless", "common", "hooks"))
-if _REAL_HOME:
-    _HOOK_UTILS_CANDIDATES.append(
-        os.path.join(_REAL_HOME, ".local", "share",
-                     "anolisa", "adapters", "tokenless", "common", "hooks"))
+    Returns ``(resolved_path, candidate_list)``.  The resolved path is
+    inserted at the front of ``sys.path`` so the shared ``hook_utils``
+    module can be imported.  Raises :exc:`ImportError` when no candidate
+    passes the trust policy.
+    """
+    # Resolve real home from passwd DB for user-install fallback path
+    # (NOT $HOME — env-controllable).
+    try:
+        import pwd as _pwd
+        real_home = _pwd.getpwuid(os.getuid()).pw_dir
+    except (ImportError, KeyError):
+        real_home = ""
+    if not os.path.isabs(real_home):
+        real_home = ""
 
-_HOOK_UTILS_RESOLVED = ""
-_rejections: list[str] = []
-for _c in _HOOK_UTILS_CANDIDATES:
-    _reason = _validate_hooks_dir(_c)
-    if _reason is None:
-        _HOOK_UTILS_RESOLVED = os.path.realpath(_c)
-        sys.path.insert(0, _HOOK_UTILS_RESOLVED)
-        break
-    _rejections.append(f"  - {_c}: {_reason}")
+    candidates = [
+        os.path.join(_HERE, "..", "common", "hooks"),                          # source-tree / symlink install
+        "/usr/share/anolisa/adapters/tokenless/common/hooks",                  # RPM system
+        "/usr/local/share/anolisa/adapters/tokenless/common/hooks",            # manual system
+    ]
+    # XDG user data dir first (anolisa FsLayout::user precedence), then the
+    # passwd-home default. XDG_DATA_HOME is env-controllable, but candidates
+    # still pass the full ownership/permission validation above.
+    xdg_data = os.environ.get("XDG_DATA_HOME", "")
+    if xdg_data and os.path.isabs(xdg_data):
+        candidates.append(
+            os.path.join(xdg_data, "anolisa", "adapters", "tokenless", "common", "hooks"))
+    if real_home:
+        candidates.append(
+            os.path.join(real_home, ".local", "share",
+                         "anolisa", "adapters", "tokenless", "common", "hooks"))
 
-if not _HOOK_UTILS_RESOLVED:
+    rejections: list[str] = []
+    for candidate in candidates:
+        reason = _validate_hooks_dir(candidate)
+        if reason is None:
+            resolved = os.path.realpath(candidate)
+            sys.path.insert(0, resolved)
+            return resolved, candidates
+        rejections.append(f"  - {candidate}: {reason}")
+
     raise ImportError(
         "tokenless: no trusted shared hook_utils module (common/hooks/) found.\n"
-        "Candidates checked (in order):\n" + "\n".join(_rejections) + "\n"
+        "Candidates checked (in order):\n" + "\n".join(rejections) + "\n"
         "Note: a candidate may be rejected by the trust policy (ownership or "
         "permissions) even though the path exists — see the reason next to "
         "each path. Install the tokenless common hooks (anolisa install "
         "tokenless) or re-run adapters/tokenless/hermes/scripts/install.sh "
         "from a complete adapter tree."
     )
+
+
+_HOOK_UTILS_RESOLVED, _HOOK_UTILS_CANDIDATES = _resolve_hook_utils()
 
 from hook_utils import (
     _TOKENLESS_FALLBACK,

--- a/src/tokenless/tests/test_hermes_plugin_import.py
+++ b/src/tokenless/tests/test_hermes_plugin_import.py
@@ -24,8 +24,6 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _PLUGIN_SRC = os.path.join(_REPO_ROOT, "adapters", "tokenless", "hermes", "__init__.py")
 _HOOKS_SRC = os.path.join(_REPO_ROOT, "adapters", "tokenless", "common", "hooks")
 
-_needs_py39 = sys.version_info < (3, 9)
-
 
 def _load_plugin(path: str, name: str):
     """Load a copy of the Hermes plugin module under a unique name."""
@@ -33,7 +31,11 @@ def _load_plugin(path: str, name: str):
     sys.modules.pop("hook_utils", None)
     spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    pre_path = sys.path[:]
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = pre_path
     return module
 
 
@@ -47,7 +49,6 @@ def _make_hooks_dir(base: str) -> str:
     return hooks
 
 
-@unittest.skipIf(_needs_py39, "hermes plugin requires Python 3.9+")
 class ValidateHooksDirTest(unittest.TestCase):
     """Unit tests for _validate_hooks_dir (loaded from the source tree)."""
 
@@ -107,7 +108,6 @@ class ValidateHooksDirTest(unittest.TestCase):
             self.assertTrue(os.path.isabs(candidate) or candidate.startswith(self.plugin._HERE))
 
 
-@unittest.skipIf(_needs_py39, "hermes plugin requires Python 3.9+")
 class CopyInstallResolutionTest(unittest.TestCase):
     """End-to-end: plugin copied to a bare dir (anolisa driver behavior)."""
 


### PR DESCRIPTION
## Description

Follow-up to #2058 addressing external review feedback:

- Encapsulate the `hook_utils` resolution loop in a private `_resolve_hook_utils()` function so temporary loop variables no longer leak into the module namespace.
- Restore `sys.path` after each plugin load in the regression test to avoid leaking resolved hooks directories between tests.
- Wire the new `test_hermes_plugin_import.py` regression test into `src/tokenless/Makefile` `test-integration` and the CI "Run hook integration tests (Python)" step.
- Remove the Python 3.8 skip in `test_hermes_plugin_import.py`; both `hermes/__init__.py` and `common/hooks/hook_utils.py` use `from __future__ import annotations`, so the 3.9+ type syntax is not evaluated at import time on Python 3.8.
- Rebase onto the latest `main` to drop the merge commit and keep a linear history.

The existing trust model, candidate order, and `ImportError` diagnostics remain unchanged.

## Related Issue

Relates to #2058

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless` (tokenless)

## Testing

- `make test-integration` passes on Python 3.8.17 (43 tests: 11 hermes + 11 rewrite + 7 resolve-agent-id + 14 compress-response skipped on 3.8 + 7 compress-schema skipped on 3.8).
- `python3.8 tests/test_hermes_plugin_import.py -v` passes.
- `git diff --check` clean.
