### PR TITLE
fix(cosh-ng): [shell] restore hint cursor

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -40,6 +40,11 @@ use pty_emit::restore_prompt_display_before_handoff;
 use terminal_recovery::{restore_terminal_after_interrupted_command, PendingTerminalRecovery};
 use terminal_size::sync_outer_terminal_winsize;
 
+// DECSC/DECRC are the terminfo `sc`/`rc` sequences for xterm-compatible
+// terminals. Unlike CSI s/u, they also restore the cursor in macOS Terminal.
+const SAVE_CURSOR: &str = "\x1b7";
+const RESTORE_CURSOR: &str = "\x1b8";
+
 pub(super) struct RawActionWatchdog {
     grace: Duration,
 }
@@ -564,7 +569,10 @@ fn write_pending_display_preserving_prompt_ghost<W: Write>(
 
 fn write_prompt_ghost<W: Write>(output: &mut W, text: &str, selection: bool) -> io::Result<()> {
     let marker = if selection { " ›" } else { "" };
-    write!(output, "\x1b[s\x1b[2m{marker} {text}\x1b[0m\x1b[u")
+    write!(
+        output,
+        "{SAVE_CURSOR}\x1b[2m{marker} {text}\x1b[0m{RESTORE_CURSOR}"
+    )
 }
 
 fn write_display_slice<W: Write>(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -7,7 +7,7 @@ use unicode_width::UnicodeWidthChar;
 
 use crate::raw_input::RawInputEvent;
 
-use super::{clear_prompt_ghost_line, OscParser, PromptReplayTracker};
+use super::{clear_prompt_ghost_line, OscParser, PromptReplayTracker, RESTORE_CURSOR, SAVE_CURSOR};
 
 /// Terminal display columns of candidate echo bytes: ANSI escape sequences
 /// are zero-width; other content is measured per Unicode width (CJK = 2).
@@ -139,14 +139,14 @@ pub(super) fn drain_raw_input_events<W: Write>(
                     write!(output, "\x1b[K")?;
                     output.write_all(&input)?;
                     if let Some(hint) = hint {
-                        write!(output, "\x1b[s\x1b[2m {hint}\x1b[0m\x1b[u")?;
+                        write!(output, "{SAVE_CURSOR}\x1b[2m {hint}\x1b[0m{RESTORE_CURSOR}")?;
                     }
                     *native_candidate_echoed_len = candidate_display_columns(&input);
                 } else {
                     write!(output, "\r\x1b[2K{prompt}")?;
                     output.write_all(&input)?;
                     if let Some(hint) = hint {
-                        write!(output, "\x1b[s\x1b[2m {hint}\x1b[0m\x1b[u")?;
+                        write!(output, "{SAVE_CURSOR}\x1b[2m {hint}\x1b[0m{RESTORE_CURSOR}")?;
                     }
                 }
                 output.flush()?;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
@@ -200,6 +200,39 @@ fn any_pty_user_write_emits_the_prompt_cwd_invalidation_barrier() {
 }
 
 #[test]
+fn candidate_hint_uses_terminfo_cursor_save_restore() {
+    let mut parser = parser_for_test("candidate-cursor-restore");
+    let (_generation, mut prompt_replay) = tracker_for_test();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let mut output = Vec::new();
+    let mut echoed = 0usize;
+
+    sender
+        .send(crate::raw_input::RawInputEvent::CandidateRedraw {
+            input: b"/m".to_vec(),
+            hint: Some("/mode approval [recommend|auto|trust]".to_string()),
+        })
+        .expect("queue candidate redraw");
+    drain_raw_input_events(
+        &receiver,
+        &mut parser,
+        &mut output,
+        "",
+        &mut echoed,
+        &mut prompt_replay,
+    )
+    .expect("draw candidate hint");
+
+    assert_eq!(
+        output,
+        b"\x1b[K/m\x1b7\x1b[2m /mode approval [recommend|auto|trust]\x1b[0m\x1b8"
+    );
+    assert_eq!(echoed, 2);
+    assert!(!output.windows(3).any(|window| window == b"\x1b[s"));
+    assert!(!output.windows(3).any(|window| window == b"\x1b[u"));
+}
+
+#[test]
 fn prompt_restore_refuses_to_arm_while_user_input_response_is_unparsed() {
     let (generation, mut prompt_replay) = tracker_for_test();
 
@@ -555,7 +588,7 @@ fn prompt_fragment_after_restore_keeps_ghost_last_on_screen() {
     .expect("write prompt fragment");
 
     assert!(
-        output.ends_with(b"\x1b[s\x1b[2m objdump\x1b[0m\x1b[u"),
+        output.ends_with(b"\x1b7\x1b[2m objdump\x1b[0m\x1b8"),
         "{}",
         String::from_utf8_lossy(&output)
     );


### PR DESCRIPTION
## Why

macOS Terminal does not reliably restore the cursor after cosh-shell renders an inline slash hint with `CSI s` / `CSI u`. The physical cursor remains at the end of the dimmed hint while the logical candidate cursor remains after the typed prefix, so Backspace redraws from the wrong position and leaves undeletable residue.

## What changed

- Use the terminfo-compatible DECSC / DECRC sequences (`ESC 7` / `ESC 8`) for cursor preservation.
- Apply the same cursor contract to slash candidate hints and prompt ghosts.
- Add byte-level regression coverage that rejects the previous `CSI s/u` output and verifies prompt-ghost replay.

## Related issue

Closes #2150

## User / Agent impact

Inline slash hints keep the cursor after the user's typed prefix in macOS Terminal. Repeated Backspace can clear `/mo` to an empty line without accumulating stale `/mode` fragments. Native Tab handoff to bash/readline remains unchanged.

## Risk and compatibility

Low risk. The change only replaces cursor save/restore output with the `sc` / `rc` sequences used by `xterm-256color` terminfo; candidate routing and input semantics are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --lib shell_host::implementation::raw_relay::tests` — 25 passed
- `cargo clippy --package cosh-shell --lib -- -D warnings`
- Pre-fix macOS Terminal screenshot confirms the cursor-at-hint-tail failure.
- Post-fix manual macOS Terminal validation is not yet user-confirmed.

## Documentation and rollback

No documentation changes are required. Revert commit `416fae84` to restore the previous terminal sequences.
