### PR TITLE
fix(tokenless): use rpm -Uvh instead of rpm -ivh for upgrade-safe installs

### DIFF
--- a/src/tokenless/adapters/tokenless/codex/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/codex/scripts/install.sh
@@ -69,7 +69,7 @@ if [[ -z "$TOKENLESS_BIN" ]]; then
     if [[ ! -f "$SRCDIR/Cargo.toml" ]]; then
         echo "[tokenless] ERROR: tokenless binary not found and no source tree at $SRCDIR" >&2
         echo "[tokenless] Install the tokenless RPM package first:" >&2
-        echo "[tokenless]   rpm -ivh tokenless-*.rpm" >&2
+        echo "[tokenless]   rpm -Uvh tokenless-*.rpm" >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

Fix `rpm -ivh` (install) to `rpm -Uvh` (upgrade) in the user-facing install hint in the codex adapter script, recommending upgrade-safe RPM installs.

## Problem

The codex adapter's `install.sh` prints a user-facing error message suggesting `rpm -ivh tokenless-*.rpm` when the tokenless binary is not found and no source tree is available. `rpm -ivh` installs alongside any existing package instead of replacing it, which can leave stale files on disk.

## Changes

- **codex install.sh**: user-facing error message updated from `rpm -ivh` to `rpm -Uvh` — upgrade mode replaces the old package before installing the new one, works for both fresh installs and upgrades
- **tokenless-env-fix.sh**: reverted the change to `install_via_rpm()` (no call sites, dead code — change had no effect)

## Related Issue

Related #2083

## Testing

- `grep -rn "rpm -ivh" src/tokenless/adapters/tokenless/codex/` returns no results after the fix
- `bash -n` syntax check passes on the modified script
- `rpm -Uvh` is the standard RPM upgrade command, equivalent to `rpm --upgrade --verbose --hash`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring