### PR TITLE
fix(docs): keep changelog locale switch onsite

### DIFF
--- a/website/scripts/generate-changelog.mjs
+++ b/website/scripts/generate-changelog.mjs
@@ -4,14 +4,22 @@ import {exists, repoRoot, toPosix, walkFiles, writeGenerated} from './lib.mjs';
 
 const componentChangelogs = (await walkFiles(path.join(repoRoot, 'src'), (file) => path.basename(file) === 'CHANGELOG.md'))
   .filter((file) => path.relative(path.join(repoRoot, 'src'), file).split(path.sep).length === 2);
+const sourceLocaleLink = /^\[(?:中文版|English)\]\(CHANGELOG(?:_zh)?\.md\)\r?\n(?:\r?\n)?/m;
 
 function displayName(source) {
   if (source === 'CHANGELOG.md' || source === 'CHANGELOG_zh.md') return 'ANOLISA';
   return path.posix.basename(path.posix.dirname(source));
 }
 
+function stripSourceLocaleLink(markdown) {
+  return markdown.replace(sourceLocaleLink, '');
+}
+
 async function document(source, language) {
-  const markdown = await readFile(path.join(repoRoot, source), 'utf8');
+  const markdown = stripSourceLocaleLink(await readFile(path.join(repoRoot, source), 'utf8'));
+  if (sourceLocaleLink.test(markdown)) {
+    throw new Error(`${source}: source locale link leaked into generated changelog`);
+  }
   return {
     name: displayName(source),
     source,


### PR DESCRIPTION
## Why

The website rewrites relative Changelog links to GitHub, so the inline
`中文版` and `English` links leave the site instead of switching locale.

## What changed

- Remove the source-only locale link while generating website Changelog data.
- Keep the bilingual links unchanged in repository Markdown for GitHub readers.
- Fail generation if a standard source locale link remains in website content.

## Related issue

no-issue: small website navigation regression

## User / Agent impact

Website readers now use the global locale selector and remain on the matching
`/changelog/` or `/zh/changelog/` route.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Source Changelog files and component fallback behavior are unchanged.

## Validation

- `npm run typecheck --prefix website`
- `npm run build --prefix website`
- `npm run check:links --prefix website`
- Manual browser validation for English and Chinese Changelog routes

## Documentation and rollback

No source documentation changed. Revert the commit to restore inline locale
links in generated Changelog content.
