### PR TITLE
feat(ci): test anolisa raw lifecycle

### DIFF
--- a/.github/workflows/_rpm-build.yaml
+++ b/.github/workflows/_rpm-build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       component:
-        description: "Component to build (copilot-shell, cosh-ng, agent-sec-core, agentsight, os-skills, tokenless, ws-ckpt, agent-memory, skillfs)"
+        description: "Component to build (copilot-shell, cosh-ng, agent-sec-core, agentsight, os-skills, tokenless, ws-ckpt, agent-memory, skillfs, anolisa)"
         required: true
         type: string
       version:
@@ -109,6 +109,12 @@ jobs:
         with:
           toolchain: '1.91.0'
 
+      - name: "Setup Rust toolchain (anolisa)"
+        if: inputs.component == 'anolisa'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.88.0'
+
       - name: "Setup Python + uv (agent-sec-core)"
         if: inputs.component == 'agent-sec-core'
         uses: astral-sh/setup-uv@v8.0.0
@@ -203,6 +209,21 @@ jobs:
             cp -p "$SOURCE_ROOT/README_zh.md" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
             cp -p "$SOURCE_ROOT/LICENSE" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
             tar -czf ~/rpmbuild/SOURCES/"${EXPECTED_TAR}" -C "$PACKAGE_DIR" "${COMPONENT}-${VERSION}"
+          fi
+
+          # The anolisa spec intentionally unpacks Source0 into `anolisa/`
+          # instead of the versioned directory emitted by package-source.
+          if [ "$COMPONENT" = "anolisa" ]; then
+            SOURCE_ROOT=$(find "$EXTRACT_DIR" -mindepth 1 -maxdepth 1 -type d | head -1)
+            if [ -z "$SOURCE_ROOT" ]; then
+              echo "ERROR: anolisa source root not found"
+              exit 1
+            fi
+
+            PACKAGE_DIR=$(mktemp -d)
+            mkdir -p "$PACKAGE_DIR/anolisa"
+            cp -a "$SOURCE_ROOT/." "$PACKAGE_DIR/anolisa/"
+            tar -czf ~/rpmbuild/SOURCES/"${EXPECTED_TAR}" -C "$PACKAGE_DIR" anolisa
           fi
 
           # Find and process spec template

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -933,7 +933,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: '1.88.0'
-          components: 'rustfmt, clippy'
+          components: 'rustfmt, clippy, llvm-tools-preview'
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -949,6 +952,19 @@ jobs:
           node npm/tests/platforms.test.js
           node npm/scripts/package-npm.js --validate
 
+      - name: Validate nightly E2E harness
+        run: |
+          bash -n src/anolisa/tests/nightly/raw-lifecycle.sh
+          src/anolisa/tests/nightly/raw-lifecycle.sh --list
+          REPO_CONFIG=$(mktemp)
+          trap 'rm -f "$REPO_CONFIG"' EXIT
+          cp src/anolisa/manifests/repo.toml "$REPO_CONFIG"
+          ANOLISA_E2E_REPO_CONFIG_PATH="$REPO_CONFIG" \
+            ANOLISA_RAW_REPO_URL="https://mirror.example.com/raw/v1/" \
+            src/anolisa/tests/nightly/raw-lifecycle.sh --configure-repo
+          grep -Fx 'base_url = "https://mirror.example.com/raw/v1/"' \
+            "$REPO_CONFIG"
+
       - name: Check formatting
         run: |
           cd src/anolisa
@@ -959,10 +975,58 @@ jobs:
           cd src/anolisa
           cargo clippy --all-targets --locked -- -D warnings
 
-      - name: Run tests
+      - name: Run documentation tests
         run: |
           cd src/anolisa
-          cargo test --locked
+          cargo test --workspace --doc --locked
+
+      - name: Run tests with coverage
+        run: |
+          cd src/anolisa
+          mkdir -p coverage
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --workspace --all-targets --locked --no-report
+          # Permission-path tests can leave their process profile write-only;
+          # llvm-profdata needs every emitted profile to be readable.
+          find target/llvm-cov-target -type f -name '*.profraw' \
+            -exec chmod u+r {} +
+          cargo llvm-cov report --json --output-path coverage/coverage.json
+          cargo llvm-cov report --lcov --output-path coverage/lcov.info
+
+      - name: Publish coverage summary
+        id: coverage
+        run: |
+          cd src/anolisa
+          LINE_COVERAGE=$(node -e '
+            const report = require("./coverage/coverage.json");
+            process.stdout.write(String(report.data[0].totals.lines.percent));
+          ')
+          FUNCTION_COVERAGE=$(node -e '
+            const report = require("./coverage/coverage.json");
+            process.stdout.write(String(report.data[0].totals.functions.percent));
+          ')
+          echo "line-coverage=${LINE_COVERAGE}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## anolisa code coverage"
+            echo ""
+            echo "| Metric | Coverage |"
+            echo "|--------|----------|"
+            printf '| Lines | **%.2f%%** |\n' "$LINE_COVERAGE"
+            printf '| Functions | %.2f%% |\n' "$FUNCTION_COVERAGE"
+            echo ""
+            echo "Coverage is reported for the full \`src/anolisa\` Rust workspace."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: anolisa-coverage
+          path: |
+            src/anolisa/coverage/coverage.json
+            src/anolisa/coverage/lcov.info
+          if-no-files-found: warn
+          retention-days: 14
 
   # =========================================================================
   # Step 10: Test SkillFS (Rust workspace)

--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -10,6 +10,10 @@ on:
         description: "Dry-run mode: build images but do NOT push to registries"
         type: boolean
         default: true
+      raw-repo-url:
+        description: "Raw repository root used by the anolisa lifecycle E2E"
+        type: string
+        default: "https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/"
 
 permissions:
   contents: read
@@ -37,6 +41,7 @@ jobs:
       ws-ckpt-version: ${{ steps.ws-ckpt.outputs.version }}
       agent-memory-version: ${{ steps.agent-memory.outputs.version }}
       skillfs-version: ${{ steps.skillfs.outputs.version }}
+      anolisa-version: ${{ steps.anolisa.outputs.version }}
       image-version: ${{ steps.image.outputs.version }}
       image-version-tag: ${{ steps.image.outputs.version_tag }}
     steps:
@@ -120,6 +125,12 @@ jobs:
         with:
           tag-match: "skillfs/v*"
 
+      - name: "Version: anolisa"
+        id: anolisa
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-match: "anolisa/v*"
+
       - name: Summary
         run: |
           echo "## Component Versions" >> $GITHUB_STEP_SUMMARY
@@ -133,6 +144,7 @@ jobs:
           echo "| ws-ckpt | \`${{ steps.ws-ckpt.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| agent-memory | \`${{ steps.agent-memory.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| skillfs | \`${{ steps.skillfs.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| anolisa | \`${{ steps.anolisa.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **image** | \`${{ steps.image.outputs.version }}\` (tag: \`${{ steps.image.outputs.version_tag }}\`) |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -255,6 +267,29 @@ jobs:
         with:
           component: skillfs
           version: ${{ needs.versions.outputs.skillfs-version }}
+          artifact-suffix: ".nightly"
+          retention-days: "7"
+
+  package-anolisa:
+    name: "Package: anolisa"
+    runs-on: anolisa-k8s-amd-nightly
+    needs: versions
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/package-source
+        with:
+          component: anolisa
+          version: ${{ needs.versions.outputs.anolisa-version }}
+          artifact-suffix: ".nightly"
+          retention-days: "7"
+
+      - name: Package vendor archive
+        uses: ./.github/actions/package-vendor
+        with:
+          component: anolisa
+          version: ${{ needs.versions.outputs.anolisa-version }}
           artifact-suffix: ".nightly"
           retention-days: "7"
 
@@ -423,6 +458,21 @@ jobs:
       vendor-artifact: "skillfs-${{ needs.versions.outputs.skillfs-version }}.nightly-vendor"
       artifact-suffix: ".nightly"
 
+  rpm-anolisa:
+    name: "RPM: anolisa (${{ matrix.arch }})"
+    needs: [versions, package-anolisa]
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    uses: ./.github/workflows/_rpm-build.yaml
+    with:
+      component: anolisa
+      version: ${{ needs.versions.outputs.anolisa-version }}
+      arch: ${{ matrix.arch }}
+      source-artifact: "anolisa-${{ needs.versions.outputs.anolisa-version }}.nightly"
+      vendor-artifact: "anolisa-${{ needs.versions.outputs.anolisa-version }}.nightly-vendor"
+      artifact-suffix: ".nightly"
+
   # ===========================================================================
   # Job 4: Build and push Docker image
   # ===========================================================================
@@ -438,6 +488,7 @@ jobs:
       - rpm-ws-ckpt
       - rpm-agent-memory
       - rpm-skillfs
+      - rpm-anolisa
       - rpm-sight
     steps:
       - uses: actions/checkout@v4
@@ -550,3 +601,81 @@ jobs:
           echo "- \`${{ env.GHCR_IMAGE }}:nightly\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Platforms**: \`linux/amd64\`, \`linux/arm64\`" >> $GITHUB_STEP_SUMMARY
+
+  # ==========================================================================
+  # Job 5: Exercise the CLI from the image against the real raw repository
+  # ==========================================================================
+  anolisa-raw-lifecycle-e2e:
+    name: E2E anolisa raw lifecycle
+    if: github.event_name == 'schedule' || inputs.dry-run != true
+    runs-on: anolisa-k8s-amd-nightly
+    timeout-minutes: 30
+    needs:
+      - versions
+      - docker-build-push
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull the image built by this run
+        env:
+          IMAGE: ${{ env.GHCR_IMAGE }}:${{ needs.versions.outputs.image-version-tag }}
+        run: docker pull --platform linux/amd64 "$IMAGE"
+
+      - name: Verify anolisa CLI is installed
+        env:
+          IMAGE: ${{ env.GHCR_IMAGE }}:${{ needs.versions.outputs.image-version-tag }}
+        run: |
+          docker run --rm --platform linux/amd64 \
+            --entrypoint anolisa \
+            "$IMAGE" --version
+
+      - name: Run real raw install, update, and uninstall
+        env:
+          IMAGE: ${{ env.GHCR_IMAGE }}:${{ needs.versions.outputs.image-version-tag }}
+          RAW_REPO_URL: ${{ inputs.raw-repo-url || 'https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/' }}
+        run: |
+          set -o pipefail
+          docker run --rm --platform linux/amd64 \
+            --entrypoint /bin/bash \
+            --env ANOLISA_RAW_REPO_URL="$RAW_REPO_URL" \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            "$IMAGE" \
+            /workspace/src/anolisa/tests/nightly/raw-lifecycle.sh \
+            2>&1 | tee anolisa-raw-lifecycle.log
+
+      - name: Publish E2E inventory summary
+        if: always()
+        env:
+          IMAGE: ${{ env.GHCR_IMAGE }}:${{ needs.versions.outputs.image-version-tag }}
+          RAW_REPO_URL: ${{ inputs.raw-repo-url || 'https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/' }}
+        run: |
+          {
+            echo "## anolisa raw lifecycle E2E"
+            echo ""
+            echo "Image: \`${IMAGE}\`"
+            echo "Raw repository: \`${RAW_REPO_URL}\`"
+            echo ""
+            echo "| Component | Status | Reason |"
+            echo "|-----------|--------|--------|"
+            awk -F '\t' '
+              !/^#/ && NF >= 4 {
+                printf "| `%s` | %s | %s |\n", $1, $3, $4
+              }
+            ' src/anolisa/tests/nightly/raw-lifecycle-cases.tsv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload E2E log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: anolisa-raw-lifecycle-${{ needs.versions.outputs.image-version-tag }}
+          path: anolisa-raw-lifecycle.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/src/anolisa/tests/nightly/raw-lifecycle-cases.tsv
+++ b/src/anolisa/tests/nightly/raw-lifecycle-cases.tsv
@@ -1,0 +1,9 @@
+# component	rpm_package	status	reason
+agent-memory	agent-memory	run	portable raw artifact with multiple published versions
+tokenless	tokenless	run	portable raw artifact with multiple published versions
+agentsight	agentsight	skip	requires a privileged eBPF-capable runtime for meaningful validation
+cosh	copilot-shell	skip	needs an isolated conflict fixture because cosh-ng is preinstalled in the image
+cosh-ng	cosh-ng	skip	needs an isolated conflict fixture because cosh is preinstalled in the image
+os-skills	os-skills	skip	published contract still uses the legacy manifest layout
+skillfs	skillfs	skip	requires FUSE and /dev/fuse
+ws-ckpt	ws-ckpt	skip	requires systemd and a btrfs test filesystem

--- a/src/anolisa/tests/nightly/raw-lifecycle.sh
+++ b/src/anolisa/tests/nightly/raw-lifecycle.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CASES_FILE="${ANOLISA_E2E_CASES_FILE:-${SCRIPT_DIR}/raw-lifecycle-cases.tsv}"
+RAW_REPO_URL="${ANOLISA_RAW_REPO_URL:-https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/}"
+REPO_CONFIG_PATH="${ANOLISA_E2E_REPO_CONFIG_PATH:-/etc/anolisa/repo.toml}"
+CURL_CONNECT_TIMEOUT_SECS="${ANOLISA_E2E_CONNECT_TIMEOUT_SECS:-10}"
+CURL_MAX_TIME_SECS="${ANOLISA_E2E_MAX_TIME_SECS:-120}"
+CURL_RETRY_MAX_TIME_SECS="${ANOLISA_E2E_RETRY_MAX_TIME_SECS:-300}"
+
+log() {
+  printf '[raw-lifecycle] %s\n' "$*"
+}
+
+fail() {
+  printf '[raw-lifecycle] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command is missing: $1"
+}
+
+artifact_arch() {
+  case "$(uname -m)" in
+    x86_64) printf 'x86_64\n' ;;
+    aarch64 | arm64) printf 'aarch64\n' ;;
+    *) fail "unsupported test architecture: $(uname -m)" ;;
+  esac
+}
+
+published_version_candidates() {
+  local component="$1"
+  local arch="$2"
+  local index_file="$3"
+
+  # This is intentionally only broad enumeration. The CLI dry-run below is
+  # authoritative for host selectors, installability, and version ordering.
+  awk -v wanted_component="$component" -v wanted_arch="$arch" '
+    function reset_entry() {
+      component = ""
+      version = ""
+      channel = ""
+      artifact_type = ""
+      os = ""
+      arch = ""
+      install_modes = ""
+    }
+    function value_after_equals(line, value) {
+      value = line
+      sub(/^[^=]*=[[:space:]]*/, "", value)
+      gsub(/^"|"$/, "", value)
+      return value
+    }
+    function emit_entry() {
+      if (component == wanted_component &&
+          version != "" &&
+          channel == "stable" &&
+          artifact_type == "tar_gz" &&
+          os == "linux" &&
+          (arch == wanted_arch || arch == "any") &&
+          install_modes ~ /"system"/ &&
+          !seen[version]++) {
+        print version
+      }
+    }
+    /^\[\[entries\]\]$/ {
+      if (inside_entry) {
+        emit_entry()
+      }
+      reset_entry()
+      inside_entry = 1
+      next
+    }
+    inside_entry && /^component[[:space:]]*=/ { component = value_after_equals($0); next }
+    inside_entry && /^version[[:space:]]*=/ { version = value_after_equals($0); next }
+    inside_entry && /^channel[[:space:]]*=/ { channel = value_after_equals($0); next }
+    inside_entry && /^artifact_type[[:space:]]*=/ { artifact_type = value_after_equals($0); next }
+    inside_entry && /^os[[:space:]]*=/ { os = value_after_equals($0); next }
+    inside_entry && /^arch[[:space:]]*=/ { arch = value_after_equals($0); next }
+    inside_entry && /^install_modes[[:space:]]*=/ { install_modes = $0; next }
+    END {
+      if (inside_entry) {
+        emit_entry()
+      }
+    }
+  ' "$index_file"
+}
+
+run_cli_json() {
+  local output
+  log "anolisa $*" >&2
+  if ! output="$(anolisa --json --no-color "$@")"; then
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+  printf '%s\n' "$output"
+}
+
+assert_json() {
+  local document="$1"
+  shift
+  if ! printf '%s\n' "$document" | jq -e "$@" >/dev/null; then
+    printf '%s\n' "$document" | jq . >&2 || printf '%s\n' "$document" >&2
+    fail "JSON assertion failed"
+  fi
+}
+
+resolve_raw_version() {
+  local component="$1"
+  local version="${2:-}"
+  local args=(
+    --dry-run install "$component"
+    --backend raw
+    --repo "$RAW_REPO_URL"
+  )
+  if [[ -n "$version" ]]; then
+    args+=(--version "$version")
+  fi
+
+  local output
+  if ! output="$(run_cli_json "${args[@]}")"; then
+    return 1
+  fi
+  assert_json "$output" \
+    --arg component "$component" \
+    '.ok == true and
+     .data.component == $component and
+     .data.backend == "raw" and
+     .data.action == "planned" and
+     .data.dry_run == true and
+     (.data.version | type == "string" and length > 0)'
+  printf '%s\n' "$output" | jq -r '.data.version'
+}
+
+configure_raw_repo() {
+  local config_path="$REPO_CONFIG_PATH"
+  [[ -f "$config_path" ]] || fail "anolisa repo config not found: ${config_path}"
+  if [[ "$RAW_REPO_URL" == *\"* || "$RAW_REPO_URL" == *\\* || "$RAW_REPO_URL" == *$'\n'* ]]; then
+    fail "raw repository URL contains characters that cannot be written to repo.toml"
+  fi
+
+  local temp_config
+  temp_config="$(mktemp "${config_path}.XXXXXX")"
+  if ! awk -v base_url="$RAW_REPO_URL" '
+    /^\[backends\.raw\]$/ {
+      in_raw = 1
+      print
+      next
+    }
+    /^\[/ { in_raw = 0 }
+    in_raw && /^base_url[[:space:]]*=/ {
+      printf "base_url = \"%s\"\n", base_url
+      replaced = 1
+      next
+    }
+    { print }
+    END { if (!replaced) exit 1 }
+  ' "$config_path" > "$temp_config"; then
+    fail "raw backend base_url is missing from ${config_path}"
+  fi
+  chmod 0644 "$temp_config"
+  mv -f "$temp_config" "$config_path"
+  log "configured raw lifecycle repository: ${RAW_REPO_URL}"
+}
+
+run_case() {
+  local component="$1"
+  local rpm_package="$2"
+  local index_file="${ANOLISA_E2E_INDEX_FILE:?ANOLISA_E2E_INDEX_FILE is required}"
+  local arch
+  arch="$(artifact_arch)"
+
+  require_command anolisa
+  require_command dnf
+  require_command jq
+  require_command rpm
+
+  if rpm -q "$rpm_package" >/dev/null 2>&1; then
+    log "removing preinstalled RPM ${rpm_package} so raw ownership is unambiguous"
+    dnf remove -y "$rpm_package"
+  fi
+  if rpm -q "$rpm_package" >/dev/null 2>&1; then
+    fail "RPM ${rpm_package} is still installed"
+  fi
+
+  mapfile -t versions < <(published_version_candidates "$component" "$arch" "$index_file")
+  if ((${#versions[@]} < 2)); then
+    fail "${component} needs at least two raw version candidates for linux/${arch}; found ${#versions[@]}"
+  fi
+
+  local latest_version
+  if ! latest_version="$(resolve_raw_version "$component")"; then
+    fail "anolisa could not resolve the latest installable ${component} version"
+  fi
+
+  local previous_version=""
+  local candidate resolved_candidate
+  for candidate in "${versions[@]}"; do
+    [[ "$candidate" == "$latest_version" ]] && continue
+    if resolved_candidate="$(resolve_raw_version "$component" "$candidate")" &&
+      [[ "$resolved_candidate" == "$candidate" ]]; then
+      previous_version="$candidate"
+      break
+    fi
+  done
+  [[ -n "$previous_version" ]] ||
+    fail "${component} needs an older installable raw version before ${latest_version}"
+  log "testing ${component}: install ${previous_version}, update from live raw index, uninstall"
+
+  local install_json
+  install_json="$(run_cli_json install "$component" \
+    --backend raw \
+    --repo "$RAW_REPO_URL" \
+    --version "$previous_version")"
+  assert_json "$install_json" \
+    --arg component "$component" \
+    --arg version "$previous_version" \
+    '.ok == true and
+     .data.component == $component and
+     .data.backend == "raw" and
+     .data.action == "installed" and
+     .data.version == $version and
+     .data.resolved_version == $version'
+
+  local status_json
+  status_json="$(run_cli_json status "$component")"
+  assert_json "$status_json" \
+    --arg component "$component" \
+    --arg version "$previous_version" \
+    '.ok == true and
+     ([.data.components[] |
+       select(.name == $component and .scope == "system" and
+              .status == "installed" and .version == $version)] | length) == 1'
+
+  local update_json
+  update_json="$(run_cli_json update "$component")"
+  assert_json "$update_json" \
+    --arg component "$component" \
+    --arg from "$previous_version" \
+    '.ok == true and
+     .data.component == $component and
+     .data.from_version == $from and
+     (.data.to_version | type == "string" and length > 0) and
+     .data.to_version != $from and
+     .data.updated == true and
+     .data.dry_run == false'
+
+  local updated_version
+  updated_version="$(jq -er '.data.to_version' <<<"$update_json")"
+  log "updated ${component}: ${previous_version} -> ${updated_version}"
+
+  status_json="$(run_cli_json status "$component")"
+  assert_json "$status_json" \
+    --arg component "$component" \
+    --arg version "$updated_version" \
+    '.ok == true and
+     ([.data.components[] |
+       select(.name == $component and .scope == "system" and
+              .status == "installed" and .version == $version)] | length) == 1'
+
+  local uninstall_json
+  uninstall_json="$(run_cli_json uninstall "$component")"
+  assert_json "$uninstall_json" \
+    --arg component "$component" \
+    '.ok == true and
+     .data.component == $component and
+     .data.package_removal == "owned files removed" and
+     .data.state_dropped == true and
+     .data.dry_run == false'
+
+  status_json="$(run_cli_json status "$component")"
+  assert_json "$status_json" \
+    --arg component "$component" \
+    '.ok == true and
+     ([.data.components[] |
+       select(.name == $component and .status == "not_installed")] | length) == 1'
+
+  log "PASS ${component}"
+}
+
+list_cases() {
+  while IFS=$'\t' read -r component rpm_package status reason; do
+    [[ -z "$component" || "$component" == \#* ]] && continue
+    printf '%s\t%s\t%s\t%s\n' "$component" "$rpm_package" "$status" "$reason"
+  done < "$CASES_FILE"
+}
+
+if [[ "${1:-}" == "--list" ]]; then
+  list_cases
+  exit 0
+fi
+
+if [[ "${1:-}" == "--versions" ]]; then
+  [[ $# -eq 4 ]] || fail "usage: $0 --versions COMPONENT ARCH INDEX_FILE"
+  published_version_candidates "$2" "$3" "$4"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--case" ]]; then
+  [[ $# -eq 3 ]] || fail "usage: $0 --case COMPONENT RPM_PACKAGE"
+  run_case "$2" "$3"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--configure-repo" ]]; then
+  [[ $# -eq 1 ]] || fail "usage: $0 --configure-repo"
+  configure_raw_repo
+  exit 0
+fi
+
+require_command curl
+[[ -f "$CASES_FILE" ]] || fail "case inventory not found: ${CASES_FILE}"
+configure_raw_repo
+
+index_file="$(mktemp)"
+trap 'rm -f "$index_file"' EXIT
+curl --fail --silent --show-error --location \
+  --connect-timeout "$CURL_CONNECT_TIMEOUT_SECS" \
+  --max-time "$CURL_MAX_TIME_SECS" \
+  --retry 3 \
+  --retry-max-time "$CURL_RETRY_MAX_TIME_SECS" \
+  --output "$index_file" "${RAW_REPO_URL%/}/index.toml"
+
+executed=0
+skipped=0
+failed=0
+while IFS=$'\t' read -r component rpm_package status reason; do
+  [[ -z "$component" || "$component" == \#* ]] && continue
+  case "$status" in
+    run)
+      executed=$((executed + 1))
+      if ANOLISA_E2E_INDEX_FILE="$index_file" \
+        bash "$0" --case "$component" "$rpm_package"; then
+        :
+      else
+        failed=$((failed + 1))
+      fi
+      ;;
+    skip)
+      skipped=$((skipped + 1))
+      log "SKIP ${component}: ${reason}"
+      ;;
+    *)
+      fail "unknown status '${status}' for ${component}"
+      ;;
+  esac
+done < "$CASES_FILE"
+
+log "summary: ${executed} executed, ${skipped} skipped, ${failed} failed"
+((executed > 0)) || fail "the inventory has no runnable cases"
+((failed == 0)) || fail "${failed} raw lifecycle case(s) failed"


### PR DESCRIPTION
## Description

Add a nightly E2E framework that exercises anolisa-cli from the image built by
the same workflow. The initial runnable cases install real raw artifacts for
agent-memory and tokenless, update them to the latest published version, and
uninstall them; unsupported components remain explicit skips in the inventory.
The anolisa CI job now reports workspace line and function coverage and uploads
JSON and LCOV reports for inspection.

## Related Issue

no-issue: initial nightly validation framework requested directly

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD or build changes

## Scope

- [x] `anolisa` (anolisa-cli)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- `bash -n src/anolisa/tests/nightly/raw-lifecycle.sh`
- `src/anolisa/tests/nightly/raw-lifecycle.sh --list`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo llvm-cov --workspace --all-targets --locked --no-report`
- Generated JSON and LCOV reports; local baseline was 83.19% line coverage
  and 80.08% function coverage.
- `cargo check --workspace --locked`
- `cargo doc --workspace --no-deps --locked`

## Additional Notes

The full image lifecycle is intentionally run on the amd64 nightly runner. The
local development host is arm64 and cannot execute the pulled amd64 image
without QEMU, so the image-level path will receive its first complete execution
in the draft PR/nightly workflow.
