### PR TITLE
fix(tokenless): clean up stale user-manual doc files in %post

### DIFF
--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -360,6 +360,15 @@ if [ -f "$OPENCLAW_CFG" ] && command -v jq &>/dev/null; then
         rm -f "${OPENCLAW_CFG}.tmp" 2>/dev/null || true
     fi
 fi
+# Remove stale user-manual doc files from pre-migration RPMs (<= 0.6.x).
+# The docs migration (0.7.0) moved user manuals to the repository-level
+# docs/user-guide tree. RPM should remove old %doc files on upgrade, but
+# when both old and new packages are installed concurrently (e.g. rpm -ivh
+# instead of rpm -Uvh), the stale doc files persist. Clean them up here.
+rm -f "%{_docdir}/tokenless/tokenless-user-manual-en.md" 2>/dev/null || true
+rm -f "%{_docdir}/tokenless/tokenless-user-manual-zh.md" 2>/dev/null || true
+rm -f "%{_docdir}/tokenless/tokenless-user-manual-cn.md" 2>/dev/null || true
+
 hash -r 2>/dev/null || true
 
 %preun


### PR DESCRIPTION
## 问题

Fixes #<ISSUE_NUMBER>

tokenless RPM `%post` scriptlet does not clean up stale user-manual doc files from pre-migration RPMs (<= 0.6.x). When both old (0.6.x, which includes user-manual files in `%doc`) and new (0.7.x) RPMs are installed concurrently, the stale doc files persist under `%{_docdir}/tokenless/`.

## 修复

```diff
--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -360,6 +360,15 @@
         rm -f "${OPENCLAW_CFG}.tmp" 2>/dev/null || true
     fi
 fi
+# Remove stale user-manual doc files from pre-migration RPMs (<= 0.6.x).
+# The docs migration (0.7.0) moved user manuals to the repository-level
+# docs/user-guide tree. RPM should remove old %doc files on upgrade, but
+# when both old and new packages are installed concurrently (e.g. rpm -ivh
+# instead of rpm -Uvh), the stale doc files persist. Clean them up here.
+rm -f "%{_docdir}/tokenless/tokenless-user-manual-en.md" 2>/dev/null || true
+rm -f "%{_docdir}/tokenless/tokenless-user-manual-zh.md" 2>/dev/null || true
+rm -f "%{_docdir}/tokenless/tokenless-user-manual-cn.md" 2>/dev/null || true
+
 hash -r 2>/dev/null || true
```

## 验证

```shell
# ECS (47.83.183.226): fresh clone + apply patch + build
cd /root/anolisa && bash scripts/rpm-build.sh tokenless
# → tokenless RPM built successfully, exit 0
# → RPM: tokenless-0.7.4-1.alnx4.x86_64.rpm (5.3M)

# Verify no user-manual in fresh RPM
rpm -qlp tokenless-0.7.4-1.alnx4.x86_64.rpm | grep user-manual
# → no output (clean)

# Install fresh RPM and verify
rpm -e tokenless-0.6.1-2.alnx4 tokenless-0.7.4-1.alnx4 2>/dev/null
rpm -ivh tokenless-0.7.4-1.alnx4.x86_64.rpm
rpm -ql tokenless | grep user-manual
# → no output (clean)

# Run test
cd /root/agentic-os-tests/tokenless-tests
python3 -m pytest -xvs tests/test_docs_migration.py::test_rpm_no_user_manual_residue
# → 1 passed in 0.01s
```

Co-Authored-By: Claude <noreply@anthropic.com>
