### PR TITLE
fix(cosh-ng): [shell] hint /auth on noauth startup

### DIFF
--- a/specs/cosh-ng-code-organization/large-file-inventory.md
+++ b/specs/cosh-ng-code-organization/large-file-inventory.md
@@ -28,7 +28,7 @@ new over-threshold file appears that is not listed here.
 |------:|------|-------|---------------------|
 | 1717 | `src/ui/agent_render/health.rs` | ui | Health banner rendering; pre-existing. Split per-severity renderers. |
 | 1628 | `src/diagnostics/health/collectors.rs` | diagnostics | Per-subsystem collectors; pre-existing. Split by collector family. |
-| 861 | `src/runtime/state.rs` | runtime | Central inline state; approval state extracted to `approval_state.rs` (main baseline 850, back under the 1000-line growth bar). The #1940 approval-terminal-state fix adds the `approval_ledger` field plus two accessors, which co-locate with their `ControlState` host. Continue per-domain splits. |
+| 928 | `src/runtime/state.rs` | runtime | Central inline state; approval state extracted to `approval_state.rs` (main baseline 871, back under the 1000-line growth bar). The #1940 approval-terminal-state fix adds the `approval_ledger` field plus two accessors, which co-locate with their `ControlState` host. The #2068 startup auth hint adds the `StartupAuthState` probe holder next to its `StartupHealthState` sibling. Continue per-domain splits. |
 | 912 | `src/evidence/output_policy.rs` | evidence | Output excerpt policy; pre-existing. Split bounding from classification. |
 | 906 | `src/adapter/fake.rs` | adapter | Test fake adapter; pre-existing. Split scripted-scenario builders. |
 | 952 | `src/ui/agent_render/approval.rs` | ui | Approval card rendering; action-row rendering extracted to `approval_actions.rs` (turn consent, #1773); irrecoverable warning extracted to `approval_warning.rs` and reason-line rendering to `approval_reason.rs` (#2064). Split per-card-kind renderers next. |

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_auth.rs
@@ -1,8 +1,17 @@
-use crate::adapter::CoshCoreAdapter;
+//! Effective AI credential state resolved through the cosh-core registry.
 
-pub(crate) fn current_ai_configured(adapter: &CoshCoreAdapter) -> Result<bool, String> {
-    let value = adapter.registry_query("auth", "state", serde_json::Value::Null)?;
-    auth_state_is_configured(&value)
+use super::CoshCoreAdapter;
+
+impl CoshCoreAdapter {
+    /// Returns whether the active provider has usable credentials.
+    ///
+    /// cosh-core owns the per-provider semantics (env vars, user/system
+    /// config layering, ECS RAM role exemption); this only transports the
+    /// resolved boolean, so provider additions never touch the shell side.
+    pub(crate) fn ai_configured(&self) -> Result<bool, String> {
+        let value = self.registry_query("auth", "state", serde_json::Value::Null)?;
+        auth_state_is_configured(&value)
+    }
 }
 
 fn auth_state_is_configured(value: &serde_json::Value) -> Result<bool, String> {
@@ -12,6 +21,8 @@ fn auth_state_is_configured(value: &serde_json::Value) -> Result<bool, String> {
     {
         return Ok(!required);
     }
+    // Legacy fallback for cores that predate `effective_auth_required`:
+    // mirrors the builtin provider shapes and is intentionally frozen.
     let active = value
         .get("active_provider")
         .and_then(serde_json::Value::as_str)
@@ -101,6 +112,17 @@ mod tests {
         });
 
         assert_eq!(auth_state_is_configured(&env_only), Ok(true));
+    }
+
+    #[test]
+    fn recognizes_effective_auth_required_as_unconfigured() {
+        let unconfigured = serde_json::json!({
+            "active_provider": "dashscope",
+            "saved_providers": [],
+            "effective_auth_required": true
+        });
+
+        assert_eq!(auth_state_is_configured(&unconfigured), Ok(false));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/mod.rs
@@ -16,6 +16,7 @@ mod control_protocol;
 #[cfg(test)]
 mod control_protocol_tests;
 mod cosh_core;
+mod cosh_core_auth;
 mod cosh_core_process;
 mod cosh_core_registry;
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -215,8 +215,14 @@ pub(crate) fn trigger_auth_from_slash<W: std::io::Write>(
     Ok(())
 }
 
-fn clear_observed_model_after_provider_change(state: &mut InlineState) {
+pub(super) fn clear_observed_model_after_provider_change(state: &mut InlineState) {
     state.personalization.foreground_model = None;
+    // Credentials just changed: drop the startup probe verdict so the
+    // no-auth surfaces re-resolve instead of trusting a pre-change
+    // snapshot (a stale `Some(false)` would keep suppressing the
+    // recommendation disclosure for the rest of the session).
+    state.startup_auth.pending = None;
+    state.startup_auth.resolved = None;
 }
 
 fn clear_observed_model_after_provider_delete(

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -551,3 +551,23 @@ fn failed_ecs_challenge_edit_retry_drops_the_ecs_auth_source() {
         Some("\u{2022}\u{2022}\u{2022}")
     );
 }
+
+#[test]
+fn provider_change_drops_stale_startup_auth_verdict() {
+    let mut state = InlineState::default();
+    state.personalization.foreground_model = Some("stale-model".to_string());
+    state.startup_auth.resolved = Some(false);
+    let (sender, receiver) = std::sync::mpsc::sync_channel::<Option<bool>>(1);
+    state.startup_auth.pending = Some(receiver);
+
+    clear_observed_model_after_provider_change(&mut state);
+
+    // A configured session must not keep suppressing no-auth surfaces
+    // with the pre-change verdict; the reset falls back to the safe
+    // "unknown" state instead of guessing the new credential outcome.
+    assert!(state.personalization.foreground_model.is_none());
+    assert!(state.startup_auth.resolved.is_none());
+    assert!(state.startup_auth.pending.is_none());
+    assert!(!state.startup_auth.ai_unconfigured());
+    drop(sender);
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/startup.rs
@@ -25,6 +25,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::StartupSwitchHint => {
             "\u{1f4a1} Run \"cosh-switch\" to switch between cosh-ng and copilot-shell"
         }
+        MessageId::StartupAuthHintLine => {
+            "\u{1f4a1} AI not configured — run /auth to unlock AI help, failure analysis, tips"
+        }
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -103,4 +103,5 @@ collect_message_ids!([
     hook_notification_ids,
     approval_system_control_ids,
     input_wait_hint_ids,
+    startup_auth_hint_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/startup.rs
@@ -17,3 +17,15 @@ macro_rules! startup_ids {
         );
     };
 }
+
+// Registered as a trailing segment so all existing MessageId
+// discriminants remain stable.
+macro_rules! startup_auth_hint_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            StartupAuthHintLine,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -176,17 +176,24 @@ mod tests {
             MessageId::ApprovalRiskPhraseSystemControl as usize,
             MessageId::AgentGovernanceHookDecisionUnspecified as usize + 1
         );
-        // The #2025/#2161 input-wait segment now owns the tail.
+        // The #2025/#2161 input-wait segment follows the system-control
+        // segment; tail ownership assertions move with each appended segment.
         assert_eq!(
             MessageId::ApprovalShellHandoffInputWaitTimeoutTitle as usize,
             MessageId::ApprovalIrrecoverableWarningLine as usize + 1
         );
         assert_eq!(
             MessageId::ApprovalShellHandoffInputWaitTimeoutTitle as usize,
-            MessageId::ALL.len() - 10
+            MessageId::ALL.len() - 11
         );
         assert_eq!(
             MessageId::ShellInputWaitHintTimeoutForecastBody as usize,
+            MessageId::ALL.len() - 2
+        );
+        // The #2068 startup auth-hint segment is the current tail; tail
+        // ownership assertions move with each appended segment.
+        assert_eq!(
+            MessageId::StartupAuthHintLine as usize,
             MessageId::ALL.len() - 1
         );
     }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/startup.rs
@@ -19,6 +19,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::StartupSwitchHint => {
             "\u{1f4a1} 运行 \"cosh-switch\" 可在 cosh-ng 与 copilot-shell 之间切换"
         }
+        MessageId::StartupAuthHintLine => {
+            "\u{1f4a1} 尚未配置 AI：运行 /auth 即可解锁自然语言提问、失败分析与个性化推荐"
+        }
         _ => return None,
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod personal_context;
 #[cfg(test)]
 mod personal_context_tests;
 pub(crate) mod personal_crypto;
-pub(crate) mod personal_effective_config;
 pub(crate) mod personal_feedback;
 pub(crate) mod personal_history;
 pub(crate) mod personal_integration;

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_runtime.rs
@@ -10,7 +10,6 @@ use crate::adapter::CoshCoreAdapter;
 
 use super::personal_context::{build_activity_context, build_host_id};
 use super::personal_crypto::{hex, hmac_sha256, random_hex, CryptoError};
-use super::personal_effective_config::current_ai_configured;
 use super::personal_feedback::{FeedbackEvent, FeedbackLifecycle, FrozenPromptBinding};
 use super::personal_history::{
     sync_native_bash_history, HistoryControl, HistorySyncResult, HistorySyncState,

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_runtime_writer.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_runtime_writer.rs
@@ -447,7 +447,7 @@ fn resolve_auth_state_bounded(adapter: &CoshCoreAdapter) -> Result<bool, Persona
     thread::Builder::new()
         .name("cosh-recommendation-auth".to_string())
         .spawn(move || {
-            let _ = sender.send(current_ai_configured(&adapter));
+            let _ = sender.send(adapter.ai_configured());
         })
         .map_err(|error| {
             PersonalRuntimeError::Operation(format!("start auth resolver: {error}"))

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
@@ -184,6 +184,20 @@ pub(crate) fn run_raw(
         inline_state.startup_health.pending =
             Some(spawn_startup_health_scan(cosh_config.health.clone()));
     }
+    // The credential probe only feeds startup-banner surfaces; without a
+    // banner it would just cost an extra cosh-core process per launch.
+    if cosh_config.ai_enabled && crate::runtime::startup::startup_banner_enabled() {
+        if let AdapterInstance::CoshCore(core) = &adapter {
+            let core = core.clone();
+            let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+            inline_state.startup_auth.pending = Some(receiver);
+            let _ = std::thread::Builder::new()
+                .name("cosh-startup-auth-probe".to_string())
+                .spawn(move || {
+                    let _ = sender.send(core.ai_configured().ok());
+                });
+        }
+    }
     let hook_feedback = load_hook_feedback_preferences();
     inline_state.hooks.feedback = hook_feedback.feedback;
     inline_state.hooks.noisy_groups = hook_feedback.noisy_groups;

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -44,12 +44,13 @@ const LOGO_COLORS: &[&str] = &[
 const RESET: &str = "\x1b[0m";
 const LOGO_MIN_WIDTH: u16 = 42;
 const STARTUP_HEALTH_ROW_WAIT: Duration = Duration::from_millis(150);
+const STARTUP_AUTH_HINT_WAIT: Duration = Duration::from_millis(150);
 
 mod recommendations;
 #[cfg(test)]
 use recommendations::{
-    plan_startup_for_render, record_visible_personal_impressions, visible_personal_candidates,
-    write_startup_suggestion_card,
+    append_startup_auth_hint, plan_startup_for_render, record_visible_personal_impressions,
+    visible_personal_candidates, write_startup_suggestion_card,
 };
 pub(crate) use recommendations::{
     render_pending_recommendation_notice, render_startup_banner, render_startup_health_banner,
@@ -105,7 +106,7 @@ fn health_report_supports_interactive_suggestions(report: &HealthScanReport) -> 
         })
 }
 
-fn startup_banner_enabled() -> bool {
+pub(crate) fn startup_banner_enabled() -> bool {
     match std::env::var("COSH_SHELL_STARTUP_BANNER") {
         Ok(value) => matches!(
             value.trim().to_ascii_lowercase().as_str(),

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup/recommendations.rs
@@ -51,6 +51,8 @@ pub(crate) fn render_startup_banner<W: Write>(
         i18n.format(MessageId::StartupCwdLine, &[("cwd", cwd)]),
         i18n.t(MessageId::StartupCommandsLine).to_string(),
     ];
+    state.startup_auth.wait_ready(STARTUP_AUTH_HINT_WAIT);
+    append_startup_auth_hint(state, &mut body);
     let recommendation_notice = append_recommendation_notice(state, &mut body);
     state.startup_health.wait_ready(STARTUP_HEALTH_ROW_WAIT);
     let suggestions = prepare_startup_suggestions(state, cwd);
@@ -123,6 +125,14 @@ pub(crate) fn render_pending_recommendation_notice<W: Write>(
     Ok(())
 }
 
+pub(super) fn append_startup_auth_hint(state: &mut InlineState, body: &mut Vec<String>) {
+    if state.personalization.ai_disabled || !state.startup_auth.ai_unconfigured() {
+        return;
+    }
+    body.push(String::new());
+    body.push(state.i18n().t(MessageId::StartupAuthHintLine).to_string());
+}
+
 fn append_recommendation_notice(state: &mut InlineState, body: &mut Vec<String>) -> bool {
     if !recommendation_notice_required(state) {
         return false;
@@ -137,6 +147,12 @@ fn recommendation_notice_required(state: &mut InlineState) -> bool {
         || state.analysis_mode == crate::runtime::state::AnalysisMode::Manual
         || state.personalization.ai_disabled
     {
+        return false;
+    }
+    // While no auth is configured the recommendation pipeline cannot run;
+    // stay quiet without consuming the first-time disclosure.
+    state.startup_auth.poll_ready();
+    if state.startup_auth.ai_unconfigured() {
         return false;
     }
     state.personalization.poll_ready();

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use super::{
-    extract_bootstrap_path, merge_path_lists, plan_startup_for_render, raw_passthrough_args,
-    record_visible_personal_impressions, render_pending_recommendation_notice,
-    startup_suggestion_mode, visible_personal_candidates, write_startup_suggestion_card,
-    StartupSuggestionMode,
+    append_startup_auth_hint, extract_bootstrap_path, merge_path_lists, plan_startup_for_render,
+    raw_passthrough_args, record_visible_personal_impressions,
+    render_pending_recommendation_notice, startup_suggestion_mode, visible_personal_candidates,
+    write_startup_suggestion_card, StartupSuggestionMode,
 };
 use crate::config::Language;
 use crate::diagnostics::health::{
@@ -19,7 +19,9 @@ use crate::recommendation::personal_model::{
 };
 use crate::recommendation::personal_planner::{PlannerCandidate, PlannerContext};
 use crate::recommendation::personal_runtime::PersonalRuntime;
-use crate::runtime::state::{AnalysisMode, InlineState, PendingInputGhostBinding};
+use crate::runtime::state::{
+    AnalysisMode, InlineState, PendingInputGhostBinding, StartupAuthState,
+};
 use crate::ui::RatatuiInlineRenderer;
 use crate::I18n;
 
@@ -562,4 +564,111 @@ fn raw_passthrough_args_preserves_shell_option() {
             "echo ok".to_string()
         ])
     );
+}
+
+#[test]
+fn startup_auth_hint_appends_only_when_probe_reports_unconfigured() {
+    let mut state = InlineState::default();
+    let mut body = vec!["/help".to_string()];
+
+    // Unresolved probe stays quiet.
+    append_startup_auth_hint(&mut state, &mut body);
+    assert_eq!(body.len(), 1);
+
+    // Configured credentials stay quiet.
+    state.startup_auth.resolved = Some(true);
+    append_startup_auth_hint(&mut state, &mut body);
+    assert_eq!(body.len(), 1);
+
+    // Explicitly unconfigured credentials add the /auth hint line.
+    state.startup_auth.resolved = Some(false);
+    append_startup_auth_hint(&mut state, &mut body);
+    assert_eq!(body.len(), 3);
+    assert_eq!(body[1], "");
+    assert!(body[2].contains("/auth"), "{:?}", body[2]);
+    assert!(body[2].contains("AI not configured"), "{:?}", body[2]);
+
+    // AI disabled by config suppresses the hint even when unconfigured.
+    let mut disabled = InlineState::default();
+    disabled.personalization.ai_disabled = true;
+    disabled.startup_auth.resolved = Some(false);
+    let mut quiet = Vec::new();
+    append_startup_auth_hint(&mut disabled, &mut quiet);
+    assert!(quiet.is_empty());
+}
+
+#[test]
+fn startup_auth_state_resolves_bounded_and_fails_quiet() {
+    // Result arrives within the wait budget.
+    let mut ready = StartupAuthState::default();
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    ready.pending = Some(receiver);
+    sender.send(Some(false)).unwrap();
+    ready.wait_ready(Duration::from_millis(150));
+    assert!(ready.ai_unconfigured());
+    assert!(ready.pending.is_none());
+
+    // Timeout leaves the probe unresolved without consuming it.
+    let mut slow = StartupAuthState::default();
+    let (slow_sender, receiver) = std::sync::mpsc::sync_channel(1);
+    slow.pending = Some(receiver);
+    slow.wait_ready(Duration::from_millis(10));
+    assert!(!slow.ai_unconfigured());
+    assert!(slow.pending.is_some());
+    // A late result is still picked up by a later non-blocking poll.
+    slow_sender.send(Some(false)).unwrap();
+    slow.poll_ready();
+    assert!(slow.ai_unconfigured());
+
+    // A dropped probe (failed thread) resolves to quiet, not to a hint.
+    let mut dropped = StartupAuthState::default();
+    let (broken_sender, receiver) = std::sync::mpsc::sync_channel::<Option<bool>>(1);
+    dropped.pending = Some(receiver);
+    drop(broken_sender);
+    dropped.wait_ready(Duration::from_millis(150));
+    assert!(!dropped.ai_unconfigured());
+    assert!(dropped.pending.is_none());
+}
+
+#[test]
+fn recommendation_notice_is_suppressed_while_auth_is_unconfigured() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-startup-notice-noauth-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let writer = PersonalRuntime::open(true, &root, 1)
+        .unwrap()
+        .spawn_writer()
+        .unwrap();
+    wait_for_writer(|| writer.poll_snapshot());
+    let mut state = InlineState {
+        personalization: crate::recommendation::personal_state::PersonalizationState {
+            writer: Some(writer),
+            ..Default::default()
+        },
+        analysis_mode: AnalysisMode::Smart,
+        ..InlineState::default()
+    };
+    state.startup_auth.resolved = Some(false);
+
+    let mut suppressed = Vec::new();
+    render_pending_recommendation_notice(&mut state, &mut suppressed).unwrap();
+    assert!(suppressed.is_empty());
+    // The first-time disclosure is preserved for a later configured startup.
+    assert!(!state.personalization.notice_shown);
+
+    state.startup_auth.resolved = Some(true);
+    let mut shown = Vec::new();
+    render_pending_recommendation_notice(&mut state, &mut shown).unwrap();
+    let text = String::from_utf8(shown).unwrap();
+    assert!(text.contains("Prompt recommendations are on"));
+    assert!(state.personalization.notice_shown);
+
+    let mut writer = state.personalization.writer.take().unwrap();
+    writer.shutdown(1, Duration::from_secs(5)).unwrap();
+    let _ = std::fs::remove_dir_all(root);
 }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/state.rs
@@ -143,6 +143,7 @@ pub(crate) struct InlineState {
     pub(crate) input_wait_facts: HashMap<String, crate::adapter::HostExecutedInputWait>,
     pub(crate) continuity: ContinuityState,
     pub(crate) startup_health: StartupHealthState,
+    pub(crate) startup_auth: StartupAuthState,
     pub(crate) personalization: PersonalizationState,
     pub(crate) audit: Option<crate::journal::audit::ShellAuditRecorder>,
 }
@@ -206,6 +207,70 @@ impl StartupHealthState {
                 self.rendered = true;
             }
         }
+    }
+}
+
+/// Background probe of the effective AI credential state, resolved via
+/// cosh-core at bootstrap so the startup banner can hint `/auth` without
+/// blocking first paint. Fail-quiet: an error, timeout, or missing probe
+/// leaves `resolved` at `None` and nothing is shown.
+///
+/// Lifecycle: the `Default` state (no probe, no verdict) is the safe
+/// state — every consumer treats it as "not unconfigured", so an
+/// `InlineState` built without bootstrap wiring can never trigger the
+/// hint. Bootstrap installs `pending` only for the CoshCore adapter
+/// with AI enabled and the banner on; a successful `/auth` credential
+/// change resets the state to `Default` so no stale verdict outlives
+/// the credentials it described.
+#[derive(Default)]
+pub(crate) struct StartupAuthState {
+    pub(crate) pending: Option<mpsc::Receiver<Option<bool>>>,
+    pub(crate) resolved: Option<bool>,
+}
+
+impl StartupAuthState {
+    pub(crate) fn wait_ready(&mut self, timeout: Duration) {
+        if self.resolved.is_some() {
+            return;
+        }
+        let Some(receiver) = &self.pending else {
+            return;
+        };
+        match receiver.recv_timeout(timeout) {
+            Ok(resolved) => {
+                self.resolved = resolved;
+                self.pending = None;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                self.pending = None;
+            }
+        }
+    }
+
+    pub(crate) fn poll_ready(&mut self) {
+        if self.resolved.is_some() {
+            return;
+        }
+        let Some(receiver) = &self.pending else {
+            return;
+        };
+        match receiver.try_recv() {
+            Ok(resolved) => {
+                self.resolved = resolved;
+                self.pending = None;
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.pending = None;
+            }
+        }
+    }
+
+    /// True only when the authority explicitly reported "no usable
+    /// credentials"; uncertainty never shows the hint.
+    pub(crate) fn ai_unconfigured(&self) -> bool {
+        self.resolved == Some(false)
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/turn_extension.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/turn_extension.rs
@@ -44,6 +44,10 @@ esac
             ("COSH_CORE_PATH", &core_str),
             ("COSH_CORE_PROCESS_LOG", &process_log_str),
             ("COSH_CORE_REQUEST_LOG", &request_log_str),
+            // Keep the process count scoped to agent-run lifecycles: the
+            // startup banner's credential probe would add a one-shot
+            // `cosh-core --registry` spawn unrelated to this contract.
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
         ],
         Path::new(env!("CARGO_MANIFEST_DIR")),
         &[


### PR DESCRIPTION
## Summary

On first launch with no auth provider configured, the startup banner is identical to a fully configured setup: nothing tells the user that AI capabilities exist or that `/auth` enables them, and the "prompt recommendations are on" notice still renders while recommendation readiness is actually `CurrentAiUnavailable`. New users have no discoverable path to the AI value proposition.

This PR probes the effective credential state in the background at bootstrap and appends one short bilingual `/auth` hint line to the banner only when cosh-core explicitly reports no usable credentials, and suppresses the contradictory recommendation notice while auth is unconfigured.

Closes #2068

## Changes

- `adapter/cosh_core_auth.rs` (new): promotes `current_ai_configured` out of `recommendation/personal_effective_config.rs` into `CoshCoreAdapter::ai_configured()`. cosh-core stays the single source of truth for per-provider semantics (`effective_auth_required` short-circuit; the legacy `saved_providers` parsing fallback is kept frozen for older cores); startup and recommendations now share one entry point.
- `runtime/state.rs`: new `StartupAuthState` probe holder (`pending` receiver + `resolved`), modeled on its `StartupHealthState` sibling; `ai_unconfigured()` is true only for an explicit `Some(false)` — errors, timeouts and missing probes stay quiet.
- `runtime/controller/bootstrap.rs`: spawns the probe thread only for the CoshCore adapter with AI enabled; transport is the existing registry query (short one-shot `cosh-core --registry` before a live core exists, local config resolution only, no network).
- `runtime/startup/recommendations.rs`: the banner waits for the probe with a bounded 150ms budget (same constant precedent as the health row) and appends `MessageId::StartupAuthHintLine` after the commands line; no late injection after the prompt appears. `recommendation_notice_required` gates on the probe so the notice is suppressed while unconfigured **without consuming the first-time disclosure**.
- i18n: `StartupAuthHintLine` is registered as a trailing segment (`startup_auth_hint_ids`) so all existing `MessageId` discriminants stay stable; tail ownership assertions re-anchored per convention.
- `specs/cosh-ng-code-organization/large-file-inventory.md`: `runtime/state.rs` entry re-baselined 861 → 928 for the new probe state.

Decision table (unlisted shapes fail quiet to current behavior):

| adapter | ai_enabled | probe | banner hint | reco notice |
|---|---|---|---|---|
| CoshCore | true | `Some(false)` | shown | suppressed (notice_shown untouched) |
| CoshCore | true | `Some(true)` / `None` | hidden | current behavior |
| CoshCore | false | not probed | hidden | current behavior |
| non-CoshCore | — | not probed | hidden | current behavior |

## Tests

- `startup_auth_hint_appends_only_when_probe_reports_unconfigured` — decision-table rows for the banner line (unresolved / configured / unconfigured / ai_disabled).
- `startup_auth_state_resolves_bounded_and_fails_quiet` — bounded wait, late pickup via non-blocking poll, disconnected-probe quiet exit.
- `recommendation_notice_is_suppressed_while_auth_is_unconfigured` — suppression keeps `notice_shown` false; a configured startup still gets the first-time disclosure.
- `cosh_core_auth` unit tests moved with the module; added `recognizes_effective_auth_required_as_unconfigured`.

## Verification

- Linux container (alinux3 arm64, Apple container runtime): `cargo test -p cosh-shell --lib` 1240 passed / `--bin cosh-shell` 2324 passed; 2 pre-existing failures (`readonly_compound_tests::executor_*`) reproduce identically on a clean `origin/main` baseline in the same container (stash control) and are unrelated. Workspace `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` green in the container.
- macOS host: fmt / commit lint / `check-layout.sh` / `check-test-inventory.sh` / upstream-drift green; workspace clippy cannot run on macOS because cosh-core HEAD does not build there (upstream regression #2164, `workspace_fs.rs` Linux-only `openat2` without platform gating).
- FAIL→PASS on the real reproduction path (real cosh-core adapter, real PTY 120x40, isolated HOME with no credentials, zh + en): before — no auth marker in the transcript, recommendation notice shown; after — hint markers present (`/auth`, "AI not configured" / "尚未配置"), notice suppressed. Positive control with a configured HOME shows no hint (zero false positives).
- Excluded scope: other workspace crates' test suites; x86_64; VM/ECS backends.

## Evidence

FAIL baseline (main `12ea0ad9`, no auth hint, contradictory notice) → PASS (this PR, hint shown, notice suppressed). Real cosh-core adapter, real PTY 120x40, isolated HOME.

| | zh | en |
|---|---|---|
| **Before** | ![fail zh](https://raw.githubusercontent.com/SunnyQjm/anolisa/bc5b29002194d36572f81adc27c6c298252be826/fail-zh.png) | ![fail en](https://raw.githubusercontent.com/SunnyQjm/anolisa/bc5b29002194d36572f81adc27c6c298252be826/fail-en.png) |
| **After** | ![pass zh](https://raw.githubusercontent.com/SunnyQjm/anolisa/bc5b29002194d36572f81adc27c6c298252be826/pass-zh.png) | ![pass en](https://raw.githubusercontent.com/SunnyQjm/anolisa/bc5b29002194d36572f81adc27c6c298252be826/pass-en.png) |

