### PR TITLE
fix(cosh-ng): [core] confine read tools

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -374,6 +374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,8 +594,10 @@ dependencies = [
  "fs2",
  "futures",
  "glob",
+ "globset",
  "hex",
  "hmac",
+ "ignore",
  "keyring",
  "nix 0.29.0",
  "notify",
@@ -674,6 +686,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1172,6 +1203,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1555,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/src/cosh-ng/Cargo.toml
+++ b/src/cosh-ng/Cargo.toml
@@ -20,6 +20,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false }
 glob = "0.3"
+globset = "=0.4.15"
+ignore = "=0.4.22"
 bincode = "1"
 clap = { version = "4", features = ["derive"] }
 which = "7"

--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -26,6 +26,8 @@ async-trait = "0.1"
 dirs = "5"
 chrono = { workspace = true, features = ["clock"] }
 glob.workspace = true
+globset.workspace = true
+ignore.workspace = true
 which.workspace = true
 toml.workspace = true
 regex.workspace = true

--- a/src/cosh-ng/crates/cosh-core/src/cli.rs
+++ b/src/cosh-ng/crates/cosh-core/src/cli.rs
@@ -187,20 +187,28 @@ impl CliArgs {
     /// instead of lexically collapsing `..`, which would mis-handle symlinks.
     /// Falls back to the process cwd when no workspace is supplied.
     pub fn workspace_root(&self) -> std::path::PathBuf {
+        let absolute = self.workspace_path();
+        std::fs::canonicalize(&absolute).unwrap_or(absolute)
+    }
+
+    /// Returns the absolute workspace pathname without reopening it for identity.
+    ///
+    /// Agent startup passes this path directly to the single root-opening
+    /// operation and derives the canonical display identity from the pinned
+    /// descriptor.
+    pub(crate) fn workspace_path(&self) -> std::path::PathBuf {
         self.workspace
             .as_deref()
             .filter(|workspace| !workspace.is_empty())
             .map(std::path::PathBuf::from)
-            .and_then(|path| {
-                let absolute = if path.is_absolute() {
+            .map(|path| {
+                if path.is_absolute() {
                     path
                 } else {
-                    std::env::current_dir().ok()?.join(path)
-                };
-                // Prefer canonicalize for filesystem-correct symlink/..
-                // semantics. If the workspace does not exist, fall back to
-                // the absolute path without lexical normalization.
-                Some(std::fs::canonicalize(&absolute).unwrap_or(absolute))
+                    std::env::current_dir()
+                        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+                        .join(path)
+                }
             })
             .unwrap_or_else(|| {
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
@@ -406,6 +414,7 @@ mod tests {
             args.workspace_root(),
             std::fs::canonicalize(&target).unwrap()
         );
+        assert_eq!(args.workspace_path(), link);
     }
 
     #[cfg(unix)]

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -24,7 +24,7 @@ use crate::provider::{
     ContentGenerator, GenerateConfig, GenerateEvent, Message, MAX_TOOL_CALL_INDEX,
 };
 use crate::tool::ask_user_question;
-use crate::tool::{ToolContext, ToolKind, ToolRegistry, ToolResult};
+use crate::tool::{SessionWorkspace, ToolContext, ToolKind, ToolRegistry, ToolResult};
 use crate::truncator::OutputTruncator;
 
 use self::tool_execution::{
@@ -58,6 +58,8 @@ pub struct CoshCore {
     pub compaction: CompactionRuntime,
     pub model: String,
     pub shell_context: Option<ShellContext>,
+    project_root: PathBuf,
+    workspace: SessionWorkspace,
     pub extension_context: Option<String>,
     pub extra_params: Option<serde_json::Value>,
     pub hook_system: HookSystem,
@@ -192,7 +194,7 @@ impl CoshCore {
         self.shell_context
             .as_ref()
             .map(|ctx| ctx.cwd.clone())
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+            .unwrap_or_else(|| self.project_root.clone())
     }
 
     /// Conservative runtime-prefix (`P`) estimate for budget computations.
@@ -958,11 +960,12 @@ impl CoshCore {
             self.messages
                 .push(Message::assistant_with_tool_calls(&text_buf, tc_infos));
 
-            let ctx = ToolContext {
-                cwd: self.cwd(),
-                session_id: self.session_id.clone(),
-                project_root: self.cwd(),
-            };
+            let ctx = ToolContext::with_workspace(
+                self.cwd(),
+                self.session_id.clone(),
+                self.project_root.clone(),
+                self.workspace.clone(),
+            );
 
             let mut interrupted = false;
             // Set once a tool call ends the run. The error is returned only after

--- a/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
@@ -13,11 +13,15 @@ impl CoshCore {
             RuntimeGeneration::healthy(1, "startup"),
             Arc::clone(&tools),
         );
+        let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let workspace = SessionWorkspace::new(&project_root);
         Self::new_with_snapshot_and_session_id(
             config,
             provider,
             snapshot,
             uuid::Uuid::new_v4().to_string(),
+            project_root,
+            workspace,
         )
     }
 
@@ -27,11 +31,15 @@ impl CoshCore {
         provider: Box<dyn ContentGenerator>,
         snapshot: RuntimeSnapshot,
     ) -> Self {
+        let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let workspace = SessionWorkspace::new(&project_root);
         Self::new_with_snapshot_and_session_id(
             config,
             provider,
             snapshot,
             uuid::Uuid::new_v4().to_string(),
+            project_root,
+            workspace,
         )
     }
 
@@ -40,6 +48,8 @@ impl CoshCore {
         provider: Box<dyn ContentGenerator>,
         snapshot: RuntimeSnapshot,
         session_id: String,
+        project_root: PathBuf,
+        workspace: SessionWorkspace,
     ) -> Self {
         let model = config.resolve_provider().model;
         let (loaded_policy, warning) = LoadedPolicy::load();
@@ -53,9 +63,8 @@ impl CoshCore {
         let tools = Arc::clone(&snapshot.tools);
         let bound_extension_generation = snapshot.generation.id;
         let extension_generation = GenerationController::new(snapshot);
-        let workspace = std::env::current_dir().ok();
-        let audit = CoreAuditRecorder::initialize(&session_id, workspace.as_deref());
-
+        let audit_workspace = std::env::current_dir().ok();
+        let audit = CoreAuditRecorder::initialize(&session_id, audit_workspace.as_deref());
         Self {
             config,
             provider,
@@ -65,6 +74,8 @@ impl CoshCore {
             compaction: CompactionRuntime::default(),
             model,
             shell_context: None,
+            project_root,
+            workspace,
             extension_context,
             extra_params: None,
             hook_system,

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -233,6 +233,40 @@ async fn project_context_reaches_the_provider_boundary() {
         .contains("## Project Context\nprovider-visible marker"));
 }
 
+#[test]
+fn shell_cwd_does_not_replace_the_fixed_project_root() {
+    let mut core = CoshCore::new(
+        CoreConfig::default(),
+        Box::new(MockProvider::new(Vec::new())),
+        ToolRegistry::new(),
+    );
+    let project_root = core.project_root.clone();
+    let directory = tempfile::tempdir().unwrap();
+
+    core.shell_context = Some(ShellContext {
+        cwd: directory.path().to_path_buf(),
+        env: std::collections::HashMap::new(),
+        last_exit_code: 0,
+    });
+
+    assert_eq!(core.project_root, project_root);
+    assert_eq!(core.cwd(), directory.path());
+}
+
+#[test]
+fn fixed_project_root_is_the_cwd_without_shell_context() {
+    let mut core = CoshCore::new(
+        CoreConfig::default(),
+        Box::new(MockProvider::new(Vec::new())),
+        ToolRegistry::new(),
+    );
+    let project_root = tempfile::tempdir().unwrap();
+    core.project_root = project_root.path().to_path_buf();
+    core.shell_context = None;
+
+    assert_eq!(core.cwd(), project_root.path());
+}
+
 #[tokio::test]
 async fn user_provided_secret_reaches_the_provider_boundary() {
     let captured = Arc::new(Mutex::new(Vec::new()));

--- a/src/cosh-ng/crates/cosh-core/src/extension/mcp.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/mcp.rs
@@ -920,11 +920,11 @@ for line in sys.stdin:
     }
 
     fn tool_context() -> ToolContext {
-        ToolContext {
-            cwd: PathBuf::from("/tmp"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/tmp"),
-        }
+        ToolContext::new(
+            PathBuf::from("/tmp"),
+            "test".to_string(),
+            PathBuf::from("/tmp"),
+        )
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -1,4 +1,5 @@
 use std::io::{self, Write};
+use std::path::PathBuf;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -11,6 +12,7 @@ use crate::metrics::TurnMetrics;
 use crate::protocol::{InputMessage, OutputMessage, ShellControlRequest};
 use crate::session::{PersistedSession, ProviderSessionId, SessionError, SessionStore};
 use crate::sls;
+use crate::tool::SessionWorkspace;
 
 mod auth;
 
@@ -23,7 +25,12 @@ use auth::request_auth;
 /// transport we cannot write to would only reproduce the #1994 hang.
 const EXIT_CONTROL_TRANSPORT_FAILURE: i32 = 74;
 
-pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> {
+pub async fn run(
+    args: &CliArgs,
+    mut config: CoreConfig,
+    project_root: PathBuf,
+    workspace: SessionWorkspace,
+) -> Result<i32, String> {
     apply_cli_overrides(args, &mut config);
 
     let stdout = io::stdout();
@@ -42,7 +49,6 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
     // such as MCP filesystem servers resolve the user's project root, not the
     // cosh-core process cwd. The helper absolutizes relative paths and treats
     // empty --workspace "" as missing.
-    let project_root = args.workspace_root();
     let mut ext_manager = ExtensionManager::new(project_root.clone());
     if !args.bare {
         ext_manager.refresh();
@@ -53,13 +59,17 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
             1
         },
     );
-    let snapshot =
-        RuntimeSnapshotBuilder::new(&mut ext_manager, &config, project_root, generation_id)
-            .with_shell_evidence(args.enable_shell_evidence_tool)
-            .with_skill_loading(!args.bare)
-            .with_tool_selection(args.tools.as_deref())
-            .build()
-            .await;
+    let snapshot = RuntimeSnapshotBuilder::new(
+        &mut ext_manager,
+        &config,
+        project_root.clone(),
+        generation_id,
+    )
+    .with_shell_evidence(args.enable_shell_evidence_tool)
+    .with_skill_loading(!args.bare)
+    .with_tool_selection(args.tools.as_deref())
+    .build()
+    .await;
     if let Some(diagnostic) = snapshot
         .diagnostics
         .iter()
@@ -117,6 +127,8 @@ pub async fn run(args: &CliArgs, mut config: CoreConfig) -> Result<i32, String> 
         provider,
         snapshot,
         session.record.session_id.to_string(),
+        project_root,
+        workspace,
     );
     let live_extension_runtime = crate::registry::LiveExtensionRuntime::new(
         engine.extension_generation.clone(),

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -137,11 +137,26 @@ async fn run() {
     if args.is_session_control() {
         std::process::exit(session_control::run());
     }
-    let workspace = args.workspace_root();
+    let agent_headless = is_agent_headless_mode(&args);
+    let (project_root, session_workspace) = if agent_headless {
+        let requested_root = args.workspace_path();
+        match tool::SessionWorkspace::try_new(&requested_root) {
+            Ok(workspace) => {
+                let project_root = workspace.root().to_path_buf();
+                (project_root, Some(workspace))
+            }
+            Err(error) => {
+                eprintln!("[cosh-core] {error}");
+                std::process::exit(2);
+            }
+        }
+    } else {
+        (args.workspace_root(), None)
+    };
     let config = if args.bare {
         CoreConfig::load_bare()
     } else {
-        CoreConfig::load_for_workspace(&workspace)
+        CoreConfig::load_for_workspace(&project_root)
     };
 
     let log_level = config.logging.effective_level(args.verbose);
@@ -149,7 +164,7 @@ async fn run() {
     tracing::info!(version = env!("CARGO_PKG_VERSION"), "cosh-core starting");
 
     if let Some(cli::Command::Mcp(mcp)) = args.command {
-        if let Err(error) = tool::mcp::run_command(mcp, &config, &workspace).await {
+        if let Err(error) = tool::mcp::run_command(mcp, &config, &project_root).await {
             eprintln!("MCP command failed: {error}");
             std::process::exit(1);
         }
@@ -157,8 +172,12 @@ async fn run() {
         registry::run(&args, config).await;
     } else if args.is_compact() {
         std::process::exit(compaction::run_compact_cli(&args, config).await);
-    } else if args.is_headless() {
-        match headless::run(&args, config).await {
+    } else if agent_headless {
+        let Some(session_workspace) = session_workspace else {
+            eprintln!("[cosh-core] headless workspace was not initialized");
+            std::process::exit(2);
+        };
+        match headless::run(&args, config, project_root, session_workspace).await {
             Ok(0) => {}
             Ok(exit_code) => std::process::exit(exit_code),
             Err(error) => {
@@ -169,6 +188,10 @@ async fn run() {
     } else {
         interactive::run(&args, config).await;
     }
+}
+
+fn is_agent_headless_mode(args: &cli::CliArgs) -> bool {
+    args.command.is_none() && !args.is_registry() && !args.is_compact() && args.is_headless()
 }
 
 #[cfg(unix)]
@@ -195,6 +218,30 @@ mod tests {
     use super::*;
     use crate::config::{AiConfig, CoreConfig, ProviderConfig};
     use std::collections::HashMap;
+
+    fn parse_args(args: &[&str]) -> cli::CliArgs {
+        let mut full = vec!["cosh-core"];
+        full.extend_from_slice(args);
+        cli::CliArgs::try_parse_from(full).unwrap()
+    }
+
+    #[test]
+    fn only_agent_mode_initializes_the_headless_workspace() {
+        assert!(is_agent_headless_mode(&parse_args(&["--headless"])));
+        assert!(!is_agent_headless_mode(&parse_args(&[
+            "--headless",
+            "mcp",
+            "list"
+        ])));
+        assert!(!is_agent_headless_mode(&parse_args(&[
+            "--headless",
+            "--registry"
+        ])));
+        assert!(!is_agent_headless_mode(&parse_args(&[
+            "--headless",
+            "--compact"
+        ])));
+    }
 
     #[test]
     fn ecs_ram_role_aliyun_provider_does_not_need_static_auth() {

--- a/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
@@ -145,11 +145,8 @@ mod tests {
     use tokio::sync::Barrier;
 
     fn test_ctx() -> ToolContext {
-        ToolContext {
-            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")),
-            session_id: "test".to_string(),
-            project_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")),
-        }
+        let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp"));
+        ToolContext::new(root.clone(), "test".to_string(), root)
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/tool/file_patterns.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/file_patterns.rs
@@ -1,95 +1,208 @@
-//! Shared path expansion for file-discovery tools.
+//! Shared descriptor-relative discovery for file-reading tools.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use glob::{glob_with, MatchOptions, Pattern};
+use glob::{MatchOptions, Pattern};
+
+use super::workspace_fs::{WorkspaceBatchNode, WorkspaceFs, WorkspaceNode, WorkspacePathNode};
 
 const MAX_MATCHES: usize = 100;
 
+pub(super) struct FileMatch {
+    pub path: PathBuf,
+    pub file: Result<File, String>,
+}
+
 pub(super) struct FileMatches {
+    pub files: Vec<FileMatch>,
+    pub truncated: bool,
+}
+
+pub(super) struct FilePathMatches {
     pub paths: Vec<PathBuf>,
     pub truncated: bool,
+    pub skipped: Vec<String>,
 }
 
 pub(super) fn expand_file_patterns(
     patterns: &[String],
     cwd: &Path,
+    workspace: &WorkspaceFs,
     max_matches: usize,
 ) -> Result<FileMatches, String> {
-    let mut matches = BTreeSet::new();
+    let mut matches = BTreeMap::new();
     let mut truncated = false;
     let max_matches = max_matches.min(MAX_MATCHES);
 
-    for pattern in patterns {
-        if expand_pattern(pattern, cwd, &mut matches, max_matches)? {
-            truncated = true;
+    for (pattern_index, pattern) in patterns.iter().enumerate() {
+        if pattern.trim().is_empty() {
+            return Err("file pattern must not be empty".to_string());
+        }
+        if let Some(node) = workspace.try_open_batch_node(cwd, pattern)? {
+            match node {
+                WorkspaceBatchNode::Node(WorkspaceNode::File(file)) => {
+                    if insert_match(&mut matches, file.display_path, Ok(file.file), max_matches) {
+                        truncated = true;
+                    }
+                }
+                WorkspaceBatchNode::Node(WorkspaceNode::Directory(directory)) => {
+                    let walked = workspace.walk_files(directory, max_matches, |_| true)?;
+                    truncated |= walked.truncated;
+                    for file in walked.files {
+                        if insert_match(&mut matches, file.display_path, Ok(file.file), max_matches)
+                        {
+                            truncated = true;
+                            break;
+                        }
+                    }
+                }
+                WorkspaceBatchNode::InaccessibleFile {
+                    display_path,
+                    error,
+                } => {
+                    if insert_match(&mut matches, display_path, Err(error), max_matches) {
+                        truncated = true;
+                    }
+                }
+            }
+        } else if pattern.chars().any(is_glob_char) {
+            let (base, suffix) = split_path_pattern(pattern);
+            let base = if base.is_empty() { "." } else { base };
+            let matcher = Pattern::new(&suffix)
+                .map_err(|error| format!("invalid glob pattern '{pattern}': {error}"))?;
+            let directory = match workspace.try_open_node(cwd, base)? {
+                Some(WorkspaceNode::Directory(directory)) => directory,
+                Some(WorkspaceNode::File(file)) => {
+                    return Err(format!("Not a directory: {}", file.display_path.display()));
+                }
+                None => continue,
+            };
+            let options = match_options();
+            let walked = workspace.walk_files(directory, max_matches, |path| {
+                matcher.matches_path_with(path, options)
+            })?;
+            truncated |= walked.truncated;
+            for file in walked.files {
+                if insert_match(&mut matches, file.display_path, Ok(file.file), max_matches) {
+                    truncated = true;
+                    break;
+                }
+            }
+        }
+        if truncated {
+            break;
+        }
+        if matches.len() >= max_matches {
+            truncated = pattern_index + 1 < patterns.len();
             break;
         }
     }
 
     Ok(FileMatches {
-        paths: matches.into_iter().collect(),
+        files: matches
+            .into_iter()
+            .map(|(path, file)| FileMatch { path, file })
+            .collect(),
         truncated,
     })
 }
 
-fn expand_pattern(
-    pattern: &str,
+pub(super) fn expand_file_paths(
+    patterns: &[String],
     cwd: &Path,
-    matches: &mut BTreeSet<PathBuf>,
+    workspace: &WorkspaceFs,
     max_matches: usize,
-) -> Result<bool, String> {
-    if pattern.trim().is_empty() {
-        return Err("file pattern must not be empty".to_string());
-    }
+) -> Result<FilePathMatches, String> {
+    let mut matches = BTreeSet::new();
+    let mut truncated = false;
+    let mut skipped = Vec::new();
+    let max_matches = max_matches.min(MAX_MATCHES);
 
-    let candidate = resolve_path(pattern, cwd);
-    if candidate.is_file() {
-        return Ok(insert_match(matches, candidate, max_matches));
-    }
-
-    let glob_pattern = if candidate.is_dir() {
-        join_glob(&candidate, "**/*")?
-    } else if candidate.is_absolute() {
-        let (base_str, glob_suffix) = split_path_pattern(pattern);
-        let base = resolve_path(base_str, cwd);
-        let escaped = Pattern::escape(
-            base.to_str()
-                .ok_or_else(|| format!("file pattern is not valid UTF-8: {}", base.display()))?,
-        );
-        if glob_suffix.is_empty() {
-            escaped
-        } else {
-            let sep = if escaped.ends_with(std::path::MAIN_SEPARATOR) {
-                ""
-            } else {
-                std::path::MAIN_SEPARATOR_STR
-            };
-            format!("{escaped}{sep}{glob_suffix}")
+    for (pattern_index, pattern) in patterns.iter().enumerate() {
+        if pattern.trim().is_empty() {
+            return Err("file pattern must not be empty".to_string());
         }
-    } else {
-        join_glob(cwd, pattern)?
-    };
-    expand_glob(&glob_pattern, matches, max_matches)
+        if let Some(node) = workspace.try_open_path_node(cwd, pattern)? {
+            match node {
+                WorkspacePathNode::File(path) => {
+                    if insert_path_match(&mut matches, path, max_matches) {
+                        truncated = true;
+                    }
+                }
+                WorkspacePathNode::Directory(directory) => {
+                    let walked = workspace.walk_file_paths(directory, max_matches, |_| true)?;
+                    truncated |= walked.truncated;
+                    for path in walked.paths {
+                        if insert_path_match(&mut matches, path, max_matches) {
+                            truncated = true;
+                            break;
+                        }
+                    }
+                }
+                WorkspacePathNode::InaccessibleDirectory {
+                    display_path,
+                    error,
+                } => skipped.push(format!("{}: {error}", display_path.display())),
+            }
+        } else if pattern.chars().any(is_glob_char) {
+            let (base, suffix) = split_path_pattern(pattern);
+            let base = if base.is_empty() { "." } else { base };
+            let matcher = Pattern::new(&suffix)
+                .map_err(|error| format!("invalid glob pattern '{pattern}': {error}"))?;
+            let directory = match workspace.try_open_path_node(cwd, base)? {
+                Some(WorkspacePathNode::Directory(directory)) => directory,
+                Some(WorkspacePathNode::File(path)) => {
+                    return Err(format!("Not a directory: {}", path.display()));
+                }
+                Some(WorkspacePathNode::InaccessibleDirectory {
+                    display_path,
+                    error,
+                }) => {
+                    skipped.push(format!("{}: {error}", display_path.display()));
+                    continue;
+                }
+                None => continue,
+            };
+            let options = match_options();
+            let walked = workspace.walk_file_paths(directory, max_matches, |path| {
+                matcher.matches_path_with(path, options)
+            })?;
+            truncated |= walked.truncated;
+            for path in walked.paths {
+                if insert_path_match(&mut matches, path, max_matches) {
+                    truncated = true;
+                    break;
+                }
+            }
+        }
+        if truncated {
+            break;
+        }
+        if matches.len() >= max_matches {
+            truncated = pattern_index + 1 < patterns.len();
+            break;
+        }
+    }
+
+    Ok(FilePathMatches {
+        paths: matches.into_iter().collect(),
+        truncated,
+        skipped,
+    })
 }
 
-/// Split a user-supplied pattern into `(literal_base, glob_suffix)`.
-///
-/// Splits the pattern at the first path segment that contains glob
-/// metacharacters (`*`, `?`, `[`, `]`).  Everything above that segment
-/// becomes the literal base (to be resolved and escaped); everything
-/// from that segment onward is the glob suffix (preserved verbatim).
-///
-/// If no segment contains glob metacharacters, the entire pattern is
-/// the literal base and the glob suffix is empty.
-fn split_path_pattern(pattern: &str) -> (&str, String) {
-    let sep = std::path::MAIN_SEPARATOR;
-    let sep_len = sep.len_utf8();
-    let is_glob_char = |c: char| matches!(c, '*' | '?' | '[' | ']');
+fn is_glob_char(character: char) -> bool {
+    matches!(character, '*' | '?' | '[' | ']')
+}
 
+/// Splits a pattern into its literal base and glob suffix.
+fn split_path_pattern(pattern: &str) -> (&str, String) {
+    let separator = std::path::MAIN_SEPARATOR;
+    let separator_len = separator.len_utf8();
     let Some(glob_index) = pattern
-        .split(sep)
+        .split(separator)
         .position(|segment| segment.chars().any(is_glob_char))
     else {
         return (pattern, String::new());
@@ -99,13 +212,12 @@ fn split_path_pattern(pattern: &str) -> (&str, String) {
     }
 
     let suffix_start = pattern
-        .split(sep)
+        .split(separator)
         .take(glob_index)
-        .map(|segment| segment.len() + sep_len)
+        .map(|segment| segment.len() + separator_len)
         .sum::<usize>();
-    let base_end = suffix_start.saturating_sub(sep_len);
-    // A leading separator forms the literal base when the first path component is a glob.
-    let base = if base_end == 0 && pattern.starts_with(sep) {
+    let base_end = suffix_start.saturating_sub(separator_len);
+    let base = if base_end == 0 && pattern.starts_with(separator) {
         std::path::MAIN_SEPARATOR_STR
     } else {
         &pattern[..base_end]
@@ -113,49 +225,31 @@ fn split_path_pattern(pattern: &str) -> (&str, String) {
     (base, pattern[suffix_start..].to_string())
 }
 
-fn join_glob(base: &Path, pattern: &str) -> Result<String, String> {
-    let base = base
-        .to_str()
-        .ok_or_else(|| format!("file pattern is not valid UTF-8: {}", base.display()))?;
-    let base = Pattern::escape(base);
-    let separator = if base.ends_with(std::path::MAIN_SEPARATOR) {
-        ""
-    } else {
-        std::path::MAIN_SEPARATOR_STR
-    };
-    Ok(format!("{base}{separator}{pattern}"))
-}
-
-fn expand_glob(
-    pattern: &str,
-    matches: &mut BTreeSet<PathBuf>,
-    max_matches: usize,
-) -> Result<bool, String> {
-    Pattern::new(pattern).map_err(|error| format!("invalid glob pattern '{pattern}': {error}"))?;
-
-    let options = MatchOptions {
+fn match_options() -> MatchOptions {
+    MatchOptions {
         case_sensitive: !cfg!(any(target_os = "macos", target_os = "windows")),
         require_literal_separator: false,
         require_literal_leading_dot: false,
-    };
-    let entries = glob_with(pattern, options)
-        .map_err(|error| format!("invalid glob pattern '{pattern}': {error}"))?;
-
-    for entry in entries {
-        match entry {
-            Ok(path) if path.is_file() => {
-                if insert_match(matches, path, max_matches) {
-                    return Ok(true);
-                }
-            }
-            Ok(_) => {}
-            Err(_) => continue,
-        }
     }
-    Ok(false)
 }
 
-fn insert_match(matches: &mut BTreeSet<PathBuf>, path: PathBuf, max_matches: usize) -> bool {
+fn insert_match(
+    matches: &mut BTreeMap<PathBuf, Result<File, String>>,
+    path: PathBuf,
+    file: Result<File, String>,
+    max_matches: usize,
+) -> bool {
+    if matches.contains_key(&path) {
+        return false;
+    }
+    if matches.len() >= max_matches {
+        return true;
+    }
+    matches.insert(path, file);
+    false
+}
+
+fn insert_path_match(matches: &mut BTreeSet<PathBuf>, path: PathBuf, max_matches: usize) -> bool {
     if matches.contains(&path) {
         return false;
     }
@@ -166,60 +260,76 @@ fn insert_match(matches: &mut BTreeSet<PathBuf>, path: PathBuf, max_matches: usi
     false
 }
 
-// resolve_path is provided by the parent module (super::resolve_path)
-// and supports ~ expansion.
-pub(super) use super::resolve_path;
-
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::symlink;
+
     use super::*;
+
+    fn expand(
+        patterns: &[String],
+        cwd: &Path,
+        root: &Path,
+        max_matches: usize,
+    ) -> Result<FileMatches, String> {
+        let workspace = WorkspaceFs::new(root)?;
+        expand_file_patterns(patterns, cwd, &workspace, max_matches)
+    }
 
     #[test]
     fn expands_exact_files_and_globs_without_duplicates() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("src/nested")).unwrap();
-        std::fs::write(dir.path().join("src/lib.rs"), "lib").unwrap();
-        std::fs::write(dir.path().join("src/nested/mod.rs"), "mod").unwrap();
-        std::fs::write(dir.path().join("src/readme.md"), "readme").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(directory.path().join("src/nested")).unwrap();
+        std::fs::write(directory.path().join("src/lib.rs"), "lib").unwrap();
+        std::fs::write(directory.path().join("src/nested/mod.rs"), "mod").unwrap();
+        std::fs::write(directory.path().join("src/readme.md"), "readme").unwrap();
 
-        let matches = expand_file_patterns(
+        let matches = expand(
             &[
                 "src/**/*.rs".to_string(),
                 "src/lib.rs".to_string(),
                 "src/readme.md".to_string(),
             ],
-            dir.path(),
+            directory.path(),
+            directory.path(),
             10,
         )
         .unwrap();
 
-        assert_eq!(matches.paths.len(), 3);
+        assert_eq!(matches.files.len(), 3);
         assert!(!matches.truncated);
     }
 
     #[test]
     fn caps_matches() {
-        let dir = tempfile::tempdir().unwrap();
+        let directory = tempfile::tempdir().unwrap();
         for index in 0..3 {
-            std::fs::write(dir.path().join(format!("{index}.txt")), "text").unwrap();
+            std::fs::write(directory.path().join(format!("{index}.txt")), "text").unwrap();
         }
 
-        let matches = expand_file_patterns(&["*.txt".to_string()], dir.path(), 2).unwrap();
+        let matches = expand(
+            &["*.txt".to_string()],
+            directory.path(),
+            directory.path(),
+            2,
+        )
+        .unwrap();
 
-        assert_eq!(matches.paths.len(), 2);
+        assert_eq!(matches.files.len(), 2);
         assert!(matches.truncated);
     }
 
     #[test]
-    fn treats_glob_metacharacters_in_base_path_as_literals() {
-        let dir = tempfile::tempdir().unwrap();
-        let base = dir.path().join("work[tree]");
+    fn treats_glob_metacharacters_in_cwd_as_literals() {
+        let directory = tempfile::tempdir().unwrap();
+        let base = directory.path().join("work[tree]");
         std::fs::create_dir(&base).unwrap();
         std::fs::write(base.join("lib.rs"), "lib").unwrap();
 
-        let matches = expand_file_patterns(&["*.rs".to_string()], &base, 10).unwrap();
+        let matches = expand(&["*.rs".to_string()], &base, &base, 10).unwrap();
 
-        assert_eq!(matches.paths, [base.join("lib.rs")]);
+        assert_eq!(matches.files.len(), 1);
+        assert_eq!(matches.files[0].path, base.join("lib.rs"));
     }
 
     #[test]
@@ -233,27 +343,90 @@ mod tests {
 
     #[test]
     fn absolute_glob_uses_resolved_literal_base() {
-        let dir = tempfile::tempdir().unwrap();
-        let sub = dir.path().join("src");
-        std::fs::create_dir_all(&sub).unwrap();
-        std::fs::write(sub.join("lib.rs"), "lib").unwrap();
-        std::fs::write(sub.join("main.rs"), "main").unwrap();
-        std::fs::write(dir.path().join("readme.md"), "readme").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("src");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::write(source.join("lib.rs"), "lib").unwrap();
+        std::fs::write(source.join("main.rs"), "main").unwrap();
+        std::fs::write(directory.path().join("readme.md"), "readme").unwrap();
+        let pattern = source.join("*.rs").to_str().unwrap().to_string();
 
-        let abs_glob = dir.path().join("src").join("*.rs");
-        let pattern = abs_glob.to_str().unwrap().to_string();
+        let matches = expand(&[pattern], Path::new("/nonexistent"), directory.path(), 10).unwrap();
 
-        let matches = expand_file_patterns(&[pattern], &PathBuf::from("/nonexistent"), 10).unwrap();
+        assert_eq!(matches.files.len(), 2);
+        assert!(matches
+            .files
+            .iter()
+            .all(|file| file.path.starts_with(&source)));
+    }
 
-        assert_eq!(matches.paths.len(), 2);
-        for p in &matches.paths {
-            assert!(
-                p.starts_with(&sub),
-                "path {:?} should be under {:?}",
-                p,
-                sub
-            );
-            assert!(p.extension().is_some_and(|e| e == "rs"));
-        }
+    #[test]
+    fn skips_symlinks_that_escape_during_discovery() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("inside.txt"), "inside").unwrap();
+        std::fs::write(parent.path().join("outside.txt"), "outside").unwrap();
+        symlink(
+            parent.path().join("outside.txt"),
+            root.join("outside-link.txt"),
+        )
+        .unwrap();
+
+        let matches = expand(&["*.txt".to_string()], &root, &root, 10).unwrap();
+
+        assert_eq!(matches.files.len(), 1);
+        assert!(matches.files[0].path.ends_with("inside.txt"));
+    }
+
+    #[test]
+    fn existing_path_with_glob_characters_takes_precedence() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("report[1].txt"), "literal").unwrap();
+        std::fs::write(directory.path().join("report1.txt"), "glob").unwrap();
+
+        let matches = expand(
+            &["report[1].txt".to_string()],
+            directory.path(),
+            directory.path(),
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(matches.files.len(), 1);
+        assert!(matches.files[0].path.ends_with("report[1].txt"));
+    }
+
+    #[test]
+    fn invalid_globs_are_rejected_before_missing_base_lookup() {
+        let directory = tempfile::tempdir().unwrap();
+        let patterns = ["missing/[".to_string()];
+        let readable_error = expand(&patterns, directory.path(), directory.path(), 10)
+            .err()
+            .unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let path_error = expand_file_paths(&patterns, directory.path(), &workspace, 10)
+            .err()
+            .unwrap();
+
+        assert!(readable_error.contains("invalid glob pattern"));
+        assert!(path_error.contains("invalid glob pattern"));
+    }
+
+    #[test]
+    fn unprocessed_exact_paths_mark_results_truncated() {
+        let directory = tempfile::tempdir().unwrap();
+        let patterns = (0..3)
+            .map(|index| {
+                let name = format!("{index}.txt");
+                std::fs::write(directory.path().join(&name), "text").unwrap();
+                name
+            })
+            .collect::<Vec<_>>();
+
+        let matches = expand(&patterns, directory.path(), directory.path(), 2).unwrap();
+
+        assert_eq!(matches.files.len(), 2);
+        assert!(matches.truncated);
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/glob.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/glob.rs
@@ -3,7 +3,8 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use super::file_patterns::expand_file_patterns;
+use super::file_patterns::expand_file_paths;
+use super::workspace_fs::WorkspaceFs;
 use super::{Tool, ToolContext, ToolKind, ToolResult};
 
 const MAX_RESULTS: usize = 100;
@@ -47,49 +48,67 @@ impl Tool for GlobTool {
             .and_then(Value::as_str)
             .ok_or("missing 'pattern' parameter")?
             .to_string();
-        let base = params
+        let path = params
             .get("path")
             .and_then(Value::as_str)
-            .map(|path| super::file_patterns::resolve_path(path, &ctx.cwd))
-            .unwrap_or_else(|| ctx.cwd.clone());
+            .unwrap_or(".")
+            .to_string();
+        let cwd = ctx.cwd.clone();
+        let workspace = ctx.workspace()?;
 
-        if !base.is_dir() {
-            return Ok(ToolResult::error(format!(
-                "Search path is not a directory: {}",
-                base.display()
-            )));
-        }
-
-        let expand_pattern = pattern.clone();
-        let expand_base = base.clone();
-        let matches = tokio::task::spawn_blocking(move || {
-            expand_file_patterns(&[expand_pattern], &expand_base, MAX_RESULTS)
-        })
-        .await
-        .map_err(|error| format!("File discovery task failed: {error}"))??;
-        if matches.paths.is_empty() {
-            return Ok(ToolResult::success(format!(
-                "No files found matching pattern \"{pattern}\" in {}",
-                base.display()
-            )));
-        }
-
-        let mut output = matches
-            .paths
-            .iter()
-            .map(|path| path.display().to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
-        if matches.truncated {
-            output.push_str("\n\n... results truncated at 100 files");
-        }
-        Ok(ToolResult::success(output))
+        tokio::task::spawn_blocking(move || glob_workspace(&pattern, &path, &cwd, &workspace))
+            .await
+            .map_err(|error| format!("Glob task failed: {error}"))?
     }
+}
+
+fn glob_workspace(
+    pattern: &str,
+    path: &str,
+    cwd: &std::path::Path,
+    workspace: &WorkspaceFs,
+) -> Result<ToolResult, String> {
+    let directory = match workspace.open_directory(cwd, path) {
+        Ok(directory) => directory,
+        Err(error) => return Ok(ToolResult::error(error)),
+    };
+    let base = directory.display_path.clone();
+    let matches = expand_file_paths(&[pattern.to_string()], &base, workspace, MAX_RESULTS)?;
+    if matches.paths.is_empty() {
+        return Ok(ToolResult::success(empty_glob_output(
+            pattern,
+            &base,
+            matches.truncated,
+        )));
+    }
+
+    let mut output = matches
+        .paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if matches.truncated {
+        output.push_str("\n\n... results truncated at 100 files");
+    }
+    Ok(ToolResult::success(output))
+}
+
+fn empty_glob_output(pattern: &str, base: &std::path::Path, truncated: bool) -> String {
+    let mut output = format!(
+        "No files found matching pattern \"{pattern}\" in {}",
+        base.display()
+    );
+    if truncated {
+        output.push_str("\n\n... results truncated before the full workspace was searched");
+    }
+    output
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::symlink;
     use std::path::PathBuf;
 
     #[tokio::test]
@@ -99,11 +118,11 @@ mod tests {
         std::fs::write(dir.path().join("one.rs"), "one").unwrap();
         std::fs::write(dir.path().join("nested/two.rs"), "two").unwrap();
         std::fs::write(dir.path().join("three.txt"), "three").unwrap();
-        let ctx = ToolContext {
-            cwd: dir.path().to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from(dir.path()),
-        };
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            PathBuf::from(dir.path()),
+        );
 
         let result = GlobTool
             .invoke(serde_json::json!({"pattern": "**/*.rs"}), &ctx)
@@ -114,5 +133,77 @@ mod tests {
         assert!(result.output.contains("one.rs"));
         assert!(result.output.contains("two.rs"));
         assert!(!result.output.contains("three.txt"));
+    }
+
+    #[tokio::test]
+    async fn does_not_follow_directory_symlink_outside_workspace() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        let outside = parent.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("secret.rs"), "secret").unwrap();
+        symlink(&outside, root.join("outside-link")).unwrap();
+        let ctx = ToolContext::new(root.clone(), "test".to_string(), root);
+
+        let result = GlobTool
+            .invoke(serde_json::json!({"pattern": "**/*.rs"}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.output.contains("secret.rs"));
+    }
+
+    #[tokio::test]
+    async fn supports_absolute_patterns() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("src");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::write(source.join("lib.rs"), "lib").unwrap();
+        let pattern = source.join("*.rs").to_string_lossy().to_string();
+        let ctx = ToolContext::new(
+            directory.path().to_path_buf(),
+            "test".to_string(),
+            directory.path().to_path_buf(),
+        );
+
+        let result = GlobTool
+            .invoke(serde_json::json!({"pattern": pattern}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("lib.rs"));
+    }
+
+    #[tokio::test]
+    async fn finds_unreadable_matching_files_without_opening_for_read() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("locked.rs");
+        std::fs::write(&path, "private").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let ctx = ToolContext::new(
+            directory.path().to_path_buf(),
+            "test".to_string(),
+            directory.path().to_path_buf(),
+        );
+
+        let result = GlobTool
+            .invoke(serde_json::json!({"pattern": "*.rs"}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("locked.rs"));
+    }
+
+    #[test]
+    fn empty_truncated_result_is_not_definitive() {
+        let output = empty_glob_output("*.rs", std::path::Path::new("/workspace"), true);
+
+        assert!(output.contains("results truncated"));
+        assert!(output.contains("full workspace"));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/grep.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/grep.rs
@@ -1,8 +1,23 @@
-use async_trait::async_trait;
-use serde_json::Value;
-use tokio::process::Command;
+//! Bounded regex search over files opened beneath the workspace root.
 
+use std::ffi::OsString;
+use std::io::{BufRead, BufReader, Cursor, Read};
+use std::path::{Component, Path, PathBuf};
+
+use async_trait::async_trait;
+use globset::{GlobBuilder, GlobMatcher};
+use regex::bytes::Regex;
+use serde_json::Value;
+
+use super::workspace_fs::{WorkspaceFile, WorkspaceFs, WorkspaceNode};
 use super::{Tool, ToolContext, ToolKind, ToolResult};
+
+const MAX_FILES: usize = 100;
+const MAX_FILE_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_MATCHES: usize = 100;
+const MAX_OUTPUT_BYTES: usize = 256 * 1024;
+const IGNORE_RULE_WARNING: &str =
+    "Some ignore rules could not be read or parsed; search results may be incomplete.";
 
 pub struct GrepTool;
 
@@ -13,7 +28,7 @@ impl Tool for GrepTool {
     }
 
     fn description(&self) -> &str {
-        "Search for a pattern in files. Uses ripgrep (rg) if available, otherwise falls back to grep."
+        "Search for a regex pattern in workspace files. Returns at most 100 matches."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -44,124 +59,1323 @@ impl Tool for GrepTool {
     async fn invoke(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
         let pattern = params
             .get("pattern")
-            .and_then(|v| v.as_str())
-            .ok_or("missing 'pattern' parameter")?;
+            .and_then(Value::as_str)
+            .ok_or("missing 'pattern' parameter")?
+            .to_string();
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or(".")
+            .to_string();
+        let include = params
+            .get("include")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let cwd = ctx.cwd.clone();
+        let workspace = ctx.workspace()?;
 
-        let search_path = params.get("path").and_then(|v| v.as_str()).unwrap_or(".");
+        tokio::task::spawn_blocking(move || {
+            grep_workspace(&pattern, &path, include.as_deref(), &cwd, &workspace)
+        })
+        .await
+        .map_err(|error| format!("Grep task failed: {error}"))?
+    }
+}
 
-        let include = params.get("include").and_then(|v| v.as_str());
+fn grep_workspace(
+    pattern: &str,
+    path: &str,
+    include: Option<&str>,
+    cwd: &Path,
+    workspace: &WorkspaceFs,
+) -> Result<ToolResult, String> {
+    let matcher = Regex::new(pattern)
+        .map_err(|error| format!("invalid regex pattern '{pattern}': {error}"))?;
+    let include = include
+        .map(IncludeMatcher::new)
+        .transpose()
+        .map_err(|error| format!("invalid include pattern: {error}"))?;
+    let node = match workspace.open_node(cwd, path) {
+        Ok(node) => node,
+        Err(error) => return Ok(ToolResult::error(error)),
+    };
 
-        let has_rg = which::which("rg").is_ok();
+    let respect_ignores = match include.as_ref() {
+        Some(pattern) => pattern.excluded,
+        None => true,
+    };
+    let (files, discovery_truncated, ignore_incomplete) = match node {
+        WorkspaceNode::File(file) => (vec![GrepInput::Opened(file)], false, false),
+        WorkspaceNode::Directory(directory) => {
+            let cwd_relative = workspace.resolve_user_path(cwd, "")?;
+            let walked = workspace.walk_relative_file_paths(
+                directory,
+                MAX_FILES,
+                respect_ignores,
+                |path| {
+                    let include_path = path_relative_to_cwd(&cwd_relative, path);
+                    include_file(&include, &include_path)
+                },
+            )?;
+            (
+                walked.paths.into_iter().map(GrepInput::Relative).collect(),
+                walked.truncated,
+                walked.ignore_incomplete,
+            )
+        }
+    };
 
-        let output = if has_rg {
-            let mut cmd = Command::new("rg");
-            cmd.arg("--line-number")
-                .arg("--no-heading")
-                .arg("--color=never")
-                .arg("--max-count=100");
-
-            if let Some(glob) = include {
-                cmd.arg("--glob").arg(glob);
+    let mut output = String::new();
+    let mut matches = 0;
+    let mut match_truncated = false;
+    let mut output_truncated = false;
+    let mut input_truncated = false;
+    let mut file_errors = Vec::new();
+    if ignore_incomplete {
+        file_errors.push(IGNORE_RULE_WARNING.to_string());
+    }
+    for input in files {
+        let file = match input {
+            GrepInput::Opened(file) => file,
+            GrepInput::Relative(relative_path) => {
+                match workspace.open_relative_node(&relative_path) {
+                    Ok(Some(WorkspaceNode::File(file))) => file,
+                    Ok(Some(WorkspaceNode::Directory(_))) => {
+                        file_errors.push(format!(
+                            "File changed into a directory: {}",
+                            workspace.display_path(&relative_path).display()
+                        ));
+                        continue;
+                    }
+                    Ok(None) => {
+                        file_errors.push(format!(
+                            "File disappeared before search: {}",
+                            workspace.display_path(&relative_path).display()
+                        ));
+                        continue;
+                    }
+                    Err(error) => {
+                        file_errors.push(error);
+                        continue;
+                    }
+                }
             }
-
-            cmd.arg(pattern).arg(search_path).current_dir(&ctx.cwd);
-
-            cmd.output().await
-        } else {
-            let mut cmd = Command::new("grep");
-            cmd.arg("-rn").arg("--color=never");
-
-            if let Some(glob) = include {
-                cmd.arg("--include").arg(glob);
-            }
-
-            cmd.arg(pattern).arg(search_path).current_dir(&ctx.cwd);
-
-            cmd.output().await
         };
+        let scan = scan_file(
+            file,
+            &matcher,
+            MAX_MATCHES.saturating_sub(matches),
+            MAX_OUTPUT_BYTES.saturating_sub(output.len()),
+        );
+        if scan.binary {
+            continue;
+        }
+        output.push_str(&scan.output);
+        matches += scan.matches;
+        match_truncated |= scan.match_truncated;
+        output_truncated |= scan.output_truncated;
+        input_truncated |= scan.input_truncated;
+        if let Some(error) = scan.error {
+            file_errors.push(error);
+        }
+        if match_truncated || output_truncated {
+            break;
+        }
+    }
 
-        match output {
-            Ok(out) => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                let stderr = String::from_utf8_lossy(&out.stderr);
-
-                if stdout.is_empty() && out.status.code() == Some(1) {
-                    return Ok(ToolResult::success("No matches found."));
-                }
-
-                let mut result = stdout.to_string();
-                if !stderr.is_empty() {
-                    result.push_str("\n[stderr]\n");
-                    result.push_str(&stderr);
-                }
-
-                Ok(ToolResult::success(result))
+    if matches == 0 {
+        if discovery_truncated
+            || match_truncated
+            || output_truncated
+            || input_truncated
+            || !file_errors.is_empty()
+        {
+            output.push_str("No matches found in the searched subset.\n");
+            if discovery_truncated || match_truncated || output_truncated || input_truncated {
+                output.push_str("\n[additional grep results omitted by output limits]\n");
             }
-            Err(e) => Err(format!("Failed to run grep: {e}")),
+            append_file_errors(&mut output, &file_errors);
+            return Ok(ToolResult::success(output));
+        }
+        return Ok(ToolResult::success("No matches found."));
+    }
+    if discovery_truncated || match_truncated || output_truncated || input_truncated {
+        output.push_str("\n[additional grep results omitted by output limits]\n");
+    }
+    append_file_errors(&mut output, &file_errors);
+    Ok(ToolResult::success(output))
+}
+
+enum GrepInput {
+    Opened(WorkspaceFile),
+    Relative(PathBuf),
+}
+
+fn append_file_errors(output: &mut String, errors: &[String]) {
+    if errors.is_empty() {
+        return;
+    }
+    output.push_str("\n[file errors]\n");
+    output.push_str(&errors.join("\n"));
+    output.push('\n');
+}
+
+struct IncludeMatcher {
+    matcher: GlobMatcher,
+    excluded: bool,
+    match_basename: bool,
+}
+
+impl IncludeMatcher {
+    fn new(pattern: &str) -> Result<Self, globset::Error> {
+        let (excluded, pattern) = pattern
+            .strip_prefix('!')
+            .map_or((false, pattern), |pattern| (true, pattern));
+        let (anchored, pattern) = pattern
+            .strip_prefix('/')
+            .map_or((false, pattern), |pattern| (true, pattern));
+        let match_basename = !anchored && !pattern.contains('/');
+        let matcher = GlobBuilder::new(pattern)
+            .case_insensitive(cfg!(any(target_os = "macos", target_os = "windows")))
+            .literal_separator(true)
+            .build()?
+            .compile_matcher();
+        Ok(Self {
+            matcher,
+            excluded,
+            match_basename,
+        })
+    }
+
+    fn includes(&self, path: &Path) -> bool {
+        let candidate = if self.match_basename {
+            path.file_name().map_or(path, Path::new)
+        } else {
+            path
+        };
+        self.matcher.is_match(candidate) != self.excluded
+    }
+}
+
+fn include_file(include: &Option<IncludeMatcher>, path: &Path) -> bool {
+    let Some(pattern) = include else {
+        return true;
+    };
+    pattern.includes(path)
+}
+
+fn path_relative_to_cwd(cwd: &Path, path: &Path) -> PathBuf {
+    let cwd = normalized_workspace_components(cwd);
+    let path = normalized_workspace_components(path);
+    let common = cwd
+        .iter()
+        .zip(&path)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut relative = PathBuf::new();
+    for _ in common..cwd.len() {
+        relative.push("..");
+    }
+    for component in &path[common..] {
+        relative.push(component);
+    }
+    if relative.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        relative
+    }
+}
+
+fn normalized_workspace_components(path: &Path) -> Vec<OsString> {
+    let mut normalized = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(component) => normalized.push(component.to_os_string()),
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+        }
+    }
+    normalized
+}
+
+struct FileScan {
+    output: String,
+    matches: usize,
+    match_truncated: bool,
+    output_truncated: bool,
+    input_truncated: bool,
+    binary: bool,
+    error: Option<String>,
+}
+
+fn scan_file(
+    file: WorkspaceFile,
+    matcher: &Regex,
+    max_matches: usize,
+    max_output_bytes: usize,
+) -> FileScan {
+    let display_path = file.display_path;
+    // Peek two bytes past the cap so a boundary LF or CRLF can be
+    // distinguished from a physical line that continues beyond the cap.
+    let mut reader = BufReader::new(file.file.take(MAX_FILE_BYTES + 2));
+    let encoding = reader.fill_buf().ok().and_then(|prefix| {
+        if prefix.starts_with(&[0xFF, 0xFE]) {
+            Some(FileEncoding::Utf16(true))
+        } else if prefix.starts_with(&[0xFE, 0xFF]) {
+            Some(FileEncoding::Utf16(false))
+        } else if prefix.starts_with(&[0xEF, 0xBB, 0xBF]) {
+            Some(FileEncoding::Utf8Bom)
+        } else {
+            None
+        }
+    });
+    let little_endian = match encoding {
+        Some(FileEncoding::Utf16(little_endian)) => little_endian,
+        Some(FileEncoding::Utf8Bom) => {
+            reader.consume(3);
+            return scan_reader(
+                reader,
+                display_path,
+                matcher,
+                max_matches,
+                max_output_bytes,
+                MAX_FILE_BYTES - 3,
+            );
+        }
+        None => {
+            return scan_reader(
+                reader,
+                display_path,
+                matcher,
+                max_matches,
+                max_output_bytes,
+                MAX_FILE_BYTES,
+            );
+        }
+    };
+
+    let mut raw = Vec::new();
+    let read_error = reader
+        .read_to_end(&mut raw)
+        .err()
+        .map(|error| format!("Failed to search {}: {error}", display_path.display()));
+    let (decoded, retained_len) = decode_utf16(&raw, little_endian);
+    let mut scan = scan_reader(
+        BufReader::new(Cursor::new(decoded)),
+        display_path,
+        matcher,
+        max_matches,
+        max_output_bytes,
+        retained_len,
+    );
+    if scan.error.is_none() {
+        scan.error = read_error;
+    }
+    scan
+}
+
+enum FileEncoding {
+    Utf8Bom,
+    Utf16(bool),
+}
+
+fn scan_reader<R: BufRead>(
+    mut reader: R,
+    display_path: PathBuf,
+    matcher: &Regex,
+    max_matches: usize,
+    max_output_bytes: usize,
+    input_limit: u64,
+) -> FileScan {
+    let mut output = String::new();
+    let mut matches = 0;
+    let mut line = Vec::new();
+    let mut line_number = 0;
+    let mut searched_bytes = 0_u64;
+    let mut input_truncated = false;
+    let mut match_truncated = false;
+    let mut output_truncated = false;
+    let mut binary = false;
+    let mut read_error = None;
+    loop {
+        line.clear();
+        let read = match reader.read_until(b'\n', &mut line) {
+            Ok(read) => read,
+            Err(error) => {
+                read_error = Some(format!(
+                    "Failed to search {}: {error}",
+                    display_path.display()
+                ));
+                break;
+            }
+        };
+        if read == 0 {
+            break;
+        }
+        if line.contains(&0) {
+            binary = true;
+            output.clear();
+            matches = 0;
+            match_truncated = false;
+            output_truncated = false;
+            break;
+        }
+        let retained_len = (input_limit.saturating_sub(searched_bytes) as usize).min(line.len());
+        searched_bytes += read as u64;
+        let matched = if retained_len < line.len() {
+            input_truncated = true;
+            if retained_len == 0 {
+                false
+            } else if line_terminator_starts_at_boundary(&line, retained_len) {
+                truncate_at_line_terminator(&mut line, retained_len);
+                matcher.is_match(&line)
+            } else {
+                let matched = has_match_within_prefix(matcher, &line, retained_len);
+                line.truncate(retained_len);
+                matched
+            }
+        } else {
+            trim_line_ending(&mut line);
+            matcher.is_match(&line)
+        };
+        line_number += 1;
+        if !matched {
+            if input_truncated {
+                break;
+            }
+            continue;
+        }
+        if matches >= max_matches {
+            match_truncated = true;
+            if input_truncated {
+                break;
+            }
+            continue;
+        }
+        if output_truncated {
+            if input_truncated {
+                break;
+            }
+            continue;
+        }
+        let rendered = String::from_utf8_lossy(&line);
+        let matched_line = format!("{}:{line_number}:{rendered}\n", display_path.display());
+        if output.len().saturating_add(matched_line.len()) > max_output_bytes {
+            output_truncated = true;
+        } else {
+            output.push_str(&matched_line);
+            matches += 1;
+        }
+        if input_truncated {
+            break;
+        }
+    }
+    FileScan {
+        output,
+        matches,
+        match_truncated,
+        output_truncated,
+        input_truncated,
+        binary,
+        error: read_error,
+    }
+}
+
+fn decode_utf16(raw: &[u8], little_endian: bool) -> (Vec<u8>, u64) {
+    let content = raw.get(2..).unwrap_or_default();
+    let decoded = decode_utf16_bytes(content, little_endian);
+    if raw.len() <= MAX_FILE_BYTES as usize {
+        let retained_len = decoded.len() as u64;
+        return (decoded.into_bytes(), retained_len);
+    }
+
+    let mut retained_end = MAX_FILE_BYTES as usize;
+    retained_end -= retained_end.saturating_sub(2) % 2;
+    if retained_end >= 4 {
+        let last = read_utf16_unit(
+            [raw[retained_end - 2], raw[retained_end - 1]],
+            little_endian,
+        );
+        if (0xD800..=0xDBFF).contains(&last) {
+            retained_end -= 2;
+        }
+    }
+    let retained = decode_utf16_bytes(&raw[2..retained_end], little_endian);
+    (decoded.into_bytes(), retained.len() as u64)
+}
+
+fn decode_utf16_bytes(bytes: &[u8], little_endian: bool) -> String {
+    let units = bytes
+        .chunks_exact(2)
+        .map(|bytes| read_utf16_unit([bytes[0], bytes[1]], little_endian))
+        .collect::<Vec<_>>();
+    let has_partial_unit = bytes.len() & 1 == 1;
+    let mut decoded = String::from_utf16_lossy(&units);
+    if has_partial_unit {
+        decoded.push(char::REPLACEMENT_CHARACTER);
+    }
+    decoded
+}
+
+fn read_utf16_unit(bytes: [u8; 2], little_endian: bool) -> u16 {
+    if little_endian {
+        u16::from_le_bytes(bytes)
+    } else {
+        u16::from_be_bytes(bytes)
+    }
+}
+
+fn trim_line_ending(line: &mut Vec<u8>) {
+    if line.last() == Some(&b'\n') {
+        line.pop();
+        if line.last() == Some(&b'\r') {
+            line.pop();
         }
     }
 }
 
+fn truncate_at_line_terminator(line: &mut Vec<u8>, retained_len: usize) {
+    let split_crlf = line.get(retained_len..) == Some(b"\n")
+        && retained_len
+            .checked_sub(1)
+            .and_then(|index| line.get(index))
+            == Some(&b'\r');
+    line.truncate(retained_len);
+    if split_crlf {
+        line.pop();
+    }
+}
+
+fn line_terminator_starts_at_boundary(line: &[u8], retained_len: usize) -> bool {
+    let omitted = &line[retained_len..];
+    omitted == b"\n" || omitted == b"\r\n"
+}
+
+fn has_match_within_prefix(matcher: &Regex, line: &[u8], retained_len: usize) -> bool {
+    matcher
+        .find_iter(line)
+        .any(|matched| matched.end() <= retained_len)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::symlink;
+
     use super::*;
-    fn test_ctx_in(dir: &std::path::Path) -> ToolContext {
-        ToolContext {
-            cwd: dir.to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.to_path_buf(),
-        }
+
+    fn test_ctx_in(directory: &Path) -> ToolContext {
+        ToolContext::new(
+            directory.to_path_buf(),
+            "test".to_string(),
+            directory.to_path_buf(),
+        )
+    }
+
+    fn mark_git_repository(directory: &Path) {
+        std::fs::create_dir(directory.join(".git")).unwrap();
     }
 
     #[tokio::test]
     async fn grep_finds_pattern() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("test.txt"), "hello world\ngoodbye world\n").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("test.txt"),
+            "hello world\ngoodbye world\n",
+        )
+        .unwrap();
 
-        let tool = GrepTool;
-        let result = tool
+        let result = GrepTool
             .invoke(
                 serde_json::json!({"pattern": "hello", "path": "."}),
-                &test_ctx_in(dir.path()),
+                &test_ctx_in(directory.path()),
             )
             .await
             .unwrap();
+
         assert!(!result.is_error);
         assert!(result.output.contains("hello"));
     }
 
     #[tokio::test]
-    async fn grep_no_match() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("test.txt"), "hello world\n").unwrap();
+    async fn grep_end_anchor_matches_before_line_endings() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("test.txt"),
+            b"unix world\nwindows world\r\nnot world!\n",
+        )
+        .unwrap();
 
-        let tool = GrepTool;
-        let result = tool
+        let result = GrepTool
             .invoke(
-                serde_json::json!({"pattern": "nonexistent_xyz", "path": "."}),
-                &test_ctx_in(dir.path()),
+                serde_json::json!({"pattern": "world$", "path": "."}),
+                &test_ctx_in(directory.path()),
             )
             .await
             .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("unix world"));
+        assert!(result.output.contains("windows world"));
+        assert!(!result.output.contains("not world!"));
+    }
+
+    #[tokio::test]
+    async fn grep_preserves_lone_and_repeated_carriage_returns() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("test.txt"),
+            b"double hit\r\r\nclean hit\nlone hit\r",
+        )
+        .unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit$", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(!result.output.contains("double hit"));
+        assert!(result.output.contains("clean hit"));
+        assert!(!result.output.contains("lone hit"));
+    }
+
+    #[test]
+    fn cut_through_line_does_not_create_an_artificial_end_match() {
+        let matcher = Regex::new("hit$").unwrap();
+        let line = b"prefix hitx\n";
+        let retained_len = "prefix hit".len();
+
+        assert!(!has_match_within_prefix(&matcher, line, retained_len));
+        assert!(!line_terminator_starts_at_boundary(line, retained_len));
+    }
+
+    #[test]
+    fn boundary_line_ending_preserves_real_end_match() {
+        let matcher = Regex::new("hit$").unwrap();
+        let mut line = b"prefix hit\r\n".to_vec();
+        let retained_len = "prefix hit".len();
+
+        assert!(line_terminator_starts_at_boundary(&line, retained_len));
+        truncate_at_line_terminator(&mut line, retained_len);
+        assert!(matcher.is_match(&line));
+    }
+
+    #[tokio::test]
+    async fn grep_no_match() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("test.txt"), "hello world\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "nonexistent_xyz", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
         assert!(!result.is_error);
         assert!(result.output.contains("No matches"));
+        assert!(!result.output.contains("omitted"));
+    }
+
+    #[tokio::test]
+    async fn grep_reports_match_limit_only_after_an_extra_match() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("matches.txt");
+        let content = (0..MAX_MATCHES)
+            .map(|index| format!("hit {index}\n"))
+            .collect::<String>();
+        std::fs::write(&path, &content).unwrap();
+
+        let complete = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "matches.txt"}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+        std::fs::write(&path, format!("{content}hit extra\n")).unwrap();
+        let truncated = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "matches.txt"}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!complete.is_error, "{}", complete.output);
+        assert!(!complete.output.contains("omitted"), "{}", complete.output);
+        assert!(!truncated.is_error, "{}", truncated.output);
+        assert!(truncated.output.contains("additional grep results omitted"));
+    }
+
+    #[tokio::test]
+    async fn grep_reports_when_no_match_result_is_incomplete() {
+        let directory = tempfile::tempdir().unwrap();
+        for index in 0..=MAX_FILES {
+            std::fs::write(directory.path().join(format!("{index:03}.txt")), "text\n").unwrap();
+        }
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "not-present", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("searched subset"));
+        assert!(result.output.contains("additional grep results omitted"));
+    }
+
+    #[tokio::test]
+    async fn grep_reports_match_omitted_by_output_limit() {
+        let directory = tempfile::tempdir().unwrap();
+        let content = format!("hit{}\n", "x".repeat(MAX_OUTPUT_BYTES));
+        std::fs::write(directory.path().join("large-line.txt"), content).unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("searched subset"));
+        assert!(result.output.contains("additional grep results omitted"));
+    }
+
+    #[tokio::test]
+    async fn grep_reports_file_truncated_by_input_limit() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut content = vec![b'x'; MAX_FILE_BYTES as usize];
+        content.extend_from_slice(b"hit\n");
+        std::fs::write(directory.path().join("large.txt"), content).unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("searched subset"));
+        assert!(result.output.contains("additional grep results omitted"));
     }
 
     #[tokio::test]
     async fn grep_with_include() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("test.rs"), "fn main() {}\n").unwrap();
-        std::fs::write(dir.path().join("test.txt"), "fn main() {}\n").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("test.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(directory.path().join("test.txt"), "fn main() {}\n").unwrap();
 
-        let tool = GrepTool;
-        let result = tool
+        let result = GrepTool
             .invoke(
-                serde_json::json!({"pattern": "fn main", "path": ".", "include": "*.rs"}),
-                &test_ctx_in(dir.path()),
+                serde_json::json!({
+                    "pattern": "fn main",
+                    "path": ".",
+                    "include": "*.rs"
+                }),
+                &test_ctx_in(directory.path()),
             )
             .await
             .unwrap();
+
         assert!(!result.is_error);
         assert!(result.output.contains("test.rs"));
+        assert!(!result.output.contains("test.txt"));
+    }
+
+    #[tokio::test]
+    async fn grep_matches_include_relative_to_shell_cwd() {
+        let directory = tempfile::tempdir().unwrap();
+        let cwd = directory.path().join("sub");
+        let source = cwd.join("src");
+        let nested = source.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(source.join("main.rs"), "hit\n").unwrap();
+        std::fs::write(nested.join("nested.rs"), "hit\n").unwrap();
+        let context = ToolContext::new(cwd, "test".to_string(), directory.path().to_path_buf());
+
+        let prefixed = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "hit",
+                    "path": "src",
+                    "include": "src/*.rs"
+                }),
+                &context,
+            )
+            .await
+            .unwrap();
+        let anchored = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "hit",
+                    "path": "src",
+                    "include": "/src/*.rs"
+                }),
+                &context,
+            )
+            .await
+            .unwrap();
+        let basename = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "hit",
+                    "path": "src",
+                    "include": "*.rs"
+                }),
+                &context,
+            )
+            .await
+            .unwrap();
+
+        assert!(!prefixed.is_error, "{}", prefixed.output);
+        assert!(prefixed.output.contains("main.rs"));
+        assert!(!prefixed.output.contains("nested.rs"));
+        assert!(!anchored.is_error, "{}", anchored.output);
+        assert!(anchored.output.contains("main.rs"));
+        assert!(!anchored.output.contains("nested.rs"));
+        assert!(!basename.is_error, "{}", basename.output);
+        assert!(basename.output.contains("main.rs"));
+        assert!(basename.output.contains("nested.rs"));
+    }
+
+    #[tokio::test]
+    async fn grep_does_not_filter_an_explicit_file_with_include() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("main.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "hit",
+                    "path": "main.rs",
+                    "include": "*.txt"
+                }),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("main.rs"));
+        assert!(result.output.contains("hit"));
+    }
+
+    #[tokio::test]
+    async fn grep_include_preserves_braces_and_exclusions() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("test.rs"), "hit\n").unwrap();
+        std::fs::write(directory.path().join("test.ts"), "hit\n").unwrap();
+        std::fs::write(directory.path().join("test.txt"), "hit\n").unwrap();
+
+        let included = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "hit",
+                    "path": ".",
+                    "include": "*.{rs,ts}"
+                }),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+        let excluded = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "hit",
+                    "path": ".",
+                    "include": "!*.rs"
+                }),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(included.output.contains("test.rs"));
+        assert!(included.output.contains("test.ts"));
+        assert!(!included.output.contains("test.txt"));
+        assert!(!excluded.output.contains("test.rs"));
+        assert!(excluded.output.contains("test.ts"));
+        assert!(excluded.output.contains("test.txt"));
+    }
+
+    #[tokio::test]
+    async fn grep_skips_hidden_and_gitignored_trees_before_file_limits() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        let hidden = directory.path().join(".cache");
+        let ignored = directory.path().join("build");
+        let source = directory.path().join("src");
+        std::fs::create_dir(&hidden).unwrap();
+        std::fs::create_dir(&ignored).unwrap();
+        std::fs::create_dir(&source).unwrap();
+        std::fs::write(directory.path().join(".gitignore"), "build/\n").unwrap();
+        for index in 0..=MAX_FILES {
+            std::fs::write(hidden.join(format!("{index:03}.txt")), "hit\n").unwrap();
+            std::fs::write(ignored.join(format!("{index:03}.txt")), "hit\n").unwrap();
+        }
+        std::fs::write(source.join("main.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("src/main.rs"));
+        assert!(!result.output.contains(".cache"));
+        assert!(!result.output.contains("build/"));
+        assert!(!result.output.contains("omitted"));
+    }
+
+    #[tokio::test]
+    async fn positive_include_overrides_ignore_rules() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        std::fs::write(directory.path().join(".gitignore"), "generated.rs\n").unwrap();
+        std::fs::write(directory.path().join("generated.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "hit",
+                    "path": ".",
+                    "include": "*.rs"
+                }),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("generated.rs"));
+    }
+
+    #[tokio::test]
+    async fn nested_search_loads_parent_ignore_rules() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        let generated = directory.path().join("src/generated");
+        std::fs::create_dir_all(&generated).unwrap();
+        std::fs::write(directory.path().join(".gitignore"), "src/generated/\n").unwrap();
+        for index in 0..=MAX_FILES {
+            std::fs::write(generated.join(format!("{index:03}.rs")), "hit\n").unwrap();
+        }
+        std::fs::write(directory.path().join("src/main.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "src"}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("src/main.rs"));
+        assert!(!result.output.contains("src/generated"));
+        assert!(!result.output.contains("omitted"));
+    }
+
+    #[tokio::test]
+    async fn parent_search_normalizes_paths_for_ignore_matching() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        let source = directory.path().join("src");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::write(directory.path().join(".gitignore"), "/generated.txt\n").unwrap();
+        std::fs::write(source.join(".gitignore"), "/visible.txt\n").unwrap();
+        std::fs::write(directory.path().join("generated.txt"), "hit generated\n").unwrap();
+        std::fs::write(directory.path().join("visible.txt"), "hit visible\n").unwrap();
+        let context = ToolContext::new(source, "test".to_string(), directory.path().to_path_buf());
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": ".."}),
+                &context,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(
+            !result.output.contains("hit generated"),
+            "{}",
+            result.output
+        );
+        assert!(result.output.contains("hit visible"), "{}", result.output);
+    }
+
+    #[tokio::test]
+    async fn grep_honors_hidden_path_whitelists() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        std::fs::write(directory.path().join(".gitignore"), "!.generated.rs\n").unwrap();
+        std::fs::write(directory.path().join(".generated.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains(".generated.rs"));
+    }
+
+    #[tokio::test]
+    async fn grep_loads_rgignore_after_gitignore() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        std::fs::write(directory.path().join(".gitignore"), "generated.rs\n").unwrap();
+        std::fs::write(directory.path().join(".rgignore"), "!generated.rs\n").unwrap();
+        std::fs::write(directory.path().join("generated.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("generated.rs"));
+    }
+
+    #[tokio::test]
+    async fn grep_requires_repository_marker_for_gitignore() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join(".gitignore"), "git-only.txt\n").unwrap();
+        std::fs::write(directory.path().join(".ignore"), "always.txt\n").unwrap();
+        std::fs::write(directory.path().join("git-only.txt"), "hit git\n").unwrap();
+        std::fs::write(directory.path().join("always.txt"), "hit always\n").unwrap();
+        std::fs::write(directory.path().join("visible.txt"), "hit visible\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("git-only.txt"));
+        assert!(!result.output.contains("always.txt"));
+        assert!(result.output.contains("visible.txt"));
+    }
+
+    #[tokio::test]
+    async fn nested_git_repository_stops_parent_gitignore_rules() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        let nested = directory.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        mark_git_repository(&nested);
+        std::fs::write(directory.path().join(".gitignore"), "blocked.txt\n").unwrap();
+        let root_blocked = directory.path().join("blocked.txt");
+        let nested_blocked = nested.join("blocked.txt");
+        std::fs::write(&root_blocked, "hit root\n").unwrap();
+        std::fs::write(&nested_blocked, "hit nested\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(!result.output.contains("hit root"), "{}", result.output);
+        assert!(result.output.contains("hit nested"), "{}", result.output);
+    }
+
+    #[tokio::test]
+    async fn grep_respects_repository_exclude_with_lowest_precedence() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        std::fs::create_dir_all(directory.path().join(".git/info")).unwrap();
+        std::fs::write(
+            directory.path().join(".git/info/exclude"),
+            "excluded.txt\nrestored.txt\n",
+        )
+        .unwrap();
+        std::fs::write(directory.path().join(".gitignore"), "!restored.txt\n").unwrap();
+        std::fs::write(directory.path().join("excluded.txt"), "hit excluded\n").unwrap();
+        std::fs::write(directory.path().join("restored.txt"), "hit restored\n").unwrap();
+        std::fs::write(directory.path().join("visible.txt"), "hit visible\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(!result.output.contains("hit excluded"), "{}", result.output);
+        assert!(result.output.contains("hit restored"), "{}", result.output);
+        assert!(result.output.contains("hit visible"), "{}", result.output);
+    }
+
+    #[tokio::test]
+    async fn grep_continues_with_non_utf8_ignore_rules() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        std::fs::write(directory.path().join(".gitignore"), b"\xff\n").unwrap();
+        std::fs::write(directory.path().join("main.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("main.rs"));
+        assert!(result.output.contains(IGNORE_RULE_WARNING));
+        assert!(!result.output.contains("output limits"));
+    }
+
+    #[tokio::test]
+    async fn grep_loads_later_ignore_sources_after_an_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if nix::unistd::Uid::effective().as_raw() == 0 {
+            return;
+        }
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        let gitignore = directory.path().join(".gitignore");
+        std::fs::write(&gitignore, "unused.txt\n").unwrap();
+        std::fs::set_permissions(&gitignore, std::fs::Permissions::from_mode(0o000)).unwrap();
+        std::fs::write(directory.path().join(".ignore"), "generated.txt\n").unwrap();
+        std::fs::write(directory.path().join("generated.txt"), "hit generated\n").unwrap();
+        std::fs::write(directory.path().join("visible.txt"), "hit visible\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+        std::fs::set_permissions(&gitignore, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(
+            !result.output.contains("hit generated"),
+            "{}",
+            result.output
+        );
+        assert!(result.output.contains("hit visible"), "{}", result.output);
+        assert!(result.output.contains(IGNORE_RULE_WARNING));
+    }
+
+    #[tokio::test]
+    async fn grep_reports_malformed_ignore_rules_and_continues() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        std::fs::write(directory.path().join(".gitignore"), "[z-a]\nignored.txt\n").unwrap();
+        std::fs::write(directory.path().join("ignored.txt"), "hit ignored\n").unwrap();
+        std::fs::write(directory.path().join("main.rs"), "hit main\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("main.rs"));
+        assert!(!result.output.contains("ignored.txt"));
+        assert!(result.output.contains(IGNORE_RULE_WARNING));
+        assert!(!result.output.contains("output limits"));
+    }
+
+    #[tokio::test]
+    async fn grep_bounds_ignore_file_memory() {
+        let directory = tempfile::tempdir().unwrap();
+        mark_git_repository(directory.path());
+        std::fs::write(
+            directory.path().join(".gitignore"),
+            vec![b'x'; 1024 * 1024 + 1],
+        )
+        .unwrap();
+        std::fs::write(directory.path().join("main.rs"), "hit\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("main.rs"));
+        assert!(result.output.contains(IGNORE_RULE_WARNING));
+    }
+
+    #[tokio::test]
+    async fn grep_discards_matches_from_binary_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let binary = format!("{}\0hit after\n", "hit before\n".repeat(MAX_MATCHES));
+        std::fs::write(directory.path().join("binary.dat"), binary).unwrap();
+        std::fs::write(directory.path().join("text.txt"), "hit text\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(!result.output.contains("binary.dat"));
+        assert!(result.output.contains("text.txt"));
+        assert!(result.output.contains("hit text"));
+    }
+
+    #[tokio::test]
+    async fn grep_decodes_utf16_bom_files() {
+        let directory = tempfile::tempdir().unwrap();
+        for (name, little_endian) in [("little.txt", true), ("big.txt", false)] {
+            let mut content = if little_endian {
+                vec![0xFF, 0xFE]
+            } else {
+                vec![0xFE, 0xFF]
+            };
+            for unit in "hit text\n".encode_utf16() {
+                let bytes = if little_endian {
+                    unit.to_le_bytes()
+                } else {
+                    unit.to_be_bytes()
+                };
+                content.extend_from_slice(&bytes);
+            }
+            std::fs::write(directory.path().join(name), content).unwrap();
+        }
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "hit", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("little.txt"));
+        assert!(result.output.contains("big.txt"));
+        assert!(result.output.contains("hit text"));
+    }
+
+    #[tokio::test]
+    async fn grep_strips_utf8_bom_before_matching() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("bom.txt"), b"\xEF\xBB\xBFhello\n").unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "^hello$", "path": "."}),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("bom.txt:1:hello"));
+    }
+
+    #[test]
+    fn grep_reports_file_read_errors_as_incomplete_results() {
+        let root = Path::new("/proc/self");
+        if !root.join("mem").exists() {
+            return;
+        }
+        let Ok(workspace) = WorkspaceFs::new(root) else {
+            return;
+        };
+
+        let result = grep_workspace("hit", "mem", None, root, &workspace).unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("searched subset"));
+        assert!(result.output.contains("[file errors]"));
+    }
+
+    #[tokio::test]
+    async fn grep_include_skips_unreadable_nonmatching_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("test.rs"), "fn main() {}\n").unwrap();
+        let excluded = directory.path().join(".env");
+        std::fs::write(&excluded, "SECRET=value\n").unwrap();
+        std::fs::set_permissions(&excluded, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({
+                    "pattern": "fn main",
+                    "path": ".",
+                    "include": "*.rs"
+                }),
+                &test_ctx_in(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("test.rs"));
+        assert!(!result.output.contains(".env"));
+    }
+
+    #[tokio::test]
+    async fn rejects_exact_symlink_that_escapes_workspace() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(parent.path().join("outside.txt"), "secret\n").unwrap();
+        symlink(parent.path().join("outside.txt"), root.join("outside-link")).unwrap();
+
+        let result = GrepTool
+            .invoke(
+                serde_json::json!({"pattern": "secret", "path": "outside-link"}),
+                &test_ctx_in(&root),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("escapes workspace root"));
+        assert!(!result.output.contains("secret\n"));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/list_directory.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/list_directory.rs
@@ -1,9 +1,14 @@
 //! Non-recursive directory listing.
 
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use std::path::Path;
+
 use async_trait::async_trait;
+use rustix::fs::{Dir, FileType};
 use serde_json::Value;
 
-use super::file_patterns::resolve_path;
+use super::workspace_fs::WorkspaceFs;
 use super::{Tool, ToolContext, ToolKind, ToolResult};
 
 const MAX_ENTRIES: usize = 200;
@@ -37,50 +42,82 @@ impl Tool for ListDirectoryTool {
     }
 
     async fn invoke(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
-        let path = resolve_path(
-            params.get("path").and_then(Value::as_str).unwrap_or("."),
-            &ctx.cwd,
-        );
-        if !path.is_dir() {
-            return Ok(ToolResult::error(format!(
-                "Path is not a directory: {}",
-                path.display()
-            )));
-        }
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or(".")
+            .to_string();
+        let cwd = ctx.cwd.clone();
+        let workspace = ctx.workspace()?;
 
-        let mut reader = tokio::fs::read_dir(&path)
+        tokio::task::spawn_blocking(move || list_workspace_directory(&workspace, &cwd, &path))
             .await
-            .map_err(|error| format!("Failed to list {}: {error}", path.display()))?;
-        let mut entries = Vec::new();
-        while let Some(entry) = reader
-            .next_entry()
-            .await
-            .map_err(|error| format!("Failed to list {}: {error}", path.display()))?
-        {
-            let file_type = entry.file_type().await.map_err(|error| {
-                format!("Failed to inspect {}: {error}", entry.path().display())
-            })?;
-            let suffix = if file_type.is_dir() { "/" } else { "" };
-            entries.push(format!("{}{}", entry.file_name().to_string_lossy(), suffix));
-        }
-        entries.sort_unstable();
-
-        let total = entries.len();
-        entries.truncate(MAX_ENTRIES);
-        let mut output = if entries.is_empty() {
-            format!("Directory is empty: {}", path.display())
-        } else {
-            entries.join("\n")
-        };
-        if total > MAX_ENTRIES {
-            output.push_str(&format!("\n\n... {} entries omitted", total - MAX_ENTRIES));
-        }
-        Ok(ToolResult::success(output))
+            .map_err(|error| format!("Directory listing task failed: {error}"))?
     }
+}
+
+fn list_workspace_directory(
+    workspace: &WorkspaceFs,
+    cwd: &Path,
+    path: &str,
+) -> Result<ToolResult, String> {
+    let directory = match workspace.open_directory(cwd, path) {
+        Ok(directory) => directory,
+        Err(error) => return Ok(ToolResult::error(error)),
+    };
+    let relative_path = directory.relative_path.clone();
+    let display_path = directory.display_path;
+    let reader = Dir::read_from(&directory.file)
+        .map_err(|error| format!("Failed to list {}: {error}", display_path.display()))?;
+    let mut entries = Vec::new();
+    for entry in reader {
+        let entry =
+            entry.map_err(|error| format!("Failed to list {}: {error}", display_path.display()))?;
+        let name = OsString::from_vec(entry.file_name().to_bytes().to_vec());
+        if name == "." || name == ".." {
+            continue;
+        }
+        let suffix = if is_directory_entry(workspace, &relative_path, &name, entry.file_type()) {
+            "/"
+        } else {
+            ""
+        };
+        entries.push(format!("{}{suffix}", name.to_string_lossy()));
+    }
+    entries.sort_unstable();
+
+    let total = entries.len();
+    entries.truncate(MAX_ENTRIES);
+    let mut output = if entries.is_empty() {
+        format!("Directory is empty: {}", display_path.display())
+    } else {
+        entries.join("\n")
+    };
+    if total > MAX_ENTRIES {
+        output.push_str(&format!("\n\n... {} entries omitted", total - MAX_ENTRIES));
+    }
+    Ok(ToolResult::success(output))
+}
+
+fn is_directory_entry(
+    workspace: &WorkspaceFs,
+    directory: &Path,
+    name: &OsString,
+    file_type: FileType,
+) -> bool {
+    if file_type == FileType::Directory {
+        return true;
+    }
+    if file_type != FileType::Unknown {
+        return false;
+    }
+    workspace.is_relative_directory(&directory.join(name))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::symlink;
+
     use super::*;
 
     #[tokio::test]
@@ -88,11 +125,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir(dir.path().join("src")).unwrap();
         std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
-        let ctx = ToolContext {
-            cwd: dir.path().to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.path().to_path_buf(),
-        };
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
 
         let result = ListDirectoryTool
             .invoke(serde_json::json!({}), &ctx)
@@ -100,5 +137,45 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.output, "Cargo.toml\nsrc/");
+    }
+
+    #[tokio::test]
+    async fn rejects_directory_symlink_that_escapes_workspace() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        let outside = parent.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+        symlink(&outside, root.join("outside-link")).unwrap();
+        let ctx = ToolContext::new(root.clone(), "test".to_string(), root);
+
+        let result = ListDirectoryTool
+            .invoke(serde_json::json!({"path": "outside-link"}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("escapes workspace root"));
+        assert!(!result.output.contains("secret.txt"));
+    }
+
+    #[test]
+    fn resolves_unknown_directory_entry_types() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let nested = directory.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::set_permissions(&nested, std::fs::Permissions::from_mode(0o111)).unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+
+        assert!(is_directory_entry(
+            &workspace,
+            Path::new("."),
+            &OsString::from("nested"),
+            FileType::Unknown,
+        ));
+        std::fs::set_permissions(&nested, std::fs::Permissions::from_mode(0o700)).unwrap();
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/mcp.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mcp.rs
@@ -985,11 +985,11 @@ mod tests {
     use super::*;
 
     fn test_context() -> ToolContext {
-        ToolContext {
-            cwd: PathBuf::from("/tmp"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/tmp"),
-        }
+        ToolContext::new(
+            PathBuf::from("/tmp"),
+            "test".to_string(),
+            PathBuf::from("/tmp"),
+        )
     }
 
     fn fake_server(script: &str) -> (tempfile::TempDir, McpServerConfig) {

--- a/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
@@ -14,11 +14,13 @@ pub mod shell_evidence;
 pub mod skill;
 pub mod todo;
 mod web_fetch;
+mod workspace_fs;
 pub mod write_file;
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -89,6 +91,99 @@ pub struct ToolContext {
     pub session_id: String,
     #[allow(dead_code)]
     pub project_root: PathBuf,
+    workspace: SessionWorkspace,
+}
+
+#[derive(Clone)]
+pub(crate) struct SessionWorkspace {
+    root: Arc<PathBuf>,
+    pinned: Arc<OnceLock<Arc<workspace_fs::WorkspaceFs>>>,
+    permanent_error: Option<Arc<str>>,
+    retry_missing: bool,
+}
+
+impl SessionWorkspace {
+    pub(crate) fn try_new(root: &Path) -> Result<Self, String> {
+        let workspace = Self::new(root);
+        if let Some(error) = &workspace.permanent_error {
+            Err(error.to_string())
+        } else {
+            Ok(workspace)
+        }
+    }
+
+    pub(crate) fn new(root: &Path) -> Self {
+        let pinned = Arc::new(OnceLock::new());
+        let (permanent_error, retry_missing) = match workspace_fs::WorkspaceFs::open_root(root) {
+            Ok(workspace) => {
+                let _ = pinned.set(Arc::new(workspace));
+                (None, false)
+            }
+            Err(workspace_fs::WorkspaceRootError::Missing(_)) => (None, true),
+            Err(workspace_fs::WorkspaceRootError::Permanent(error)) => (Some(error.into()), false),
+        };
+        Self {
+            root: Arc::new(root.to_path_buf()),
+            pinned,
+            permanent_error,
+            retry_missing,
+        }
+    }
+
+    /// Returns the identity derived from the pinned root when available.
+    pub(crate) fn root(&self) -> &Path {
+        self.pinned
+            .get()
+            .map_or(self.root.as_path(), |workspace| workspace.root())
+    }
+
+    fn get(&self) -> Result<Arc<workspace_fs::WorkspaceFs>, String> {
+        if let Some(workspace) = self.pinned.get() {
+            return Ok(Arc::clone(workspace));
+        }
+        if let Some(error) = &self.permanent_error {
+            return Err(error.to_string());
+        }
+        if !self.retry_missing {
+            return Err("workspace root is unavailable".to_string());
+        }
+
+        let workspace = Arc::new(
+            workspace_fs::WorkspaceFs::open_root(&self.root).map_err(|error| error.to_string())?,
+        );
+        let _ = self.pinned.set(Arc::clone(&workspace));
+        Ok(self.pinned.get().map_or(workspace, Arc::clone))
+    }
+}
+
+impl ToolContext {
+    pub(crate) fn new(cwd: PathBuf, session_id: String, project_root: PathBuf) -> Self {
+        let workspace = SessionWorkspace::new(&project_root);
+        Self {
+            cwd,
+            session_id,
+            project_root,
+            workspace,
+        }
+    }
+
+    pub(crate) fn with_workspace(
+        cwd: PathBuf,
+        session_id: String,
+        project_root: PathBuf,
+        workspace: SessionWorkspace,
+    ) -> Self {
+        Self {
+            cwd,
+            session_id,
+            project_root,
+            workspace,
+        }
+    }
+
+    fn workspace(&self) -> Result<Arc<workspace_fs::WorkspaceFs>, String> {
+        self.workspace.get()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -436,17 +531,30 @@ mod tests {
     #[tokio::test]
     async fn tool_invoke() {
         let tool = DummyTool;
-        let ctx = ToolContext {
-            cwd: PathBuf::from("/tmp"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/tmp"),
-        };
+        let ctx = ToolContext::new(
+            PathBuf::from("/tmp"),
+            "test".to_string(),
+            PathBuf::from("/tmp"),
+        );
         let result = tool
             .invoke(serde_json::json!({"input": "hello"}), &ctx)
             .await
             .unwrap();
         assert_eq!(result.output, "echo: hello");
         assert!(!result.is_error);
+    }
+
+    #[test]
+    fn missing_workspace_is_pinned_after_creation() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        let workspace = SessionWorkspace::new(&root);
+        assert!(workspace.get().is_err());
+
+        std::fs::create_dir(&root).unwrap();
+        let pinned = workspace.get().unwrap();
+
+        assert!(pinned.open_directory(&root, ".").is_ok());
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/tool/read_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/read_file.rs
@@ -71,27 +71,24 @@ impl Tool for ReadFileTool {
         let path_str = params
             .get("path")
             .and_then(|v| v.as_str())
-            .ok_or("missing 'path' parameter")?;
+            .ok_or("missing 'path' parameter")?
+            .to_string();
 
         if path_str.starts_with("terminal-output://") {
             return Ok(ToolResult::error(self.terminal_output_guidance));
         }
 
-        let path = resolve_path(path_str, &ctx.cwd);
-
-        if !path.exists() {
-            return Ok(ToolResult::error(format!(
-                "File not found: {}",
-                path.display()
-            )));
-        }
-        if !path.is_file() {
-            return Ok(ToolResult::error(format!("Not a file: {}", path.display())));
-        }
-
-        let file = tokio::fs::File::open(&path)
+        let cwd = ctx.cwd.clone();
+        let workspace = ctx.workspace()?;
+        let opened = tokio::task::spawn_blocking(move || workspace.open_file(&cwd, &path_str))
             .await
-            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+            .map_err(|error| format!("Read-file open task failed: {error}"))?;
+        let opened = match opened {
+            Ok(opened) => opened,
+            Err(error) => return Ok(ToolResult::error(error)),
+        };
+        let path = opened.display_path;
+        let file = tokio::fs::File::from_std(opened.file);
         let metadata = file
             .metadata()
             .await
@@ -153,34 +150,27 @@ impl Tool for ReadFileTool {
     }
 }
 
-// resolve_path is provided by the parent module (super::resolve_path)
-// and supports ~ expansion.
-use super::resolve_path;
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
-    use tempfile::NamedTempFile;
+    use std::os::unix::fs::symlink;
+    use std::path::Path;
 
-    fn test_ctx() -> ToolContext {
-        ToolContext {
-            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")),
-            session_id: "test".to_string(),
-            project_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")),
-        }
+    fn test_ctx(root: &Path) -> ToolContext {
+        ToolContext::new(root.to_path_buf(), "test".to_string(), root.to_path_buf())
     }
 
     #[tokio::test]
     async fn read_existing_file() {
-        let tmp = NamedTempFile::new().unwrap();
-        std::fs::write(tmp.path(), "line1\nline2\nline3\n").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("input.txt");
+        std::fs::write(&path, "line1\nline2\nline3\n").unwrap();
 
         let tool = ReadFileTool::new();
         let result = tool
             .invoke(
-                serde_json::json!({"path": tmp.path().to_str().unwrap()}),
-                &test_ctx(),
+                serde_json::json!({"path": path.to_str().unwrap()}),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
@@ -192,14 +182,15 @@ mod tests {
 
     #[tokio::test]
     async fn read_with_offset_and_limit() {
-        let tmp = NamedTempFile::new().unwrap();
-        std::fs::write(tmp.path(), "a\nb\nc\nd\ne\n").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("input.txt");
+        std::fs::write(&path, "a\nb\nc\nd\ne\n").unwrap();
 
         let tool = ReadFileTool::new();
         let result = tool
             .invoke(
-                serde_json::json!({"path": tmp.path().to_str().unwrap(), "offset": 1, "limit": 2}),
-                &test_ctx(),
+                serde_json::json!({"path": path.to_str().unwrap(), "offset": 1, "limit": 2}),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
@@ -211,14 +202,18 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_file_larger_than_limit() {
-        let tmp = NamedTempFile::new().unwrap();
-        tmp.as_file().set_len((MAX_FILE_BYTES + 1) as u64).unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("large.txt");
+        std::fs::File::create(&path)
+            .unwrap()
+            .set_len((MAX_FILE_BYTES + 1) as u64)
+            .unwrap();
 
         let tool = ReadFileTool::new();
         let result = tool
             .invoke(
-                serde_json::json!({"path": tmp.path().to_str().unwrap()}),
-                &test_ctx(),
+                serde_json::json!({"path": path.to_str().unwrap()}),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
@@ -229,11 +224,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_nonexistent_file() {
+        let directory = tempfile::tempdir().unwrap();
         let tool = ReadFileTool::new();
         let result = tool
             .invoke(
-                serde_json::json!({"path": "/tmp/definitely_not_a_real_file_xyz"}),
-                &test_ctx(),
+                serde_json::json!({"path": "definitely_not_a_real_file_xyz"}),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
@@ -242,12 +238,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn follows_internal_symlink_and_rejects_external_symlink() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("inside.txt"), "inside").unwrap();
+        std::fs::write(parent.path().join("outside.txt"), "outside").unwrap();
+        symlink("inside.txt", root.join("inside-link")).unwrap();
+        symlink(parent.path().join("outside.txt"), root.join("outside-link")).unwrap();
+        let tool = ReadFileTool::new();
+
+        let result = tool
+            .invoke(serde_json::json!({"path": "inside-link"}), &test_ctx(&root))
+            .await
+            .unwrap();
+        assert!(result.output.contains("inside"));
+
+        let result = tool
+            .invoke(
+                serde_json::json!({"path": "outside-link"}),
+                &test_ctx(&root),
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(
+            result.output.contains("escapes workspace root"),
+            "{}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn reuses_workspace_pinned_when_context_is_created() {
+        let parent = tempfile::tempdir().unwrap();
+        let container = parent.path().join("container");
+        let root = container.join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("value.txt"), "trusted").unwrap();
+        let ctx = test_ctx(&root);
+
+        let moved = parent.path().join("moved");
+        std::fs::rename(&container, &moved).unwrap();
+        let replacement = parent.path().join("replacement");
+        std::fs::create_dir_all(replacement.join("workspace")).unwrap();
+        std::fs::write(replacement.join("workspace/value.txt"), "outside").unwrap();
+        symlink(&replacement, &container).unwrap();
+
+        let result = ReadFileTool::new()
+            .invoke(serde_json::json!({"path": "value.txt"}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(result.output.contains("trusted"));
+        assert!(!result.output.contains("outside"));
+    }
+
+    #[tokio::test]
     async fn read_terminal_output_ref_fails_closed() {
         let tool = ReadFileTool::with_shell_evidence_tool_guidance();
         let result = tool
             .invoke(
                 serde_json::json!({"path": "terminal-output://raw-session/cmd-1"}),
-                &test_ctx(),
+                &test_ctx(Path::new("/tmp")),
             )
             .await
             .unwrap();
@@ -267,7 +320,7 @@ mod tests {
         let result = tool
             .invoke(
                 serde_json::json!({"path": "terminal-output://raw-session/cmd-1"}),
-                &test_ctx(),
+                &test_ctx(Path::new("/tmp")),
             )
             .await
             .unwrap();

--- a/src/cosh-ng/crates/cosh-core/src/tool/read_many_files.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/read_many_files.rs
@@ -1,12 +1,12 @@
 //! Bounded multi-file reads with optional glob expansion.
 
-use std::path::Path;
+use std::fs::File;
 
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::io::AsyncReadExt;
 
-use super::file_patterns::expand_file_patterns;
+use super::file_patterns::expand_file_paths;
 use super::{Tool, ToolContext, ToolKind, ToolResult};
 
 const MAX_FILES: usize = 50;
@@ -61,18 +61,41 @@ impl Tool for ReadManyFilesTool {
         }
 
         let cwd = ctx.cwd.clone();
-        let matches =
-            tokio::task::spawn_blocking(move || expand_file_patterns(&patterns, &cwd, MAX_FILES))
-                .await
-                .map_err(|error| format!("File discovery task failed: {error}"))??;
+        let workspace = ctx.workspace()?;
+        let discovery_workspace = workspace.clone();
+        let matches = tokio::task::spawn_blocking(move || {
+            expand_file_paths(&patterns, &cwd, &discovery_workspace, MAX_FILES)
+        })
+        .await
+        .map_err(|error| format!("File discovery task failed: {error}"))?;
+        let matches = match matches {
+            Ok(matches) => matches,
+            Err(error) => return Ok(ToolResult::error(error)),
+        };
+        let mut skipped = matches.skipped;
         if matches.paths.is_empty() {
-            return Ok(ToolResult::success("No matching files found."));
+            let mut output = no_matching_files_output(matches.truncated).to_string();
+            append_skipped_files(&mut output, &skipped);
+            return Ok(ToolResult::success(output));
         }
 
         let mut output = String::new();
-        let mut skipped = Vec::new();
-        for path in &matches.paths {
-            let (bytes, file_truncated) = match read_bounded(path).await {
+        for path in matches.paths {
+            let open_workspace = workspace.clone();
+            let open_path = path.clone();
+            let file = match tokio::task::spawn_blocking(move || {
+                open_workspace.open_display_file(&open_path)
+            })
+            .await
+            .map_err(|error| format!("File open task failed: {error}"))?
+            {
+                Ok(file) => file.file,
+                Err(error) => {
+                    skipped.push(format!("{}: {error}", path.display()));
+                    continue;
+                }
+            };
+            let (bytes, file_truncated) = match read_bounded(file).await {
                 Ok(result) => result,
                 Err(error) => {
                     skipped.push(format!("{}: {error}", path.display()));
@@ -104,17 +127,31 @@ impl Tool for ReadManyFilesTool {
         if matches.truncated || output.len() >= MAX_TOTAL_BYTES {
             output.push_str("\n[additional files omitted by output limits]\n");
         }
-        if !skipped.is_empty() {
-            output.push_str("\nSkipped files:\n");
-            output.push_str(&skipped.join("\n"));
-            output.push('\n');
-        }
+        append_skipped_files(&mut output, &skipped);
         Ok(ToolResult::success(output))
     }
 }
 
-async fn read_bounded(path: &Path) -> Result<(Vec<u8>, bool), std::io::Error> {
-    let file = tokio::fs::File::open(path).await?;
+fn append_skipped_files(output: &mut String, skipped: &[String]) {
+    if skipped.is_empty() {
+        return;
+    }
+    output.push_str("\nSkipped files:\n");
+    output.push_str(&skipped.join("\n"));
+    output.push('\n');
+}
+
+fn no_matching_files_output(truncated: bool) -> &'static str {
+    if truncated {
+        "No matching files found in the searched subset.\n\n\
+         [additional files omitted by output limits]\n"
+    } else {
+        "No matching files found."
+    }
+}
+
+async fn read_bounded(file: File) -> Result<(Vec<u8>, bool), std::io::Error> {
+    let file = tokio::fs::File::from_std(file);
     let mut reader = file.take((MAX_FILE_BYTES + 1) as u64);
     let mut bytes = Vec::with_capacity(MAX_FILE_BYTES + 1);
     reader.read_to_end(&mut bytes).await?;
@@ -138,6 +175,8 @@ fn text_prefix(bytes: &[u8]) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::symlink;
+
     use super::*;
 
     #[tokio::test]
@@ -145,11 +184,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a.txt"), "alpha").unwrap();
         std::fs::write(dir.path().join("b.txt"), "beta").unwrap();
-        let ctx = ToolContext {
-            cwd: dir.path().to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.path().to_path_buf(),
-        };
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
 
         let result = ReadManyFilesTool
             .invoke(serde_json::json!({"paths": ["*.txt"]}), &ctx)
@@ -163,12 +202,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reads_file_limit_after_path_only_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        for index in 0..MAX_FILES {
+            std::fs::write(dir.path().join(format!("{index:02}.txt")), "text").unwrap();
+        }
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
+
+        let result = ReadManyFilesTool
+            .invoke(serde_json::json!({"paths": ["."]}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert_eq!(result.output.matches("--- ").count(), MAX_FILES);
+        assert!(!result.output.contains("additional files omitted"));
+    }
+
+    #[tokio::test]
     async fn bounds_large_files_during_read() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("large.txt");
         std::fs::write(&path, vec![b'x'; MAX_FILE_BYTES * 4]).unwrap();
 
-        let (bytes, truncated) = read_bounded(&path).await.unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        let (bytes, truncated) = read_bounded(file).await.unwrap();
 
         assert_eq!(bytes.len(), MAX_FILE_BYTES);
         assert!(truncated);
@@ -178,11 +240,11 @@ mod tests {
     async fn skips_binary_files() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("binary.dat"), [0, 159, 146, 150]).unwrap();
-        let ctx = ToolContext {
-            cwd: dir.path().to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.path().to_path_buf(),
-        };
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
 
         let result = ReadManyFilesTool
             .invoke(serde_json::json!({"paths": ["binary.dat"]}), &ctx)
@@ -191,5 +253,96 @@ mod tests {
 
         assert!(result.output.contains("not a UTF-8 text file"));
         assert!(!result.output.contains('\u{fffd}'));
+    }
+
+    #[tokio::test]
+    async fn skips_unreadable_exact_file_and_reads_later_paths() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if nix::unistd::Uid::effective().as_raw() == 0 {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked.txt");
+        std::fs::write(&locked, "locked").unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        std::fs::write(dir.path().join("readable.txt"), "readable").unwrap();
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
+
+        let result = ReadManyFilesTool
+            .invoke(
+                serde_json::json!({"paths": ["locked.txt", "readable.txt"]}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("readable.txt ---\nreadable"));
+        assert!(result.output.contains("Skipped files:"));
+        assert!(result.output.contains("locked.txt: Permission denied"));
+    }
+
+    #[tokio::test]
+    async fn skips_unreadable_exact_directory_and_reads_later_paths() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if nix::unistd::Uid::effective().as_raw() == 0 {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked-dir");
+        std::fs::create_dir(&locked).unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o111)).unwrap();
+        std::fs::write(dir.path().join("readable.txt"), "readable").unwrap();
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
+
+        let result = ReadManyFilesTool
+            .invoke(
+                serde_json::json!({"paths": ["locked-dir", "readable.txt"]}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("readable.txt ---\nreadable"));
+        assert!(result.output.contains("Skipped files:"));
+        assert!(result.output.contains("locked-dir: Permission denied"));
+    }
+
+    #[tokio::test]
+    async fn rejects_exact_symlink_that_escapes_workspace() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(parent.path().join("outside.txt"), "outside").unwrap();
+        symlink(parent.path().join("outside.txt"), root.join("outside-link")).unwrap();
+        let ctx = ToolContext::new(root.clone(), "test".to_string(), root);
+
+        let result = ReadManyFilesTool
+            .invoke(serde_json::json!({"paths": ["outside-link"]}), &ctx)
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("escapes workspace root"));
+    }
+
+    #[test]
+    fn empty_truncated_discovery_is_not_definitive() {
+        let output = no_matching_files_output(true);
+
+        assert!(output.contains("searched subset"));
+        assert!(output.contains("additional files omitted"));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/save_memory.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/save_memory.rs
@@ -174,11 +174,7 @@ mod tests {
     use std::path::Path;
 
     fn context(dir: &Path) -> ToolContext {
-        ToolContext {
-            cwd: dir.to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.to_path_buf(),
-        }
+        ToolContext::new(dir.to_path_buf(), "test".to_string(), dir.to_path_buf())
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/tool/shell.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/shell.rs
@@ -98,11 +98,8 @@ mod tests {
     use std::path::PathBuf;
 
     fn test_ctx() -> ToolContext {
-        ToolContext {
-            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")),
-            session_id: "test".to_string(),
-            project_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")),
-        }
+        let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp"));
+        ToolContext::new(root.clone(), "test".to_string(), root)
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/tool/skill.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/skill.rs
@@ -135,11 +135,11 @@ mod tests {
         mgr.refresh().await;
 
         let tool = SkillTool::new(mgr);
-        let ctx = ToolContext {
-            cwd: PathBuf::from("/nonexistent"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/nonexistent"),
-        };
+        let ctx = ToolContext::new(
+            PathBuf::from("/nonexistent"),
+            "test".to_string(),
+            PathBuf::from("/nonexistent"),
+        );
         let result = tool
             .invoke(serde_json::json!({"action": "list"}), &ctx)
             .await
@@ -155,11 +155,11 @@ mod tests {
         mgr.refresh().await;
 
         let tool = SkillTool::new(mgr);
-        let ctx = ToolContext {
-            cwd: PathBuf::from("/nonexistent"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/nonexistent"),
-        };
+        let ctx = ToolContext::new(
+            PathBuf::from("/nonexistent"),
+            "test".to_string(),
+            PathBuf::from("/nonexistent"),
+        );
         let result = tool
             .invoke(
                 serde_json::json!({"action": "invoke", "name": "missing"}),
@@ -188,11 +188,11 @@ mod tests {
         mgr.refresh().await;
 
         let tool = SkillTool::new(mgr);
-        let ctx = ToolContext {
-            cwd: dir.path().to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.path().to_path_buf(),
-        };
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
         let result = tool
             .invoke(
                 serde_json::json!({"action": "invoke", "name": "demo"}),
@@ -220,11 +220,11 @@ mod tests {
         mgr.refresh().await;
 
         let tool = SkillTool::new(mgr);
-        let ctx = ToolContext {
-            cwd: dir.path().to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.path().to_path_buf(),
-        };
+        let ctx = ToolContext::new(
+            dir.path().to_path_buf(),
+            "test".to_string(),
+            dir.path().to_path_buf(),
+        );
         let result = tool
             .invoke(serde_json::json!({"action": "list"}), &ctx)
             .await

--- a/src/cosh-ng/crates/cosh-core/src/tool/todo.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/todo.rs
@@ -132,11 +132,11 @@ mod tests {
     use std::path::PathBuf;
 
     fn test_ctx() -> ToolContext {
-        ToolContext {
-            cwd: PathBuf::from("/tmp"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/tmp"),
-        }
+        ToolContext::new(
+            PathBuf::from("/tmp"),
+            "test".to_string(),
+            PathBuf::from("/tmp"),
+        )
     }
 
     #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/tool/web_fetch.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/web_fetch.rs
@@ -179,11 +179,11 @@ mod tests {
                 .await
                 .unwrap();
         });
-        let ctx = ToolContext {
-            cwd: PathBuf::from("/tmp"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/tmp"),
-        };
+        let ctx = ToolContext::new(
+            PathBuf::from("/tmp"),
+            "test".to_string(),
+            PathBuf::from("/tmp"),
+        );
 
         let result = WebFetchTool::new()
             .invoke(
@@ -201,11 +201,11 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_non_http_urls() {
-        let ctx = ToolContext {
-            cwd: PathBuf::from("/tmp"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/tmp"),
-        };
+        let ctx = ToolContext::new(
+            PathBuf::from("/tmp"),
+            "test".to_string(),
+            PathBuf::from("/tmp"),
+        );
 
         let result = WebFetchTool::new()
             .invoke(serde_json::json!({"url": "file:///etc/passwd"}), &ctx)
@@ -231,11 +231,11 @@ mod tests {
                 .await
                 .unwrap();
         });
-        let ctx = ToolContext {
-            cwd: PathBuf::from("/tmp"),
-            session_id: "test".to_string(),
-            project_root: PathBuf::from("/tmp"),
-        };
+        let ctx = ToolContext::new(
+            PathBuf::from("/tmp"),
+            "test".to_string(),
+            PathBuf::from("/tmp"),
+        );
 
         let result = WebFetchTool::new()
             .invoke(

--- a/src/cosh-ng/crates/cosh-core/src/tool/workspace_fs.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/workspace_fs.rs
@@ -1,0 +1,1775 @@
+//! Descriptor-relative filesystem access confined to the session workspace.
+
+use std::collections::VecDeque;
+use std::ffi::OsString;
+use std::fmt;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+use rustix::fs::{openat2, readlinkat, Dir, FileType, Mode, OFlags, ResolveFlags, CWD};
+
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+use super::expand_tilde;
+
+const MAX_WALK_ENTRIES: usize = 10_000;
+const MAX_IGNORE_FILE_BYTES: u64 = 1024 * 1024;
+const MAX_IGNORE_TOTAL_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_SYMLINKS: usize = 40;
+const RESOLVE_FLAGS: ResolveFlags = ResolveFlags::BENEATH
+    .union(ResolveFlags::NO_MAGICLINKS)
+    .union(ResolveFlags::NO_XDEV);
+const ROOT_RESOLVE_FLAGS: ResolveFlags = ResolveFlags::NO_MAGICLINKS;
+const PIN_FLAGS: OFlags = OFlags::PATH.union(OFlags::CLOEXEC).union(OFlags::NOFOLLOW);
+const READ_FLAGS: OFlags = OFlags::RDONLY
+    .union(OFlags::CLOEXEC)
+    .union(OFlags::NONBLOCK);
+
+#[derive(Debug)]
+enum WorkspaceOpenError {
+    Escape(PathBuf),
+    Inaccessible(PathBuf),
+    SymlinkLoop(PathBuf),
+    Unsupported(PathBuf),
+    Other(String),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WorkspaceNodeKind {
+    File,
+    Directory,
+}
+
+pub(super) enum WorkspaceRootError {
+    Missing(String),
+    Permanent(String),
+}
+
+impl fmt::Display for WorkspaceRootError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing(message) | Self::Permanent(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl fmt::Display for WorkspaceOpenError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Escape(path) => {
+                write!(formatter, "Path escapes workspace root: {}", path.display())
+            }
+            Self::Inaccessible(path) => {
+                write!(formatter, "Permission denied: {}", path.display())
+            }
+            Self::SymlinkLoop(path) => {
+                write!(
+                    formatter,
+                    "Too many symbolic links while opening {}",
+                    path.display()
+                )
+            }
+            Self::Unsupported(path) => {
+                write!(
+                    formatter,
+                    "Unsupported filesystem object: {}",
+                    path.display()
+                )
+            }
+            Self::Other(message) => formatter.write_str(message),
+        }
+    }
+}
+
+/// A regular file opened beneath the workspace root.
+#[derive(Debug)]
+pub(super) struct WorkspaceFile {
+    pub relative_path: PathBuf,
+    pub display_path: PathBuf,
+    pub file: File,
+}
+
+/// A directory opened beneath the workspace root.
+#[derive(Debug)]
+pub(super) struct WorkspaceDirectory {
+    pub relative_path: PathBuf,
+    pub display_path: PathBuf,
+    pub file: File,
+}
+
+/// An opened regular file or directory.
+pub(super) enum WorkspaceNode {
+    File(WorkspaceFile),
+    Directory(WorkspaceDirectory),
+}
+
+/// An exact path discovered for a multi-file read.
+pub(super) enum WorkspaceBatchNode {
+    Node(WorkspaceNode),
+    InaccessibleFile {
+        display_path: PathBuf,
+        error: String,
+    },
+}
+
+/// A metadata-only regular-file path or the result of opening an exact directory.
+pub(super) enum WorkspacePathNode {
+    File(PathBuf),
+    Directory(WorkspaceDirectory),
+    InaccessibleDirectory {
+        display_path: PathBuf,
+        error: String,
+    },
+}
+
+/// Bounded file discovery results.
+pub(super) struct WalkedFiles {
+    pub files: Vec<WorkspaceFile>,
+    pub truncated: bool,
+}
+
+/// Bounded metadata-only file discovery results.
+pub(super) struct WalkedFilePaths {
+    pub paths: Vec<PathBuf>,
+    pub truncated: bool,
+}
+
+/// Bounded workspace-relative metadata-only file discovery results.
+pub(super) struct WalkedRelativeFilePaths {
+    pub paths: Vec<PathBuf>,
+    pub truncated: bool,
+    pub ignore_incomplete: bool,
+}
+
+#[derive(Clone, Default)]
+struct IgnoreMatchers {
+    git_exclude: Vec<Gitignore>,
+    gitignore: Vec<Gitignore>,
+    ignore: Vec<Gitignore>,
+    rgignore: Vec<Gitignore>,
+}
+
+impl IgnoreMatchers {
+    fn extend(&mut self, loaded: LoadedIgnoreMatchers) {
+        self.git_exclude.extend(loaded.git_exclude);
+        self.gitignore.extend(loaded.gitignore);
+        self.ignore.extend(loaded.ignore);
+        self.rgignore.extend(loaded.rgignore);
+    }
+}
+
+#[derive(Default)]
+struct LoadedIgnoreMatchers {
+    git_exclude: Option<Gitignore>,
+    gitignore: Option<Gitignore>,
+    ignore: Option<Gitignore>,
+    rgignore: Option<Gitignore>,
+    incomplete: bool,
+}
+
+struct LoadedIgnoreFile {
+    matcher: Option<Gitignore>,
+    incomplete: bool,
+}
+
+struct GitMarker {
+    is_directory: bool,
+}
+
+/// Pins a trusted workspace root and resolves untrusted paths beneath it.
+pub(super) struct WorkspaceFs {
+    root: PathBuf,
+    requested_root: PathBuf,
+    directory: File,
+}
+
+impl WorkspaceFs {
+    pub fn new(root: &Path) -> Result<Self, String> {
+        Self::open_root(root).map_err(|error| error.to_string())
+    }
+
+    pub(super) fn open_root(root: &Path) -> Result<Self, WorkspaceRootError> {
+        let requested_root = root.to_path_buf();
+        let descriptor = openat2(
+            CWD,
+            root,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+            ROOT_RESOLVE_FLAGS,
+        )
+        .map_err(|error| {
+            if error == rustix::io::Errno::NOSYS {
+                return platform_support_error(error);
+            }
+            let message = format!("Failed to open workspace root {}: {error}", root.display());
+            if error == rustix::io::Errno::NOENT {
+                WorkspaceRootError::Missing(message)
+            } else {
+                WorkspaceRootError::Permanent(message)
+            }
+        })?;
+        let directory = File::from(descriptor);
+        Self::check_platform_support(&directory)?;
+        let root = root_path_from_descriptor(&directory, root)?;
+        Ok(Self {
+            root,
+            requested_root,
+            directory,
+        })
+    }
+
+    fn check_platform_support(directory: &File) -> Result<(), WorkspaceRootError> {
+        openat2(directory, ".", PIN_FLAGS, Mode::empty(), RESOLVE_FLAGS)
+            .map(drop)
+            .map_err(platform_support_error)
+    }
+
+    /// Returns the display identity derived from the pinned root descriptor.
+    pub(super) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn resolve_user_path(&self, cwd: &Path, path: &str) -> Result<PathBuf, String> {
+        let expanded = expand_tilde(path);
+        let absolute = if expanded.is_absolute() {
+            expanded
+        } else {
+            cwd.join(expanded)
+        };
+        let relative = self.strip_root_prefix(&absolute).map_err(|_| {
+            format!(
+                "Path escapes workspace root {}: {}",
+                self.root.display(),
+                absolute.display()
+            )
+        })?;
+        if relative.as_os_str().is_empty() {
+            Ok(PathBuf::from("."))
+        } else {
+            Ok(relative.to_path_buf())
+        }
+    }
+
+    pub fn display_path(&self, relative_path: &Path) -> PathBuf {
+        self.root.join(relative_path)
+    }
+
+    fn strip_root_prefix<'a>(&self, path: &'a Path) -> Result<&'a Path, ()> {
+        path.strip_prefix(&self.root)
+            .or_else(|_| path.strip_prefix(&self.requested_root))
+            .map_err(|_| ())
+    }
+
+    pub fn open_node(&self, cwd: &Path, path: &str) -> Result<WorkspaceNode, String> {
+        let relative_path = self.resolve_user_path(cwd, path)?;
+        self.open_relative_node(&relative_path)?.ok_or_else(|| {
+            format!(
+                "Path not found: {}",
+                self.display_path(&relative_path).display()
+            )
+        })
+    }
+
+    pub fn try_open_node(&self, cwd: &Path, path: &str) -> Result<Option<WorkspaceNode>, String> {
+        let relative_path = self.resolve_user_path(cwd, path)?;
+        self.open_relative_node(&relative_path)
+    }
+
+    pub fn try_open_batch_node(
+        &self,
+        cwd: &Path,
+        path: &str,
+    ) -> Result<Option<WorkspaceBatchNode>, String> {
+        let relative_path = self.resolve_user_path(cwd, path)?;
+        match self.open_relative_node_inner(&relative_path) {
+            Ok(node) => Ok(node.map(WorkspaceBatchNode::Node)),
+            Err(WorkspaceOpenError::Inaccessible(display_path)) => {
+                match self.pin_relative_node_kind(&relative_path) {
+                    Ok(Some(WorkspaceNodeKind::File)) => {
+                        Ok(Some(WorkspaceBatchNode::InaccessibleFile {
+                            display_path,
+                            error: "Permission denied".to_string(),
+                        }))
+                    }
+                    Ok(Some(WorkspaceNodeKind::Directory)) => {
+                        Err(WorkspaceOpenError::Inaccessible(display_path).to_string())
+                    }
+                    Ok(None) => Ok(None),
+                    Err(error) => Err(error.to_string()),
+                }
+            }
+            Err(error) => Err(error.to_string()),
+        }
+    }
+
+    pub fn try_open_path_node(
+        &self,
+        cwd: &Path,
+        path: &str,
+    ) -> Result<Option<WorkspacePathNode>, String> {
+        let relative_path = self.resolve_user_path(cwd, path)?;
+        let kind = self
+            .pin_relative_node_kind(&relative_path)
+            .map_err(|error| error.to_string())?;
+        match kind {
+            Some(WorkspaceNodeKind::File) => Ok(Some(WorkspacePathNode::File(
+                self.display_path(&relative_path),
+            ))),
+            Some(WorkspaceNodeKind::Directory) => {
+                match self.open_relative_node_inner(&relative_path) {
+                    Ok(Some(WorkspaceNode::Directory(directory))) => {
+                        Ok(Some(WorkspacePathNode::Directory(directory)))
+                    }
+                    Ok(Some(WorkspaceNode::File(_))) | Ok(None) => Ok(None),
+                    Err(WorkspaceOpenError::Inaccessible(display_path)) => {
+                        Ok(Some(WorkspacePathNode::InaccessibleDirectory {
+                            display_path,
+                            error: "Permission denied".to_string(),
+                        }))
+                    }
+                    Err(error) => Err(error.to_string()),
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub fn open_file(&self, cwd: &Path, path: &str) -> Result<WorkspaceFile, String> {
+        match self.open_node(cwd, path)? {
+            WorkspaceNode::File(file) => Ok(file),
+            WorkspaceNode::Directory(directory) => {
+                Err(format!("Not a file: {}", directory.display_path.display()))
+            }
+        }
+    }
+
+    /// Reopens a previously discovered display path beneath the pinned root.
+    pub fn open_display_file(&self, path: &Path) -> Result<WorkspaceFile, String> {
+        let relative_path = self.strip_root_prefix(path).map_err(|_| {
+            format!(
+                "Path escapes workspace root {}: {}",
+                self.root.display(),
+                path.display()
+            )
+        })?;
+        match self.open_relative_node(relative_path)? {
+            Some(WorkspaceNode::File(file)) => Ok(file),
+            Some(WorkspaceNode::Directory(directory)) => {
+                Err(format!("Not a file: {}", directory.display_path.display()))
+            }
+            None => Err(format!("Path not found: {}", path.display())),
+        }
+    }
+
+    pub fn open_directory(&self, cwd: &Path, path: &str) -> Result<WorkspaceDirectory, String> {
+        match self.open_node(cwd, path)? {
+            WorkspaceNode::Directory(directory) => Ok(directory),
+            WorkspaceNode::File(file) => {
+                Err(format!("Not a directory: {}", file.display_path.display()))
+            }
+        }
+    }
+
+    pub fn open_relative_node(
+        &self,
+        relative_path: &Path,
+    ) -> Result<Option<WorkspaceNode>, String> {
+        self.open_relative_node_inner(relative_path)
+            .map_err(|error| error.to_string())
+    }
+
+    fn open_relative_node_inner(
+        &self,
+        relative_path: &Path,
+    ) -> Result<Option<WorkspaceNode>, WorkspaceOpenError> {
+        if relative_path.is_absolute() {
+            return Err(WorkspaceOpenError::Other(format!(
+                "Workspace-relative path must not be absolute: {}",
+                relative_path.display()
+            )));
+        }
+        let Some(file) = self.open_beneath(relative_path)? else {
+            return Ok(None);
+        };
+        let metadata = file.metadata().map_err(|error| {
+            WorkspaceOpenError::Other(format!(
+                "Failed to inspect {}: {error}",
+                self.display_path(relative_path).display()
+            ))
+        })?;
+        let display_path = self.display_path(relative_path);
+        if metadata.is_file() {
+            Ok(Some(WorkspaceNode::File(WorkspaceFile {
+                relative_path: relative_path.to_path_buf(),
+                display_path,
+                file,
+            })))
+        } else if metadata.is_dir() {
+            Ok(Some(WorkspaceNode::Directory(WorkspaceDirectory {
+                relative_path: relative_path.to_path_buf(),
+                display_path,
+                file,
+            })))
+        } else {
+            Err(WorkspaceOpenError::Unsupported(display_path))
+        }
+    }
+
+    fn open_beneath(&self, relative_path: &Path) -> Result<Option<File>, WorkspaceOpenError> {
+        self.resolve_beneath(relative_path, true)
+    }
+
+    fn pin_beneath(&self, relative_path: &Path) -> Result<Option<File>, WorkspaceOpenError> {
+        self.resolve_beneath(relative_path, false)
+    }
+
+    fn resolve_beneath(
+        &self,
+        relative_path: &Path,
+        readable: bool,
+    ) -> Result<Option<File>, WorkspaceOpenError> {
+        let display_path = self.display_path(relative_path);
+        let mut remaining = path_components(relative_path)?;
+        let root = self.directory.try_clone().map_err(|error| {
+            WorkspaceOpenError::Other(format!(
+                "Failed to clone workspace root descriptor {}: {error}",
+                self.root.display()
+            ))
+        })?;
+        let mut directories = vec![root];
+        let mut followed_symlinks = 0;
+
+        loop {
+            let Some(component) = remaining.pop_front() else {
+                return if readable {
+                    reopen_pinned(
+                        directories.last().expect("workspace root descriptor"),
+                        &display_path,
+                        true,
+                    )
+                } else {
+                    Ok(directories.pop())
+                };
+            };
+            if component == "." {
+                continue;
+            }
+            if component == ".." {
+                if directories.len() == 1 {
+                    return Err(WorkspaceOpenError::Escape(display_path));
+                }
+                directories.pop();
+                continue;
+            }
+
+            let current = directories.last().expect("workspace root descriptor");
+            // Pin before inspecting so a concurrent rename cannot change which
+            // symlink target or directory the remainder is resolved against.
+            let Some(pinned) =
+                open_component(current, Path::new(&component), &display_path, PIN_FLAGS)?
+            else {
+                return Ok(None);
+            };
+            let metadata = pinned.metadata().map_err(|error| {
+                WorkspaceOpenError::Other(format!(
+                    "Failed to inspect {}: {error}",
+                    display_path.display()
+                ))
+            })?;
+
+            if metadata.file_type().is_symlink() {
+                followed_symlinks += 1;
+                if followed_symlinks > MAX_SYMLINKS {
+                    return Err(WorkspaceOpenError::SymlinkLoop(display_path));
+                }
+                let target = readlinkat(&pinned, "", Vec::new()).map_err(|error| {
+                    WorkspaceOpenError::Other(format!(
+                        "Failed to read symbolic link {}: {error}",
+                        display_path.display()
+                    ))
+                })?;
+                let target = PathBuf::from(OsString::from_vec(target.into_bytes()));
+                let target = if target.is_absolute() {
+                    // The kernel cannot reinterpret a host-absolute target for
+                    // RESOLVE_BENEATH, so reroot only lexically internal targets.
+                    let target = self
+                        .strip_root_prefix(&target)
+                        .map_err(|_| WorkspaceOpenError::Escape(display_path.clone()))?;
+                    directories.truncate(1);
+                    target
+                } else {
+                    target.as_path()
+                };
+                prepend_components(&mut remaining, target)?;
+                continue;
+            }
+
+            if !remaining.is_empty() {
+                if !metadata.is_dir() {
+                    return Err(WorkspaceOpenError::Other(format!(
+                        "Not a directory: {}",
+                        display_path.display()
+                    )));
+                }
+                directories.push(pinned);
+                continue;
+            }
+
+            return if readable && metadata.is_file() {
+                reopen_pinned(&pinned, &display_path, false)
+            } else if readable && metadata.is_dir() {
+                reopen_pinned(&pinned, &display_path, true)
+            } else if readable {
+                Err(WorkspaceOpenError::Unsupported(display_path))
+            } else {
+                Ok(Some(pinned))
+            };
+        }
+    }
+
+    fn pin_relative_node_kind(
+        &self,
+        relative_path: &Path,
+    ) -> Result<Option<WorkspaceNodeKind>, WorkspaceOpenError> {
+        let Some(file) = self.pin_beneath(relative_path)? else {
+            return Ok(None);
+        };
+        let metadata = file.metadata().map_err(|error| {
+            WorkspaceOpenError::Other(format!(
+                "Failed to inspect {}: {error}",
+                self.display_path(relative_path).display()
+            ))
+        })?;
+        if metadata.is_file() {
+            Ok(Some(WorkspaceNodeKind::File))
+        } else if metadata.is_dir() {
+            Ok(Some(WorkspaceNodeKind::Directory))
+        } else {
+            Err(WorkspaceOpenError::Unsupported(
+                self.display_path(relative_path),
+            ))
+        }
+    }
+
+    pub fn is_relative_directory(&self, relative_path: &Path) -> bool {
+        matches!(
+            self.pin_relative_node_kind(relative_path),
+            Ok(Some(WorkspaceNodeKind::Directory))
+        )
+    }
+
+    fn classify_walk_entry(
+        &self,
+        relative_path: &Path,
+        entry_type: FileType,
+    ) -> Result<Option<WorkspaceNodeKind>, WorkspaceOpenError> {
+        match entry_type {
+            FileType::RegularFile => Ok(Some(WorkspaceNodeKind::File)),
+            FileType::Directory => Ok(Some(WorkspaceNodeKind::Directory)),
+            FileType::Symlink | FileType::Unknown => self.pin_relative_node_kind(relative_path),
+            _ => Ok(None),
+        }
+    }
+
+    pub fn walk_files<F>(
+        &self,
+        directory: WorkspaceDirectory,
+        max_files: usize,
+        include: F,
+    ) -> Result<WalkedFiles, String>
+    where
+        F: FnMut(&Path) -> bool,
+    {
+        self.walk_files_with_ignores(directory, max_files, false, include)
+    }
+
+    fn walk_files_with_ignores<F>(
+        &self,
+        directory: WorkspaceDirectory,
+        max_files: usize,
+        respect_ignores: bool,
+        include: F,
+    ) -> Result<WalkedFiles, String>
+    where
+        F: FnMut(&Path) -> bool,
+    {
+        let (mut files, truncated, _) = self.walk_matching_files(
+            directory,
+            max_files,
+            respect_ignores,
+            include,
+            |workspace, relative_path| match workspace.open_relative_node_inner(relative_path)? {
+                Some(WorkspaceNode::File(file)) => Ok(Some(file)),
+                Some(WorkspaceNode::Directory(_)) | None => Ok(None),
+            },
+        )?;
+        files.sort_by(|left, right| left.display_path.cmp(&right.display_path));
+        Ok(WalkedFiles { files, truncated })
+    }
+
+    pub fn walk_file_paths<F>(
+        &self,
+        directory: WorkspaceDirectory,
+        max_files: usize,
+        include: F,
+    ) -> Result<WalkedFilePaths, String>
+    where
+        F: FnMut(&Path) -> bool,
+    {
+        let (mut paths, truncated, _) = self.walk_matching_files(
+            directory,
+            max_files,
+            false,
+            include,
+            |workspace, relative_path| match workspace.pin_relative_node_kind(relative_path)? {
+                Some(WorkspaceNodeKind::File) => Ok(Some(workspace.display_path(relative_path))),
+                Some(WorkspaceNodeKind::Directory) | None => Ok(None),
+            },
+        )?;
+        paths.sort();
+        Ok(WalkedFilePaths { paths, truncated })
+    }
+
+    pub fn walk_relative_file_paths<F>(
+        &self,
+        directory: WorkspaceDirectory,
+        max_files: usize,
+        respect_ignores: bool,
+        mut include: F,
+    ) -> Result<WalkedRelativeFilePaths, String>
+    where
+        F: FnMut(&Path) -> bool,
+    {
+        let base_path = directory.relative_path.clone();
+        let (mut paths, truncated, ignore_incomplete) = self.walk_matching_files(
+            directory,
+            max_files,
+            respect_ignores,
+            |relative_to_base| include(&base_path.join(relative_to_base)),
+            |workspace, relative_path| match workspace.pin_relative_node_kind(relative_path)? {
+                Some(WorkspaceNodeKind::File) => Ok(Some(relative_path.to_path_buf())),
+                Some(WorkspaceNodeKind::Directory) | None => Ok(None),
+            },
+        )?;
+        paths.sort();
+        Ok(WalkedRelativeFilePaths {
+            paths,
+            truncated,
+            ignore_incomplete,
+        })
+    }
+
+    fn walk_matching_files<F, T, C>(
+        &self,
+        directory: WorkspaceDirectory,
+        max_files: usize,
+        respect_ignores: bool,
+        mut include: F,
+        mut collect_file: C,
+    ) -> Result<(Vec<T>, bool, bool), String>
+    where
+        F: FnMut(&Path) -> bool,
+        C: FnMut(&Self, &Path) -> Result<Option<T>, WorkspaceOpenError>,
+    {
+        let base_path = directory.relative_path.clone();
+        let ignore_base_path = if respect_ignores {
+            normalize_workspace_relative_path(&base_path)
+        } else {
+            PathBuf::new()
+        };
+        let mut ignore_budget = MAX_IGNORE_TOTAL_BYTES;
+        let (initial_ignore_matchers, initial_inside_git, initial_ignore_incomplete) =
+            if respect_ignores {
+                self.load_parent_ignore_matchers(&ignore_base_path, &mut ignore_budget)?
+            } else {
+                (IgnoreMatchers::default(), false, false)
+            };
+        let mut queue = VecDeque::from([(
+            PathBuf::new(),
+            Some(directory.file),
+            Vec::new(),
+            initial_ignore_matchers,
+            initial_inside_git,
+        )]);
+        let mut files = Vec::new();
+        let mut visited_entries = 0;
+        let mut incomplete = false;
+        let mut ignore_incomplete = initial_ignore_incomplete;
+        let mut limit_reached = false;
+
+        while let Some((
+            relative_directory,
+            pinned_directory,
+            mut ancestors,
+            mut ignore_matchers,
+            mut inside_git,
+        )) = queue.pop_front()
+        {
+            let directory_file = match pinned_directory {
+                Some(file) => file,
+                None => {
+                    let relative_to_root = base_path.join(&relative_directory);
+                    match self.open_relative_node_inner(&relative_to_root) {
+                        Ok(Some(WorkspaceNode::Directory(directory))) => directory.file,
+                        Ok(Some(WorkspaceNode::File(_))) | Ok(None) => continue,
+                        Err(WorkspaceOpenError::Escape(_))
+                        | Err(WorkspaceOpenError::Unsupported(_)) => continue,
+                        Err(WorkspaceOpenError::Inaccessible(_))
+                        | Err(WorkspaceOpenError::SymlinkLoop(_)) => {
+                            incomplete = true;
+                            continue;
+                        }
+                        Err(error) => return Err(error.to_string()),
+                    }
+                }
+            };
+            let metadata = directory_file.metadata().map_err(|error| {
+                format!(
+                    "Failed to inspect directory {}: {error}",
+                    self.display_path(&base_path.join(&relative_directory))
+                        .display()
+                )
+            })?;
+            let identity = (metadata.dev(), metadata.ino());
+            if ancestors.contains(&identity) {
+                continue;
+            }
+            ancestors.push(identity);
+            if respect_ignores {
+                let relative_to_root = base_path.join(&relative_directory);
+                let ignore_relative_to_root = ignore_base_path.join(&relative_directory);
+                let git_directory = match self.git_marker(&relative_to_root) {
+                    Ok(Some(marker)) => {
+                        ignore_matchers.git_exclude.clear();
+                        ignore_matchers.gitignore.clear();
+                        inside_git = true;
+                        marker.is_directory
+                    }
+                    Ok(None) => false,
+                    Err(WorkspaceOpenError::Inaccessible(_))
+                    | Err(WorkspaceOpenError::Escape(_))
+                    | Err(WorkspaceOpenError::SymlinkLoop(_)) => {
+                        ignore_incomplete = true;
+                        false
+                    }
+                    Err(WorkspaceOpenError::Unsupported(_)) => false,
+                    Err(error) => return Err(error.to_string()),
+                };
+                match self.load_ignore_matchers(
+                    &relative_to_root,
+                    &ignore_relative_to_root,
+                    inside_git,
+                    git_directory,
+                    &mut ignore_budget,
+                ) {
+                    Ok(loaded) => {
+                        ignore_incomplete |= loaded.incomplete;
+                        ignore_matchers.extend(loaded);
+                    }
+                    Err(WorkspaceOpenError::Inaccessible(_))
+                    | Err(WorkspaceOpenError::Escape(_))
+                    | Err(WorkspaceOpenError::SymlinkLoop(_)) => ignore_incomplete = true,
+                    Err(WorkspaceOpenError::Unsupported(_)) => {}
+                    Err(error) => return Err(error.to_string()),
+                }
+            }
+            let reader = match Dir::read_from(&directory_file) {
+                Ok(entries) => entries,
+                Err(error) if is_permission_error(error) => {
+                    incomplete = true;
+                    continue;
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "Failed to list directory {}: {error}",
+                        self.display_path(&base_path.join(&relative_directory))
+                            .display()
+                    ));
+                }
+            };
+            let remaining_entries = MAX_WALK_ENTRIES.saturating_sub(visited_entries);
+            let mut entries = Vec::new();
+            let mut entries_overflow = false;
+            for entry in reader {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(error) if is_permission_error(error) => {
+                        incomplete = true;
+                        break;
+                    }
+                    Err(error) => {
+                        return Err(format!(
+                            "Failed to list directory {}: {error}",
+                            self.display_path(&base_path.join(&relative_directory))
+                                .display()
+                        ));
+                    }
+                };
+                let name_bytes = entry.file_name().to_bytes();
+                if name_bytes == b"." || name_bytes == b".." {
+                    continue;
+                }
+                if entries.len() >= remaining_entries {
+                    entries_overflow = true;
+                    break;
+                }
+                let name = OsString::from_vec(name_bytes.to_vec());
+                entries.push((name, entry.file_type(), name_bytes.first() == Some(&b'.')));
+            }
+            if entries_overflow {
+                limit_reached = true;
+                break;
+            }
+            visited_entries += entries.len();
+            entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+
+            for (name, entry_type, hidden) in entries {
+                let relative_to_base = relative_directory.join(name);
+                let relative_to_root = base_path.join(&relative_to_base);
+                let node_kind = match self.classify_walk_entry(&relative_to_root, entry_type) {
+                    Ok(Some(node_kind)) => node_kind,
+                    Ok(None)
+                    | Err(WorkspaceOpenError::Escape(_))
+                    | Err(WorkspaceOpenError::Unsupported(_)) => continue,
+                    Err(WorkspaceOpenError::Inaccessible(_))
+                    | Err(WorkspaceOpenError::SymlinkLoop(_)) => {
+                        incomplete = true;
+                        continue;
+                    }
+                    Err(error) => return Err(error.to_string()),
+                };
+                if respect_ignores {
+                    let ignore_relative_to_root = ignore_base_path.join(&relative_to_base);
+                    let ignore_status = ignore_status(
+                        &ignore_matchers,
+                        &ignore_relative_to_root,
+                        node_kind == WorkspaceNodeKind::Directory,
+                    );
+                    if ignore_status == Some(true) || (hidden && ignore_status != Some(false)) {
+                        continue;
+                    }
+                }
+                match node_kind {
+                    WorkspaceNodeKind::Directory => {
+                        queue.push_back((
+                            relative_to_base,
+                            None,
+                            ancestors.clone(),
+                            ignore_matchers.clone(),
+                            inside_git,
+                        ));
+                    }
+                    WorkspaceNodeKind::File => {
+                        if !include(&relative_to_base) {
+                            continue;
+                        }
+                        if files.len() >= max_files {
+                            limit_reached = true;
+                            break;
+                        }
+                        let file = match collect_file(self, &relative_to_root) {
+                            Ok(Some(file)) => file,
+                            Ok(None)
+                            | Err(WorkspaceOpenError::Escape(_))
+                            | Err(WorkspaceOpenError::Unsupported(_)) => continue,
+                            Err(WorkspaceOpenError::Inaccessible(_))
+                            | Err(WorkspaceOpenError::SymlinkLoop(_)) => {
+                                incomplete = true;
+                                continue;
+                            }
+                            Err(error) => return Err(error.to_string()),
+                        };
+                        files.push(file);
+                    }
+                }
+            }
+            if limit_reached {
+                break;
+            }
+        }
+        Ok((files, incomplete || limit_reached, ignore_incomplete))
+    }
+
+    fn git_marker(
+        &self,
+        relative_directory: &Path,
+    ) -> Result<Option<GitMarker>, WorkspaceOpenError> {
+        let Some(directory) = self.pin_beneath(relative_directory)? else {
+            return Ok(None);
+        };
+        let marker_path = relative_directory.join(".git");
+        let Some(marker) = open_component(
+            &directory,
+            Path::new(".git"),
+            &self.display_path(&marker_path),
+            PIN_FLAGS,
+        )?
+        else {
+            return Ok(None);
+        };
+        marker
+            .metadata()
+            .map(|metadata| {
+                Some(GitMarker {
+                    is_directory: metadata.is_dir(),
+                })
+            })
+            .map_err(|error| {
+                WorkspaceOpenError::Other(format!(
+                    "Failed to inspect Git marker {}: {error}",
+                    self.display_path(&marker_path).display()
+                ))
+            })
+    }
+
+    fn load_ignore_matchers(
+        &self,
+        relative_directory: &Path,
+        matcher_directory: &Path,
+        inside_git: bool,
+        git_directory: bool,
+        ignore_budget: &mut u64,
+    ) -> Result<LoadedIgnoreMatchers, WorkspaceOpenError> {
+        let mut loaded = LoadedIgnoreMatchers::default();
+        if git_directory {
+            record_ignore_file(
+                &mut loaded.git_exclude,
+                &mut loaded.incomplete,
+                self.load_ignore_file(
+                    relative_directory,
+                    matcher_directory,
+                    ".git/info/exclude",
+                    ignore_budget,
+                ),
+            )?;
+        }
+        if inside_git {
+            record_ignore_file(
+                &mut loaded.gitignore,
+                &mut loaded.incomplete,
+                self.load_ignore_file(
+                    relative_directory,
+                    matcher_directory,
+                    ".gitignore",
+                    ignore_budget,
+                ),
+            )?;
+        }
+        record_ignore_file(
+            &mut loaded.ignore,
+            &mut loaded.incomplete,
+            self.load_ignore_file(
+                relative_directory,
+                matcher_directory,
+                ".ignore",
+                ignore_budget,
+            ),
+        )?;
+        record_ignore_file(
+            &mut loaded.rgignore,
+            &mut loaded.incomplete,
+            self.load_ignore_file(
+                relative_directory,
+                matcher_directory,
+                ".rgignore",
+                ignore_budget,
+            ),
+        )?;
+        Ok(loaded)
+    }
+
+    fn load_ignore_file(
+        &self,
+        relative_directory: &Path,
+        matcher_directory: &Path,
+        name: &str,
+        ignore_budget: &mut u64,
+    ) -> Result<LoadedIgnoreFile, WorkspaceOpenError> {
+        let relative_path = relative_directory.join(name);
+        let file = match self.open_relative_node_inner(&relative_path) {
+            Ok(Some(WorkspaceNode::File(file))) => file,
+            Ok(Some(WorkspaceNode::Directory(_))) | Ok(None) => {
+                return Ok(LoadedIgnoreFile {
+                    matcher: None,
+                    incomplete: false,
+                });
+            }
+            Err(error) => return Err(error),
+        };
+        let read_limit = MAX_IGNORE_FILE_BYTES.min(*ignore_budget);
+        if read_limit == 0 {
+            return Ok(LoadedIgnoreFile {
+                matcher: None,
+                incomplete: true,
+            });
+        }
+
+        let mut builder = GitignoreBuilder::new(matcher_directory);
+        let mut incomplete = false;
+        let source = Some(file.display_path.clone());
+        let mut reader = BufReader::new(file.file.take(read_limit + 1));
+        let mut line = Vec::new();
+        let mut index = 0;
+        let mut bytes_read = 0_u64;
+        loop {
+            line.clear();
+            let read = match reader.read_until(b'\n', &mut line) {
+                Ok(read) => read,
+                Err(_) => {
+                    incomplete = true;
+                    break;
+                }
+            };
+            if read == 0 {
+                break;
+            }
+            bytes_read += read as u64;
+            if bytes_read > read_limit {
+                incomplete = true;
+                break;
+            }
+            trim_ignore_line_ending(&mut line);
+            let line = String::from_utf8_lossy(&line);
+            incomplete |= matches!(&line, std::borrow::Cow::Owned(_));
+            let line = if index == 0 {
+                line.trim_start_matches('\u{feff}')
+            } else {
+                &line
+            };
+            incomplete |= builder.add_line(source.clone(), line).is_err();
+            index += 1;
+        }
+        *ignore_budget = ignore_budget.saturating_sub(bytes_read.min(read_limit));
+        builder
+            .build()
+            .map(|matcher| LoadedIgnoreFile {
+                matcher: Some(matcher),
+                incomplete,
+            })
+            .map_err(|error| {
+                WorkspaceOpenError::Other(format!(
+                    "Failed to compile ignore rules under {}: {error}",
+                    self.display_path(relative_directory).display()
+                ))
+            })
+    }
+
+    fn load_parent_ignore_matchers(
+        &self,
+        base_path: &Path,
+        ignore_budget: &mut u64,
+    ) -> Result<(IgnoreMatchers, bool, bool), String> {
+        if base_path.as_os_str().is_empty() || base_path == Path::new(".") {
+            return Ok((IgnoreMatchers::default(), false, false));
+        }
+        let mut directories = Vec::new();
+        let mut parent = base_path.parent();
+        while let Some(path) = parent {
+            directories.push(if path.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                path.to_path_buf()
+            });
+            if path.as_os_str().is_empty() {
+                break;
+            }
+            parent = path.parent();
+        }
+        directories.reverse();
+
+        let mut matchers = IgnoreMatchers::default();
+        let mut inside_git = false;
+        let mut incomplete = false;
+        for directory in directories {
+            let git_directory = match self.git_marker(&directory) {
+                Ok(Some(marker)) => {
+                    matchers.git_exclude.clear();
+                    matchers.gitignore.clear();
+                    inside_git = true;
+                    marker.is_directory
+                }
+                Ok(None) => false,
+                Err(WorkspaceOpenError::Inaccessible(_))
+                | Err(WorkspaceOpenError::Escape(_))
+                | Err(WorkspaceOpenError::SymlinkLoop(_)) => {
+                    incomplete = true;
+                    false
+                }
+                Err(WorkspaceOpenError::Unsupported(_)) => false,
+                Err(error) => return Err(error.to_string()),
+            };
+            match self.load_ignore_matchers(
+                &directory,
+                &directory,
+                inside_git,
+                git_directory,
+                ignore_budget,
+            ) {
+                Ok(loaded) => {
+                    incomplete |= loaded.incomplete;
+                    matchers.extend(loaded);
+                }
+                Err(WorkspaceOpenError::Unsupported(_)) => {}
+                Err(WorkspaceOpenError::Inaccessible(_))
+                | Err(WorkspaceOpenError::Escape(_))
+                | Err(WorkspaceOpenError::SymlinkLoop(_)) => incomplete = true,
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+        Ok((matchers, inside_git, incomplete))
+    }
+}
+
+fn normalize_workspace_relative_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(component) => components.push(component.to_os_string()),
+            std::path::Component::ParentDir => {
+                if components.last().is_some_and(|component| component != "..") {
+                    components.pop();
+                } else {
+                    components.push(OsString::from(".."));
+                }
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return path.to_path_buf();
+            }
+        }
+    }
+    if components.is_empty() {
+        return PathBuf::from(".");
+    }
+    components.into_iter().collect()
+}
+
+fn record_ignore_file(
+    target: &mut Option<Gitignore>,
+    incomplete: &mut bool,
+    result: Result<LoadedIgnoreFile, WorkspaceOpenError>,
+) -> Result<(), WorkspaceOpenError> {
+    match result {
+        Ok(file) => {
+            *target = file.matcher;
+            *incomplete |= file.incomplete;
+        }
+        Err(WorkspaceOpenError::Inaccessible(_))
+        | Err(WorkspaceOpenError::Escape(_))
+        | Err(WorkspaceOpenError::SymlinkLoop(_)) => *incomplete = true,
+        Err(WorkspaceOpenError::Unsupported(_)) => {}
+        Err(error) => return Err(error),
+    }
+    Ok(())
+}
+
+fn ignore_status(matchers: &IgnoreMatchers, path: &Path, is_directory: bool) -> Option<bool> {
+    matcher_status(&matchers.rgignore, path, is_directory)
+        .or_else(|| matcher_status(&matchers.ignore, path, is_directory))
+        .or_else(|| matcher_status(&matchers.gitignore, path, is_directory))
+        .or_else(|| matcher_status(&matchers.git_exclude, path, is_directory))
+}
+
+fn matcher_status(matchers: &[Gitignore], path: &Path, is_directory: bool) -> Option<bool> {
+    matchers.iter().rev().find_map(|matcher| {
+        let matched = matcher.matched(path, is_directory);
+        if matched.is_ignore() {
+            Some(true)
+        } else if matched.is_whitelist() {
+            Some(false)
+        } else {
+            None
+        }
+    })
+}
+
+fn trim_ignore_line_ending(line: &mut Vec<u8>) {
+    if line.last() == Some(&b'\n') {
+        line.pop();
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+    }
+}
+
+fn is_permission_error(error: rustix::io::Errno) -> bool {
+    matches!(error, rustix::io::Errno::ACCESS | rustix::io::Errno::PERM)
+}
+
+fn reopen_pinned(
+    pinned: &File,
+    display_path: &Path,
+    directory: bool,
+) -> Result<Option<File>, WorkspaceOpenError> {
+    let descriptor_path = PathBuf::from(format!("/proc/self/fd/{}", pinned.as_raw_fd()));
+    let flags = if directory {
+        READ_FLAGS | OFlags::DIRECTORY
+    } else {
+        READ_FLAGS
+    };
+    match openat2(
+        CWD,
+        &descriptor_path,
+        flags,
+        Mode::empty(),
+        ResolveFlags::empty(),
+    ) {
+        Ok(descriptor) => Ok(Some(File::from(descriptor))),
+        Err(rustix::io::Errno::ACCESS | rustix::io::Errno::PERM) => {
+            Err(WorkspaceOpenError::Inaccessible(display_path.to_path_buf()))
+        }
+        Err(error) => Err(WorkspaceOpenError::Other(format!(
+            "Failed to open {}: {error}",
+            display_path.display()
+        ))),
+    }
+}
+
+fn platform_support_error(error: rustix::io::Errno) -> WorkspaceRootError {
+    if error == rustix::io::Errno::NOSYS {
+        WorkspaceRootError::Permanent(format!(
+            "Workspace-confined read tools require Linux openat2 support \
+             (kernel 5.6 or newer): {error}"
+        ))
+    } else {
+        WorkspaceRootError::Permanent(format!(
+            "Failed to verify openat2 support for workspace confinement: {error}"
+        ))
+    }
+}
+
+fn root_path_from_descriptor(
+    directory: &File,
+    requested_root: &Path,
+) -> Result<PathBuf, WorkspaceRootError> {
+    let descriptor_path = PathBuf::from(format!("/proc/self/fd/{}", directory.as_raw_fd()));
+    let root = std::fs::read_link(&descriptor_path).map_err(|error| {
+        WorkspaceRootError::Permanent(format!(
+            "Failed to identify pinned workspace root {}: {error}",
+            requested_root.display()
+        ))
+    })?;
+    let metadata = directory.metadata().map_err(|error| {
+        WorkspaceRootError::Permanent(format!(
+            "Failed to inspect pinned workspace root {}: {error}",
+            requested_root.display()
+        ))
+    })?;
+    if !root.is_absolute() || metadata.nlink() == 0 {
+        return Err(WorkspaceRootError::Permanent(format!(
+            "Pinned workspace root changed during startup: {}",
+            requested_root.display()
+        )));
+    }
+    Ok(root)
+}
+
+fn path_components(path: &Path) -> Result<VecDeque<OsString>, WorkspaceOpenError> {
+    let mut components = VecDeque::new();
+    prepend_components(&mut components, path)?;
+    Ok(components)
+}
+
+fn prepend_components(
+    remaining: &mut VecDeque<OsString>,
+    path: &Path,
+) -> Result<(), WorkspaceOpenError> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => components.push(OsString::from(".")),
+            std::path::Component::ParentDir => components.push(OsString::from("..")),
+            std::path::Component::Normal(component) => components.push(component.to_os_string()),
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return Err(WorkspaceOpenError::Other(format!(
+                    "Workspace-relative path must not be absolute: {}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    for component in components.into_iter().rev() {
+        remaining.push_front(component);
+    }
+    Ok(())
+}
+
+fn open_component(
+    directory: &File,
+    component: &Path,
+    display_path: &Path,
+    flags: OFlags,
+) -> Result<Option<File>, WorkspaceOpenError> {
+    match openat2(directory, component, flags, Mode::empty(), RESOLVE_FLAGS) {
+        Ok(descriptor) => Ok(Some(File::from(descriptor))),
+        Err(rustix::io::Errno::NOENT) => Ok(None),
+        Err(rustix::io::Errno::XDEV) => Err(WorkspaceOpenError::Escape(display_path.to_path_buf())),
+        Err(rustix::io::Errno::ACCESS | rustix::io::Errno::PERM) => {
+            Err(WorkspaceOpenError::Inaccessible(display_path.to_path_buf()))
+        }
+        Err(error) => Err(WorkspaceOpenError::Other(format!(
+            "Failed to open {}: {error}",
+            display_path.display()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+    use std::os::unix::fs::symlink;
+
+    use super::*;
+
+    #[test]
+    fn accepts_internal_symlinks_and_rejects_escapes() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("inside.txt"), "inside").unwrap();
+        std::fs::write(parent.path().join("outside.txt"), "outside").unwrap();
+        symlink("inside.txt", root.join("inside-link")).unwrap();
+        symlink(root.join("inside.txt"), root.join("absolute-inside-link")).unwrap();
+        symlink(parent.path().join("outside.txt"), root.join("outside-link")).unwrap();
+        let workspace = WorkspaceFs::new(&root).unwrap();
+
+        let mut inside = workspace.open_file(&root, "inside-link").unwrap();
+        let mut content = String::new();
+        inside.file.read_to_string(&mut content).unwrap();
+        assert_eq!(content, "inside");
+        let mut absolute_inside = workspace.open_file(&root, "absolute-inside-link").unwrap();
+        content.clear();
+        absolute_inside.file.read_to_string(&mut content).unwrap();
+        assert_eq!(content, "inside");
+        let error = workspace.open_file(&root, "outside-link").unwrap_err();
+        assert!(error.contains("escapes workspace root"), "{error}");
+
+        let outside_directory = parent.path().join("outside-directory");
+        std::fs::create_dir(&outside_directory).unwrap();
+        std::fs::write(outside_directory.join("secret.txt"), "secret").unwrap();
+        symlink(&outside_directory, root.join("outside-directory-link")).unwrap();
+        let error = workspace
+            .open_file(&root, "outside-directory-link/secret.txt")
+            .unwrap_err();
+        assert!(error.contains("escapes workspace root"), "{error}");
+    }
+
+    #[test]
+    fn absolute_paths_must_start_inside_the_workspace() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("inside.txt"), "inside").unwrap();
+        let outside = parent.path().join("outside.txt");
+        std::fs::write(&outside, "outside").unwrap();
+        let workspace = WorkspaceFs::new(&root).unwrap();
+
+        assert!(workspace
+            .open_file(&root, root.join("inside.txt").to_str().unwrap())
+            .is_ok());
+        let error = workspace
+            .open_file(&root, outside.to_str().unwrap())
+            .unwrap_err();
+        assert!(error.contains("escapes workspace root"), "{error}");
+    }
+
+    #[test]
+    fn walker_skips_external_symlinks_and_follows_internal_ones() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("workspace");
+        std::fs::create_dir_all(root.join("real")).unwrap();
+        std::fs::write(root.join("real/inside.txt"), "inside").unwrap();
+        std::fs::write(parent.path().join("outside.txt"), "outside").unwrap();
+        symlink(root.join("real"), root.join("internal-dir")).unwrap();
+        symlink(parent.path().join("outside.txt"), root.join("outside-link")).unwrap();
+        let workspace = WorkspaceFs::new(&root).unwrap();
+        let directory = workspace.open_directory(&root, ".").unwrap();
+
+        let walked = workspace.walk_files(directory, 10, |_| true).unwrap();
+        let paths = walked
+            .files
+            .iter()
+            .map(|file| file.relative_path.clone())
+            .collect::<Vec<_>>();
+
+        assert!(paths.iter().any(|path| path.ends_with("inside.txt")));
+        assert!(!paths.iter().any(|path| path.ends_with("outside-link")));
+    }
+
+    #[test]
+    fn root_descriptor_survives_path_replacement() {
+        let parent = tempfile::tempdir().unwrap();
+        let container = parent.path().join("container");
+        let original_root = container.join("workspace");
+        std::fs::create_dir_all(&original_root).unwrap();
+        std::fs::write(original_root.join("value.txt"), "trusted").unwrap();
+        let workspace = WorkspaceFs::new(&original_root).unwrap();
+
+        let moved = parent.path().join("moved");
+        std::fs::rename(&container, &moved).unwrap();
+        let replacement = parent.path().join("replacement");
+        std::fs::create_dir_all(replacement.join("workspace")).unwrap();
+        std::fs::write(replacement.join("workspace/value.txt"), "outside").unwrap();
+        symlink(&replacement, &container).unwrap();
+
+        let mut file = workspace
+            .open_file(&original_root, "value.txt")
+            .unwrap()
+            .file;
+        let mut content = String::new();
+        file.read_to_string(&mut content).unwrap();
+        assert_eq!(content, "trusted");
+    }
+
+    #[test]
+    fn root_identity_is_derived_from_the_pinned_descriptor() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        let link = directory.path().join("workspace-link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let workspace = WorkspaceFs::new(&link).unwrap();
+
+        assert_eq!(workspace.root(), target);
+    }
+
+    #[test]
+    fn live_root_name_may_end_with_deleted_marker() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("workspace (deleted)");
+        std::fs::create_dir(&root).unwrap();
+
+        let workspace = WorkspaceFs::new(&root).unwrap();
+
+        assert_eq!(workspace.root(), root);
+    }
+
+    #[test]
+    fn configured_root_alias_accepts_absolute_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        let link = directory.path().join("workspace-link");
+        let outside = directory.path().join("outside");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(target.join("inside.txt"), "inside").unwrap();
+        std::fs::write(outside.join("inside.txt"), "outside").unwrap();
+        symlink(&target, &link).unwrap();
+        let workspace = WorkspaceFs::new(&link).unwrap();
+        std::fs::remove_file(&link).unwrap();
+        symlink(&outside, &link).unwrap();
+
+        let file = link.join("inside.txt");
+        let mut file = workspace
+            .open_file(&target, file.to_str().unwrap())
+            .unwrap()
+            .file;
+        let mut content = String::new();
+        file.read_to_string(&mut content).unwrap();
+
+        assert_eq!(content, "inside");
+    }
+
+    #[test]
+    fn absolute_symlink_targets_accept_the_configured_root_alias() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        let link = directory.path().join("workspace-link");
+        let outside = directory.path().join("outside");
+        std::fs::create_dir_all(target.join("releases/v1")).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(target.join("releases/v1/value.txt"), "inside").unwrap();
+        std::fs::write(outside.join("value.txt"), "outside").unwrap();
+        symlink(&target, &link).unwrap();
+        symlink(link.join("releases/v1/value.txt"), target.join("current")).unwrap();
+        let workspace = WorkspaceFs::new(&link).unwrap();
+        std::fs::remove_file(&link).unwrap();
+        symlink(&outside, &link).unwrap();
+
+        let mut file = workspace.open_file(&target, "current").unwrap().file;
+        let mut content = String::new();
+        file.read_to_string(&mut content).unwrap();
+
+        assert_eq!(content, "inside");
+    }
+
+    #[test]
+    fn searchable_root_does_not_require_list_permission_for_exact_reads() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if nix::unistd::Uid::effective().as_raw() == 0 {
+            return;
+        }
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("workspace");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("readable.txt"), "inside").unwrap();
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o111)).unwrap();
+
+        let result = WorkspaceFs::new(&root).and_then(|workspace| {
+            workspace.open_file(&root, "readable.txt").map(|mut file| {
+                let mut content = String::new();
+                file.file.read_to_string(&mut content).unwrap();
+                content
+            })
+        });
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert_eq!(result.unwrap(), "inside");
+    }
+
+    #[test]
+    fn rejects_nested_mounts() {
+        if !Path::new("/proc/self/status").exists() {
+            return;
+        }
+        let workspace = WorkspaceFs::new(Path::new("/")).unwrap();
+
+        let error = workspace
+            .open_file(Path::new("/"), "/proc/self/status")
+            .unwrap_err();
+
+        assert!(error.contains("escapes workspace root"), "{error}");
+    }
+
+    #[test]
+    fn walker_does_not_retain_sibling_directory_descriptors() {
+        if !Path::new("/proc/self/fd").exists() {
+            return;
+        }
+        let directory = tempfile::tempdir().unwrap();
+        for index in 0..128 {
+            let child = directory.path().join(format!("child-{index:03}"));
+            std::fs::create_dir(&child).unwrap();
+            std::fs::write(child.join("file.txt"), "text").unwrap();
+        }
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+        let mut workspace_descriptors = 0;
+
+        workspace
+            .walk_files(root, 1, |_| {
+                workspace_descriptors = std::fs::read_dir("/proc/self/fd")
+                    .unwrap()
+                    .filter_map(Result::ok)
+                    .filter_map(|entry| std::fs::read_link(entry.path()).ok())
+                    .filter(|path| path.starts_with(directory.path()))
+                    .count();
+                true
+            })
+            .unwrap();
+
+        assert!(workspace_descriptors <= 4, "{workspace_descriptors}");
+    }
+
+    #[test]
+    fn relative_file_discovery_does_not_retain_file_descriptors() {
+        if !Path::new("/proc/self/fd").exists() {
+            return;
+        }
+        let directory = tempfile::tempdir().unwrap();
+        for index in 0..100 {
+            std::fs::write(directory.path().join(format!("{index:03}.txt")), "text").unwrap();
+        }
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+
+        let walked = workspace
+            .walk_relative_file_paths(root, 100, false, |_| true)
+            .unwrap();
+        let workspace_descriptors = std::fs::read_dir("/proc/self/fd")
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter_map(|entry| std::fs::read_link(entry.path()).ok())
+            .filter(|path| path.starts_with(directory.path()))
+            .count();
+
+        assert_eq!(walked.paths.len(), 100);
+        assert!(!walked.truncated);
+        assert!(workspace_descriptors <= 2, "{workspace_descriptors}");
+    }
+
+    #[test]
+    fn special_files_are_classified_before_readable_open() {
+        use std::os::unix::net::UnixListener;
+
+        let directory = tempfile::tempdir().unwrap();
+        let socket = directory.path().join("service.sock");
+        let _listener = UnixListener::bind(&socket).unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+
+        let error = workspace
+            .open_file(directory.path(), "service.sock")
+            .unwrap_err();
+
+        assert!(error.contains("Unsupported filesystem object"), "{error}");
+    }
+
+    #[test]
+    fn exact_match_limit_is_not_reported_as_truncated() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("one.txt"), "one").unwrap();
+        std::fs::write(directory.path().join("two.txt"), "two").unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+
+        let walked = workspace.walk_file_paths(root, 2, |_| true).unwrap();
+
+        assert_eq!(walked.paths.len(), 2);
+        assert!(!walked.truncated);
+    }
+
+    #[test]
+    fn capped_walk_returns_lexicographically_first_files() {
+        let directory = tempfile::tempdir().unwrap();
+        for index in (0..10).rev() {
+            std::fs::write(directory.path().join(format!("{index:02}.txt")), "text").unwrap();
+        }
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+
+        let walked = workspace.walk_file_paths(root, 3, |_| true).unwrap();
+        let names = walked
+            .paths
+            .iter()
+            .filter_map(|path| path.file_name())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["00.txt", "01.txt", "02.txt"]);
+        assert!(walked.truncated);
+    }
+
+    #[test]
+    fn walker_filters_known_regular_files_before_opening() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("included.rs"), "included").unwrap();
+        let excluded = directory.path().join("excluded.env");
+        std::fs::write(&excluded, "excluded").unwrap();
+        std::fs::set_permissions(&excluded, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+
+        let walked = workspace
+            .walk_files(root, 10, |path| {
+                path.extension().is_some_and(|extension| extension == "rs")
+            })
+            .unwrap();
+
+        assert_eq!(walked.files.len(), 1);
+        assert!(walked.files[0].relative_path.ends_with("included.rs"));
+    }
+
+    #[test]
+    fn walker_marks_unreadable_subdirectories_incomplete() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if nix::unistd::Uid::effective().as_raw() == 0 {
+            return;
+        }
+
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("visible.rs"), "visible").unwrap();
+        let locked = directory.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        std::fs::write(locked.join("hidden.rs"), "hidden").unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+
+        let walked = workspace.walk_files(root, 10, |_| true);
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let walked = walked.unwrap();
+
+        assert!(walked
+            .files
+            .iter()
+            .any(|file| file.relative_path.ends_with("visible.rs")));
+        assert!(!walked
+            .files
+            .iter()
+            .any(|file| file.relative_path.ends_with("hidden.rs")));
+        assert!(walked.truncated);
+    }
+
+    #[test]
+    fn permission_errors_are_recognized_as_inaccessible() {
+        assert!(is_permission_error(rustix::io::Errno::ACCESS));
+        assert!(is_permission_error(rustix::io::Errno::PERM));
+    }
+
+    #[test]
+    fn directory_alias_preserves_all_searchable_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let real = directory.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("inside.rs"), "inside").unwrap();
+        symlink("..", real.join("loop")).unwrap();
+        symlink("real", directory.path().join("alias")).unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+
+        let walked = workspace.walk_file_paths(root, 10, |_| true).unwrap();
+
+        assert_eq!(
+            walked.paths,
+            vec![
+                directory.path().join("alias/inside.rs"),
+                real.join("inside.rs"),
+            ]
+        );
+        assert!(!walked.truncated);
+    }
+
+    #[test]
+    fn walker_skips_cyclic_symlinks_and_keeps_valid_files() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("valid.txt"), "valid").unwrap();
+        symlink("b", directory.path().join("a")).unwrap();
+        symlink("a", directory.path().join("b")).unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+        let root = workspace.open_directory(directory.path(), ".").unwrap();
+
+        let walked = workspace.walk_file_paths(root, 10, |_| true).unwrap();
+        let exact_error = workspace.open_file(directory.path(), "a").unwrap_err();
+
+        assert_eq!(walked.paths.len(), 1);
+        assert!(walked.paths[0].ends_with("valid.txt"));
+        assert!(walked.truncated);
+        assert!(
+            exact_error.contains("Too many symbolic links"),
+            "{exact_error}"
+        );
+    }
+
+    #[test]
+    fn unknown_entry_classifies_unreadable_file_without_read_access() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let unreadable = directory.path().join("excluded.env");
+        std::fs::write(&unreadable, "excluded").unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let workspace = WorkspaceFs::new(directory.path()).unwrap();
+
+        let kind = workspace
+            .classify_walk_entry(Path::new("excluded.env"), FileType::Unknown)
+            .unwrap();
+
+        assert!(matches!(kind, Some(WorkspaceNodeKind::File)));
+    }
+
+    #[test]
+    fn unsupported_openat2_has_an_actionable_startup_error() {
+        let error = platform_support_error(rustix::io::Errno::NOSYS).to_string();
+
+        assert!(error.contains("require Linux openat2 support"), "{error}");
+        assert!(error.contains("kernel 5.6 or newer"), "{error}");
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
@@ -117,11 +117,7 @@ mod tests {
     use super::*;
 
     fn test_ctx_in(dir: &Path) -> ToolContext {
-        ToolContext {
-            cwd: dir.to_path_buf(),
-            session_id: "test".to_string(),
-            project_root: dir.to_path_buf(),
-        }
+        ToolContext::new(dir.to_path_buf(), "test".to_string(), dir.to_path_buf())
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Why

Auto-approved read tools must stay confined to the workspace root captured at
process startup. Using the mutable shell cwd as the project root lets a later
`cd` silently move that trust boundary, while reopening a stored root pathname
or validating before a separate reopen leaves race windows.

## What changed

- In agent-headless mode, pin the absolute requested root once with an
  `openat2` metadata descriptor, derive its display identity from that fd, and
  pass the exact identity and descriptor through startup.
- Acquire readable directory descriptors only for enumeration, so searchable
  but non-listable roots still support exact child reads.
- Default the effective cwd to that fixed root when no shell context is present;
  an explicit shell context may still select a directory inside the workspace.
- If the configured workspace is initially missing, retry only that `ENOENT`
  case and pin the first successful open; keep permanent failures fail-closed.
- Route `read_file`, `read_many_files`, `grep`, `glob`, and
  `list_directory` through one descriptor-relative workspace filesystem.
- Resolve paths component by component with pinned descriptors, allowing
  relative and absolute symlinks that remain lexically inside the workspace
  while rejecting escapes, magic links, mount crossings, and swap races.
- Permit absolute user paths and symlink targets beneath either the canonical
  startup root or its configured alias; aliases reroot to the pinned descriptor
  and are never reopened.
- Pin final nodes with `O_PATH`, classify them before readable open, reject
  special files, and reopen confirmed files/directories through the same
  descriptor to avoid side effects and final-component TOCTOU races.
- Classify regular, symlink, and `DT_UNKNOWN` walk entries through metadata-only
  pinned handles before include filtering and any readable open.
- Run synchronous confined opens, grep and glob discovery, and directory
  enumeration on Tokio's blocking pool; preserve exact LF/CRLF regex semantics.
- Preserve ripgrep-compatible include braces and exclusions with `globset`.
  Directory globs with `/` match cwd-relative paths without letting `*` cross
  separators, basename globs match at any depth, explicit file operands bypass
  include filters, and positive globs override ignore rules.
- Apply hidden plus ancestor/nested `.gitignore`/`.ignore`/`.rgignore`
  filtering before discovery limits, while honoring explicit hidden-path
  whitelists. `.gitignore` and in-workspace `.git/info/exclude` activate only
  inside a repository and stop at nested repository boundaries; `.ignore` and
  `.rgignore` remain independent.
  Parsing uses shared per-file and traversal byte budgets; malformed,
  non-UTF-8, or truncated rules warn without aborting the search.
- Discover grep and read-many candidates as paths and confined-open them
  sequentially so file limits do not also become live-fd requirements.
- Buffer grep results per file and discard binary files when a NUL is detected,
  including NULs found after the match/output collection limit.
- Strip UTF-8 BOMs and decode BOM-marked UTF-16LE/BE files within the existing
  raw-byte limit before applying binary detection.
- Prevent directory cycles using per-path ancestor identities so real paths and
  internal symlink aliases remain independently searchable. Cyclic symlink
  entries are skipped with an incomplete-result signal instead of aborting the walk.
- Sort each bounded directory batch before traversal so capped discovery chooses
  a deterministic subset.
- Mark traversal truncated only after observing an omitted match or incomplete
  subtree, and retain grep matches when another file reports a read error.
- Preserve incomplete-result signals for inaccessible subtrees, empty
  discovery, remaining exact-path inputs, output limits, and per-file byte
  truncation; unreadable exact batch files are reported and skipped individually.
- Detect an unlinked pinned root from descriptor metadata rather than parsing
  the `/proc/self/fd` display suffix.

## Related issue

Closes #2100

## Type / scope

- [x] Bug fix
- [x] cosh-ng

## User impact

Read-only tools remain available across shell directory changes, but cannot
read outside the original workspace through absolute paths, `..`, symlink
escapes, mount crossings, root-path replacement, or validation/open races.
Internal absolute symlinks continue to work, and truncated discovery and grep
results are explicitly reported as incomplete.

## Risk and compatibility

The confined resolver requires Linux `openat2` support (kernel 5.6 or newer)
and `/proc/self/fd` for deriving the pinned root identity and reopening a
classified descriptor. Startup fails explicitly when either facility is
unavailable rather than using a weaker fallback. Existing result limits remain
unchanged. Filesystems that cross mount boundaries under the workspace are
rejected intentionally by `RESOLVE_NO_XDEV`. The new `globset` dependency is
pinned to the Rust-1.74-compatible Edition-2021 `0.4.15` release.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --package cosh-core --all-targets`
- `cargo test --package cosh-core tool::grep::tests -- --nocapture`
  (30 passed)
- `cargo test --package cosh-core tool::workspace_fs::tests -- --nocapture`
  (22 passed)
- `cargo test --package cosh-core tool::read_file::tests -- --nocapture`
  (8 passed)
- `cargo test --package cosh-core tool::glob::tests -- --nocapture`
  (5 passed)
- `cargo test --package cosh-core tool::read_many_files::tests -- --nocapture`
  (7 passed)
- `cargo test --package cosh-core tool::file_patterns::tests -- --nocapture`
  (9 passed)
- `prlimit --nofile=32:32 cargo test -p cosh-core \
  tool::read_many_files::tests::reads_file_limit_after_path_only_discovery \
  --locked -- --exact` (1 passed)
- `cargo test --package cosh-core tool::list_directory::tests -- --nocapture`
  (3 passed)
- `cargo test --package cosh-core --test jsonl_protocol -- --nocapture`
  (9 passed)
- `cargo test --package cosh-core --test registry_protocol -- --nocapture`
  (24 passed)
- `cargo test --package cosh-core --test compaction_lifecycle -- --nocapture`
  (8 passed)
- `cargo test --package cosh-core --test cli_tools -- --nocapture`
  (3 passed)
- fixed-project-root/no-shell-context regression (1 passed)
- shell-cwd/fixed-root regression (1 passed)
- missing-workspace retry regression (1 passed)
- `cargo clippy --package cosh-core --all-targets --locked -- -D warnings`
- Rust 1.74 validation attempted: the existing v4 lockfile is not parseable by
  Cargo 1.74; a temporary v3-header retry reaches the pre-existing
  Edition-2024 `time-core 0.1.9` baseline blocker.

## Rollback

Revert commit `0ca9e92f`.