### PR TITLE
fix(cosh-ng): [shell] normalize csi-u backspace in candidate input

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/navigation.rs
@@ -1,5 +1,6 @@
 //! Keyboard navigation shared by interactive card captures.
 
+use super::super::event_parser::is_csi_u_backspace_params;
 use super::{
     capture_action_set, is_csi_final_byte, question_choice_count, CardInputState, RawInputCapture,
     RawInputEvent,
@@ -41,6 +42,16 @@ impl CardInputState {
             (b"13;2" | b"13;3", b'u') if matches!(capture, RawInputCapture::PromptDraft { .. }) => {
                 self.draft.insert_newline();
                 events.extend(self.input_event(capture));
+            }
+            // CSI-u Backspace edits exactly like 0x7f (#2150): draft cards
+            // delete one character, free-text captures pop the buffer.
+            (params, b'u') if is_csi_u_backspace_params(params) => {
+                if matches!(capture, RawInputCapture::PromptDraft { .. }) {
+                    self.draft.backspace();
+                    events.extend(self.input_event(capture));
+                } else if self.free_text.pop().is_some() {
+                    events.extend(self.input_event(capture));
+                }
             }
             (b"27;2;13" | b"27;3;13", b'~')
                 if matches!(capture, RawInputCapture::PromptDraft { .. }) =>

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -1046,3 +1046,84 @@ fn draft_pasted_tab_is_inserted_as_data() {
         .expect("paste must report a draft change");
     assert_eq!(changed, "第一行A\tB", "pasted tab must survive: {changed}");
 }
+
+// CSI-u Backspace (#2150) edits the draft like 0x7f: one character per
+// sequence, numeric modifier variants included.
+#[test]
+fn draft_csi_u_backspace_deletes_one_char() {
+    let capture = draft_capture();
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let (events, _) = state.consume_split(&capture, b"\x1b[127u");
+    let changed = events
+        .iter()
+        .find_map(|event| match event {
+            RawInputEvent::PromptDraftChanged { text, .. } => Some(text.clone()),
+            _ => None,
+        })
+        .expect("CSI-u backspace must report a draft change");
+    assert_eq!(changed, "第一");
+
+    let (events, _) = state.consume_split(&capture, b"\x1b[127;2u");
+    let changed = events
+        .iter()
+        .find_map(|event| match event {
+            RawInputEvent::PromptDraftChanged { text, .. } => Some(text.clone()),
+            _ => None,
+        })
+        .expect("modifier variant must report a draft change");
+    assert_eq!(changed, "第");
+}
+
+// CSI-u Backspace (#2150) pops free-text captures exactly like 0x7f.
+#[test]
+fn text_question_csi_u_backspace_pops_like_delete() {
+    let capture = RawInputCapture::TextQuestion {
+        id: "auth@field-0-1".to_string(),
+        initial_text: "qwen3.7-max".to_string(),
+        secret: false,
+    };
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    assert_eq!(
+        state.consume(&capture, b"\x1b[127u"),
+        vec![RawInputEvent::CardInput(
+            "auth@field-0-1".to_string(),
+            "qwen3.7-ma".to_string(),
+        )]
+    );
+    // An empty buffer stays a silent no-op, matching 0x7f.
+    state.reset();
+    state.apply_capture(&capture);
+    let _ = state.consume(&capture, b"\x7f".repeat(16).as_slice());
+    assert_eq!(state.consume(&capture, b"\x1b[127u"), vec![]);
+}
+
+// A CSI-u Backspace split across reads reassembles through the pending
+// CSI holder before it edits the draft: no fragment leaks as text.
+#[test]
+fn draft_split_csi_u_backspace_reassembles_before_editing() {
+    let capture = draft_capture();
+    let mut state = CardInputState::default();
+    state.apply_capture(&capture);
+
+    let (events, _) = state.consume_split(&capture, b"\x1b[127;2");
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, RawInputEvent::PromptDraftChanged { .. })),
+        "held CSI prefix must not edit the draft yet: {events:?}"
+    );
+
+    let (events, _) = state.consume_split(&capture, b"u");
+    let changed = events
+        .iter()
+        .find_map(|event| match event {
+            RawInputEvent::PromptDraftChanged { text, .. } => Some(text.clone()),
+            _ => None,
+        })
+        .expect("joined CSI-u backspace must delete one char");
+    assert_eq!(changed, "第一");
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -130,6 +130,14 @@ impl CandidateLineBuffer {
                     }
                 }
             }
+            // CSI-u Backspace deletes like 0x7f (#2150): terminals speaking
+            // the extended keyboard protocol encode Backspace as `ESC [ 127 u`
+            // with an optional numeric modifier.
+            if let Some(len) = csi_u_backspace_len(&bytes[idx..]) {
+                self.pop_visible_char();
+                idx += len;
+                continue;
+            }
             match bytes[idx] {
                 CTRL_U => {
                     self.clear();
@@ -454,6 +462,37 @@ fn is_partial_paste_delimiter(suffix: &[u8]) -> bool {
     !suffix.is_empty()
         && suffix.len() < BRACKETED_PASTE_START.len()
         && (BRACKETED_PASTE_START.starts_with(suffix) || BRACKETED_PASTE_END.starts_with(suffix))
+}
+
+/// Length of a whole CSI-u Backspace sequence at the head of `bytes`
+/// (#2150): `ESC [ 127 u` or `ESC [ 127 ; <digits> u`. Any other
+/// codepoint, colon sub-parameters, or a sequence split across reads
+/// stays unrecognized and keeps the fail-closed Unsafe route.
+pub(super) fn csi_u_backspace_len(bytes: &[u8]) -> Option<usize> {
+    if !bytes.starts_with(b"\x1b[") {
+        return None;
+    }
+    let param_len = bytes[2..]
+        .iter()
+        .take_while(|byte| matches!(byte, b'0'..=b'9' | b';'))
+        .count();
+    if bytes.get(2 + param_len) != Some(&b'u') {
+        return None;
+    }
+    is_csi_u_backspace_params(&bytes[2..2 + param_len]).then_some(2 + param_len + 1)
+}
+
+/// CSI parameter body of a CSI-u Backspace (#2150): `127` alone or with
+/// one numeric modifier (`127;<digits>`); readline does not distinguish
+/// Backspace modifiers either, so all variants delete one character.
+pub(super) fn is_csi_u_backspace_params(params: &[u8]) -> bool {
+    match params.strip_prefix(b"127") {
+        Some(b"") => true,
+        Some([b';', modifier @ ..]) => {
+            !modifier.is_empty() && modifier.iter().all(u8::is_ascii_digit)
+        }
+        _ => false,
+    }
 }
 
 /// Only an explicit `??` candidate may compose soft newlines.

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -402,6 +402,113 @@ mod tests {
         );
     }
 
+    // CSI-u Backspace (#2150) deletes like 0x7f on the native candidate
+    // path: `/au` erases to an empty inactive buffer, and every deletion
+    // keeps the line Pending instead of poisoning it Unsafe.
+    #[test]
+    fn csi_u_backspace_deletes_native_candidate_to_empty() {
+        let mut line = CandidateLineBuffer::default();
+        line.push(b"/au");
+        for _ in 0..3 {
+            line.push(b"\x1b[127u");
+            assert_eq!(status_of(&line), CandidateLineStatus::Pending);
+        }
+        assert!(line.visible_line_bytes().is_empty());
+        assert!(!line.is_active());
+        // One more Backspace on the empty buffer stays a clean no-op.
+        line.push(b"\x1b[127u");
+        assert!(!line.is_active());
+    }
+
+    // CSI-u Backspace modifier variants (#2150): any single numeric
+    // modifier deletes one character, matching readline's indifference.
+    #[test]
+    fn csi_u_backspace_modifier_variants_delete_one_char() {
+        for sequence in [
+            b"\x1b[127;2u".as_slice(),
+            b"\x1b[127;3u".as_slice(),
+            b"\x1b[127;5u".as_slice(),
+            b"\x1b[127;13u".as_slice(),
+        ] {
+            let mut line = CandidateLineBuffer::default();
+            line.push(b"/au");
+            line.push(sequence);
+            assert_eq!(
+                line.visible_line_bytes(),
+                b"/a",
+                "variant {:?} must delete one char",
+                String::from_utf8_lossy(sequence)
+            );
+        }
+    }
+
+    // CSI-u Backspace removes a full UTF-8 character, not a single byte.
+    #[test]
+    fn csi_u_backspace_deletes_whole_utf8_char() {
+        let mut line = soft_buffer();
+        line.push("??分析".as_bytes());
+        line.push(b"\x1b[127u");
+        assert_eq!(line.visible_line_bytes(), "??分".as_bytes());
+    }
+
+    // CSI-u Backspace removes a soft newline as one visible character,
+    // matching the 0x7f semantics of matrix #12.
+    #[test]
+    fn csi_u_backspace_deletes_soft_newline_whole() {
+        let mut line = soft_buffer();
+        line.push("分析".as_bytes());
+        line.push(b"\x1b[13;2u");
+        line.push(b"\x1b[127u");
+        line.push(b"\r");
+        let CandidateLineStatus::Complete { line: text, .. } = status_of(&line) else {
+            panic!("draft must complete after CSI-u backspace");
+        };
+        assert_eq!(text, "分析");
+    }
+
+    // Malformed or unrelated CSI-u forms stay fail-closed: the bytes are
+    // buffered untouched and the line flushes Unsafe, byte-identical to
+    // the pre-fix route.
+    #[test]
+    fn malformed_csi_u_backspace_forms_stay_unsafe() {
+        for sequence in [
+            b"\x1b[127;u".as_slice(),
+            b"\x1b[127;2;3u".as_slice(),
+            b"\x1b[127:1u".as_slice(),
+            b"\x1b[1270u".as_slice(),
+            b"\x1b[12u".as_slice(),
+            b"\x1b[127~".as_slice(),
+        ] {
+            let mut line = CandidateLineBuffer::default();
+            line.push(b"/au");
+            line.push(sequence);
+            assert_eq!(
+                status_of(&line),
+                CandidateLineStatus::Unsafe,
+                "form {:?} must stay Unsafe",
+                String::from_utf8_lossy(sequence)
+            );
+            assert_eq!(
+                &line.bytes[..3],
+                b"/au",
+                "draft prefix must stay intact for the flush"
+            );
+        }
+    }
+
+    // A CSI-u Backspace split across PTY reads is not reassembled: the
+    // fragments stay buffered and the completed sequence flushes Unsafe
+    // (fail-closed; terminals write key sequences atomically).
+    #[test]
+    fn split_csi_u_backspace_stays_fail_closed() {
+        let mut line = CandidateLineBuffer::default();
+        line.push(b"/au");
+        line.push(b"\x1b[12");
+        assert_eq!(status_of(&line), CandidateLineStatus::Pending);
+        line.push(b"7u");
+        assert_eq!(status_of(&line), CandidateLineStatus::Unsafe);
+    }
+
     // Matrix #19 precondition: a draft of only soft newlines normalizes to
     // whitespace-only text (relay consumes it without submitting).
     #[test]


### PR DESCRIPTION
## Summary

Terminals speaking the CSI-u extended keyboard protocol (kitty keyboard
protocol) encode Backspace as `ESC [ 127 u`, optionally with a numeric
modifier. cosh-shell's candidate input parsing only recognized `0x7f`,
`0x08` and `CSI 3~`, so a CSI-u Backspace could not delete a slash
inline hint: the sequence leaked into the candidate buffer byte by
byte, `candidate_line_status` classified the line `Unsafe`, and the
draft flushed to bash as an invalid command with `27u` residue per
keypress (`bash: /au27u27u27u: No such file or directory`). The
prompt-draft card CSI dispatch silently dropped the same sequence, so
Backspace did nothing there either.

This PR normalizes `ESC [ 127 u` and `ESC [ 127 ; <digits> u` to
Backspace semantics in both cosh-owned input paths, sharing a single
params predicate. Every other CSI-u form (colon sub-parameters, empty
or non-numeric modifiers, other codepoints, sequences split across PTY
reads on the candidate path) keeps the fail-closed `Unsafe` route
byte-identically.

Scope note: the prompt-draft card path is a second landing site beyond
the issue body — the audit found the identical gap there
(`(127, u)` fell through the CSI dispatch), and both sites share the
same predicate, so they are fixed together. Capturing raw Backspace
bytes from real user terminals (issue next-step 1) is a non-goal here:
the fix acts on the byte sequence regardless of its origin, and
fail-closed handling covers unknown forms.

## Changes

- `raw_input/event_parser.rs`: add `csi_u_backspace_len` /
  `is_csi_u_backspace_params` (strict grammar
  `ESC '[' "127" (';' DIGIT+)? 'u'`); `CandidateLineBuffer::push`
  pops one visible character on match, inheriting the existing `0x7f`
  semantics for UTF-8 characters and soft newlines via
  `pop_visible_char`.
- `raw_input/card_capture/navigation.rs`: the CSI dispatch mirrors the
  `0x7f` arm — prompt drafts delete one character
  (`draft.backspace()`), free-text captures pop the buffer.
- Tests: 6 candidate-buffer cases (`raw_input/mod.rs`) covering
  delete-to-empty, modifier variants, whole-UTF-8-char and
  whole-soft-newline deletion, malformed forms staying `Unsafe`, and
  split sequences staying fail-closed; 3 card cases
  (`card_capture/tests.rs`) covering draft editing with modifiers,
  free-text pop parity with `0x7f`, and split-sequence reassembly
  through the pending CSI holder.

## Tests

- `cargo test -p cosh-shell --lib`: 1245 passed / 0 failed (9 new).
- `cargo clippy -p cosh-shell --all-targets`: clean.
- `crates/cosh-shell/scripts/check-layout.sh`,
  `scripts/check-test-inventory.sh`: pass.

## Verification

- Real-PTY FAIL→PASS matrix (isolated HOME, scripted PTY driving the
  real binary, 120x32), pre-fix vs post-fix builds:

  | scenario | pre-fix | post-fix |
  |---|---|---|
  | `\x1b[127u` ×3 on `/au` slash hint | FAIL: `/au27u27u27u` invalid command, `$?=127` | PASS: deletes to empty, `$?=0`, no residue |
  | `0x7f` / `0x08` / `\x1b[3~` controls | PASS | PASS (no regression) |
  | `\x1b[127u` ×3 in prompt-draft card (`??…` + Alt+Enter) | FAIL: draft unchanged | PASS: soft newline + chars deleted |

- Focused scope only: `cosh-shell` lib tests, `clippy -p cosh-shell`,
  both repo gates, and the PTY matrix above ran locally (macOS host).
  Excluded scope (not run locally): workspace-wide clippy and the
  `tests/` integration binaries — full `raw_cli` was exercised but its
  failure set is identical to the unmodified base on this host
  (pre-existing macOS-specific failures; `cosh-core` does not build on
  macOS due to Linux-only `openat2`); relying on Linux CI for these.

## Evidence

Full-size final frames from the real-PTY runs (pre-fix = unmodified
base `ac7cf4f4`, post-fix = this branch):

| | pre-fix | post-fix |
|---|---|---|
| slash hint `/au` + `\x1b[127u` ×3 | ![pre-fix f1](https://raw.githubusercontent.com/SunnyQjm/anolisa/522f153d837d1ccf8adb983a004df60b963bf7d3/pre-fix-f1-slash-invalid-command.png) | ![post-fix f1](https://raw.githubusercontent.com/SunnyQjm/anolisa/522f153d837d1ccf8adb983a004df60b963bf7d3/post-fix-f1-clean-delete.png) |
| prompt-draft card + `\x1b[127u` ×3 | ![pre-fix d1](https://raw.githubusercontent.com/SunnyQjm/anolisa/522f153d837d1ccf8adb983a004df60b963bf7d3/pre-fix-d1-draft-unchanged.png) | ![post-fix d1](https://raw.githubusercontent.com/SunnyQjm/anolisa/522f153d837d1ccf8adb983a004df60b963bf7d3/post-fix-d1-draft-deleted.png) |

Post-fix slash-hint replay (animated):

![post-fix f1 replay](https://raw.githubusercontent.com/SunnyQjm/anolisa/522f153d837d1ccf8adb983a004df60b963bf7d3/post-fix-f1-replay.gif)

Closes #2150
