### PR TITLE
fix(cosh-ng): [core] make truncation UTF-8-safe

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/compression.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compression.rs
@@ -1,6 +1,8 @@
 use crate::provider::Message;
+use crate::truncator::truncate_to_byte_limit;
 
-const CHARS_PER_TOKEN: usize = 4;
+const BYTES_PER_TOKEN: usize = 4;
+const SUMMARY_MESSAGE_BYTES: usize = 200;
 
 pub struct ChatCompression {
     context_limit: u64,
@@ -16,11 +18,11 @@ impl ChatCompression {
     }
 
     pub fn estimate_tokens(messages: &[Message]) -> u64 {
-        let total_chars: usize = messages
+        let total_bytes: usize = messages
             .iter()
             .map(|m| m.content.as_text().len() + m.role.len() + 4)
             .sum();
-        (total_chars / CHARS_PER_TOKEN) as u64
+        (total_bytes / BYTES_PER_TOKEN) as u64
     }
 
     pub fn needs_compression(&self, messages: &[Message]) -> bool {
@@ -59,8 +61,11 @@ impl ChatCompression {
             if text.is_empty() {
                 continue;
             }
-            let truncated = if text.len() > 200 {
-                format!("{}...", &text[..200])
+            let truncated = if text.len() > SUMMARY_MESSAGE_BYTES {
+                format!(
+                    "{}...",
+                    truncate_to_byte_limit(&text, SUMMARY_MESSAGE_BYTES)
+                )
             } else {
                 text.to_string()
             };
@@ -133,5 +138,33 @@ mod tests {
         let summary = ChatCompression::build_summary(&messages);
         assert!(summary.contains("[user]"));
         assert!(summary.contains("[assistant]"));
+    }
+
+    fn assert_summary_truncation(input: &str, expected: &str) {
+        let summary = ChatCompression::build_summary(&[Message::user(input)]);
+        assert_eq!(summary, format!("[user] {expected}..."));
+    }
+
+    #[test]
+    fn summary_preserves_ascii_truncation_behavior() {
+        assert_summary_truncation(&"a".repeat(201), &"a".repeat(200));
+    }
+
+    #[test]
+    fn summary_truncates_multibyte_text_at_exact_utf8_boundaries() {
+        assert_summary_truncation(
+            &format!("{}中z", "a".repeat(197)),
+            &format!("{}中", "a".repeat(197)),
+        );
+        assert_summary_truncation(
+            &format!("{}😀z", "a".repeat(196)),
+            &format!("{}😀", "a".repeat(196)),
+        );
+    }
+
+    #[test]
+    fn summary_rounds_multibyte_limits_down_to_utf8_boundaries() {
+        assert_summary_truncation(&format!("{}中", "a".repeat(199)), &"a".repeat(199));
+        assert_summary_truncation(&format!("{}😀", "a".repeat(198)), &"a".repeat(198));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/truncator.rs
+++ b/src/cosh-ng/crates/cosh-core/src/truncator.rs
@@ -1,23 +1,31 @@
 pub struct OutputTruncator {
-    pub max_chars: usize,
+    pub max_bytes: usize,
     pub max_lines: usize,
 }
 
 impl Default for OutputTruncator {
     fn default() -> Self {
         Self {
-            max_chars: 25000,
+            max_bytes: 25000,
             max_lines: 1000,
         }
     }
 }
 
+pub(crate) fn truncate_to_byte_limit(value: &str, max_bytes: usize) -> &str {
+    let mut boundary = max_bytes.min(value.len());
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    &value[..boundary]
+}
+
 impl OutputTruncator {
     pub fn truncate(&self, output: &str) -> (String, bool) {
         let line_count = output.lines().count();
-        let char_count = output.len();
+        let byte_count = output.len();
 
-        if char_count <= self.max_chars && line_count <= self.max_lines {
+        if byte_count <= self.max_bytes && line_count <= self.max_lines {
             return (output.to_string(), false);
         }
 
@@ -26,11 +34,11 @@ impl OutputTruncator {
             let kept = &lines[..self.max_lines];
             kept.join("\n")
         } else {
-            output[..self.max_chars].to_string()
+            truncate_to_byte_limit(output, self.max_bytes).to_string()
         };
 
         let result = format!(
-            "{truncated}\n\n[output truncated: {char_count} chars / {line_count} lines → {} chars]",
+            "{truncated}\n\n[output truncated: {byte_count} bytes / {line_count} lines → {} bytes]",
             truncated.len()
         );
         (result, true)
@@ -52,26 +60,61 @@ mod tests {
     #[test]
     fn truncates_by_line_count() {
         let t = OutputTruncator {
-            max_chars: 100_000,
+            max_bytes: 100_000,
             max_lines: 3,
         };
         let input = "line1\nline2\nline3\nline4\nline5\n";
         let (result, truncated) = t.truncate(input);
         assert!(truncated);
-        assert!(result.starts_with("line1\nline2\nline3"));
-        assert!(result.contains("[output truncated:"));
+        assert_eq!(
+            result,
+            "line1\nline2\nline3\n\n[output truncated: 30 bytes / 5 lines → 17 bytes]"
+        );
     }
 
     #[test]
-    fn truncates_by_char_count() {
+    fn truncates_by_byte_count() {
         let t = OutputTruncator {
-            max_chars: 10,
+            max_bytes: 10,
             max_lines: 100_000,
         };
         let input = "a]".repeat(20);
         let (result, truncated) = t.truncate(&input);
         assert!(truncated);
-        assert!(result.contains("[output truncated:"));
+        assert_eq!(
+            result,
+            "a]a]a]a]a]\n\n[output truncated: 40 bytes / 1 lines → 10 bytes]"
+        );
+    }
+
+    fn assert_truncation(input: &str, max_bytes: usize, expected: &str) {
+        let t = OutputTruncator {
+            max_bytes,
+            max_lines: 100_000,
+        };
+        let (result, truncated) = t.truncate(input);
+
+        assert!(truncated);
+        assert_eq!(
+            result,
+            format!(
+                "{expected}\n\n[output truncated: {} bytes / 1 lines → {} bytes]",
+                input.len(),
+                expected.len()
+            )
+        );
+    }
+
+    #[test]
+    fn truncates_multibyte_output_at_exact_utf8_boundaries() {
+        assert_truncation("中文a", 6, "中文");
+        assert_truncation("😀a", 4, "😀");
+    }
+
+    #[test]
+    fn rounds_multibyte_output_limits_down_to_utf8_boundaries() {
+        assert_truncation("中文", 5, "中");
+        assert_truncation("a😀", 3, "a");
     }
 
     #[test]


### PR DESCRIPTION
## Why

`OutputTruncator` and `ChatCompression::build_summary` treated Rust byte lengths as
characters and sliced at unchecked byte offsets. When a 25,000-byte or 200-byte cap landed
inside Chinese text or emoji, `cosh-core` panicked.

## What changed

- Added a small shared byte-budget helper that rounds limits down to a valid UTF-8 boundary.
- Renamed byte-budget fields and counters and report truncation lengths in bytes.
- Added exact-boundary and split-boundary regression coverage for Chinese text and emoji.
- Tightened compatibility coverage for ASCII truncation, line limits, ellipses, and recent messages.

## Related issue

Closes #2096
Closes #2097

## User / Agent impact

Long multibyte tool output and compression summaries are safely truncated instead of crashing.
ASCII limits, line-limit behavior, ellipses, truncation notices, and recent-message retention are
preserved; notice length units now accurately say bytes.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Only the truncation notice unit label changes from characters to bytes; size caps and
retained-content behavior remain byte-based and unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package cosh-core --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR=/tmp cargo test --workspace --locked --quiet -- --test-threads=1`
- `cargo build --workspace --release --locked`

## Documentation and rollback

No documentation changes are required. Revert the commit to restore the previous behavior.