### PR TITLE
feat(ktuner): add distribution channel

### DIFF
--- a/.github/actions/package-source/action.yaml
+++ b/.github/actions/package-source/action.yaml
@@ -61,6 +61,7 @@ runs:
           ws-ckpt)        SRC_DIR="src/ws-ckpt" ;;
           agent-memory)   SRC_DIR="src/agent-memory" ;;
           skillfs)        SRC_DIR="src/skillfs" ;;
+          ktuner)         SRC_DIR="src/ktuner" ;;
           anolisa)        SRC_DIR="src/anolisa" ;;
           *)
             echo "ERROR: Unknown component: $COMPONENT"

--- a/.github/components.json
+++ b/.github/components.json
@@ -232,7 +232,7 @@
       "label": "component:ktuner",
       "commit_scope": "ktuner",
       "commit_scope_aliases": [],
-      "release_tag_prefix": null,
+      "release_tag_prefix": "ktuner/v",
       "ci_key": "ktuner",
       "issue_triagers": [],
       "status": "incubating"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ on:
       - 'ckpt/v*'
       - 'memory/v*'
       - 'skillfs/v*'
+      - 'ktuner/v*'
       - 'anolisa/v*'
 
 permissions:
@@ -60,6 +61,7 @@ jobs:
             ckpt)     COMPONENT="ws-ckpt" ;;
             memory)   COMPONENT="agent-memory" ;;
             skillfs)  COMPONENT="skillfs" ;;
+            ktuner)   COMPONENT="ktuner" ;;
             anolisa)  COMPONENT="anolisa" ;;
             *)
               echo "Unknown scope: $SCOPE"
@@ -306,6 +308,7 @@ jobs:
             ws-ckpt)        PREFIX="ckpt/v" ;;
             agent-memory)   PREFIX="memory/v" ;;
             skillfs)        PREFIX="skillfs/v" ;;
+            ktuner)         PREFIX="ktuner/v" ;;
             anolisa)        PREFIX="anolisa/v" ;;
           esac
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -52,6 +52,7 @@ macOS arm64, use `--backend raw --install-mode user` instead.
 | Create workspace recovery points | [ws-ckpt](user-guide/en/runtime/ws-ckpt.md) |
 | Mount Skills on demand | [SkillFS](user-guide/en/runtime/skillfs.md) |
 | Reuse context across sessions | [Agent Memory](user-guide/en/token-saving/agent-memory.md) |
+| Tune kernel parameters deterministically | [ktuner](user-guide/en/user-entrypoint/ktuner.md) |
 
 Each component page starts with its supported platforms and preferred
 installation path. Linux-only components must be installed and run on Linux.

--- a/docs/QUICKSTART_zh.md
+++ b/docs/QUICKSTART_zh.md
@@ -51,6 +51,7 @@ export PATH="$HOME/.local/bin:$PATH"
 | 创建工作区恢复点 | [ws-ckpt](user-guide/zh/runtime/ws-ckpt.md) |
 | 按需挂载 Skills | [SkillFS](user-guide/zh/runtime/skillfs.md) |
 | 跨 Session 复用上下文 | [Agent Memory](user-guide/zh/token-saving/agent-memory.md) |
+| 确定性调优内核参数 | [ktuner](user-guide/zh/user-entrypoint/ktuner.md) |
 
 每个组件页面都会首先说明支持的平台和首选安装路径。仅支持 Linux 的组件必须在
 Linux 上安装和运行。

--- a/docs/user-guide/en/user-entrypoint/ktuner.md
+++ b/docs/user-guide/en/user-entrypoint/ktuner.md
@@ -14,7 +14,22 @@ It is designed to be driven by cosh and other ANOLISA-compatible agents as a too
 
 ## Installation
 
-ktuner ships with the ANOLISA source tree under `src/ktuner/`. Build it from source:
+ktuner ships as an RPM for Linux x86_64 (system mode only). Install it with
+the ANOLISA component manager, selecting the RPM backend — ktuner has no raw
+release and there is no cross-backend fallback:
+
+```bash
+sudo anolisa install ktuner --backend rpm
+```
+
+Or install the RPM directly and let ANOLISA track it:
+
+```bash
+sudo yum install ktuner
+sudo anolisa --install-mode system adopt ktuner
+```
+
+To build from source instead:
 
 ```bash
 cd src/ktuner
@@ -29,8 +44,6 @@ sudo install -o root -g root -m 755 target/release/ktuner /usr/local/bin/ktuner
 ```
 
 The examples below assume `ktuner` is on your `PATH`.
-
-> Packaged distribution (`anolisa install ktuner` / RPM) is still being planned with the maintainers; until then, build from source.
 
 ---
 

--- a/docs/user-guide/zh/user-entrypoint/ktuner.md
+++ b/docs/user-guide/zh/user-entrypoint/ktuner.md
@@ -14,7 +14,20 @@ ktuner 是规则引擎，不是 LLM：每条建议都来自读取 `/proc/sys` �
 
 ## 安装
 
-ktuner 随 ANOLISA 源码树发布，位于 `src/ktuner/`。从源码构建：
+ktuner 以 RPM 形式发布，支持 Linux x86_64（仅 system mode）。通过 ANOLISA 组件管理器安装，显式选择 RPM backend——ktuner 没有 raw 发布，且 backend 之间没有回退：
+
+```bash
+sudo anolisa install ktuner --backend rpm
+```
+
+也可以直接安装 RPM 并让 ANOLISA 纳入管理：
+
+```bash
+sudo yum install ktuner
+sudo anolisa --install-mode system adopt ktuner
+```
+
+或者从源码构建：
 
 ```bash
 cd src/ktuner
@@ -29,8 +42,6 @@ sudo install -o root -g root -m 755 target/release/ktuner /usr/local/bin/ktuner
 ```
 
 下面的示例假设 `ktuner` 已在 `PATH` 中。
-
-> 打包分发方式（`anolisa install ktuner` / RPM）仍在与维护者规划中；在此之前请从源码构建。
 
 ---
 

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -5,7 +5,7 @@
 #   ./scripts/rpm-build.sh <package>        Build a single package
 #   ./scripts/rpm-build.sh all              Build all packages
 #
-# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory, skillfs, anolisa, cosh-ng
+# Packages: copilot-shell, agent-sec-core, os-skills, agentsight, tokenless, agent-memory, skillfs, ktuner, anolisa, cosh-ng
 #
 # Environment variables:
 #   VERSION    Override version for .spec.in templates (default: auto-detect)
@@ -27,6 +27,7 @@ SIGHT_DIR="${ROOT_DIR}/src/agentsight"
 TOKEN_DIR="${ROOT_DIR}/src/tokenless"
 MEM_DIR="${ROOT_DIR}/src/agent-memory"
 SKILLFS_DIR="${ROOT_DIR}/src/skillfs"
+KTUNER_DIR="${ROOT_DIR}/src/ktuner"
 COSH_DIR="${ROOT_DIR}/src/cosh-ng"
 SANDBOX_PKG_DIR="${ROOT_DIR}/src/anolisa/packaging/sandbox"
 
@@ -778,6 +779,85 @@ EOF
 }
 
 # =============================================================================
+# ktuner
+# =============================================================================
+build_ktuner() {
+    log "=========================================="
+    log "Building RPM: ktuner"
+    log "=========================================="
+
+    local spec_in="${KTUNER_DIR}/ktuner.spec.in"
+    if [ ! -f "$spec_in" ]; then
+        err "Spec template not found: $spec_in"
+        return 1
+    fi
+
+    local version="${VERSION:-}"
+    if [ -z "$version" ]; then
+        version=$(grep -m1 '^version = ' "${KTUNER_DIR}/Cargo.toml" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || true)
+    fi
+    if [ -z "$version" ]; then
+        version=$(grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+' "$spec_in" | head -1)
+    fi
+    if [ -z "$version" ]; then
+        err "Cannot determine ktuner version. Set VERSION env or ensure Cargo.toml/spec exists."
+        return 1
+    fi
+
+    local pkg_name
+    pkg_name=$(parse_spec_name "$spec_in")
+    local tarball_name="${pkg_name}-${version}.tar.gz"
+    local vendor_tarball_name="${pkg_name}-${version}-vendor.tar.gz"
+    local spec_file
+    spec_file=$(process_spec_template "$spec_in" "$version")
+
+    log "Step 1/3: Creating source tarball ${tarball_name}..."
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
+    mkdir -p "$pkg_dir"
+
+    tar -cf - -C "$KTUNER_DIR" \
+        --exclude='target' \
+        --exclude='vendor' \
+        --exclude='.cargo' \
+        . | tar -xf - -C "$pkg_dir"
+
+    if [ -L "${pkg_dir}/LICENSE" ] && [ -f "${ROOT_DIR}/LICENSE" ]; then
+        rm -f "${pkg_dir}/LICENSE"
+        cp -p "${ROOT_DIR}/LICENSE" "${pkg_dir}/LICENSE"
+    fi
+
+    tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
+    rm -rf "$tmp_dir"
+
+    log "Step 2/3: Creating vendor tarball ${vendor_tarball_name}..."
+    local vendor_tmp
+    vendor_tmp=$(mktemp -d)
+    mkdir -p "${vendor_tmp}/.cargo"
+    (
+        cd "$KTUNER_DIR"
+        cargo vendor --locked "${vendor_tmp}/vendor" >/dev/null
+    )
+    cat > "${vendor_tmp}/.cargo/config.toml" <<'EOF'
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+    tar -czf "${BUILD_DIR}/SOURCES/${vendor_tarball_name}" -C "$vendor_tmp" vendor .cargo
+    rm -rf "$vendor_tmp"
+
+    log "Step 3/3: Running rpmbuild..."
+    "$RPMBUILD" -ba --nodeps \
+        --define "_topdir ${BUILD_DIR}" \
+        "$spec_file"
+
+    ok "ktuner RPM built successfully"
+}
+
+# =============================================================================
 # cosh-ng
 # =============================================================================
 build_cosh_ng() {
@@ -1144,6 +1224,7 @@ usage() {
     echo "  tokenless                 Build tokenless RPM"
     echo "  agent-memory              Build agent-memory RPM"
     echo "  skillfs                   Build skillfs RPM"
+    echo "  ktuner                    Build ktuner RPM"
     echo "  anolisa                   Build anolisa RPM"
     echo "  cosh-ng                   Build cosh-ng RPM"
     echo "  gvisor-runsc              Build gvisor-runsc RPM (sandbox)"
@@ -1202,6 +1283,9 @@ case "$TARGET" in
     skillfs)
         build_skillfs
         ;;
+    ktuner)
+        build_ktuner
+        ;;
     anolisa)
         build_anolisa
         ;;
@@ -1234,6 +1318,7 @@ case "$TARGET" in
         build_tokenless
         build_agent_memory
         build_skillfs
+        build_ktuner
         build_anolisa
         build_cosh_ng
         ;;

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -847,6 +847,43 @@ name = "copilot-shell"
     }
 
     #[test]
+    fn repository_component_indexes_v1_and_v2_register_the_same_components() {
+        // The CLI resolves identities only through the v2 index, while released
+        // clients keep reading v1; a component registered in one file but not
+        // the other becomes unresolvable for one of the two populations.
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let v1_path = manifest_dir.join("../../manifests/components.toml");
+        let v2_path = manifest_dir.join("../../manifests/components-v2.toml");
+
+        let v2 = ComponentIndex::load(&v2_path).expect("component index v2 must parse");
+        let v2_names: BTreeSet<String> = v2
+            .components
+            .iter()
+            .map(|component| component.name.clone())
+            .collect();
+
+        let v1_body = std::fs::read_to_string(&v1_path).expect("read v1 component index");
+        let v1: toml::Table = toml::from_str(&v1_body).expect("parse v1 component index");
+        let v1_names: BTreeSet<String> = v1["components"]
+            .as_array()
+            .expect("v1 index declares [[components]] rows")
+            .iter()
+            .map(|entry| {
+                entry["name"]
+                    .as_str()
+                    .expect("v1 component row carries a name")
+                    .to_string()
+            })
+            .collect();
+
+        assert_eq!(
+            v1_names, v2_names,
+            "components registered in only one of components.toml / components-v2.toml \
+             cannot be resolved by clients reading the other"
+        );
+    }
+
+    #[test]
     fn component_index_requires_at_least_one_target() {
         let source = r#"
 schema_version = 2

--- a/src/anolisa/manifests/components-v2.toml
+++ b/src/anolisa/manifests/components-v2.toml
@@ -168,3 +168,15 @@ kind = "rpm"
 package = "skillfs"
 provides = "anolisa-component(skillfs)"
 legacy_adopt = true
+
+[[components]]
+name = "ktuner"
+display_name = "Kernel Tuner"
+summary = "Deterministic kernel-tuning engine for ANOLISA agents"
+targets = [{ os = "linux", arch = "x86_64" }]
+
+[[components.backends]]
+kind = "rpm"
+package = "ktuner"
+provides = "anolisa-component(ktuner)"
+legacy_adopt = true

--- a/src/anolisa/manifests/components.toml
+++ b/src/anolisa/manifests/components.toml
@@ -157,3 +157,18 @@ kind = "rpm"
 package = "skillfs"
 provides = "anolisa-component(skillfs)"
 legacy_adopt = true
+
+[[components]]
+name = "ktuner"
+display_name = "Kernel Tuner"
+summary = "Deterministic kernel-tuning engine for ANOLISA agents"
+
+[[components.backends]]
+kind = "raw"
+package = "ktuner"
+
+[[components.backends]]
+kind = "rpm"
+package = "ktuner"
+provides = "anolisa-component(ktuner)"
+legacy_adopt = true

--- a/src/anolisa/manifests/components.toml
+++ b/src/anolisa/manifests/components.toml
@@ -164,10 +164,6 @@ display_name = "Kernel Tuner"
 summary = "Deterministic kernel-tuning engine for ANOLISA agents"
 
 [[components.backends]]
-kind = "raw"
-package = "ktuner"
-
-[[components.backends]]
 kind = "rpm"
 package = "ktuner"
 provides = "anolisa-component(ktuner)"

--- a/src/anolisa/manifests/components.toml
+++ b/src/anolisa/manifests/components.toml
@@ -162,6 +162,7 @@ legacy_adopt = true
 name = "ktuner"
 display_name = "Kernel Tuner"
 summary = "Deterministic kernel-tuning engine for ANOLISA agents"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "rpm"

--- a/src/ktuner/CHANGELOG.md
+++ b/src/ktuner/CHANGELOG.md
@@ -10,4 +10,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial kernel-tuning engine: `check`/`tune`/`fix`/`why`/`rollback` commands
   evaluate 207 rules and output structured JSON tuning recommendations.
-- RPM packaging and ANOLISA distribution registration.

--- a/src/ktuner/CHANGELOG.md
+++ b/src/ktuner/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial kernel-tuning engine: `check`/`tune`/`fix`/`why`/`rollback` commands
   evaluate 207 rules and output structured JSON tuning recommendations.
+- RPM packaging and ANOLISA distribution registration.

--- a/src/ktuner/LICENSE
+++ b/src/ktuner/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Alibaba Cloud
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/ktuner/README.md
+++ b/src/ktuner/README.md
@@ -90,11 +90,25 @@ All output goes to **stdout as JSON**. Errors go to **stderr as JSON**. No ANSI 
 
 ## Installation
 
-Install ktuner via the ANOLISA component manager:
+Install ktuner via the ANOLISA component manager (RPM backend):
 
 ```bash
-sudo anolisa install ktuner
+sudo anolisa install ktuner --backend rpm
 ```
+
+ktuner ships as an RPM only. Pass `--backend rpm` explicitly: the default
+backend resolves raw artifacts and has no ktuner release, and there is no
+cross-backend fallback.
+
+Install via yum/dnf:
+
+```bash
+sudo yum install ktuner
+```
+
+Installs:
+- `/usr/local/bin/ktuner` — CLI binary
+- `/usr/share/anolisa/components/ktuner/component.toml` — component contract
 
 Or build from source:
 

--- a/src/ktuner/README.md
+++ b/src/ktuner/README.md
@@ -87,3 +87,19 @@ All output goes to **stdout as JSON**. Errors go to **stderr as JSON**. No ANSI 
 - **Code-execution deny-list**: `kernel.core_pattern`, `kernel.modprobe`, `kernel.hotplug`, `kernel.poweroff_cmd`, `kernel.modules_disabled`, `kernel.kexec_load_disabled`, `kernel.usermodehelper.*`, `fs.binfmt_misc.*` are unconditionally blocked from any write path (tune/fix/rollback). Matching is done on the resolved filesystem path, not the parameter spelling, so slash/dot/traversal variants are all caught.
 - **Rollback safety**: Partial failures preserve the rollback ledger; originals are never lost.
 - **No autonomous root**: ktuner checks `euid == 0` and errors out if not root. cosh's sandbox-guard + permission prompt ensure the human approves before any `sudo ktuner tune` executes.
+
+## Installation
+
+Install ktuner via the ANOLISA component manager:
+
+```bash
+sudo anolisa install ktuner
+```
+
+Or build from source:
+
+```bash
+cd src/ktuner
+cargo build --release
+sudo install -m 0755 target/release/ktuner /usr/local/bin/ktuner
+```

--- a/src/ktuner/component.toml
+++ b/src/ktuner/component.toml
@@ -1,0 +1,24 @@
+manifest_version = 2
+anolisa_min_version = "0.1.0"
+
+[component]
+name = "ktuner"
+version = "0.1.0"
+layer = "runtime"
+domain = "tools"
+description = "Deterministic kernel-tuning engine for ANOLISA agents"
+stability = "experimental"
+
+[install]
+modes = ["system"]
+
+[backends.rpm]
+package = "ktuner"
+
+[environment]
+requires_os = "linux"
+
+[[health_checks]]
+name = "binary"
+kind = "command"
+command = "{bindir}/ktuner --version"

--- a/src/ktuner/ktuner.spec.in
+++ b/src/ktuner/ktuner.spec.in
@@ -1,0 +1,55 @@
+%define anolis_release 1
+%global         rustflags -C opt-level=3 -C codegen-units=1
+%global         debug_package %{nil}
+%global         _localbindir /usr/local/bin
+
+Name:           ktuner
+Version:        @VERSION@
+Release:        %{anolis_release}%{?dist}
+Summary:        Deterministic kernel-tuning engine for ANOLISA agents
+
+License:        Apache-2.0
+URL:            https://github.com/alibaba/anolisa
+Source0:        %{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.gz
+
+# Cargo.toml does not pin rust-version; build with the repo toolchain.
+BuildRequires:  rust
+BuildRequires:  cargo
+# Required by Rust crates with C build scripts (libc bindings).
+BuildRequires:  gcc
+
+Provides:       anolisa-component(ktuner)
+
+%description
+ktuner is a deterministic kernel-tuning engine that diagnoses the running
+system against a curated rule set and outputs structured JSON tuning
+recommendations, with apply/rollback support for ANOLISA agents.
+
+%prep
+%setup -q -a 1 -n %{name}-%{version}
+
+%build
+export RUSTFLAGS="%{rustflags}"
+cargo build --release --locked --offline
+
+%install
+rm -rf %{buildroot}
+
+install -d -m 0755 %{buildroot}%{_localbindir}
+install -p -m 0755 target/release/ktuner %{buildroot}%{_localbindir}/ktuner
+
+install -d -m 0755 %{buildroot}%{_datadir}/anolisa/components/ktuner
+install -p -m 0644 component.toml \
+    %{buildroot}%{_datadir}/anolisa/components/ktuner/component.toml
+
+%files
+%license LICENSE
+%doc README.md CHANGELOG.md
+%attr(0755,root,root) %{_localbindir}/ktuner
+%dir %{_datadir}/anolisa/components/ktuner
+%{_datadir}/anolisa/components/ktuner/component.toml
+
+%changelog
+* Sat Jul 25 2026 Jiangtian Feng <jiangtianf97@163.com> - 0.1.0-1
+- Package ktuner from the ANOLISA monorepo.


### PR DESCRIPTION
## Description

ktuner was merged in #1278 but had no packaging or distribution registration, so the built binary never reached user hosts and the cosh first-run check (#1279) could not find it. This PR wires ktuner into the existing RPM + release pipeline following the skillfs pattern: RPM spec, component contract, `components.toml` registration, release workflow tag allowlist, and `rpm-build.sh` integration.

## Related Issue

closes #1339

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [x] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [x] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [x] Multiple / Project-wide (`ktuner` + `anolisa` + CI release workflow)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `bash scripts/rpm-build.sh ktuner`: end-to-end RPM build verified; `rpm -qlp` confirms `/usr/local/bin/ktuner`, the component contract file, and `Provides: anolisa-component(ktuner)`.
- `cd src/ktuner && cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test`: all pass on rust 1.89.0 (191 tests).
- anolisa manifest parsing test `repository_component_index_template_is_valid` passes with the new ktuner entry.
- Spec validated via `rpmspec -P`.

## Additional Notes

- OSS tarball distribution-index entry is deferred until `manifests/distribution-index/` lands on main.
- Artifact upload and sha256 population are tracked as release-ops work (P1-J convention).
