### PR TITLE
fix(docs): expose GitHub on mobile

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -109,6 +109,8 @@ const config: Config = {
           href: 'https://github.com/alibaba/anolisa',
           label: 'GitHub',
           position: 'right',
+          className: 'headerGithubLink',
+          'aria-label': 'ANOLISA GitHub repository',
         },
         {type: 'localeDropdown', position: 'right'},
       ],

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1289,6 +1289,31 @@ html[lang='zh-CN'] .agentEntryHero h1 {
 }
 
 @media (max-width: 996px) {
+  .navbar__item.headerGithubLink {
+    --github-mark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C6.48 2 2 6.58 2 12.23c0 4.52 2.87 8.35 6.84 9.71.5.1.68-.22.68-.49 0-.24-.01-1.04-.01-1.89-2.78.62-3.37-1.21-3.37-1.21-.45-1.18-1.11-1.49-1.11-1.49-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.89 1.57 2.34 1.11 2.91.85.09-.66.35-1.11.64-1.37-2.22-.26-4.56-1.14-4.56-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.28 2.75 1.05A9.3 9.3 0 0 1 12 6.96a9.3 9.3 0 0 1 2.5.35c1.91-1.33 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.8-4.57 5.05.36.32.68.95.68 1.92 0 1.39-.01 2.5-.01 2.84 0 .27.18.59.69.49A10.24 10.24 0 0 0 22 12.23C22 6.58 17.52 2 12 2Z'/%3E%3C/svg%3E");
+
+    display: flex;
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    font-size: 0;
+  }
+
+  .navbar__item.headerGithubLink::before {
+    width: 22px;
+    height: 22px;
+    background: currentColor;
+    content: '';
+    -webkit-mask: var(--github-mark) center / contain no-repeat;
+    mask: var(--github-mark) center / contain no-repeat;
+  }
+
+  .navbar__item.headerGithubLink svg {
+    display: none;
+  }
+
   html:has(.homePage) {
     scroll-snap-type: none;
   }
@@ -1446,7 +1471,7 @@ html[lang='zh-CN'] .agentEntryHero h1 {
     grid-template-columns: 1fr;
   }
 
-  .navbar__items--right > .navbar__item:not(:last-child) {
+  .navbar__items--right > .navbar__item:not(:last-child):not(.headerGithubLink) {
     display: none;
   }
 }


### PR DESCRIPTION
## Description

The mobile navbar moved the GitHub link into the navigation drawer, leaving no
direct repository entry in the first viewport. This change keeps the existing
link visible as a compact GitHub icon below the mobile breakpoint while
preserving the text label in the drawer and desktop navigation.

## Related Issue

no-issue: small responsive navigation fix discovered after the site refresh

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [x] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `npm --prefix website run typecheck`
- `npm --prefix website run build`
- `npm --prefix website run check:links`
- Verified English and Chinese navbar behavior at 320 px and 390 px widths.
- Verified the 40 px mobile target, desktop text link, and drawer text link.

## Additional Notes

The icon uses the current text color, so it follows both light and dark themes.
