### PR TITLE
feat(docs): add Tokenless one-line setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,17 @@ ANOLISA CLI is the common installation entry point. Enable cosh-ng, Token-less,
 or other capabilities as needed.
 
 ```bash
+# Install the CLI only
 curl -fsSL https://get.agentic-os.sh | bash
 
+# Or install the CLI and Tokenless together
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+
 anolisa install cosh-ng
-anolisa install tokenless
 ```
 
-Run `cosh-ng` to enter the Agent-native shell, or point any existing Agent at
-it — Token-less applies to tool calls without further configuration.
+Run `cosh-ng` to enter the Agent-native shell. For Tokenless, scan the installed
+Agent frameworks and explicitly enable the matching adapter.
 
 [Read the Quick Start →](docs/QUICKSTART.md)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -102,14 +102,17 @@ ANOLISA 正在完善面向 Agent 的执行环境：
 ANOLISA CLI 是统一的安装入口，cosh-ng、Token-less 和其他能力都可以按需启用。
 
 ```bash
+# 仅安装 CLI
 curl -fsSL https://get.agentic-os.sh | bash
 
+# 或同时安装 CLI 和 Tokenless
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+
 anolisa install cosh-ng
-anolisa install tokenless
 ```
 
-运行 `cosh-ng` 进入 Agent-native shell，或让现有的任意 Agent 接上——Token-less
-会作用于工具调用，无需额外配置。
+运行 `cosh-ng` 进入 Agent-native shell。使用 Tokenless 时，先扫描已经安装的
+Agent 框架，再显式启用匹配的 Adapter。
 
 [查看快速开始 →](docs/QUICKSTART_zh.md)
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -12,6 +12,12 @@ ANOLISA is a server-side operating layer for AI Agent workloads. It provides Tok
 curl -fsSL https://get.agentic-os.sh | bash
 ```
 
+To install the CLI and Tokenless together, pass the capability to the installer:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+```
+
 > Alinux 4 users can also install via `sudo yum install anolisa`.
 
 Verify:

--- a/docs/QUICKSTART_zh.md
+++ b/docs/QUICKSTART_zh.md
@@ -12,6 +12,12 @@ ANOLISA 是面向 AI Agent 工作负载的服务端操作系统层。通过统�
 curl -fsSL https://get.agentic-os.sh | bash
 ```
 
+如需同时安装 CLI 和 Tokenless，可将能力名称传给安装脚本：
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+```
+
 > Alinux 4 用户也可通过 `sudo yum install anolisa` 安装。
 
 验证：

--- a/docs/user-guide/en/installation.md
+++ b/docs/user-guide/en/installation.md
@@ -14,6 +14,15 @@ The `anolisa` CLI is the unified entry point for managing all ANOLISA components
 curl -fsSL https://get.agentic-os.sh | bash
 ```
 
+To install the CLI and Tokenless in one pass:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+```
+
+The capability argument installs Tokenless only. It does not enable an Agent
+adapter or make system-level changes.
+
 ### Option B: YUM (Alinux)
 
 ```bash

--- a/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
@@ -18,14 +18,17 @@ Savings vary by task. Short tasks or tasks that are mostly conversation may show
 
 ## 2. Install Tokenless
 
-Install the anolisa CLI first, then use it to install Tokenless:
+Install the anolisa CLI and Tokenless together:
 
 ```bash
-curl -fsSL https://get.agentic-os.sh | bash
-anolisa --version
-anolisa install tokenless
-tokenless --version
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+~/.local/bin/anolisa --version
+~/.local/bin/tokenless --version
 ```
+
+If the anolisa CLI is already installed, run `anolisa install tokenless`
+instead. The capability argument installs Tokenless but does not modify any
+agent configuration; enable the matching adapter explicitly in the next step.
 
 ## 3. Start using Tokenless
 

--- a/docs/user-guide/zh/installation.md
+++ b/docs/user-guide/zh/installation.md
@@ -14,6 +14,14 @@
 curl -fsSL https://get.agentic-os.sh | bash
 ```
 
+如需一次完成 CLI 和 Tokenless 安装：
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+```
+
+能力参数只安装 Tokenless，不会启用 Agent Adapter，也不会执行系统级变更。
+
 ### 方式 B：YUM（Alinux）
 
 ```bash

--- a/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
@@ -18,14 +18,16 @@ Tokenless 帮助 AI Agent 用更少的 Token 完成原来的工作。
 
 ## 2. 安装 Tokenless
 
-先安装 anolisa CLI，再用它安装 Tokenless：
+同时安装 anolisa CLI 和 Tokenless：
 
 ```bash
-curl -fsSL https://get.agentic-os.sh | bash
-anolisa --version
-anolisa install tokenless
-tokenless --version
+curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+~/.local/bin/anolisa --version
+~/.local/bin/tokenless --version
 ```
+
+如果已经安装 anolisa CLI，可直接运行 `anolisa install tokenless`。能力参数只安装
+Tokenless，不会修改任何 Agent 配置；下一步仍需显式启用对应的 Adapter。
 
 ## 3. 开始使用 Tokenless
 

--- a/website/agent-index/overrides.json
+++ b/website/agent-index/overrides.json
@@ -12,38 +12,36 @@
       "install_name": "sec-core"
     },
     "tokenless": {
-      "install": "npm install -g anolisa-tokenless",
-      "install_method": "npm",
+      "install": "curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless",
+      "install_method": "bootstrap",
       "install_variants": [
         {
-          "method": "cli",
-          "preferred": false,
-          "command": "anolisa install tokenless",
+          "method": "bootstrap",
+          "preferred": true,
+          "command": "curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless",
           "platforms": [
             {
               "os": "linux",
-              "architectures": ["x86_64"]
+              "architectures": ["x86_64", "aarch64"]
             },
             {
               "os": "macos",
               "architectures": ["aarch64"]
             }
           ],
-          "requires": ["anolisa"],
+          "requires": ["curl", "bash"],
           "preflight": [
-            "anolisa --json env",
-            "anolisa --json list",
-            "anolisa --dry-run install tokenless"
+            "command -v curl",
+            "command -v bash"
           ],
           "verify": [
-            "anolisa --json adapter scan",
-            "anolisa --json status tokenless",
-            "anolisa --json doctor tokenless"
+            "~/.local/bin/anolisa --json status tokenless",
+            "~/.local/bin/tokenless --version"
           ]
         },
         {
           "method": "npm",
-          "preferred": true,
+          "preferred": false,
           "command": "npm install -g anolisa-tokenless",
           "platforms": [
             {

--- a/website/content.config.ts
+++ b/website/content.config.ts
@@ -1,4 +1,5 @@
 export type Locale = 'en' | 'zh';
 
 export const repositoryUrl = 'https://github.com/alibaba/anolisa';
-export const installCommand = 'curl -fsSL https://get.agentic-os.sh | bash';
+export const installCommand =
+  'curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless';

--- a/website/scripts/generate-agent-index.mjs
+++ b/website/scripts/generate-agent-index.mjs
@@ -203,6 +203,25 @@ const installCommand = quickstart.match(
 )?.[0];
 if (!installCommand) throw new Error('Could not derive the canonical install command from docs/QUICKSTART.md');
 
+const tokenlessQuickstartPath =
+  'docs/user-guide/en/token-saving/tokenless/QUICKSTART.md';
+const tokenlessFrameworkPath =
+  'docs/user-guide/en/token-saving/tokenless/framework-integration.md';
+const tokenlessQuickstart = await readFile(
+  path.join(repoRoot, tokenlessQuickstartPath),
+  'utf8',
+);
+const tokenlessFramework = await readFile(
+  path.join(repoRoot, tokenlessFrameworkPath),
+  'utf8',
+);
+const tokenlessInstallCommand = tokenlessQuickstart.match(
+  /curl\s+-fsSL\s+https:\/\/get\.agentic-os\.sh\s+\|\s+bash\s+-s\s+--\s+tokenless/,
+)?.[0];
+if (!tokenlessInstallCommand) {
+  throw new Error(`Could not derive Tokenless install command from ${tokenlessQuickstartPath}`);
+}
+
 const agentsMarkdown = await readFile(path.join(repoRoot, 'AGENTS.md'), 'utf8');
 const componentRows = parseOverview(agentsMarkdown);
 const components = [];
@@ -359,6 +378,32 @@ const indexText = [
 ].join('\n');
 await writeFile(path.join(agentsOutput, 'repo-index.txt'), indexText);
 
+const tokenlessSetup = [
+  '# ANOLISA Tokenless Setup for Agents',
+  '',
+  'Goal: Install Tokenless and enable it for a compatible Agent already present on the host.',
+  '',
+  '## Required workflow',
+  '',
+  '1. Detect the operating system, architecture, Agent, and Agent version.',
+  '2. Check the platform and framework matrices below. Stop on an unsupported host.',
+  '3. Show the plan and ask before making changes.',
+  `4. Install the CLI and Tokenless with: ${tokenlessInstallCommand}`,
+  '5. Run `~/.local/bin/anolisa adapter scan` and select only the Agent the user intends to modify.',
+  '6. Run `~/.local/bin/anolisa adapter enable tokenless <agent>` after confirmation.',
+  '7. Ask the user to restart the Agent, perform a representative tool task, and verify with `tokenless stats summary`.',
+  '8. Do not claim model-bill savings from Tokenless statistics; they measure only content processed by Tokenless.',
+  '',
+  `===== ${tokenlessQuickstartPath} =====`,
+  '',
+  tokenlessQuickstart,
+  '',
+  `===== ${tokenlessFrameworkPath} =====`,
+  '',
+  tokenlessFramework,
+].join('\n');
+await writeFile(path.join(agentsOutput, 'tokenless.txt'), tokenlessSetup);
+
 function enumBody(source, enumName) {
   const enumStart = source.search(new RegExp(`(?:pub\\s+)?enum\\s+${enumName}\\b`));
   if (enumStart < 0) throw new Error(`Could not find enum ${enumName}`);
@@ -436,7 +481,7 @@ await writeFile(path.join(agentsOutput, 'changelog.txt'), changelogText.join('\n
 
 await writeGenerated(
   'static/llms.txt',
-  `# ANOLISA\n\n> A server-side operating layer for AI agent workloads.\n\n- Website: ${siteHref()}\n- Documentation: ${siteHref('docs/')}\n- Quickstart: ${siteHref('docs/quickstart/')}\n- User guide: ${siteHref('docs/user-guide/')}\n- Developer guide: ${siteHref('docs/developer-guide/')}\n- Chinese documentation: ${siteHref('zh/docs/')}\n- Agent setup workflow: ${siteHref('agents/')}\n- Repository index: ${siteHref('agents/repo-index.json')}\n- CLI reference: ${siteHref('agents/cli-reference.txt')}\n- Changelog: ${siteHref('agents/changelog.txt')}\n- Full English documentation: ${siteHref('llms-full.txt')}\n- Source: ${index.repository}\n- Source commit: ${sourceCommit}\n`,
+  `# ANOLISA\n\n> A server-side operating layer for AI agent workloads.\n\n- Website: ${siteHref()}\n- Documentation: ${siteHref('docs/')}\n- Quickstart: ${siteHref('docs/quickstart/')}\n- User guide: ${siteHref('docs/user-guide/')}\n- Developer guide: ${siteHref('docs/developer-guide/')}\n- Chinese documentation: ${siteHref('zh/docs/')}\n- Agent setup workflow: ${siteHref('agents/')}\n- Tokenless setup for Agents: ${siteHref('agents/tokenless.txt')}\n- Repository index: ${siteHref('agents/repo-index.json')}\n- CLI reference: ${siteHref('agents/cli-reference.txt')}\n- Changelog: ${siteHref('agents/changelog.txt')}\n- Full English documentation: ${siteHref('llms-full.txt')}\n- Source: ${index.repository}\n- Source commit: ${sourceCommit}\n`,
 );
 
 const fullDocumentation = [];

--- a/website/src/pages/agents.tsx
+++ b/website/src/pages/agents.tsx
@@ -6,18 +6,18 @@ import type {Locale} from '../../content.config';
 const content = {
   en: {
     eyebrow: 'anolisa://agents',
-    title: 'ANOLISA Agent Entry Point',
+    title: 'Set up Tokenless with your Agent',
     intro:
-      'Read the repository index and CLI reference for current capabilities, platform scope, and setup methods.',
+      'Use the Tokenless setup guide to check compatibility, install the capability, and enable the matching Agent adapter.',
     note:
       'Automated setup currently covers Linux and macOS. Ask before making system changes.',
     endpoints: 'Machine-readable endpoints',
   },
   zh: {
     eyebrow: 'anolisa://agents',
-    title: 'ANOLISA Agent 入口',
+    title: '让 Agent 配置 Tokenless',
     intro:
-      '读取仓库索引和 CLI 参考，获取当前可用能力、平台范围与安装方式。',
+      '读取 Tokenless 配置指南，检查兼容性、安装能力并启用匹配的 Agent Adapter。',
     note: '自动安装目前面向 Linux 与 macOS；执行系统变更前应先征得用户确认。',
     endpoints: '机器可读入口',
   },
@@ -28,6 +28,7 @@ export default function AgentsPage() {
   const locale: Locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
   const t = content[locale];
   const endpointItems = [
+    ['tokenless.txt', useBaseUrl('/agents/tokenless.txt')],
     ['repo-index.json', useBaseUrl('/agents/repo-index.json')],
     ['repo-index.txt', useBaseUrl('/agents/repo-index.txt')],
     ['cli-reference.txt', useBaseUrl('/agents/cli-reference.txt')],

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -11,14 +11,14 @@ const content = {
   en: {
     badge: 'Agentic OS 1.0',
     lead: 'An operating system layer built for agents.',
-    hook: 'Cut 30–70% of your agent’s tool-output tokens with one command.',
+    hook: 'Use Tokenless to cut redundant tool-output tokens without replacing your Agent.',
     systemScope: 'Just one thing the OS does for your agent — it also runs, recovers, and secures it.',
     statement:
       'The users of operating systems have changed. ANOLISA makes agents first-class participants at the system layer.',
-    installLabel: 'One entry point. Enable what you need.',
-    agentLabel: 'Bring your Agent in',
+    installLabel: 'Install Tokenless with one command.',
+    agentLabel: 'Let your Agent set up Tokenless',
     agentPrompt:
-      'Read https://agentic-os.sh/agents/ to learn how to use ANOLISA, then help me install it for this environment.',
+      'Help me install and enable ANOLISA Tokenless for the compatible Agent in this environment. Read https://agentic-os.sh/agents/ first, show me the plan, and ask before system changes.',
     copy: 'Copy',
     copied: 'Copied',
     surfaceLabel: 'ANOLISA system surface',
@@ -35,13 +35,13 @@ const content = {
   zh: {
     badge: 'Agentic OS 1.0',
     lead: 'Agent 原生的操作系统层。',
-    hook: '一条命令，让 Agent 少烧 30–70% 的工具输出 token。',
+    hook: '用 Tokenless 压缩工具输出，不必更换正在使用的 Agent。',
     systemScope: '这只是操作系统为 Agent 做的一件事——它还让 Agent 跑得起、退得回、守得住。',
     statement: '操作系统的使用者已经改变。ANOLISA 让 Agent 成为系统中的一等公民。',
-    installLabel: '一个入口，按需启用',
-    agentLabel: '让你的 Agent 接入',
+    installLabel: '一条命令安装 Tokenless',
+    agentLabel: '让你的 Agent 配置 Tokenless',
     agentPrompt:
-      '阅读 https://agentic-os.sh/agents/，了解如何使用 ANOLISA，并根据当前环境帮我完成安装。',
+      '帮我为当前环境中兼容的 Agent 安装并启用 ANOLISA Tokenless。先阅读 https://agentic-os.sh/agents/，说明执行计划，并在系统级变更前征得确认。',
     copy: '复制',
     copied: '已复制',
     surfaceLabel: 'ANOLISA 系统能力视图',

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# install.sh — lightweight installer for the anolisa CLI.
+# install.sh — bootstrap installer for the anolisa CLI and selected capabilities.
 #
 # Usage:
 #   curl -fsSL https://get.agentic-os.sh | bash
+#   curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
 #
 # Environment overrides:
 #   ANOLISA_VERSION      version to install      (default: stable)
@@ -22,10 +23,39 @@ MANIFEST_SCHEMA=""
 RESOLVED_VERSION=""
 ARTIFACT_URL=""
 ARTIFACT_SHA256=""
+TARGET_COMPONENT=""
 
 log()  { printf '\033[1;32m%s\033[0m %s\n' "==>" "$*"; }
 warn() { printf '\033[1;33m%s\033[0m %s\n' "warn:" "$*" >&2; }
 err()  { printf '\033[1;31m%s\033[0m %s\n' "error:" "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Install the ANOLISA CLI, optionally followed by a supported capability.
+
+Usage:
+  install.sh
+  install.sh tokenless
+
+Examples:
+  curl -fsSL https://get.agentic-os.sh | bash
+  curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
+EOF
+}
+
+parse_args() {
+  case "$#" in
+    0) ;;
+    1)
+      case "$1" in
+        tokenless) TARGET_COMPONENT="$1" ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unsupported capability: $1 (supported: tokenless)" ;;
+      esac
+      ;;
+    *) err "expected at most one capability argument" ;;
+  esac
+}
 
 cleanup() {
   [ -z "$TMPDIR_INSTALL" ] || rm -rf "$TMPDIR_INSTALL"
@@ -175,6 +205,7 @@ sha256_verify() {
 }
 
 main() {
+  parse_args "$@"
   detect_platform
   command -v curl >/dev/null 2>&1 || err "curl is required but not found"
   command -v tar  >/dev/null 2>&1 || err "tar is required but not found"
@@ -249,7 +280,12 @@ main() {
   esac
 
   log "$installed_version"
+  if [ "$TARGET_COMPONENT" = "tokenless" ]; then
+    log "installing Tokenless"
+    "${INSTALL_DIR}/anolisa" install tokenless
+    log "Tokenless installed"
+  fi
   log "done"
 }
 
-main
+main "$@"


### PR DESCRIPTION
## Why

The public bootstrap command and Agent prompt only described a general ANOLISA
installation. That made capability-focused campaigns require users and Agents
to infer the extra Tokenless install step. This change gives Tokenless a
verifiable one-line entry while preserving explicit consent for Agent adapter
changes.

## What changed

- Accept `tokenless` as an allowlisted installer argument and forward it to the
  installed ANOLISA CLI.
- Lead the homepage install command and Agent prompt with the Tokenless
  capability.
- Generate `/agents/tokenless.txt` from the canonical Quick Start and framework
  integration guides.
- Update the English and Chinese README, Quick Start, and installation guides.

## Related issue

no-issue: capability-focused onboarding requested during website UX review

## User / Agent impact

Users can now install ANOLISA CLI and Tokenless together:

```bash
curl -fsSL https://get.agentic-os.sh | bash -s -- tokenless
```

Agent adapters remain a separate, explicit command. Existing installer usage
without arguments is unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The public bootstrapper now invokes the installed CLI for one allowlisted
user-mode component. Unknown or additional arguments fail before downloads.
The script never enables an Agent adapter or invokes `sudo`.

## Validation

- `bash -n website/static/install.sh`
- `npm run prepare --prefix website`
- `npm run typecheck --prefix website`
- `npm run build --prefix website`
- `npm run check:links --prefix website`
- Isolated macOS arm64 smoke test installed ANOLISA CLI 0.2.15 and Tokenless
  0.7.4, then returned `installed` from `anolisa --json status tokenless`.

## Documentation and rollback

English and Chinese onboarding sources now publish the capability argument and
keep adapter enablement as a separate step. Reverting this commit restores the
CLI-only bootstrap command and removes the generated Tokenless Agent endpoint.
