### PR TITLE
fix(cosh-ng): [shell] run project hooks for send-to-shell

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/hooks/engine.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/engine.rs
@@ -237,13 +237,18 @@ impl HookEngine {
     }
 }
 
+/// Origins where the command was explicitly typed or confirmed by the user
+/// at their own shell prompt, as opposed to agent/internal automation paths.
+fn is_user_shell_origin(origin: CommandOrigin) -> bool {
+    matches!(
+        origin,
+        CommandOrigin::UserInteractive | CommandOrigin::UserSendToShell
+    )
+}
+
 fn external_hook_allowed_for_origin(config: &ExternalHookConfig, origin: CommandOrigin) -> bool {
     match config.source {
-        ExternalHookSource::User => matches!(
-            origin,
-            CommandOrigin::UserInteractive | CommandOrigin::UserSendToShell
-        ),
-        ExternalHookSource::Project => matches!(origin, CommandOrigin::UserInteractive),
+        ExternalHookSource::User | ExternalHookSource::Project => is_user_shell_origin(origin),
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/hooks/engine/tests/project.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/engine/tests/project.rs
@@ -73,7 +73,7 @@ fn trusted_project_hook_executes_after_match() {
 
 #[cfg(unix)]
 #[test]
-fn trusted_project_hook_skips_non_user_interactive_origin() {
+fn trusted_project_hook_runs_only_for_user_shell_origins() {
     let project = std::env::temp_dir().join("cosh_hook_test_project_origin_gate");
     let hooks_dir = project.join(".cosh/hooks");
     let _ = fs::remove_dir_all(&project);
@@ -94,7 +94,6 @@ fn trusted_project_hook_skips_non_user_interactive_origin() {
     engine.load_project_hooks_from_root(&project, true);
 
     for origin in [
-        crate::types::CommandOrigin::UserSendToShell,
         crate::types::CommandOrigin::UserAnalysisAction,
         crate::types::CommandOrigin::AgentHandoff,
         crate::types::CommandOrigin::ProviderTool,
@@ -110,13 +109,23 @@ fn trusted_project_hook_skips_non_user_interactive_origin() {
         assert!(!marker.exists(), "origin {origin:?} executed project hook");
     }
 
-    let findings = engine.evaluate_with_disabled_and_origin(
-        &make_block("echo hi"),
-        &HashSet::new(),
+    for origin in [
         crate::types::CommandOrigin::UserInteractive,
-    );
-    assert_eq!(findings.len(), 1);
-    assert!(marker.exists());
+        crate::types::CommandOrigin::UserSendToShell,
+    ] {
+        let findings = engine.evaluate_with_disabled_and_origin(
+            &make_block("echo hi"),
+            &HashSet::new(),
+            origin,
+        );
+        assert_eq!(
+            findings.len(),
+            1,
+            "origin {origin:?} should run project hook"
+        );
+        assert!(marker.exists(), "origin {origin:?} skipped project hook");
+        let _ = fs::remove_file(&marker);
+    }
 
     let _ = fs::remove_dir_all(&project);
 }

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/send_to_shell.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/send_to_shell.rs
@@ -415,3 +415,50 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
         "{output}"
     );
 }
+
+#[test]
+fn raw_cli_send_to_shell_command_triggers_trusted_project_hook() {
+    let fixture = temp_shell_home("send-to-shell-project-hook");
+    let project = fixture.join("project");
+    let hooks_dir = project.join(".cosh/hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    write_executable(
+        &hooks_dir.join("project-guard.sh"),
+        "#!/bin/sh\n# cosh-hook: project-guard\n# match-commands: git\nprintf '{\"hook_id\":\"project-guard\",\"severity\":\"warning\",\"title\":\"PROJECT GUARD SEND TO SHELL\",\"description\":\"project hook fired\",\"suggestion\":\"review against project policy\"}'\n",
+    );
+    let trust_store = fixture.join("trusted-project-hooks");
+    fs::write(
+        &trust_store,
+        format!(
+            "# cosh-shell trusted project hook roots\n{}\n",
+            project.display()
+        ),
+    )
+    .unwrap();
+
+    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+        "fake",
+        &[],
+        &[(
+            "COSH_SHELL_PROJECT_TRUST_STORE",
+            trust_store.to_str().unwrap(),
+        )],
+        &project,
+        vec![
+            (
+                b"?? provider interactive failure\n".to_vec(),
+                Duration::ZERO,
+            ),
+            (
+                b"/send-to-shell handoff-1\n".to_vec(),
+                Duration::from_millis(2_500),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(4_000)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&fixture);
+
+    assert!(output.contains("Sending to shell"), "{output}");
+    assert!(output.contains("$ git status"), "{output}");
+    assert!(output.contains("PROJECT GUARD SEND TO SHELL"), "{output}");
+}


### PR DESCRIPTION
# Summary

Trusted project hooks (`<repo>/.cosh/hooks`) were silently skipped when a
command entered the shell through the agent card send-to-shell action
(`CommandOrigin::UserSendToShell`), while the same command typed at the
prompt (`UserInteractive`) triggered them. User-source hooks
(`~/.copilot-shell/cosh/hooks`) already run for both origins, so the
asymmetry left the agent-recommended command path without project
advisory coverage, with no signal to the user that the gap exists.

`UserSendToShell` is a user-actor origin: the command is explicitly
confirmed by the user on the interactive shell handoff card
(`approval/handoff.rs`, `source: "send_to_shell"`, `actor: "user"`), and
trusted project hooks additionally sit behind the explicit project trust
gate. No written design rationale exists for excluding it, so this PR
aligns the project-hook origin gate with the user-hook gate.

# Changes

- `hooks/engine.rs`: introduce a shared `is_user_shell_origin` predicate
  (`UserInteractive | UserSendToShell`) and collapse both
  `ExternalHookSource` arms onto it, so the origin gate can no longer
  drift between hook sources. Agent/internal automation origins
  (`AgentHandoff`, `ProviderTool`, `ShellInternal`, `UserAnalysisAction`,
  `Unknown`) remain excluded for both sources.
- `hooks/engine/tests/project.rs`: re-anchor
  `trusted_project_hook_skips_non_user_interactive_origin` as
  `trusted_project_hook_runs_only_for_user_shell_origins` — positive
  assertions for both user shell origins plus negative assertions for
  the full automation origin set.
- `tests/raw_cli/provider_handoff/send_to_shell.rs`: new integration
  test `raw_cli_send_to_shell_command_triggers_trusted_project_hook`
  covering the full `/send-to-shell` → `UserSendToShell` → trusted
  project hook chain (real PTY, real hook subprocess, real trust store
  via `COSH_SHELL_PROJECT_TRUST_STORE`).

# Tests

- `trusted_project_hook_runs_only_for_user_shell_origins` (re-anchored,
  lib + bin targets)
- `raw_cli_send_to_shell_command_triggers_trusted_project_hook` (new,
  FAIL on the pre-fix engine: hook card never rendered, exit 101; PASS
  after the fix)
- Probe-level FAIL→PASS: asserting the expected behavior on the
  unmodified base commit fails with `findings=0`, passes after the fix.

# Verification

Focused scope (all green):

- `cargo test -p cosh-shell --lib` — 1211 passed
- `cargo test -p cosh-shell --bin cosh-shell` — 2280 passed, 1 ignored
  (pre-existing)
- `cargo test -p cosh-shell --test raw_cli provider_handoff` — 31 passed
- `cargo clippy -p cosh-shell --all-targets -- -D warnings` — clean
- `crates/cosh-shell/scripts/check-layout.sh`,
  `scripts/check-test-inventory.sh` — pass
- L3 security review — 0 findings

Real-environment acceptance (container, arm64, real cosh-core adapter,
real provider, real PTY): in a trusted project, an interactive-origin
command renders the project hook finding card (screenshot in Evidence).

Excluded scope (not run): other workspace crates, release gate,
non-arm64 architectures.

Known boundary (unrelated to this fix): with the current real
cosh-core+qwen chain, a failing command (`exit != 0`, stderr
`not a tty`) is reported as tool-level `success`, so the interactive
shell handoff card (`[Send to shell]`) is not reachable end-to-end with
a real provider today; the `UserSendToShell` chain is therefore covered
by the raw_cli integration test above, which drives the production
handoff path with a scripted adapter event feed against a real PTY.

# Evidence

Real-environment acceptance screenshot (container arm64, real cosh-core
adapter, real provider, real PTY; trusted project, interactive-origin
command renders the project hook finding card):

![trusted project hook card, interactive origin](https://raw.githubusercontent.com/SunnyQjm/anolisa/f83b8cc6f4b6d8f03289845b0c6db1fa9c3e7498/interactive-origin-hook-card.png)

Closes #2089
