### PR TITLE
fix(ci): restore component auto-label and owner mapping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,8 +32,8 @@
 /src/ws-ckpt/                           @Ziqi002                    # auto-label: component:ckpt
 /src/blaze/                             @casparant                  # auto-label: component:blaze
 /src/ktuner/                            @jfeng18                    # auto-label: component:ktuner
-/src/tokenless/                         @Forrest-ly @shiloong @ikunkun-sys      # auto-label: component:tokenless
-/src/agent-memory/                      @shiloong @ikunkun-sys      # auto-label: component:memory
+/src/tokenless/                         @Forrest-ly @ikunkun-sys    # auto-label: component:tokenless
+/src/agent-memory/                      @ikunkun-sys                # auto-label: component:memory
 /src/anolisa/                           @kongche-jbw @ikunkun-sys   # auto-label: component:anolisa
 /src/cosh-ng/                           @KaiLongZhou                # auto-label: component:cosh-ng
 /src/cosh-ng/crates/cosh-shell/         @SunnyQjm                   # auto-label: component:cosh-ng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,8 @@
 /src/agent-sec-core/*.spec.in           @yangdao479                 # auto-label: component:sec-core
 /src/os-skills/                         @Ziqi002                    # auto-label: component:skill
 /src/ws-ckpt/                           @Ziqi002                    # auto-label: component:ckpt
-/src/osbase/                            @casparant                  # auto-label: component:osbase
+/src/blaze/                             @casparant                  # auto-label: component:blaze
+/src/ktuner/                            @jfeng18                    # auto-label: component:ktuner
 /src/tokenless/                         @Forrest-ly @shiloong @ikunkun-sys      # auto-label: component:tokenless
 /src/agent-memory/                      @shiloong @ikunkun-sys      # auto-label: component:memory
 /src/anolisa/                           @kongche-jbw @ikunkun-sys   # auto-label: component:anolisa

--- a/.github/maintainers.json
+++ b/.github/maintainers.json
@@ -55,9 +55,6 @@
                     "github": "Forrest-ly"
                 },
                 {
-                    "github": "shiloong"
-                },
-                {
                     "github": "ikunkun-sys"
                 }
             ]
@@ -84,9 +81,6 @@
         {
             "label": "component:memory",
             "maintainers": [
-                {
-                    "github": "shiloong"
-                },
                 {
                     "github": "ikunkun-sys"
                 }

--- a/.github/maintainers.json
+++ b/.github/maintainers.json
@@ -121,6 +121,22 @@
                     "github": "KaiLongZhou"
                 }
             ]
+        },
+        {
+            "label": "component:blaze",
+            "maintainers": [
+                {
+                    "github": "casparant"
+                }
+            ]
+        },
+        {
+            "label": "component:ktuner",
+            "maintainers": [
+                {
+                    "github": "jfeng18"
+                }
+            ]
         }
     ],
     "default": {


### PR DESCRIPTION
## Description

The osbase→anvil→blaze renames updated CI workflows and commitlint scopes but left `.github/CODEOWNERS` pointing at the removed `src/osbase/` path. Since `pr-opened.yml` parses label rules from CODEOWNERS `# auto-label:` annotations and `issue-automation.yml` resolves assignees from `maintainers.json`, PRs touching `src/blaze/` got no `component:blaze` label and assignment fell back to the default maintainer. `src/ktuner/` was never registered in either file and had the same gap. This PR replaces the stale osbase entry with blaze (@casparant), registers ktuner (@jfeng18), and also removes shiloong from tokenless/agent-memory ownership as he no longer maintains any component.

## Related Issue

no-issue: automation config fix, discovered while triaging mislabeled blaze PRs

## Type / Scope

- [x] ci

## Testing

Config-only change. Verified `maintainers.json` parses as valid JSON; both `component:blaze` and `component:ktuner` labels already exist in the repo; per pr-opened.yml design, CODEOWNERS annotation changes take effect without workflow edits.