### PR TITLE
fix(blaze): persist backend PID handoff

### DIFF
--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -799,11 +799,15 @@ mod tests {
     use blaze_core::template::TemplateRegistry;
 
     use crate::file_provider::FileStorageProvider;
+    #[cfg(target_os = "linux")]
+    use crate::spawner::BubblewrapSpawner;
     use crate::spawner::{
         BackendInstance, BackendSpawner, DynBackendInstance, DynSpawner, GuestMockSpawner,
         MockSpawner, SpawnFailure, SpawnResult, SpawnerRegistry,
     };
     use crate::state::ServerState;
+    #[cfg(target_os = "linux")]
+    use tokio::sync::Notify;
 
     use super::*;
 
@@ -1140,6 +1144,39 @@ mod tests {
             Err(BlazeError::BackendError {
                 msg: "partial owner must remain registered".into(),
             })
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    struct PreSpawnBoundarySpawner {
+        reached: Arc<Notify>,
+    }
+
+    #[cfg(target_os = "linux")]
+    #[async_trait]
+    impl BackendSpawner for PreSpawnBoundarySpawner {
+        async fn prepare_spawn(&self, run_dir: &Path) -> blaze_core::Result<()> {
+            BubblewrapSpawner.prepare_spawn(run_dir).await
+        }
+
+        async fn spawn(
+            &self,
+            _request: SpawnRequest,
+        ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+            self.reached.notify_one();
+            std::future::pending().await
+        }
+
+        async fn probe(&self, _binary_path: &Path) -> blaze_core::Result<bool> {
+            Ok(true)
+        }
+
+        async fn cleanup_orphan(
+            &self,
+            instance_id: Uuid,
+            run_dir: &Path,
+        ) -> blaze_core::Result<()> {
+            BubblewrapSpawner.cleanup_orphan(instance_id, run_dir).await
         }
     }
 
@@ -2020,6 +2057,226 @@ mod tests {
 
         created_json(&state, &test_request()).await;
         assert!(observed.load(Ordering::Acquire));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn restart_reconciles_durable_starting_before_spawn() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut config = test_config(&temp);
+        config.storage.rootfs_size = 64;
+        config.storage.mem_size = 32;
+        config
+            .backends
+            .insert(BackendKind::Bubblewrap.as_str().into(), "/bin/true".into());
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let reached = Arc::new(Notify::new());
+        let state = build_test_state(
+            config.clone(),
+            test_policy(BackendKind::Bubblewrap, false),
+            spawners(
+                BackendKind::Bubblewrap,
+                Arc::new(PreSpawnBoundarySpawner {
+                    reached: reached.clone(),
+                }),
+            ),
+            BackendKind::Bubblewrap,
+            storage,
+        );
+        let create_state = state.clone();
+        let create =
+            tokio::spawn(async move { create_instance(&create_state, &test_request()).await });
+        tokio::time::timeout(std::time::Duration::from_secs(2), reached.notified())
+            .await
+            .expect("create reached the pre-spawn boundary");
+
+        let instance = state
+            .manager
+            .list()
+            .expect("instances")
+            .into_iter()
+            .next()
+            .expect("durable create state");
+        let persisted = SandboxInstance::load(&config.daemon.state_dir, instance.id)
+            .expect("load durable Starting state");
+        assert_eq!(persisted.state, SandboxState::Creating);
+        assert_eq!(persisted.backend_ownership, BackendOwnership::Starting);
+        let pid_file = config
+            .daemon
+            .state_dir
+            .join(instance.id.to_string())
+            .join("backend.pid");
+        assert_eq!(std::fs::read(&pid_file).expect("prepared PID handoff"), b"");
+        assert!(
+            config
+                .storage
+                .instances_dir
+                .join(instance.id.to_string())
+                .is_dir()
+        );
+
+        create.abort();
+        assert!(
+            create
+                .await
+                .expect_err("simulated daemon exit cancels create")
+                .is_cancelled()
+        );
+        drop(state);
+
+        let recovered_storage: Arc<dyn StorageProvider> =
+            Arc::new(FileStorageProvider::with_images(
+                config.storage.images_dir.clone(),
+                config.storage.instances_dir.clone(),
+            ));
+        let recovered = build_test_state(
+            config.clone(),
+            test_policy(BackendKind::Bubblewrap, false),
+            spawners(BackendKind::Bubblewrap, Arc::new(BubblewrapSpawner)),
+            BackendKind::Bubblewrap,
+            recovered_storage,
+        );
+
+        let report = recovered.manager.reconcile_startup().await;
+
+        assert_eq!(report.attempted, 1);
+        assert_eq!(report.completed, 1);
+        assert!(report.failures.is_empty());
+        assert_eq!(
+            recovered
+                .manager
+                .get(instance.id)
+                .expect("reconciled state")
+                .state,
+            SandboxState::Destroyed
+        );
+        assert!(
+            !config
+                .storage
+                .instances_dir
+                .join(instance.id.to_string())
+                .exists()
+        );
+        assert!(
+            config
+                .daemon
+                .state_dir
+                .join(instance.id.to_string())
+                .join("backend.stopped")
+                .is_file()
+        );
+        assert!(!pid_file.exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn restart_retains_locked_handoff_until_retry() {
+        use std::os::fd::AsRawFd;
+
+        let temp = tempfile::tempdir().expect("temp");
+        let mut config = test_config(&temp);
+        config.storage.rootfs_size = 64;
+        config.storage.mem_size = 32;
+        let storage = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let mut instance = SandboxInstance::new(
+            BackendKind::Bubblewrap,
+            WorkloadClass::AgentTool,
+            "sha256:locked-handoff".into(),
+            StartPath::Cold,
+            "pid-handoff-test".into(),
+        );
+        instance
+            .transition(SandboxState::Creating)
+            .expect("creating");
+        instance.begin_operation(OperationKind::Create);
+        let run_dir = config.daemon.state_dir.join(instance.id.to_string());
+        BubblewrapSpawner
+            .prepare_spawn(&run_dir)
+            .await
+            .expect("prepare PID handoff");
+        instance.backend_ownership = BackendOwnership::Starting;
+        instance
+            .persist(&config.daemon.state_dir)
+            .expect("persist Starting state");
+        storage
+            .acquire(&AcquireOpts {
+                instance_id: instance.id.to_string(),
+                rootfs_size: config.storage.rootfs_size,
+                mem_size: config.storage.mem_size,
+            })
+            .await
+            .expect("storage");
+        let pid_file = run_dir.join("backend.pid");
+        let handoff = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&pid_file)
+            .expect("open PID handoff");
+        assert_eq!(
+            unsafe { libc::flock(handoff.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0,
+            "lock PID handoff"
+        );
+        let state = build_test_state(
+            config.clone(),
+            test_policy(BackendKind::Bubblewrap, false),
+            spawners(BackendKind::Bubblewrap, Arc::new(BubblewrapSpawner)),
+            BackendKind::Bubblewrap,
+            storage,
+        );
+
+        let first = state.manager.reconcile_startup().await;
+
+        assert_eq!(first.attempted, 1);
+        assert_eq!(first.completed, 0);
+        assert_eq!(first.failures.len(), 1);
+        assert!(first.failures[0].error.contains("still in progress"));
+        assert_eq!(
+            state
+                .manager
+                .get(instance.id)
+                .expect("retained state")
+                .state,
+            SandboxState::RecoveryRequired
+        );
+        assert!(
+            config
+                .storage
+                .instances_dir
+                .join(instance.id.to_string())
+                .is_dir()
+        );
+        assert!(!run_dir.join("backend.stopped").exists());
+
+        drop(handoff);
+        let retry = state.manager.reconcile_startup().await;
+
+        assert_eq!(retry.attempted, 1);
+        assert_eq!(retry.completed, 1);
+        assert!(retry.failures.is_empty());
+        assert_eq!(
+            state
+                .manager
+                .get(instance.id)
+                .expect("destroyed state")
+                .state,
+            SandboxState::Destroyed
+        );
+        assert!(
+            !config
+                .storage
+                .instances_dir
+                .join(instance.id.to_string())
+                .exists()
+        );
+        assert!(run_dir.join("backend.stopped").is_file());
+        assert!(!pid_file.exists());
     }
 
     #[tokio::test]

--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -291,6 +291,30 @@ impl SandboxManager {
         };
         crate::failpoint::pause("create-after-storage-acquire").await;
 
+        let work_dir = self.state_dir.join(instance.id.to_string());
+        let spawner = match self.spawners.get(self.active_backend) {
+            Some(spawner) => spawner,
+            None => {
+                return Err(self
+                    .cleanup_failed_create(
+                        &mut instance,
+                        storage,
+                        None,
+                        false,
+                        BlazeDaemonError::Internal(format!(
+                            "active backend {} has no registered spawner",
+                            self.active_backend
+                        )),
+                    )
+                    .await);
+            }
+        };
+        if let Err(error) = spawner.prepare_spawn(&work_dir).await {
+            return Err(self
+                .cleanup_failed_create(&mut instance, storage, None, false, error.into())
+                .await);
+        }
+
         instance.backend_ownership = BackendOwnership::Starting;
         if let Err(error) = instance.persist(&self.state_dir) {
             instance.backend_ownership = BackendOwnership::NotStarted;
@@ -311,30 +335,12 @@ impl SandboxManager {
                 .await);
         }
 
-        let spawner = match self.spawners.get(self.active_backend) {
-            Some(spawner) => spawner,
-            None => {
-                instance.backend_ownership = BackendOwnership::NotStarted;
-                return Err(self
-                    .cleanup_failed_create(
-                        &mut instance,
-                        storage,
-                        None,
-                        false,
-                        BlazeDaemonError::Internal(format!(
-                            "active backend {} has no registered spawner",
-                            self.active_backend
-                        )),
-                    )
-                    .await);
-            }
-        };
         let spawn = match crate::failpoint::backend("create-spawn") {
             Ok(()) => {
                 spawner
                     .spawn(SpawnRequest {
                         instance_id: instance.id,
-                        run_dir: self.state_dir.join(instance.id.to_string()),
+                        run_dir: work_dir,
                         binary_path: request.binary_path,
                         storage: storage.clone(),
                         backend: request.decision.backend,

--- a/src/blaze/crates/blazed/src/spawner.rs
+++ b/src/blaze/crates/blazed/src/spawner.rs
@@ -32,6 +32,8 @@ use uuid::Uuid;
 pub use firecracker::FirecrackerSpawner;
 
 const TERMINATION_GRACE: Duration = Duration::from_secs(5);
+#[cfg(target_os = "linux")]
+const PID_HANDOFF_GRACE: Duration = Duration::from_secs(1);
 const STOPPED_MARKER: &str = "backend.stopped";
 
 /// Result reported when a backend process exits.
@@ -146,6 +148,11 @@ impl From<std::io::Error> for SpawnFailure {
 /// Factory for owned backend runtime instances.
 #[async_trait]
 pub trait BackendSpawner: Send + Sync {
+    /// Persist backend-specific pre-spawn ownership metadata.
+    async fn prepare_spawn(&self, _run_dir: &Path) -> Result<()> {
+        Ok(())
+    }
+
     /// Start a new sandbox.
     async fn spawn(
         &self,
@@ -191,13 +198,20 @@ pub struct BubblewrapSpawner;
 
 #[async_trait]
 impl BackendSpawner for BubblewrapSpawner {
+    async fn prepare_spawn(&self, run_dir: &Path) -> Result<()> {
+        tokio::fs::create_dir_all(run_dir).await?;
+        prepare_pid_handoff(&run_dir.join("backend.pid"))
+    }
+
     async fn spawn(
         &self,
         request: SpawnRequest,
     ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
         tokio::fs::create_dir_all(&request.run_dir).await?;
         remove_file_if_exists(&request.run_dir.join(STOPPED_MARKER)).await?;
-        let child = Command::new(&request.binary_path)
+        let pid_file = request.run_dir.join("backend.pid");
+        let mut command = Command::new(&request.binary_path);
+        command
             .args([
                 "--ro-bind",
                 "/",
@@ -217,22 +231,12 @@ impl BackendSpawner for BubblewrapSpawner {
             ])
             .env("BLAZE_INSTANCE_ID", request.instance_id.to_string())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?;
-        let pid_file = request.run_dir.join("backend.pid");
+            .stderr(Stdio::null());
+        let pid_handoff = configure_pid_handoff(&mut command, &pid_file)?;
+        let child = command.spawn();
+        drop(pid_handoff);
+        let child = child?;
         let stopped_marker = request.run_dir.join(STOPPED_MARKER);
-        if let Some(pid) = child.id()
-            && let Err(error) = tokio::fs::write(&pid_file, format!("{pid}\n")).await
-        {
-            let owner: DynBackendInstance = Arc::new(ProcessInstance::new(
-                request.instance_id,
-                BackendKind::Bubblewrap,
-                child,
-                pid_file,
-                stopped_marker,
-            ));
-            return Err(SpawnFailure::compensate_started(error.into(), owner).await);
-        }
         let instance = ProcessInstance::new(
             request.instance_id,
             BackendKind::Bubblewrap,
@@ -671,6 +675,147 @@ pub(super) fn stopped_marker(run_dir: &Path) -> PathBuf {
     run_dir.join(STOPPED_MARKER)
 }
 
+#[cfg(unix)]
+pub(super) struct PidHandoff {
+    _file: std::fs::File,
+}
+
+#[cfg(not(unix))]
+pub(super) struct PidHandoff;
+
+#[cfg(unix)]
+pub(super) fn prepare_pid_handoff(pid_file: &Path) -> Result<()> {
+    use std::ffi::CString;
+    use std::os::fd::FromRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let pid_path =
+        CString::new(pid_file.as_os_str().as_bytes()).map_err(|_| BlazeError::BackendError {
+            msg: format!("PID file path contains a NUL byte: {}", pid_file.display()),
+        })?;
+    let fd = unsafe {
+        libc::open(
+            pid_path.as_ptr(),
+            libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            0o600,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    file.sync_all()?;
+    if let Some(parent) = pid_file.parent() {
+        std::fs::File::open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(super) fn prepare_pid_handoff(pid_file: &Path) -> Result<()> {
+    let file = std::fs::File::create(pid_file)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(super) fn configure_pid_handoff(command: &mut Command, pid_file: &Path) -> Result<PidHandoff> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::process::CommandExt;
+
+    let pid_path =
+        CString::new(pid_file.as_os_str().as_bytes()).map_err(|_| BlazeError::BackendError {
+            msg: format!("PID file path contains a NUL byte: {}", pid_file.display()),
+        })?;
+    let fd = unsafe {
+        libc::open(
+            pid_path.as_ptr(),
+            libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let child_fd = file.as_raw_fd();
+    // SAFETY: the closure calls only async-signal-safe libc functions and does
+    // not allocate after fork. The returned guard keeps `child_fd` open and
+    // locked until `Command::spawn` completes.
+    unsafe {
+        command
+            .as_std_mut()
+            .pre_exec(move || write_current_pid(child_fd));
+    }
+    Ok(PidHandoff { _file: file })
+}
+
+#[cfg(not(unix))]
+pub(super) fn configure_pid_handoff(
+    _command: &mut Command,
+    _pid_file: &Path,
+) -> Result<PidHandoff> {
+    Ok(PidHandoff)
+}
+
+#[cfg(unix)]
+fn write_current_pid(fd: libc::c_int) -> std::io::Result<()> {
+    if unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::ftruncate(fd, 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    write_pid_and_sync(fd)
+}
+
+#[cfg(unix)]
+fn write_pid_and_sync(fd: libc::c_int) -> std::io::Result<()> {
+    let mut buffer = [0_u8; 16];
+    let mut cursor = buffer.len();
+    cursor -= 1;
+    buffer[cursor] = b'\n';
+    let mut pid = unsafe { libc::getpid() } as u32;
+    loop {
+        cursor -= 1;
+        buffer[cursor] = b'0' + (pid % 10) as u8;
+        pid /= 10;
+        if pid == 0 {
+            break;
+        }
+    }
+
+    let mut remaining = &buffer[cursor..];
+    while !remaining.is_empty() {
+        let written = unsafe {
+            libc::write(
+                fd,
+                remaining.as_ptr().cast::<libc::c_void>(),
+                remaining.len(),
+            )
+        };
+        if written < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        if written == 0 {
+            return Err(std::io::ErrorKind::WriteZero.into());
+        }
+        remaining = &remaining[written as usize..];
+    }
+    if unsafe { libc::fsync(fd) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 async fn cleanup_process_run_dir(instance_id: Uuid, run_dir: &Path, backend: &str) -> Result<()> {
     let stopped_marker = stopped_marker(run_dir);
     if stopped_marker.is_file() {
@@ -702,17 +847,9 @@ pub(super) async fn terminate_recorded_process(
     pid_file: &Path,
     backend: &str,
 ) -> Result<()> {
-    let raw = match tokio::fs::read_to_string(pid_file).await {
-        Ok(raw) => raw,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Err(BlazeError::BackendError {
-                msg: format!(
-                    "cannot confirm {backend} instance {instance_id} stopped: missing PID metadata {}",
-                    pid_file.display()
-                ),
-            });
-        }
-        Err(error) => return Err(error.into()),
+    let raw = match wait_for_pid_handoff(pid_file).await? {
+        Some(raw) => raw,
+        None => return Ok(()),
     };
     let pid: u32 = raw
         .trim()
@@ -760,6 +897,74 @@ pub(super) async fn terminate_recorded_process(
         });
     }
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_pid_handoff(pid_file: &Path) -> Result<Option<String>> {
+    let deadline = Instant::now() + PID_HANDOFF_GRACE;
+    loop {
+        match read_pid_handoff(pid_file)? {
+            PidHandoffState::NotStarted => return Ok(None),
+            PidHandoffState::Missing => {
+                return Err(BlazeError::BackendError {
+                    msg: format!(
+                        "cannot confirm backend process ownership: missing PID handoff {}",
+                        pid_file.display()
+                    ),
+                });
+            }
+            PidHandoffState::Ready(raw) => return Ok(Some(raw)),
+            PidHandoffState::InProgress => {}
+        }
+        if Instant::now() >= deadline {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "cannot confirm backend process ownership: PID handoff is still in progress at {}",
+                    pid_file.display()
+                ),
+            });
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[cfg(target_os = "linux")]
+enum PidHandoffState {
+    Missing,
+    NotStarted,
+    InProgress,
+    Ready(String),
+}
+
+#[cfg(target_os = "linux")]
+fn read_pid_handoff(pid_file: &Path) -> Result<PidHandoffState> {
+    use std::io::{Read, Seek, SeekFrom};
+    use std::os::fd::AsRawFd;
+
+    let mut file = match std::fs::OpenOptions::new().read(true).open(pid_file) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(PidHandoffState::Missing);
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::EAGAIN)
+            || error.raw_os_error() == Some(libc::EWOULDBLOCK)
+        {
+            return Ok(PidHandoffState::InProgress);
+        }
+        return Err(error.into());
+    }
+    file.seek(SeekFrom::Start(0))?;
+    let mut raw = String::new();
+    file.read_to_string(&mut raw)?;
+    if raw.trim().is_empty() {
+        Ok(PidHandoffState::NotStarted)
+    } else {
+        Ok(PidHandoffState::Ready(raw))
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -973,19 +1178,90 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn orphan_cleanup_rejects_missing_pid_without_stop_record() {
+    async fn orphan_cleanup_accepts_pre_spawn_handoff_without_pid() {
+        let temp = tempfile::tempdir().expect("temp");
+        prepare_pid_handoff(&temp.path().join("backend.pid")).expect("prepare handoff");
+        cleanup_process_run_dir(Uuid::new_v4(), temp.path(), "test")
+            .await
+            .expect("an unlocked empty handoff proves the backend was not started");
+        assert!(stopped_marker(temp.path()).is_file());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn orphan_cleanup_rejects_missing_pid_handoff() {
         let temp = tempfile::tempdir().expect("temp");
         let error = cleanup_process_run_dir(Uuid::new_v4(), temp.path(), "test")
             .await
-            .expect_err("missing metadata cannot prove termination");
-        assert!(error.to_string().contains("missing PID metadata"));
+            .expect_err("missing handoff cannot prove backend ownership");
 
-        record_backend_stopped(&stopped_marker(temp.path()))
+        assert!(error.to_string().contains("missing PID handoff"));
+        assert!(!stopped_marker(temp.path()).exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn orphan_cleanup_retains_an_active_pid_handoff() {
+        let temp = tempfile::tempdir().expect("temp");
+        let pid_file = temp.path().join("backend.pid");
+        prepare_pid_handoff(&pid_file).expect("prepare handoff");
+        let mut command = Command::new("sleep");
+        let handoff = configure_pid_handoff(&mut command, &pid_file).expect("configure handoff");
+
+        let error = cleanup_process_run_dir(Uuid::new_v4(), temp.path(), "test")
             .await
-            .expect("record stopped");
-        cleanup_process_run_dir(Uuid::new_v4(), temp.path(), "test")
+            .expect_err("an active handoff cannot prove the backend absent");
+
+        assert!(
+            error
+                .to_string()
+                .contains("PID handoff is still in progress")
+        );
+        assert!(!stopped_marker(temp.path()).exists());
+        drop(handoff);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn pid_handoff_is_visible_when_spawn_returns() {
+        let temp = tempfile::tempdir().expect("temp");
+        let instance_id = Uuid::new_v4();
+        let pid_file = temp.path().join("backend.pid");
+        prepare_pid_handoff(&pid_file).expect("prepare handoff");
+        let mut command = Command::new("sleep");
+        command
+            .arg("60")
+            .env("BLAZE_INSTANCE_ID", instance_id.to_string());
+        let handoff = configure_pid_handoff(&mut command, &pid_file).expect("configure handoff");
+        let mut child = command.spawn().expect("spawn child");
+        drop(handoff);
+        wait_for_instance_marker(&child, instance_id).await;
+
+        assert_eq!(
+            std::fs::read_to_string(&pid_file)
+                .expect("pid handoff")
+                .trim(),
+            child.id().expect("child pid").to_string()
+        );
+        terminate_recorded_process(instance_id, &pid_file, "test")
             .await
-            .expect("durable stop record proves termination");
+            .expect("terminate handed-off process");
+        child.wait().await.expect("reap child");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn failed_pid_handoff_preparation_does_not_start_backend() {
+        let temp = tempfile::tempdir().expect("temp");
+        let instance_id = Uuid::new_v4();
+        let pid_file = temp.path().join("missing").join("backend.pid");
+        let mut command = Command::new("sleep");
+        command
+            .arg("60")
+            .env("BLAZE_INSTANCE_ID", instance_id.to_string());
+
+        assert!(configure_pid_handoff(&mut command, &pid_file).is_err());
+        assert!(!pid_file.exists());
     }
 
     #[cfg(target_os = "linux")]

--- a/src/blaze/crates/blazed/src/spawner/firecracker.rs
+++ b/src/blaze/crates/blazed/src/spawner/firecracker.rs
@@ -22,7 +22,8 @@ use super::netns::{NetworkManager, NetworkSlot};
 use super::terminate_recorded_process;
 use super::{
     BackendInstance, BackendSpawner, DynBackendInstance, SpawnFailure, SpawnResult,
-    record_backend_stopped, remove_file_if_exists, spawn_result, stopped_marker, terminate_child,
+    configure_pid_handoff, prepare_pid_handoff, record_backend_stopped, remove_file_if_exists,
+    spawn_result, stopped_marker, terminate_child,
 };
 
 const NETWORK_BOOT_IP: &str = "ip=169.254.0.2::169.254.0.1:255.255.255.252::eth0:off";
@@ -97,7 +98,6 @@ impl FirecrackerSpawner {
         let network_temp_file = network_metadata_temp(&network_file);
         remove_if_exists(&api_socket).await?;
         remove_if_exists(&guest_socket).await?;
-        remove_if_exists(&pid_file).await?;
         remove_file_if_exists(&stopped_marker).await?;
         remove_if_exists(&network_file).await?;
         remove_if_exists(&network_temp_file).await?;
@@ -258,7 +258,28 @@ impl FirecrackerSpawner {
                 )
                 .await);
         }
-        let mut child = match command.spawn() {
+        let pid_handoff = match configure_pid_handoff(&mut command, &pid_file) {
+            Ok(pid_handoff) => pid_handoff,
+            Err(error) => {
+                return Err(self
+                    .compensate_before_spawn(
+                        request.instance_id,
+                        runtime_files(
+                            api_socket,
+                            guest_socket,
+                            pid_file,
+                            stopped_marker,
+                            network_file,
+                        ),
+                        network,
+                        error,
+                    )
+                    .await);
+            }
+        };
+        let child = command.spawn();
+        drop(pid_handoff);
+        let mut child = match child {
             Ok(child) => child,
             Err(source) => {
                 return Err(self
@@ -277,24 +298,6 @@ impl FirecrackerSpawner {
                     .await);
             }
         };
-        if let Some(pid) = child.id()
-            && let Err(error) = tokio::fs::write(&pid_file, format!("{pid}\n")).await
-        {
-            let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
-                request.instance_id,
-                Some(child),
-                runtime_files(
-                    api_socket,
-                    guest_socket,
-                    pid_file,
-                    stopped_marker,
-                    network_file,
-                ),
-                network,
-                self.network.clone(),
-            ));
-            return Err(SpawnFailure::compensate_started(error.into(), owner).await);
-        }
         if let Err(error) = wait_for_socket(&api_socket, &mut child, self.socket_timeout).await {
             let owner: DynBackendInstance = Arc::new(FirecrackerInstance::new(
                 request.instance_id,
@@ -354,6 +357,11 @@ impl FirecrackerSpawner {
 
 #[async_trait]
 impl BackendSpawner for FirecrackerSpawner {
+    async fn prepare_spawn(&self, run_dir: &Path) -> Result<()> {
+        tokio::fs::create_dir_all(run_dir).await?;
+        prepare_pid_handoff(&run_dir.join("firecracker.pid"))
+    }
+
     async fn spawn(
         &self,
         request: SpawnRequest,
@@ -1403,7 +1411,7 @@ mod tests {
             .await
             .expect_err("unknown launch state must fail closed");
 
-        assert!(error.to_string().contains("missing PID metadata"));
+        assert!(error.to_string().contains("missing PID handoff"));
         assert!(network_temp_file.exists());
         assert!(!stopped_marker(temp.path()).exists());
         assert_eq!(
@@ -1427,7 +1435,7 @@ mod tests {
             .await
             .expect_err("unknown launch state must fail closed");
 
-        assert!(error.to_string().contains("missing PID metadata"));
+        assert!(error.to_string().contains("missing PID handoff"));
         assert!(!stopped_marker(temp.path()).exists());
         assert_eq!(
             runner.calls(),
@@ -1550,7 +1558,7 @@ mod tests {
             .await
             .expect_err("missing process metadata must block cleanup");
 
-        assert!(error.to_string().contains("missing PID metadata"));
+        assert!(error.to_string().contains("missing PID handoff"));
         assert!(network_file.exists());
         assert!(runner.calls().is_empty());
     }


### PR DESCRIPTION
## Description

This PR makes Blaze's existing sandbox create, destroy, and restart cleanup
paths distinguish a process backend that never started from one whose process
may still exist.

### Why this is needed

Before this change, lifecycle state could record
`BackendOwnership::Starting` before a backend PID was durable. Bubblewrap and
Firecracker wrote their PID files only after `Command::spawn` returned. If the
daemon exited after the child was created but before that write completed,
restart cleanup found no PID metadata and could not determine whether a process
still required cleanup.

### Before

- `Starting` ownership could be durable while no PID handoff existed.
- A missing PID correctly remained an unknown state, but destroy and restart
  cleanup could not distinguish "spawn never started" from "spawn may have
  started."
- Bubblewrap and Firecracker used separate parent-side PID writes.
- The managed create path did not publish an explicit pre-spawn boundary.

### After

- Each process spawner creates and synchronizes an empty PID handoff before
  `Starting` ownership is published.
- The child writes and synchronizes its PID before `exec` while holding an
  inherited file lock.
- Cleanup treats a missing handoff as unknown, an unlocked empty handoff as
  proof that no process crossed the spawn boundary, a locked handoff as an
  in-progress spawn, and a populated handoff as a process to validate and
  terminate.
- Bubblewrap and Firecracker use the same handoff protocol.
- If the daemon stops after durable `Starting` but before `spawn`, restart
  reconciliation can prove that no process started and complete cleanup. If
  the handoff is still locked, reconciliation retains ownership and succeeds
  only after a later retry can classify it.

The design adds a synchronous metadata boundary to process startup and a
bounded wait when cleanup observes an active handoff. That cost keeps existing
destroy and restart cleanup from guessing about process ownership.

### Commit delivery

#### `7c788e40c8b1 fix(blaze): persist backend PID handoff`

The single commit adds the shared handoff protocol, wires it into both process
spawners and the production `SandboxManager::create` path, updates restart
cleanup, and covers missing, empty, locked, populated, preparation-failure, and
daemon-restart states.

### Why this is one PR

All changed code establishes one invariant: a durable `Starting` record must
have enough PID handoff state for cleanup to classify the spawn boundary. The
spawner contract, create-path ordering, cleanup logic, and restart tests form
one end-to-end backend ownership correction.

### Not in this PR

- Adopting an already-running backend after daemon restart.
- Changing VM network allocation policy.
- Adding lifecycle or guest-operation API routes.

## Related Issue

closes #2180

Tracked under #1829.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `blaze` (blaze)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

The exact submitted commit
`7c788e40c8b167303de98ff95cf08f0a8f1190e8` was verified on Linux x86_64
in a fresh source tree with an initially empty Cargo target directory:

```text
cargo fmt --all -- --check
cargo build --workspace --locked
cargo build --workspace --all-features --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
```

Results:

- Default features: 52 blaze-core tests and 105 blazed tests passed.
- All features: 52 blaze-core tests and 115 blazed tests passed.
- `restart_reconciles_durable_starting_before_spawn` proves restart cleanup
  converges after durable `Starting` but before child creation.
- `restart_retains_locked_handoff_until_retry` proves an in-progress handoff
  retains storage and lifecycle ownership until a later retry can complete.
- Child-side PID publication, missing/empty/populated handoff classification,
  preparation failure, and Firecracker network-compensation tests passed.
- The commit message passed repository commitlint and contains the required
  Weisson sign-off for this bugfix.

Hosted checks are reported by GitHub separately and are not included in these
Linux results.

## Additional Notes

- Declared base: `main` at
  `4ec67cfef3377b32e6d8125d9533825901fdeffc`.
- No sibling PR is required for the handoff invariant.
