### PR TITLE
fix(cosh-ng): [shell] reject zero idle timeout

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/poll.rs
@@ -538,10 +538,25 @@ fn active_run_has_stalled_shell_evidence_delivery(active_run: &ActiveAgentRun) -
 }
 
 fn shell_evidence_idle_timeout() -> Duration {
-    Duration::from_secs(
+    shell_evidence_idle_timeout_from_config(
         std::env::var("COSH_SHELL_EVIDENCE_IDLE_TIMEOUT_SECS")
             .ok()
+            .as_deref(),
+    )
+}
+
+// Resolve the idle window from its configured value, falling back to the
+// default when it is missing, malformed, or zero. Zero has to be rejected
+// rather than honoured: `elapsed() >= Duration::ZERO` holds on the very first
+// poll of a run, so a zero window would report every active run as stalled and
+// restart the fallback continuation on every poll cycle. Parsing is split out
+// of the env read so the boundaries stay testable without mutating the
+// process-global environment.
+fn shell_evidence_idle_timeout_from_config(configured: Option<&str>) -> Duration {
+    Duration::from_secs(
+        configured
             .and_then(|value| value.parse::<u64>().ok())
+            .filter(|secs| *secs > 0)
             .unwrap_or(DEFAULT_SHELL_EVIDENCE_IDLE_TIMEOUT_SECS),
     )
 }

--- a/src/cosh-ng/crates/cosh-shell/src/agent/poll/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/poll/tests.rs
@@ -253,6 +253,45 @@ fn stalled_shell_evidence_delivery_uses_last_activity_idle_time() {
 }
 
 #[test]
+fn shell_evidence_idle_timeout_rejects_zero_and_keeps_valid_values() {
+    assert_eq!(
+        shell_evidence_idle_timeout_from_config(Some("30")),
+        Duration::from_secs(30)
+    );
+    assert_eq!(
+        shell_evidence_idle_timeout_from_config(Some("1")),
+        Duration::from_secs(1)
+    );
+
+    let default = Duration::from_secs(DEFAULT_SHELL_EVIDENCE_IDLE_TIMEOUT_SECS);
+    // #2094: a configured `0` must fall back like a malformed value instead of
+    // becoming a zero idle window.
+    assert_eq!(shell_evidence_idle_timeout_from_config(Some("0")), default);
+    assert_eq!(shell_evidence_idle_timeout_from_config(Some("00")), default);
+    for malformed in ["", "-1", "abc", "1.5", "5s", " 5"] {
+        assert_eq!(
+            shell_evidence_idle_timeout_from_config(Some(malformed)),
+            default,
+            "malformed value {malformed:?} must fall back to the default"
+        );
+    }
+    assert_eq!(shell_evidence_idle_timeout_from_config(None), default);
+}
+
+#[test]
+fn resolved_shell_evidence_idle_timeout_is_never_zero() {
+    // `active_run_has_stalled_shell_evidence_delivery` compares against this
+    // window with `>=`, so a zero window would report every poll of every run
+    // as stalled and restart the fallback continuation in a loop.
+    for configured in [Some("0"), Some(""), Some("abc"), Some("-1"), None] {
+        assert!(
+            !shell_evidence_idle_timeout_from_config(configured).is_zero(),
+            "configuration {configured:?} must not resolve to a zero idle window"
+        );
+    }
+}
+
+#[test]
 fn stalled_shell_fallback_waits_for_pending_interaction_to_close() {
     assert!(!should_start_stalled_provider_shell_fallback(
         StalledProviderShellFallbackInputs {


### PR DESCRIPTION
## Why

`COSH_SHELL_EVIDENCE_IDLE_TIMEOUT_SECS` was parsed as a bare `u64`, so a configured `0` (a typo, or an `EnvironmentFile` entry) became a zero idle window. `active_run_has_stalled_shell_evidence_delivery` compares the run's idle time with `>=`, and that always holds against `Duration::ZERO`, so every poll cycle of every active run was classified as stalled and restarted the shell-evidence fallback continuation. The result is a fallback storm: the poll loop spins, CPU saturates, and the log volume explodes.

## What changed

`shell_evidence_idle_timeout` now rejects a configured `0` and falls back to the existing non-zero default (15s), the same path a malformed value already takes. Clamping to one second was considered and rejected: it would silently invent a window the operator never asked for and still fire fallbacks far more aggressively than intended. Valid positive values, malformed values, and the missing-variable case behave exactly as before.

The env read is split from the decision into a pure `shell_evidence_idle_timeout_from_config(Option<&str>)` helper, so the zero / positive / malformed / missing boundaries are unit-testable without mutating the process-global environment.

## Related issue

closes #2094

## User / Agent impact

Setting `COSH_SHELL_EVIDENCE_IDLE_TIMEOUT_SECS=0` no longer disables the idle window; it is ignored in favour of the 15s default. No other configured value changes behaviour.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The only behaviour change is for the previously pathological `0` setting, which had no legitimate use (it made every run look permanently stalled). The value was undocumented, so no documentation contract is broken.

## Validation

Run from `src/cosh-ng`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p cosh-shell --bin cosh-shell agent::poll::` — 15 passed (includes the two new boundary tests)
- `cargo test -p cosh-shell --lib` — 1211 passed
- `cargo test -p cosh-shell --test logic` — 9 passed
- `cargo test -p cosh-shell --test raw_cli provider_handoff` — 30 passed; `... raw_cli_streamed_tool_fallback` — 2 passed (both suites configure this env var)
- `crates/cosh-shell/scripts/check-layout.sh` — layout audit passed

Negative control: with the new lower-bound guard removed, both added tests fail (`0` resolves to a `0ns` window), confirming they cover the reported defect.

Edge cases asserted: `0`, `00`, `1`, `30`, `""`, `-1`, `abc`, `1.5`, `5s`, `" 5"`, and an unset variable.

One pre-existing failure is unrelated to this change: `activity::runtime_tests::activity_tool_output_details_show_internal_output_ref_in_debug` fails identically on the unmodified base commit when the temporary directory path is long enough to wrap inside the rendered card.

## Documentation and rollback

No documentation changes — the variable is not documented, and the fix only rejects a value that could never work. Rollback is a single-commit revert; there is no state or migration involved.