### PR TITLE
fix(blaze): reject linked storage artifacts

### DIFF
--- a/src/blaze/crates/blazed/src/file_provider.rs
+++ b/src/blaze/crates/blazed/src/file_provider.rs
@@ -86,7 +86,7 @@ async fn require_slot_path(
     path: &Path,
     required_type: RequiredPathType,
 ) -> Result<()> {
-    match tokio::fs::metadata(path).await {
+    match tokio::fs::symlink_metadata(path).await {
         Ok(metadata) if required_type.matches(&metadata) => Ok(()),
         Ok(_) => Err(BlazeError::StorageIncomplete {
             instance_id: instance_id.to_string(),
@@ -519,6 +519,85 @@ mod tests {
                 expected: "file",
             } if instance_id == "missing-artifact" && path == &slot.mem_diff_path
         ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconstruct_rejects_a_linked_slot_root() {
+        use std::os::unix::fs::symlink;
+
+        let storage = tempfile::TempDir::new().unwrap();
+        let target = tempfile::TempDir::new().unwrap();
+        for artifact in ["rootfs.ext4", "mem.bin", "mem.diff", "rootfs.diff"] {
+            tokio::fs::write(target.path().join(artifact), b"external")
+                .await
+                .unwrap();
+        }
+        symlink(target.path(), storage.path().join("linked-slot")).unwrap();
+        let provider = FileStorageProvider::new(storage.path().to_path_buf());
+
+        let error = provider
+            .reconstruct("linked-slot")
+            .await
+            .expect_err("linked slot root must be rejected");
+
+        assert!(matches!(
+            error,
+            BlazeError::StorageIncomplete {
+                ref instance_id,
+                ref path,
+                expected: "directory",
+            } if instance_id == "linked-slot" && path == &storage.path().join("linked-slot")
+        ));
+        assert!(
+            std::fs::symlink_metadata(storage.path().join("linked-slot"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(target.path().is_dir());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconstruct_rejects_a_linked_slot_artifact() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(temp.path().to_path_buf());
+        let slot = provider
+            .acquire(&AcquireOpts {
+                instance_id: "linked-artifact".into(),
+                rootfs_size: 64,
+                mem_size: 32,
+            })
+            .await
+            .unwrap();
+        tokio::fs::remove_file(&slot.mem_diff_path).await.unwrap();
+        let external = temp.path().join("external-memory-diff");
+        tokio::fs::write(&external, b"external").await.unwrap();
+        symlink(&external, &slot.mem_diff_path).unwrap();
+
+        let error = provider
+            .reconstruct("linked-artifact")
+            .await
+            .expect_err("linked artifact must be rejected");
+
+        assert!(matches!(
+            error,
+            BlazeError::StorageIncomplete {
+                ref instance_id,
+                ref path,
+                expected: "file",
+            } if instance_id == "linked-artifact" && path == &slot.mem_diff_path
+        ));
+        assert!(
+            std::fs::symlink_metadata(&slot.mem_diff_path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(external.is_file());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

File-provider reconstruction derives each sandbox slot from a validated ID, but
its metadata checks followed symbolic links. A linked slot root or required
artifact could therefore be mistaken for a complete object owned directly by
the provider.

Reconstruction must classify the filesystem object at the derived path without
following a link to another location.

## What changed

- The required-path check now uses link-aware metadata.
- `FileStorageProvider::reconstruct` requires the slot root to be a direct
  directory and each required runtime artifact to be a direct regular file.
- A linked root or artifact returns `StorageIncomplete`; the external target
  is left unchanged.
- Focused tests cover both a linked slot root and a linked required artifact.

The single commit `506731f7dbaf` is limited to the reconstruction boundary.
It keeps the classification change and its direct regressions together because
they define one file-provider rule: links already present when reconstruct
examines an owned slot are not accepted as provider-owned artifacts.

## Related issue

refs #1829

## User / Agent impact

Reconstructing a file-provider slot now fails when its root or a required
artifact is a symbolic link. Direct provider-owned files retain their existing
layout and behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change is limited to invalid linked reconstruction inputs. The on-disk file
layout, allocation capacity, and independent slot copies are unchanged.

Two stronger object-lifetime guarantees are intentionally not claimed here:

- [#2232](https://github.com/alibaba/anolisa/issues/2232) tracks descriptor-
  relative, no-follow operation for the production `flush_dirty` caller.
- [#2233](https://github.com/alibaba/anolisa/issues/2233) tracks binding the
  returned `StorageSlot` to the exact objects accepted during reconstruction.

Those changes require flush consumers or a `StorageSlot` /
`StorageProvider` contract change and remain separate bugfixes. This PR only
rejects links present at reconstruction classification time.

## Validation

The exact submitted commit
`506731f7dbaf007e15934c6cc6ae63251b0e685c` was verified on Linux x86_64
in a fresh source tree with an initially empty Cargo target directory:

```text
cargo fmt --all -- --check
cargo build --workspace --locked
cargo build --workspace --all-features --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
```

Results:

- Default features: 52 blaze-core tests and 101 blazed tests passed.
- All features: 52 blaze-core tests and 111 blazed tests passed.
- `reconstruct_rejects_a_linked_slot_root` and
  `reconstruct_rejects_a_linked_slot_artifact` passed.
- The commit message passed repository commitlint and contains only the
  required Weisson sign-off for this bugfix.

Hosted checks are reported by GitHub separately and are not included in these
Linux results.

## Documentation and rollback

No storage format or user documentation changed. Reverting the single commit
restores link-following reconstruction checks; no data migration is required.
