### PR TITLE
feat(tokenless): add 3 mainstream bench fixtures and L1-L4 tokenless benchmark

### DIFF
--- a/src/tokenless/crates/tokenless-schema/examples/bench.rs
+++ b/src/tokenless/crates/tokenless-schema/examples/bench.rs
@@ -1,0 +1,222 @@
+//! Tokenless compression benchmark — throughput & latency metrics.
+//!
+//! Run: `cargo run --example bench --release -p tokenless-schema`
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use tokenless_ccr::{InMemoryStore, StashStore};
+use tokenless_schema::{ResponseCompressor, SchemaCompressor};
+
+fn load_fixture(dir: &str, name: &str) -> Value {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let path = format!("{}/tests/fixtures/{}/{}", manifest, dir, name);
+    let content = std::fs::read_to_string(&path).expect("load fixture");
+    serde_json::from_str(&content).expect("parse fixture")
+}
+
+const ITERATIONS: u32 = 5_000;
+
+struct BenchResult {
+    name: String,
+    iterations: u32,
+    total: Duration,
+    orig_bytes: usize,
+    comp_bytes: usize,
+    stash_count: usize,
+}
+
+impl BenchResult {
+    fn throughput_mbps(&self) -> f64 {
+        let total_bytes = self.orig_bytes as f64 * self.iterations as f64;
+        total_bytes / self.total.as_secs_f64() / 1_000_000.0
+    }
+
+    fn avg_latency_us(&self) -> f64 {
+        self.total.as_micros() as f64 / self.iterations as f64
+    }
+
+    fn compression_ratio(&self) -> f64 {
+        (1.0 - self.comp_bytes as f64 / self.orig_bytes as f64) * 100.0
+    }
+}
+
+fn run_schema_bench(name: &str, fixture: &Value, stash: bool) -> BenchResult {
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = if stash {
+        SchemaCompressor::new().with_stash_store(store.clone() as Arc<dyn StashStore>)
+    } else {
+        SchemaCompressor::new()
+    };
+
+    let orig_bytes = serde_json::to_string(fixture).unwrap().len();
+
+    let start = Instant::now();
+    let mut comp_bytes = 0usize;
+    for _ in 0..ITERATIONS {
+        let compressed = compressor.compress(fixture);
+        comp_bytes = serde_json::to_string(&compressed).unwrap().len();
+    }
+    let total = start.elapsed();
+
+    BenchResult {
+        name: name.to_string(),
+        iterations: ITERATIONS,
+        total,
+        orig_bytes,
+        comp_bytes,
+        stash_count: store.len(),
+    }
+}
+
+fn run_response_bench(name: &str, fixture: &Value, stash: bool) -> BenchResult {
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = if stash {
+        ResponseCompressor::new().with_stash_store(store.clone() as Arc<dyn StashStore>)
+    } else {
+        ResponseCompressor::new()
+    };
+
+    let orig_bytes = serde_json::to_string(fixture).unwrap().len();
+
+    let start = Instant::now();
+    let mut comp_bytes = 0usize;
+    for _ in 0..ITERATIONS {
+        let compressed = compressor.compress(fixture);
+        comp_bytes = serde_json::to_string(&compressed).unwrap().len();
+    }
+    let total = start.elapsed();
+
+    BenchResult {
+        name: name.to_string(),
+        iterations: ITERATIONS,
+        total,
+        orig_bytes,
+        comp_bytes,
+        stash_count: store.len(),
+    }
+}
+
+fn print_result(r: &BenchResult) {
+    println!(
+        "  {:<40} {:>7.1} MB/s  {:>7.1} µs/op  {:>5.1}% saved  stash={}",
+        r.name,
+        r.throughput_mbps(),
+        r.avg_latency_us(),
+        r.compression_ratio(),
+        r.stash_count,
+    );
+}
+
+fn main() {
+    let schema_fixtures: Vec<(&str, Value)> = [
+        "simple_calculator.json",
+        "hubspot_contact.json",
+        "stripe_payment.json",
+        "github_create_issue.json",
+        "slack_send_message.json",
+        "aws_describe_instances.json",
+    ]
+    .iter()
+    .map(|name| (*name, load_fixture("schemas", name)))
+    .collect();
+
+    let response_fixtures: Vec<(&str, Value)> = [
+        ("github_issues.json", "lossy field removal"),
+        ("github_issues_stashable.json", "reversible array stash"),
+    ]
+    .iter()
+    .map(|(name, _)| (*name, load_fixture("responses", name)))
+    .collect();
+
+    println!("Tokenless Benchmark ({} iterations per test)\n", ITERATIONS);
+
+    println!("L1 — SchemaCompressor (no stash)");
+    for (name, fixture) in &schema_fixtures {
+        print_result(&run_schema_bench(
+            &format!("schema/{}", name),
+            fixture,
+            false,
+        ));
+    }
+
+    println!("\nL1 — SchemaCompressor + Stash (reversible)");
+    for (name, fixture) in &schema_fixtures {
+        print_result(&run_schema_bench(
+            &format!("schema+stash/{}", name),
+            fixture,
+            true,
+        ));
+    }
+
+    println!("\nL1 — ResponseCompressor (lossy field removal)");
+    print_result(&run_response_bench(
+        "response/github_issues.json",
+        &response_fixtures[0].1,
+        false,
+    ));
+
+    println!("\nL1 — ResponseCompressor + Stash (reversible array truncation)");
+    print_result(&run_response_bench(
+        "response+stash/github_issues_stashable.json",
+        &response_fixtures[1].1,
+        true,
+    ));
+
+    println!("\nL4 — Full pipeline aggregate");
+    let store = Arc::new(InMemoryStore::new());
+    let schema_comp =
+        SchemaCompressor::new().with_stash_store(store.clone() as Arc<dyn StashStore>);
+    let resp_comp =
+        ResponseCompressor::new().with_stash_store(store.clone() as Arc<dyn StashStore>);
+
+    let mut total_orig = 0usize;
+    let mut total_comp = 0usize;
+
+    // Precompute serialized byte lengths outside the timed loop so the
+    // measurement boundary matches L1 (which also precomputes orig_bytes
+    // before starting the timer). Including serialization inside the loop
+    // would add work L1 does not include, making throughput figures incomparable.
+    let schema_orig_bytes: Vec<usize> = schema_fixtures
+        .iter()
+        .map(|(_, f)| serde_json::to_string(f).unwrap().len())
+        .collect();
+    let response_orig_bytes: Vec<usize> = response_fixtures
+        .iter()
+        .map(|(_, f)| serde_json::to_string(f).unwrap().len())
+        .collect();
+
+    let start = Instant::now();
+    for _ in 0..ITERATIONS {
+        for (i, (_, fixture)) in schema_fixtures.iter().enumerate() {
+            let compressed = schema_comp.compress(fixture);
+            total_orig += schema_orig_bytes[i];
+            total_comp += serde_json::to_string(&compressed).unwrap().len();
+        }
+        for (i, (_, fixture)) in response_fixtures.iter().enumerate() {
+            let compressed = resp_comp.compress(fixture);
+            total_orig += response_orig_bytes[i];
+            total_comp += serde_json::to_string(&compressed).unwrap().len();
+        }
+    }
+    let total_time = start.elapsed();
+
+    let combined_mbps = total_orig as f64 / total_time.as_secs_f64() / 1_000_000.0;
+    let saved = (1.0 - total_comp as f64 / total_orig as f64) * 100.0;
+
+    println!(
+        "  {:<40} {:>7.1} MB/s  overall {:.1}% saved  stash={}",
+        "full-pipeline",
+        combined_mbps,
+        saved,
+        store.len(),
+    );
+    println!(
+        "\n  Total processed: {} bytes in {:.2}s ({} iterations over {} fixtures)",
+        total_orig,
+        total_time.as_secs_f64(),
+        ITERATIONS,
+        schema_fixtures.len() + response_fixtures.len(),
+    );
+}

--- a/src/tokenless/crates/tokenless-schema/tests/fixtures/responses/github_issues.json
+++ b/src/tokenless/crates/tokenless-schema/tests/fixtures/responses/github_issues.json
@@ -1,0 +1,228 @@
+{
+  "total_count": 156,
+  "incomplete_results": false,
+  "items": [
+    {
+      "id": 1234567890,
+      "node_id": "MDExOlB1bGxSZXF1ZXN0OTg3NjU0MzIx",
+      "number": 42,
+      "title": "Fix memory leak in connection pooling when TLS handshake fails mid-stream",
+      "state": "open",
+      "locked": false,
+      "assignee": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "id": 208045946,
+          "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
+          "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a",
+          "default": true
+        },
+        {
+          "id": 208045947,
+          "node_id": "MDU6TGFiZWwyMDgwNDU5NDc=",
+          "url": "https://api.github.com/repos/octocat/Hello-World/labels/P1",
+          "name": "P1",
+          "description": "Critical priority issue requiring immediate attention",
+          "color": "e11d48",
+          "default": false
+        }
+      ],
+      "milestone": {
+        "url": "https://api.github.com/repos/octocat/Hello-World/milestones/1",
+        "html_url": "https://github.com/octocat/Hello-World/milestone/1",
+        "labels_url": "https://api.github.com/repos/octocat/Hello-World/milestones/1/labels",
+        "id": 1002604,
+        "node_id": "MDk6TWlsZXN0b25lMTAwMjYwNA==",
+        "number": 1,
+        "title": "v1.0",
+        "description": "Tracking milestone for the v1.0 release",
+        "creator": {
+          "login": "octocat",
+          "id": 1,
+          "node_id": "MDQ6VXNlcjE=",
+          "type": "User"
+        },
+        "open_issues": 4,
+        "closed_issues": 8,
+        "state": "open"
+      },
+      "comments": 12,
+      "created_at": "2026-01-15T10:30:00Z",
+      "updated_at": "2026-07-20T14:22:33Z",
+      "closed_at": null,
+      "author_association": "OWNER",
+      "body": "## Description\n\nWhen a TLS handshake fails mid-stream during connection pool rotation, the underlying socket buffer is not released. Over time this accumulates and causes OOM errors under sustained load.\n\n## Steps to Reproduce\n\n1. Set up a connection pool with TLS\n2. Simulate handshake failures using a proxy\n3. Observe memory usage growing linearly with each failure\n\n## Expected Behavior\n\nSocket buffers should be cleaned up on handshake failure.\n\n## Environment\n\n- OS: Linux 5.15\n- Runtime: Node.js 20.11\n- Library version: 3.2.1\n\n## Stack Trace\n\n```\nError: TLS handshake timeout\n    at TLSSocket.onConnectSecure (node:_tls_wrap:1567:34)\n    at TLSSocket.emit (node:events:519:28)\n    at TLSSocket._finishInit (node:_tls_wrap:986:8)\n```",
+      "debug": {
+        "request_id": "req_abc123def456",
+        "trace_id": "trace-xyz-789",
+        "handler": "issues_controller#show",
+        "duration_ms": 42,
+        "db_queries": 7
+      },
+      "user": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "type": "User",
+        "site_admin": false
+      },
+      "html_url": "https://github.com/octocat/Hello-World/issues/42",
+      "url": "https://api.github.com/repos/octocat/Hello-World/issues/42",
+      "repository_url": "https://api.github.com/repos/octocat/Hello-World",
+      "labels_url": "https://api.github.com/repos/octocat/Hello-World/issues/42/labels{/name}",
+      "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/42/comments",
+      "events_url": "https://api.github.com/repos/octocat/Hello-World/issues/42/events"
+    },
+    {
+      "id": 1234567891,
+      "node_id": "MDExOlB1bGxSZXF1ZXN0OTg3NjU0MzIy",
+      "number": 41,
+      "title": "Add support for batch webhook delivery with retry logic",
+      "state": "closed",
+      "locked": false,
+      "assignee": null,
+      "labels": [
+        {
+          "id": 208045948,
+          "node_id": "MDU6TGFiZWwyMDgwNDU5NDg=",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef",
+          "default": true
+        }
+      ],
+      "milestone": null,
+      "comments": 3,
+      "created_at": "2026-01-10T08:15:00Z",
+      "updated_at": "2026-06-01T09:00:00Z",
+      "closed_at": "2026-06-01T09:00:00Z",
+      "author_association": "CONTRIBUTOR",
+      "body": "This PR adds batch webhook delivery to reduce HTTP overhead when sending notifications to multiple endpoints.",
+      "debug": null,
+      "user": {
+        "login": "contributor42",
+        "id": 999,
+        "node_id": "MDQ6VXNlcjk5OQ==",
+        "type": "User",
+        "site_admin": false
+      },
+      "html_url": "https://github.com/octocat/Hello-World/issues/41",
+      "url": "https://api.github.com/repos/octocat/Hello-World/issues/41"
+    },
+    {
+      "id": 1234567892,
+      "node_id": "MDExOlB1bGxSZXF1ZXN0OTg3NjU0MzIz",
+      "number": 40,
+      "title": "Refactor authentication middleware to support OAuth 2.1 PKCE flow",
+      "state": "open",
+      "locked": true,
+      "assignee": {
+        "login": "security-lead",
+        "id": 456,
+        "node_id": "MDQ6VXNlcjQ1Ng==",
+        "type": "User"
+      },
+      "labels": [
+        {
+          "id": 208045949,
+          "name": "security",
+          "description": "Security-related changes requiring careful review",
+          "color": "0075ca",
+          "default": false
+        },
+        {
+          "id": 208045950,
+          "name": "in-progress",
+          "description": "Currently being worked on",
+          "color": "e4e669",
+          "default": false
+        }
+      ],
+      "milestone": {
+        "id": 1002605,
+        "number": 2,
+        "title": "v1.1",
+        "state": "open"
+      },
+      "comments": 28,
+      "created_at": "2026-02-01T12:00:00Z",
+      "updated_at": "2026-07-22T16:45:00Z",
+      "closed_at": null,
+      "author_association": "MEMBER",
+      "body": "## Overview\n\nMigrating from OAuth 2.0 implicit grant to OAuth 2.1 with PKCE for improved security posture. This affects all third-party integrations.\n\n## Breaking Changes\n\n- Implicit grant flow is deprecated\n- All clients must register redirect URIs\n- Refresh tokens now rotate on use",
+      "debug": {
+        "request_id": "req_xyz789",
+        "handler": "issues_controller#show",
+        "duration_ms": 38
+      }
+    },
+    {
+      "id": 1234567893,
+      "number": 39,
+      "title": "Improve error messages for rate-limited API responses",
+      "state": "open",
+      "locked": false,
+      "assignee": null,
+      "labels": [],
+      "comments": 1,
+      "created_at": "2026-03-10T09:00:00Z",
+      "updated_at": "2026-03-10T09:30:00Z",
+      "closed_at": null,
+      "body": "Current error messages when hitting rate limits are confusing. Users don't know when they can retry or how to request higher limits.",
+      "trace": "internal-trace-id-abc",
+      "stack": "at ApiRateLimiter.check (/app/src/middleware/rate-limit.js:45:12)\nat processTicksAndRejections (node:internal/process/task_queues:95:5)"
+    },
+    {
+      "id": 1234567894,
+      "number": 38,
+      "title": "Add GraphQL subscription support for real-time issue updates",
+      "state": "open",
+      "locked": false,
+      "assignee": {
+        "login": "frontend-lead",
+        "id": 789,
+        "type": "User"
+      },
+      "labels": [
+        {
+          "id": 208045951,
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef",
+          "default": true
+        }
+      ],
+      "comments": 7,
+      "created_at": "2026-04-05T14:20:00Z",
+      "updated_at": "2026-07-18T11:00:00Z",
+      "closed_at": null,
+      "body": "Implement GraphQL subscriptions using WebSocket transport for pushing real-time updates on issue state changes, new comments, and label modifications. This will enable the frontend to maintain live dashboards without polling."
+    }
+  ]
+}

--- a/src/tokenless/crates/tokenless-schema/tests/fixtures/responses/github_issues_stashable.json
+++ b/src/tokenless/crates/tokenless-schema/tests/fixtures/responses/github_issues_stashable.json
@@ -1,0 +1,949 @@
+{
+  "total_count": 35,
+  "incomplete_results": false,
+  "items": [
+    {
+      "id": 1234567891,
+      "number": 101,
+      "title": "Issue 1: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 1,
+      "created_at": "2026-02-02T10:00:00Z",
+      "updated_at": "2026-07-02T12:00:00Z",
+      "body": "This is issue 1 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user1",
+        "id": 1,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/101"
+    },
+    {
+      "id": 1234567892,
+      "number": 102,
+      "title": "Issue 2: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 2,
+      "created_at": "2026-03-03T10:00:00Z",
+      "updated_at": "2026-07-03T12:00:00Z",
+      "body": "This is issue 2 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user2",
+        "id": 2,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/102"
+    },
+    {
+      "id": 1234567893,
+      "number": 103,
+      "title": "Issue 3: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 3,
+      "created_at": "2026-04-04T10:00:00Z",
+      "updated_at": "2026-07-04T12:00:00Z",
+      "body": "This is issue 3 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user3",
+        "id": 3,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/103"
+    },
+    {
+      "id": 1234567894,
+      "number": 104,
+      "title": "Issue 4: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 4,
+      "created_at": "2026-05-05T10:00:00Z",
+      "updated_at": "2026-07-05T12:00:00Z",
+      "body": "This is issue 4 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user4",
+        "id": 4,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/104"
+    },
+    {
+      "id": 1234567895,
+      "number": 105,
+      "title": "Issue 5: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 5,
+      "created_at": "2026-06-06T10:00:00Z",
+      "updated_at": "2026-07-06T12:00:00Z",
+      "body": "This is issue 5 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user5",
+        "id": 5,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/105"
+    },
+    {
+      "id": 1234567896,
+      "number": 106,
+      "title": "Issue 6: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 6,
+      "created_at": "2026-07-07T10:00:00Z",
+      "updated_at": "2026-07-07T12:00:00Z",
+      "body": "This is issue 6 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user6",
+        "id": 6,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/106"
+    },
+    {
+      "id": 1234567897,
+      "number": 107,
+      "title": "Issue 7: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 7,
+      "created_at": "2026-08-08T10:00:00Z",
+      "updated_at": "2026-07-08T12:00:00Z",
+      "body": "This is issue 7 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user7",
+        "id": 7,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/107"
+    },
+    {
+      "id": 1234567898,
+      "number": 108,
+      "title": "Issue 8: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 8,
+      "created_at": "2026-09-09T10:00:00Z",
+      "updated_at": "2026-07-09T12:00:00Z",
+      "body": "This is issue 8 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user8",
+        "id": 8,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/108"
+    },
+    {
+      "id": 1234567899,
+      "number": 109,
+      "title": "Issue 9: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 9,
+      "created_at": "2026-01-10T10:00:00Z",
+      "updated_at": "2026-07-10T12:00:00Z",
+      "body": "This is issue 9 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user9",
+        "id": 9,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/109"
+    },
+    {
+      "id": 1234567900,
+      "number": 110,
+      "title": "Issue 10: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 10,
+      "created_at": "2026-02-11T10:00:00Z",
+      "updated_at": "2026-07-11T12:00:00Z",
+      "body": "This is issue 10 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user10",
+        "id": 10,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/110"
+    },
+    {
+      "id": 1234567901,
+      "number": 111,
+      "title": "Issue 11: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 11,
+      "created_at": "2026-03-12T10:00:00Z",
+      "updated_at": "2026-07-12T12:00:00Z",
+      "body": "This is issue 11 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user11",
+        "id": 11,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/111"
+    },
+    {
+      "id": 1234567902,
+      "number": 112,
+      "title": "Issue 12: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 12,
+      "created_at": "2026-04-13T10:00:00Z",
+      "updated_at": "2026-07-13T12:00:00Z",
+      "body": "This is issue 12 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user12",
+        "id": 12,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/112"
+    },
+    {
+      "id": 1234567903,
+      "number": 113,
+      "title": "Issue 13: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 13,
+      "created_at": "2026-05-14T10:00:00Z",
+      "updated_at": "2026-07-14T12:00:00Z",
+      "body": "This is issue 13 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user13",
+        "id": 13,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/113"
+    },
+    {
+      "id": 1234567904,
+      "number": 114,
+      "title": "Issue 14: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 14,
+      "created_at": "2026-06-15T10:00:00Z",
+      "updated_at": "2026-07-15T12:00:00Z",
+      "body": "This is issue 14 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user14",
+        "id": 14,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/114"
+    },
+    {
+      "id": 1234567905,
+      "number": 115,
+      "title": "Issue 15: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 15,
+      "created_at": "2026-07-16T10:00:00Z",
+      "updated_at": "2026-07-16T12:00:00Z",
+      "body": "This is issue 15 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user15",
+        "id": 15,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/115"
+    },
+    {
+      "id": 1234567906,
+      "number": 116,
+      "title": "Issue 16: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 16,
+      "created_at": "2026-08-17T10:00:00Z",
+      "updated_at": "2026-07-17T12:00:00Z",
+      "body": "This is issue 16 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user16",
+        "id": 16,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/116"
+    },
+    {
+      "id": 1234567907,
+      "number": 117,
+      "title": "Issue 17: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 17,
+      "created_at": "2026-09-18T10:00:00Z",
+      "updated_at": "2026-07-18T12:00:00Z",
+      "body": "This is issue 17 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user17",
+        "id": 17,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/117"
+    },
+    {
+      "id": 1234567908,
+      "number": 118,
+      "title": "Issue 18: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 18,
+      "created_at": "2026-01-19T10:00:00Z",
+      "updated_at": "2026-07-19T12:00:00Z",
+      "body": "This is issue 18 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user18",
+        "id": 18,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/118"
+    },
+    {
+      "id": 1234567909,
+      "number": 119,
+      "title": "Issue 19: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 19,
+      "created_at": "2026-02-20T10:00:00Z",
+      "updated_at": "2026-07-20T12:00:00Z",
+      "body": "This is issue 19 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user19",
+        "id": 19,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/119"
+    },
+    {
+      "id": 1234567910,
+      "number": 120,
+      "title": "Issue 20: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 20,
+      "created_at": "2026-03-21T10:00:00Z",
+      "updated_at": "2026-07-21T12:00:00Z",
+      "body": "This is issue 20 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user20",
+        "id": 20,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/120"
+    },
+    {
+      "id": 1234567911,
+      "number": 121,
+      "title": "Issue 21: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 21,
+      "created_at": "2026-04-22T10:00:00Z",
+      "updated_at": "2026-07-22T12:00:00Z",
+      "body": "This is issue 21 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user21",
+        "id": 21,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/121"
+    },
+    {
+      "id": 1234567912,
+      "number": 122,
+      "title": "Issue 22: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 22,
+      "created_at": "2026-05-23T10:00:00Z",
+      "updated_at": "2026-07-23T12:00:00Z",
+      "body": "This is issue 22 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user22",
+        "id": 22,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/122"
+    },
+    {
+      "id": 1234567913,
+      "number": 123,
+      "title": "Issue 23: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 23,
+      "created_at": "2026-06-24T10:00:00Z",
+      "updated_at": "2026-07-24T12:00:00Z",
+      "body": "This is issue 23 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user23",
+        "id": 23,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/123"
+    },
+    {
+      "id": 1234567914,
+      "number": 124,
+      "title": "Issue 24: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 24,
+      "created_at": "2026-07-25T10:00:00Z",
+      "updated_at": "2026-07-25T12:00:00Z",
+      "body": "This is issue 24 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user24",
+        "id": 24,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/124"
+    },
+    {
+      "id": 1234567915,
+      "number": 125,
+      "title": "Issue 25: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 25,
+      "created_at": "2026-08-26T10:00:00Z",
+      "updated_at": "2026-07-26T12:00:00Z",
+      "body": "This is issue 25 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user25",
+        "id": 25,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/125"
+    },
+    {
+      "id": 1234567916,
+      "number": 126,
+      "title": "Issue 26: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 26,
+      "created_at": "2026-09-27T10:00:00Z",
+      "updated_at": "2026-07-27T12:00:00Z",
+      "body": "This is issue 26 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user26",
+        "id": 26,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/126"
+    },
+    {
+      "id": 1234567917,
+      "number": 127,
+      "title": "Issue 27: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 27,
+      "created_at": "2026-01-28T10:00:00Z",
+      "updated_at": "2026-07-28T12:00:00Z",
+      "body": "This is issue 27 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user27",
+        "id": 27,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/127"
+    },
+    {
+      "id": 1234567918,
+      "number": 128,
+      "title": "Issue 28: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 28,
+      "created_at": "2026-02-01T10:00:00Z",
+      "updated_at": "2026-07-01T12:00:00Z",
+      "body": "This is issue 28 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user28",
+        "id": 28,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/128"
+    },
+    {
+      "id": 1234567919,
+      "number": 129,
+      "title": "Issue 29: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 29,
+      "created_at": "2026-03-02T10:00:00Z",
+      "updated_at": "2026-07-02T12:00:00Z",
+      "body": "This is issue 29 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user29",
+        "id": 29,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/129"
+    },
+    {
+      "id": 1234567920,
+      "number": 130,
+      "title": "Issue 30: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 30,
+      "created_at": "2026-04-03T10:00:00Z",
+      "updated_at": "2026-07-03T12:00:00Z",
+      "body": "This is issue 30 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user30",
+        "id": 30,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/130"
+    },
+    {
+      "id": 1234567921,
+      "number": 131,
+      "title": "Issue 31: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 31,
+      "created_at": "2026-05-04T10:00:00Z",
+      "updated_at": "2026-07-04T12:00:00Z",
+      "body": "This is issue 31 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user31",
+        "id": 31,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/131"
+    },
+    {
+      "id": 1234567922,
+      "number": 132,
+      "title": "Issue 32: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 32,
+      "created_at": "2026-06-05T10:00:00Z",
+      "updated_at": "2026-07-05T12:00:00Z",
+      "body": "This is issue 32 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user32",
+        "id": 32,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/132"
+    },
+    {
+      "id": 1234567923,
+      "number": 133,
+      "title": "Issue 33: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 33,
+      "created_at": "2026-07-06T10:00:00Z",
+      "updated_at": "2026-07-06T12:00:00Z",
+      "body": "This is issue 33 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user33",
+        "id": 33,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/133"
+    },
+    {
+      "id": 1234567924,
+      "number": 134,
+      "title": "Issue 34: Example GitHub issue for tokenless benchmark testing",
+      "state": "open",
+      "locked": false,
+      "comments": 34,
+      "created_at": "2026-08-07T10:00:00Z",
+      "updated_at": "2026-07-07T12:00:00Z",
+      "body": "This is issue 34 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user34",
+        "id": 34,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        },
+        {
+          "name": "enhancement",
+          "color": "a2eeef"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/134"
+    },
+    {
+      "id": 1234567925,
+      "number": 135,
+      "title": "Issue 35: Example GitHub issue for tokenless benchmark testing",
+      "state": "closed",
+      "locked": false,
+      "comments": 35,
+      "created_at": "2026-09-08T10:00:00Z",
+      "updated_at": "2026-07-08T12:00:00Z",
+      "body": "This is issue 35 body text describing a bug or feature request. It contains enough text to be a realistic API response payload without requiring truncation.",
+      "author_association": "CONTRIBUTOR",
+      "user": {
+        "login": "user35",
+        "id": 35,
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "html_url": "https://github.com/octocat/Hello-World/issues/135"
+    }
+  ]
+}

--- a/src/tokenless/crates/tokenless-schema/tests/fixtures/schemas/aws_describe_instances.json
+++ b/src/tokenless/crates/tokenless-schema/tests/fixtures/schemas/aws_describe_instances.json
@@ -1,0 +1,72 @@
+{
+  "type": "function",
+  "function": {
+    "name": "describe_instances",
+    "description": "Describes the specified EC2 instances or all instances. If you specify one or more instance IDs, Amazon EC2 returns information for those instances. If you do not specify instance IDs, Amazon EC2 returns information for all relevant instances. If you specify an invalid instance ID, an error is returned. If you specify an instance that you do not own, it is not included in the returned results.",
+    "parameters": {
+      "type": "object",
+      "title": "Describe Instances Request",
+      "properties": {
+        "instance_ids": {
+          "type": "array",
+          "title": "Instance IDs",
+          "description": "The IDs of the instances to describe. You can specify up to 1000 instance IDs in a single request. If you specify an invalid instance ID, an error is returned.",
+          "items": {
+            "type": "string",
+            "title": "Instance ID"
+          }
+        },
+        "filters": {
+          "type": "array",
+          "title": "Filters",
+          "description": "The filters to apply when describing instances. Multiple filters are combined using AND logic. Wildcards (* and ?) are supported in filter values.",
+          "items": {
+            "type": "object",
+            "title": "Filter",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Filter Name",
+                "description": "The name of the filter. Common filter names include: architecture, availability-zone, block-device-mapping.device-name, block-device-mapping.status, block-device-mapping.volume-id, dns-name, group-id, group-name, image-id, instance-id, instance-lifecycle, instance-state-code, instance-state-name, instance-type, ip-address, key-name, launch-index, monitoring-state, owner-id, placement-group-name, platform, private-dns-name, private-ip-address, product-code, product-code.type, ramdisk-id, reason, requester-id, reservation-id, root-device-name, root-device-type, source-dest-check, spot-instance-request-id, state-reason-code, state-reason-message, subnet-id, tag, tag-key, tag-value, tenancy, virtualization-type, vpc-id.",
+                "enum": ["architecture", "availability-zone", "dns-name", "group-id", "group-name", "image-id", "instance-id", "instance-state-name", "instance-type", "ip-address", "key-name", "private-dns-name", "private-ip-address", "subnet-id", "tag", "tag-key", "vpc-id"]
+              },
+              "values": {
+                "type": "array",
+                "title": "Filter Values",
+                "description": "One or more filter values. Filter values are case-sensitive.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["name", "values"]
+          }
+        },
+        "max_results": {
+          "type": "integer",
+          "title": "Max Results",
+          "description": "The maximum number of items to return for this request. To get the next page of items, make another request and include the token from the previous response in the NextToken parameter. You cannot specify this parameter and the NextToken parameter in the same request.",
+          "default": 100,
+          "minimum": 5,
+          "maximum": 1000
+        },
+        "next_token": {
+          "type": "string",
+          "title": "Next Token",
+          "description": "The token returned from a previous paginated request. Pagination continues from the end of the items returned by the previous request."
+        },
+        "dry_run": {
+          "type": "boolean",
+          "title": "Dry Run",
+          "description": "Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation."
+        },
+        "include_all_instances": {
+          "type": "boolean",
+          "title": "Include All Instances",
+          "description": "Include all instances, including those that are in the terminated state. By default, terminated instances are not included."
+        }
+      },
+      "required": []
+    }
+  }
+}

--- a/src/tokenless/crates/tokenless-schema/tests/fixtures/schemas/github_create_issue.json
+++ b/src/tokenless/crates/tokenless-schema/tests/fixtures/schemas/github_create_issue.json
@@ -1,0 +1,69 @@
+{
+  "type": "function",
+  "function": {
+    "name": "create_issue",
+    "description": "Create a new issue in a GitHub repository. This tool allows you to create issues with titles, descriptions, labels, assignees, and milestones. Issues are used to track bugs, feature requests, and other tasks in a repository.",
+    "parameters": {
+      "type": "object",
+      "title": "Create Issue Parameters",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "title": "Repository Owner",
+          "description": "The account owner of the repository. The name is not case sensitive."
+        },
+        "repo": {
+          "type": "string",
+          "title": "Repository Name",
+          "description": "The name of the repository without the .git extension. The name is not case sensitive."
+        },
+        "title": {
+          "type": "string",
+          "title": "Issue Title",
+          "description": "The title of the issue. This is a required field and should be a concise summary of the problem or feature request."
+        },
+        "body": {
+          "type": "string",
+          "title": "Issue Body",
+          "description": "The body text of the issue. Supports GitHub Flavored Markdown for formatting, including headers, lists, code blocks, and links."
+        },
+        "assignees": {
+          "type": "array",
+          "title": "Assignees",
+          "description": "An array of usernames to assign to this issue. Each user must have write access to the repository.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "labels": {
+          "type": "array",
+          "title": "Labels",
+          "description": "An array of label names to associate with this issue. Labels help categorize and filter issues.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "milestone": {
+          "type": "integer",
+          "title": "Milestone Number",
+          "description": "The number of the milestone to associate this issue with. Use null to remove any milestone."
+        },
+        "projects": {
+          "type": "array",
+          "title": "Projects",
+          "description": "An array of project board IDs to associate this issue with.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "priority": {
+          "type": "string",
+          "title": "Priority",
+          "description": "The priority level of the issue, used for project management and triage.",
+          "enum": ["critical", "high", "medium", "low", "none"]
+        }
+      },
+      "required": ["owner", "repo", "title"]
+    }
+  }
+}

--- a/src/tokenless/crates/tokenless-schema/tests/fixtures/schemas/slack_send_message.json
+++ b/src/tokenless/crates/tokenless-schema/tests/fixtures/schemas/slack_send_message.json
@@ -1,0 +1,119 @@
+{
+  "type": "function",
+  "function": {
+    "name": "send_message",
+    "description": "Send a message to a specified Slack channel. This tool posts a message to a public channel, private channel, direct message, or multi-person direct message. It supports rich text formatting through Slack's Block Kit framework, including sections, dividers, actions, and context blocks.",
+    "parameters": {
+      "type": "object",
+      "title": "Send Message Parameters",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "title": "Channel ID",
+          "description": "The channel ID, private group ID, or user ID to send the message to. Can be an encoded ID (e.g., C123456) or a channel name."
+        },
+        "text": {
+          "type": "string",
+          "title": "Message Text",
+          "description": "The main text of the message. This field is required and supports Slack's mrkdwn formatting for bold, italic, strikethrough, links, and channel/user references."
+        },
+        "blocks": {
+          "type": "array",
+          "title": "Block Kit Blocks",
+          "description": "An array of Block Kit layout blocks that define the visual structure of the message. Supports section, divider, image, actions, context, input, file, and header block types.",
+          "items": {
+            "type": "object",
+            "title": "Block",
+            "properties": {
+              "type": {
+                "type": "string",
+                "title": "Block Type",
+                "description": "The type of block.",
+                "enum": ["section", "divider", "image", "actions", "context", "header", "input", "file"]
+              },
+              "text": {
+                "type": "object",
+                "title": "Block Text",
+                "description": "The text object for the block content.",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "title": "Text Type",
+                    "enum": ["plain_text", "mrkdwn"]
+                  },
+                  "text": {
+                    "type": "string",
+                    "title": "Text Content"
+                  }
+                }
+              },
+              "block_id": {
+                "type": "string",
+                "title": "Block ID",
+                "description": "A unique identifier for the block, used for interaction payloads."
+              }
+            },
+            "required": ["type"]
+          }
+        },
+        "attachments": {
+          "type": "array",
+          "title": "Attachments",
+          "description": "An array of legacy attachment objects. Prefer using Block Kit blocks for new integrations.",
+          "items": {
+            "type": "object",
+            "title": "Attachment",
+            "properties": {
+              "color": {
+                "type": "string",
+                "title": "Attachment Color",
+                "description": "A hex color code (e.g., #36a64f) or predefined good/warning/danger."
+              },
+              "title": {
+                "type": "string",
+                "title": "Attachment Title"
+              },
+              "text": {
+                "type": "string",
+                "title": "Attachment Text"
+              },
+              "fields": {
+                "type": "array",
+                "title": "Fields",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "title": { "type": "string" },
+                    "value": { "type": "string" },
+                    "short": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "thread_ts": {
+          "type": "string",
+          "title": "Thread Timestamp",
+          "description": "Provide another message's ts value to make this message a reply in a thread. Do not use the reply_broadcast parameter when also setting thread_ts."
+        },
+        "reply_broadcast": {
+          "type": "boolean",
+          "title": "Reply Broadcast",
+          "description": "Used in conjunction with thread_ts and indicates whether reply should be made visible to everyone in the channel or conversation."
+        },
+        "unfurl_links": {
+          "type": "boolean",
+          "title": "Unfurl Links",
+          "description": "Pass true to enable unfurling of primarily text-based content."
+        },
+        "unfurl_media": {
+          "type": "boolean",
+          "title": "Unfurl Media",
+          "description": "Pass false to disable unfurling of media content."
+        }
+      },
+      "required": ["channel", "text"]
+    }
+  }
+}

--- a/src/tokenless/crates/tokenless-schema/tests/integration_test.rs
+++ b/src/tokenless/crates/tokenless-schema/tests/integration_test.rs
@@ -4,6 +4,8 @@
 //! including real-world fixture schemas.
 
 use serde_json::{Value, json};
+use std::sync::Arc;
+use tokenless_ccr::{InMemoryStore, StashStore};
 use tokenless_schema::{ResponseCompressor, SchemaCompressor};
 
 // ============================================================
@@ -18,6 +20,17 @@ fn load_schema(name: &str) -> Value {
     let path = format!("{}/{}", fixtures_dir(), name);
     let content = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("Failed to load schema {}: {}", path, e));
+    serde_json::from_str(&content).unwrap()
+}
+
+fn response_fixtures_dir() -> String {
+    format!("{}/tests/fixtures/responses", env!("CARGO_MANIFEST_DIR"))
+}
+
+fn load_response(name: &str) -> Value {
+    let path = format!("{}/{}", response_fixtures_dir(), name);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to load response {}: {}", path, e));
     serde_json::from_str(&content).unwrap()
 }
 
@@ -434,6 +447,9 @@ fn test_all_fixtures_produce_valid_json() {
         "simple_calculator.json",
         "hubspot_contact.json",
         "stripe_payment.json",
+        "github_create_issue.json",
+        "slack_send_message.json",
+        "aws_describe_instances.json",
     ];
 
     for name in files {
@@ -458,6 +474,16 @@ fn test_all_fixtures_produce_valid_json() {
             comp_len,
             orig_len
         );
+
+        // The top-level "type": "function" discriminant must be preserved when present.
+        if schema.get("type").is_some() {
+            assert_eq!(
+                compressed.get("type"),
+                schema.get("type"),
+                "{}: top-level \"type\" field must survive compression",
+                name
+            );
+        }
     }
 }
 
@@ -468,6 +494,9 @@ fn test_fixture_compression_ratio_benchmark() {
         "simple_calculator.json",
         "hubspot_contact.json",
         "stripe_payment.json",
+        "github_create_issue.json",
+        "slack_send_message.json",
+        "aws_describe_instances.json",
     ];
 
     let mut total_orig = 0usize;
@@ -496,10 +525,363 @@ fn test_fixture_compression_ratio_benchmark() {
         total_orig, total_comp, avg_saved
     );
 
-    // At minimum some compression should occur on complex schemas
     assert!(
         avg_saved >= 5.0,
         "Average compression should be >= 5%, got {:.1}%",
         avg_saved
+    );
+}
+
+// ============================================================
+// Tokenless Benchmark: L1–L4 layered compression
+// ============================================================
+//
+// L1 — Individual compressors (each compressor alone)
+// L2 — Pairs (schema + response combined on tool call data)
+// L3 — Triple (schema + response + stash/CCR reversible)
+// L4 — Full pipeline (all optimizations combined)
+
+const ALL_SCHEMA_FIXTURES: &[&str] = &[
+    "simple_calculator.json",
+    "hubspot_contact.json",
+    "stripe_payment.json",
+    "github_create_issue.json",
+    "slack_send_message.json",
+    "aws_describe_instances.json",
+];
+
+const RESPONSE_FIXTURES: &[&str] = &["github_issues.json"];
+
+// github_issues_stashable.json has 35 items, which exceeds the default
+// truncate_arrays_at=32, so the array tail gets stashed reversibly.
+// Use this fixture wherever we need to assert store.len() > 0.
+const RESPONSE_STASH_FIXTURES: &[&str] = &["github_issues_stashable.json"];
+
+fn byte_len(v: &Value) -> usize {
+    serde_json::to_string(v).unwrap().len()
+}
+
+#[test]
+fn bench_l1_schema_compressor() {
+    println!("\n=== L1: SchemaCompressor (individual) ===");
+    let compressor = SchemaCompressor::new();
+
+    let mut total_orig = 0usize;
+    let mut total_comp = 0usize;
+
+    for name in ALL_SCHEMA_FIXTURES {
+        let schema = load_schema(name);
+        let compressed = compressor.compress(&schema);
+        let orig = byte_len(&schema);
+        let comp = byte_len(&compressed);
+        let saved = (1.0 - comp as f64 / orig as f64) * 100.0;
+        println!(
+            "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
+            name, orig, comp, saved
+        );
+        total_orig += orig;
+        total_comp += comp;
+    }
+
+    let overall = (1.0 - total_comp as f64 / total_orig as f64) * 100.0;
+    println!(
+        "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
+        "TOTAL", total_orig, total_comp, overall
+    );
+
+    assert!(
+        overall >= 5.0,
+        "L1 schema: expected >= 5% savings, got {:.1}%",
+        overall
+    );
+}
+
+#[test]
+fn bench_l1_response_compressor() {
+    println!("\n=== L1: ResponseCompressor (individual) ===");
+    let compressor = ResponseCompressor::new();
+
+    let mut total_orig = 0usize;
+    let mut total_comp = 0usize;
+
+    for name in RESPONSE_FIXTURES {
+        let response = load_response(name);
+        let compressed = compressor.compress(&response);
+        let orig = byte_len(&response);
+        let comp = byte_len(&compressed);
+        let saved = (1.0 - comp as f64 / orig as f64) * 100.0;
+        println!(
+            "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
+            name, orig, comp, saved
+        );
+        total_orig += orig;
+        total_comp += comp;
+    }
+
+    let overall = (1.0 - total_comp as f64 / total_orig as f64) * 100.0;
+    println!(
+        "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
+        "TOTAL", total_orig, total_comp, overall
+    );
+
+    assert!(
+        overall > 0.0,
+        "L1 response: expected some savings, got {:.1}%",
+        overall
+    );
+}
+
+#[test]
+fn bench_l1_stash_schema() {
+    println!("\n=== L1: SchemaCompressor + Stash (reversible) ===");
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new().with_stash_store(store.clone());
+
+    let mut total_orig = 0usize;
+    let mut total_comp = 0usize;
+
+    for name in ALL_SCHEMA_FIXTURES {
+        let schema = load_schema(name);
+        let compressed = compressor.compress(&schema);
+        let orig = byte_len(&schema);
+        let comp = byte_len(&compressed);
+        let saved = (1.0 - comp as f64 / orig as f64) * 100.0;
+        println!(
+            "  {:<35} {:>6} -> {:>6} ({:.1}% saved, stash={})",
+            name,
+            orig,
+            comp,
+            saved,
+            store.len()
+        );
+        total_orig += orig;
+        total_comp += comp;
+    }
+
+    let overall = (1.0 - total_comp as f64 / total_orig as f64) * 100.0;
+    println!(
+        "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
+        "TOTAL", total_orig, total_comp, overall
+    );
+
+    assert!(store.len() > 0, "L1 stash schema: expected stashed entries");
+}
+
+#[test]
+fn bench_l1_stash_response() {
+    println!("\n=== L1: ResponseCompressor + Stash (reversible) ===");
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new().with_stash_store(store.clone());
+
+    let mut total_orig = 0usize;
+    let mut total_comp = 0usize;
+
+    // Use a fixture with 35 items so the array tail (items 33-35) is stashed
+    // reversibly. github_issues.json has only 5 items, which never triggers
+    // array truncation, so stash=0 and the lossless label would be incorrect.
+    for name in RESPONSE_STASH_FIXTURES {
+        let response = load_response(name);
+        let compressed = compressor.compress(&response);
+        let orig = byte_len(&response);
+        let comp = byte_len(&compressed);
+        let saved = (1.0 - comp as f64 / orig as f64) * 100.0;
+        println!(
+            "  {:<35} {:>6} -> {:>6} ({:.1}% saved, stash={})",
+            name,
+            orig,
+            comp,
+            saved,
+            store.len()
+        );
+        total_orig += orig;
+        total_comp += comp;
+    }
+
+    let overall = (1.0 - total_comp as f64 / total_orig as f64) * 100.0;
+    println!(
+        "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
+        "TOTAL", total_orig, total_comp, overall
+    );
+
+    assert!(
+        store.len() > 0,
+        "L1 stash response: expected stash entries from array truncation (fixture has 35 items, limit=32)"
+    );
+    assert!(overall > 0.0, "L1 stash response: expected some savings");
+
+    // Verify round-trip: the compressed output must contain a <<tokenless:…>> marker
+    // and the store must return the exact original dropped payload for that key.
+    let response = load_response(RESPONSE_STASH_FIXTURES[0]);
+    let items = response["items"]
+        .as_array()
+        .expect("fixture must have items array");
+    let dropped_original = Value::Array(items[32..].to_vec());
+
+    let compressed = compressor.compress(&response);
+    let compressed_str = serde_json::to_string(&compressed).unwrap();
+    let hash = tokenless_ccr::extract_hash(&compressed_str).expect(
+        "compressed output must contain a <<tokenless:KEY>> marker for the truncated array tail",
+    );
+    let retrieved = store
+        .retrieve(hash)
+        .expect("store retrieve must not error")
+        .expect("stash key must be present and non-expired");
+    let tail: serde_json::Value =
+        serde_json::from_str(&retrieved).expect("stashed payload must be valid JSON");
+    assert!(
+        tail.is_array(),
+        "stashed payload must be an array of the dropped items, got: {:?}",
+        tail
+    );
+    assert!(
+        !tail.as_array().unwrap().is_empty(),
+        "stashed array must be non-empty"
+    );
+    assert_eq!(
+        tail, dropped_original,
+        "retrieved tail must match the original dropped items exactly"
+    );
+}
+
+#[test]
+fn bench_l2_schema_response_pipeline() {
+    println!("\n=== L2: Schema + Response pipeline ===");
+    let schema_compressor = SchemaCompressor::new();
+    let response_compressor = ResponseCompressor::new();
+
+    for schema_name in ALL_SCHEMA_FIXTURES {
+        let schema = load_schema(schema_name);
+        let compressed_schema = schema_compressor.compress(&schema);
+        let schema_saved =
+            (1.0 - byte_len(&compressed_schema) as f64 / byte_len(&schema) as f64) * 100.0;
+
+        for resp_name in RESPONSE_FIXTURES {
+            let response = load_response(resp_name);
+            let compressed_response = response_compressor.compress(&response);
+            let resp_saved =
+                (1.0 - byte_len(&compressed_response) as f64 / byte_len(&response) as f64) * 100.0;
+
+            let combined_orig = byte_len(&schema) + byte_len(&response);
+            let combined_comp = byte_len(&compressed_schema) + byte_len(&compressed_response);
+            let combined_saved = (1.0 - combined_comp as f64 / combined_orig as f64) * 100.0;
+
+            println!(
+                "  {} + {}: schema {:.1}% | response {:.1}% | combined {:.1}% ({} -> {})",
+                schema_name,
+                resp_name,
+                schema_saved,
+                resp_saved,
+                combined_saved,
+                combined_orig,
+                combined_comp
+            );
+        }
+    }
+}
+
+#[test]
+fn bench_l3_schema_response_stash_pipeline() {
+    println!("\n=== L3: Schema + Response + Stash pipeline ===");
+    let store = Arc::new(InMemoryStore::new());
+    let schema_compressor = SchemaCompressor::new().with_stash_store(store.clone());
+    let response_compressor = ResponseCompressor::new().with_stash_store(store.clone());
+
+    for schema_name in ALL_SCHEMA_FIXTURES {
+        let schema = load_schema(schema_name);
+        let compressed_schema = schema_compressor.compress(&schema);
+
+        // Use the 35-item stashable response fixture so the response compressor
+        // actually writes stash entries. The 5-item fixture never triggers
+        // array truncation and would make store.len()>0 come from schema only.
+        for resp_name in RESPONSE_STASH_FIXTURES {
+            let response = load_response(resp_name);
+            let compressed_response = response_compressor.compress(&response);
+
+            let combined_orig = byte_len(&schema) + byte_len(&response);
+            let combined_comp = byte_len(&compressed_schema) + byte_len(&compressed_response);
+            let combined_saved = (1.0 - combined_comp as f64 / combined_orig as f64) * 100.0;
+
+            println!(
+                "  {} + {}: combined {:.1}% ({} -> {}, stash={})",
+                schema_name,
+                resp_name,
+                combined_saved,
+                combined_orig,
+                combined_comp,
+                store.len()
+            );
+        }
+    }
+
+    assert!(
+        store.len() > 0,
+        "L3: expected stashed entries for reversibility"
+    );
+}
+
+#[test]
+fn bench_l4_full_pipeline_aggregate() {
+    println!("\n=== L4: Full pipeline aggregate benchmark ===");
+    println!("Schema fixtures + response fixtures with all optimizations enabled");
+
+    let store = Arc::new(InMemoryStore::new());
+    let schema_compressor = SchemaCompressor::new().with_stash_store(store.clone());
+    let response_compressor = ResponseCompressor::new().with_stash_store(store.clone());
+
+    let mut grand_orig = 0usize;
+    let mut grand_comp = 0usize;
+
+    println!("  --- Schema compression ---");
+    for name in ALL_SCHEMA_FIXTURES {
+        let schema = load_schema(name);
+        let compressed = schema_compressor.compress(&schema);
+        let orig = byte_len(&schema);
+        let comp = byte_len(&compressed);
+        println!(
+            "    {:<35} {:>6} -> {:>6} ({:.1}%)",
+            name,
+            orig,
+            comp,
+            (1.0 - comp as f64 / orig as f64) * 100.0
+        );
+        grand_orig += orig;
+        grand_comp += comp;
+    }
+
+    println!("  --- Response compression ---");
+    for name in RESPONSE_FIXTURES {
+        let response = load_response(name);
+        let compressed = response_compressor.compress(&response);
+        let orig = byte_len(&response);
+        let comp = byte_len(&compressed);
+        println!(
+            "    {:<35} {:>6} -> {:>6} ({:.1}%)",
+            name,
+            orig,
+            comp,
+            (1.0 - comp as f64 / orig as f64) * 100.0
+        );
+        grand_orig += orig;
+        grand_comp += comp;
+    }
+
+    let overall = (1.0 - grand_comp as f64 / grand_orig as f64) * 100.0;
+    println!(
+        "\n  GRAND TOTAL: {} -> {} bytes ({:.1}% saved)",
+        grand_orig, grand_comp, overall
+    );
+    println!(
+        "  Stash entries: {} (schema fields stashed reversibly; response savings include lossy field removal)",
+        store.len()
+    );
+    println!("  L4 layers: SchemaCompressor + ResponseCompressor + CCR Stash");
+    println!(
+        "  Note: TOON encoding (4th layer) requires external binary, not included in this Rust bench"
+    );
+
+    assert!(overall > 0.0, "L4: expected positive overall savings");
+    assert!(
+        store.len() > 0,
+        "L4: stash should contain reversible entries"
     );
 }


### PR DESCRIPTION
## Summary

- Add 3 mainstream API schema fixtures (GitHub Create Issue, Slack Send Message, AWS Describe Instances) and 2 response fixtures (GitHub Issues list, and a 35-item stashable variant)
- Implement L1-L4 layered benchmark tests: L1 = individual compressors (schema, response, stash-enabled variants), L2 = schema+response pipeline, L3 = schema+response+stash, L4 = full aggregate pipeline
- Add standalone throughput/latency benchmark binary (`cargo run --example bench --release`)
- Expand existing schema fixture benchmark from 3 to 6 schemas

## Key design fixes

- Response-stash benchmarks now use the 35-item stashable fixture so array truncation writes real stash entries; the 5-item fixture is only used for the lossy field-removal path
- L1 and L4 throughput boundaries are aligned: input byte counts are precomputed before the timed loop
- Round-trip test compares the retrieved stash payload byte-for-byte with the original dropped array tail

## Benchmark Results (release build, 5000 iterations)

| Layer | Compressor | Throughput | Savings | Stash |
|-------|-----------|------------|---------|-------|
| L1 | SchemaCompressor (no stash) | 43-57 MB/s | 0-36% per fixture | 0 |
| L1 | SchemaCompressor + Stash | 33-41 MB/s | 0-37% per fixture | >0 |
| L1 | ResponseCompressor (lossy field removal) | 89 MB/s | 8.2% | 0 |
| L1 | ResponseCompressor + Stash (reversible array truncation) | 80 MB/s | 8.1% | 1 |
| L4 | Full pipeline | 46 MB/s | 10.4% aggregate | 43 |

## Testing

- All 26 integration tests pass (`cargo test -p tokenless-schema --test integration_test`)
- Full workspace tests pass (`cargo test --workspace`)
- Benchmark binary runs successfully in release mode
- `cargo fmt --all -- --check` and `cargo clippy -p tokenless-schema --all-targets -- -D warnings` pass

Fixes ANO-65