### PR TITLE
fix(blaze): validate startup state inventory

### DIFF
--- a/docs/user-guide/en/runtime/blaze.md
+++ b/docs/user-guide/en/runtime/blaze.md
@@ -56,6 +56,38 @@ After a daemon restart, a later destroy request can reconstruct a recorded
 network slot. Blaze does not run a background scan or retry controller for
 orphaned network resources.
 
+Before any startup reconciliation begins, Blaze loads the complete persisted
+sandbox lifecycle inventory. Every UUID owner directory and its `state.json`
+must be canonical and directly readable. Before accepting the inventory, Blaze
+completes a second enumeration of the canonical UUID names and compares the
+complete set with the initial scan. It then revalidates every retained owner
+directory and `state.json` against the objects read earlier. Startup stops
+before the API listeners open if the second enumeration finds a missing or new
+UUID, if the following object checks find a replacement, or if a `Destroyed`
+record does not prove cleanup completed. Blaze does not repair or delete the
+invalid owner directory or its `state.json`; it remains available for operator
+repair.
+
+Blaze state writes are supported only through `StateStore`. A production daemon
+keeps an exclusive advisory lock on the state root, and the startup scan holds
+the in-process ownership-map lock until publication. These locks serialize
+cooperating Blaze writers. A process that modifies the state files directly
+without participating in the state-root lock is outside this consistency
+contract.
+
+### Detecting an inventory validation failure
+
+Inventory validation happens before Blaze binds either its Unix or optional TCP
+listener. If validation fails, the daemon exits with a non-zero status and no
+API endpoint is available; `/v1/health` therefore fails to connect instead of
+returning a degraded health response.
+
+For the packaged systemd service, inspect `systemctl status blazed` and
+`journalctl -u blazed` for the validation error; record-specific errors include
+the affected sandbox ID. Blaze leaves the rejected record in place. Repair or
+restore that record, then restart the service and confirm that `/v1/health`
+responds.
+
 ## Host Integration Boundary
 
 Blaze configures the sandbox-local network path. Routing beyond the host and DNS

--- a/docs/user-guide/zh/runtime/blaze.md
+++ b/docs/user-guide/zh/runtime/blaze.md
@@ -50,6 +50,30 @@ Blaze 会保留 ownership，不会将 slot 重新交给分配器，以便后续 
 daemon 重启后，后续 destroy 请求可以根据已有记录重新识别 network slot。
 Blaze 不会在后台扫描或自动重试孤立的网络资源。
 
+开始任何启动恢复之前，Blaze 会完整读取已持久化的 sandbox 生命周期清单。每个
+UUID 所属目录及其中的 `state.json` 都必须使用规范形式并且可以直接读取。接受
+清单前，Blaze 会先完成第二次规范 UUID 名称枚举，并将完整集合与首次扫描结果
+比较；随后再逐一确认保留的 owner 目录和 `state.json` 仍是先前读取的对象。如果
+第二次枚举发现 UUID 缺失或新增、后续对象检查发现替换，或者 `Destroyed` 记录
+未能证明清理完成，daemon 会在打开 API 监听器前停止，并保留原条目供运维人员
+修复。
+
+Blaze 只支持通过 `StateStore` 写入状态。生产 daemon 会一直持有 state root 的
+排他 advisory lock，启动扫描也会持有进程内 ownership map 锁直至发布，因此遵守
+这些锁的 Blaze 写入操作会被串行化。未参与 state root 锁、直接修改状态文件的
+外部进程不属于这一致性合同的支持范围。
+
+### 识别清单校验失败
+
+Blaze 会在绑定 Unix listener 或可选 TCP listener 之前完成清单校验。如果校验
+失败，daemon 会以非零状态退出，所有 API endpoint 都不可用；因此请求
+`/v1/health` 时会连接失败，而不是收到表示降级状态的健康检查响应。
+
+使用随软件包提供的 systemd service 时，可通过 `systemctl status blazed` 和
+`journalctl -u blazed` 查看校验错误；与记录有关的错误会包含受影响的 sandbox
+ID。Blaze 会保留被拒绝的记录。修复或恢复该记录后，重新启动 service，并确认
+`/v1/health` 可以响应。
+
 ## 主机集成边界
 
 Blaze 负责配置 sandbox 本地的网络路径。主机以外的路由和 DNS 仍由主机运维方

--- a/src/blaze/README.md
+++ b/src/blaze/README.md
@@ -172,9 +172,32 @@ resources. A successful create finishes in `Running`; a successful destroy
 finishes in `Destroyed`. If compensation cannot release every owned resource,
 the sandbox remains visible as `RecoveryRequired` so destroy can be retried.
 
-At startup, the daemon reconciles each non-terminal sandbox independently.
-Failure to clean up one sandbox does not prevent the remaining records from
-being processed or the API from starting.
+At startup, Blaze first validates the complete lifecycle inventory. Only after
+that inventory is complete and consistent does the daemon reconcile each
+non-terminal sandbox independently. A cleanup failure during this later
+reconciliation leaves that sandbox `RecoveryRequired`, but does not prevent the
+remaining accepted records from being processed or the API from starting.
+
+Inventory validation is fail-closed. Startup stops before the API listeners
+open if a UUID-owned entry is not a canonically named directory; if its
+`state.json` is missing, unreadable, a
+symbolic link or directory, or has another hard link; if the stored sandbox ID
+differs from the directory name; or if a `Destroyed` record still reports an
+active operation or backend ownership that may still be live. Blaze does not
+repair or delete these records automatically. Before accepting the inventory,
+Blaze completes a second enumeration of the canonical UUID names and compares
+the complete set with the initial scan. It then checks that every retained UUID
+directory and `state.json` still refer to the objects it read. Startup stops if
+the second enumeration finds an added or removed entry, or if the following
+object checks find that either retained object disappeared or was replaced.
+This consistency contract applies to Blaze state writers: the production store
+holds the state-root advisory lock, and the scan holds the in-process ownership
+map lock until publication. Direct file changes by a process that bypasses the
+state-root lock are unsupported.
+
+See the
+[lifecycle state consistency design](docs/design/lifecycle-state-consistency.md)
+for the writer-coordination, inventory-publication, and failure boundaries.
 
 The operation journal records the operation and start time, not completion of
 each resource step. An interrupted create is cleaned up rather than resumed,

--- a/src/blaze/README_zh.md
+++ b/src/blaze/README_zh.md
@@ -163,8 +163,25 @@ sandbox create 自动选择它；后续 create 支持会从同一个 catalog 解
 `Running`，销毁成功后状态为 `Destroyed`。如果失败补偿不能释放全部已有
 资源，sandbox 会保留为可查询的 `RecoveryRequired`，后续可以再次执行销毁。
 
-daemon 启动时会逐个处理未结束的 sandbox。单个 sandbox 清理失败不会阻止
-其他记录继续处理，也不会阻止 API 启动。
+daemon 启动时，Blaze 会先校验完整的生命周期清单。只有清单完整且一致时，
+daemon 才会逐个处理未结束的 sandbox。后续逐项恢复期间，如果单个 sandbox
+清理失败，该 sandbox 会保留为 `RecoveryRequired`，但不会阻止其他已通过校验的
+记录继续处理，也不会阻止 API 启动。
+
+清单校验采用 fail-closed 策略。如果 UUID 所属条目不是规范命名的目录，
+`state.json` 缺失、不可读、是符号链接或目录、存在其他
+硬链接，记录内的 sandbox ID 与目录名不同，或者 `Destroyed` 记录仍保留活动操作
+或可能仍存活的后端所有权，daemon 都会在打开 API 监听器前停止。Blaze 不会自动
+修复或删除这些记录。接受这份清单前，Blaze 还会确认每个 UUID 名称和其中的
+`state.json` 仍然指向刚才读取的对象；具体流程是先完成第二次规范 UUID 名称
+枚举并比较完整集合，再逐一复验保留的目录和记录。如果第二次枚举发现条目新增
+或删除，或者后续对象检查发现保留对象消失或被替换，daemon 会停止启动。这一
+一致性合同面向 Blaze 状态写入者：生产 store 持有 state root advisory lock，扫描
+也会持有进程内 ownership map 锁直至发布。绕过 state root 锁直接修改文件的外部
+进程不在支持范围内。
+
+写入协调、清单发布和失败边界参见
+[生命周期状态一致性设计](docs/design/lifecycle-state-consistency_zh.md)。
 
 操作记录只保存操作类型和开始时间，不记录每个资源步骤是否已经完成。中断的
 创建会被清理而不是从原位置继续，重启后也不会接管先前的后端进程。恢复失败

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -45,9 +45,7 @@ pub struct ServerState {
 }
 
 impl ServerState {
-    /// Build a server state, scanning `state_dir` to repopulate the
-    /// `instances` map from previous runs (best-effort; corrupt entries
-    /// are skipped with a warning).
+    /// Build a server state after validating every owned lifecycle record.
     #[allow(clippy::too_many_arguments)]
     pub fn build_with_store(
         config: DaemonConfig,
@@ -121,10 +119,7 @@ impl ServerState {
         template_catalog: TemplateCatalog,
         state_store: StateStore,
     ) -> Result<Self> {
-        let instances = state_store.scan().unwrap_or_else(|err| {
-            tracing::warn!(error = %err, "failed to scan state_dir, starting empty");
-            HashMap::new()
-        });
+        let instances = state_store.scan()?;
         let (manager, resources) = SandboxManager::new(SandboxManagerInit {
             instances,
             pool,
@@ -159,13 +154,56 @@ impl ServerState {
 
 #[cfg(test)]
 mod tests {
-    use blaze_core::lifecycle::StartPath;
+    use blaze_core::lifecycle::{BackendOwnership, SandboxState, StartPath};
     use blaze_core::policy::WorkloadClass;
 
     use crate::file_provider::FileStorageProvider;
     use crate::spawner::{MockSpawner, SpawnerRegistry};
 
     use super::*;
+
+    fn build_with_state_root(
+        temporary: &std::path::Path,
+        state_root: std::path::PathBuf,
+    ) -> Result<ServerState> {
+        let images = temporary.join("images");
+        let instances = temporary.join("instances");
+        for directory in [&state_root, &images, &instances] {
+            std::fs::create_dir_all(directory).expect("test directory");
+        }
+
+        let mut config = DaemonConfig::default();
+        config.daemon.state_dir = state_root.clone();
+        config.storage.images_dir = images.clone();
+        config.storage.instances_dir = instances.clone();
+        config.template.dir = temporary.join("templates");
+        config.template.import_root = Some(temporary.join("template-imports"));
+        std::fs::create_dir(
+            config
+                .template
+                .import_root
+                .as_ref()
+                .expect("template import root"),
+        )
+        .expect("template import directory");
+        let template_catalog = TemplateCatalog::open(&config.template).expect("template catalog");
+        let mut spawners = SpawnerRegistry::new();
+        spawners.insert(BackendKind::Mock, Arc::new(MockSpawner));
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(FileStorageProvider::with_images(images, instances));
+
+        ServerState::build_with_store(
+            config,
+            PolicyEngine::new(),
+            PoolManager::new(),
+            HookRegistry::new(),
+            spawners,
+            BackendKind::Mock,
+            storage,
+            template_catalog,
+            StateStore::new(state_root),
+        )
+    }
 
     #[test]
     fn builder_uses_the_preopened_state_store_after_path_replacement() {
@@ -251,5 +289,52 @@ mod tests {
                 .is_file()
         );
         assert!(!configured_root.join(new_instance.id.to_string()).exists());
+    }
+
+    #[test]
+    fn builder_propagates_an_invalid_owned_inventory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let state_root = temporary.path().join("state");
+        let corrupt_id = Uuid::new_v4();
+        let corrupt_owner = state_root.join(corrupt_id.to_string());
+        std::fs::create_dir_all(&corrupt_owner).expect("corrupt owner directory");
+        std::fs::write(corrupt_owner.join("state.json"), b"{not-json").expect("corrupt state");
+
+        let result = build_with_state_root(temporary.path(), state_root);
+
+        assert!(matches!(
+            result,
+            Err(crate::error::BlazeDaemonError::RecoveryRequired(message))
+                if message.contains(&corrupt_id.to_string())
+                    && message.contains("cannot load persisted instance")
+        ));
+    }
+
+    #[test]
+    fn builder_propagates_a_terminal_cleanup_violation() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let state_root = temporary.path().join("state");
+        let mut stored = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:terminal".into(),
+            StartPath::Cold,
+            "default".into(),
+        );
+        stored
+            .transition(SandboxState::Destroyed)
+            .expect("terminal transition");
+        stored.backend_ownership = BackendOwnership::Running;
+        stored.persist(&state_root).expect("persist state");
+
+        let result = build_with_state_root(temporary.path(), state_root);
+
+        assert!(matches!(
+            result,
+            Err(crate::error::BlazeDaemonError::RecoveryRequired(message))
+                if message.contains(&stored.id.to_string())
+                    && message.contains("does not prove completed cleanup")
+                    && message.contains("backend ownership Running")
+        ));
     }
 }

--- a/src/blaze/crates/blazed/src/state_store.rs
+++ b/src/blaze/crates/blazed/src/state_store.rs
@@ -11,10 +11,10 @@ use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use blaze_core::lifecycle::SandboxInstance;
+use blaze_core::lifecycle::{BackendOwnership, SandboxInstance, SandboxState};
 use rustix::fs::{
-    AtFlags, Dir, FlockOperation, Mode, OFlags, RenameFlags, flock, fstat, fsync, mkdirat, open,
-    openat, renameat, renameat_with, unlinkat,
+    AtFlags, Dir, DirEntry, FileType, FlockOperation, Mode, OFlags, RenameFlags, Stat, flock,
+    fstat, fsync, mkdirat, open, openat, renameat, renameat_with, statat, unlinkat,
 };
 use rustix::io::Errno;
 use uuid::Uuid;
@@ -226,13 +226,61 @@ impl StateStore {
         Self::load_from(&run_dir)
     }
 
-    /// Best-effort startup scan of persisted lifecycle records.
+    /// Validate and load every owned lifecycle record before request handling.
     ///
     /// The scan owns the run-directory map for its complete duration and must
-    /// run before request handling starts. This prevents a stale scan result
-    /// from restoring ownership after a concurrent terminal commit.
+    /// run before request handling starts. Supported lifecycle writers use the
+    /// same store, so this lock prevents a stale scan result from restoring
+    /// ownership after a concurrent terminal commit. The production store's
+    /// state-root lock excludes other cooperating Blaze daemons.
     pub fn scan(&self) -> Result<HashMap<Uuid, SandboxInstance>> {
+        self.scan_with_hooks(|_| Ok(()), || Ok(()), |_| Ok(()))
+    }
+
+    #[cfg(test)]
+    fn scan_with_owner_hook<F>(&self, mut after_owner: F) -> Result<HashMap<Uuid, SandboxInstance>>
+    where
+        F: FnMut(Uuid) -> Result<()>,
+    {
+        self.scan_with_hooks(&mut after_owner, || Ok(()), |_| Ok(()))
+    }
+
+    #[cfg(test)]
+    fn scan_with_prevalidation_hook<F>(
+        &self,
+        mut before_validation: F,
+    ) -> Result<HashMap<Uuid, SandboxInstance>>
+    where
+        F: FnMut() -> Result<()>,
+    {
+        self.scan_with_hooks(|_| Ok(()), &mut before_validation, |_| Ok(()))
+    }
+
+    #[cfg(test)]
+    fn scan_with_post_final_enumeration_hook<F>(
+        &self,
+        mut after_final_enumeration: F,
+    ) -> Result<HashMap<Uuid, SandboxInstance>>
+    where
+        F: FnMut(&[Uuid]) -> Result<()>,
+    {
+        self.scan_with_hooks(|_| Ok(()), || Ok(()), &mut after_final_enumeration)
+    }
+
+    fn scan_with_hooks<F, G, H>(
+        &self,
+        mut after_owner: F,
+        mut before_validation: G,
+        mut after_final_enumeration: H,
+    ) -> Result<HashMap<Uuid, SandboxInstance>>
+    where
+        F: FnMut(Uuid) -> Result<()>,
+        G: FnMut() -> Result<()>,
+        H: FnMut(&[Uuid]) -> Result<()>,
+    {
         let mut instances = HashMap::new();
+        let mut scanned_run_dirs = HashMap::new();
+        let mut scanned_owners = Vec::new();
         let mut run_dirs =
             self.inner.run_dirs.lock().map_err(|_| {
                 BlazeDaemonError::Internal("state run-directory lock poisoned".into())
@@ -257,13 +305,17 @@ impl StateStore {
             let Ok(id) = Uuid::parse_str(name) else {
                 continue;
             };
-            let run_dir = match self.open_run_dir_object(id) {
-                Ok(run_dir) => run_dir,
-                Err(error) => {
-                    tracing::warn!(instance = %id, %error, "skipping invalid instance directory");
-                    continue;
-                }
-            };
+            let canonical_name = id.to_string();
+            if name != canonical_name {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "owned state directory {name} is a non-canonical UUID alias for {canonical_name}"
+                )));
+            }
+            let run_dir = self.open_scanned_run_dir(&entry, id).map_err(|error| {
+                BlazeDaemonError::RecoveryRequired(format!(
+                    "cannot open persisted instance directory {id}: {error}"
+                ))
+            })?;
             if let Err(error) = remove_file_if_exists(&run_dir.inner.directory, TEMP_STATE_FILE) {
                 tracing::warn!(
                     instance = %id,
@@ -271,27 +323,71 @@ impl StateStore {
                     "failed to remove stale state record temporary file"
                 );
             }
-            match Self::load_from(&run_dir) {
-                Ok(instance) => {
-                    let ownership =
-                        if instance.state == blaze_core::lifecycle::SandboxState::Destroyed {
-                            RunDirEntry::Released
-                        } else {
-                            RunDirEntry::Owned(run_dir)
-                        };
-                    run_dirs.insert(id, ownership);
-                    instances.insert(id, instance);
-                }
-                Err(error) => {
-                    tracing::warn!(instance = %id, %error, "skipping corrupt instance state");
-                }
+            let (instance, record_identity) =
+                Self::load_from_with_identity(&run_dir).map_err(|error| {
+                    BlazeDaemonError::RecoveryRequired(format!(
+                        "cannot load persisted instance {id}: {error}"
+                    ))
+                })?;
+            if instance.id != id {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "persisted instance id {} does not match owned directory {id}",
+                    instance.id
+                )));
             }
+            validate_terminal_record(&instance)?;
+            let ownership = if instance.state == SandboxState::Destroyed {
+                RunDirEntry::Released
+            } else {
+                RunDirEntry::Owned(run_dir.clone())
+            };
+            scanned_owners.push((id, run_dir, record_identity));
+            scanned_run_dirs.insert(id, ownership);
+            instances.insert(id, instance);
+            after_owner(id)?;
         }
+        before_validation()?;
+        self.revalidate_scanned_inventory(&scanned_owners, &mut after_final_enumeration)?;
+        *run_dirs = scanned_run_dirs;
         tracing::info!(
             instances = instances.len(),
             "rehydrated instances from state_dir"
         );
         Ok(instances)
+    }
+
+    fn open_scanned_run_dir(&self, entry: &DirEntry, id: Uuid) -> Result<OwnedRunDir> {
+        let name = entry.file_name().to_str().map_err(|_| {
+            BlazeDaemonError::RecoveryRequired(format!(
+                "owned state path for instance {id} has a non-UTF-8 name"
+            ))
+        })?;
+        let inspected = statat(&self.inner.root, name, AtFlags::SYMLINK_NOFOLLOW)
+            .map_err(std::io::Error::from)?;
+        if !is_directory(&inspected) {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "owned state path {id} is not a directory"
+            )));
+        }
+        if inspected.st_ino != entry.ino() {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "owned state path {id} is not the directory observed during the state scan"
+            )));
+        }
+        let changed = format!("owned state path {id} changed while it was opened");
+        let directory = open_inspected_object(
+            &self.inner.root,
+            name,
+            &inspected,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            is_directory,
+            &changed,
+        )?;
+        Ok(OwnedRunDir::new(
+            id,
+            self.inner.configured_root.join(id.to_string()),
+            directory,
+        ))
     }
 
     fn cached_run_dir(&self, id: Uuid) -> Result<Option<OwnedRunDir>> {
@@ -308,6 +404,7 @@ impl StateStore {
         }
     }
 
+    #[cfg(test)]
     fn open_run_dir_object(&self, id: Uuid) -> Result<OwnedRunDir> {
         let name = id.to_string();
         let directory = openat(
@@ -534,6 +631,110 @@ impl StateStore {
         Ok(Some(same_opened_object(&linked, &run_dir.inner.directory)?))
     }
 
+    fn revalidate_scanned_owner(
+        &self,
+        id: Uuid,
+        run_dir: &OwnedRunDir,
+        record_identity: &Stat,
+    ) -> Result<()> {
+        match self.linked_directory_matches(&id.to_string(), run_dir) {
+            Ok(Some(true)) => {}
+            Ok(Some(false)) => {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "owned state path {id} changed before inventory publication"
+                )));
+            }
+            Ok(None) => {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "owned state path {id} disappeared before inventory publication"
+                )));
+            }
+            Err(error) => {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "owned state path {id} could not be revalidated before inventory publication: {error}"
+                )));
+            }
+        }
+        let current_record = statat(
+            &run_dir.inner.directory,
+            STATE_FILE,
+            AtFlags::SYMLINK_NOFOLLOW,
+        )
+        .map_err(|error| {
+            BlazeDaemonError::RecoveryRequired(format!(
+                "owned state record for {id} could not be revalidated before inventory publication: {}",
+                std::io::Error::from(error)
+            ))
+        })?;
+        if !is_direct_state_record(&current_record)
+            || !same_stat_object(record_identity, &current_record)
+        {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "owned state record for {id} changed before inventory publication"
+            )));
+        }
+        Ok(())
+    }
+
+    fn revalidate_scanned_inventory<F>(
+        &self,
+        scanned_owners: &[(Uuid, OwnedRunDir, Stat)],
+        after_final_enumeration: &mut F,
+    ) -> Result<()>
+    where
+        F: FnMut(&[Uuid]) -> Result<()>,
+    {
+        let scanned_owners = scanned_owners
+            .iter()
+            .map(|(id, run_dir, record_identity)| (*id, (run_dir, record_identity)))
+            .collect::<HashMap<_, _>>();
+        let mut current_ids = Vec::with_capacity(scanned_owners.len());
+        let entries = Dir::read_from(&self.inner.root).map_err(std::io::Error::from)?;
+        for entry in entries {
+            let entry = entry.map_err(std::io::Error::from)?;
+            let Ok(name) = entry.file_name().to_str() else {
+                continue;
+            };
+            if is_state_staging_name(name) {
+                continue;
+            }
+            let Ok(id) = Uuid::parse_str(name) else {
+                continue;
+            };
+            if name != id.to_string() {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "owned state directory {name} changed the inventory before publication"
+                )));
+            }
+            if !scanned_owners.contains_key(&id) {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "owned state directory {id} was added before inventory publication"
+                )));
+            }
+            current_ids.push(id);
+        }
+        // Complete the name-set walk before checking any retained object's
+        // identity so an early entry is not accepted while later names are
+        // still being enumerated.
+        let enumerated_ids = current_ids;
+        let mut current_ids = enumerated_ids.clone();
+        current_ids.sort_unstable();
+        let mut scanned_ids = scanned_owners.keys().copied().collect::<Vec<_>>();
+        scanned_ids.sort_unstable();
+        if current_ids != scanned_ids {
+            return Err(BlazeDaemonError::RecoveryRequired(
+                "owned state directory set changed before inventory publication".into(),
+            ));
+        }
+        after_final_enumeration(&enumerated_ids)?;
+        // Set completeness is now established; validate every retained object
+        // against the handles and record identity captured by the initial scan.
+        for (id, (run_dir, record_identity)) in scanned_owners {
+            self.revalidate_scanned_owner(id, run_dir, record_identity)?;
+        }
+        Ok(())
+    }
+
     fn revalidate_uncertain(&self, id: Uuid, run_dir: &OwnedRunDir) -> Result<()> {
         let name = id.to_string();
         let linkage = crate::failpoint::state("state-post-publication-identity")
@@ -568,29 +769,88 @@ impl StateStore {
         self.discard_staging(&run_dir, staging_name)
     }
 
+    #[cfg(test)]
     fn load_from(run_dir: &OwnedRunDir) -> Result<SandboxInstance> {
-        let state = openat(
+        Self::load_from_with_identity(run_dir).map(|(instance, _)| instance)
+    }
+
+    fn load_from_with_identity(run_dir: &OwnedRunDir) -> Result<(SandboxInstance, Stat)> {
+        let inspected = statat(
             &run_dir.inner.directory,
             STATE_FILE,
-            OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
-            Mode::empty(),
+            AtFlags::SYMLINK_NOFOLLOW,
         )
         .map_err(std::io::Error::from)?;
-        let mut state = File::from(state);
-        if !state.metadata()?.is_file() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "{} must be a regular file",
-                    run_dir.inner.configured_path.join(STATE_FILE).display()
-                ),
-            )
-            .into());
+        if !is_direct_state_record(&inspected) {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "owned state record for {} is not a direct regular file",
+                run_dir.instance_id()
+            )));
         }
+        let changed = format!(
+            "owned state record for {} changed while it was opened",
+            run_dir.instance_id()
+        );
+        let state = open_inspected_object(
+            &run_dir.inner.directory,
+            STATE_FILE,
+            &inspected,
+            OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+            is_direct_state_record,
+            &changed,
+        )?;
+        let mut state = File::from(state);
         let mut raw = Vec::new();
         state.read_to_end(&mut raw)?;
-        Ok(serde_json::from_slice(&raw)?)
+        Ok((serde_json::from_slice(&raw)?, inspected))
     }
+}
+
+fn is_directory(metadata: &Stat) -> bool {
+    FileType::from_raw_mode(metadata.st_mode) == FileType::Directory
+}
+
+fn is_direct_state_record(metadata: &Stat) -> bool {
+    FileType::from_raw_mode(metadata.st_mode) == FileType::RegularFile && metadata.st_nlink == 1
+}
+
+fn open_inspected_object(
+    directory: &OwnedFd,
+    name: &str,
+    inspected: &Stat,
+    flags: OFlags,
+    expected_type: fn(&Stat) -> bool,
+    changed: &str,
+) -> Result<OwnedFd> {
+    let object = openat(directory, name, flags, Mode::empty()).map_err(std::io::Error::from)?;
+    let opened = fstat(&object).map_err(std::io::Error::from)?;
+    if !expected_type(&opened) || !same_stat_object(inspected, &opened) {
+        return Err(BlazeDaemonError::RecoveryRequired(changed.into()));
+    }
+    Ok(object)
+}
+
+fn same_stat_object(left: &Stat, right: &Stat) -> bool {
+    left.st_dev == right.st_dev && left.st_ino == right.st_ino
+}
+
+fn validate_terminal_record(instance: &SandboxInstance) -> Result<()> {
+    if instance.state != SandboxState::Destroyed {
+        return Ok(());
+    }
+    if matches!(
+        instance.backend_ownership,
+        BackendOwnership::NotStarted | BackendOwnership::Stopped
+    ) && instance.operation.is_none()
+    {
+        return Ok(());
+    }
+    Err(BlazeDaemonError::RecoveryRequired(format!(
+        "destroyed instance {} does not prove completed cleanup: backend ownership {:?}, active operation {:?}",
+        instance.id,
+        instance.backend_ownership,
+        instance.operation.as_ref().map(|operation| operation.kind)
+    )))
 }
 
 fn remove_file_if_exists(directory: &OwnedFd, name: &str) -> Result<()> {
@@ -752,6 +1012,672 @@ mod tests {
             StartPath::Cold,
             "default".into(),
         )
+    }
+
+    fn scan_root(root: &Path) -> Result<HashMap<Uuid, SandboxInstance>> {
+        StateStore::new(root.to_path_buf()).scan()
+    }
+
+    fn find_scanned_entry(store: &StateStore, id: Uuid) -> DirEntry {
+        let expected = id.to_string();
+        Dir::read_from(&store.inner.root)
+            .expect("read state root")
+            .map(|entry| entry.expect("state entry"))
+            .find(|entry| entry.file_name().to_bytes() == expected.as_bytes())
+            .expect("owned state entry")
+    }
+
+    #[test]
+    fn scan_rejects_corrupt_owned_state() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let id = Uuid::new_v4();
+        let owner = temporary.path().join(id.to_string());
+        std::fs::create_dir(&owner).expect("owner directory");
+        std::fs::write(owner.join(STATE_FILE), b"{not-json").expect("corrupt state");
+
+        let error = scan_root(temporary.path()).expect_err("corrupt state must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&id.to_string())
+                    && message.contains("cannot load persisted instance")
+        ));
+    }
+
+    #[test]
+    fn failed_scan_does_not_publish_a_partial_owner_inventory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let first = instance();
+        first.persist(temporary.path()).expect("first state");
+        let second = instance();
+        second.persist(temporary.path()).expect("second state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let mut processed = Vec::new();
+        let mut corrupted = None;
+
+        let error = store
+            .scan_with_owner_hook(|processed_id| {
+                processed.push(processed_id);
+                if processed.len() == 1 {
+                    let pending_id = if processed_id == first.id {
+                        second.id
+                    } else {
+                        assert_eq!(processed_id, second.id);
+                        first.id
+                    };
+                    std::fs::write(
+                        temporary
+                            .path()
+                            .join(pending_id.to_string())
+                            .join(STATE_FILE),
+                        b"{not-json",
+                    )?;
+                    corrupted = Some(pending_id);
+                }
+                Ok(())
+            })
+            .expect_err("corrupt pending state must stop the scan");
+
+        assert_eq!(processed.len(), 1);
+        let corrupted = corrupted.expect("one pending owner was corrupted");
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&corrupted.to_string())
+                    && message.contains("cannot load persisted instance")
+        ));
+        assert_eq!(store.retained_run_dir_count(), 0);
+    }
+
+    #[test]
+    fn scan_rejects_a_processed_owner_replaced_before_publication() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let instance = instance();
+        instance.persist(temporary.path()).expect("persisted state");
+        let owner = temporary.path().join(instance.id.to_string());
+        let displaced = temporary.path().join("displaced-owner");
+        let store = StateStore::new(temporary.path().to_path_buf());
+
+        let error = store
+            .scan_with_owner_hook(|processed_id| {
+                assert_eq!(processed_id, instance.id);
+                std::fs::rename(&owner, &displaced)?;
+                std::fs::create_dir(&owner)?;
+                std::fs::copy(displaced.join(STATE_FILE), owner.join(STATE_FILE))?;
+                Ok(())
+            })
+            .expect_err("a replaced processed owner must stop the scan");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&instance.id.to_string())
+                    && message.contains("changed before inventory publication")
+        ));
+        assert_eq!(store.retained_run_dir_count(), 0);
+        assert!(owner.join(STATE_FILE).is_file());
+        assert!(displaced.join(STATE_FILE).is_file());
+    }
+
+    #[test]
+    fn scan_rejects_a_processed_record_replaced_before_publication() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let instance = instance();
+        instance.persist(temporary.path()).expect("persisted state");
+        let owner = temporary.path().join(instance.id.to_string());
+        let record = owner.join(STATE_FILE);
+        let displaced = owner.join("state.read-by-scan.json");
+        let replacement = instance.clone();
+        let store = StateStore::new(temporary.path().to_path_buf());
+
+        let error = store
+            .scan_with_owner_hook(|processed_id| {
+                assert_eq!(processed_id, instance.id);
+                std::fs::rename(&record, &displaced)?;
+                std::fs::write(&record, serde_json::to_vec_pretty(&replacement)?)?;
+                Ok(())
+            })
+            .expect_err("a replaced processed record must stop the scan");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&instance.id.to_string())
+                    && message.contains("record")
+                    && message.contains("changed before inventory publication")
+        ));
+        assert_eq!(store.retained_run_dir_count(), 0);
+        assert!(record.is_file());
+        assert!(displaced.is_file());
+    }
+
+    #[test]
+    fn scan_rejects_an_owner_added_before_publication() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let first = instance();
+        first
+            .persist(temporary.path())
+            .expect("first persisted state");
+        let added = instance();
+        let store = StateStore::new(temporary.path().to_path_buf());
+
+        let error = store
+            .scan_with_prevalidation_hook(|| {
+                added.persist(temporary.path())?;
+                Ok(())
+            })
+            .expect_err("an owner added after enumeration must stop the scan");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&added.id.to_string())
+                    && message.contains("was added before inventory publication")
+        ));
+        assert_eq!(store.retained_run_dir_count(), 0);
+        assert!(temporary.path().join(first.id.to_string()).is_dir());
+        assert!(temporary.path().join(added.id.to_string()).is_dir());
+    }
+
+    #[test]
+    fn scan_rejects_an_early_owner_replaced_after_final_enumeration() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let first = instance();
+        first.persist(temporary.path()).expect("first state");
+        let second = instance();
+        second.persist(temporary.path()).expect("second state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let mut replaced = None;
+
+        let error = store
+            .scan_with_post_final_enumeration_hook(|enumerated_ids| {
+                assert_eq!(enumerated_ids.len(), 2);
+                let earlier_id = enumerated_ids[0];
+                let owner = temporary.path().join(earlier_id.to_string());
+                let displaced = temporary.path().join(format!("displaced-{earlier_id}"));
+                std::fs::rename(&owner, &displaced)?;
+                std::fs::create_dir(&owner)?;
+                std::fs::copy(displaced.join(STATE_FILE), owner.join(STATE_FILE))?;
+                replaced = Some((earlier_id, displaced));
+                Ok(())
+            })
+            .expect_err("an owner replaced after the final enumeration must stop the scan");
+
+        let (replaced_id, displaced) = replaced.expect("one enumerated owner was replaced");
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&replaced_id.to_string())
+                    && message.contains("changed before inventory publication")
+        ));
+        assert_eq!(store.retained_run_dir_count(), 0);
+        assert!(
+            temporary
+                .path()
+                .join(replaced_id.to_string())
+                .join(STATE_FILE)
+                .is_file()
+        );
+        assert!(displaced.join(STATE_FILE).is_file());
+    }
+
+    #[test]
+    fn scan_rejects_an_early_record_replaced_after_final_enumeration() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let first = instance();
+        first.persist(temporary.path()).expect("first state");
+        let second = instance();
+        second.persist(temporary.path()).expect("second state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let mut replaced = None;
+
+        let error = store
+            .scan_with_post_final_enumeration_hook(|enumerated_ids| {
+                assert_eq!(enumerated_ids.len(), 2);
+                let earlier_id = enumerated_ids[0];
+                let owner = temporary.path().join(earlier_id.to_string());
+                let record = owner.join(STATE_FILE);
+                let displaced = owner.join("state.read-by-scan.json");
+                std::fs::rename(&record, &displaced)?;
+                std::fs::copy(&displaced, &record)?;
+                replaced = Some((earlier_id, record, displaced));
+                Ok(())
+            })
+            .expect_err("a record replaced after the final enumeration must stop the scan");
+
+        let (replaced_id, record, displaced) =
+            replaced.expect("one enumerated record was replaced");
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&replaced_id.to_string())
+                    && message.contains("record")
+                    && message.contains("changed before inventory publication")
+        ));
+        assert_eq!(store.retained_run_dir_count(), 0);
+        assert!(record.is_file());
+        assert!(displaced.is_file());
+    }
+
+    #[test]
+    fn scan_rejects_a_non_canonical_uuid_alias() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let valid = instance();
+        valid.persist(temporary.path()).expect("valid state");
+        let alias = valid.id.simple().to_string();
+        let alias_owner = temporary.path().join(&alias);
+        std::fs::create_dir(&alias_owner).expect("alias owner directory");
+        std::fs::write(alias_owner.join(STATE_FILE), b"{not-json").expect("alias state");
+
+        let error = scan_root(temporary.path()).expect_err("UUID alias must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&alias)
+                    && message.contains(&valid.id.to_string())
+                    && message.contains("non-canonical UUID alias")
+        ));
+    }
+
+    #[test]
+    fn scan_rejects_a_uuid_named_regular_file() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let id = Uuid::new_v4();
+        std::fs::write(temporary.path().join(id.to_string()), b"not a directory")
+            .expect("UUID-shaped file");
+
+        let error = scan_root(temporary.path()).expect_err("UUID file must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&id.to_string()) && message.contains("is not a directory")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_rejects_a_uuid_named_symbolic_link() {
+        use std::os::unix::fs::symlink;
+
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let target = temporary.path().join("unowned-target");
+        std::fs::create_dir(&target).expect("target directory");
+        let id = Uuid::new_v4();
+        symlink(&target, temporary.path().join(id.to_string())).expect("UUID-shaped link");
+
+        let error = scan_root(temporary.path()).expect_err("UUID link must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&id.to_string()) && message.contains("is not a directory")
+        ));
+    }
+
+    #[test]
+    fn scan_rejects_state_owned_by_a_different_directory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let stored = instance();
+        stored.persist(temporary.path()).expect("persist state");
+        let directory_id = Uuid::new_v4();
+        std::fs::rename(
+            temporary.path().join(stored.id.to_string()),
+            temporary.path().join(directory_id.to_string()),
+        )
+        .expect("rename owner directory");
+
+        let error = scan_root(temporary.path()).expect_err("mismatched ID must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&stored.id.to_string())
+                    && message.contains(&directory_id.to_string())
+        ));
+    }
+
+    #[test]
+    fn scan_rejects_a_non_regular_state_record() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let id = Uuid::new_v4();
+        let owner = temporary.path().join(id.to_string());
+        std::fs::create_dir_all(owner.join(STATE_FILE)).expect("record directory");
+
+        let error = scan_root(temporary.path()).expect_err("record directory must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&id.to_string())
+                    && message.contains("cannot load persisted instance")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_rejects_a_symbolic_link_state_record() {
+        use std::os::unix::fs::symlink;
+
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let external = tempfile::tempdir().expect("external directory");
+        let stored = instance();
+        stored.persist(external.path()).expect("external state");
+        let owner = temporary.path().join(stored.id.to_string());
+        std::fs::create_dir(&owner).expect("owner directory");
+        symlink(
+            external.path().join(stored.id.to_string()).join(STATE_FILE),
+            owner.join(STATE_FILE),
+        )
+        .expect("record link");
+
+        let error = scan_root(temporary.path()).expect_err("record link must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&stored.id.to_string())
+                    && message.contains("cannot load persisted instance")
+        ));
+    }
+
+    #[test]
+    fn scan_rejects_a_hard_link_state_record() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let external = tempfile::tempdir().expect("external directory");
+        let stored = instance();
+        stored.persist(external.path()).expect("external state");
+        let owner = temporary.path().join(stored.id.to_string());
+        std::fs::create_dir(&owner).expect("owner directory");
+        std::fs::hard_link(
+            external.path().join(stored.id.to_string()).join(STATE_FILE),
+            owner.join(STATE_FILE),
+        )
+        .expect("record hard link");
+
+        let error = scan_root(temporary.path()).expect_err("hard link must stop startup");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&stored.id.to_string())
+                    && message.contains("cannot load persisted instance")
+        ));
+    }
+
+    #[test]
+    fn scan_rejects_destroyed_state_with_uncleared_ownership() {
+        for ownership in [
+            BackendOwnership::Unknown,
+            BackendOwnership::Starting,
+            BackendOwnership::Running,
+        ] {
+            let temporary = tempfile::tempdir().expect("temporary directory");
+            let mut stored = instance();
+            stored
+                .transition(SandboxState::Destroyed)
+                .expect("terminal transition");
+            stored.backend_ownership = ownership;
+            stored.persist(temporary.path()).expect("persist state");
+
+            let error = scan_root(temporary.path())
+                .expect_err("uncleared terminal ownership must stop startup");
+
+            assert!(matches!(
+                error,
+                BlazeDaemonError::RecoveryRequired(message)
+                    if message.contains(&stored.id.to_string())
+                        && message.contains("does not prove completed cleanup")
+            ));
+        }
+    }
+
+    #[test]
+    fn scan_rejects_destroyed_state_with_an_active_operation() {
+        for operation in [
+            blaze_core::lifecycle::OperationKind::Create,
+            blaze_core::lifecycle::OperationKind::Destroy,
+        ] {
+            let temporary = tempfile::tempdir().expect("temporary directory");
+            let mut stored = instance();
+            stored.backend_ownership = BackendOwnership::Stopped;
+            stored
+                .transition(SandboxState::Destroyed)
+                .expect("terminal transition");
+            stored.begin_operation(operation);
+            stored.persist(temporary.path()).expect("persist state");
+
+            let error =
+                scan_root(temporary.path()).expect_err("terminal operation must stop startup");
+
+            assert!(matches!(
+                error,
+                BlazeDaemonError::RecoveryRequired(message)
+                    if message.contains(&stored.id.to_string())
+                        && message.contains(&format!("active operation Some({operation:?})"))
+            ));
+        }
+    }
+
+    #[test]
+    fn scan_rejects_legacy_destroyed_state_without_ownership_evidence() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let mut stored = instance();
+        stored
+            .transition(SandboxState::Destroyed)
+            .expect("terminal transition");
+        let mut record = serde_json::to_value(&stored).expect("serialize state");
+        let fields = record.as_object_mut().expect("state object");
+        fields.remove("backend_ownership");
+        fields.remove("operation");
+        let owner = temporary.path().join(stored.id.to_string());
+        std::fs::create_dir(&owner).expect("owner directory");
+        std::fs::write(
+            owner.join(STATE_FILE),
+            serde_json::to_vec_pretty(&record).expect("serialize legacy state"),
+        )
+        .expect("write legacy state");
+
+        let error = scan_root(temporary.path())
+            .expect_err("legacy terminal state must prove ownership was released");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&stored.id.to_string())
+                    && message.contains("backend ownership Unknown")
+                    && message.contains("does not prove completed cleanup")
+        ));
+    }
+
+    #[test]
+    fn scan_accepts_destroyed_state_that_proves_cleanup() {
+        for ownership in [BackendOwnership::NotStarted, BackendOwnership::Stopped] {
+            let temporary = tempfile::tempdir().expect("temporary directory");
+            let mut stored = instance();
+            stored.backend_ownership = ownership;
+            stored
+                .transition(SandboxState::Destroyed)
+                .expect("terminal transition");
+            stored.persist(temporary.path()).expect("persist state");
+
+            let records = scan_root(temporary.path()).expect("clean terminal state");
+
+            assert_eq!(records[&stored.id].state, SandboxState::Destroyed);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_rejects_an_owner_replaced_by_a_link_after_enumeration() {
+        use std::os::unix::fs::symlink;
+
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let external = tempfile::tempdir().expect("external directory");
+        let stored = instance();
+        stored.persist(temporary.path()).expect("local state");
+        stored.persist(external.path()).expect("external state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let entry = find_scanned_entry(&store, stored.id);
+        let configured = temporary.path().join(stored.id.to_string());
+        std::fs::rename(&configured, temporary.path().join("moved-owner"))
+            .expect("move scanned owner");
+        symlink(external.path().join(stored.id.to_string()), &configured)
+            .expect("replace owner with link");
+
+        let error = store
+            .open_scanned_run_dir(&entry, stored.id)
+            .expect_err("replacement link must not be followed");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&stored.id.to_string())
+                    && message.contains("is not a directory")
+        ));
+    }
+
+    #[test]
+    fn scan_rejects_an_owner_replaced_after_enumeration() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let replacement = tempfile::tempdir().expect("replacement directory");
+        let stored = instance();
+        stored.persist(temporary.path()).expect("local state");
+        stored
+            .persist(replacement.path())
+            .expect("replacement state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let entry = find_scanned_entry(&store, stored.id);
+        let configured = temporary.path().join(stored.id.to_string());
+        std::fs::rename(&configured, temporary.path().join("moved-owner"))
+            .expect("move scanned owner");
+        std::fs::rename(replacement.path().join(stored.id.to_string()), &configured)
+            .expect("replace owner directory");
+
+        let error = store
+            .open_scanned_run_dir(&entry, stored.id)
+            .expect_err("replacement directory must be rejected");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message)
+                if message.contains(&stored.id.to_string())
+                    && message.contains("observed during the state scan")
+        ));
+    }
+
+    #[test]
+    fn owner_identity_check_rejects_replacement_between_inspect_and_open() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let replacement = tempfile::tempdir().expect("replacement directory");
+        let stored = instance();
+        stored.persist(temporary.path()).expect("local state");
+        stored
+            .persist(replacement.path())
+            .expect("replacement state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let name = stored.id.to_string();
+        let inspected = statat(&store.inner.root, name.as_str(), AtFlags::SYMLINK_NOFOLLOW)
+            .expect("inspect owner directory");
+        let configured = temporary.path().join(&name);
+        std::fs::rename(&configured, temporary.path().join("moved-owner"))
+            .expect("move inspected owner");
+        std::fs::rename(replacement.path().join(&name), &configured)
+            .expect("replace inspected owner");
+        let changed = format!("owned state path {} changed while it was opened", stored.id);
+
+        let error = open_inspected_object(
+            &store.inner.root,
+            &name,
+            &inspected,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            is_directory,
+            &changed,
+        )
+        .expect_err("replacement directory must fail identity validation");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message) if message == changed
+        ));
+    }
+
+    #[test]
+    fn state_record_identity_check_rejects_replacement_between_inspect_and_open() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let stored = instance();
+        stored.persist(temporary.path()).expect("stored state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let owner = store
+            .open_run_dir_object(stored.id)
+            .expect("open owner directory");
+        let inspected = statat(
+            &owner.inner.directory,
+            STATE_FILE,
+            AtFlags::SYMLINK_NOFOLLOW,
+        )
+        .expect("inspect state record");
+        let configured = temporary.path().join(stored.id.to_string());
+        std::fs::rename(
+            configured.join(STATE_FILE),
+            configured.join("state.original.json"),
+        )
+        .expect("move inspected state record");
+        let mut replacement = stored.clone();
+        replacement.policy_name = "replacement".into();
+        std::fs::write(
+            configured.join(STATE_FILE),
+            serde_json::to_vec_pretty(&replacement).expect("serialize replacement state"),
+        )
+        .expect("replace inspected state record");
+        let changed = format!(
+            "owned state record for {} changed while it was opened",
+            stored.id
+        );
+
+        let error = open_inspected_object(
+            &owner.inner.directory,
+            STATE_FILE,
+            &inspected,
+            OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+            is_direct_state_record,
+            &changed,
+        )
+        .expect_err("replacement record must fail identity validation");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::RecoveryRequired(message) if message == changed
+        ));
+    }
+
+    #[test]
+    fn record_lookup_stays_bound_to_the_opened_owner_directory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let replacement = tempfile::tempdir().expect("replacement directory");
+        let stored = instance();
+        stored.persist(temporary.path()).expect("original state");
+        let mut replacement_record = stored.clone();
+        replacement_record.policy_name = "replacement".into();
+        replacement_record
+            .persist(replacement.path())
+            .expect("replacement state");
+        let store = StateStore::new(temporary.path().to_path_buf());
+        let entry = find_scanned_entry(&store, stored.id);
+        let owner = store
+            .open_scanned_run_dir(&entry, stored.id)
+            .expect("open scanned owner");
+        let configured = temporary.path().join(stored.id.to_string());
+        std::fs::rename(&configured, temporary.path().join("moved-owner"))
+            .expect("move opened owner");
+        std::fs::rename(replacement.path().join(stored.id.to_string()), &configured)
+            .expect("replace owner path");
+
+        let loaded = StateStore::load_from(&owner).expect("load opened owner record");
+
+        assert_eq!(loaded.policy_name, stored.policy_name);
     }
 
     #[test]
@@ -1026,6 +1952,7 @@ mod tests {
         std::fs::create_dir(&root).expect("state directory");
         let writer = StateStore::new(root.clone());
         let mut instance = instance();
+        instance.backend_ownership = BackendOwnership::Stopped;
         instance
             .transition(blaze_core::lifecycle::SandboxState::Destroyed)
             .expect("destroy transition");

--- a/src/blaze/docs/design/lifecycle-state-consistency.md
+++ b/src/blaze/docs/design/lifecycle-state-consistency.md
@@ -1,0 +1,118 @@
+# Lifecycle State Consistency
+
+[中文版](lifecycle-state-consistency_zh.md)
+
+Blaze must reconstruct a complete persisted sandbox inventory before it can
+reconcile resources or serve API requests. This document defines how the daemon
+coordinates lifecycle-state writers, validates the startup inventory, and
+publishes that inventory without exposing a partial result.
+
+This protocol does not change the HTTP API, configuration keys, or the
+persisted JSON format.
+
+## Terms and owned objects
+
+The **state root** is the directory configured by `daemon.state_dir`. Each
+persisted sandbox record is stored in one canonically named UUID directory
+below that root. Its `state.json` file contains the lifecycle record used
+during restart.
+
+`StateStore` is the supported entry point for lifecycle-record persistence. It
+keeps the opened state-root directory object for its lifetime instead of
+reopening the configured pathname. For each active sandbox, it also retains an
+opened UUID directory object. Later record and runtime-directory operations are
+derived from these opened objects.
+
+The **startup inventory** contains the validated lifecycle record for every
+UUID-owned directory. A separate retained-owner map keeps the opened UUID
+directories that the daemon must continue to use for later lifecycle and
+backend operations.
+
+## Writer coordination
+
+A production daemon takes a non-blocking exclusive advisory lock on the opened
+state root before it scans lifecycle records. Another Blaze daemon following
+the same protocol cannot start with that state root until the first daemon
+releases the lock.
+
+Inside one daemon, the startup scan holds the `StateStore` run-directory map
+lock for the complete scan and publication sequence. Lifecycle persistence
+also enters this map through `StateStore`, so a supported in-process writer
+cannot publish or release an owner while startup is constructing the
+inventory. Per-sandbox record writes have an additional writer lock.
+
+These two locks serve different purposes: the state-root lock coordinates
+cooperating daemon processes, while the run-directory map lock coordinates
+writers inside one daemon.
+
+## Startup publication protocol
+
+Startup follows this order:
+
+1. Open the configured state root, take its advisory lock, and retain that
+   opened directory object.
+2. Enumerate UUID-owned entries and build private instance and retained-owner
+   maps. For every UUID entry, require:
+   - a canonical lowercase, hyphenated UUID directory name;
+   - a directory rather than a link or another filesystem object, and the same
+     directory object observed during enumeration;
+   - a regular `state.json` with exactly one hard link, opened relative to that
+     directory instead of through a replacement path;
+   - a record whose sandbox ID matches the directory name; and
+   - for `Destroyed`, no active operation and backend ownership of
+     `NotStarted` or `Stopped`.
+3. Complete a second enumeration of canonical UUID names and compare its full
+   set with the first scan.
+4. After the second enumeration has finished, revalidate every retained UUID
+   directory and `state.json` against the objects accepted by the first scan.
+5. Only after every check succeeds, publish the retained-owner map and return
+   the instance map to `ServerState`.
+6. Reconcile the accepted sandbox records, then bind the configured Unix and
+   TCP API listeners.
+
+The name-set comparison must finish before object revalidation begins. This
+ordering prevents an early owner from being accepted while the final directory
+enumeration is still processing later UUID entries.
+
+## Failure behavior
+
+Any missing, malformed, unexpectedly typed, aliased, or internally
+inconsistent UUID record stops daemon startup. If the final name-set comparison
+or object revalidation detects an added, removed, or replaced owner or record,
+startup also stops. The scan does not publish a partial retained-owner map, and
+the daemon does not open its API listeners.
+
+Blaze leaves a rejected UUID directory and its `state.json` unchanged for
+operator inspection and repair. Existing cleanup of state-publication staging
+entries remains separate from rejected-record handling.
+
+After a complete inventory has been accepted, startup reconciliation processes
+each non-terminal sandbox independently. A cleanup failure for one sandbox can
+leave that sandbox in `RecoveryRequired` without turning the already validated
+inventory into a partial one.
+
+## Consistency boundary
+
+This protocol covers lifecycle-state writers that use `StateStore` and daemon
+processes that participate in the state-root advisory lock. The advisory lock
+does not prevent an unrelated process from modifying the directory directly.
+A finite sequence of directory scans cannot provide an atomic snapshot against
+such a writer.
+
+Direct modification that bypasses the state-root lock is unsupported. Stronger
+isolation for that path is tracked in
+[#2459](https://github.com/alibaba/anolisa/issues/2459).
+
+## Maintainer invariants
+
+Future lifecycle-state changes must preserve these rules:
+
+- production lifecycle writes go through `StateStore`;
+- the state-root owner is acquired before inventory scanning and retained
+  while request handlers can write lifecycle state;
+- startup holds the run-directory map lock until the complete inventory is
+  accepted or rejected;
+- the final UUID enumeration completes before retained objects are
+  revalidated; and
+- no request handler can observe either startup map before all inventory
+  checks have passed.

--- a/src/blaze/docs/design/lifecycle-state-consistency_zh.md
+++ b/src/blaze/docs/design/lifecycle-state-consistency_zh.md
@@ -1,0 +1,97 @@
+# 生命周期状态一致性
+
+[English](lifecycle-state-consistency.md)
+
+Blaze 必须完整重建已经持久化的 sandbox 清单，才能开始资源恢复或提供 API
+请求。本设计说明 daemon 如何协调生命周期状态写入、校验启动清单，以及如何在
+不暴露部分结果的前提下发布该清单。
+
+这一协议不改变 HTTP API、配置项或持久化 JSON 格式。
+
+## 概念与持有对象
+
+**state root** 是 `daemon.state_dir` 配置的目录。每条已经持久化的 sandbox
+记录都保存在该目录下一个以规范 UUID 命名的目录中，其中的 `state.json`
+保存重启时使用的生命周期记录。
+
+`StateStore` 是生命周期记录持久化的受支持入口。它会在自身存续期间一直保留
+已经打开的 state-root 目录对象，而不是重新打开配置路径。对于每个活动
+sandbox，它还会保留已经打开的 UUID 目录对象；后续记录和运行目录操作都从
+这些已经打开的对象派生。
+
+**启动清单**包含每个 UUID 所属目录中通过校验的生命周期记录。另一个
+retained-owner map 保存 daemon 后续执行生命周期和 backend 操作时必须继续使用
+的已打开 UUID 目录。
+
+## 写入协调
+
+production daemon 会在扫描生命周期记录前，对已经打开的 state root 取得非阻塞
+排他 advisory lock。另一个遵守相同协议的 Blaze daemon 必须等到前一个 daemon
+释放 lock 后，才能使用同一个 state root 启动。
+
+在单个 daemon 内，启动扫描会在完整扫描和发布过程中持续持有 `StateStore` 的
+run-directory map lock。生命周期持久化也通过 `StateStore` 进入该 map，因此
+受支持的进程内 writer 不能在启动清单构建期间发布或释放 owner。每个 sandbox
+的记录写入还使用独立的 writer lock。
+
+这两类 lock 的职责不同：state-root lock 协调遵守协议的 daemon 进程，
+run-directory map lock 协调单个 daemon 内的 writer。
+
+## 启动发布流程
+
+启动按照以下顺序执行：
+
+1. 打开配置的 state root，取得 advisory lock，并保留这个已经打开的目录对象。
+2. 枚举 UUID 所属条目，在私有的 instance map 和 retained-owner map 中构建
+   结果。每个 UUID 条目必须满足：
+   - 目录名是规范的小写、带连字符 UUID；
+   - 条目本身是目录而不是链接或其他文件系统对象，并且与枚举时观察到的是
+     同一个目录对象；
+   - `state.json` 是只有一个硬链接的普通文件，并且相对于该目录打开，而不是
+     通过可能已经被替换的路径打开；
+   - 记录内的 sandbox ID 与目录名一致；
+   - `Destroyed` 记录没有活动 operation，并且 backend ownership 为
+     `NotStarted` 或 `Stopped`。
+3. 完成第二次规范 UUID 名称枚举，并将完整集合与首次扫描结果比较。
+4. 第二次枚举完成后，逐个确认保留的 UUID 目录和 `state.json` 仍与首次扫描
+   接受的对象一致。
+5. 只有全部检查通过后，才发布 retained-owner map，并将 instance map 返回给
+   `ServerState`。
+6. 处理已经接受的 sandbox 记录，随后绑定配置的 Unix 和 TCP API listener。
+
+名称集合比较必须在对象复验开始前完成。这个顺序可以避免较早的 owner 已经通过
+检查，而最终目录枚举仍在处理后续 UUID 条目。
+
+## 失败行为
+
+UUID 记录缺失、格式错误、类型异常、使用别名或内部状态不一致，都会使 daemon
+停止启动。如果最终名称集合比较或对象复验发现 owner 或记录新增、删除或替换，
+启动也会停止。扫描不会发布部分 retained-owner map，daemon 也不会打开 API
+listener。
+
+Blaze 会保留被拒绝的 UUID 目录及其 `state.json`，供运维人员检查和修复。
+已有的状态发布 staging 条目清理流程与拒绝记录的处理相互独立。
+
+完整清单通过校验后，启动恢复会分别处理每个非终态 sandbox。单个 sandbox
+清理失败时可以保留为 `RecoveryRequired`，但不会把已经通过校验的清单变成
+部分清单。
+
+## 一致性边界
+
+本协议覆盖通过 `StateStore` 写入生命周期状态、并参与 state-root advisory
+lock 的 daemon 进程。advisory lock 不会阻止无关进程直接修改该目录；有限次数
+的目录扫描也无法针对这种 writer 提供原子快照。
+
+绕过 state-root lock 的直接修改不在支持范围内。该路径的进一步隔离由
+[#2459](https://github.com/alibaba/anolisa/issues/2459) 跟踪。
+
+## 维护约束
+
+后续生命周期状态改动必须保持以下规则：
+
+- production 生命周期写入必须经过 `StateStore`；
+- 必须在 inventory 扫描前取得 state-root owner，并在 request handler 仍可能
+  写入生命周期状态期间持续持有；
+- 启动过程必须持有 run-directory map lock，直到完整清单被接受或拒绝；
+- 必须先完成最终 UUID 枚举，再复验保留对象；
+- 所有清单检查完成前，request handler 不能观察到任何一个启动 map。


### PR DESCRIPTION
## Description

This PR prevents Blaze from starting with an incomplete or ambiguous view of persisted sandbox state.

During startup, Blaze reads every saved sandbox record before it reconciles resources and opens its configured API listeners. If an owned record cannot be trusted, startup now stops instead of silently omitting that sandbox.

### Before

The startup scan was best effort. It could skip a malformed, aliased, unreadable, unexpectedly typed, or internally inconsistent UUID-owned entry and continue with a partial ownership map.

A record marked `Destroyed` also did not have to prove that no operation or backend process remained.

### After

Startup now:

- accepts only canonically named UUID directories;
- opens each directory relative to the already opened state root and verifies that it is the same filesystem object observed during scanning;
- reads `state.json` relative to that directory and requires a direct, single-link regular file;
- requires the sandbox ID in the record to match the directory name;
- accepts `Destroyed` only when no operation remains and backend ownership is `NotStarted` or `Stopped`;
- builds the startup maps privately, completes a second full UUID-name enumeration, compares the complete set, and only then revalidates every retained directory and `state.json`; and
- publishes the maps only after all checks succeed, propagating any error before a configured Unix or TCP API listener is opened.

Rejected sandbox records are left available for operator inspection. Existing cleanup of state-publication staging entries is unchanged.

Inventory validation and per-sandbox reconciliation are separate stages. Blaze starts reconciliation only after the complete inventory has passed validation. A later cleanup failure leaves that accepted sandbox `RecoveryRequired` while allowing the remaining accepted records to proceed; an inventory validation failure stops the entire daemon before it serves requests.

The user guide now explains how operators observe this failure: the daemon exits non-zero, no API listener or `/v1/health` response is available, and the record-specific error can be read through the packaged systemd service status and journal.

The production `StateStore` keeps the opened state-root object and its advisory lock for cooperating Blaze daemons. The scan also holds the in-process ownership-map lock until publication. A process that changes these files while bypassing this protocol is outside the supported consistency boundary and is tracked by #2459.

### Commit

#### `b51bd7b6986a fix(blaze): validate startup state inventory`

- **Intent:** prevent the daemon from serving requests with missing or ambiguous persisted ownership information.
- **Implementation:** validates UUID names, directory and record identity, record contents, terminal cleanup evidence, the final UUID set, and all retained objects before atomically publishing the startup inventory.
- **Delivery state:** active in the daemon startup path; the configured listeners are created only after validation and startup reconciliation succeed.

This remains one commit because record validation, all-or-nothing publication, startup error propagation, regression tests, operator documentation, and the developer-facing protocol description jointly establish one fail-closed startup rule. Removing any one of them would leave either the behavior or its maintenance contract incomplete.

### Not in this PR

- automatic repair or deletion of rejected sandbox records;
- isolation from processes that bypass the state-root advisory lock (#2459);
- daemon endpoint ownership or accepted-connection draining;
- HTTP operation, request/response schema, configuration-key, or persisted-format changes.

## Related Issue

closes #2369

Follow-up hardening: #2459

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [x] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective
- [x] I have updated the documentation
- [x] Formatting, strict Clippy, tests, and rustdoc pass on Linux
- [x] Lock files are up to date

## Testing

Exact candidate:

- Commit: `b51bd7b6986afe4398d418ba564e57c815e2e067`
- Tree: `9cc16e993457e3820d75254e8ec68e5f3a987d04`
- Parent: `fa0c8369d300d90a6470965dc564e20b09487eb7`
- Diff: 8 files, 1,377 insertions, 54 deletions
- Source archive SHA-256: `168ede87c0d49101448ebf0ad9181f1c84512f1e8b124de2cc57f714a22c8b44`

Linux x86_64, rustc/cargo 1.88.0; default and all-features runs used separate initially empty target directories:

- default locked metadata, all-target build, strict Clippy, 299/299 tests, and strict rustdoc — PASS;
- all-features locked metadata, all-target build, strict Clippy, 317/317 tests, and strict rustdoc — PASS;
- `StateStore` tests — 37/37 PASS;
- `ServerState` tests — 3/3 PASS;
- `builder_propagates_a_terminal_cleanup_violation` — 1/1 PASS;
- post-final-enumeration owner replacement and `state.json` replacement — 1/1 each PASS;
- corrupt JSON and `Destroyed + Running` inventories both stopped with record-specific errors before Unix/TCP listeners or health became available;
- a valid inventory served health over both configured listeners and stopped cleanly — PASS;
- four independent removal checks proved that final ordering, owner identity, record identity, and all-or-nothing map publication are causally required — PASS;
- documentation lint, relative links, diff check, commitlint, trailers, and public-boundary checks — PASS.

Hosted PR Lint, Docs, Components, and Pages checks on this rewritten head all passed. The full-PR automated review on this exact head found no major issues.

## Documentation and rollback

The English and Chinese README and user guide explain the two startup stages, fail-closed inventory behavior, and operator diagnosis. The bilingual design documents define writer coordination, publication order, failure behavior, the unsupported direct-writer boundary, and invariants future changes must preserve:

- `src/blaze/docs/design/lifecycle-state-consistency.md`
- `src/blaze/docs/design/lifecycle-state-consistency_zh.md`

Reverting this single commit restores the previous best-effort scan. No data conversion is required.

## Still to do

1. Obtain maintainer approval before merge.