### PR TITLE
fix(sight): map cosh session tmp file writes

### DIFF
--- a/src/agentsight/src/bpf/filewrite.bpf.c
+++ b/src/agentsight/src/bpf/filewrite.bpf.c
@@ -2,7 +2,8 @@
 // Copyright (c) 2025 AgentSight Project
 //
 // File write BPF program
-// Monitors vfs_write calls from traced processes writing to .jsonl files
+// Monitors vfs_write calls from traced processes writing to agent session
+// files (.jsonl and cosh-core atomic-write temp files)
 // Uses fentry (BPF trampoline) for minimal overhead on the hot vfs_write path
 #include "vmlinux.h"
 #include <bpf/bpf_core_read.h>
@@ -16,6 +17,8 @@
 #define UUID_LEN 36
 // Expected filename: <uuid>.jsonl = 36 + 6 = 42 chars
 #define UUID_JSONL_LEN (UUID_LEN + 6)
+// cosh-core atomic-write temp file: .<uuid>.<uuid>.tmp = 1 + 36 + 1 + 36 + 4 = 78 chars
+#define COSH_TMP_LEN (1 + UUID_LEN + 1 + UUID_LEN + 4)
 
 static __always_inline int is_hex(char c)
 {
@@ -64,7 +67,7 @@ int BPF_PROG(trace_vfs_write, struct file *file, const char *buf, size_t count, 
     if (ret <= 0)
         return 0;
 
-    // We accept two filename shapes; both checks use only compile-time fixed
+    // We accept three filename shapes; all checks use only compile-time fixed
     // offsets, so the eBPF verifier doesn't have to track dynamic length math.
     //   1. `<UUID>.jsonl`              (exactly 42 chars + NUL = 43)
     //                                  OpenClaw / Cosh / Claude Code
@@ -72,6 +75,15 @@ int BPF_PROG(trace_vfs_write, struct file *file, const char *buf, size_t count, 
     //                                  Codex CLI rollouts; userspace
     //                                  extracts the trailing UUID via
     //                                  ResponseSessionMapper.
+    //   3. `.<UUID>.<UUID>.tmp`        (exactly 78 chars + NUL = 79)
+    //                                  cosh-core atomic session writes:
+    //                                  content goes to this temp file and is
+    //                                  then renamed to `<session-UUID>.json`,
+    //                                  so the rename target never reaches
+    //                                  vfs_write — the temp name is the only
+    //                                  chance to capture session content.
+    //                                  Userspace extracts the first UUID as
+    //                                  the session id.
     //
     // The rollout check is intentionally a *prefix* match (`rollout-`)
     // without verifying the `.jsonl` suffix: the eBPF verifier rejects
@@ -98,7 +110,19 @@ int BPF_PROG(trace_vfs_write, struct file *file, const char *buf, size_t count, 
         && fname[6] == 't'
         && fname[7] == '-';
 
-    if (!matched_strict && !matched_rollout)
+    // Strict full-pattern match (both UUIDs validated) so that generic
+    // dotfile temp names from other programs don't flood the ring buffer.
+    int matched_cosh_tmp = (ret == COSH_TMP_LEN + 1)
+        && fname[0] == '.'
+        && fname[1 + UUID_LEN] == '.'
+        && fname[2 + 2 * UUID_LEN] == '.'
+        && fname[3 + 2 * UUID_LEN] == 't'
+        && fname[4 + 2 * UUID_LEN] == 'm'
+        && fname[5 + 2 * UUID_LEN] == 'p'
+        && is_uuid(fname + 1)
+        && is_uuid(fname + 2 + UUID_LEN);
+
+    if (!matched_strict && !matched_rollout && !matched_cosh_tmp)
         return 0;
 
     // Reserve space in ring buffer

--- a/src/agentsight/src/response_map.rs
+++ b/src/agentsight/src/response_map.rs
@@ -6,8 +6,11 @@
 //! # Data Flow
 //!
 //! ```text
-//! FileWriteEvent { filename: "<UUID>.jsonl", buf: JSONL bytes }
-//!     → parse filename to extract UUID as session_id
+//! FileWriteEvent { filename: session file (see shapes below), buf: JSONL bytes }
+//!     → parse filename to extract UUID as session_id:
+//!         `<UUID>.jsonl`                → the UUID stem
+//!         `rollout-<ts>-<UUID>.jsonl`   → the trailing UUID
+//!         `.<UUID>.<UUID>.tmp`          → the first UUID
 //!     → parse buf lines as JSON, extract "responseId" field
 //!     → store responseId → sessionId in LRU cache
 //! ```
@@ -16,6 +19,11 @@
 //! not embed an LLM `response_id` inside the JSONL, so we instead remember
 //! the most-recent UUID per writing pid and look it up by the HTTP call's
 //! pid as a fallback.
+//!
+//! cosh-core persists sessions atomically: content is written to a temp file
+//! named `.<session-UUID>.<random-UUID>.tmp` and then renamed to
+//! `<session-UUID>.json`, so vfs_write only ever sees the temp name and the
+//! session id must be recovered from its first UUID.
 
 use std::num::NonZeroUsize;
 
@@ -111,7 +119,8 @@ impl ResponseSessionMapper {
             Some(id) => id,
             None => {
                 log::trace!(
-                    "ResponseSessionMapper: filename not UUID.jsonl format: {}",
+                    "ResponseSessionMapper: filename not a recognized session file \
+                     (UUID.jsonl, rollout-*.jsonl, or .<UUID>.<UUID>.tmp): {}",
                     event.filename
                 );
                 return;
@@ -163,11 +172,30 @@ impl ResponseSessionMapper {
     }
 
     /// Extract UUID from a filename like `<UUID>.jsonl` or `/path/to/<UUID>.jsonl`.
-    /// Also recognizes Codex CLI's `rollout-<ts>-<UUID>.jsonl` form by
-    /// extracting the trailing 36-char UUID.
+    /// Also recognizes Codex CLI's `rollout-<ts>-<UUID>.jsonl` form (trailing
+    /// 36-char UUID) and cosh-core's atomic-write temp form
+    /// `.<session-UUID>.<random-UUID>.tmp` (first UUID is the session id).
     fn extract_session_id(filename: &str) -> Option<String> {
         // Take the last path component
         let basename = filename.rsplit('/').next().unwrap_or(filename);
+
+        // cosh-core atomic writes: the final `<UUID>.json` is produced by
+        // rename and never hits vfs_write, so the temp name is the only place
+        // the session id appears. Match the full pattern strictly (mirrors the
+        // BPF-side filter) to avoid picking up unrelated dotfile temp names.
+        if let Some(stem) = basename
+            .strip_prefix('.')
+            .and_then(|rest| rest.strip_suffix(".tmp"))
+        {
+            // stem = "<UUID>.<UUID>" (36 + 1 + 36 chars)
+            if stem.len() == 73 && stem.as_bytes()[36] == b'.' {
+                let (session, random) = (&stem[..36], &stem[37..]);
+                if Self::is_uuid(session) && Self::is_uuid(random) {
+                    return Some(session.to_string());
+                }
+            }
+            return None;
+        }
 
         // Strip .jsonl suffix
         let stem = basename.strip_suffix(".jsonl")?;
@@ -182,6 +210,16 @@ impl ResponseSessionMapper {
             .captures(stem)
             .and_then(|cap| cap.get(1))
             .map(|m| m.as_str().to_string())
+    }
+
+    /// Canonical 36-char UUID shape check: hyphens at 8/13/18/23, hex elsewhere.
+    /// Mirrors `is_uuid` in `filewrite.bpf.c` so both sides accept the same set.
+    fn is_uuid(s: &str) -> bool {
+        s.len() == 36
+            && s.bytes().enumerate().all(|(i, b)| match i {
+                8 | 13 | 18 | 23 => b == b'-',
+                _ => b.is_ascii_hexdigit(),
+            })
     }
 
     /// Extract "responseId" or "response_id" value from a single JSONL line using regex.
@@ -273,6 +311,97 @@ mod tests {
     #[test]
     fn test_extract_session_id_wrong_length() {
         assert!(ResponseSessionMapper::extract_session_id("short.jsonl").is_none());
+    }
+
+    #[test]
+    fn test_extract_session_id_cosh_tmp() {
+        // cosh-core atomic-write temp file: first UUID is the session id.
+        let id = ResponseSessionMapper::extract_session_id(
+            ".550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp",
+        );
+        assert_eq!(id.as_deref(), Some("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_extract_session_id_cosh_tmp_with_path() {
+        let id = ResponseSessionMapper::extract_session_id(
+            "/home/user/.cosh/sessions/.550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp",
+        );
+        assert_eq!(id.as_deref(), Some("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_extract_session_id_cosh_tmp_requires_leading_dot() {
+        // Same shape without the leading dot must not match the tmp branch.
+        assert!(
+            ResponseSessionMapper::extract_session_id(
+                "550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_extract_session_id_cosh_tmp_rejects_bad_uuid_length() {
+        // First segment is 35 chars (truncated UUID) — must not match.
+        assert!(
+            ResponseSessionMapper::extract_session_id(
+                ".550e8400-e29b-41d4-a716-44665544000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_extract_session_id_cosh_tmp_rejects_non_hex_uuid() {
+        // Second segment contains 'g' — not a valid UUID.
+        assert!(
+            ResponseSessionMapper::extract_session_id(
+                ".550e8400-e29b-41d4-a716-446655440000.0198f00g-1a2b-4c3d-8e4f-556677889900.tmp",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_extract_session_id_cosh_tmp_rejects_wrong_suffix() {
+        assert!(
+            ResponseSessionMapper::extract_session_id(
+                ".550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.txt",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_process_and_query_cosh_tmp() {
+        // End-to-end: a cosh-core temp-file write maps response_id to the
+        // session UUID taken from the temp filename's first UUID.
+        let mut mapper = ResponseSessionMapper::new();
+        let event = FileWriteEvent {
+            pid: 4321,
+            tid: 4321,
+            uid: 1000,
+            timestamp_ns: 0,
+            write_size: 0,
+            comm: "cosh".to_string(),
+            filename: ".550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp"
+                .to_string(),
+            cgroup_id: 0,
+            buf: br#"{"response_id":"chatcmpl-11112222-3333-4444-5555-666677778888","model":"qwen-plus"}
+"#
+            .to_vec(),
+        };
+        mapper.process_filewrite(&event);
+
+        assert_eq!(
+            mapper.get_session_by_response_id("chatcmpl-11112222-3333-4444-5555-666677778888"),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            mapper.get_session_by_pid(4321),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

cosh-core persists session files atomically: content is written to a temp file named `.{session_uuid}.{random_uuid}.tmp` and then `renameat`-ed to `<uuid>.json`. Since the rename target never goes through `vfs_write`, the filewrite probe (which only accepted `<uuid>.jsonl` names) never saw cosh session content, so the cosh session mapping never took effect. This PR adds a strictly-shaped match for the tmp name in the BPF filter (both UUIDs validated so generic dotfile temps from other programs don't flood the ring buffer), and userspace extracts the leading UUID as the session id.

## Related Issue

Relates to #2059

This PR fixes only defect 1 of that issue (the `.json`/`.jsonl` session mapping never taking effect for cosh-core). Defect 2 (PID-anchored grouping breakage) is out of scope here and remains open, so no closing keyword is used.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [x] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass

## Testing

- Linux ECS (rustc 1.89.0, kernel 6.6): `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test` suite pass.
- BPF load test: the updated `filewrite.bpf.c` is accepted by the eBPF verifier on kernel 6.6.
- End-to-end on a real machine: the probe captures cosh-core tmp-file write events and establishes both the responseId→sessionId and pid→sessionId mappings; negative control with an invalid-UUID tmp name produces zero events.
