### PR TITLE
fix(tokenless): harden agent-id attribution

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -201,6 +201,7 @@ test-integration:
 	python3 tests/test_compress_response_hook.py
 	python3 tests/test_compress_schema_hook.py
 	python3 tests/test_rewrite_hook.py
+	python3 tests/test_resolve_agent_id.py
 
 test-adapters:
 	@echo "==> Testing qoder adapter installer..."

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -522,23 +522,57 @@ def detect_cosh_ng_runtime() -> tuple | None:
     return None
 
 
-def resolve_agent_id(default: str = "tokenless") -> str:
+def _agent_id_from_argv(argv: list[str] | None) -> str | None:
+    """Return an explicit ``--agent-id`` value from hook command arguments.
+
+    Adapters declare the agent id in ``hooks.json``. The host always honours
+    the hook ``command`` string, but does not reliably propagate the declared
+    ``env`` map to every hook execution context — PreToolUse rewrite and
+    sub-agent task runs have been observed dropping it, collapsing attribution
+    to the fallback. An id passed as a command argument is therefore the robust
+    channel. Accepts both ``--agent-id VALUE`` and ``--agent-id=VALUE``;
+    unrelated arguments are ignored so hooks that take no other options are
+    unaffected.
+    """
+    args = sys.argv[1:] if argv is None else argv
+    for index, arg in enumerate(args):
+        if arg == "--agent-id":
+            following = args[index + 1] if index + 1 < len(args) else ""
+            return following or None
+        if arg.startswith("--agent-id="):
+            return arg[len("--agent-id="):] or None
+    return None
+
+
+def resolve_agent_id(default: str = "unknown", argv: list[str] | None = None) -> str:
     """Resolve the agent ID used for stats attribution.
 
-    Runtime detection wins over ``TOKENLESS_AGENT_ID``. The shared extension
-    manifest sets that variable to ``copilot-shell``, and now that Cosh-NG
-    honours hook ``env`` (#1617) an unconditional read would attribute Cosh-NG
-    sessions to copilot-shell. ``COSH_RUNTIME`` / ``COSH_NG_VERSION`` are
-    injected by the host after the manifest env, so they take precedence over
-    the declared env map.
+    Precedence, highest first:
+
+    1. **Cosh-NG runtime detection.** The shared extension manifest sets
+       ``TOKENLESS_AGENT_ID=copilot-shell``, and since Cosh-NG honours hook
+       ``env`` (#1617) an unconditional read would attribute Cosh-NG sessions
+       to copilot-shell. ``COSH_RUNTIME`` / ``COSH_NG_VERSION`` are injected by
+       the host after the manifest env, so they win.
+    2. **``--agent-id`` command argument** — the robust declared channel, since
+       the host always honours the hook ``command`` string.
+    3. **``TOKENLESS_AGENT_ID`` environment variable** — the legacy declared
+       channel, kept for backward compatibility but not always propagated.
+    4. **``default``** — a visible ``"unknown"`` sentinel rather than the tool's
+       own name, so an attribution gap is observable in stats instead of
+       masquerading as a real ``tokenless`` agent.
 
     This is attribution only. The signal is cooperative — a manifest controls
-    its own ``command`` and could reassign these — so it must never gate
-    anything security-relevant.
+    its own ``command`` and env and could reassign these — so it must never
+    gate anything security-relevant.
     """
     if detect_cosh_ng_runtime() is not None:
         return "cosh-ng"
-    return os.environ.get("TOKENLESS_AGENT_ID") or default
+    return (
+        _agent_id_from_argv(argv)
+        or os.environ.get("TOKENLESS_AGENT_ID")
+        or default
+    )
 
 
 def parse_version(version_str: str) -> tuple | None:

--- a/src/tokenless/adapters/tokenless/qoder/hooks.json
+++ b/src/tokenless/adapters/tokenless/qoder/hooks.json
@@ -22,7 +22,7 @@
             "type": "command",
             "name": "tokenless-rewrite",
             "description": "Rewrites shell commands via rtk for token savings",
-            "command": "python3 ${QODER_TOKENLESS_HOOKS}/rewrite_hook.py",
+            "command": "python3 ${QODER_TOKENLESS_HOOKS}/rewrite_hook.py --agent-id qoder-cli",
             "timeout": 5000,
             "env": { "TOKENLESS_AGENT_ID": "qoder-cli" }
           }
@@ -37,7 +37,7 @@
             "type": "command",
             "name": "tokenless-compress-response",
             "description": "Compresses tool responses and encodes to TOON format",
-            "command": "python3 ${QODER_TOKENLESS_HOOKS}/compress_response_hook.py",
+            "command": "python3 ${QODER_TOKENLESS_HOOKS}/compress_response_hook.py --agent-id qoder-cli",
             "timeout": 10000,
             "env": { "TOKENLESS_AGENT_ID": "qoder-cli" }
           }

--- a/src/tokenless/adapters/tokenless/qoder/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/qoder/scripts/install.sh
@@ -159,20 +159,26 @@ if not isinstance(existing_hooks, dict):
 
 for event, entries in resolved['hooks'].items():
     existing = existing_hooks.get(event, [])
-    existing_names = set()
-    for e in existing:
-        for h in (e.get('hooks') or []):
-            if h.get('name'):
-                existing_names.add(h['name'])
-    for entry in entries:
-        entry_name = None
-        for h in (entry.get('hooks') or []):
-            if h.get('name'):
-                entry_name = h['name']
-                break
-        if entry_name and entry_name not in existing_names:
-            existing.append(entry)
-    existing_hooks[event] = existing
+    # Names this component manages for this event.
+    incoming_names = {
+        h['name']
+        for entry in entries
+        for h in (entry.get('hooks') or [])
+        if h.get('name')
+    }
+
+    # Upsert, not append-by-name: drop the matcher groups we own (those whose
+    # named hooks are entirely ours) so a re-install refreshes a changed
+    # command or env. Append-only would leave a stale entry — e.g. an existing
+    # tokenless hook installed before --agent-id would never gain it. Groups
+    # carrying any foreign hook are preserved untouched.
+    def _owned_by_us(entry):
+        named = [h.get('name') for h in (entry.get('hooks') or []) if h.get('name')]
+        return bool(named) and all(name in incoming_names for name in named)
+
+    refreshed = [entry for entry in existing if not _owned_by_us(entry)]
+    refreshed.extend(entries)
+    existing_hooks[event] = refreshed
 
 cfg['hooks'] = existing_hooks
 

--- a/src/tokenless/tests/test-qoder-adapter-install.sh
+++ b/src/tokenless/tests/test-qoder-adapter-install.sh
@@ -120,8 +120,10 @@ for entries in cfg.get('hooks', {}).values():
     for entry in entries:
         for hook in entry.get('hooks') or []:
             parts = shlex.split(hook.get('command', ''))
-            if parts and not os.path.exists(parts[-1]):
-                missing.append(hook['command'])
+            scripts = [p for p in parts if p.endswith(('.py', '.sh'))]
+            for script in scripts:
+                if not os.path.exists(script):
+                    missing.append(hook['command'])
 print('\n'.join(missing))
 PYEOF
 )"
@@ -143,6 +145,50 @@ if [ -f "$SETTINGS" ] && grep -qF 'tokenless@local' "$SETTINGS"; then
     log_pass "settings.json enables tokenless@local plugin"
 else
     log_fail "settings.json missing plugins.enabled entry"
+fi
+
+# 6. UPGRADE (upsert, not append): a re-install must refresh a stale managed
+#    hook whose command changed, and must never touch foreign hooks.
+python3 - "$SETTINGS" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+cfg = json.load(open(path))
+pre = cfg.setdefault('hooks', {}).setdefault('PreToolUse', [])
+# Make the managed rewrite hook look pre-upgrade (no --agent-id)...
+for entry in pre:
+    for hook in entry.get('hooks') or []:
+        if hook.get('name') == 'tokenless-rewrite':
+            hook['command'] = hook['command'].replace(' --agent-id qoder-cli', '')
+# ...and add a foreign hook the installer must preserve untouched.
+pre.append({
+    'matcher': '*',
+    'hooks': [{'type': 'command', 'name': 'foreign-guard', 'command': 'echo keep-me'}],
+})
+json.dump(cfg, open(path, 'w'), indent=2)
+PYEOF
+
+HOME="$FAKE_HOME" ANOLISA_ADAPTER_DIR="$ADAPTER_DIR" bash "$INSTALL_SH" >/dev/null 2>&1
+reinstall_rc=$?
+upsert_problems="$(SETTINGS="$SETTINGS" python3 - <<'PYEOF'
+import json, os
+cfg = json.load(open(os.environ['SETTINGS']))
+pre = cfg.get('hooks', {}).get('PreToolUse', [])
+rewrites = [h for e in pre for h in (e.get('hooks') or []) if h.get('name') == 'tokenless-rewrite']
+foreign = [h for e in pre for h in (e.get('hooks') or []) if h.get('name') == 'foreign-guard']
+problems = []
+if len(rewrites) != 1:
+    problems.append(f'expected 1 tokenless-rewrite, found {len(rewrites)}')
+elif '--agent-id qoder-cli' not in rewrites[0].get('command', ''):
+    problems.append('tokenless-rewrite command was not refreshed with --agent-id')
+if len(foreign) != 1:
+    problems.append(f'foreign hook not preserved (found {len(foreign)})')
+print('; '.join(problems))
+PYEOF
+)"
+if [ $reinstall_rc -eq 0 ] && [ -z "$upsert_problems" ]; then
+    log_pass "re-install upserts stale managed hook and preserves foreign hooks"
+else
+    log_fail "upsert regression: ${upsert_problems:-installer exited $reinstall_rc}"
 fi
 
 echo ""

--- a/src/tokenless/tests/test_resolve_agent_id.py
+++ b/src/tokenless/tests/test_resolve_agent_id.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Unit tests for hook_utils.resolve_agent_id attribution precedence.
+
+The agent id must be resolvable via a robust ``--agent-id`` command argument
+(the host always honours the hook ``command`` string), fall back to the
+``TOKENLESS_AGENT_ID`` env var, and surface a visible ``"unknown"`` sentinel —
+never the tool's own name — when neither is present, so an attribution gap is
+observable in stats instead of masquerading as a real ``tokenless`` agent.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_HOOKS_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "adapters"
+    / "tokenless"
+    / "common"
+    / "hooks"
+)
+
+_spec = importlib.util.spec_from_file_location(
+    "hook_utils", _HOOKS_DIR / "hook_utils.py"
+)
+assert _spec and _spec.loader
+hook_utils = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hook_utils)
+
+
+class ResolveAgentIdTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved_env = os.environ.copy()
+        # Host-owned signals must not leak in from the caller's environment.
+        for key in ("TOKENLESS_AGENT_ID", "COSH_RUNTIME", "COSH_NG_VERSION"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._saved_env)
+
+    def test_missing_signals_yield_visible_unknown(self) -> None:
+        self.assertEqual(hook_utils.resolve_agent_id(argv=[]), "unknown")
+
+    def test_env_used_when_no_argument(self) -> None:
+        os.environ["TOKENLESS_AGENT_ID"] = "claude-code"
+        self.assertEqual(hook_utils.resolve_agent_id(argv=[]), "claude-code")
+
+    def test_argument_wins_over_env(self) -> None:
+        os.environ["TOKENLESS_AGENT_ID"] = "claude-code"
+        self.assertEqual(
+            hook_utils.resolve_agent_id(argv=["--agent-id", "qoder-cli"]),
+            "qoder-cli",
+        )
+
+    def test_argument_equals_form(self) -> None:
+        self.assertEqual(
+            hook_utils.resolve_agent_id(argv=["--agent-id=qoder-cli"]),
+            "qoder-cli",
+        )
+
+    def test_blank_argument_falls_through_to_env(self) -> None:
+        os.environ["TOKENLESS_AGENT_ID"] = "claude-code"
+        self.assertEqual(
+            hook_utils.resolve_agent_id(argv=["--agent-id", ""]),
+            "claude-code",
+        )
+
+    def test_cosh_ng_runtime_wins_over_argument_and_env(self) -> None:
+        os.environ["TOKENLESS_AGENT_ID"] = "copilot-shell"
+        os.environ["COSH_RUNTIME"] = "cosh-ng"
+        self.assertEqual(
+            hook_utils.resolve_agent_id(argv=["--agent-id", "qoder-cli"]),
+            "cosh-ng",
+        )
+
+    def test_reads_process_argv_by_default(self) -> None:
+        saved = sys.argv
+        try:
+            sys.argv = ["compress_response_hook.py", "--agent-id", "qoder-cli"]
+            self.assertEqual(hook_utils.resolve_agent_id(), "qoder-cli")
+        finally:
+            sys.argv = saved
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

`hook_utils.resolve_agent_id()` collapsed to the tool's own name (`"tokenless"`) whenever the adapter-declared `TOKENLESS_AGENT_ID` env was not propagated to a hook process. This was observed on the `PreToolUse` rewrite path and on sub-agent task runs, so records from a single logical session scattered across bogus `agent_id`s (`qoder-cli` for compress vs. a fake `tokenless` for rewrite, under a reused synthetic `session_id`), making `tokenless stats summary` impossible to break down per consumer/session.

## What changed

- `resolve_agent_id()` gains a robust `--agent-id` **command-argument** channel. The host always honours the hook `command` string, unlike the declared `env` map that was being dropped. Precedence is now: cosh-ng runtime → `--agent-id` arg → `TOKENLESS_AGENT_ID` env → default.
- The silent default changes from `"tokenless"` to a visible `"unknown"` sentinel, so an attribution gap is observable in stats instead of masquerading as a real agent.
- The `qoder` adapter's two recorder hooks now pass `--agent-id qoder-cli` on the command line (the `env` block is kept for backward compatibility).

## Related issue

refs #2158

## User / Agent impact

Stats records that previously fell back to the fake `agent_id="tokenless"` will now record `"unknown"` (visible gap) or, for the qoder adapter, the correct `"qoder-cli"` delivered via command argument. No behavior change for consumers whose declared env is already propagated.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Attribution-only, cooperative signal (never gates anything security-relevant). The `default` value change is the sole behavioral shift and only affects previously-unattributed fallback records.

## Validation

- `python3 tests/test_resolve_agent_id.py` (new, 7 cases: arg wins over env, `=` form, blank-arg fallthrough, cosh-ng precedence, visible default, reads real argv)
- Regression: `test_compress_response_hook.py` (14), `test_compress_schema_hook.py` (7), `test_rewrite_hook.py` (11) — all pass
- `bash tests/test-qoder-adapter-install.sh` — 7/7 (fixed a fragile `parts[-1]` script-existence assertion to check the actual `.py`/`.sh` token so it tolerates command arguments)
- New test wired into the Makefile `test-integration` target
- Note: ruff/black/isort were not available in the authoring environment; style was hand-matched to line-length 100 — CI is the authoritative lint gate. Rust was not built (macOS; tokenless is Linux-build-only per AGENTS.md), and this change is Python/adapter-only.

## Documentation and rollback

No documentation changes (per `specs/documentation-standard.md`, CHANGELOG is written only in release version-bump PRs; no version bump here). Revert is a single-commit revert; the added `--agent-id` args and the resolution precedence are self-contained and the `env` blocks remain intact.