### PR TITLE
fix(cosh-ng): [shell] redact handoff evidence

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/evidence/redaction.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/redaction.rs
@@ -200,7 +200,8 @@ fn sensitive_flag_pattern() -> &'static Regex {
                 (?:^|\s)
                 --(?:password|passwd|passphrase|token|access[_-]?token|refresh[_-]?token|
                      id[_-]?token|secret|client[_-]?secret|api[_-]?key|apikey|
-                     access[_-]?key[_-]?secret|security[_-]?token|authorization)
+                     access[_-]?key[_-]?(?:id|secret)|security[_-]?token|authorization|
+                     cookie|set[_-]?cookie)
                 (?:=|\s+)
             )
             (?:
@@ -229,7 +230,8 @@ fn sensitive_assignment_pattern() -> &'static Regex {
                    dashscope[_-]?api[_-]?key|openai[_-]?api[_-]?key|
                    client[_-]?secret|security[_-]?token|refresh[_-]?token|
                    access[_-]?token|github[_-]?token|id[_-]?token|
-                   password|passphrase|passwd|api[_-]?key|apikey|token|secret)
+                   password|passphrase|passwd|api[_-]?key|apikey|token|secret|
+                   cookie|set[_-]?cookie)
                 ["']?
                 \s*(?:=|:)\s*
             )
@@ -259,7 +261,7 @@ fn opaque_token_pattern() -> &'static Regex {
     PATTERN.get_or_init(|| {
         // The pattern is a compile-time constant covered by the tests below.
         Regex::new(
-            r"\b(?:sk-[A-Za-z0-9_-]{10,}|sk_(?:live|test)_[A-Za-z0-9]{10,}|glpat-[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|AIza[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,})\b",
+            r"\b(?:sk-[A-Za-z0-9_-]{10,}|sk_(?:live|test)_[A-Za-z0-9]{10,}|glpat-[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|AIza[A-Za-z0-9_-]{20,}|(?i:xox.)-[A-Za-z0-9-]{10,})\b",
         )
         .unwrap_or_else(|_| unreachable!("static opaque token pattern must compile"))
     })
@@ -341,6 +343,9 @@ mod tests {
             "ALIBABA_CLOUD_ACCESS_KEY_ID=LTAIexampleaccesskey ",
             "OPENAI_API_KEY=sk-example-secret ",
             "curl --password 'hunter2' --access-token=token-value ",
+            "--access-key-id flag-id --cookie flag-cookie ",
+            "--set-cookie=flag-set-cookie authorization=assignment-auth ",
+            "cookie=assignment-cookie set-cookie=assignment-set-cookie ",
             "'https://example.test/?client_secret=query-value&next=ok'\n",
             "https://user:url-password@example.test/path\n",
             r#"{"api_key":"json-value","password":"json-password"}"#,
@@ -356,6 +361,12 @@ mod tests {
             "LTAIexampleaccesskey",
             "hunter2",
             "token-value",
+            "flag-id",
+            "flag-cookie",
+            "flag-set-cookie",
+            "assignment-auth",
+            "assignment-cookie",
+            "assignment-set-cookie",
             "query-value",
             "url-password",
             "json-value",
@@ -367,6 +378,10 @@ mod tests {
             assert!(!redacted.contains(secret), "{redacted}");
         }
         assert!(redacted.contains("next=ok"), "{redacted}");
+        assert!(
+            redacted.contains("Authorization: Basic <redacted>"),
+            "{redacted}"
+        );
     }
 
     #[test]
@@ -423,8 +438,9 @@ mod tests {
     #[test]
     fn redacts_multiple_opaque_token_shapes() {
         let slack_token = ["xoxb", "1234567890", "abcdefghijklmnop"].join("-");
+        let marker_wildcard_slack_token = "xoxc-123456789012345";
         let input = format!(
-            "{}{slack_token} {}",
+            "{}{slack_token} {marker_wildcard_slack_token} {}",
             concat!(
                 "Bearer first.secret.value and bearer second-secret ",
                 "ghp_abcdefghijklmnopqrstuvwxyz123456 ",
@@ -456,6 +472,7 @@ mod tests {
             "npm_",
             "hf_",
             "xoxb-",
+            marker_wildcard_slack_token,
             "eyJhbGciOiJIUzI1NiJ9",
         ] {
             assert!(!redacted.contains(secret), "{redacted}");

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
@@ -507,6 +507,83 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
 }
 
 #[test]
+fn raw_cli_cosh_core_failed_host_executed_preserves_redacted_stderr() {
+    let home = temp_shell_home("cosh-core-host-executed-redacted-stderr");
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let cosh_core_path = bin_dir.join("cosh-core");
+    write_executable(
+        &cosh_core_path,
+        r#"#!/bin/sh
+read -r init
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"init-1","response":{"subtype":"initialize","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":true}}}}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-cosh-core-redacted-stderr","model":"cosh-core-test"}'
+read -r user_message
+case "$user_message" in
+  *cosh-core-provider-redacted-stderr*)
+    printf '%s\n' '{"type":"control_request","request_id":"ctrl-redacted-stderr","request":{"subtype":"can_use_tool","tool_name":"shell","input":{"command":"(python3 /definitely-missing/install_openclaw.py --api-key redaction-regression-secret --cookie cookie-regression-secret --model-id qwen-test; printf \"%s%s%s%s%s\\n\" \"--cookie \" \"cookie-output-\" \"secret \" \"xox\" \"c-123456789012345\" >&2; exit 2)"},"tool_use_id":"toolu-redacted-stderr"}}'
+    while IFS= read -r response; do
+      case "$response" in
+        *'"type":"approval_receipt"'*) continue ;;
+        *) break ;;
+      esac
+    done
+    case "$response" in
+      *'"behavior":"host_executed_shell"'*'<redacted sensitive command>'*"can't open file"*'--cookie <redacted>'*'"exit_code":2'*) ;;
+      *)
+        printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-redacted-stderr","is_error":true,"result":"host result omitted redacted stderr"}'
+        exit 1
+        ;;
+    esac
+    case "$response" in
+      *cookie-output-secret*|*xoxc-123456789012345*)
+        printf '%s\n' '{"type":"result","subtype":"error","session_id":"sess-cosh-core-redacted-stderr","is_error":true,"result":"host result leaked output credential"}'
+        exit 1
+        ;;
+    esac
+    printf '%s\n' '{"type":"assistant","session_id":"sess-cosh-core-redacted-stderr","message":{"content":[{"type":"text","text":"FAILED STDERR EVIDENCE RECEIVED"}]}}'
+    printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-redacted-stderr","is_error":false,"result":"done"}'
+    exit 0
+    ;;
+esac
+printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core-redacted-stderr","is_error":false,"result":"ignored"}'
+"#,
+    );
+    let home_str = home.to_string_lossy().to_string();
+    let cosh_core_path_str = cosh_core_path.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "cosh-core",
+        &[],
+        &[("HOME", &home_str), ("COSH_CORE_PATH", &cosh_core_path_str)],
+        vec![
+            (b"/mode approval auto\n".to_vec(), Duration::ZERO),
+            (
+                b"?? cosh-core-provider-redacted-stderr\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"\n".to_vec(), Duration::from_millis(2_000)),
+            (b"/debug session\n".to_vec(), Duration::from_millis(6_000)),
+            (b"true\n".to_vec(), Duration::from_millis(500)),
+            (b"exit\n".to_vec(), Duration::from_millis(500)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(
+        output.contains("FAILED STDERR EVIDENCE RECEIVED"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("host result omitted redacted stderr"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("host result leaked output credential"),
+        "{output}"
+    );
+}
+
+#[test]
 fn raw_cli_cosh_core_host_executed_long_command_continues_same_turn() {
     let home = temp_shell_home("cosh-core-host-executed-long");
     let bin_dir = home.join("bin");


### PR DESCRIPTION
## Why

PR #2151 now owns handoff identity and closure through one-time claim tokens. Once that path returns foreground output to the provider, the evidence redactor must cover every credential shape recognized by the shell marker so actionable stderr can be delivered without leaking newly generated secrets.

## What changed

- Align provider evidence redaction with marker-recognized access-key, cookie, set-cookie, and xox? token forms.
- Add a raw cosh-core regression proving a token-claimed failed handoff returns exit code 2 and actionable stderr while redacting output-only credentials.
- Preserve #2151 D-6 semantics: provider-authored command metadata remains original, while durable and LLM evidence surfaces stay redacted.

## Related issue

Closes #2134

Builds on #2151.

## User / Agent impact

After a credential-bearing foreground command fails, the provider receives the failure exit status and redacted stderr in the same turn, so it can diagnose and correct the command without receiving credentials produced by the command output.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

Low compatibility risk. This only broadens shared evidence redaction and adds no protocol fields or alternate handoff identity path.

## Validation

- cargo fmt --all -- --check
- cargo test --locked -p cosh-shell --lib evidence::redaction::tests (8 passed)
- cargo test --locked -p cosh-shell --test raw_cli cosh_core::host_executed::raw_cli_cosh_core_failed_host_executed_preserves_redacted_stderr -- --exact (1 passed)
- cargo clippy --locked -p cosh-shell --all-targets -- -D warnings
- crates/cosh-shell/scripts/check-layout.sh
- scripts/check-test-inventory.sh

## Documentation and rollback

No documentation changes are required. Roll back by reverting commit 79e91d16.