### PR TITLE
fix(tokenless): isolate fixer output

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -451,7 +451,7 @@ if [ "$missing_count" -gt 0 ] \
     && [ -n "$FIX_SCRIPT" ] \
     && [ -r "$FIX_SCRIPT" ] \
     && is_trusted_file "$FIX_SCRIPT"; then
-    echo "$MISSING_DEP_JSONS" | bash "$FIX_SCRIPT" fix-all 2>/dev/null || true
+    echo "$MISSING_DEP_JSONS" | bash "$FIX_SCRIPT" fix-all >/dev/null 2>&1 || true
     hash -r 2>/dev/null || true
 
     # Re-scan to check if fix succeeded

--- a/src/tokenless/tests/test-tool-ready-readable-fixer.sh
+++ b/src/tokenless/tests/test-tool-ready-readable-fixer.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 
 [ "${1:-}" = "fix-all" ]
 cat >/dev/null
+echo "[tokenless-env-fix] simulated fixer output"
 touch "$TOKENLESS_FIX_MARKER"
 EOF
 chmod 0644 "$FIXER"
@@ -55,6 +56,11 @@ OUTPUT=$(
 )
 
 [ -f "$MARKER" ]
+if ! jq -e -s 'length == 1 and (.[0] | type == "object")' \
+    <<<"$OUTPUT" >/dev/null; then
+    echo "expected one JSON object without fixer output, got: $OUTPUT" >&2
+    exit 1
+fi
 grep -q "NOT_READY" <<<"$OUTPUT"
 grep -q "Skip retry" <<<"$OUTPUT"
 


### PR DESCRIPTION
## Why

After #2128 made invalid hook output fail closed, the tokenless Phase 3
readiness path still forwarded human-readable fixer output before its final
JSON response. A fixer diagnostic therefore turned an intended readiness
result into a generic hook protocol block.

## What changed

- Discard fixer stdout and stderr before the hook emits its protocol response.
- Make the regression fixer noisy and assert the hook emits exactly one JSON
  object.

## Related issue

Follow-up to #2101 and #2128.

## User / Agent impact

Tokenless readiness checks no longer fail with a generic JSON protocol block
when the environment fixer prints diagnostics. The post-fix rescan still
produces the intended pass-through or dependency feedback decision.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

The change preserves core fail-closed parsing and only prevents internal fixer
diagnostics from contaminating the hook protocol channel.

## Validation

- `bash -n adapters/tokenless/common/hooks/tool_ready_hook.sh`
- `bash -n tests/test-tool-ready-readable-fixer.sh`
- `bash tests/test-tool-ready-readable-fixer.sh`
- `git diff --check`

## Documentation and rollback

No documentation change is required. Revert commit `df4a33de` to restore the
previous Phase 3 output handling.
