### PR TITLE
chore(tokenless): bump version to 0.7.4

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.3"
+version = "0.7.4"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/.anolisa/component.toml
+++ b/src/tokenless/.anolisa/component.toml
@@ -6,7 +6,7 @@
 # Installed to: %{_datadir}/anolisa/components/tokenless/component.toml
 [component]
 name = "tokenless"
-version = "0.7.3"
+version = "0.7.4"
 
 [[adapters]]
 framework = "openclaw"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -7,6 +7,19 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-07-31
+
+### Added
+
+- Tokenless can now be installed from npm on Linux and macOS x64/arm64, including the `tokenless`, `rtk`, and `toon` binaries plus framework adapters ([#1929](https://github.com/alibaba/anolisa/pull/1929)).
+- `tokenless stats diff` now explains estimated savings for records, sessions, and tool uses with text or JSON reports and bounded unified diffs ([#1991](https://github.com/alibaba/anolisa/pull/1991)).
+- `TOKENLESS_DATA_DIR` now sets one trusted directory for both statistics and reversible-compression databases while preserving per-database overrides ([#2038](https://github.com/alibaba/anolisa/pull/2038)).
+
+### Fixed
+
+- The Qwencode adapter now declares its delivered `compress-toon` capability, keeping adapter discovery consistent with its compression behavior ([#1945](https://github.com/alibaba/anolisa/pull/1945)).
+- Hermes copy installations now resolve shared hook resources from trusted system, XDG, and user data paths with actionable diagnostics when no safe candidate exists ([#2058](https://github.com/alibaba/anolisa/pull/2058)).
+
 ## [0.7.3] - 2026-07-28
 
 ### Added
@@ -203,6 +216,7 @@ Releases from 0.7.2 onward follow
 
 - introduce tokenless into ANOLISA (#199)
 
-[Unreleased]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.3...HEAD
+[Unreleased]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.4...HEAD
+[0.7.4]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.3...tokenless/v0.7.4
 [0.7.3]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.2...tokenless/v0.7.3
 [0.7.2]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.1...tokenless/v0.7.2

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "clap",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "regex",
  "serde_json",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "MIT"
 

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -45,9 +45,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.3",
-    "@anolisa/tokenless-linux-arm64": "0.7.3",
-    "@anolisa/tokenless-darwin-x64": "0.7.3",
-    "@anolisa/tokenless-darwin-arm64": "0.7.3"
+    "@anolisa/tokenless-linux-x64": "0.7.4",
+    "@anolisa/tokenless-linux-arm64": "0.7.4",
+    "@anolisa/tokenless-darwin-x64": "0.7.4",
+    "@anolisa/tokenless-darwin-arm64": "0.7.4"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -1,4 +1,4 @@
-%define anolis_release 3
+%define anolis_release 1
 %global debug_package %{nil}
 
 Name:           tokenless
@@ -446,6 +446,13 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Fri Jul 31 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.4-1
+- feat(tokenless): distribute prebuilt binaries and adapters through npm for Linux and macOS x64/arm64
+- feat(tokenless): add `tokenless stats diff` reports for records, sessions, and tool uses
+- feat(tokenless): add `TOKENLESS_DATA_DIR` for shared statistics and stash database placement
+- fix(tokenless): declare the Qwencode `compress-toon` capability
+- fix(tokenless): resolve Hermes shared hooks from trusted system and user data paths
+
 * Thu Jul 16 2026 Lin Yan <linyan.lin@alibaba-inc.com> - 0.7.0-3
 - fix(tokenless): declare all shipped adapters (claude-code, codex, cosh, qoder) in RPM component contract template; exclude generated component.toml from source tarball to prevent stale contracts (GH-1470)
 


### PR DESCRIPTION
## Description

This bumps Tokenless from v0.7.3 to v0.7.4 across Cargo, npm platform packages, RPM metadata, and both component manifests. The release remains anchored to the Cargo workspace version so every distribution channel publishes the same version. The changelog aggregates the user-visible npm distribution, statistics diff, shared database directory, Qwencode capability, and Hermes hook-resolution changes included in this release.

## Related Issue

no-issue: release metadata synchronization for Tokenless v0.7.4

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [x] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (475 passed, 2 ignored)
- `cargo doc --workspace --no-deps --locked`
- `make check-component-contract`
- Stamped `tokenless.spec.in` with v0.7.4 and validated it with `rpmspec -P`
- Parsed all npm package manifests and verified locked Cargo metadata

## Additional Notes

No runtime code changed, so no new tests were required. The RPM `anolis_release` counter is reset to 1 for the new upstream version.
