### PR TITLE
chore(anolisa): bump version to 0.2.16

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.16] - 2026-08-03
+
+### Added
+
+- Successful `anolisa update <component>` and `anolisa update all` operations
+  now report adapters whose resource bundles changed, with the exact
+  `anolisa adapter enable ...` or `anolisa adapter status ...` follow-up
+  command. JSON responses expose the same information through stable
+  `adapter_actions` arrays
+  ([#2018](https://github.com/alibaba/anolisa/pull/2018)).
+
+### Fixed
+
+- Raw system-scope installs on Debian-family hosts no longer fail with
+  `rpm not found on PATH` when both RPM tooling and an RPM database are absent.
+  An existing or newly appearing RPM database still stops the raw install
+  before files change
+  ([#2061](https://github.com/alibaba/anolisa/pull/2061)).
+
 ## [0.2.15] - 2026-07-30
 
 ### Added
@@ -739,6 +758,23 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.16] - 2026-08-03
+
+### 新增
+
+- 成功执行的 `anolisa update <component>` 和 `anolisa update all` 现会报告
+  resource bundle 已变化的 adapter，并给出准确的 `anolisa adapter enable ...`
+  或 `anolisa adapter status ...` 后续命令。JSON 响应通过稳定的
+  `adapter_actions` 数组提供同样的信息
+  ([#2018](https://github.com/alibaba/anolisa/pull/2018))。
+
+### 修复
+
+- 在同时缺少 RPM 工具和 RPM database 的 Debian 系发行版上，system scope
+  raw 安装不再因 `rpm not found on PATH` 而失败。如果已有 RPM database，
+  或安装期间新出现 RPM database，仍会在任何文件变更前停止 raw 安装
+  ([#2061](https://github.com/alibaba/anolisa/pull/2061))。
 
 ## [0.2.15] - 2026-07-30
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Thu Jul 30 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Mon Aug 03 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Component updates now report adapter bundles that need follow-up.
+- Raw installs now work without rpm tooling on deb-family hosts that have no rpm database.
+
+* Thu Jul 30 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.15-1
 - Interactive install and uninstall commands now report phase-based activity.
 - Human errors now use conventional labels while JSON retains machine codes.
 - Update notices now quote their recommended commands.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.15",
-    "@anolisa/cli-linux-arm64": "0.2.15",
-    "@anolisa/cli-darwin-arm64": "0.2.15"
+    "@anolisa/cli-linux-x64": "0.2.16",
+    "@anolisa/cli-linux-arm64": "0.2.16",
+    "@anolisa/cli-darwin-arm64": "0.2.16"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA CLI 0.2.16 needs one consistent release boundary across Cargo, npm, and RPM distributions. The release notes are curated from the exact changes since 0.2.15 so users see the final adapter-update reporting and Debian-family raw-install behavior rather than intermediate implementation details.

## What changed

- Bump the ANOLISA Cargo workspace and lockfile packages to 0.2.16.
- Synchronize the root npm package, native optional dependencies, and all platform packages.
- Add semantically equivalent English and Chinese changelog entries for PRs #2018 and #2061.
- Freeze the previous RPM changelog row at 0.2.15 and open the 0.2.16 row.

## Related issue

no-issue: release aggregation for ANOLISA CLI v0.2.16

## User / Agent impact

Component updates now report adapter bundles that require follow-up, including structured `adapter_actions` in JSON. Raw system-scope installs on Debian-family hosts no longer require RPM tooling when no RPM database exists, while existing or newly appearing RPM databases still fail closed.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The JSON update surface gains a stable `adapter_actions` array. The privileged raw-install change is limited to Debian-family hosts with neither RPM tooling nor RPM database evidence; RPM-family and unknown hosts remain fail-closed.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `target/debug/anolisa --version` → `anolisa 0.2.16`
- Release metadata audit for 0.2.16
- `git diff --check`

## Documentation and rollback

The bilingual component changelog and RPM changelog are updated in this PR. Roll back by reverting commit `8848e73817b7ba384a5b7e9be95d9a5420b29374`; the bump itself introduces no additional runtime behavior.