### PR TITLE
fix(cosh-ng): [core] block invalid hook JSON

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/extension/scaffold.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/scaffold.rs
@@ -183,7 +183,7 @@ fn build_template(
             let directory = root.join("hooks");
             fs::create_dir_all(&directory).map_err(scaffold_write_error)?;
             let hook = directory.join("guard.sh");
-            fs::write(&hook, "#!/bin/sh\nexit 0\n").map_err(scaffold_write_error)?;
+            fs::write(&hook, "#!/bin/sh\nprintf '%s\\n' '{}'\n").map_err(scaffold_write_error)?;
             set_executable(&hook)?;
             fields.insert(
                 "hooks".to_string(),
@@ -314,6 +314,21 @@ mod tests {
                 )
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hook_template_emits_valid_pass_through_json() {
+        let temporary = tempfile::tempdir().unwrap();
+        let target = temporary.path().join("example.hook");
+        scaffold_extension(&target, ExtensionTemplate::Hook).unwrap();
+
+        let output = std::process::Command::new(target.join("hooks/guard.sh"))
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let parsed: crate::hook::HookOutput = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(parsed.decision.is_none());
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::de::{value::MapAccessDeserializer, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 use crate::config::{HookDefinition, HooksConfig};
@@ -55,13 +56,64 @@ pub struct HookInput {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct HookOutput {
+    #[serde(rename = "continue")]
+    pub should_continue: Option<bool>,
+    #[serde(alias = "stopReason")]
+    pub stop_reason: Option<String>,
+    #[serde(alias = "suppressOutput")]
+    pub suppress_output: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_present_string")]
     pub decision: Option<String>,
     pub reason: Option<String>,
     #[serde(alias = "systemMessage")]
     pub system_message: Option<String>,
     #[serde(alias = "hookSpecificOutput")]
     pub hook_specific_output: Option<Value>,
+}
+
+fn deserialize_present_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Some)
+}
+
+struct ObjectOnlyHookOutput(HookOutput);
+
+impl<'de> Deserialize<'de> for ObjectOnlyHookOutput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ObjectVisitor;
+
+        impl<'de> Visitor<'de> for ObjectVisitor {
+            type Value = ObjectOnlyHookOutput;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a hook output JSON object")
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                HookOutput::deserialize(MapAccessDeserializer::new(map)).map(ObjectOnlyHookOutput)
+            }
+        }
+
+        deserializer.deserialize_map(ObjectVisitor)
+    }
+}
+
+fn decode_hook_output(raw: &[u8]) -> Option<HookOutput> {
+    // Decode from the original bytes so invalid UTF-8 and duplicate fields
+    // remain protocol errors instead of being normalized before validation.
+    serde_json::from_slice::<ObjectOnlyHookOutput>(raw)
+        .ok()
+        .map(|output| output.0)
 }
 
 // ─── Aggregated Results ──────────────────────────────────────────────
@@ -918,16 +970,33 @@ impl HookSystem {
 
         match exit_code {
             0 => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let trimmed = stdout.trim();
-                if trimmed.is_empty() {
-                    return HookOutput::default();
+                // Exit 0 claims the hook ran successfully, so its stdout must
+                // follow the hook JSON protocol. Anything else — blank,
+                // truncated, or mixed with debug text — fails closed instead
+                // of silently passing the protected action through.
+                match decode_hook_output(&output.stdout) {
+                    Some(output)
+                        if classify_hook_decision(output.decision.as_deref())
+                            != HookDecisionClass::Invalid =>
+                    {
+                        Self::redact_hook_output(output)
+                    }
+                    Some(_) | None => {
+                        // Neither the serde error nor the raw stdout may be
+                        // logged: both can carry fragments of sensitive
+                        // hook output.
+                        tracing::warn!(
+                            target: "cosh_hook",
+                            "Hook '{safe_command}' exited 0 but its stdout violates the hook JSON protocol; \
+                             failing closed with a block decision"
+                        );
+                        HookOutput {
+                            decision: Some("block".to_string()),
+                            reason: Some(INVALID_HOOK_OUTPUT_REASON.to_string()),
+                            ..Default::default()
+                        }
+                    }
                 }
-                let output = serde_json::from_str::<HookOutput>(trimmed).unwrap_or_else(|e| {
-                    tracing::warn!(target: "cosh_hook", "Failed to parse output from '{safe_command}': {e}");
-                    HookOutput::default()
-                });
-                Self::redact_hook_output(output)
             }
             2 => {
                 // System block via exit code 2
@@ -938,8 +1007,7 @@ impl HookSystem {
                     } else {
                         stderr.trim().to_string()
                     }),
-                    system_message: None,
-                    hook_specific_output: None,
+                    ..Default::default()
                 })
             }
             _ => {
@@ -954,6 +1022,9 @@ impl HookSystem {
     }
 
     fn redact_hook_output(mut output: HookOutput) -> HookOutput {
+        output.stop_reason = output
+            .stop_reason
+            .map(|value| crate::redaction::redact_text(&value));
         output.reason = output
             .reason
             .map(|value| crate::redaction::redact_text(&value));
@@ -1146,13 +1217,35 @@ pub fn merge_json_pub(a: Value, b: Value) -> Value {
 
 // ─── Decision Aggregation Primitives ─────────────────────────────────
 
+const INVALID_HOOK_OUTPUT_REASON: &str =
+    "Hook output violates the hook JSON protocol; blocking for safety";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HookDecisionClass {
+    Passthrough,
+    Block,
+    Ask,
+    Allow,
+    Invalid,
+}
+
+fn classify_hook_decision(raw: Option<&str>) -> HookDecisionClass {
+    match raw {
+        None | Some("") => HookDecisionClass::Passthrough,
+        Some("block") | Some("deny") | Some("reject") => HookDecisionClass::Block,
+        Some("ask") => HookDecisionClass::Ask,
+        Some("approve") | Some("allow") => HookDecisionClass::Allow,
+        Some(_) => HookDecisionClass::Invalid,
+    }
+}
+
 /// Fold a raw hook output decision string into the running `HookDecision`.
 ///
 /// Priority (highest wins): Block > Ask > Allow > Passthrough.
 /// "reject" is treated as equivalent to "block"/"deny" (used by Stop hooks).
 fn fold_decision(current: HookDecision, raw: Option<&str>, reason: Option<String>) -> HookDecision {
-    match raw {
-        Some("block") | Some("deny") | Some("reject") => {
+    match classify_hook_decision(raw) {
+        HookDecisionClass::Block => {
             // Preserve the first non-empty block reason; don't let a later
             // hook without a reason overwrite an existing detailed message.
             match (&current, &reason) {
@@ -1160,15 +1253,19 @@ fn fold_decision(current: HookDecision, raw: Option<&str>, reason: Option<String
                 _ => HookDecision::Block(reason.unwrap_or_else(|| "Blocked by hook".to_string())),
             }
         }
-        Some("ask") => match current {
+        HookDecisionClass::Ask => match current {
             HookDecision::Block(_) => current,
             _ => HookDecision::Ask,
         },
-        Some("approve") | Some("allow") => match current {
+        HookDecisionClass::Allow => match current {
             HookDecision::Passthrough => HookDecision::Allow,
             _ => current,
         },
-        _ => current,
+        HookDecisionClass::Passthrough => current,
+        HookDecisionClass::Invalid => match current {
+            HookDecision::Block(_) => current,
+            _ => HookDecision::Block(INVALID_HOOK_OUTPUT_REASON.to_string()),
+        },
     }
 }
 
@@ -1277,7 +1374,7 @@ mod tests {
     #[test]
     fn parse_hook_output_block() {
         let json = r#"{"decision":"block","reason":"unsafe command"}"#;
-        let out: HookOutput = serde_json::from_str(json).unwrap();
+        let out = decode_hook_output(json.as_bytes()).unwrap();
         assert_eq!(out.decision.as_deref(), Some("block"));
         assert_eq!(out.reason.as_deref(), Some("unsafe command"));
     }
@@ -1286,16 +1383,48 @@ mod tests {
     fn parse_hook_output_allow_with_patch() {
         let json =
             r#"{"decision":"allow","hook_specific_output":{"tool_input":{"safe_mode":true}}}"#;
-        let out: HookOutput = serde_json::from_str(json).unwrap();
+        let out = decode_hook_output(json.as_bytes()).unwrap();
         assert_eq!(out.decision.as_deref(), Some("allow"));
         let patch = out.hook_specific_output.unwrap();
         assert_eq!(patch["tool_input"]["safe_mode"], true);
     }
 
     #[test]
+    fn parse_hook_output_accepts_camel_case_aliases() {
+        let json = r#"{"continue":false,"stopReason":"stop","suppressOutput":true,"systemMessage":"notice","hookSpecificOutput":{"additionalContext":"context"}}"#;
+        let out = decode_hook_output(json.as_bytes()).unwrap();
+        assert_eq!(out.should_continue, Some(false));
+        assert_eq!(out.stop_reason.as_deref(), Some("stop"));
+        assert_eq!(out.suppress_output, Some(true));
+        assert_eq!(out.system_message.as_deref(), Some("notice"));
+        assert_eq!(
+            out.hook_specific_output.unwrap()["additionalContext"],
+            "context"
+        );
+    }
+
+    #[test]
+    fn hook_decision_classification_matches_protocol() {
+        for (raw, expected) in [
+            (None, HookDecisionClass::Passthrough),
+            (Some(""), HookDecisionClass::Passthrough),
+            (Some("block"), HookDecisionClass::Block),
+            (Some("deny"), HookDecisionClass::Block),
+            (Some("reject"), HookDecisionClass::Block),
+            (Some("ask"), HookDecisionClass::Ask),
+            (Some("approve"), HookDecisionClass::Allow),
+            (Some("allow"), HookDecisionClass::Allow),
+            (Some("blok"), HookDecisionClass::Invalid),
+        ] {
+            assert_eq!(classify_hook_decision(raw), expected, "{raw:?}");
+        }
+    }
+
+    #[test]
     fn hook_output_is_redacted_before_aggregation() {
         let secret = "short-hook-secret";
         let output = HookOutput {
+            stop_reason: Some(format!("token={secret}")),
             decision: Some("block".to_string()),
             reason: Some(format!("password={secret}")),
             system_message: Some(format!("Bearer {secret}")),
@@ -1303,11 +1432,13 @@ mod tests {
                 "additionalContext": format!("api_key={secret}"),
                 "tool_input": {"token": secret}
             })),
+            ..Default::default()
         };
 
         let output = HookSystem::redact_hook_output(output);
         let serialized = format!(
-            "{} {} {}",
+            "{} {} {} {}",
+            output.stop_reason.as_deref().unwrap_or_default(),
             output.reason.as_deref().unwrap_or_default(),
             output.system_message.as_deref().unwrap_or_default(),
             output
@@ -1504,6 +1635,134 @@ mod tests {
             .fire_pre_tool_use("s1", "/tmp", "tool-1", "any", &serde_json::json!({}), None)
             .await;
         assert_eq!(result.decision, HookDecision::Block("blocked".to_string()));
+    }
+
+    async fn pre_tool_use_result_for(command: &str) -> PreToolUseResult {
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![HookDefinition {
+                command: command.to_string(),
+                name: Some("protocol-probe".to_string()),
+                matcher: None,
+                timeout: Some(5000),
+                sequential: None,
+                env: Default::default(),
+            }],
+            ..Default::default()
+        };
+        let sys = HookSystem::from_config(&config);
+        sys.fire_pre_tool_use(
+            "s1",
+            "/tmp",
+            "tool-1",
+            "shell",
+            &serde_json::json!({}),
+            None,
+        )
+        .await
+    }
+
+    fn expect_fail_closed_block(result: PreToolUseResult) {
+        match &result.decision {
+            HookDecision::Block(reason) => {
+                assert!(reason.to_lowercase().contains("json"), "{reason}");
+            }
+            other => panic!("expected a fail-closed Block, got {other:?}"),
+        }
+        assert!(result.tool_input_patch.is_none());
+        assert_eq!(result.notifications.len(), 1);
+        assert_eq!(result.notifications[0].decision.as_deref(), Some("block"));
+    }
+
+    #[tokio::test]
+    async fn exit_zero_debug_text_stdout_fails_closed() {
+        let result = pre_tool_use_result_for("echo 'debug: not json'").await;
+        // Raw stdout must not leak into the user-visible block reason.
+        if let HookDecision::Block(reason) = &result.decision {
+            assert!(!reason.contains("debug: not json"), "{reason}");
+        }
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_truncated_json_stdout_fails_closed() {
+        let result = pre_tool_use_result_for("printf '%s' '{\"decision\":\"block\"'").await;
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_unknown_decision_fails_closed() {
+        let result = pre_tool_use_result_for("echo '{\"decision\":\"blok\"}'").await;
+        // Do not expose rejected protocol values through the block reason.
+        if let HookDecision::Block(reason) = &result.decision {
+            assert!(!reason.contains("blok"), "{reason}");
+        }
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_unknown_field_fails_closed() {
+        let result = pre_tool_use_result_for("echo '{\"decison\":\"block\"}'").await;
+        // Do not expose rejected protocol keys through the block reason.
+        if let HookDecision::Block(reason) = &result.decision {
+            assert!(!reason.contains("decison"), "{reason}");
+        }
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_array_stdout_fails_closed() {
+        let result = pre_tool_use_result_for("echo '[null,null,null,null,null,null,null]'").await;
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_non_utf8_stdout_fails_closed() {
+        let result = pre_tool_use_result_for(
+            r#"python3 -c 'import sys; sys.stdout.buffer.write(b"{\"reason\":\"\xff\"}")'"#,
+        )
+        .await;
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_null_decision_fails_closed() {
+        let result = pre_tool_use_result_for("echo '{\"decision\":null}'").await;
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_duplicate_decision_fails_closed() {
+        let result =
+            pre_tool_use_result_for("echo '{\"decision\":\"block\",\"decision\":\"\"}'").await;
+        expect_fail_closed_block(result);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_empty_or_blank_stdout_fails_closed() {
+        for command in ["printf ''", "printf '   \\n\\t  '"] {
+            let result = pre_tool_use_result_for(command).await;
+            expect_fail_closed_block(result);
+        }
+    }
+
+    #[tokio::test]
+    async fn exit_zero_empty_object_stays_passthrough() {
+        let result = pre_tool_use_result_for("echo '{}'").await;
+        assert_eq!(result.decision, HookDecision::Passthrough);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_empty_decision_stays_passthrough() {
+        let result = pre_tool_use_result_for("echo '{\"decision\":\"\"}'").await;
+        assert_eq!(result.decision, HookDecision::Passthrough);
+    }
+
+    #[tokio::test]
+    async fn exit_zero_valid_block_json_keeps_its_reason() {
+        let result =
+            pre_tool_use_result_for("echo '{\"decision\":\"block\",\"reason\":\"policy\"}'").await;
+        assert_eq!(result.decision, HookDecision::Block("policy".to_string()));
     }
 
     // ===== Task 1: matcher 双向工具名兼容 =====
@@ -1778,6 +2037,7 @@ mod tests {
                     },
                 },
             }])),
+            ..Default::default()
         };
 
         let output = HookSystem::redact_hook_output(output);
@@ -1804,6 +2064,7 @@ mod tests {
             hook_specific_output: Some(serde_json::json!({
                 "api_key": "leaked-value",
             })),
+            ..Default::default()
         };
 
         let output = HookSystem::redact_hook_output(output);
@@ -2164,7 +2425,7 @@ mod tests {
             enabled: true,
             pre_tool_use: vec![],
             post_tool_use: vec![HookDefinition {
-                command: r#"python3 -c 'import sys,json; print(json.dumps({"hook_specific_output": {"updatedToolResponse": "compressed!", "additionalContext": "env-hint"}}))'"#.to_string(),
+                command: r#"python3 -c 'import sys,json; print(json.dumps({"suppressOutput": True, "hookSpecificOutput": {"updatedToolResponse": "compressed!", "additionalContext": "env-hint"}}))'"#.to_string(),
                 name: Some("compressor".to_string()),
                 matcher: None,
                 timeout: Some(5000),

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -5,18 +5,19 @@
 # Hook event: PreToolUse (matcher: "" — matches all tools)
 # Requires: jq
 #
-# Design: fail-open. If jq is missing or any phase fails, exit 0 silently.
+# Design: fail-open. Skipped checks emit a valid pass-through hook response.
 #
 # Four-Phase Flow:
 #   Phase 1 — LOOKUP:   Find tool in config dictionary. Not found → skip.
-#   Phase 2 — CHECK:    Scan system readiness. All ready → continue silently.
-#   Phase 3 — FIX:      Auto-install missing deps. Success → continue silently.
+#   Phase 2 — CHECK:    Scan system readiness. All ready → pass through.
+#   Phase 3 — FIX:      Auto-install missing deps. Success → pass through.
 #   Phase 4 — FEEDBACK: Fix failed. Inject additionalContext → "Skip retry".
 
 set -euo pipefail
 
 VERBOSE="${TOKENLESS_VERBOSE:-}"
 log_v() { [ -n "$VERBOSE" ] && echo "[tokenless:ready] $1" >&2 || true; }
+pass_through() { printf '%s\n' '{}'; exit 0; }
 
 USER_HOME="${HOME:-}"
 case "$USER_HOME" in
@@ -25,7 +26,7 @@ case "$USER_HOME" in
 esac
 
 # --- Dependency check (fail-open) ---
-if ! command -v jq &>/dev/null; then log_v "jq not found, skipping"; exit 0; fi
+if ! command -v jq &>/dev/null; then log_v "jq not found, skipping"; pass_through; fi
 
 # --- File trust validation ---
 # User-writable paths must be owned by current user and not world-writable.
@@ -134,7 +135,7 @@ for candidate in \
 done
 
 # --- Read input (fail-open) ---
-INPUT=$(cat || { exit 0; })
+if ! INPUT=$(cat); then pass_through; fi
 
 # ============================================================================
 # Phase 1: LOOKUP — Find tool in config dictionary
@@ -142,9 +143,9 @@ INPUT=$(cat || { exit 0; })
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo '')
 log_v "Phase 1 LOOKUP: tool_name=$TOOL_NAME"
-if [ -z "$TOOL_NAME" ]; then exit 0; fi
+if [ -z "$TOOL_NAME" ]; then pass_through; fi
 
-if [ ! -f "$SPEC_FILE" ]; then log_v "spec file not found, skipping"; exit 0; fi
+if [ ! -f "$SPEC_FILE" ]; then log_v "spec file not found, skipping"; pass_through; fi
 
 # Resolve: aliases reverse lookup → exact key → case-insensitive fallback
 # Each spec entry has an "aliases" array listing tool names from all agent
@@ -176,7 +177,7 @@ fi
 
 if [ -z "$SPEC_KEY" ]; then
     log_v "Phase 1: $TOOL_NAME not in spec dict → skip"
-    exit 0
+    pass_through
 fi
 log_v "Phase 1: $TOOL_NAME → $SPEC_KEY found in spec dict"
 
@@ -429,8 +430,8 @@ if $IS_READY && [ "$missing_count_rec" -gt 0 ]; then
 fi
 
 if $IS_READY && ! $IS_PARTIAL; then
-    log_v "Phase 2 CHECK: $TOOL_NAME → READY, silent pass"
-    exit 0
+    log_v "Phase 2 CHECK: $TOOL_NAME → READY, pass-through"
+    pass_through
 fi
 if $IS_PARTIAL; then
     log_v "Phase 2 CHECK: $TOOL_NAME → PARTIAL (recommended missing: ${RECOMMENDED_MISSING_LIST})"
@@ -498,7 +499,7 @@ if [ "$missing_count" -gt 0 ] \
     fi
 
     if [ -z "$STILL_MISSING" ] && ! $HAS_VERSION_LOW && [ -z "$PERM_MISSING" ]; then
-        exit 0
+        pass_through
     fi
 
     # After fix, re-check readiness
@@ -512,7 +513,7 @@ if [ "$missing_count" -gt 0 ] \
             "hookEventName": "PreToolUse",
             "additionalContext": $context
           }
-        }' || exit 0
+        }' || pass_through
         exit 0
     fi
 fi
@@ -531,7 +532,7 @@ if $IS_PARTIAL && ! $HAS_REQUIRED_MISSING && ! $HAS_VERSION_LOW && [ -z "$PERM_M
         "hookEventName": "PreToolUse",
         "additionalContext": $context
       }
-    }' || exit 0
+    }' || pass_through
     exit 0
 fi
 
@@ -560,4 +561,4 @@ jq -n --arg context "$DIAG_MSG" --arg reason "$DIAG_MSG" '{
     "hookEventName": "PreToolUse",
     "additionalContext": $context
   }
-}' || exit 0
+}' || pass_through

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -533,11 +533,11 @@ test_tool_ready() {
     fi
 
     # ==========================================
-    # 6.21 tool-ready hook: READY (silent exit)
+    # 6.21 tool-ready hook: READY (protocol pass-through)
     # ==========================================
-    log_info "Test 6.21: tool-ready hook — READY silent exit"
+    log_info "Test 6.21: tool-ready hook — READY protocol pass-through"
     local ready_out=$(echo '{"tool_name":"Shell","tool_input":{"command":"ls"}}' | bash "$READY_SCRIPT" 2>&1)
-    [ -z "$ready_out" ] && log_pass "tool-ready READY produces no output" || log_fail "tool-ready READY unexpected output: $ready_out"
+    [ "$ready_out" = '{}' ] && log_pass "tool-ready READY emits pass-through JSON" || log_fail "tool-ready READY unexpected output: $ready_out"
 
     # ==========================================
     # 6.22 tool-ready hook: NOT_READY + Skip retry

--- a/src/tokenless/tests/test-tool-ready-readable-fixer.sh
+++ b/src/tokenless/tests/test-tool-ready-readable-fixer.sh
@@ -12,7 +12,7 @@ FIXER="$TEST_DIR/tokenless-env-fix.sh"
 MARKER="$TEST_DIR/fixer-called"
 
 cat > "$SPEC" <<'EOF'
-{"TestMissing":{"required":[{"binary":"tokenless-missing-for-test","package":"tokenless-missing-for-test","manager":"rpm"}],"recommended":[],"permissions":[]}}
+{"TestReady":{"required":[],"recommended":[],"permissions":[]},"TestMissing":{"required":[{"binary":"tokenless-missing-for-test","package":"tokenless-missing-for-test","manager":"rpm"}],"recommended":[],"permissions":[]}}
 EOF
 
 cat > "$FIXER" <<'EOF'
@@ -24,6 +24,27 @@ cat >/dev/null
 touch "$TOKENLESS_FIX_MARKER"
 EOF
 chmod 0644 "$FIXER"
+
+EMPTY_PATH="$TEST_DIR/empty-path"
+mkdir "$EMPTY_PATH"
+NO_JQ_OUTPUT=$(PATH="$EMPTY_PATH" /bin/bash "$HOOK" </dev/null)
+[ "$NO_JQ_OUTPUT" = '{}' ]
+
+PASSTHROUGH_OUTPUT=$(
+    echo '{"tool_name":"TestReady","tool_input":{"command":"test"}}' \
+        | TOKENLESS_TOOL_READY_SPEC="$SPEC" \
+          TOKENLESS_ENV_FIX_SCRIPT="$FIXER" \
+          bash "$HOOK"
+)
+[ "$PASSTHROUGH_OUTPUT" = '{}' ]
+
+UNKNOWN_TOOL_OUTPUT=$(
+    echo '{"tool_name":"UnknownTool","tool_input":{}}' \
+        | TOKENLESS_TOOL_READY_SPEC="$SPEC" \
+          TOKENLESS_ENV_FIX_SCRIPT="$FIXER" \
+          bash "$HOOK"
+)
+[ "$UNKNOWN_TOOL_OUTPUT" = '{}' ]
 
 OUTPUT=$(
     echo '{"tool_name":"TestMissing","tool_input":{"command":"test"}}' \


### PR DESCRIPTION
## Why

Hooks that exited successfully but emitted malformed or empty JSON fell back
to an allow decision. Syntactically valid JSON with an unknown `decision`,
a misspelled or duplicate field, an explicit null decision, or a positional
array could also pass through. Lossy UTF-8 conversion could normalize invalid
bytes into an otherwise accepted object.

## What changed

Treat exit-zero output that does not satisfy the hook JSON protocol as a
blocking decision. Decode directly from the original stdout bytes with an
object-only visitor, preserving Serde's duplicate-field detection and rejecting
invalid UTF-8 or non-object shapes. Distinguish an omitted decision from an
explicit null value, then validate supported fields and decisions through one
shared classifier.

Preserve missing or empty decisions as pass-through, accept every established
common field, and reject unknown keys or decision values. The generated Hook
scaffold and bundled tokenless tool-readiness hook emit `{}` for valid
pass-through paths.

## Related issue

closes #2101

## User / Agent impact

Hook scripts that exit 0 must emit a valid UTF-8 JSON object using supported
top-level fields and decision values. Malformed, empty, array-shaped,
duplicate-key, null-decision, or schema-invalid stdout blocks the protected
action instead of silently allowing it. Common control fields remain accepted,
and bundled tokenless hooks remain compatible.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

This intentionally changes fail-open behavior to fail-closed for invalid hook
protocol output. Existing third-party hooks that exit 0 without a valid JSON
object must be corrected. Repository-provided pass-through hooks have been
updated, and extensible event-specific data remains supported inside
`hookSpecificOutput`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package cosh-core parse_hook_output_` (3 passed)
- `cargo test --package cosh-core exit_zero_` (12 passed)
- `cargo clippy --package cosh-core --all-targets -- -D warnings`
- Earlier bundled-hook amendment:
  `bash -n adapters/tokenless/common/hooks/tool_ready_hook.sh`
- Earlier bundled-hook amendment:
  `bash -n tests/test-tool-ready-readable-fixer.sh`
- Earlier bundled-hook amendment:
  `bash tests/test-tool-ready-readable-fixer.sh`
- Earlier compatibility amendment:
  `cargo test --package cosh-core hook_output_is_redacted_before_aggregation`
  (1 passed)
- Earlier compatibility amendment:
  `cargo test --package cosh-core post_tool_use_hook_emits_updated_tool_response`
  (1 passed)
- Earlier amendment:
  `cargo test --package cosh-core extension::scaffold::tests` (3 passed)
- Earlier revision: `cargo clippy --workspace --all-targets -- -D warnings`
- Earlier revision: `cargo test --workspace -- --test-threads=1`
- Earlier revision: `cargo build --workspace --release`

The latest parser amendments used scoped checks; the full workspace suite was
not rerun.

## Documentation and rollback

No documentation change is required. Revert commit `dbefcd97` to restore the
previous fail-open behavior.
