### PR TITLE
fix(cosh-ng): [core] make file writes atomic

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/tool/atomic_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/atomic_file.rs
@@ -1,0 +1,590 @@
+//! Durable atomic replacement for general user files written by tools.
+
+use std::fmt;
+use std::fs::{self, File, OpenOptions, Permissions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+const TEMP_NAME_ATTEMPTS: usize = 16;
+const SYMLINK_LIMIT: usize = 40;
+
+#[derive(Debug)]
+pub(super) enum ReplaceError {
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    Conflict {
+        path: PathBuf,
+    },
+    Committed {
+        path: PathBuf,
+        source: io::Error,
+    },
+}
+
+impl fmt::Display for ReplaceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io {
+                operation,
+                path,
+                source,
+            } => write!(
+                formatter,
+                "failed to {operation} {}: {source}",
+                path.display()
+            ),
+            Self::Conflict { path } => write!(
+                formatter,
+                "Edit conflict: {} changed after it was read; no changes were written",
+                path.display()
+            ),
+            Self::Committed { path, source } => write!(
+                formatter,
+                "replacement of {} was committed, but syncing its parent directory failed: \
+                 {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ReplaceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } | Self::Committed { source, .. } => Some(source),
+            Self::Conflict { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct FileSnapshot {
+    bytes: Vec<u8>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl FileSnapshot {
+    fn read(path: &Path) -> io::Result<Self> {
+        let mut file = File::open(path)?;
+        let metadata = file.metadata()?;
+        let mut bytes = Vec::with_capacity(metadata.len().try_into().unwrap_or(0));
+        file.read_to_end(&mut bytes)?;
+
+        Ok(Self {
+            bytes,
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+        })
+    }
+
+    pub(super) fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    fn still_matches(&self, current: &Self) -> bool {
+        self.bytes == current.bytes && {
+            #[cfg(unix)]
+            {
+                self.device == current.device && self.inode == current.inode
+            }
+            #[cfg(not(unix))]
+            {
+                true
+            }
+        }
+    }
+}
+
+pub(super) async fn read_snapshot(path: PathBuf) -> Result<FileSnapshot, ReplaceError> {
+    let error_path = path.clone();
+    tokio::task::spawn_blocking(move || FileSnapshot::read(&path))
+        .await
+        .map_err(|error| ReplaceError::Io {
+            operation: "join snapshot read for",
+            path: error_path.clone(),
+            source: io::Error::other(error),
+        })?
+        .map_err(|source| ReplaceError::Io {
+            operation: "read",
+            path: error_path,
+            source,
+        })
+}
+
+pub(super) async fn replace(
+    path: PathBuf,
+    bytes: Vec<u8>,
+    expected: Option<FileSnapshot>,
+) -> Result<(), ReplaceError> {
+    let error_path = path.clone();
+    tokio::task::spawn_blocking(move || {
+        replace_with_hooks(
+            &path,
+            &bytes,
+            expected.as_ref(),
+            |_, _| Ok(()),
+            |_, _| Ok(()),
+            |_| Ok(()),
+        )
+    })
+    .await
+    .map_err(|error| ReplaceError::Io {
+        operation: "join atomic replacement for",
+        path: error_path,
+        source: io::Error::other(error),
+    })?
+}
+
+fn replace_with_hooks<BeforeWrite, BeforeCommit, BeforeDirectorySync>(
+    requested_path: &Path,
+    bytes: &[u8],
+    expected: Option<&FileSnapshot>,
+    before_write: BeforeWrite,
+    before_commit: BeforeCommit,
+    before_directory_sync: BeforeDirectorySync,
+) -> Result<(), ReplaceError>
+where
+    BeforeWrite: FnOnce(&Path, &Path) -> io::Result<()>,
+    BeforeCommit: FnOnce(&Path, &Path) -> io::Result<()>,
+    BeforeDirectorySync: FnOnce(&Path) -> io::Result<()>,
+{
+    let target = resolve_target(requested_path).map_err(|source| ReplaceError::Io {
+        operation: "resolve",
+        path: requested_path.to_path_buf(),
+        source,
+    })?;
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    let permissions = target_permissions(&target)?;
+    let (mut temporary, mut guard) = create_temporary(parent)?;
+
+    if let Some(permissions) = permissions {
+        temporary
+            .set_permissions(permissions)
+            .map_err(|source| io_error("preserve permissions on", guard.path(), source))?;
+    }
+    before_write(&target, guard.path())
+        .map_err(|source| io_error("prepare temporary file for", &target, source))?;
+    temporary
+        .write_all(bytes)
+        .map_err(|source| io_error("write temporary file", guard.path(), source))?;
+    temporary
+        .flush()
+        .map_err(|source| io_error("flush temporary file", guard.path(), source))?;
+    temporary
+        .sync_all()
+        .map_err(|source| io_error("sync temporary file", guard.path(), source))?;
+    drop(temporary);
+
+    // The directory inode stays stable across rename, so every helper user
+    // serializes the snapshot check and commit on the same advisory lock.
+    let directory =
+        File::open(parent).map_err(|source| io_error("open parent directory", parent, source))?;
+    directory
+        .lock_exclusive()
+        .map_err(|source| io_error("lock parent directory", parent, source))?;
+    before_commit(&target, guard.path())
+        .map_err(|source| io_error("prepare replacement of", &target, source))?;
+    if let Some(expected) = expected {
+        let current = match FileSnapshot::read(&target) {
+            Ok(current) => current,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => {
+                return Err(ReplaceError::Conflict { path: target });
+            }
+            Err(source) => return Err(io_error("verify", &target, source)),
+        };
+        if !expected.still_matches(&current) {
+            return Err(ReplaceError::Conflict { path: target });
+        }
+    }
+
+    fs::rename(guard.path(), &target)
+        .map_err(|source| io_error("atomically replace", &target, source))?;
+    guard.disarm();
+
+    before_directory_sync(parent).map_err(|source| ReplaceError::Committed {
+        path: target.clone(),
+        source,
+    })?;
+    directory
+        .sync_all()
+        .map_err(|source| ReplaceError::Committed {
+            path: target,
+            source,
+        })?;
+    Ok(())
+}
+
+fn resolve_target(path: &Path) -> io::Result<PathBuf> {
+    let mut target = path.to_path_buf();
+    let mut followed = 0;
+    loop {
+        match fs::symlink_metadata(&target) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                if followed == SYMLINK_LIMIT {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "too many symbolic links while resolving target",
+                    ));
+                }
+                let referent = fs::read_link(&target)?;
+                target = if referent.is_absolute() {
+                    referent
+                } else {
+                    target
+                        .parent()
+                        .unwrap_or_else(|| Path::new("."))
+                        .join(referent)
+                };
+                followed += 1;
+            }
+            Ok(_) => return Ok(target),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(target),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn target_permissions(path: &Path) -> Result<Option<Permissions>, ReplaceError> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(Some(metadata.permissions())),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(io_error("inspect permissions for", path, source)),
+    }
+}
+
+fn create_temporary(parent: &Path) -> Result<(File, TemporaryGuard), ReplaceError> {
+    for _ in 0..TEMP_NAME_ATTEMPTS {
+        let path = parent.join(format!(".cosh-tmp-{}", uuid::Uuid::new_v4()));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o666);
+
+        match options.open(&path) {
+            Ok(file) => return Ok((file, TemporaryGuard::new(path))),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(source) => return Err(io_error("create temporary file", &path, source)),
+        }
+    }
+
+    Err(io_error(
+        "create unique temporary file in",
+        parent,
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "temporary name collision limit reached",
+        ),
+    ))
+}
+
+fn io_error(operation: &'static str, path: &Path, source: io::Error) -> ReplaceError {
+    ReplaceError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+struct TemporaryGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TemporaryGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TemporaryGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) fn replace_with_before_commit_for_test<BeforeCommit>(
+    path: &Path,
+    bytes: &[u8],
+    expected: &FileSnapshot,
+    before_commit: BeforeCommit,
+) -> Result<(), ReplaceError>
+where
+    BeforeCommit: FnOnce(&Path, &Path) -> io::Result<()>,
+{
+    replace_with_hooks(
+        path,
+        bytes,
+        Some(expected),
+        |_, _| Ok(()),
+        before_commit,
+        |_| Ok(()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, SeekFrom};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    use super::*;
+
+    fn temporary_entries(parent: &Path) -> Vec<PathBuf> {
+        fs::read_dir(parent)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(".cosh-tmp-"))
+            })
+            .collect()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn replacement_uses_rename_and_preserves_permissions() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("source.rs");
+        fs::write(&target, b"old content").unwrap();
+        fs::set_permissions(&target, Permissions::from_mode(0o640)).unwrap();
+        let original_inode = fs::metadata(&target).unwrap().ino();
+        let mut original_handle = File::open(&target).unwrap();
+
+        replace_with_hooks(
+            &target,
+            b"new content",
+            None,
+            |_, _| Ok(()),
+            |_, _| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"new content");
+        assert_ne!(fs::metadata(&target).unwrap().ino(), original_inode);
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+        original_handle.seek(SeekFrom::Start(0)).unwrap();
+        let mut original_content = String::new();
+        original_handle
+            .read_to_string(&mut original_content)
+            .unwrap();
+        assert_eq!(original_content, "old content");
+        assert!(temporary_entries(directory.path()).is_empty());
+    }
+
+    #[test]
+    fn pre_commit_failure_keeps_target_and_cleans_unique_same_directory_temp() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("config.toml");
+        fs::write(&target, b"stable").unwrap();
+        let mut temporary_path = None;
+
+        let error = replace_with_hooks(
+            &target,
+            b"candidate",
+            None,
+            |_, _| Ok(()),
+            |_, temporary| {
+                temporary_path = Some(temporary.to_path_buf());
+                Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "injected interruption",
+                ))
+            },
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        let temporary_path = temporary_path.unwrap();
+        assert_eq!(temporary_path.parent(), Some(directory.path()));
+        assert!(temporary_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with(".cosh-tmp-"));
+        assert!(error.to_string().contains("injected interruption"));
+        assert_eq!(fs::read(&target).unwrap(), b"stable");
+        assert!(!temporary_path.exists());
+    }
+
+    #[test]
+    fn rename_failure_keeps_target_and_cleans_temp() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("existing-directory");
+        fs::create_dir(&target).unwrap();
+
+        let error = replace_with_hooks(
+            &target,
+            b"candidate",
+            None,
+            |_, _| Ok(()),
+            |_, _| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("atomically replace"));
+        assert!(target.is_dir());
+        assert!(temporary_entries(directory.path()).is_empty());
+    }
+
+    #[test]
+    fn concurrent_content_change_is_rejected_without_overwrite() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("source.rs");
+        fs::write(&target, b"original").unwrap();
+        let snapshot = FileSnapshot::read(&target).unwrap();
+
+        let error = replace_with_hooks(
+            &target,
+            b"edited",
+            Some(&snapshot),
+            |_, _| Ok(()),
+            |target, _| fs::write(target, b"intervening change"),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ReplaceError::Conflict { .. }));
+        assert_eq!(fs::read(&target).unwrap(), b"intervening change");
+        assert!(temporary_entries(directory.path()).is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn same_content_replacement_is_detected_by_file_identity() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("source.rs");
+        fs::write(&target, b"original").unwrap();
+        let snapshot = FileSnapshot::read(&target).unwrap();
+
+        let error = replace_with_hooks(
+            &target,
+            b"edited",
+            Some(&snapshot),
+            |_, _| Ok(()),
+            |target, _| {
+                let replacement = target.with_extension("replacement");
+                fs::write(&replacement, b"original")?;
+                fs::rename(replacement, target)
+            },
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ReplaceError::Conflict { .. }));
+        assert_eq!(fs::read(&target).unwrap(), b"original");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn existing_permissions_are_applied_before_any_content_is_written() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("credentials.txt");
+        fs::write(&target, b"old secret").unwrap();
+        fs::set_permissions(&target, Permissions::from_mode(0o600)).unwrap();
+        let mut observed_mode = None;
+        let mut observed_length = None;
+
+        let error = replace_with_hooks(
+            &target,
+            b"new secret",
+            None,
+            |_, temporary| {
+                let metadata = fs::metadata(temporary)?;
+                observed_mode = Some(metadata.permissions().mode() & 0o777);
+                observed_length = Some(metadata.len());
+                Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "stop before write",
+                ))
+            },
+            |_, _| Ok(()),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        assert_eq!(observed_mode, Some(0o600));
+        assert_eq!(observed_length, Some(0));
+        assert!(error.to_string().contains("stop before write"));
+        assert_eq!(fs::read(&target).unwrap(), b"old secret");
+        assert!(temporary_entries(directory.path()).is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_snapshot_commits_allow_only_one_writer() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("source.rs");
+        fs::write(&target, b"original").unwrap();
+        let first_snapshot = read_snapshot(target.clone()).await.unwrap();
+        let second_snapshot = read_snapshot(target.clone()).await.unwrap();
+
+        let (first, second) = tokio::join!(
+            replace(target.clone(), b"first".to_vec(), Some(first_snapshot)),
+            replace(target.clone(), b"second".to_vec(), Some(second_snapshot)),
+        );
+
+        assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+        assert_eq!(
+            usize::from(matches!(first, Err(ReplaceError::Conflict { .. })))
+                + usize::from(matches!(second, Err(ReplaceError::Conflict { .. }))),
+            1
+        );
+        assert!(matches!(
+            fs::read(&target).unwrap().as_slice(),
+            b"first" | b"second"
+        ));
+    }
+
+    #[test]
+    fn parent_sync_failure_reports_that_replacement_was_committed() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("source.rs");
+        fs::write(&target, b"old").unwrap();
+
+        let error = replace_with_hooks(
+            &target,
+            b"new",
+            None,
+            |_, _| Ok(()),
+            |_, _| Ok(()),
+            |_| Err(io::Error::other("injected sync failure")),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ReplaceError::Committed { .. }));
+        assert!(error.to_string().contains("was committed"));
+        assert!(error.to_string().contains("injected sync failure"));
+        assert_eq!(fs::read(&target).unwrap(), b"new");
+        assert!(temporary_entries(directory.path()).is_empty());
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
+use super::atomic_file::{self, ReplaceError};
 use super::{Tool, ToolContext, ToolKind, ToolResult};
 
 pub struct EditTool;
@@ -45,6 +46,22 @@ impl Tool for EditTool {
     }
 
     async fn invoke(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
+        self.invoke_with_snapshot_hook(params, ctx, || async {})
+            .await
+    }
+}
+
+impl EditTool {
+    async fn invoke_with_snapshot_hook<AfterSnapshot, AfterSnapshotFuture>(
+        &self,
+        params: Value,
+        ctx: &ToolContext,
+        after_snapshot: AfterSnapshot,
+    ) -> Result<ToolResult, String>
+    where
+        AfterSnapshot: FnOnce() -> AfterSnapshotFuture,
+        AfterSnapshotFuture: std::future::Future<Output = ()>,
+    {
         let path_str = params
             .get("path")
             .and_then(|v| v.as_str())
@@ -71,9 +88,12 @@ impl Tool for EditTool {
             )));
         }
 
-        let content = tokio::fs::read_to_string(&path)
+        let snapshot = atomic_file::read_snapshot(path.clone())
             .await
             .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+        let content = std::str::from_utf8(snapshot.bytes())
+            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+        after_snapshot().await;
 
         let count = content.matches(old_string).count();
         if count == 0 {
@@ -95,9 +115,14 @@ impl Tool for EditTool {
             content.replacen(old_string, new_string, 1)
         };
 
-        tokio::fs::write(&path, &new_content)
-            .await
-            .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+        if let Err(error) =
+            atomic_file::replace(path.clone(), new_content.into_bytes(), Some(snapshot)).await
+        {
+            if matches!(error, ReplaceError::Conflict { .. }) {
+                return Ok(ToolResult::error(error.to_string()));
+            }
+            return Err(format!("Failed to write {}: {error}", path.display()));
+        }
 
         Ok(ToolResult::success(format!(
             "Replaced {count} occurrence(s) in {}",
@@ -113,8 +138,11 @@ use super::resolve_path;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::path::PathBuf;
+    use std::sync::Arc;
     use tempfile::NamedTempFile;
+    use tokio::sync::Barrier;
 
     fn test_ctx() -> ToolContext {
         ToolContext {
@@ -211,5 +239,81 @@ mod tests {
 
         let content = std::fs::read_to_string(tmp.path()).unwrap();
         assert_eq!(content, "ccc bbb ccc");
+    }
+
+    #[tokio::test]
+    async fn edit_commit_rejects_an_intervening_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.rs");
+        fs::write(&path, "hello world").unwrap();
+        let snapshot = atomic_file::read_snapshot(path.clone()).await.unwrap();
+
+        let error = atomic_file::replace_with_before_commit_for_test(
+            &path,
+            b"goodbye world",
+            &snapshot,
+            |target, _| {
+                let replacement = target.with_extension("replacement");
+                fs::write(&replacement, "intervening content")?;
+                fs::rename(replacement, target)
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ReplaceError::Conflict { .. }));
+        assert_eq!(fs::read_to_string(path).unwrap(), "intervening content");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_edit_invocations_allow_one_commit_and_one_conflict() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.rs");
+        fs::write(&path, "hello world").unwrap();
+        let tool = EditTool;
+        let context = test_ctx();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let first_barrier = Arc::clone(&barrier);
+        let second_barrier = Arc::clone(&barrier);
+        let (first, second) = tokio::join!(
+            tool.invoke_with_snapshot_hook(
+                serde_json::json!({
+                    "path": path,
+                    "old_string": "hello",
+                    "new_string": "first"
+                }),
+                &context,
+                move || async move {
+                    first_barrier.wait().await;
+                },
+            ),
+            tool.invoke_with_snapshot_hook(
+                serde_json::json!({
+                    "path": path,
+                    "old_string": "hello",
+                    "new_string": "second"
+                }),
+                &context,
+                move || async move {
+                    second_barrier.wait().await;
+                },
+            ),
+        );
+
+        let first = first.unwrap();
+        let second = second.unwrap();
+        assert_eq!(
+            usize::from(!first.is_error) + usize::from(!second.is_error),
+            1
+        );
+        assert_eq!(
+            usize::from(first.output.starts_with("Edit conflict:"))
+                + usize::from(second.output.starts_with("Edit conflict:")),
+            1
+        );
+        assert!(matches!(
+            fs::read_to_string(path).unwrap().as_str(),
+            "first world" | "second world"
+        ));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod ask_user_question;
+mod atomic_file;
 pub mod edit;
 mod file_patterns;
 mod glob;

--- a/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
@@ -65,7 +65,7 @@ impl Tool for WriteFileTool {
             }
         }
 
-        tokio::fs::write(&path, content)
+        super::atomic_file::replace(path.clone(), content.as_bytes().to_vec(), None)
             .await
             .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
 
@@ -109,6 +109,11 @@ fn placeholder_markers(content: &str) -> Vec<&'static str> {
 mod tests {
     use std::path::Path;
 
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+    #[cfg(unix)]
+    use std::path::PathBuf;
+
     use super::*;
 
     fn test_ctx_in(dir: &Path) -> ToolContext {
@@ -117,6 +122,21 @@ mod tests {
             session_id: "test".to_string(),
             project_root: dir.to_path_buf(),
         }
+    }
+
+    #[cfg(unix)]
+    fn create_symlink_chain(dir: &Path, length: usize) -> (PathBuf, PathBuf) {
+        let target = dir.join("target.txt");
+        for index in (0..length).rev() {
+            let link = dir.join(format!("link-{index}.txt"));
+            let referent = if index + 1 == length {
+                PathBuf::from("target.txt")
+            } else {
+                PathBuf::from(format!("link-{}.txt", index + 1))
+            };
+            symlink(referent, link).unwrap();
+        }
+        (dir.join("link-0.txt"), target)
     }
 
     #[tokio::test]
@@ -170,6 +190,88 @@ mod tests {
             .unwrap();
         assert!(!result.is_error);
         assert!(dir.path().join("relative.txt").exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_follows_relative_dangling_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_dir = dir.path().join("target");
+        std::fs::create_dir(&target_dir).unwrap();
+        let link = dir.path().join("relative-link.txt");
+        let target = target_dir.join("created.txt");
+        symlink("target/created.txt", &link).unwrap();
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": link, "content": "relative target"}),
+                &test_ctx_in(dir.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "relative target");
+        assert!(link.is_symlink());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_follows_absolute_dangling_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("absolute-link.txt");
+        let target = dir.path().join("created.txt");
+        symlink(&target, &link).unwrap();
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": link, "content": "absolute target"}),
+                &test_ctx_in(dir.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "absolute target");
+        assert!(link.is_symlink());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_follows_symlink_chain_at_system_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let (link, target) = create_symlink_chain(dir.path(), 40);
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": link, "content": "forty links"}),
+                &test_ctx_in(dir.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "forty links");
+        assert!(link.is_symlink());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_rejects_symlink_chain_over_system_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let (link, target) = create_symlink_chain(dir.path(), 41);
+
+        let error = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": link, "content": "forty-one links"}),
+                &test_ctx_in(dir.path()),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.contains("too many symbolic links"));
+        assert!(!target.exists());
+        assert!(link.is_symlink());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

The `write_file` and `edit` tools wrote directly to their destination, so an interruption could
leave a truncated or partially written file. Edit also needed to reject stale snapshots without
allowing two cooperating writers to pass validation and commit concurrently.

## What changed

- Replace user files through unique same-directory temporary files, flush and sync their content,
  atomically rename them, and sync the parent directory.
- Apply existing file permissions before writing temporary content and clean up temporary files on
  every pre-commit failure path.
- Resolve existing and dangling symlinks without replacing the link, accept valid chains through
  the 40-link system limit, and reject longer chains.
- Serialize snapshot validation and rename on a stable parent-directory advisory lock, and report
  an edit conflict when the file identity or content changed after the snapshot was read.
- Add interruption, cleanup, permission, symlink, inode, and concurrent production-tool tests.

## Related issue

Fixes #2098

## User / Agent impact

File writes no longer expose partial destination content. Existing modes and symlinks are retained,
and competing edits return an explicit conflict instead of silently overwriting one another.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The replacement path preserves existing permissions before temporary content is written. The
directory lock is advisory: it serializes users of this helper, while the identity and content
snapshot detects external changes observed before the final commit.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --package cosh-core --locked` (879 passed)
- `cargo build --workspace --release --locked`
- The known unrelated `cosh-shell` baseline still fails when run exactly:
  `activity_tool_output_details_show_internal_output_ref_in_debug` (0 passed, 1 failed,
  2277 filtered out); the debug output path wraps before `.txt`.

## Documentation and rollback

No documentation changes are needed. Revert commit `6a4d674e` to restore the previous direct-write
behavior.