### PR TITLE
fix(cosh-ng): [shell] show hook context

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -6,6 +6,7 @@ use crate::agent::events::{
     flush_cosh_request_filter_into_active_run, render_agent_structured_events,
     render_held_events_into_active_run, state_has_pending_interaction,
 };
+use crate::agent::governance::hook_notification_display_text;
 use crate::agent::run::{
     has_queued_run_before_held_text, start_agent_run_with_origin, start_pending_agent_run,
     ActiveAgentRun, PendingRequestClass,
@@ -88,7 +89,14 @@ pub(crate) fn finish_active_agent_run<W: Write>(
     }
     // Drain any unconsumed pending hook notifications into deferred_events
     // (orphan case: hook returned block, so no ToolPermissionRequest was emitted)
+    let i18n = I18n::new(active_run.language);
     for notification in active_run.pending_hook_notifications.drain(..) {
+        let display_text = hook_notification_display_text(
+            &notification.hook_name,
+            &notification.message,
+            notification.decision.as_deref(),
+            &i18n,
+        );
         active_run.deferred_events.push(GovernedEvent {
             decision: GovernanceDecision::Display,
             policy_decision: GovernancePolicyDecision::DisplayOnly,
@@ -100,7 +108,7 @@ pub(crate) fn finish_active_agent_run<W: Write>(
                 decision: notification.decision,
             },
             reason: "orphan hook notification".to_string(),
-            display_text: String::new(),
+            display_text,
             auto_execute: false,
         });
     }
@@ -310,7 +318,7 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-    use crate::agent::run::{PendingAgentRequest, PendingRequestClass};
+    use crate::agent::run::{PendingAgentRequest, PendingHookNotification, PendingRequestClass};
     use crate::runtime::state::InlineState;
     use crate::types::{AgentMode, AgentRequest, CommandBlock, CommandStatus, OutputRefs};
 
@@ -381,42 +389,38 @@ mod tests {
         assert!(rendered.contains("STALE ANSWER"), "{rendered}");
     }
 
+    #[test]
+    fn finish_renders_orphan_hook_notification_with_fallbacks() {
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut state = InlineState::default();
+        let mut active_run = active_run(&adapter, "run-1", Language::ZhCn);
+        active_run
+            .pending_hook_notifications
+            .push(PendingHookNotification {
+                tool_use_id: Some("tool-1".to_string()),
+                hook_name: "  ".to_string(),
+                message: String::new(),
+                decision: Some("\n".to_string()),
+            });
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        finish_active_agent_run(&mut state, &mut output, &adapter).expect("finish run");
+
+        let rendered = String::from_utf8_lossy(&output);
+        assert!(rendered.contains("Hook: 未知 Hook"), "{rendered}");
+        assert!(rendered.contains("消息: 未提供消息"), "{rendered}");
+        assert!(rendered.contains("决策: 未指定"), "{rendered}");
+        assert!(!rendered.contains("unknown hook"), "{rendered}");
+    }
+
     // Finishes an active `run-1` holding one text delta, with an approved handoff
     // owned by `handoff_run_id` still outstanding. Returns what was rendered plus
     // the resulting state.
     fn finish_run_with_handoff_owned_by(handoff_run_id: &str) -> (String, InlineState) {
         let adapter = AdapterInstance::Fake(FakeAgentAdapter);
         let mut state = InlineState::default();
-        let run_request = request("run-1");
-        let handle = adapter.start_cancellable(run_request.clone(), CoshApprovalMode::Recommend);
-        let renderer = RatatuiInlineRenderer::for_terminal();
-        let mut active_run = ActiveAgentRun {
-            request: run_request,
-            origin: AgentRunOrigin::Standard,
-            handle,
-            provider_name: "fake",
-            language: Language::EnUs,
-            renderer: renderer.clone(),
-            status_animation: renderer.status_animation(),
-            markdown_stream: renderer.stream_markdown_agent(),
-            governed_events: Vec::new(),
-            deferred_events: Vec::new(),
-            held_events: Vec::new(),
-            cosh_request_filter: crate::evidence::stream::CoshRequestStreamFilter::default(),
-            pending_cosh_requests: Vec::new(),
-            pending_cosh_request_audits: Vec::new(),
-            rendered_governed_event_count: 0,
-            selectable_after_event_index: None,
-            started_at: Instant::now(),
-            last_activity_at: Instant::now(),
-            last_heartbeat_at: Instant::now(),
-            current_phase: String::new(),
-            current_message: String::new(),
-            has_visible_text_delta: false,
-            completed: true,
-            host_completed_tool_ids: Vec::new(),
-            pending_hook_notifications: Vec::new(),
-        };
+        let mut active_run = active_run(&adapter, "run-1", Language::EnUs);
         active_run.held_events.push(GovernedEvent {
             decision: GovernanceDecision::Display,
             policy_decision: GovernancePolicyDecision::DisplayOnly,
@@ -446,6 +450,39 @@ mod tests {
         finish_active_agent_run(&mut state, &mut output, &adapter).expect("finish run");
 
         (String::from_utf8_lossy(&output).to_string(), state)
+    }
+
+    fn active_run(adapter: &AdapterInstance, id: &str, language: Language) -> ActiveAgentRun {
+        let run_request = request(id);
+        let handle = adapter.start_cancellable(run_request.clone(), CoshApprovalMode::Recommend);
+        let renderer = RatatuiInlineRenderer::for_terminal().with_language(language);
+        ActiveAgentRun {
+            request: run_request,
+            origin: AgentRunOrigin::Standard,
+            handle,
+            provider_name: "fake",
+            language,
+            renderer: renderer.clone(),
+            status_animation: renderer.status_animation(),
+            markdown_stream: renderer.stream_markdown_agent(),
+            governed_events: Vec::new(),
+            deferred_events: Vec::new(),
+            held_events: Vec::new(),
+            cosh_request_filter: crate::evidence::stream::CoshRequestStreamFilter::default(),
+            pending_cosh_requests: Vec::new(),
+            pending_cosh_request_audits: Vec::new(),
+            rendered_governed_event_count: 0,
+            selectable_after_event_index: None,
+            started_at: Instant::now(),
+            last_activity_at: Instant::now(),
+            last_heartbeat_at: Instant::now(),
+            current_phase: String::new(),
+            current_message: String::new(),
+            has_visible_text_delta: false,
+            completed: true,
+            host_completed_tool_ids: Vec::new(),
+            pending_hook_notifications: Vec::new(),
+        }
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/agent/governance.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/governance.rs
@@ -190,12 +190,15 @@ pub fn govern_agent_events_with_language(
                 false,
             ),
             AgentEvent::HookNotification {
-                hook_name, message, ..
+                hook_name,
+                message,
+                decision,
+                ..
             } => (
                 GovernanceDecision::Display,
                 GovernancePolicyDecision::DisplayOnly,
                 "hook notification is display-only".to_string(),
-                format!("{hook_name}: {message}"),
+                hook_notification_display_text(hook_name, message, decision.as_deref(), &i18n),
                 false,
             ),
         };
@@ -222,6 +225,39 @@ pub fn govern_agent_events_with_language(
         events: governed,
         audit,
     }
+}
+
+pub(crate) fn hook_notification_display_text(
+    hook_name: &str,
+    message: &str,
+    decision: Option<&str>,
+    i18n: &I18n,
+) -> String {
+    let hook_name = hook_name.trim();
+    let hook_name = if hook_name.is_empty() {
+        i18n.t(MessageId::AgentGovernanceHookUnknown)
+    } else {
+        hook_name
+    };
+    let message = message.trim();
+    let message = if message.is_empty() {
+        i18n.t(MessageId::AgentGovernanceHookNoMessage)
+    } else {
+        message
+    };
+    let decision = decision
+        .map(str::trim)
+        .filter(|decision| !decision.is_empty())
+        .unwrap_or_else(|| i18n.t(MessageId::AgentGovernanceHookDecisionUnspecified));
+
+    i18n.format(
+        MessageId::AgentGovernanceHookNotification,
+        &[
+            ("hook", hook_name),
+            ("message", message),
+            ("decision", decision),
+        ],
+    )
 }
 
 fn render_recommended_commands(commands: &[String], i18n: &I18n) -> String {

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/agent.rs
@@ -70,6 +70,12 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AgentGovernanceToolSubject => "{tool} tool",
         MessageId::AgentGovernanceBlockedUserApprovalLine => "Blocked: user approval required",
         MessageId::AgentGovernanceQuestionLine => "Question: {question}",
+        MessageId::AgentGovernanceHookNotification => {
+            "Hook: {hook}\nMessage: {message}\nDecision: {decision}"
+        }
+        MessageId::AgentGovernanceHookUnknown => "unknown hook",
+        MessageId::AgentGovernanceHookNoMessage => "no message provided",
+        MessageId::AgentGovernanceHookDecisionUnspecified => "unspecified",
         MessageId::AgentRecommendedCommandsLabel => "recommended commands:",
         MessageId::InterceptNoticeTitle => "AI request",
         MessageId::InterceptNoticeBody => "Sending input to Agent: {input}",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -100,4 +100,5 @@ collect_message_ids!([
     agent_recovery_reason_ids,
     auth_ids,
     agent_recovery_retry_ids,
+    hook_notification_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/agent.rs
@@ -139,3 +139,16 @@ macro_rules! agent_recovery_retry_ids {
         );
     };
 }
+
+macro_rules! hook_notification_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            AgentGovernanceHookNotification,
+            AgentGovernanceHookUnknown,
+            AgentGovernanceHookNoMessage,
+            AgentGovernanceHookDecisionUnspecified,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -145,15 +145,14 @@ mod tests {
             846
         );
         // The #1913 capture-notice segment remains pinned ahead of the
-        // appended shell-recovery reason and auth messages.
+        // appended shell-recovery, auth, and hook-notification messages.
         assert_eq!(MessageId::CaptureInputRejectedTitle as usize, 847);
         assert_eq!(MessageId::CaptureInputRejectedBody as usize, 848);
         assert_eq!(
             MessageId::AgentRecoveryTriggerLine as usize,
             MessageId::CaptureInputRejectedBody as usize + 1
         );
-        // The #2031 recovery-retry segment is the current tail; the tail
-        // ownership assertions move with each appended segment.
+        // The #2031 recovery-retry segment remains pinned after auth.
         assert_eq!(
             MessageId::AuthSelectProviderQuestion as usize,
             MessageId::AgentRecoveryTriggerLine as usize + 1
@@ -162,13 +161,15 @@ mod tests {
             MessageId::AgentRecoverySameSessionRetryLine as usize,
             MessageId::AuthSelectProviderQuestion as usize + 1
         );
+        // Hook-notification messages are the current tail; tail ownership
+        // assertions move with each appended segment.
         assert_eq!(
-            MessageId::AgentRecoverySameSessionRetryLine as usize,
-            MessageId::ALL.len() - 1
+            MessageId::AgentGovernanceHookNotification as usize,
+            MessageId::AgentRecoverySameSessionRetryLine as usize + 1
         );
         assert_eq!(
-            MessageId::AuthSelectProviderQuestion as usize,
-            MessageId::ALL.len() - 2
+            MessageId::AgentGovernanceHookDecisionUnspecified as usize,
+            MessageId::ALL.len() - 1
         );
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/agent.rs
@@ -64,6 +64,12 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::AgentGovernanceToolSubject => "{tool} tool",
         MessageId::AgentGovernanceBlockedUserApprovalLine => "已阻止: 需要用户审批",
         MessageId::AgentGovernanceQuestionLine => "问题: {question}",
+        MessageId::AgentGovernanceHookNotification => {
+            "Hook: {hook}\n消息: {message}\n决策: {decision}"
+        }
+        MessageId::AgentGovernanceHookUnknown => "未知 Hook",
+        MessageId::AgentGovernanceHookNoMessage => "未提供消息",
+        MessageId::AgentGovernanceHookDecisionUnspecified => "未指定",
         MessageId::AgentRecommendedCommandsLabel => "推荐命令:",
         MessageId::InterceptNoticeTitle => "AI 请求",
         MessageId::InterceptNoticeBody => "正在把输入交给 Agent: {input}",

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mvp_loop_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mvp_loop_tests.rs
@@ -248,6 +248,25 @@ fn governance_outputs_executable_policy_decisions() {
 }
 
 #[test]
+fn governance_preserves_hook_notification_context() {
+    let governed = govern_agent_events(
+        &[AgentEvent::HookNotification {
+            run_id: "run-1".to_string(),
+            hook_name: "sandbox-guard".to_string(),
+            message: "blocked reboot".to_string(),
+            tool_use_id: Some("tool-1".to_string()),
+            decision: Some("block".to_string()),
+        }],
+        &Policy::default(),
+    );
+
+    assert_eq!(
+        governed.events[0].display_text,
+        "Hook: sandbox-guard\nMessage: blocked reboot\nDecision: block"
+    );
+}
+
+#[test]
 fn governance_display_text_uses_requested_language_for_shell_owned_fallbacks() {
     let events = vec![
         AgentEvent::StatusChanged {
@@ -308,6 +327,13 @@ fn governance_display_text_uses_requested_language_for_shell_owned_fallbacks() {
             error_code: None,
             max_turns: None,
         },
+        AgentEvent::HookNotification {
+            run_id: "run-1".to_string(),
+            hook_name: String::new(),
+            message: "  ".to_string(),
+            tool_use_id: Some("tool-1".to_string()),
+            decision: None,
+        },
     ];
 
     let governed = govern_agent_events_with_language(&events, &Policy::default(), Language::ZhCn);
@@ -330,12 +356,18 @@ fn governance_display_text_uses_requested_language_for_shell_owned_fallbacks() {
     assert!(text.contains("Agent 已取消"), "{text}");
     assert!(text.contains("原因: 用户请求取消"), "{text}");
     assert!(text.contains("分析返回错误"), "{text}");
+    assert!(text.contains("Hook: 未知 Hook"), "{text}");
+    assert!(text.contains("消息: 未提供消息"), "{text}");
+    assert!(text.contains("决策: 未指定"), "{text}");
     assert!(!text.contains("Approval required:"), "{text}");
     assert!(!text.contains("analysis returned an error"), "{text}");
     assert!(!text.contains("Blocked: user approval required"), "{text}");
     assert!(!text.contains("recommended commands:"), "{text}");
     assert!(!text.contains("Tool output:"), "{text}");
     assert!(!text.contains("Question: Agent needs your input"), "{text}");
+    assert!(!text.contains("unknown hook"), "{text}");
+    assert!(!text.contains("no message provided"), "{text}");
+    assert!(!text.contains("unspecified"), "{text}");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Hook notifications now use one stable formatter for both normal governance handling and the
finish-time orphan drain. The formatter preserves hook name, message, and decision, with explicit
fallbacks for missing or whitespace-only fields, so governance panels never lose the blocking
context. Sandbox bypass approval semantics remain unchanged.

## Related Issue

closes #2067

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [x] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [x] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `cargo test --package cosh-shell --bin cosh-shell finish_renders_orphan_hook_notification_with_fallbacks`
- `cargo test --package cosh-shell --bin cosh-shell governance_preserves_hook_notification_context`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo build --package cosh-shell --release --locked`
- `cargo test --package cosh-shell --bin cosh-shell -- --test-threads=4` completed with 2,212 passed and 1 ignored; the unrelated `activity_tool_output_details_show_internal_output_ref_in_debug` assertion failed because a long temporary output-reference path wrapped before `.txt`.

## Additional Notes

No ECS, real-provider, remote manual UI, or screenshot validation was performed. The existing
sandbox bypass approval flow is intentionally outside this fix.