### PR TITLE
fix(cosh-ng): [shell] monotonic input-wait clock

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel.rs
@@ -330,24 +330,56 @@ pub(crate) fn timeout_eligible(kind: &InteractiveHintKind) -> bool {
 
 /// Shared input-wait episode clock between the relay loop (producer: the
 /// sentinel sampler) and the runtime controller (consumer: the #2161
-/// input-wait timeout). Stores the epoch-millis when the current
-/// timeout-eligible episode began; 0 means "not waiting". The producer
-/// clears it on output activity, ineligible/None classifications, and
-/// handoff exit, so the consumer's duration read is always the length of
-/// the *current uninterrupted* wait (re-entry restarts the clock).
+/// input-wait timeout). Stores the monotonic-millis (see [`Self::now_ms`])
+/// when the current timeout-eligible episode began; 0 means "not
+/// waiting". The producer clears it on output activity, ineligible/None
+/// classifications, and handoff exit, so the consumer's duration read is
+/// always the length of the *current uninterrupted* wait (re-entry
+/// restarts the clock).
 #[derive(Debug, Clone, Default)]
 pub(crate) struct InputWaitStatus {
     waiting_since_ms: Arc<AtomicU64>,
+    /// Test-only pinned clock (0 = use the real monotonic clock).
+    /// Shared across clones like the episode stamp so producer/consumer
+    /// handles observe the same simulated time; absent from release
+    /// builds so the production layout stays a single atomic.
+    #[cfg(test)]
+    test_clock_ms: Arc<AtomicU64>,
 }
 
 impl InputWaitStatus {
+    /// Milliseconds on a process-local monotonic clock (#2168 review
+    /// P1-1): an `Instant` anchor makes the interrupt timer immune to
+    /// NTP/VM/container wall-clock jumps, which with `SystemTime` could
+    /// fire a false SIGINT (forward jump) or never fire (backward jump).
+    /// Only differences of this clock are ever used; the constant offset
+    /// keeps values strictly positive (0 stays "not waiting") and leaves
+    /// backdating headroom early in the process lifetime.
+    ///
+    /// Bounds: the `1 << 32` offset is a ~49.7-day base, and elapsed
+    /// milliseconds only reach the remaining u64 range after ~584 million
+    /// years of process uptime — consumers may treat this value as
+    /// overflow-free for any conceivable timeout configuration.
     fn now_ms() -> u64 {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0)
-            .max(1)
+        use std::sync::OnceLock;
+        static EPOCH: OnceLock<Instant> = OnceLock::new();
+        let epoch = *EPOCH.get_or_init(Instant::now);
+        Instant::now().duration_since(epoch).as_millis() as u64 + (1 << 32)
+    }
+
+    /// Clock reading feeding the production chain. Tests may pin it via
+    /// [`Self::set_test_clock_ms`] to drive deterministic forward/backward
+    /// jump scenarios through `mark_waiting`/`waiting_for`; the real path
+    /// stays the lock-free `Instant` read above (#2176 review P2).
+    fn clock_ms(&self) -> u64 {
+        #[cfg(test)]
+        {
+            let pinned = self.test_clock_ms.load(Ordering::Acquire);
+            if pinned != 0 {
+                return pinned;
+            }
+        }
+        Self::now_ms()
     }
 
     /// Marks the start of an eligible wait episode; keeps the original
@@ -355,7 +387,7 @@ impl InputWaitStatus {
     pub(crate) fn mark_waiting(&self) {
         let _ = self.waiting_since_ms.compare_exchange(
             0,
-            Self::now_ms(),
+            self.clock_ms(),
             Ordering::AcqRel,
             Ordering::Acquire,
         );
@@ -371,15 +403,32 @@ impl InputWaitStatus {
         if since == 0 {
             return None;
         }
-        Some(Duration::from_millis(Self::now_ms().saturating_sub(since)))
+        Some(Duration::from_millis(Self::elapsed_ms(
+            self.clock_ms(),
+            since,
+        )))
+    }
+
+    /// Jump-defensive elapsed arithmetic: a start stamp ahead of `now`
+    /// (impossible on the monotonic clock; the backward-jump failure
+    /// mode of the former wall-clock implementation) clamps to zero
+    /// rather than underflowing into an instant timeout.
+    fn elapsed_ms(now_ms: u64, since_ms: u64) -> u64 {
+        now_ms.saturating_sub(since_ms)
     }
 
     #[cfg(test)]
     pub(crate) fn backdate_for_test(&self, age: Duration) {
         self.waiting_since_ms.store(
-            Self::now_ms().saturating_sub(age.as_millis() as u64),
+            self.clock_ms().saturating_sub(age.as_millis() as u64),
             Ordering::Release,
         );
+    }
+
+    /// Pins the episode clock for tests (0 restores the real clock).
+    #[cfg(test)]
+    pub(crate) fn set_test_clock_ms(&self, ms: u64) {
+        self.test_clock_ms.store(ms, Ordering::Release);
     }
 }
 
@@ -465,47 +514,90 @@ mod linux {
     /// Cost bound per sample (#2168 review): stop probing group members
     /// after this many, keeping the worst case fail-quiet, not slow.
     const MAX_PGRP_PROBES: usize = 32;
+    #[cfg(test)]
+    pub(super) const MAX_PGRP_PROBES_FOR_TEST: usize = MAX_PGRP_PROBES;
 
     pub(super) fn fill_foreground_block_state(fg_pgid: i32, snapshot: &mut InteractiveSnapshot) {
+        // #2168 review P1-2: probe the group leader first — the common
+        // single-process foreground group (read -p, sudo, pagers) then
+        // resolves without scanning the whole process table.
+        //
+        // Assumption scope: when the leader is not the blocked reader
+        // (a descendant is), this shortcut simply misses and the walk
+        // below degrades to the pre-shortcut full-table scan — the
+        // shortcut is budgeted separately (#2176 review P2), so all
+        // MAX_PGRP_PROBES fallback slots stay available to non-leader
+        // members and every member base could reach is still reached.
+        // Enumeration order stays /proc-dependent exactly as before;
+        // evidence is per-group (one blocked member suffices), so order
+        // can only affect which member supplies the wording-only
+        // `fg_comm`, never the verdict.
+        let leader_in_group = process_pgid(fg_pgid) == Some(fg_pgid);
+        if leader_in_group && probe_member(fg_pgid, snapshot) {
+            return;
+        }
         let Ok(entries) = std::fs::read_dir("/proc") else {
             return;
         };
-        let mut probed = 0usize;
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let Some(pid) = name.to_str().and_then(|s| s.parse::<i32>().ok()) else {
-                continue;
-            };
-            if process_pgid(pid) != Some(fg_pgid) {
-                continue;
+        let members = entries.flatten().filter_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse::<i32>().ok()?;
+            if pid == fg_pgid && leader_in_group {
+                return None;
             }
-            probed += 1;
-            if probed > MAX_PGRP_PROBES {
-                return;
-            }
-            let wchan = read_proc(pid, "wchan").unwrap_or_default();
-            let syscall = read_proc(pid, "syscall").unwrap_or_default();
-            // #2168 review: a blocked read(2) only counts when the fd it
-            // waits on resolves to the tty — `sleep 130 | cat` blocks in a
-            // pipe read on fd 0 and must never accrue input-wait timeout.
-            let blocked_read = blocked_read_fd(&syscall)
-                .map(|fd| fd_is_tty(pid, fd))
-                .unwrap_or(false);
-            if TTY_READ_WCHANS.contains(&wchan.trim()) || blocked_read {
-                snapshot.blocked_tty_read = true;
-                snapshot.fg_comm = read_proc(pid, "comm")
-                    .map(|comm| comm.trim().to_string())
-                    .filter(|comm| !comm.is_empty())
-                    .or_else(|| snapshot.fg_comm.take());
-                // Evidence is per-group: one blocked member is enough.
-                return;
-            }
-            if snapshot.fg_comm.is_none() {
-                snapshot.fg_comm = read_proc(pid, "comm")
-                    .map(|comm| comm.trim().to_string())
-                    .filter(|comm| !comm.is_empty());
+            (process_pgid(pid) == Some(fg_pgid)).then_some(pid)
+        });
+        scan_members(members, |pid| probe_member(pid, snapshot));
+    }
+
+    /// Walks fallback group members with the full probe budget: up to
+    /// MAX_PGRP_PROBES members are probed, stopping early on the first
+    /// evidence hit. Extracted so the budget contract (a blocked member
+    /// in the last slot is still probed; the bound stays fail-quiet)
+    /// is testable without a live /proc (#2176 review P2).
+    pub(super) fn scan_members(
+        members: impl Iterator<Item = i32>,
+        mut probe: impl FnMut(i32) -> bool,
+    ) -> bool {
+        for pid in members.take(MAX_PGRP_PROBES) {
+            if probe(pid) {
+                return true;
             }
         }
+        false
+    }
+
+    /// Probes one foreground-group member; returns true once
+    /// blocked-tty-read evidence is found (evidence is per-group: one
+    /// blocked member is enough, the caller stops scanning).
+    ///
+    /// `fg_comm` is a wording prior only (see the field docs on
+    /// [`InteractiveSnapshot`]): it merely sharpens hint copy and never
+    /// carries identity semantics — which member it names may depend on
+    /// probe order, and that is acceptable by design.
+    fn probe_member(pid: i32, snapshot: &mut InteractiveSnapshot) -> bool {
+        let wchan = read_proc(pid, "wchan").unwrap_or_default();
+        let syscall = read_proc(pid, "syscall").unwrap_or_default();
+        // #2168 review: a blocked read(2) only counts when the fd it
+        // waits on resolves to the tty — `sleep 130 | cat` blocks in a
+        // pipe read on fd 0 and must never accrue input-wait timeout.
+        let blocked_read = blocked_read_fd(&syscall)
+            .map(|fd| fd_is_tty(pid, fd))
+            .unwrap_or(false);
+        if TTY_READ_WCHANS.contains(&wchan.trim()) || blocked_read {
+            snapshot.blocked_tty_read = true;
+            snapshot.fg_comm = member_comm(pid).or_else(|| snapshot.fg_comm.take());
+            return true;
+        }
+        if snapshot.fg_comm.is_none() {
+            snapshot.fg_comm = member_comm(pid);
+        }
+        false
+    }
+
+    fn member_comm(pid: i32) -> Option<String> {
+        read_proc(pid, "comm")
+            .map(|comm| comm.trim().to_string())
+            .filter(|comm| !comm.is_empty())
     }
 
     /// Parses `/proc/<pid>/syscall`: the fd argument of a blocked read(2),

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel_tests.rs
@@ -204,6 +204,44 @@ fn linux_probe_requires_tty_evidence_for_blocked_reads() {
     assert!(!linux::tty_path("socket:[999]"));
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_fallback_scan_keeps_full_probe_budget() {
+    // #2176 review P2: a missed leader shortcut must not consume
+    // fallback slots — a blocked reader sitting in the *last* budget
+    // slot (the 32nd non-leader member in /proc order) is still probed
+    // and still produces the verdict, exactly as the pre-shortcut scan
+    // did.
+    let budget = linux::MAX_PGRP_PROBES_FOR_TEST;
+    let blocked_pid = budget as i32; // last member inside the budget
+    let mut probes = Vec::new();
+    let hit = linux::scan_members(1..=blocked_pid, |pid| {
+        probes.push(pid);
+        pid == blocked_pid
+    });
+    assert!(hit, "evidence in the last budget slot must be found");
+    assert_eq!(probes.len(), budget, "every budget slot must be probed");
+
+    // The bound itself stays fail-quiet: a member beyond the budget is
+    // never probed, and the scan reports no evidence.
+    let mut probed_beyond = false;
+    let over_budget = blocked_pid + 1;
+    let hit = linux::scan_members(1..=over_budget, |pid| {
+        probed_beyond |= pid == over_budget;
+        pid == over_budget
+    });
+    assert!(!hit);
+    assert!(!probed_beyond, "budget bound must cap the scan");
+
+    // Early evidence short-circuits the walk.
+    let mut count = 0;
+    assert!(linux::scan_members(1..=blocked_pid, |pid| {
+        count += 1;
+        pid == 3
+    }));
+    assert_eq!(count, 3);
+}
+
 #[test]
 fn input_wait_status_marks_clears_and_restarts() {
     let status = InputWaitStatus::default();
@@ -222,4 +260,60 @@ fn input_wait_status_marks_clears_and_restarts() {
     status.mark_waiting();
     let restarted = status.waiting_for().expect("restarted episode");
     assert!(restarted < Duration::from_secs(30), "{restarted:?}");
+}
+
+#[test]
+fn input_wait_clock_is_jump_defensive() {
+    // Drive wall-clock jump scenarios through the production call chain
+    // (`mark_waiting` -> `waiting_for`) on a pinned episode clock
+    // (#2176 review P2): the consumer-visible duration must reflect
+    // exactly the episode-clock delta, never a jump artifact.
+    let base = 1u64 << 32;
+    let status = InputWaitStatus::default();
+
+    // Forward jump shape: a timeout may only fire after the configured
+    // wait truly elapsed on the episode clock. With the former
+    // `SystemTime` chain a wall jump inflated this reading and fired a
+    // false SIGINT seconds into a legitimate wait.
+    status.set_test_clock_ms(base);
+    status.mark_waiting();
+    assert_eq!(status.waiting_for(), Some(Duration::ZERO));
+    status.set_test_clock_ms(base + 120_000);
+    assert_eq!(status.waiting_for(), Some(Duration::from_millis(120_000)));
+
+    // Backward jump artifact (start stamp ahead of "now"): re-mark at a
+    // late reading, then pull the clock back — the duration clamps to
+    // zero instead of underflowing into a giant elapsed value; the
+    // episode keeps running and resumes counting past the stamp.
+    status.clear();
+    status.set_test_clock_ms(base + 120_000);
+    status.mark_waiting();
+    status.set_test_clock_ms(base + 115_000);
+    assert_eq!(status.waiting_for(), Some(Duration::ZERO));
+    status.set_test_clock_ms(base + 180_000);
+    assert_eq!(status.waiting_for(), Some(Duration::from_millis(60_000)));
+
+    // A producer clear/re-mark under the pinned clock restarts the
+    // episode from the current reading, not from any stale stamp.
+    status.clear();
+    status.mark_waiting();
+    assert_eq!(status.waiting_for(), Some(Duration::ZERO));
+
+    // Clock-source discriminator: the real readings are anchored to a
+    // process-local `Instant` epoch, so `now_ms - offset` is process
+    // uptime — orders of magnitude below UNIX-epoch milliseconds
+    // (~1.7e12 in 2026). Reverting `now_ms` to a `SystemTime`-derived
+    // value trips this bound immediately.
+    let uptime_ms = InputWaitStatus::now_ms() - base;
+    assert!(
+        uptime_ms < 1_000_000_000_000, // ~31.7 years of process uptime
+        "now_ms looks wall-clock derived: {uptime_ms}ms past offset"
+    );
+    // Monotonic readings are strictly non-decreasing across calls, and
+    // the offset keeps every reading past the "not waiting" sentinel
+    // with backdating headroom.
+    let a = InputWaitStatus::now_ms();
+    let b = InputWaitStatus::now_ms();
+    assert!(b >= a, "monotonic clock went backwards: {a} -> {b}");
+    assert!(a >= base);
 }


### PR DESCRIPTION
# fix(cosh-ng): [shell] monotonic input-wait clock

Refs #2174 (item 0) — follow-up to #2168 delivering the two post-merge P1 review items from @KaiLongZhou. Verification and disposition were recorded in https://github.com/alibaba/anolisa/pull/2168#issuecomment-5171446486; this PR lands exactly that reviewed change set.

## Changes

- **P1-1 monotonic clock**: `InputWaitStatus::now_ms()` previously used `SystemTime` epoch-millis in the `AtomicU64` episode clock, so a wall-clock jump forward larger than `shell.input_wait_timeout_secs` could SIGINT a foreground command that had only waited seconds, and a backward jump could defer the interrupt into a #2161-style hang. The clock now derives from a process-wide `OnceLock<Instant>` anchor (constant offset keeps values non-zero and leaves backdate headroom). The lock-free atomic structure and `compare_exchange` semantics are unchanged — `clear` stays on the relay per-chunk hot path with no new synchronization.
- **P1-2 /proc group-leader shortcut**: `fill_foreground_block_state` now probes `/proc/<fg_pgid>` first (the group leader usually is the blocked reader for `read -p` / sudo / pager foreground groups) and returns on blocked-read evidence; only when the leader shows no evidence does it fall back to the bounded full-table scan (`MAX_PGRP_PROBES` kept, evidence early-exit kept). Member probing is extracted into `probe_member()`. Cross-sample caching is deliberately **not** introduced: the shortcut removes the common-path cost, and a stale member list would add a correctness face to the fail-quiet probe without measured benefit.

Two files touched: `crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel.rs` and `interactive_sentinel_tests.rs` (+233/−47 at head `5991de1f`, review rounds included).

## Tests

- `input_wait_clock_is_jump_defensive` drives the production chain (`mark_waiting()`/`waiting_for()`) on a test-pinned episode clock: forward jump (duration equals the clock delta exactly), backward jump (stamp ahead of now clamps to zero, episode keeps counting), clear/re-mark restart; plus a clock-source discriminator bound (`now_ms − offset` must be process-uptime scale) that fails against a `SystemTime` revert — verified FAIL→PASS by temporarily reverting `now_ms()` (review round 1).
- `linux_fallback_scan_keeps_full_probe_budget` (Linux-gated) pins the budget contract of the extracted `scan_members()`: a blocked reader in the last fallback slot is still probed (a missed leader shortcut consumes no fallback slot), the `MAX_PGRP_PROBES` bound stays fail-quiet, and evidence short-circuits the walk (review round 2).
- `input_wait_status_marks_clears_and_restarts` covers mark/backdate/clear/restart semantics; `sleep 130 | cat` pipe counter-example (fd0→tty check) remains covered by existing unit tests. Sentinel suite: 13 tests (11 on macOS, +2 Linux-gated).
- Final validation at head `5991de1f` (rebased onto `4349e319`): host macOS `--lib` 1293 ✓, `--bins` 2382 ✓, `cargo fmt --check` ✓, workspace `clippy --all-targets` ✓, `check-layout.sh` ✓, `check-test-inventory.sh` ✓. Linux coverage of the two Linux-gated tests is arbitrated by CI (same policy as #2168).

## Verification

Behavior-preserving hardening: no config, contract, or i18n surface changes; the #2168 acceptance evidence (FAIL→PASS + counter-evidence GIFs) remains representative. Excluded scope: re-running the full real-provider acceptance matrix (no behavioral surface changed), Alinux4 release verification (tracked with the rest of #2174).

