### PR TITLE
fix(cosh-ng): gate trust-mode shell execution on hook verdicts

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -21,7 +21,9 @@ use crate::extension::{GenerationController, RuntimeGeneration, RuntimeSnapshot}
 use crate::hook::{HookDecision, HookNotification, HookSystem, PreToolUseResult};
 use crate::loop_detect::LoopDetector;
 use crate::metrics::TurnMetrics;
-use crate::protocol::{InputMessage, OutputMessage, ShellContext, ShellControlRequest};
+use crate::protocol::{
+    ClientControlCapabilities, InputMessage, OutputMessage, ShellContext, ShellControlRequest,
+};
 use crate::provider::{
     ContentGenerator, GenerateConfig, GenerateEvent, Message, MAX_TOOL_CALL_INDEX,
 };
@@ -84,6 +86,13 @@ pub struct CoshCore {
     request_counter: AtomicU32,
     truncator: OutputTruncator,
     loop_detector: LoopDetector,
+    /// Control capabilities the attached client declared at `initialize`.
+    ///
+    /// Defaults to "no capabilities" (headless or legacy clients), which
+    /// keeps trust-mode shell execution provider-native. A client declaring
+    /// both flags opts trust-mode shell commands into the core-issued
+    /// approval channel instead (#2067).
+    pub client_capabilities: ClientControlCapabilities,
     /// First control-transport failure of this process, if any.
     ///
     /// Set from `&self` paths (`handle_ask_user`, `handle_shell_evidence`), so
@@ -260,6 +269,17 @@ impl CoshCore {
         };
 
         if mode == ApprovalMode::Trust {
+            // A control client that can answer `can_use_tool` and execute the
+            // foreground handoff takes over trust-mode shell execution: the
+            // approval channel is the only path where a hook Block reaches a
+            // deterministic verdict instead of racing the shell-side staging
+            // grace window (#2067). Legacy clients keep local execution.
+            if self.client_capabilities.can_handle_can_use_tool
+                && self.client_capabilities.can_handle_host_executed_shell
+                && tool.kind() == ToolKind::ShellExec
+            {
+                return Outcome::RequireApproval;
+            }
             return Outcome::Allow;
         }
 
@@ -1230,6 +1250,13 @@ impl CoshCore {
                             &result.output,
                             result.is_error,
                         ));
+                        // Release the staged provider-native call on the
+                        // client: without this result event the shell can
+                        // only drop the staged call after its grace timeout,
+                        // which opened the block-bypass handoff race (#2067).
+                        // The machine-readable verdict marker lets the client
+                        // journal the rejection without trusting result text.
+                        self.emit_provider_native_hook_block_result(writer, &tc.id, &result);
                         self.audit.record_tool_terminal(
                             tool_scope,
                             &tc.name,
@@ -1288,6 +1315,10 @@ impl CoshCore {
                             &tc.name,
                             if hook_requires_approval {
                                 "hook_ask"
+                            } else if self.config.agent.approval_mode == ApprovalMode::Trust {
+                                // In trust mode a non-hook RequireApproval is
+                                // the capable-client shell handoff reroute.
+                                "trust_shell_handoff"
                             } else {
                                 "policy_approval"
                             },
@@ -1699,6 +1730,22 @@ impl CoshCore {
                 &result.output,
                 result.is_error,
             ),
+        );
+    }
+
+    /// The M2 hook-block release: emits the provider-native error result
+    /// with the machine-readable verdict marker so the client can tell a
+    /// hook rejection apart from an executed-but-failed command without
+    /// reading user-controlled text (#2156).
+    fn emit_provider_native_hook_block_result<W: Write>(
+        &self,
+        writer: &mut W,
+        tool_use_id: &str,
+        result: &ToolResult,
+    ) {
+        self.emit(
+            writer,
+            &OutputMessage::tool_result_hook_blocked(&self.session_id, tool_use_id, &result.output),
         );
     }
 

--- a/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
@@ -88,6 +88,7 @@ impl CoshCore {
             request_counter: AtomicU32::new(0),
             truncator: OutputTruncator::default(),
             loop_detector: LoopDetector::new(),
+            client_capabilities: crate::protocol::ClientControlCapabilities::default(),
             control_transport_failure: std::sync::OnceLock::new(),
         }
     }

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -3930,3 +3930,200 @@ async fn audit_failure_after_transport_failure_still_pairs_the_history() {
         core.messages
     );
 }
+
+// ─── #2067: trust-mode shell handoff reroute & blocked-call release ───
+
+fn trust_shell_core(calls: Arc<AtomicUsize>, provider: MockProvider) -> CoshCore {
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = ApprovalMode::Trust;
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool { calls }));
+    CoshCore::new(config, Box::new(provider), tools)
+}
+
+fn fully_capable_client() -> ClientControlCapabilities {
+    ClientControlCapabilities {
+        can_handle_can_use_tool: true,
+        can_handle_host_executed_shell: true,
+    }
+}
+
+#[test]
+fn trust_classify_reroutes_shell_for_fully_capable_client() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut core = trust_shell_core(calls, MockProvider::new(vec![]));
+    core.client_capabilities = fully_capable_client();
+    assert!(matches!(
+        core.classify_tool("shell", &serde_json::json!({"command":"echo hi"})),
+        Outcome::RequireApproval
+    ));
+}
+
+#[test]
+fn trust_classify_keeps_shell_local_without_full_capabilities() {
+    let params = serde_json::json!({"command":"echo hi"});
+
+    // Legacy client: no initialize capabilities at all.
+    let calls = Arc::new(AtomicUsize::new(0));
+    let core = trust_shell_core(calls, MockProvider::new(vec![]));
+    assert!(matches!(
+        core.classify_tool("shell", &params),
+        Outcome::Allow
+    ));
+
+    // Half-capable is not capable: both halves of the exchange are required.
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut core = trust_shell_core(calls, MockProvider::new(vec![]));
+    core.client_capabilities = ClientControlCapabilities {
+        can_handle_can_use_tool: true,
+        can_handle_host_executed_shell: false,
+    };
+    assert!(matches!(
+        core.classify_tool("shell", &params),
+        Outcome::Allow
+    ));
+}
+
+#[test]
+fn trust_classify_keeps_non_shell_tools_local_for_capable_client() {
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = ApprovalMode::Trust;
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(ExternalTool));
+    let mut core = CoshCore::new(config, Box::new(MockProvider::new(vec![])), tools);
+    core.client_capabilities = fully_capable_client();
+    assert!(matches!(
+        core.classify_tool("example.ops/mcp/server/tool", &serde_json::json!({})),
+        Outcome::Allow
+    ));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn trust_capable_client_shell_call_requests_approval_without_any_hook() {
+    // No hooks configured: in trust mode the reroute alone must raise the
+    // approval request, and it must not be flagged as hook-driven.
+    let provider = approval_provider();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut core = trust_shell_core(Arc::clone(&calls), provider);
+    core.client_capabilities = fully_capable_client();
+
+    let (pipe_reader, pipe_writer) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+    let mut writer = std::io::BufWriter::new(pipe_writer);
+    let mut reader = empty_reader().await;
+
+    core.handle_user_message("run echo hi", &mut reader, &mut writer)
+        .await
+        .expect("an unanswered approval ends the turn as interrupted, not as an error");
+
+    drop(writer);
+    let mut lines = std::io::BufRead::lines(std::io::BufReader::new(pipe_reader));
+    let request = lines
+        .by_ref()
+        .map_while(Result::ok)
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
+        .find(|value| value["request"]["subtype"] == "can_use_tool")
+        .expect("trust-mode shell call must be rerouted to can_use_tool for a capable client");
+    assert_eq!(request["request"]["tool_name"], "shell");
+    assert_eq!(request["request"]["tool_use_id"], "call-1");
+    // `hook_requires_approval` skips serialization when false, so the wire
+    // field must be absent here: the reroute is policy-driven, not hook-driven.
+    assert!(request["request"]["hook_requires_approval"].is_null());
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "no decision arrived, so the tool must not have run"
+    );
+}
+
+#[tokio::test]
+async fn hook_block_releases_staged_call_with_provider_native_result() {
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-block".to_string(),
+                name: "shell".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: r#"{"command":"touch /tmp/should-not-exist"}"#.to_string(),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("blocked acknowledged".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+    let calls = Arc::new(AtomicUsize::new(0));
+    // Hooks are bound into the HookSystem at construction time, so the block
+    // hook must be in the config handed to `CoshCore::new`.
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = ApprovalMode::Trust;
+    config.hooks = config::HooksConfig {
+        enabled: true,
+        pre_tool_use: vec![config::HookDefinition {
+            command: "echo '{\"decision\":\"block\",\"reason\":\"no touch\"}'".to_string(),
+            name: Some("block-shell".to_string()),
+            matcher: Some("shell".to_string()),
+            timeout: Some(5000),
+            sequential: None,
+            fail_open: false,
+            env: Default::default(),
+        }],
+        ..Default::default()
+    };
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(CountingShellTool {
+        calls: Arc::clone(&calls),
+    }));
+    let mut core = CoshCore::new(config, Box::new(provider), tools);
+
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+    core.handle_user_message("touch it", &mut reader, &mut output)
+        .await
+        .unwrap();
+
+    let output_str = String::from_utf8(output).unwrap();
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a blocked command must never execute"
+    );
+    assert!(
+        output_str.contains(r#""type":"tool_result""#),
+        "the blocked call must be released with a provider-native tool result: {output_str}"
+    );
+    assert!(
+        output_str.contains(r#""tool_use_id":"call-block""#),
+        "{output_str}"
+    );
+    assert!(
+        output_str.contains("Blocked by hook: no touch"),
+        "{output_str}"
+    );
+    assert!(
+        output_str.contains(r#""cosh_hook_verdict":"blocked""#),
+        "the blocked release must carry the machine-readable verdict marker: {output_str}"
+    );
+    assert!(
+        !output_str.contains("can_use_tool"),
+        "a hook block is a verdict, not an approval request: {output_str}"
+    );
+    assert!(
+        output_str.contains("blocked acknowledged"),
+        "the turn must continue after the blocked result reaches the LLM: {output_str}"
+    );
+    let blocked_results = core
+        .messages
+        .iter()
+        .filter(|m| m.tool_call_id.as_deref() == Some("call-block"))
+        .count();
+    assert_eq!(
+        blocked_results, 1,
+        "the LLM must see the blocked result exactly once"
+    );
+}

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -342,6 +342,7 @@ where
             ShellControlRequest::Initialize {
                 fire_session_start,
                 protocol_version,
+                capabilities,
             } => {
                 if let Some(received_version) = protocol_version {
                     if received_version != CONTROL_PROTOCOL_VERSION {
@@ -352,6 +353,7 @@ where
                         return InputLineResult::ProtocolMismatch;
                     }
                 }
+                engine.client_capabilities = capabilities;
                 engine.emit(
                     writer,
                     &OutputMessage::initialize_success(

--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -117,6 +117,20 @@ pub struct ShellContext {
     pub last_exit_code: i32,
 }
 
+/// Control capabilities a client declares in its `initialize` request.
+///
+/// Every field defaults to `false` so a legacy client that predates this
+/// field keeps the pre-capability behavior exactly; the core only switches
+/// trust-mode shell execution onto the approval channel when the client has
+/// opted into both halves of that exchange (#2067).
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub struct ClientControlCapabilities {
+    #[serde(default)]
+    pub can_handle_can_use_tool: bool,
+    #[serde(default)]
+    pub can_handle_host_executed_shell: bool,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "subtype")]
 pub enum ShellControlRequest {
@@ -132,6 +146,8 @@ pub enum ShellControlRequest {
         /// Missing or null only for legacy shells that predate negotiation.
         #[serde(default)]
         protocol_version: Option<u32>,
+        #[serde(default)]
+        capabilities: ClientControlCapabilities,
     },
 
     #[serde(rename = "interrupt")]
@@ -353,6 +369,13 @@ pub enum UserContentBlock {
         tool_use_id: String,
         is_error: bool,
         content: String,
+        /// Machine-readable hook terminal verdict (#2156), present only when
+        /// a hook blocked the call. Clients must key rejection semantics on
+        /// this marker instead of inferring from the result text, which the
+        /// command itself can control. Absent on every other result, so the
+        /// field is additive and absent-safe for older clients.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cosh_hook_verdict: Option<String>,
     },
 }
 
@@ -576,6 +599,25 @@ impl OutputMessage {
                     tool_use_id: tool_use_id.to_string(),
                     is_error,
                     content: content.to_string(),
+                    cosh_hook_verdict: None,
+                }],
+            },
+        }
+    }
+
+    /// A blocked tool result carrying the machine-readable hook verdict
+    /// marker (#2156). Only the M2 hook-block release uses this constructor;
+    /// every other result keeps the marker absent.
+    pub fn tool_result_hook_blocked(session_id: &str, tool_use_id: &str, content: &str) -> Self {
+        Self::User {
+            session_id: session_id.to_string(),
+            message: UserOutputMessage {
+                role: "user".to_string(),
+                content: vec![UserContentBlock::ToolResult {
+                    tool_use_id: tool_use_id.to_string(),
+                    is_error: true,
+                    content: content.to_string(),
+                    cosh_hook_verdict: Some("blocked".to_string()),
                 }],
             },
         }
@@ -903,13 +945,41 @@ mod tests {
                 request,
             } => {
                 assert_eq!(request_id, "init-1");
-                assert!(matches!(
-                    request,
+                match request {
                     ShellControlRequest::Initialize {
-                        fire_session_start: true,
-                        protocol_version: None,
+                        fire_session_start,
+                        protocol_version,
+                        capabilities,
+                    } => {
+                        assert!(fire_session_start);
+                        assert!(protocol_version.is_none());
+                        assert!(!capabilities.can_handle_can_use_tool);
+                        assert!(!capabilities.can_handle_host_executed_shell);
                     }
-                ));
+                    _ => panic!("expected Initialize variant"),
+                }
+            }
+            _ => panic!("expected ControlRequest variant"),
+        }
+    }
+
+    #[test]
+    fn parse_initialize_request_with_client_capabilities() {
+        let json = r#"{"request_id":"init-2","type":"control_request","request":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell":true}}}"#;
+        let msg: InputMessage = serde_json::from_str(json).expect("should parse initialize");
+        match msg {
+            InputMessage::ControlRequest {
+                request_id,
+                request,
+            } => {
+                assert_eq!(request_id, "init-2");
+                match request {
+                    ShellControlRequest::Initialize { capabilities, .. } => {
+                        assert!(capabilities.can_handle_can_use_tool);
+                        assert!(capabilities.can_handle_host_executed_shell);
+                    }
+                    _ => panic!("expected Initialize variant"),
+                }
             }
             _ => panic!("expected ControlRequest variant"),
         }

--- a/src/cosh-ng/crates/cosh-shell/src/activity/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/activity/runtime.rs
@@ -322,6 +322,29 @@ pub(crate) fn record_activity_rows_with_policy(
                     Some(row)
                 }
             }
+            AgentEvent::ToolHookVerdict {
+                run_id,
+                tool_id,
+                verdict,
+            } => {
+                if verdict == "blocked" {
+                    state
+                        .control
+                        .mark_provider_hook_blocked_result(run_id, tool_id);
+                    // A block marker arriving after the staging grace converts
+                    // the provisional staged_unresolved journal entry into the
+                    // final rejection (#2156).
+                    crate::approval::requests::reconcile_staged_unresolved_entry(
+                        state,
+                        run_id,
+                        tool_id,
+                        ApprovalRequestStatus::Blocked,
+                        "cosh-core",
+                        "hook_block",
+                    );
+                }
+                None
+            }
             _ => None,
         };
         if let Some(row) = row {

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream.rs
@@ -430,6 +430,13 @@ impl ClaudeStreamParser {
                 continue;
             }
             let status = result.status;
+            if let Some(verdict) = result.hook_verdict {
+                events.push(AgentEvent::ToolHookVerdict {
+                    run_id: self.run_id.clone(),
+                    tool_id: tool_id.clone(),
+                    verdict,
+                });
+            }
             for (stream, content) in result.outputs {
                 events.push(AgentEvent::ToolOutputDelta {
                     run_id: self.run_id.clone(),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream_extract.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/claude_stream_extract.rs
@@ -294,6 +294,11 @@ pub(super) struct ParsedToolResult {
     pub(super) tool_id: String,
     pub(super) status: String,
     pub(super) outputs: Vec<(String, String)>,
+    /// The core's machine-readable hook verdict marker (#2156), parsed from
+    /// the `cosh_hook_verdict` wire field. `Some("blocked")` means a hook
+    /// verdict rejected the call; `None` means any other outcome, including
+    /// a real command whose output merely mentions hook text.
+    pub(super) hook_verdict: Option<String>,
 }
 
 pub(super) fn tool_result_part(
@@ -306,6 +311,10 @@ pub(super) fn tool_result_part(
             .and_then(|value| value.as_str())
             .unwrap_or("tool-result")
             .to_string();
+        let hook_verdict = part
+            .get("cosh_hook_verdict")
+            .and_then(|value| value.as_str())
+            .map(ToString::to_string);
         return Some(ParsedToolResult {
             tool_id,
             status: tool_result_status(part),
@@ -313,6 +322,7 @@ pub(super) fn tool_result_part(
                 .into_iter()
                 .map(|(stream, text)| (stream.to_string(), text))
                 .collect(),
+            hook_verdict,
         });
     }
 
@@ -371,6 +381,7 @@ pub(super) fn tool_result_part(
         tool_id,
         status,
         outputs: vec![(stream.to_string(), bound_tool_output(output))],
+        hook_verdict: None,
     })
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
@@ -72,14 +72,21 @@ pub(crate) fn serialize_initialize_without_session_start(request_id: &str) -> St
     .to_string()
 }
 
-/// Encodes the versioned initialize handshake used by persistent cosh-core.
+/// Encodes the versioned initialize handshake used by persistent cosh-core,
+/// declaring the control capabilities this adapter implements. The core only
+/// moves trust-mode shell execution onto the approval channel when both are
+/// declared (#2067); foreign drivers (claude/qwen) keep the plain payload.
 pub fn serialize_cosh_core_initialize(request_id: &str) -> String {
     json!({
         "request_id": request_id,
         "type": "control_request",
         "request": {
             "subtype": "initialize",
-            "protocol_version": CONTROL_PROTOCOL_VERSION
+            "protocol_version": CONTROL_PROTOCOL_VERSION,
+            "capabilities": {
+                "can_handle_can_use_tool": true,
+                "can_handle_host_executed_shell": true
+            }
         }
     })
     .to_string()

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
@@ -27,6 +27,11 @@ pub use session::{
     SessionErrorInfo, SessionHealth, SessionList, SessionManagementClient, SessionSummary,
 };
 
+/// Provider name of the cosh-core driver. Verdict-channel behavior is keyed
+/// on this single constant so a provider rename or alias cannot silently
+/// disable the fail-closed guards (#2156).
+pub(crate) const COSH_CORE_PROVIDER_NAME: &str = "cosh-core";
+
 #[derive(Debug, Clone)]
 /// Adapter that delegates Agent turns and session ownership to cosh-core.
 pub struct CoshCoreAdapter {
@@ -320,7 +325,7 @@ impl CoshCoreAdapter {
 
 impl AgentAdapter for CoshCoreAdapter {
     fn name(&self) -> &'static str {
-        "cosh-core"
+        COSH_CORE_PROVIDER_NAME
     }
 
     fn capabilities(&self) -> AgentBackendCapabilities {

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
@@ -36,6 +36,7 @@ pub use claude::ClaudeCodeAdapter;
 use claude_stream::ClaudeStreamParser;
 pub use control_protocol::*;
 pub(crate) use cosh_core::max_turn_limit;
+pub(crate) use cosh_core::COSH_CORE_PROVIDER_NAME;
 pub use cosh_core::{
     CoshCoreAdapter, SessionClearFailure, SessionClearInterruption, SessionClearPlan,
     SessionClearResult, SessionErrorInfo, SessionHealth, SessionList, SessionManagementClient,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/process.rs
@@ -488,6 +488,7 @@ pub(crate) fn agent_event_is_provider_progress(event: &AgentEvent) -> bool {
         | AgentEvent::ToolPermissionRequest { .. }
         | AgentEvent::ToolOutputDelta { .. }
         | AgentEvent::ToolCompleted { .. }
+        | AgentEvent::ToolHookVerdict { .. }
         | AgentEvent::AgentCompleted { .. }
         | AgentEvent::AgentFailed { .. }
         | AgentEvent::AgentCancelled { .. }

--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
@@ -66,9 +66,25 @@ pub(crate) fn render_trusted_tool<W: Write>(
         }
         if provider_tool_call_fallback
             && request_is_executable_bash_tool(&request)
+            && provider_native_shell_result_is_hook_block(state, &request)
+        {
+            // The core verdict arrived inside the staging window as a block:
+            // preserve the rejection instead of replaying an approval.
+            record_hook_blocked_staged_request(state, request);
+            continue;
+        }
+        if provider_tool_call_fallback
+            && request_is_executable_bash_tool(&request)
             && provider_native_shell_result_already_visible(state, &request)
         {
             render_completed_provider_native_shell_request(state, request, output)?;
+            continue;
+        }
+        if provider_tool_call_fallback && active_run_is_cosh_core(state) {
+            // M3 (#2067): a grace-released bare ToolCall has no core-visible
+            // verdict; executing it here is what bypassed hook blocks. Journal
+            // the desync and leave execution to the core-owned channels.
+            record_staged_unresolved_request(state, request);
             continue;
         }
         if !provider_tool_call_fallback && defer_fallback_bash_tool(state, request.clone(), output)?
@@ -134,6 +150,17 @@ fn assessment_requires_interactive_approval(assessment: &CommandAssessment) -> b
         || assessment.reasons.contains(&"unresolvable-launcher-chain")
 }
 
+/// M3 is scoped to the cosh-core driver: claude/qwen also report
+/// `control_protocol`, but they have no core-side verdict channel, so their
+/// grace-release fallback remains the only trust surface (I4/R4).
+fn active_run_is_cosh_core(state: &InlineState) -> bool {
+    state
+        .agent_run
+        .active
+        .as_ref()
+        .is_some_and(|run| run.provider_name == crate::adapter::COSH_CORE_PROVIDER_NAME)
+}
+
 fn trust_mode_blocks_shell_request(
     request: &mut RuntimeApprovalRequest,
     source: AssessmentSource,
@@ -194,9 +221,23 @@ pub(crate) fn render_auto_approved_tool<W: Write>(
         }
         if provider_tool_call_fallback
             && request_is_executable_bash_tool(&request)
+            && provider_native_shell_result_is_hook_block(state, &request)
+        {
+            record_hook_blocked_staged_request(state, request);
+            continue;
+        }
+        if provider_tool_call_fallback
+            && request_is_executable_bash_tool(&request)
             && provider_native_shell_result_already_visible(state, &request)
         {
             render_completed_provider_native_shell_request(state, request, output)?;
+            continue;
+        }
+        if provider_tool_call_fallback && active_run_is_cosh_core(state) {
+            // M3 (#2067): a grace-released bare ToolCall has no core-visible
+            // verdict; executing it here is what bypassed hook blocks. Journal
+            // the desync and leave execution to the core-owned channels.
+            record_staged_unresolved_request(state, request);
             continue;
         }
         if request_is_readonly_builtin_tool(&request) {
@@ -306,6 +347,27 @@ pub(crate) fn render_auto_approved_tool<W: Write>(
 
     render_approval_requests(state, &blocked_approval_ids, output)?;
     Ok(false)
+}
+
+/// The core's machine-readable blocked verdict: the M2 hook-block release
+/// marks the provider-native result with `cosh_hook_verdict: "blocked"` on
+/// the wire, and the adapter surfaces it as a ToolHookVerdict event that
+/// sets this flag (#2156). Keying on the flag covers every fail-closed
+/// morphology (block/deny/reject, hook failure, message-less blocks) and —
+/// unlike result text — cannot be forged by the command's own output.
+fn provider_native_shell_result_is_hook_block(
+    state: &InlineState,
+    request: &RuntimeApprovalRequest,
+) -> bool {
+    if request.provider_shell_request_kind.is_control_permission() {
+        return false;
+    }
+    let Some(tool_id) = request.tool_use_id.as_deref() else {
+        return false;
+    };
+    state
+        .control
+        .provider_hook_result_is_blocked(&request.run_id, tool_id)
 }
 
 fn provider_native_shell_result_already_visible(

--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge_tests.rs
@@ -1277,3 +1277,421 @@ fn carried_system_control_defeats_trust_key_and_trust_mode() {
         }
     }
 }
+
+fn streamed_bash_tool_call() -> GovernedEvent {
+    GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::NeedsUserApproval,
+        event: AgentEvent::ToolCall {
+            run_id: "run-1".to_string(),
+            tool_id: Some("toolu-staged".to_string()),
+            name: "Bash".to_string(),
+            input: r#"{"command":"echo staged"}"#.to_string(),
+        },
+        reason: "grace-released staged tool call".to_string(),
+        display_text: "grace-released staged tool call".to_string(),
+        auto_execute: false,
+    }
+}
+
+fn active_run_with_provider(provider_name: &'static str) -> crate::agent::run::ActiveAgentRun {
+    let (mut active_run, _approval_rx) =
+        crate::agent::run::test_support::test_active_run_with_id("run-1");
+    active_run.provider_name = provider_name;
+    active_run
+}
+
+#[test]
+fn cosh_core_grace_released_tool_call_with_block_verdict_journals_rejection() {
+    // #2156: the hook verdict arrives inside the staging window as a block
+    // and the core releases the normalized provider-native error result
+    // ("Blocked by hook: ..."); the staged call must be journaled as a
+    // rejection, never replayed as auto-approved and executed.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    state.agent_run.active = Some(active_run_with_provider("cosh-core"));
+    // The activity path already surfaced the core's block verdict marker.
+    state
+        .control
+        .mark_provider_hook_blocked_result("run-1", "toolu-staged");
+    state
+        .control
+        .mark_provider_shell_transcript_seen("run-1", "toolu-staged");
+    let mut output = Vec::new();
+
+    render_trusted_tool(
+        &mut state,
+        &[streamed_bash_tool_call()],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool");
+
+    let entry = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+        .expect("the blocked staged call must be journaled");
+    assert_eq!(entry.decision, ApprovalRequestStatus::Blocked);
+    assert_eq!(entry.execution_path, Some("hook_block"));
+    assert!(
+        state
+            .approvals
+            .journal
+            .iter()
+            .all(|entry| entry.tool_use_id.as_deref() != Some("toolu-staged")
+                || entry.decision != ApprovalRequestStatus::Approved),
+        "a hook-blocked staged call must never journal an approval"
+    );
+    let rendered = String::from_utf8(output).expect("utf8");
+    assert!(
+        !rendered.contains("Auto-approved"),
+        "a hook-blocked staged call must not render an approval card: {rendered}"
+    );
+    assert!(
+        state.control.shell_handoff().approved_is_empty(),
+        "no handoff may be queued for a hook-blocked staged call"
+    );
+}
+
+#[test]
+fn hook_block_detection_keys_on_the_wire_verdict_marker() {
+    // #2156: every fail-closed morphology (raw block/deny/reject, hook
+    // failures, message-less blocks) reaches the shell as one machine-readable
+    // wire marker, surfaced through ToolHookVerdict into the blocked-result
+    // flag. Detection keys on the flag, not on result text.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    state.agent_run.active = Some(active_run_with_provider("cosh-core"));
+    state
+        .control
+        .mark_provider_hook_blocked_result("run-1", "toolu-staged");
+    let mut output = Vec::new();
+
+    render_trusted_tool(
+        &mut state,
+        &[streamed_bash_tool_call()],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool");
+
+    let entry = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+        .expect("the blocked call must be journaled");
+    assert_eq!(entry.decision, ApprovalRequestStatus::Blocked);
+    assert_eq!(entry.execution_path, Some("hook_block"));
+}
+
+#[test]
+fn command_output_cannot_forge_a_hook_block() {
+    // A real command whose own output begins with the hook-block text must
+    // still journal as approved and executed: only the machine-readable wire
+    // marker may route to the rejection journal (#2156 review).
+    for text in [
+        "Blocked by hook: no touch",              // forged reason shape
+        "Blocked by hook: Hook failure: timeout", // forged failure shape
+        "Blocked by hook: Blocked by hook",       // forged empty-reason shape
+        "  Blocked by hook: leading whitespace",
+    ] {
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        let mut state = InlineState {
+            approval_mode: CoshApprovalMode::Trust,
+            ..InlineState::default()
+        };
+        state.agent_run.active = Some(active_run_with_provider("cosh-core"));
+        state
+            .control
+            .record_provider_tool_output_delta("run-1", "toolu-staged", "stderr", text);
+        state
+            .control
+            .mark_provider_shell_transcript_seen("run-1", "toolu-staged");
+        let mut output = Vec::new();
+
+        render_trusted_tool(
+            &mut state,
+            &[streamed_bash_tool_call()],
+            None,
+            AgentRunOrigin::Standard,
+            &mut output,
+            &adapter,
+        )
+        .expect("render trusted tool");
+
+        let entry = state
+            .approvals
+            .journal
+            .iter()
+            .find(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+            .unwrap_or_else(|| panic!("{text}: the executed call must be journaled"));
+        assert_eq!(entry.decision, ApprovalRequestStatus::Approved, "{text}");
+        assert_eq!(
+            entry.execution_path,
+            Some("provider_native_shell_tool_execution"),
+            "{text}"
+        );
+    }
+}
+
+#[test]
+fn late_allow_verdict_reconciles_the_provisional_staged_entry() {
+    // #2156: the hook takes longer than the 200 ms grace, so M3 journals the
+    // provisional staged_unresolved first; the late can_use_tool verdict then
+    // approves and executes. The journal must end with exactly one terminal
+    // entry that matches what actually happened — not a contradictory
+    // Blocked+Approved pair.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    state.agent_run.active = Some(active_run_with_provider("cosh-core"));
+    let mut output = Vec::new();
+
+    render_trusted_tool(
+        &mut state,
+        &[streamed_bash_tool_call()],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool");
+    let provisional = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+        .expect("M3 must journal the desync");
+    assert_eq!(provisional.execution_path, Some("staged_unresolved"));
+
+    // The late control-channel verdict arrives and trust auto-approves it.
+    let late_request = shell_request(
+        ProviderShellRequestKind::ControlPermission,
+        Some("ctrl-late"),
+        Some("toolu-staged"),
+    );
+    crate::approval::requests::record_auto_approved_request(&mut state, late_request);
+
+    let entries = state
+        .approvals
+        .journal
+        .iter()
+        .filter(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+        .count();
+    assert_eq!(
+        entries, 1,
+        "each tool_use_id must have exactly one terminal journal entry"
+    );
+    let entry = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+        .expect("the reconciled entry");
+    assert_eq!(entry.decision, ApprovalRequestStatus::Approved);
+    assert_eq!(
+        entry.execution_path,
+        Some("staged_resolved_late_verdict"),
+        "the reconciled entry keeps the late-verdict provenance"
+    );
+}
+
+#[test]
+fn executed_but_failed_result_still_journals_the_approval() {
+    // A genuinely executed command that failed (nonzero exit) keeps the
+    // completed-replay semantics: it was approved and did run. Only the
+    // core's normalized block marker routes to the rejection journal.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    state.agent_run.active = Some(active_run_with_provider("cosh-core"));
+    state.control.record_provider_tool_output_delta(
+        "run-1",
+        "toolu-staged",
+        "stderr",
+        "permission denied",
+    );
+    state
+        .control
+        .mark_provider_shell_transcript_seen("run-1", "toolu-staged");
+    let mut output = Vec::new();
+
+    render_trusted_tool(
+        &mut state,
+        &[streamed_bash_tool_call()],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool");
+
+    let entry = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+        .expect("the executed call must be journaled");
+    assert_eq!(entry.decision, ApprovalRequestStatus::Approved);
+    assert_eq!(
+        entry.execution_path,
+        Some("provider_native_shell_tool_execution")
+    );
+}
+
+#[test]
+fn late_verdict_reconcile_is_scoped_to_its_own_run() {
+    // #2156: two consecutive runs can reuse the same tool id; a late verdict
+    // from the newer run must never rewrite the older run's provisional
+    // entry, and each run keeps its own terminal state.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    state.agent_run.active = Some(active_run_with_provider("cosh-core"));
+    let mut output = Vec::new();
+
+    // Run 1 leaves a provisional staged_unresolved entry for the shared id.
+    render_trusted_tool(
+        &mut state,
+        &[streamed_bash_tool_call()],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool");
+
+    // A new run starts; its late verdict arrives for the same tool id.
+    if let Some(active) = state.agent_run.active.as_mut() {
+        active.request.id = "run-2".to_string();
+    }
+    let late_request = RuntimeApprovalRequest {
+        run_id: "run-2".to_string(),
+        ..shell_request(
+            ProviderShellRequestKind::ControlPermission,
+            Some("ctrl-late"),
+            Some("toolu-staged"),
+        )
+    };
+    crate::approval::requests::record_auto_approved_request(&mut state, late_request);
+
+    let run1 = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| {
+            entry.run_id == "run-1" && entry.tool_use_id.as_deref() == Some("toolu-staged")
+        })
+        .expect("run-1 provisional entry must remain");
+    assert_eq!(run1.decision, ApprovalRequestStatus::Blocked);
+    assert_eq!(
+        run1.execution_path,
+        Some("staged_unresolved"),
+        "the older run's provisional entry must not be rewritten by another run"
+    );
+    let run2 = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| {
+            entry.run_id == "run-2" && entry.tool_use_id.as_deref() == Some("toolu-staged")
+        })
+        .expect("run-2 must journal its own terminal approval");
+    assert_eq!(run2.decision, ApprovalRequestStatus::Approved);
+}
+
+#[test]
+fn cosh_core_grace_released_tool_call_never_executes() {
+    // M3 (#2067): under cosh-core a bare grace-released ToolCall has no
+    // core-visible verdict; it must be journaled as staged_unresolved
+    // instead of auto-approved or handed off.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    state.agent_run.active = Some(active_run_with_provider("cosh-core"));
+    let mut output = Vec::new();
+
+    render_trusted_tool(
+        &mut state,
+        &[streamed_bash_tool_call()],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool");
+
+    assert!(
+        state.approvals.requests.is_empty(),
+        "no approval request may be created for an unresolved staged call"
+    );
+    assert!(
+        state.control.shell_handoff().approved_is_empty(),
+        "no handoff may be queued for an unresolved staged call"
+    );
+    let entry = state
+        .approvals
+        .journal
+        .iter()
+        .find(|entry| entry.tool_use_id.as_deref() == Some("toolu-staged"))
+        .expect("the desync must be journaled");
+    assert_eq!(entry.execution_path, Some("staged_unresolved"));
+}
+
+#[test]
+fn non_cosh_core_grace_released_tool_call_keeps_legacy_fallback() {
+    // I4/R4: claude/qwen report control_protocol but have no core verdict
+    // channel, so their grace-release fallback must keep auto-approving.
+    let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+    let mut state = InlineState {
+        approval_mode: CoshApprovalMode::Trust,
+        ..InlineState::default()
+    };
+    state.agent_run.active = Some(active_run_with_provider("qwen"));
+    let mut output = Vec::new();
+
+    render_trusted_tool(
+        &mut state,
+        &[streamed_bash_tool_call()],
+        None,
+        AgentRunOrigin::Standard,
+        &mut output,
+        &adapter,
+    )
+    .expect("render trusted tool");
+
+    assert_eq!(state.approvals.requests.len(), 1);
+    assert_eq!(
+        state.approvals.requests[0].status,
+        ApprovalRequestStatus::Approved
+    );
+    assert!(
+        state
+            .approvals
+            .journal
+            .iter()
+            .all(|entry| entry.execution_path != Some("staged_unresolved")),
+        "the M3 guard must not reach non-cosh-core drivers"
+    );
+}

--- a/src/cosh-ng/crates/cosh-shell/src/agent/events/classification.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/events/classification.rs
@@ -45,6 +45,7 @@ pub(super) fn should_render_governance_block(event: &GovernedEvent) -> bool {
         | AgentEvent::HookNotification { .. } => true,
         AgentEvent::ToolOutputDelta { .. }
         | AgentEvent::ToolCompleted { .. }
+        | AgentEvent::ToolHookVerdict { .. }
         | AgentEvent::TextDelta { .. }
         | AgentEvent::AgentCompleted { .. }
         | AgentEvent::AuthRequired { .. }

--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -90,18 +90,11 @@ pub(crate) fn finish_active_agent_run<W: Write>(
         return Ok(());
     }
     // Drain any unconsumed pending hook notifications into deferred_events
-    // (orphan case: hook returned block, so no ToolPermissionRequest was emitted)
+    // (orphan case: hook returned block, so no ToolPermissionRequest was
+    // emitted). Route them through governance so the rendered block carries
+    // real display text instead of an empty card (#2067).
     let i18n = I18n::new(active_run.language);
-    let run_id = active_run.request.id.clone();
-    for notification in active_run.pending_hook_notifications.drain(..) {
-        active_run
-            .deferred_events
-            .push(pending_hook_notification_event(
-                &run_id,
-                &notification,
-                &i18n,
-            ));
-    }
+    drain_orphan_hook_notifications(&mut active_run);
     if !active_run.deferred_events.is_empty() {
         // Projection is throwaway and display-only: `deferred_events` itself
         // still holds every original notification for approval linking and
@@ -221,6 +214,16 @@ pub(crate) fn finish_active_agent_run<W: Write>(
     }
 
     Ok(())
+}
+
+fn drain_orphan_hook_notifications(active_run: &mut ActiveAgentRun) {
+    let events = crate::agent::run::take_pending_hook_notification_events(active_run);
+    if events.is_empty() {
+        return;
+    }
+    let mut governed =
+        govern_agent_events_with_language(&events, &Policy::default(), active_run.language).events;
+    active_run.deferred_events.append(&mut governed);
 }
 
 fn active_run_provider_timed_out(active_run: &ActiveAgentRun) -> bool {
@@ -642,5 +645,35 @@ mod tests {
 
         assert_eq!(trim_queued_requests_after_provider_timeout(&mut state), 0);
         assert_eq!(state.agent_run.queued_requests.len(), 2);
+    }
+
+    // F2 (#2067): an orphan hook block notification must drain through
+    // governance so the deferred render carries real display text instead of
+    // an empty card.
+    #[test]
+    fn finish_drains_orphan_hook_notification_with_visible_display_text() {
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut state = InlineState::default();
+        let mut active_run = active_run(&adapter, "run-1", Language::EnUs);
+        active_run
+            .pending_hook_notifications
+            .push(crate::agent::run::PendingHookNotification {
+                tool_use_id: Some("toolu-1".to_string()),
+                hook_name: "guard".to_string(),
+                message: String::new(),
+                decision: Some("block".to_string()),
+            });
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        finish_active_agent_run(&mut state, &mut output, &adapter).expect("finish run");
+
+        let rendered = String::from_utf8(output).expect("utf8");
+        assert!(
+            rendered.contains("Hook: guard")
+                && rendered.contains("Message: no message provided")
+                && rendered.contains("Decision: block"),
+            "the orphan block must render visible governance text: {rendered}"
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/agent/governance.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/governance.rs
@@ -127,6 +127,16 @@ pub fn govern_agent_events_with_language(
                 ),
                 false,
             ),
+            AgentEvent::ToolHookVerdict { .. } => (
+                // The verdict marker is audit metadata; the rejection is
+                // already visible via the failed tool result and the
+                // governance hook panel.
+                GovernanceDecision::Display,
+                GovernancePolicyDecision::AuditOnly,
+                "hook verdict marker is audit-only".to_string(),
+                String::new(),
+                false,
+            ),
             AgentEvent::ToolCompleted {
                 tool_id, status, ..
             } => (

--- a/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/heartbeat.rs
@@ -265,6 +265,10 @@ pub(crate) fn remember_agent_activity(active_run: &mut ActiveAgentRun, governed:
                     );
                 }
             }
+            AgentEvent::ToolHookVerdict { .. } => {
+                // Audit-only marker: the status line is already driven by the
+                // tool result events around it.
+            }
             AgentEvent::AgentCompleted { summary, .. } => {
                 active_run.current_phase = i18n.t(MessageId::AgentStatusCompleted).to_string();
                 active_run.current_message = display_agent_summary(summary, &i18n);

--- a/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/run.rs
@@ -475,12 +475,53 @@ pub(crate) fn stop_active_agent_run_without_rendering<W: Write>(
     );
     active_run.handle.cancel();
     active_run.status_animation.clear(output)?;
+    // Surface unconsumed hook notifications before teardown; dropping them
+    // with the run is how block decisions went missing (#2067).
+    drain_pending_hook_notifications(&mut active_run, output)?;
     active_run.held_events.clear();
     active_run.deferred_events.clear();
     active_run.cosh_request_filter.clear();
     active_run.pending_cosh_requests.clear();
     active_run.pending_cosh_request_audits.clear();
     output.flush()?;
+    Ok(())
+}
+
+/// Takes the run's unconsumed hook notifications as governable events.
+pub(crate) fn take_pending_hook_notification_events(
+    active_run: &mut ActiveAgentRun,
+) -> Vec<AgentEvent> {
+    let run_id = active_run.request.id.clone();
+    active_run
+        .pending_hook_notifications
+        .drain(..)
+        .map(|notification| AgentEvent::HookNotification {
+            run_id: run_id.clone(),
+            hook_name: notification.hook_name,
+            message: notification.message,
+            tool_use_id: notification.tool_use_id,
+            decision: notification.decision,
+        })
+        .collect()
+}
+
+/// Drains unconsumed hook notifications through governance and renders them
+/// with the guarded writer. Teardown paths must surface an orphan block/ask
+/// decision instead of dropping it with the run (#2067).
+pub(crate) fn drain_pending_hook_notifications<W: Write>(
+    active_run: &mut ActiveAgentRun,
+    output: &mut W,
+) -> std::io::Result<()> {
+    let events = take_pending_hook_notification_events(active_run);
+    if events.is_empty() {
+        return Ok(());
+    }
+    let governed =
+        govern_agent_events_with_language(&events, &Policy::default(), active_run.language).events;
+    active_run
+        .renderer
+        .write_governed_events(output, &governed)?;
+    active_run.governed_events.extend(governed);
     Ok(())
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/agent/turn_extension.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/turn_extension.rs
@@ -25,7 +25,7 @@ pub(crate) fn note_capped_run(
     active_run: &ActiveAgentRun,
     committed_provider_session: Option<String>,
 ) -> bool {
-    if active_run.provider_name != "cosh-core"
+    if active_run.provider_name != crate::adapter::COSH_CORE_PROVIDER_NAME
         || active_run.origin != AgentRunOrigin::Standard
         || state.agent_run.pending_turn_extension.is_some()
         || !state.agent_run.queued_requests.is_empty()

--- a/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
@@ -332,10 +332,25 @@ pub(crate) fn record_auto_approved_request(
         }
     }
     state.approvals.requests.push(request.clone());
-    state
-        .approvals
-        .journal
-        .push(approval_journal_entry(&request, "agent-auto"));
+    // A late control-channel verdict converts the provisional
+    // staged_unresolved entry into the final approval instead of doubling
+    // the journal with a contradictory Blocked+Approved pair (#2156).
+    let reconciled = request.tool_use_id.as_deref().is_some_and(|tool_id| {
+        reconcile_staged_unresolved_entry(
+            state,
+            &request.run_id,
+            tool_id,
+            ApprovalRequestStatus::Approved,
+            "agent-auto",
+            "staged_resolved_late_verdict",
+        )
+    });
+    if !reconciled {
+        state
+            .approvals
+            .journal
+            .push(approval_journal_entry(&request, "agent-auto"));
+    }
     request
 }
 
@@ -353,6 +368,72 @@ pub(crate) fn record_deferred_fallback_request(
         .journal
         .push(approval_journal_entry(&request, "cosh-shell"));
     request
+}
+
+/// Journals a grace-released cosh-core ToolCall whose core verdict never
+/// became visible. M3 (#2067): such a call must not execute and must not be
+/// auto-approved — the journal entry is the audit trail, keyed
+/// `staged_unresolved` so a protocol desync stays distinguishable from a
+/// user or policy decision.
+pub(crate) fn record_staged_unresolved_request(
+    state: &mut InlineState,
+    mut request: RuntimeApprovalRequest,
+) {
+    // The journal source is `cosh-shell` because the protocol desync is
+    // detected shell-side, without any core verdict on the wire.
+    request.status = ApprovalRequestStatus::Blocked;
+    request.execution_path = Some("staged_unresolved");
+    state
+        .approvals
+        .journal
+        .push(approval_journal_entry(&request, "cosh-shell"));
+}
+
+/// A staged ToolCall whose hook verdict arrived inside the staging window
+/// as Block: the core released the provider-native error result, so the
+/// call never executed. Journal the rejection — never an auto-approval —
+/// so the audit trail reflects the hook verdict instead of claiming an
+/// approved provider-native execution (#2156). The journal source is
+/// `cosh-core` because the block verdict originates from the core's hook
+/// system; the shell only records it.
+pub(crate) fn record_hook_blocked_staged_request(
+    state: &mut InlineState,
+    mut request: RuntimeApprovalRequest,
+) {
+    request.status = ApprovalRequestStatus::Blocked;
+    request.execution_path = Some("hook_block");
+    state
+        .approvals
+        .journal
+        .push(approval_journal_entry(&request, "cosh-core"));
+}
+
+/// A `staged_unresolved` journal entry is provisional, not terminal
+/// (#2156): the grace timer fired before the core's verdict, so when the
+/// late verdict arrives — an approval resolution through the control
+/// channel, or a block-marked provider-native result — the provisional
+/// entry converts in place to the final state. Each tool_use_id ends with
+/// exactly one terminal journal entry consistent with what actually
+/// happened to the command.
+pub(crate) fn reconcile_staged_unresolved_entry(
+    state: &mut InlineState,
+    run_id: &str,
+    tool_use_id: &str,
+    decision: ApprovalRequestStatus,
+    actor: &'static str,
+    execution_path: &'static str,
+) -> bool {
+    let Some(entry) = state.approvals.journal.iter_mut().find(|entry| {
+        entry.run_id == run_id
+            && entry.tool_use_id.as_deref() == Some(tool_use_id)
+            && entry.execution_path == Some("staged_unresolved")
+    }) else {
+        return false;
+    };
+    entry.decision = decision;
+    entry.actor = actor;
+    entry.execution_path = Some(execution_path);
+    true
 }
 
 pub(crate) fn refresh_shell_request_assessment(

--- a/src/cosh-ng/crates/cosh-shell/src/approval/resolution.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/resolution.rs
@@ -9,6 +9,7 @@ use crate::approval::handoff::{
 };
 use crate::approval::journal::{approval_audit_input, approval_journal_entry};
 use crate::approval::provider::provider_approval_status;
+use crate::approval::requests::reconcile_staged_unresolved_entry;
 use crate::runtime::prelude::*;
 
 pub(crate) struct AppliedApprovalDecision {
@@ -198,10 +199,25 @@ fn finalize_approval_decision(
                 .grant_run_batch_consent(request.run_id.clone());
         }
     }
-    state
-        .approvals
-        .journal
-        .push(approval_journal_entry(&request, actor));
+    // A late verdict on a grace-released staged call converts the
+    // provisional staged_unresolved entry rather than adding a second,
+    // contradictory terminal record for the same tool_use_id (#2156).
+    let reconciled = request.tool_use_id.as_deref().is_some_and(|tool_id| {
+        reconcile_staged_unresolved_entry(
+            state,
+            &request.run_id,
+            tool_id,
+            request.status,
+            actor,
+            "staged_resolved_late_verdict",
+        )
+    });
+    if !reconciled {
+        state
+            .approvals
+            .journal
+            .push(approval_journal_entry(&request, actor));
+    }
     let run_approved_tool = request.status == ApprovalRequestStatus::Approved
         && request_is_executable_bash_tool(&request);
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/cancel.rs
@@ -140,6 +140,9 @@ fn cancel_active_agent_run<W: Write>(
     active_run.deferred_events.clear();
     clear_active_run_request_buffers(&mut active_run);
     active_run.markdown_stream.finish(output, None)?;
+    // Surface unconsumed hook notifications before teardown; dropping them
+    // with the run is how block decisions went missing (#2067).
+    crate::agent::run::drain_pending_hook_notifications(&mut active_run, output)?;
     state.agent_run.held_events.clear();
     suppress_pending_work_after_agent_cancel(state);
     state.agent_run.needs_prompt_after_run = true;
@@ -511,5 +514,34 @@ mod tests {
             host_completed_tool_ids: Vec::new(),
             pending_hook_notifications: Vec::new(),
         }
+    }
+
+    // F2-ext (#2067): cancelling a run with a pending hook block
+    // notification must surface the decision through governance instead of
+    // dropping it with the run.
+    #[test]
+    fn cancel_surfaces_pending_hook_block_notification() {
+        let mut state = InlineState::default();
+        let mut active_run = test_active_run();
+        active_run
+            .pending_hook_notifications
+            .push(crate::agent::run::PendingHookNotification {
+                tool_use_id: Some("toolu-1".to_string()),
+                hook_name: "guard".to_string(),
+                message: "no touch".to_string(),
+                decision: Some("block".to_string()),
+            });
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        cancel_active_agent_run(&mut state, &mut output).expect("cancel run");
+
+        let rendered = String::from_utf8(output).expect("utf8");
+        assert!(
+            rendered.contains("Hook: guard")
+                && rendered.contains("Message: no touch")
+                && rendered.contains("Decision: block"),
+            "cancel must surface the pending block decision: {rendered}"
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mvp_loop_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mvp_loop_tests.rs
@@ -10,10 +10,10 @@ use crate::parser::{
 };
 use crate::types::{
     AgentEvent, CommandStatus, CoshApprovalMode, FindingKind, GovernanceDecision,
-    GovernancePolicyDecision, InterventionDecision, Policy, QuestionSelectionMode, ShellEvent,
-    ShellEventKind,
+    GovernancePolicyDecision, GovernedEvent, InterventionDecision, Policy, QuestionSelectionMode,
+    ShellEvent, ShellEventKind,
 };
-use crate::ui::render_transcript;
+use crate::ui::{render_transcript, RatatuiInlineRenderer};
 use crate::Language;
 
 fn failed_command_events() -> Vec<ShellEvent> {
@@ -569,4 +569,38 @@ fn claude_code_adapter_is_dry_run_by_default_and_governed() {
     assert_eq!(governed.events.len(), claude_events.len());
     assert_eq!(governed.audit.len(), claude_events.len());
     assert!(governed.events.iter().all(|event| !event.auto_execute));
+}
+
+#[test]
+fn write_governed_events_skips_empty_display_text() {
+    // F3 (#2067): a batch whose events carry no visible content must not
+    // render an empty titled card. Lives here instead of next to the
+    // renderer because the whole ui tree is shared between the lib shim and
+    // the bin target, and new tests must not grow the lib/bin overlap.
+    let event = GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::HookNotification {
+            run_id: "run-1".to_string(),
+            hook_name: "guard".to_string(),
+            message: String::new(),
+            tool_use_id: Some("toolu-1".to_string()),
+            decision: None,
+        },
+        reason: "orphan".to_string(),
+        display_text: String::new(),
+        auto_execute: false,
+    };
+    let renderer = RatatuiInlineRenderer::with_width(80);
+    let mut output = Vec::new();
+
+    renderer
+        .write_governed_events(&mut output, &[event])
+        .unwrap();
+
+    assert!(
+        output.is_empty(),
+        "an empty display text must not render a card: {}",
+        String::from_utf8_lossy(&output)
+    );
 }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
@@ -103,7 +103,8 @@ pub(crate) use crate::approval::handoff::{
 pub(crate) use crate::approval::panel::render_approval_requests;
 pub(crate) use crate::approval::requests::{
     approval_request_from_governed_event, record_approval_requests, record_auto_approved_request,
-    record_deferred_fallback_request, refresh_shell_request_assessment,
+    record_deferred_fallback_request, record_hook_blocked_staged_request,
+    record_staged_unresolved_request, refresh_shell_request_assessment,
 };
 pub(crate) use crate::approval::runtime::render_approval_resolution;
 pub(crate) use crate::question::runtime::{

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/provider_tool_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/provider_tool_state.rs
@@ -12,6 +12,10 @@ pub(crate) struct ProviderToolState {
     rendered_shell_transcript_outputs: HashSet<ProviderToolKey>,
     delivered_host_executed_shell_results: HashSet<String>,
     foreground_shell_commands: HashSet<String>,
+    /// Tool calls the core marked with the machine-readable hook verdict
+    /// (#2156): the only source the approval bridge may use to tell a hook
+    /// rejection apart from an executed command.
+    hook_blocked_results: HashSet<ProviderToolKey>,
 }
 
 impl ProviderToolState {
@@ -162,6 +166,16 @@ impl ProviderToolState {
     pub(crate) fn mark_shell_transcript_output(&mut self, run_id: &str, tool_id: &str) {
         self.rendered_shell_transcript_outputs
             .insert(ProviderToolKey::new(run_id, tool_id));
+    }
+
+    pub(crate) fn mark_hook_blocked_result(&mut self, run_id: &str, tool_id: &str) {
+        self.hook_blocked_results
+            .insert(ProviderToolKey::new(run_id, tool_id));
+    }
+
+    pub(crate) fn hook_result_is_blocked(&self, run_id: &str, tool_id: &str) -> bool {
+        self.hook_blocked_results
+            .contains(&ProviderToolKey::new(run_id, tool_id))
     }
 
     pub(crate) fn mark_shell_transcript_seen(&mut self, run_id: &str, tool_id: &str) {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -669,6 +669,12 @@ impl ControlState {
         self.provider_tool
             .mark_shell_transcript_seen(run_id, tool_id);
     }
+    pub(crate) fn mark_provider_hook_blocked_result(&mut self, run_id: &str, tool_id: &str) {
+        self.provider_tool.mark_hook_blocked_result(run_id, tool_id);
+    }
+    pub(crate) fn provider_hook_result_is_blocked(&self, run_id: &str, tool_id: &str) -> bool {
+        self.provider_tool.hook_result_is_blocked(run_id, tool_id)
+    }
     pub(crate) fn provider_shell_transcript_output_seen(
         &self,
         run_id: &str,

--- a/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
@@ -458,6 +458,15 @@ pub enum AgentEvent {
         tool_id: String,
         status: String,
     },
+    /// The core's machine-readable hook verdict for a tool call (#2156).
+    /// Emitted only when the provider-native result carries the
+    /// `cosh_hook_verdict` wire marker; the bridge keys rejection semantics
+    /// on this event, never on user-controllable result text.
+    ToolHookVerdict {
+        run_id: String,
+        tool_id: String,
+        verdict: String,
+    },
     AgentCompleted {
         run_id: String,
         summary: String,

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
@@ -142,10 +142,17 @@ impl RatatuiInlineRenderer {
         output: &mut W,
         governed_events: &[GovernedEvent],
     ) -> io::Result<()> {
+        let lines = self.governed_event_lines(governed_events);
+        // An event batch without visible content (e.g. an orphan hook
+        // notification whose display text was never populated) must not
+        // render an empty titled card (#2067).
+        if lines.iter().all(|line| line.trim().is_empty()) {
+            return Ok(());
+        }
         self.write_block(
             output,
             self.i18n().t(crate::MessageId::AgentGovernanceTitle),
-            self.governed_event_lines(governed_events),
+            lines,
             None,
         )
     }

--- a/src/cosh-ng/crates/cosh-shell/tests/fixtures/provider/cosh_core/mock_cosh_core_init_caps_cli.sh
+++ b/src/cosh-ng/crates/cosh-shell/tests/fixtures/provider/cosh_core/mock_cosh_core_init_caps_cli.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Asserts the persistent cosh-core initialize handshake carries both the
+# protocol version and the control capability pair (#2156), then completes a
+# trivial turn.
+read -r init
+if echo "$init" | grep -q '"subtype":"initialize"' \
+  && echo "$init" | grep -q '"protocol_version"' \
+  && echo "$init" | grep -q '"can_handle_can_use_tool":true' \
+  && echo "$init" | grep -q '"can_handle_host_executed_shell":true'; then
+  echo '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true}}}}'
+  echo '{"type":"system","subtype":"init","model":"mock-cosh-core","session_id":"mock-cosh-core-init-caps"}'
+else
+  echo '{"type":"result","subtype":"error","session_id":"mock-cosh-core-init-caps","is_error":true,"result":"initialize missing protocol_version or capabilities"}'
+  exit 1
+fi
+read -r line
+echo '{"type":"assistant","session_id":"mock-cosh-core-init-caps","message":{"content":[{"type":"text","text":"init handshake accepted"}]}}'
+echo '{"type":"result","subtype":"success","session_id":"mock-cosh-core-init-caps","is_error":false,"result":"init ok"}'

--- a/src/cosh-ng/crates/cosh-shell/tests/protocol/control.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/protocol/control.rs
@@ -49,5 +49,7 @@ fn wait_for_cosh_core_session(
 mod approval_round_trip;
 #[path = "control/host_executed.rs"]
 mod host_executed;
+#[path = "control/initialize_wire.rs"]
+mod initialize_wire;
 #[path = "control/provider_modes.rs"]
 mod provider_modes;

--- a/src/cosh-ng/crates/cosh-shell/tests/protocol/control/initialize_wire.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/protocol/control/initialize_wire.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[test]
+fn cosh_core_initialize_carries_protocol_version_and_capabilities() {
+    // #2156: the persistent cosh-core transport must send the versioned
+    // initialize handshake with the control capability pair, on the wire —
+    // the mock core rejects the session when either is missing.
+    let adapter = make_cosh_core_adapter("mock_cosh_core_init_caps_cli.sh");
+    let request = make_request("init-caps-wire");
+    let handle = adapter.start_cancellable(request, CoshApprovalMode::Auto);
+
+    let events = collect_events_until(&handle, Duration::from_secs(5), |event| {
+        matches!(
+            event,
+            AgentEvent::AgentCompleted { .. } | AgentEvent::AgentFailed { .. }
+        )
+    });
+
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::TextDelta { text, .. } if text.contains("init handshake accepted")
+        )) && events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::AgentCompleted { .. })),
+        "the versioned initialize with capabilities must be accepted, got: {events:?}"
+    );
+}

--- a/src/cosh-ng/docs/design/trust-shell-capability-negotiation.md
+++ b/src/cosh-ng/docs/design/trust-shell-capability-negotiation.md
@@ -1,0 +1,115 @@
+# Trust-mode shell capability negotiation (#2156)
+
+Owner: cosh-core `protocol.rs`/`core.rs` (classify + verdict release) and cosh-shell
+`adapter/control_protocol` (capability declaration) with `agent/approval_bridge`
+(staged-call disposition). Introduced by the #2156 fix as the approval half of #2067.
+
+## Problem
+
+In trust approval mode, a streamed `ToolCall` reaches the shell before the core's
+hook verdict and enters a 200 ms staging grace. Without a wire contract for the
+verdict, a grace-released staged call could be auto-approved or handed off and
+execute despite a hook Block — and even when the Block won the race, the bridge
+journaled the replayed result as `Approved` + provider-native execution.
+
+## Wire contract
+
+The `initialize` control request gains an optional `capabilities` object:
+
+```json
+{
+  "subtype": "initialize",
+  "capabilities": {
+    "can_handle_can_use_tool": true,
+    "can_handle_host_executed_shell": true
+  }
+}
+```
+
+- **Additive and absent-safe in both directions.** Both fields default to `false`;
+  a legacy client or legacy core keeps the pre-capability behavior exactly.
+- **Fail-closed pairing.** The core reroutes trust-mode `ShellExec` classification
+  to `RequireApproval` (audit reason `trust_shell_handoff`) only when *both* flags
+  are true: `can_use_tool` obtains the verdict and `host_executed_shell` returns
+  the result, so a semi-capable client would strand mid-handoff. An asymmetric
+  declaration is treated as fully absent until an explicit protocol decision says
+  otherwise; capabilities are session-scoped and set once at initialize.
+- **Block release.** When a hook blocks a rerouted call, the core emits the
+  provider-native `tool_result` on the wire, deterministically releasing the
+  staged call instead of letting the grace timer decide. The result carries a
+  machine-readable verdict marker — `"cosh_hook_verdict": "blocked"` on the
+  tool_result content block, present only for hook blocks — so the client keys
+  rejection semantics on a core-controlled field, never on result text (which
+  the executed command itself can control). Absent on every other result, so
+  legacy clients and legacy cores are both unaffected.
+
+## Client behavior matrix
+
+| client | capabilities sent | trust shell call path |
+| --- | --- | --- |
+| cosh-shell persistent control transport (`cosh_core_service`) | both flags | `can_use_tool` → trust auto-approve → foreground handoff; verdict-gated, executed exactly once |
+| cosh-shell one-shot sync transport (`cosh_core_process/input.rs`) | none | legacy provider-native — its stdin writer thread cannot answer `can_use_tool`, so declaring capabilities would strand staged calls |
+| claude / qwen drivers | none (plain initialize) | legacy provider-native fallback unchanged |
+
+## Staged-call disposition matrix (shell bridge)
+
+| verdict timing | verdict | wire signal | branch | journal (terminal) |
+| --- | --- | --- | --- | --- |
+| within grace | Block (any morphology) | result with `cosh_hook_verdict` | hook-block branch (ahead of completed-replay) | `Blocked` + `hook_block`; no approval card |
+| within grace | Allow, executed ok/failed | result without marker | completed-replay | `Approved` + execution recorded |
+| within grace | Allow, command outputs the block text itself | result without marker | completed-replay | `Approved` + execution recorded (forgery has no effect) |
+| after grace | Allow | late `can_use_tool` | M3 provisional, then reconcile | one entry: `Approved` + `staged_resolved_late_verdict` |
+| after grace | Block | late marked result | M3 provisional, then reconcile | one entry: `Blocked` + `hook_block` |
+| never | — | nothing | M3 fail-closed guard | `Blocked` + `staged_unresolved` (true desync) |
+
+Invariants:
+
+- **Machine-readable verdicts only.** The bridge never infers a hook block
+  from result text or notification strings; the `cosh_hook_verdict` wire field
+  is the sole source, covering raw `block`/`deny`/`reject`, hook failures, and
+  message-less blocks in one form.
+- **One terminal journal entry per tool_use_id.** `staged_unresolved` is a
+  provisional record of the grace-window desync; when the late verdict arrives
+  (control-channel approval/denial, or a block-marked result), the entry
+  converts in place — keeping the `staged_resolved_late_verdict` provenance —
+  instead of doubling the journal with a contradictory pair.
+- **Ordering-race safe.** If the staged call bridges before the marker lands,
+  M3 records the provisional entry and the marker's arrival reconciles it.
+
+The hook notification itself stays pending so finish/cancel drains still
+surface it through governance. Non-cosh-core drivers never produce these wire
+markers, so their legacy fallback is untouched.
+
+## Rollback
+
+Revert the fix commits; with capabilities absent both sides fall back to legacy
+behavior. Changelog entries are aggregated by the version-bump PR, not here.
+
+## Follow-up: `approval_bridge.rs` split plan
+
+The bridge file stands at 941 lines after this fix (AGENTS.md: >700 needs a
+split plan; >1000 must not gain features). The two render loops share the
+four-branch staged-call disposition (foreground-covered → hook-block →
+completed-replay → M3 guard). Before the next feature PR touches this file,
+extract that disposition into one shared
+`resolve_staged_provider_tool_call(state, request) -> StagedCallDisposition`
+helper consumed by both loops (est. −60 lines), then reassess whether the
+remaining trust/auto surface warrants a further `approval_bridge/` split.
+
+## Decision note: activity → approval reconcile edge
+
+`activity/runtime.rs` converts a provisional `staged_unresolved` journal entry
+when the block verdict marker arrives. This is the first `activity → approval`
+edge, and it is deliberate:
+
+- The reconcile must run at event-processing time. A late block marker can
+  arrive when no bridge pass is running (the staged call was already bridged
+  at grace release), so deferring the conversion to the bridge would leave the
+  provisional entry stuck until an unrelated call happens to bridge.
+- Activity performs no approval-state surgery itself; it calls the approval
+  owner's `pub(crate)` API (`reconcile_staged_unresolved_entry`), which owns
+  the journal mutation — the same shape as the existing activity → control
+  state recorders (`record_provider_tool_output_delta` et al.).
+- The alternative (a queued runtime command consumed by an approval owner)
+  adds an indirection layer with no additional invariant protection, since the
+  conversion rule is already centralized in that one API.


### PR DESCRIPTION
## Why

Issue #2067's display half (the empty governance panel) was fixed by #2082; its **approval half** remains and is tracked as #2156: in trust approval mode with the cosh-core driver, a hook **block** verdict on a shell tool call can still be bypassed — the blocked command may execute via the 200 ms staging-grace race (proven by the run13 decisive experiment: the marker file was created despite a block-all probe hook), and no formal Allow/Deny panel ever appears.

Root cause chain:

1. **Core**: trust-mode `classify_tool` allowed `ShellExec` tools provider-natively, so no `can_use_tool` control request ever carried the hook verdict; the Block branch also emitted no provider-native tool result.
2. **Shell**: the staged call is released by the 200 ms grace timer and can be executed via the trust auto-approve/handoff fallback — the speculation window.
3. Post-#2082 this also creates a perception gap: the block notification now renders, yet the command may still have executed — "looks blocked, actually ran" is worse than a black box.

## What changed

Two commits, each compiling independently (rebased onto #2082):

- **`[core]`** — M1: new `ClientControlCapabilities` on the initialize request; trust + ShellExec + a fully-capable client now returns `RequireApproval` (audit reason `trust_shell_handoff`), routing the call through the control channel. M2: the Block branch emits the provider-native `tool_result`, deterministically releasing the staged call. Capabilities absent = legacy behavior, so headless and older clients are unchanged.
- **`[shell]`** — declares both capabilities in initialize (cosh-core driver only; claude/qwen keep the plain form); M3 fail-closed guard: a grace-released bare ToolCall under cosh-core is journaled `staged_unresolved` instead of auto-approved/handed off. Display side builds on #2082's i18n hook formatter: orphan notifications drain through the same governance pipeline on the finish path plus the **cancel/stop paths #2082 did not cover** (F2-ext), and an empty event batch never renders a blank card (F3).

Design deviation worth review attention: the M3 guard is keyed on `provider_name == "cosh-core"` rather than the `control_protocol` capability as the design note suggested — claude/qwen also report `control_protocol: true` but have no core-side verdict channel, so keying on the capability would have broken their legacy fallback (R4/I4).

## Related issue

closes #2156 — the approval-side remainder of #2067, whose display side was fixed by #2082.

## User / Agent impact

- Trust mode + cosh-core: shell tool calls now flow `can_use_tool` → trust auto-approve → foreground handoff — verdict-gated, executed exactly once.
- Hook-blocked commands no longer execute; the block reason renders via the shared i18n formatter (`Hook:` / `Message:` / `Decision:`) when the run finishes or is cancelled.
- No behavior change for claude/qwen/fake drivers, legacy shell, or headless clients (capabilities absent = old behavior).

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

- **Contract**: initialize request gains an optional `capabilities` object; additive and absent-safe in both directions (R1). Monorepo ships both crates together.
- **Security-sensitive**: trust-mode shell execution is now verdict-gated — that is the fix.
- **R2**: a blocked call shows both a failed tool-call line and the governance panel — intentional (line = command context, panel = verdict); F3 prevents empty duplicates.
- **R3**: hook latency now gates streaming of post-ToolCall events until verdict (previously masked by the 200 ms release); hooks are already synchronous for every other tool kind.
- **R4**: covered by the provider_name scoping above; provider_handoff/raw_cli suites are the regression net and stay green.
- **R5**: approval_bridge.rs now stands at 941 lines (>700 waiver band, not the >1000 forbidden zone); the staged-call disposition split plan is recorded in `docs/design/trust-shell-capability-negotiation.md` and lands before the next feature PR touches the file.

## Validation

- `cargo test -p cosh-core`: 697 bin green (+2 `session::store` failures reproducing on the pristine base — pre-existing root-environment issue, verified via stash control); 83 lib green.
- `cargo test -p cosh-shell`: 2285 bin + 1212 lib green; `test inventory audit passed` (lib/bin overlap 674/674); raw_cli cosh_core subset 50 green post-rebase.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- CI: Test cosh-ng / Test cosh-ng fast checks / Build cosh-ng release all green on the rebased head.
- New focused tests: capability parse (absent/present), trust reroute (capable/legacy/semi-capable/non-shell), wire-level `can_use_tool` without hooks, block release exactly-once (I5), M3 guard both directions, F2 finish drain, F2-ext cancel drain, F3 empty-batch skip (bin-only location, per the lib/bin overlap audit). Governance formatter coverage rides on upstream's `mvp_loop_tests` hook-context cases.
- **Real-machine PTY FAIL→PASS acceptance: complete** (canonical case `TRUST-HOOK-BLOCK-2156`, real cosh-core + real provider, isolated alinux3 container). FAIL baseline on merge-base `92a67aa8`: grace-released staged call executed despite hook Block (marker created, no panel). PASS on this head: deterministic wire release, governance panel (`Decision: block`), marker never created. Full evidence set (transcripts, casts, screenshots, WebM, provider-parity index) in the follow-up comment below.

## Documentation and rollback

- `src/cosh-ng/CHANGELOG.md` `[0.14.0] — Unreleased` entries for both crates.
- Rollback: revert the two commits; with capabilities absent, both sides fall back to legacy behavior.


