### PR TITLE
docs(website): lead hero subtitle with token savings

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -10,8 +10,8 @@ const content = {
   en: {
     badge: 'Agentic OS 1.0',
     lead: 'An operating system layer built for agents.',
-    capabilities: 'Sandbox isolation. Kernel observability. Token efficiency.',
-    deployment: 'Managed as one system and deployed through one entry point.',
+    hook: "Cut 30–70% of your agent's tool-output tokens with one command.",
+    systemScope: 'Just one thing the OS does for your agent — it also runs, recovers, and secures it.',
     statement:
       'The users of operating systems have changed. ANOLISA makes agents first-class participants at the system layer.',
     installLabel: 'One entry point. Enable what you need.',
@@ -34,8 +34,8 @@ const content = {
   zh: {
     badge: 'Agentic OS 1.0',
     lead: 'Agent 原生的操作系统层。',
-    capabilities: '沙箱隔离、内核可观测、Token 优化。',
-    deployment: '由一个系统统一管理，通过一个入口完成部署。',
+    hook: '一条命令，让 Agent 少烧 30–70% 的工具输出 token。',
+    systemScope: '这只是操作系统为 Agent 做的一件事——它还让 Agent 跑得起、退得回、守得住。',
     statement: '操作系统的使用者已经改变。ANOLISA 让 Agent 成为系统中的一等公民。',
     installLabel: '一个入口，按需启用',
     agentLabel: '让你的 Agent 接入',
@@ -306,7 +306,7 @@ export default function Home() {
   const heroGlyph = useBaseUrl('/img/brand/anolisa-glyph-signal.svg');
 
   return (
-    <Layout title={t.lead} description={`${t.capabilities} ${t.deployment}`}>
+    <Layout title={t.lead} description={`${t.hook} ${t.systemScope}`}>
       <Head>
         <meta property="og:type" content="website" />
       </Head>
@@ -324,8 +324,8 @@ export default function Home() {
               </div>
               <div className="heroPositioning">
                 <p>{t.lead}</p>
-                <p>{t.capabilities}</p>
-                <p>{t.deployment}</p>
+                <p>{t.hook}</p>
+                <p>{t.systemScope}</p>
               </div>
               <p className="heroStatement">{t.statement}</p>
 


### PR DESCRIPTION
## Summary
- Rewrite the hero subtitle (en + zh) in `website/src/pages/index.tsx`.
- Line 1 is now a sharp, immediately-usable wedge: 30–70% tool-output token savings with one command — the one thing a passerby (individual dev running a coding agent, mostly on Mac) can use on day one, cross-platform.
- Line 2 lifts it back to the OS layer and points to more it does for the agent (run, recover, secure — sandbox·cosh / ws-ckpt / sec-core), setting up the "first-class participants" statement right below.

## Why
The previous copy ("Sandbox isolation. Kernel observability. Token efficiency.") led with Linux-only, production-stack capabilities the target passerby cannot touch on day one, and buried the one immediately-usable hook. This reorders around the entry capability while keeping the OS-layer framing intact.

## Before / After (en)
- Before: `Sandbox isolation. Kernel observability. Token efficiency.` / `Managed as one system and deployed through one entry point.`
- After: `Cut 30–70% of your agent's tool-output tokens with one command.` / `Just one thing the OS does for your agent — it also runs, recovers, and secures it.`

## Test plan
- [ ] `cd website && npm run build` (or the site's build command) passes.
- [ ] Hero renders two subtitle lines under the H2 in both en and zh locales.
- [ ] Meta description (`${t.capabilities} ${t.deployment}`) reads correctly.