### PR TITLE
fix(cosh-ng): [shell] route sensitive nl to agent

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/journal/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/mod.rs
@@ -42,6 +42,15 @@ fn redacted_event(event: &ShellEvent) -> ShellEvent {
     event.terminal_output_ref = event.terminal_output_ref.as_deref().map(redact);
     if event.component.as_deref() == Some("card_secret") {
         event.input = event.input.as_ref().map(|_| "<redacted>".to_string());
+    } else if event
+        .routing
+        .as_ref()
+        .is_some_and(|routing| routing.sensitive)
+    {
+        // The shell-side secret gate marked this input sensitive; redact the
+        // whole field rather than trusting the regex patterns to re-detect
+        // every form the gate matched (e.g. short keys like `sk-fbaa6`).
+        event.input = event.input.as_ref().map(|_| "<redacted>".to_string());
     } else if event.component.as_deref() == Some("slash") {
         event.input = event.input.as_deref().map(redact_slash_input);
     } else {
@@ -92,7 +101,7 @@ fn json_to_io(err: serde_json::Error) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::{read_shell_events, write_shell_events};
-    use crate::types::ShellEvent;
+    use crate::types::{ShellEvent, ShellRoutingMetadata};
 
     #[test]
     fn journal_redacts_commands_prompts_and_secret_card_input() {
@@ -176,6 +185,113 @@ mod tests {
             events[3].input.as_deref(),
             Some("/extensions settings set fixture endpoint **********************")
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Inputs the shell secret gate marked sensitive are redacted as a whole
+    /// field, including short-key forms the regex patterns do not match
+    /// (#2138: `sk-fbaa6` is below the opaque-token minimum length).
+    #[test]
+    fn journal_redacts_sensitive_routed_input_whole_field() {
+        let path = std::env::temp_dir().join(format!(
+            "cosh-shell-sensitive-routing-journal-{}-{}.jsonl",
+            std::process::id(),
+            now_nanos()
+        ));
+        let input = "帮我安装下openclaw,模型使用qwen3.8-max,API Key: sk-fbaa6";
+        let mut sensitive = ShellEvent::user_input_intercepted("session-1", input);
+        sensitive.component = Some("natural_language".to_string());
+        sensitive.routing = Some(ShellRoutingMetadata {
+            generation: 3,
+            top_level_missing: true,
+            proven: true,
+            sensitive: true,
+            unsafe_input: false,
+        });
+
+        write_shell_events(&path, &[sensitive]).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.contains("sk-fbaa6"), "{content}");
+        let events = read_shell_events(&path).unwrap();
+        assert_eq!(events[0].input.as_deref(), Some("<redacted>"));
+        assert!(events[0].routing.as_ref().is_some_and(|r| r.sensitive));
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// T0.1 matrix: one representative per `_cosh_command_has_secret`
+    /// pattern family. Whole-field redaction keyed off the sensitive
+    /// routing flag must hide every form the shell gate matches, without
+    /// relying on the regex patterns to re-detect them.
+    #[test]
+    fn journal_redacts_every_shell_gate_pattern_family() {
+        let path = std::env::temp_dir().join(format!(
+            "cosh-shell-gate-matrix-journal-{}-{}.jsonl",
+            std::process::id(),
+            now_nanos()
+        ));
+        let family_inputs = [
+            "帮我配好 API Key: sk-fbaa6",             // opaque sk- short key
+            "用这个 token ghp_matrixtoken 部署",      // github token prefix
+            "调用时带 bearer matrix-bearer-value 头", // bearer
+            "连接 https://user:matrixurlpass@db.example.com 看看", // URL password
+            "跑 deploy --password matrixflagvalue 试试", // sensitive flag
+            "环境里 access_key_secret=matrixassign 生效吗", // sensitive assignment
+            "AK 是 LTAImatrixakvalue0 请检查",        // alibaba access key
+            "迁移 AKIAMATRIXKEY0123456 这个账号",     // aws access key
+        ];
+        let secrets = [
+            "sk-fbaa6",
+            "ghp_matrixtoken",
+            "matrix-bearer-value",
+            "matrixurlpass",
+            "matrixflagvalue",
+            "matrixassign",
+            "LTAImatrixakvalue0",
+            "AKIAMATRIXKEY0123456",
+        ];
+        let events = family_inputs
+            .iter()
+            .map(|input| {
+                let mut event = ShellEvent::user_input_intercepted("session-1", *input);
+                event.component = Some("natural_language".to_string());
+                event.routing = Some(ShellRoutingMetadata {
+                    generation: 1,
+                    top_level_missing: true,
+                    proven: true,
+                    sensitive: true,
+                    unsafe_input: false,
+                });
+                event
+            })
+            // The sensitive + unsafe_input combination must redact the same
+            // way: whole-field redaction keys off `sensitive` alone.
+            .chain(std::iter::once({
+                let mut event = ShellEvent::user_input_intercepted(
+                    "session-1",
+                    "环境里 access_key_secret=matrixassign 生效吗",
+                );
+                event.component = Some("natural_language".to_string());
+                event.routing = Some(ShellRoutingMetadata {
+                    generation: 1,
+                    top_level_missing: true,
+                    proven: false,
+                    sensitive: true,
+                    unsafe_input: true,
+                });
+                event
+            }))
+            .collect::<Vec<_>>();
+
+        write_shell_events(&path, &events).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        for secret in secrets {
+            assert!(!content.contains(secret), "{secret} leaked: {content}");
+        }
+        for event in read_shell_events(&path).unwrap() {
+            assert_eq!(event.input.as_deref(), Some("<redacted>"));
+        }
         let _ = std::fs::remove_file(path);
     }
 

--- a/src/cosh-ng/crates/cosh-shell/src/parser/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/parser/mod.rs
@@ -275,7 +275,7 @@ pub fn agent_request_from_intercepted_input(
         .unwrap_or_else(|| "<unknown>".to_string());
     let block_id = format!("input-{sequence}");
 
-    Some(AgentRequest {
+    let mut request = AgentRequest {
         id: format!("agent-request-{block_id}"),
         session_id: event.session_id.clone(),
         command_block: CommandBlock {
@@ -305,7 +305,17 @@ pub fn agent_request_from_intercepted_input(
         user_confirmed: true,
         hook_finding: None,
         recommended_skill: None,
-    })
+    };
+    // Carry the shell-side sensitive flag so durable sinks past the
+    // journal (personalization activity store) can whole-field redact.
+    if event
+        .routing
+        .as_ref()
+        .is_some_and(|routing| routing.sensitive)
+    {
+        crate::types::mark_request_sensitive_input(&mut request);
+    }
+    Some(request)
 }
 
 pub fn agent_request_confirmed_by_events(events: &[ShellEvent]) -> bool {
@@ -600,6 +610,29 @@ mod tests {
             .context_hints
             .iter()
             .any(|hint| hint == "__cosh_context_binding=failed_command"));
+    }
+
+    /// #2138: the sensitive routing flag on an intercept event must land
+    /// on the request as the in-band hint so durable sinks past the
+    /// journal can whole-field redact; unflagged intercepts stay clean.
+    #[test]
+    fn intercepted_input_request_carries_sensitive_hint_from_routing() {
+        let mut event = ShellEvent::user_input_intercepted("session-1", "带 key 的句子");
+        event.routing = Some(crate::types::ShellRoutingMetadata {
+            generation: 1,
+            top_level_missing: false,
+            proven: false,
+            sensitive: true,
+            unsafe_input: false,
+        });
+        let request = super::agent_request_from_intercepted_input(&event, 1, true)
+            .expect("sensitive request");
+        assert!(crate::types::request_has_sensitive_input(&request));
+
+        let plain_event = ShellEvent::user_input_intercepted("session-1", "普通句子");
+        let plain_request = super::agent_request_from_intercepted_input(&plain_event, 2, true)
+            .expect("plain request");
+        assert!(!crate::types::request_has_sensitive_input(&plain_request));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_record.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_record.rs
@@ -6,9 +6,9 @@ use crate::types::{
 
 use super::personal_model::{
     ActivityContext, ActivityOutcome, ActivityPayload, ActivityRecord, ActivitySource,
-    AgentRequestBindingKind, ShellActivityOrigin, ToolCategory,
+    AgentRequestBindingKind, RedactionKind, RedactionReport, ShellActivityOrigin, ToolCategory,
 };
-use super::personal_sanitize::{sanitize_agent_request, sanitize_shell_command};
+use super::personal_sanitize::{sanitize_agent_request, sanitize_shell_command, SanitizedText};
 
 pub(crate) fn shell_command_record(
     block: &CommandBlock,
@@ -73,7 +73,23 @@ pub(crate) fn agent_request_record(
         AgentContextBinding::ControlProtocolEvidence
         | AgentContextBinding::ShellHandoffContinuation => return None,
     };
-    let sanitized = sanitize_agent_request(request.user_input.as_deref()?).ok()?;
+    let user_input = request.user_input.as_deref()?;
+    // The shell-side secret gate flagged this input sensitive: redact the
+    // whole field (journal precedent, #2138) instead of trusting the
+    // sanitizer regexes to re-detect every shell-gate form (`sk-fbaa6`
+    // is below the opaque-token minimum length).
+    let sanitized = if crate::types::request_has_sensitive_input(request) {
+        SanitizedText {
+            text: "<redacted>".to_string(),
+            report: RedactionReport {
+                replacements: vec![RedactionKind::Secret],
+                truncated: false,
+                sanitizer_version: 1,
+            },
+        }
+    } else {
+        sanitize_agent_request(user_input).ok()?
+    };
 
     Some(ActivityRecord {
         activity_id: activity_id.to_string(),

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_record_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_record_tests.rs
@@ -111,6 +111,37 @@ fn agent_request_keeps_sanitized_text_and_opaque_session_only() {
     );
 }
 
+/// The shell secret gate flagged this input sensitive (#2138): the
+/// personalization sink must whole-field redact instead of trusting the
+/// sanitizer regexes — `sk-fbaa6` is below the opaque-token minimum
+/// length and would survive `sanitize_agent_request` verbatim.
+#[test]
+fn agent_request_with_sensitive_hint_redacts_whole_input_field() {
+    let mut sensitive_request = request();
+    sensitive_request.user_input =
+        Some("帮我安装下openclaw,模型使用qwen3.8-max,API Key: sk-fbaa6".to_string());
+    crate::types::mark_request_sensitive_input(&mut sensitive_request);
+
+    let record = agent_request_record(
+        &sensitive_request,
+        AgentContextBinding::FreeForm,
+        "act-request",
+        "session-opaque",
+        "fingerprint-request",
+        "intent-opaque",
+        Default::default(),
+        None,
+    )
+    .expect("request activity");
+
+    let json = serde_json::to_string(&record).unwrap();
+    assert!(!json.contains("sk-fbaa6"), "{json}");
+    let ActivityPayload::AgentRequest { text, .. } = record.payload else {
+        panic!("agent request payload");
+    };
+    assert_eq!(text, "<redacted>");
+}
+
 #[test]
 fn control_continuations_are_not_new_user_intents() {
     for binding in [

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -191,9 +191,10 @@ _cosh_emit_intercept_marker() {
   local input="$1"
   local reason="$2"
   local top_level_missing="${3:-false}"
+  local sensitive="${4:-false}"
   local timestamp
   timestamp="$(_cosh_now_ms)"
-  printf '\033]1337;COSH;{"event":"intercept","token":"%s","session_id":"%s","timestamp_ms":%s,"cwd":"%s","command":"%s","reason":"%s","status":0,"generation":%s,"top_level_missing":%s}\a' \
+  printf '\033]1337;COSH;{"event":"intercept","token":"%s","session_id":"%s","timestamp_ms":%s,"cwd":"%s","command":"%s","reason":"%s","status":0,"generation":%s,"top_level_missing":%s,"sensitive":%s}\a' \
     "$(_cosh_json_escape "$COSH_MARKER_TOKEN")" \
     "$(_cosh_json_escape "$COSH_SESSION_ID")" \
     "$timestamp" \
@@ -201,7 +202,8 @@ _cosh_emit_intercept_marker() {
     "$(_cosh_json_escape "$input")" \
     "$(_cosh_json_escape "$reason")" \
     "${_COSH_ATTEMPT_GENERATION:-0}" \
-    "$top_level_missing"
+    "$top_level_missing" \
+    "$sensitive"
 }
 _cosh_emit_top_level_missing_marker() {
   local intent="$1"
@@ -246,13 +248,14 @@ _cosh_is_slash_control_candidate() {
 # natural_language verdict on a provably-ENOENT path intercepts (dangling
 # symlinks and permission-opaque paths keep their native 126/127 errors),
 # everything else keeps the native bash error byte-identical to the
-# pre-fix behavior.
+# pre-fix behavior. Secret-bearing lines are not vetoed here (#2138):
+# both callers compute the sensitive flag, scrub history, and mark the
+# intercept so durable sinks redact the whole input field.
 _cosh_should_intercept_missing_path() {
   local first_word="$1"
   local command="$2"
   [[ "$first_word" == */* ]] || return 1
   [[ "${_COSH_AI_ENABLED:-1}" == 1 ]] || return 1
-  ! _cosh_command_has_secret "$command" || return 1
   _cosh_path_provably_missing "$first_word" || return 1
   local intent
   intent="$(_cosh_classify_missing "$command" "$first_word" missing_path)"
@@ -428,8 +431,6 @@ _cosh_begin_attempt() {
   _COSH_ATTEMPT_TOKEN_FINGERPRINT=
   if _cosh_command_has_secret "$input"; then
     _COSH_ATTEMPT_SENSITIVE=1
-    _COSH_ATTEMPT_TOKEN_FINGERPRINT="$(_cosh_token_fingerprint "$top_token")" || _COSH_ATTEMPT_ACTIVE=0
-    return 0
   fi
   _cosh_utf8_han_status "$input"
   utf8_status=$?
@@ -489,7 +490,7 @@ command_not_found_handle() {
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
   fi
-  if [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 || "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]]; then
+  if [[ "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]]; then
     local command_fingerprint
     command_fingerprint="$(_cosh_token_fingerprint "$command")"
     if [[ -z "$command_fingerprint"
@@ -499,10 +500,8 @@ command_not_found_handle() {
     fi
     _COSH_ATTEMPT_ACTIVE=0
     local sensitive=false
-    local unsafe=false
     [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 ]] && sensitive=true
-    [[ "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]] && unsafe=true
-    _cosh_emit_top_level_missing_marker "ambiguous" "$sensitive" "$unsafe"
+    _cosh_emit_top_level_missing_marker "ambiguous" "$sensitive" true
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
   fi
@@ -517,23 +516,25 @@ command_not_found_handle() {
     return $?
   fi
   _COSH_ATTEMPT_ACTIVE=0
+  local sensitive=false
+  [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 ]] && sensitive=true
   local reason
   if reason="$(_cosh_should_intercept_unknown "$command" "$original" "$(($# + 1))")"; then
-    _cosh_emit_intercept_marker "$original" "$reason"
+    _cosh_emit_intercept_marker "$original" "$reason" false "$sensitive"
     return 0
   fi
   local intent
   intent="$(_cosh_classify_missing "$original" "$command")"
   if [[ "$intent" == "natural_language" && "${_COSH_AI_ENABLED:-1}" == 1 ]]; then
     if [[ "${_COSH_HAS_USER_COMMAND_NOT_FOUND:-0}" == 1 ]]; then
-      _cosh_emit_top_level_missing_marker "$intent" false false
+      _cosh_emit_top_level_missing_marker "$intent" "$sensitive" false
       _cosh_delegate_bash_command_not_found "$command" "$@"
       return $?
     fi
-    _cosh_emit_intercept_marker "$original" "natural_language" true
+    _cosh_emit_intercept_marker "$original" "natural_language" true "$sensitive"
     return 0
   fi
-  _cosh_emit_top_level_missing_marker "$intent" false false
+  _cosh_emit_top_level_missing_marker "$intent" "$sensitive" false
   _cosh_delegate_bash_command_not_found "$command" "$@"
   return $?
 }
@@ -688,15 +689,17 @@ _cosh_preexec_marker() {
         fallback_first_word="${fallback_command%%[[:space:]]*}"
         fallback_argc=2
       fi
+      local fallback_sensitive=false
+      _cosh_command_has_secret "$fallback_command" && fallback_sensitive=true
       local fallback_reason
       if fallback_reason="$(_cosh_should_intercept_unknown "$fallback_first_word" "$fallback_command" "$fallback_argc")"; then
-        _cosh_emit_intercept_marker "$fallback_command" "$fallback_reason"
+        _cosh_emit_intercept_marker "$fallback_command" "$fallback_reason" false "$fallback_sensitive"
         _COSH_AT_PROMPT=0
         eval "$active_debug_trap" 2>/dev/null || true
         return 1
       fi
       if _cosh_should_intercept_missing_path "$fallback_first_word" "$fallback_command"; then
-        _cosh_emit_intercept_marker "$fallback_command" "natural_language"
+        _cosh_emit_intercept_marker "$fallback_command" "natural_language" false "$fallback_sensitive"
         _COSH_AT_PROMPT=0
         eval "$active_debug_trap" 2>/dev/null || true
         return 1
@@ -727,22 +730,27 @@ _cosh_preexec_marker() {
           first_word="${command%%[[:space:]]*}"
           argc=2
         fi
+        local intercept_sensitive=false
+        _cosh_command_has_secret "$command" && intercept_sensitive=true
         local reason
         if reason="$(_cosh_should_intercept_unknown "$first_word" "$command" "$argc")"; then
           # Intercepted lines return 1 before the secret redaction below
           # ever runs, so scrub credential-bearing entries here or the raw
           # text would persist in native history (routed slash submissions
           # enter history via readline before the trap fires).
-          if _cosh_command_has_secret "$command"; then
+          if [[ "$intercept_sensitive" == true ]]; then
             builtin history -d "$history_no" 2>/dev/null || true
           fi
-          _cosh_emit_intercept_marker "$command" "$reason"
+          _cosh_emit_intercept_marker "$command" "$reason" false "$intercept_sensitive"
           _COSH_AT_PROMPT=0
           eval "$active_debug_trap" 2>/dev/null || true
           return 1
         fi
         if _cosh_should_intercept_missing_path "$first_word" "$command"; then
-          _cosh_emit_intercept_marker "$command" "natural_language"
+          if [[ "$intercept_sensitive" == true ]]; then
+            builtin history -d "$history_no" 2>/dev/null || true
+          fi
+          _cosh_emit_intercept_marker "$command" "natural_language" false "$intercept_sensitive"
           _COSH_AT_PROMPT=0
           eval "$active_debug_trap" 2>/dev/null || true
           return 1

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -117,9 +117,10 @@ _cosh_emit_intercept_marker() {
   local input="$1"
   local reason="$2"
   local top_level_missing="${3:-false}"
+  local sensitive="${4:-false}"
   local timestamp
   timestamp="$(_cosh_now_ms)"
-  printf '\033]1337;COSH;{"event":"intercept","token":"%s","session_id":"%s","timestamp_ms":%s,"cwd":"%s","command":"%s","reason":"%s","status":0,"generation":%s,"top_level_missing":%s}\a' \
+  printf '\033]1337;COSH;{"event":"intercept","token":"%s","session_id":"%s","timestamp_ms":%s,"cwd":"%s","command":"%s","reason":"%s","status":0,"generation":%s,"top_level_missing":%s,"sensitive":%s}\a' \
     "$(_cosh_json_escape "$COSH_MARKER_TOKEN")" \
     "$(_cosh_json_escape "$COSH_SESSION_ID")" \
     "$timestamp" \
@@ -127,7 +128,8 @@ _cosh_emit_intercept_marker() {
     "$(_cosh_json_escape "$input")" \
     "$(_cosh_json_escape "$reason")" \
     "${_COSH_ATTEMPT_GENERATION:-0}" \
-    "$top_level_missing"
+    "$top_level_missing" \
+    "$sensitive"
 }
 _cosh_emit_top_level_missing_marker() {
   local intent="$1"
@@ -370,8 +372,6 @@ _cosh_begin_attempt() {
   _COSH_ATTEMPT_TOKEN_FINGERPRINT=
   if _cosh_command_has_secret "$input"; then
     _COSH_ATTEMPT_SENSITIVE=1
-    _COSH_ATTEMPT_TOKEN_FINGERPRINT="$(_cosh_token_fingerprint "$top_token")" || _COSH_ATTEMPT_ACTIVE=0
-    return 0
   fi
   _cosh_utf8_han_status "$input"
   utf8_status=$?
@@ -431,7 +431,7 @@ command_not_found_handler() {
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
   fi
-  if [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 || "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]]; then
+  if [[ "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]]; then
     local command_fingerprint
     command_fingerprint="$(_cosh_token_fingerprint "$command")"
     if [[ -z "$command_fingerprint"
@@ -441,10 +441,8 @@ command_not_found_handler() {
     fi
     _COSH_ATTEMPT_ACTIVE=0
     local sensitive=false
-    local unsafe=false
     [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 ]] && sensitive=true
-    [[ "${_COSH_ATTEMPT_UNSAFE:-0}" == 1 ]] && unsafe=true
-    _cosh_emit_top_level_missing_marker "ambiguous" "$sensitive" "$unsafe"
+    _cosh_emit_top_level_missing_marker "ambiguous" "$sensitive" true
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
   fi
@@ -459,23 +457,25 @@ command_not_found_handler() {
     return $?
   fi
   _COSH_ATTEMPT_ACTIVE=0
+  local sensitive=false
+  [[ "${_COSH_ATTEMPT_SENSITIVE:-0}" == 1 ]] && sensitive=true
   local reason
   if reason="$(_cosh_should_intercept_unknown "$command" "$original" "$(($# + 1))")"; then
-    _cosh_emit_intercept_marker "$original" "$reason"
+    _cosh_emit_intercept_marker "$original" "$reason" false "$sensitive"
     return 0
   fi
   local intent
   intent="$(_cosh_classify_missing "$original" "$command")"
   if [[ "$intent" == "natural_language" && "${_COSH_AI_ENABLED:-1}" == 1 ]]; then
     if [[ "${_COSH_HAS_USER_COMMAND_NOT_FOUND:-0}" == 1 ]]; then
-      _cosh_emit_top_level_missing_marker "$intent" false false
+      _cosh_emit_top_level_missing_marker "$intent" "$sensitive" false
       _cosh_delegate_zsh_command_not_found "$command" "$@"
       return $?
     fi
-    _cosh_emit_intercept_marker "$original" "natural_language" true
+    _cosh_emit_intercept_marker "$original" "natural_language" true "$sensitive"
     return 0
   fi
-  _cosh_emit_top_level_missing_marker "$intent" false false
+  _cosh_emit_top_level_missing_marker "$intent" "$sensitive" false
   _cosh_delegate_zsh_command_not_found "$command" "$@"
   return $?
 }
@@ -525,7 +525,9 @@ _cosh_preexec_marker() {
     fi
     local reason
     if reason="$(_cosh_should_intercept_unknown "$first_word" "$command" "$argc")"; then
-      _cosh_emit_intercept_marker "$command" "$reason"
+      local intercept_sensitive=false
+      _cosh_command_has_secret "$command" && intercept_sensitive=true
+      _cosh_emit_intercept_marker "$command" "$reason" false "$intercept_sensitive"
       return 1
     fi
     _cosh_begin_attempt "$command" "$first_word" "$expansion_drift"

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -686,7 +686,7 @@ impl OscParser {
         cwd: Option<String>,
         reason: &str,
     ) {
-        self.push_intercept_event_with_routing(session_id, input, cwd, reason, None, false);
+        self.push_intercept_event_with_routing(session_id, input, cwd, reason, None, false, false);
     }
 
     pub(super) fn push_control_event(&mut self, input: &str) {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/routing.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/routing.rs
@@ -26,6 +26,7 @@ impl OscParser {
             let reason = marker
                 .reason
                 .unwrap_or_else(|| "natural_language".to_string());
+            let sensitive = marker.sensitive.unwrap_or(false);
             self.intervention_cuts.push(self.clean.len());
             self.intervention_display_cuts
                 .push((self.display.len(), DisplayCutKind::Intercept));
@@ -43,6 +44,7 @@ impl OscParser {
                 &reason,
                 generation,
                 correlated,
+                sensitive,
             );
             if correlated {
                 self.current = None;
@@ -85,10 +87,21 @@ impl OscParser {
         reason: &str,
         generation: Option<u64>,
         top_level_missing: bool,
+        sensitive: bool,
     ) {
         let command_id = top_level_missing
             .then(|| self.current.as_ref().map(|command| command.id.clone()))
             .flatten();
+        // Sensitive intercepts always carry routing metadata (even without
+        // top-level-missing provenance) so the journal can redact the whole
+        // input field before it reaches disk.
+        let routing = (top_level_missing || sensitive).then_some(ShellRoutingMetadata {
+            generation: generation.unwrap_or_default(),
+            top_level_missing,
+            proven: top_level_missing,
+            sensitive,
+            unsafe_input: false,
+        });
         self.events.push(ShellEvent {
             kind: ShellEventKind::UserInputIntercepted,
             session_id: session_id.to_string(),
@@ -108,13 +121,7 @@ impl OscParser {
             command_origin: None,
             shell_environment_generation: None,
             audit_identity: None,
-            routing: top_level_missing.then_some(ShellRoutingMetadata {
-                generation: generation.unwrap_or_default(),
-                top_level_missing,
-                proven: top_level_missing,
-                sensitive: false,
-                unsafe_input: false,
-            }),
+            routing,
             capture: None,
         });
     }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -57,6 +57,49 @@ fn routing_markers_require_matching_attempt_generation() {
 }
 
 #[test]
+fn intercept_marker_sensitive_flag_reaches_routing_metadata() {
+    let mut parser = parser_for_test("routing-sensitive");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"preexec\",\"token\":\"test-marker-token\",\"session_id\":\"routing-sensitive\",\"command\":\"<redacted sensitive command>\",\"cwd\":\"/tmp\",\"generation\":1}\x07")
+        .expect("feed preexec");
+    parser
+        .feed("\x1b]1337;COSH;{\"event\":\"intercept\",\"token\":\"test-marker-token\",\"session_id\":\"routing-sensitive\",\"command\":\"帮我安装下openclaw,模型使用qwen3.8-max,API Key: sk-fbaa6\",\"reason\":\"natural_language\",\"generation\":1,\"top_level_missing\":true,\"sensitive\":true}\x07".as_bytes())
+        .expect("feed sensitive intercept");
+
+    let intercept = parser
+        .events
+        .iter()
+        .find(|event| event.kind == ShellEventKind::UserInputIntercepted)
+        .expect("sensitive intercept event");
+    // The raw input still reaches the agent path in memory; only durable
+    // sinks (journal) redact it, keyed off the sensitive routing flag.
+    assert!(intercept
+        .input
+        .as_deref()
+        .is_some_and(|input| input.contains("sk-fbaa6")));
+    assert!(intercept.routing.as_ref().is_some_and(|routing| {
+        routing.sensitive && routing.top_level_missing && routing.proven
+    }));
+}
+
+#[test]
+fn intercept_marker_without_sensitive_field_defaults_to_not_sensitive() {
+    let mut parser = parser_for_test("routing-legacy");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"intercept\",\"token\":\"test-marker-token\",\"session_id\":\"routing-legacy\",\"command\":\"/skills detail\",\"reason\":\"slash\",\"cwd\":\"/tmp\"}\x07")
+        .expect("feed legacy intercept");
+
+    let intercept = parser
+        .events
+        .iter()
+        .find(|event| event.kind == ShellEventKind::UserInputIntercepted)
+        .expect("legacy intercept event");
+    // Legacy markers (no sensitive field, no top-level-missing provenance)
+    // keep the pre-#2138 shape: no routing metadata at all.
+    assert!(intercept.routing.is_none());
+}
+
+#[test]
 fn trusted_history_file_marker_is_private_and_observed() {
     let observed = Arc::new(Mutex::new(Vec::new()));
     let sink = Arc::clone(&observed);

--- a/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/mod.rs
@@ -363,6 +363,26 @@ fn context_binding_from_hint(hint: &str) -> Option<AgentContextBinding> {
     }
 }
 
+/// In-band marker for requests whose input the shell-side secret gate
+/// flagged sensitive (#2138). `__cosh_` hints never reach provider
+/// prompts; durable sinks (personalization activity store) key off it
+/// to redact the whole input field instead of trusting sanitizer
+/// regexes to re-detect every shell-gate form.
+pub(crate) const SENSITIVE_INPUT_HINT: &str = "__cosh_sensitive_input=true";
+
+pub(crate) fn mark_request_sensitive_input(request: &mut AgentRequest) {
+    if !request_has_sensitive_input(request) {
+        request.context_hints.push(SENSITIVE_INPUT_HINT.to_string());
+    }
+}
+
+pub(crate) fn request_has_sensitive_input(request: &AgentRequest) -> bool {
+    request
+        .context_hints
+        .iter()
+        .any(|hint| hint == SENSITIVE_INPUT_HINT)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum QuestionSelectionMode {

--- a/src/cosh-ng/crates/cosh-shell/src/types/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/public.rs
@@ -14,6 +14,7 @@ pub use implementation::{
 
 #[allow(unused_imports)]
 pub(crate) use implementation::{
+    mark_request_sensitive_input, request_has_sensitive_input,
     request_is_analysis_only_continuation, set_request_context_binding, AgentContextBinding,
     BuiltinFactRecord, BuiltinFindingFacts, EvaluatedHookFinding, HighMemoryProcessFacts,
     HookProvenance, MemoryPressureFacts, MetricsConfidence, ProcessMemoryFact,

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -427,7 +427,10 @@ fn shell_host_bash_sensitive_missing_emits_raw_free_provenance() {
         .find(|event| event.kind == ShellEventKind::CommandRoutingObserved)
         .unwrap_or_else(|| panic!("routing provenance: {:?}", output.events));
 
-    assert_eq!(routing.component.as_deref(), Some("ambiguous"));
+    // Post-#2138 the sensitive gate no longer short-circuits ahead of intent
+    // classification: `--token=...` vetoes to intent=command, which keeps the
+    // native error and emits raw-free provenance with the sensitive flag.
+    assert_eq!(routing.component.as_deref(), Some("command"));
     assert!(routing.routing.as_ref().is_some_and(|metadata| {
         metadata.generation == 1
             && metadata.top_level_missing
@@ -441,10 +444,78 @@ fn shell_host_bash_sensitive_missing_emits_raw_free_provenance() {
     assert!(String::from_utf8_lossy(&output.terminal_output).contains("command not found"));
 }
 
+/// #2138: natural-language input carrying a secret routes to the agent like
+/// regular NL (intercept event emitted, sensitive routing flag set) instead
+/// of being silently vetoed to the native command-not-found error. The
+/// harness returns journal-redacted events, so the intercept input must be
+/// the whole-field redaction and the raw key must never appear (V3); the raw
+/// text reaching the in-memory agent path is anchored in osc_tests.
 #[test]
-fn shell_host_missing_cksum_fails_closed_without_sensitive_provenance() {
+fn shell_host_sensitive_natural_language_routes_to_agent_with_flag() {
+    let issue_input = "帮我安装下openclaw,模型使用qwen3.8-max,API Key: sk-fbaa6";
+    let mut shells = Vec::new();
+    if bash_supports_command_not_found_handler() {
+        shells.push("bash");
+    }
+    if Command::new("zsh").arg("--version").output().is_ok() {
+        shells.push("zsh");
+    }
+    for shell in shells {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-shell-{shell}-sensitive-nl-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let config = ShellHostConfig::new(format!("{shell}-sensitive-nl"), &work_dir);
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &[ScriptedInput::user_line(issue_input)])
+        } else {
+            run_scripted_zsh(&config, &[ScriptedInput::user_line(issue_input)])
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+
+        let terminal = String::from_utf8_lossy(&output.terminal_output);
+        assert!(
+            !terminal.contains("command not found") && !terminal.contains("未找到命令"),
+            "{shell}: {terminal}"
+        );
+        let intercept = output
+            .events
+            .iter()
+            .find(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.component.as_deref() == Some("natural_language")
+            })
+            .unwrap_or_else(|| panic!("{shell}: sensitive NL intercept: {:?}", output.events));
+        assert_eq!(intercept.input.as_deref(), Some("<redacted>"), "{shell}");
+        assert!(
+            intercept
+                .routing
+                .as_ref()
+                .is_some_and(|routing| routing.sensitive && routing.top_level_missing),
+            "{shell}: {intercept:?}"
+        );
+        assert!(
+            !format!("{:?}", output.events).contains("sk-fbaa6"),
+            "{shell}: {:?}",
+            output.events
+        );
+        let journal = std::fs::read_to_string(&output.journal_path).unwrap();
+        assert!(!journal.contains("sk-fbaa6"), "{shell}: {journal}");
+    }
+}
+
+#[test]
+fn shell_host_missing_cksum_keeps_raw_free_sensitive_provenance() {
+    // Post-#2138 the sensitive path shares the regular literal-first-word
+    // identity check and no longer depends on the cksum fingerprint, so a
+    // broken cksum only degrades the unsafe (invalid UTF-8) path. Sensitive
+    // provenance must still be emitted, raw-free, with the native error.
     let input = "missing_sensitive_cli --token=secretvalue";
-    let mut shells = vec!["bash"];
+    let mut shells = Vec::new();
+    if bash_supports_command_not_found_handler() {
+        shells.push("bash");
+    }
     if Command::new("zsh").arg("--version").output().is_ok() {
         shells.push("zsh");
     }
@@ -484,14 +555,20 @@ fn shell_host_missing_cksum_fails_closed_without_sensitive_provenance() {
         assert!(output.events.iter().any(|event| {
             event.kind == ShellEventKind::CommandFailed && event.exit_code == Some(127)
         }));
+        let routing = output
+            .events
+            .iter()
+            .find(|event| event.kind == ShellEventKind::CommandRoutingObserved)
+            .unwrap_or_else(|| panic!("{shell}: routing provenance: {:?}", output.events));
+        assert_eq!(routing.component.as_deref(), Some("command"), "{shell}");
         assert!(
-            !output
-                .events
-                .iter()
-                .any(|event| event.kind == ShellEventKind::CommandRoutingObserved),
-            "{shell}: {:?}",
-            output.events
+            routing.routing.as_ref().is_some_and(|metadata| {
+                metadata.top_level_missing && metadata.sensitive && !metadata.unsafe_input
+            }),
+            "{shell}: {routing:?}"
         );
+        assert!(routing.input.is_none(), "{shell}");
+        assert!(routing.command.is_none(), "{shell}");
         assert!(
             !format!("{:?}", output.events).contains("secretvalue"),
             "{shell}: {:?}",
@@ -1955,6 +2032,73 @@ fn shell_host_bash_missing_path_natural_language_intercepts() {
     );
 }
 
+/// #2138 review round 2: the missing-path route (#1919) must not keep its
+/// own secret veto — a slash-bearing NL prompt carrying a key intercepts
+/// like the CNF route, with the sensitive routing flag and the journal
+/// whole-field redaction (raw key never reaches durable evidence).
+#[test]
+fn shell_host_bash_sensitive_missing_path_natural_language_intercepts() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-missing-path-sensitive-nl-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+    let mut config = ShellHostConfig::new("missing-path-sensitive-nl", &work_dir);
+    config
+        .env_overrides
+        .push(("LANG".to_string(), "C.UTF-8".to_string()));
+    config
+        .env_overrides
+        .push(("LC_ALL".to_string(), "C.UTF-8".to_string()));
+
+    let prompt =
+        "你读一下，并安装这个skill：/nonexistent-cosh-1919-probe/SKILL.md API Key: sk-fbaa6";
+    let output =
+        run_scripted_bash(&config, &[ScriptedInput::user_line(prompt)]).expect("scripted bash pty");
+
+    let intercept = output
+        .events
+        .iter()
+        .find(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.component.as_deref() == Some("natural_language")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "sensitive missing-path natural-language intercept: {:?}",
+                output.events
+            )
+        });
+    // The harness returns journal-redacted events: the sensitive flag must
+    // trigger the whole-field redaction and no correlation exists (the
+    // command never started, so top_level_missing stays false).
+    assert_eq!(intercept.input.as_deref(), Some("<redacted>"));
+    assert!(
+        intercept
+            .routing
+            .as_ref()
+            .is_some_and(|routing| routing.sensitive && !routing.top_level_missing),
+        "{intercept:?}"
+    );
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    assert!(
+        !terminal.contains("No such file or directory"),
+        "{terminal}"
+    );
+    assert!(
+        !format!("{:?}", output.events).contains("sk-fbaa6"),
+        "{:?}",
+        output.events
+    );
+    let journal = std::fs::read_to_string(&output.journal_path).unwrap();
+    assert!(!journal.contains("sk-fbaa6"), "{journal}");
+}
+
 #[test]
 fn routing_c1_cnf_han_tier_a_routes_to_agent() {
     for shell in ["bash", "zsh"] {
@@ -2673,8 +2817,11 @@ fn routing_c2_valid_quoted_command_and_inner_whitespace_keep_their_owners() {
 }
 
 // Issue #1919 fail-closed counterproofs: the missing-path branch must never
-// fire for existing paths (I1/D6), plain-English typo paths (I2/D3), or
-// secret-bearing input (I3) — bash native behavior stays byte-identical.
+// fire for existing paths (I1/D6) or plain-English typo paths (I2/D3) —
+// bash native behavior stays byte-identical. (The former I3 secret
+// counterproof is retired by #2138: secret-bearing missing-path NL now
+// intercepts with the sensitive flag, anchored in
+// shell_host_bash_sensitive_missing_path_natural_language_intercepts.)
 #[test]
 fn shell_host_bash_missing_path_counterproofs_stay_native() {
     if Command::new("bash").arg("--version").output().is_err() {
@@ -2728,13 +2875,11 @@ fn shell_host_bash_missing_path_counterproofs_stay_native() {
     let existing_data = format!("{} 帮我读一下", data_path.display());
     let dangling_input = format!("{} 帮我读一下", dangling_path.display());
     let opaque_input = format!("{} 帮我读一下", opaque_file.display());
-    let secret_input = "打开./conf-1919.toml password=secretvalue";
     let output = run_scripted_bash(
         &config,
         &[
             ScriptedInput::user_line(existing_exec.clone()),
             ScriptedInput::user_line("/usr/bin/nonexistent-cosh-1919-probe"),
-            ScriptedInput::user_line(secret_input),
             ScriptedInput::user_line(existing_data.clone()),
             ScriptedInput::user_line(dangling_input.clone()),
             ScriptedInput::user_line(opaque_input.clone()),


### PR DESCRIPTION
# Summary

Sensitive natural-language input (a sentence carrying a secret-shaped token, e.g. an API key) was vetoed before intent classification: the bash/zsh command-not-found gate only emitted `top_level_missing(sensitive=true)` — which has no UI consumer — and then fell through to the native `command not found` error, so the agent never saw the request. The punctuation blamed in the issue title is a red herring: a control run of the same sentence without the key intercepts fine; the secret-shaped token is the only trigger.

This PR routes sensitive NL through the same identity/classify path as regular input, and moves the privacy boundary from "raw text never leaves the shell" to "raw text never reaches durable local evidence" (matching the existing `??` explicit-entry contract, where raw text already reaches the model).

Closes #2138

# Changes

- **bash/zsh markers** (`shell_host/marker/bash.rs`, `zsh.rs`): `_cosh_begin_attempt` keeps the raw line for sensitive input; the CNF sensitive short-circuit is removed (unsafe/invalid-UTF-8 keeps the cksum fingerprint path); every intercept marker emission carries a `sensitive` flag; the bash missing-path intercept now also scrubs credential-bearing native history entries like the slash path already did.
- **OscParser** (`shell_host/osc.rs`, `osc/routing.rs`): the intercept marker `sensitive` flag lands in `ShellRoutingMetadata`; sensitive intercepts always carry routing metadata so durable sinks can key off it; markers without the field parse as `sensitive=false` (legacy compatible).
- **journal** (`journal/mod.rs`): events flagged sensitive redact the whole `input` field (`card_secret` precedent) instead of trusting the redaction regexes to re-detect every shell-gate form (`sk-fbaa6` is below the opaque-token minimum length; `API Key:` is not in the assignment word list).
- **personalization store** (`parser/mod.rs`, `types/`, `recommendation/personal_record.rs`, review round 1, Codex P1): the intercept's sensitive routing flag rides the `AgentRequest` as an in-band `__cosh_sensitive_input=true` context hint (`__cosh_` hints never reach provider prompts), and `agent_request_record` whole-field redacts flagged inputs — the activity store previously persisted `sanitize_agent_request` output, which the short key also survives.
- **missing-path route** (`marker/bash.rs`, review round 2, Codex P1): `_cosh_should_intercept_missing_path` drops its residual secret veto — the #1919 route kept its own short-circuit, so slash-bearing sensitive NL still fell to the native path error; both callers already compute the sensitive flag and scrub history. zsh has no missing-path route (#1919 is bash-specific slash-word execution semantics). The former I3 secret counterproof is re-anchored to the new contract.
- Native error output for sensitive intent=command input stays byte-identical (`top_level_missing` provenance keeps the sensitive flag and no longer depends on the cksum fingerprint); shell history exclusion is unchanged.

# Tests

New / re-anchored:

- `journal_redacts_sensitive_routed_input_whole_field` — sensitive routed event lands as `<redacted>` in the journal file.
- `journal_redacts_every_shell_gate_pattern_family` — matrix over 8 shell-gate pattern families (short `sk-` key, `ghp_` token, bearer, URL password, `--password` flag, sensitive assignment, LTAI/AKIA access keys) plus a `sensitive=true, unsafe_input=true` combination row; whole-field redaction covers each.
- `intercept_marker_sensitive_flag_reaches_routing_metadata` / `intercept_marker_without_sensitive_field_defaults_to_not_sensitive` — parser transport and legacy-marker compatibility.
- `intercepted_input_request_carries_sensitive_hint_from_routing` — the sensitive routing flag lands on the `AgentRequest` as the in-band hint; unflagged intercepts stay clean.
- `agent_request_with_sensitive_hint_redacts_whole_input_field` — personalization sink-level regression: a flagged request serializes with `text = <redacted>` and no plaintext key.
- `shell_host_bash_sensitive_missing_path_natural_language_intercepts` — missing-path route (#1919) with a key appended: intercepts with `routing.sensitive=true` instead of the native path error (FAIL on the pre-fix tree, PASS after); the counterproof suite's former I3 secret row is retired accordingly.
- `shell_host_sensitive_natural_language_routes_to_agent_with_flag` — bash+zsh: sensitive NL reaches the agent path with `routing.sensitive=true` and no raw text in the journal.
- `shell_host_missing_cksum_keeps_raw_free_sensitive_provenance` (re-anchors the previous fail-closed test): sensitive provenance no longer depends on the cksum fingerprint; missing cksum only affects the unsafe path.

# Verification

Focused scope (green; marker/journal/osc suites in an anolisos 23.4 container, bash 5.2.15 / zsh 5.9; review-round additions on the host):

- `cargo test -p cosh-shell --lib` (1228) and `--bin cosh-shell` (2306) full green after the review-round fix; `tests/shell_host` marker suite; `cargo clippy -p cosh-shell --all-targets -D warnings`; `cargo fmt --check`; `check-layout.sh` and `check-test-inventory.sh`.
- Real-machine FAIL→PASS: real PTY (120x40) + real cosh-core, issue sentence verbatim. Base binary (8c975aa6): scenario-a FAILs (native CNF error, agent never engaged). Fix binary: scenario-a and control scenario-b PASS, deterministic across a second run; zsh smoke 2/2.
- Durable-evidence check on the fix run: `grep -r "sk-fbaa6"` over journal/audit/HISTFILE finds no plaintext on the cosh-shell side (the only hit is the cosh-core provider session file, which is inside the existing "raw text reaches the model" contract shared with `??`).

Excluded scope (not run): full workspace test suite beyond cosh-shell; other crates unaffected by this diff.

# Evidence

Real PTY runs (anolisos 23.4 container, real cosh-core; the `sk-fbaa6` key shown on screen is the fake token quoted verbatim from #2138). Recordings replay the exact issue sentence.

## FAIL → PASS: issue sentence (scenario-a, bash)

**Before (base 8c975aa6)** — sensitive NL falls through to the native `command not found`, agent never engaged:

![base-fail scenario-a](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/base-fail-scenario-a-issue-line.gif)

**After (this PR)** — the same sentence routes to the agent, which answers and raises a real approval card:

![fix-pass scenario-a](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-scenario-a-issue-line.gif)

## Control: same sentence without the key (scenario-b)

Intercepted fine both before and after — confirming the secret-shaped token, not the punctuation, was the trigger:

![fix-pass scenario-b](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-scenario-b-control-no-key.gif)

## zsh symmetry smoke

Same sensitive sentence under the zsh marker also reaches the agent:

![fix-pass zsh scenario-a](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-zsh-scenario-a-issue-line.gif)

<details>
<summary>Additional assets (final-frame screenshots, remaining GIFs)</summary>

- [base-fail scenario-a final frame](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/base-fail-scenario-a-issue-line-final.png)
- [base-fail scenario-b GIF](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/base-fail-scenario-b-control-no-key.gif) / [final frame](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/base-fail-scenario-b-control-no-key-final.png)
- [fix-pass scenario-a final frame](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-scenario-a-issue-line-final.png)
- [fix-pass scenario-b final frame](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-scenario-b-control-no-key-final.png)
- [fix-pass zsh scenario-a final frame](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-zsh-scenario-a-issue-line-final.png)
- [fix-pass zsh scenario-b GIF](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-zsh-scenario-b-control-no-key.gif) / [final frame](https://raw.githubusercontent.com/SunnyQjm/anolisa/40b5f2d976882dc12ef6378ee361237e9c764b6c/fix-pass-zsh-scenario-b-control-no-key-final.png)

</details>
