### PR TITLE
fix(sight): keep session across cosh restarts

### DIFF
--- a/src/agentsight/src/genai/builder.rs
+++ b/src/agentsight/src/genai/builder.rs
@@ -244,6 +244,7 @@ impl GenAIBuilder {
         &self,
         request: &ParsedRequest,
         conn_id: &ConnectionId,
+        response_mapper: &ResponseSessionMapper,
         pid_agent_name_cache: &impl PidAgentNameCache,
     ) -> Option<PendingCallInfo> {
         // Only process known LLM API paths
@@ -387,6 +388,22 @@ impl GenAIBuilder {
         let pid_i32 = conn_id.pid as i32;
 
         let session_id = metadata_session
+            .or_else(|| {
+                // Mapper first (same order as call_builder.rs): a FileWrite
+                // from this pid already revealed the real session UUID, which
+                // groups the crash-drain record with the normal calls of the
+                // same session instead of an isolated crash bucket (#2059).
+                //
+                // Known limitation: pid_map has no lifecycle bound, so a
+                // recycled pid whose new process has not yet written a session
+                // file can surface the previous process's mapping here. This
+                // mis-groups only orphan calls that would otherwise get a
+                // synthetic crash hash, and needs pid reuse + zero FileWrite +
+                // drain to coincide — accepted instead of lifecycle tracking.
+                response_mapper
+                    .get_session_by_pid(conn_id.pid)
+                    .map(str::to_string)
+            })
             .or_else(|| {
                 self.id_resolver
                     .peek_session_id(agent_name_str, pid_i32, &first_user_text)
@@ -612,9 +629,10 @@ mod tests {
         let builder = GenAIBuilder::new();
         let body = r#"{"model":"gpt-4","messages":[{"role":"system","content":"sys"},{"role":"user","content":"hello"}]}"#;
         let req = make_request("/v1/chat/completions", body);
+        let mapper = ResponseSessionMapper::new();
         let cache = std::collections::HashMap::new();
         let pending = builder
-            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &cache)
+            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &mapper, &cache)
             .unwrap();
         assert_eq!(pending.model.as_deref(), Some("gpt-4"));
         assert_eq!(pending.provider.as_deref(), Some("openai"));
@@ -628,9 +646,10 @@ mod tests {
         let builder = GenAIBuilder::new();
         let body = r#"{"model":"gpt-4","input":[{"role":"user","content":"hello"}],"instructions":"sys prompt"}"#;
         let req = make_request("/v1/responses", body);
+        let mapper = ResponseSessionMapper::new();
         let cache = std::collections::HashMap::new();
         let pending = builder
-            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &cache)
+            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &mapper, &cache)
             .unwrap();
         assert_eq!(pending.model.as_deref(), Some("gpt-4"));
         assert_eq!(pending.provider.as_deref(), Some("openai"));
@@ -643,10 +662,16 @@ mod tests {
         let builder = GenAIBuilder::new();
         let body = r#"{"model":"gpt-4","messages":[]}"#;
         let req = make_request("/api/health", body);
+        let mapper = ResponseSessionMapper::new();
         let cache = std::collections::HashMap::new();
         assert!(
             builder
-                .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &cache)
+                .build_pending_from_request(
+                    &req,
+                    &ConnectionId { pid: 1, ssl_ptr: 2 },
+                    &mapper,
+                    &cache
+                )
                 .is_none()
         );
     }
@@ -657,9 +682,10 @@ mod tests {
         // LLM path but body lacks both "messages" and "input".
         let body = r#"{"model":"gpt-4","stream":true}"#;
         let req = make_request("/v1/chat/completions", body);
+        let mapper = ResponseSessionMapper::new();
         let cache = std::collections::HashMap::new();
         let pending = builder
-            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &cache)
+            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &mapper, &cache)
             .expect("LLM path should still create pending even without messages");
         assert_eq!(pending.model.as_deref(), Some("gpt-4"));
         assert!(pending.user_query.is_none());
@@ -679,6 +705,7 @@ mod tests {
         let text = "hello";
         let body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}"#;
         let req = make_request("/v1/chat/completions", body);
+        let mapper = ResponseSessionMapper::new();
         let cache = std::collections::HashMap::new();
 
         // 先跑一次拿到 build_pending_from_request 实际解析出的 agent_name
@@ -686,7 +713,7 @@ mod tests {
         // 不一定是 make_request 里设置的 "test"，所以直接从返回值里读，
         // 保证后面手动调用 `resolve_conversation_id` 时用的 key 与它一致）。
         let pending = builder
-            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &cache)
+            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &mapper, &cache)
             .expect("LLM path should create pending");
         let agent_name = pending.agent_name.clone().unwrap_or_default();
 
@@ -698,7 +725,7 @@ mod tests {
 
         // 2. 该轮后续调用超时/进程崩溃，确认不会再有 finish_reason。
         builder
-            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &cache)
+            .build_pending_from_request(&req, &ConnectionId { pid: 1, ssl_ptr: 2 }, &mapper, &cache)
             .expect("LLM path should create pending");
 
         // 3. 数十分钟后同一段固定文本触发了一轮全新的真实对话，应得到不同的 conversation_id。
@@ -709,6 +736,96 @@ mod tests {
         assert_ne!(
             turn1, turn2,
             "build_pending_from_request 应驱逐锚点，让相同文本开启新的一轮对话"
+        );
+    }
+
+    /// A pid → session UUID mapping registered by a FileWrite event must win
+    /// over the peek/crash-fallback chain in the crash-drain path (#2059).
+    /// Reverting the mapper lookup in `build_pending_from_request` makes this
+    /// test fail (session_id would become the 32-hex crash fallback).
+    #[test]
+    fn test_build_pending_from_request_uses_mapper_pid_session() {
+        let builder = GenAIBuilder::new();
+        let body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}"#;
+        let req = make_request("/v1/chat/completions", body);
+        let cache = std::collections::HashMap::new();
+
+        // Pre-seed pid 4242 → session UUID via a cosh-core atomic-write temp
+        // file, the same way the filewrite probe feeds the mapper at runtime.
+        let mut mapper = ResponseSessionMapper::new();
+        mapper.process_filewrite(&crate::probes::FileWriteEvent {
+            pid: 4242,
+            tid: 4242,
+            uid: 0,
+            timestamp_ns: 0,
+            write_size: 0,
+            comm: "cosh-core".to_string(),
+            filename:
+                ".550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp"
+                    .to_string(),
+            cgroup_id: 0,
+            buf: Vec::new(),
+        });
+
+        let pending = builder
+            .build_pending_from_request(
+                &req,
+                &ConnectionId {
+                    pid: 4242,
+                    ssl_ptr: 2,
+                },
+                &mapper,
+                &cache,
+            )
+            .expect("LLM path should create pending");
+        assert_eq!(
+            pending.session_id.as_deref(),
+            Some("550e8400-e29b-41d4-a716-446655440000"),
+            "mapper pid → session UUID must win over the crash fallback"
+        );
+    }
+
+    /// Without a mapper hit the crash-drain path must keep its previous
+    /// behavior: fall back to the 32-hex `crash_fallback_id` (peek misses on
+    /// a fresh builder).
+    #[test]
+    fn test_build_pending_from_request_falls_back_without_mapper_hit() {
+        let builder = GenAIBuilder::new();
+        let body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}"#;
+        let req = make_request("/v1/chat/completions", body);
+        let cache = std::collections::HashMap::new();
+        // Mapper knows a different pid only.
+        let mut mapper = ResponseSessionMapper::new();
+        mapper.process_filewrite(&crate::probes::FileWriteEvent {
+            pid: 9999,
+            tid: 9999,
+            uid: 0,
+            timestamp_ns: 0,
+            write_size: 0,
+            comm: "cosh-core".to_string(),
+            filename:
+                ".550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp"
+                    .to_string(),
+            cgroup_id: 0,
+            buf: Vec::new(),
+        });
+
+        let pending = builder
+            .build_pending_from_request(
+                &req,
+                &ConnectionId {
+                    pid: 4242,
+                    ssl_ptr: 2,
+                },
+                &mapper,
+                &cache,
+            )
+            .expect("LLM path should create pending");
+        let session_id = pending.session_id.expect("fallback session_id");
+        assert_eq!(
+            session_id.len(),
+            32,
+            "unmapped pid must keep the 32-hex crash fallback, got {session_id}"
         );
     }
 }

--- a/src/agentsight/src/storage/sqlite/genai/pending.rs
+++ b/src/agentsight/src/storage/sqlite/genai/pending.rs
@@ -689,6 +689,45 @@ impl GenAISqliteStore {
         )?;
         Ok(())
     }
+
+    /// Retroactively replace a fallback session_id after the real session
+    /// UUID became known via a late FileWrite mapping (issue #2059).
+    ///
+    /// Only rows still carrying the 32-char lowercase-hex fallback shape are
+    /// touched — both `crash_fallback_id` and `domain_hash` (id_resolver.rs)
+    /// emit `format!("{digest:x}")`, i.e. lowercase hex, truncated to 32.
+    /// Anything else — 36-char mapper or metadata UUIDs, or a future
+    /// non-UUID "real" session id — must not be overwritten by a later,
+    /// possibly different, pid mapping.
+    ///
+    /// Returns the number of rows updated (0 or 1 — call_id is unique).
+    ///
+    /// Named distinctly from `update_session_id` (session.rs), which is the
+    /// unguarded variant used by the drain-path reconciliation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the SQLite connection lock cannot be acquired
+    /// or the UPDATE statement fails to execute.
+    pub fn update_fallback_session_id(
+        &self,
+        call_id: &str,
+        new_session_id: &str,
+    ) -> Result<usize, Box<dyn std::error::Error>> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        // GLOB is case-sensitive (unlike LIKE), so uppercase hex fails the
+        // guard by design; a NULL session_id yields NULL and never matches.
+        let updated = conn.execute(
+            "UPDATE genai_events
+             SET session_id = ?1
+             WHERE call_id = ?2
+               AND session_id != ?1
+               AND length(session_id) = 32
+               AND session_id NOT GLOB '*[^0-9a-f]*'",
+            params![new_session_id, call_id],
+        )?;
+        Ok(updated)
+    }
 }
 
 // ─── Helper for loop detection ───────────────────────────────────────────────

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -1266,3 +1266,97 @@ fn poison_recovery_flush_still_operational() {
 
     cleanup_db(&path);
 }
+
+// ─── update_fallback_session_id (retroactive session fix-up, issue #2059) ─────────────
+
+/// Read the current session_id of a call directly from the table.
+fn session_id_of(store: &GenAISqliteStore, call_id: &str) -> Option<String> {
+    let conn = store.conn.lock().unwrap();
+    conn.query_row(
+        "SELECT session_id FROM genai_events WHERE call_id = ?1",
+        rusqlite::params![call_id],
+        |r| r.get(0),
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_update_fallback_session_id_replaces_hash_fallback() {
+    // 32-hex fallback (id_resolver shape) must be replaced by the real UUID.
+    let store = make_store_with_pending(&[(
+        "c1",
+        "0123456789abcdef0123456789abcdef",
+        "conv-1",
+        "main",
+        1000,
+    )]);
+    let uuid = "550e8400-e29b-41d4-a716-446655440000";
+    let updated = store.update_fallback_session_id("c1", uuid).unwrap();
+    assert_eq!(updated, 1, "hash-shaped session_id must be updated");
+    assert_eq!(session_id_of(&store, "c1").as_deref(), Some(uuid));
+}
+
+#[test]
+fn test_update_fallback_session_id_keeps_uuid_session() {
+    // A 36-char session_id is a trusted mapper/metadata UUID — never overwrite.
+    let existing = "11111111-2222-4333-8444-555555555555";
+    let store = make_store_with_pending(&[("c1", existing, "conv-1", "main", 1000)]);
+    let updated = store
+        .update_fallback_session_id("c1", "550e8400-e29b-41d4-a716-446655440000")
+        .unwrap();
+    assert_eq!(
+        updated, 0,
+        "existing UUID session_id must not be overwritten"
+    );
+    assert_eq!(session_id_of(&store, "c1").as_deref(), Some(existing));
+}
+
+#[test]
+fn test_update_fallback_session_id_unknown_call_id() {
+    let store = make_store_with_pending(&[(
+        "c1",
+        "0123456789abcdef0123456789abcdef",
+        "conv-1",
+        "main",
+        1000,
+    )]);
+    let updated = store
+        .update_fallback_session_id("no-such-call", "550e8400-e29b-41d4-a716-446655440000")
+        .unwrap();
+    assert_eq!(updated, 0, "unknown call_id must update nothing");
+}
+
+#[test]
+fn test_update_fallback_session_id_keeps_other_lengths() {
+    // Anything that is not the 32-hex fallback shape — e.g. a 20-char custom
+    // session id — must be left alone, not just 36-char UUIDs.
+    let existing = "custom-session-20ch!";
+    assert_eq!(existing.len(), 20);
+    let store = make_store_with_pending(&[("c1", existing, "conv-1", "main", 1000)]);
+    let updated = store
+        .update_fallback_session_id("c1", "550e8400-e29b-41d4-a716-446655440000")
+        .unwrap();
+    assert_eq!(updated, 0, "non-32-char session_id must not be overwritten");
+    assert_eq!(session_id_of(&store, "c1").as_deref(), Some(existing));
+}
+
+#[test]
+fn test_update_fallback_session_id_keeps_non_hex_32_chars() {
+    // 32 chars but not lowercase hex ('Z' and uppercase) — not a fallback
+    // shape, must be left alone. Reverting the NOT GLOB guard fails this.
+    for existing in [
+        "Z123456789abcdef0123456789abcdef",
+        "0123456789ABCDEF0123456789abcdef",
+    ] {
+        assert_eq!(existing.len(), 32);
+        let store = make_store_with_pending(&[("c1", existing, "conv-1", "main", 1000)]);
+        let updated = store
+            .update_fallback_session_id("c1", "550e8400-e29b-41d4-a716-446655440000")
+            .unwrap();
+        assert_eq!(
+            updated, 0,
+            "non-hex 32-char session_id must not be overwritten"
+        );
+        assert_eq!(session_id_of(&store, "c1").as_deref(), Some(existing));
+    }
+}

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -88,6 +88,10 @@ pub struct AgentSight {
     response_mapper: ResponseSessionMapper,
     /// Pending GenAI events awaiting session_id resolution from ResponseSessionMapper
     pending_genai: Vec<PendingGenAI>,
+    /// Calls exported with a fallback session_id after the deferral window
+    /// timed out, keyed by pid, awaiting a late FileWrite mapping for
+    /// retroactive session fix-up (issue #2059).
+    retro_session_fixup: lru::LruCache<u32, Vec<RetroFixupEntry>>,
     /// Total estimated bytes of all pending_genai entries (for memory budget enforcement).
     pending_genai_bytes: usize,
     /// Runtime limits for bounded buffers and eviction policies.
@@ -134,6 +138,20 @@ impl PendingGenAI {
 
 /// Maximum time to wait for ResponseSessionMapper to resolve a session_id
 const PENDING_SESSION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// How long a timeout-escaped call stays eligible for retroactive session
+/// fix-up after export (see `apply_retro_session_fixup`). Generous compared
+/// to `PENDING_SESSION_TIMEOUT` because the write that reveals the session
+/// UUID may only happen at the end of a long agent turn.
+const RETRO_FIXUP_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// Maximum number of pids tracked for retroactive session fix-up.
+const RETRO_FIXUP_CAPACITY: usize = 256;
+
+/// One timeout-escaped call awaiting retroactive session fix-up:
+/// (call_id, registration time, agent_name of the pid at registration time).
+/// The agent name guards against pid reuse (see `apply_retro_session_fixup`).
+type RetroFixupEntry = (String, std::time::Instant, Option<String>);
 
 impl AgentSight {
     /// Create a new AgentSight instance from configuration
@@ -562,6 +580,11 @@ impl AgentSight {
                 ResponseSessionMapper::disabled()
             },
             pending_genai: Vec::new(),
+            // RETRO_FIXUP_CAPACITY is a non-zero constant, so the unwrap is
+            // guaranteed unreachable.
+            retro_session_fixup: lru::LruCache::new(
+                std::num::NonZeroUsize::new(RETRO_FIXUP_CAPACITY).unwrap(),
+            ),
             pending_genai_bytes: 0,
             runtime_limits: config.runtime_limits,
             ffi_sender: None,
@@ -684,6 +707,19 @@ impl AgentSight {
         // Handle FileWrite events via callback (not through the pipeline)
         if let Event::FileWrite(ref fw_event) = event {
             self.handle_filewrite_event(fw_event);
+            // The refreshed pid → session mapping may allow repairing calls
+            // that already escaped the deferral window with a fallback id.
+            if let Some(ref store) = self.genai_sqlite_store {
+                apply_retro_session_fixup(
+                    &mut self.retro_session_fixup,
+                    &self.response_mapper,
+                    store,
+                    fw_event.pid,
+                    self.pid_agent_name_cache
+                        .peek(&fw_event.pid)
+                        .map(String::as_str),
+                );
+            }
             // After mapper is updated, try to resolve any pending GenAI events
             self.resolve_pending_genai();
             return None;
@@ -1331,6 +1367,7 @@ impl AgentSight {
             if let Some(pending) = self.genai_builder.build_pending_from_request(
                 request,
                 conn_id,
+                &self.response_mapper,
                 &self.pid_agent_name_cache,
             ) {
                 if let Some(ref store) = self.genai_sqlite_store {
@@ -1395,6 +1432,7 @@ impl AgentSight {
             if let Some(mut pending) = self.genai_builder.build_pending_from_request(
                 &request,
                 &conn_id,
+                &self.response_mapper,
                 &self.pid_agent_name_cache,
             ) {
                 pending.pending_origin = PendingOrigin::IdleDrain;
@@ -1488,6 +1526,7 @@ impl AgentSight {
             if let Some(pending) = self.genai_builder.build_pending_from_request(
                 &request,
                 &conn_id,
+                &self.response_mapper,
                 &self.pid_agent_name_cache,
             ) {
                 if let Some(ref store) = self.genai_sqlite_store {
@@ -1750,6 +1789,40 @@ impl AgentSight {
         }
     }
 
+    /// Remember timeout-escaped LLM calls so a later FileWrite from the same
+    /// pid can retroactively repair their fallback session_id (issue #2059).
+    fn register_retro_session_fixup(&mut self, pid: u32, events: &[GenAISemanticEvent]) {
+        let call_ids = retro_fixup_call_ids(pid, events);
+        if call_ids.is_empty() {
+            return;
+        }
+        // All events of a deferred batch belong to one call from one process,
+        // so the first LLMCall's agent_name identifies the pid's owner. It is
+        // compared against the pid's owner at fix-up time to catch pid reuse.
+        let agent_name = events.iter().find_map(|e| match e {
+            GenAISemanticEvent::LLMCall(call) => Some(call.agent_name.clone()),
+            _ => None,
+        });
+        let agent_name = agent_name.flatten();
+        let now = std::time::Instant::now();
+        let mut entries = self.retro_session_fixup.pop(&pid).unwrap_or_default();
+        // Drop already-expired entries so a chatty pid cannot grow the list
+        // beyond what the fix-up window can ever consume.
+        entries.retain(|(_, ts, _)| ts.elapsed() <= RETRO_FIXUP_WINDOW);
+        entries.extend(call_ids.into_iter().map(|id| (id, now, agent_name.clone())));
+        // `push` (unlike `put`) reports the LRU victim; the pid's own entry
+        // was popped above, so any Some here is a capacity eviction — surface
+        // it because the evicted pid silently loses its fix-up chance.
+        if let Some((evicted_pid, evicted)) = self.retro_session_fixup.push(pid, entries) {
+            if evicted_pid != pid {
+                log::debug!(
+                    "retro fix-up registry full: evicted pid={evicted_pid} with {} pending fix-up(s)",
+                    evicted.len()
+                );
+            }
+        }
+    }
+
     /// Try to resolve pending GenAI events whose session_id can now be looked up.
     /// Called after FileWrite events update the ResponseSessionMapper.
     fn resolve_pending_genai(&mut self) {
@@ -1787,6 +1860,7 @@ impl AgentSight {
                     "Deferred session_id timed out for response_id={}, using fallback",
                     pending.response_id
                 );
+                self.register_retro_session_fixup(pending.pid, &pending.events);
                 to_export.push(pending.events);
             } else {
                 // Still waiting
@@ -1819,6 +1893,7 @@ impl AgentSight {
                     "Deferred session_id expired for response_id={}, using fallback",
                     pending.response_id
                 );
+                self.register_retro_session_fixup(pending.pid, &pending.events);
                 to_export.push(pending.events);
             } else {
                 still_pending.push(pending);
@@ -1834,6 +1909,12 @@ impl AgentSight {
     }
 
     /// Flush all remaining pending GenAI events (on shutdown).
+    ///
+    /// No retro fix-up registration here: the process is exiting, so no
+    /// further FileWrite can ever arrive to repair a fallback session_id.
+    /// The runtime already repaired what it could via
+    /// `apply_retro_session_fixup`; the remaining pendings are persisted with
+    /// whatever session_id they carry now (real UUID or fallback).
     fn flush_all_pending_genai(&mut self) {
         let pending_items: Vec<_> = self.pending_genai.drain(..).collect();
         for pending in &pending_items {
@@ -1868,6 +1949,8 @@ impl AgentSight {
         let (to_export, still_pending) = take_deferred_genai_for_pid(pending_items, pid);
         self.pending_genai = still_pending;
 
+        // No retro fix-up registration here: the pid is dead, so the FileWrite
+        // that would reveal its session mapping can never arrive anymore.
         for events in &to_export {
             self.complete_and_export_deferred_genai(events);
             self.detect_and_store_interruptions(events);
@@ -2104,6 +2187,92 @@ fn take_deferred_genai_for_pid(
     }
 
     (to_export, still_pending)
+}
+
+/// Collect the call_ids eligible for retroactive session fix-up from a
+/// timeout-escaped deferred batch.
+///
+/// pid 0 is the placeholder used when `pending_info` was missing at queue
+/// time; it can never match a real FileWrite pid, so it yields nothing.
+/// Extracted as a free function so the registration filter is unit-testable
+/// without constructing a full `AgentSight` instance.
+fn retro_fixup_call_ids(pid: u32, events: &[GenAISemanticEvent]) -> Vec<String> {
+    if pid == 0 {
+        return Vec::new();
+    }
+    events
+        .iter()
+        .filter_map(|e| match e {
+            GenAISemanticEvent::LLMCall(call) => Some(call.call_id.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Retroactively repair the session_id of calls that escaped the deferral
+/// window before `pid`'s FileWrite mapping arrived (issue #2059).
+///
+/// The pid entry is kept while the mapping is still unknown (a later write
+/// within `RETRO_FIXUP_WINDOW` may bring it) and consumed once the mapping is
+/// available; individual entries older than the window are dropped. Extracted
+/// as a free function so the fix-up path is unit-testable without a full
+/// `AgentSight` instance (mirrors `record_agent_crash_interruptions`).
+///
+/// `current_agent` (the pid's owner in `pid_agent_name_cache` at fix-up time)
+/// guards against pid reuse: when both the registered and the current agent
+/// are known and differ, the pid has been recycled by another process and the
+/// entry is dropped. Known residual limitation: a pid wrapped around within
+/// the window to a *same-named* traced agent that writes a session file can
+/// still be mis-repaired — vanishingly rare, and the double guard (32-hex
+/// shape in `update_fallback_session_id` + this agent check) limits the harm
+/// to a grouping deviation of orphan fallback rows.
+fn apply_retro_session_fixup(
+    fixups: &mut lru::LruCache<u32, Vec<RetroFixupEntry>>,
+    mapper: &ResponseSessionMapper,
+    store: &GenAISqliteStore,
+    pid: u32,
+    current_agent: Option<&str>,
+) {
+    // Cheap peek first: the vast majority of FileWrite events belong to pids
+    // with no timeout-escaped calls.
+    if fixups.peek(&pid).is_none() {
+        return;
+    }
+    let Some(session_id) = mapper.get_session_by_pid(pid).map(str::to_string) else {
+        return;
+    };
+    let Some(entries) = fixups.pop(&pid) else {
+        return;
+    };
+    // Entries whose UPDATE errored are re-registered below so a later write
+    // retries them; the window check above them bounds the retries.
+    let mut failed: Vec<RetroFixupEntry> = Vec::new();
+    for (call_id, registered_at, entry_agent) in entries {
+        if registered_at.elapsed() > RETRO_FIXUP_WINDOW {
+            continue;
+        }
+        if let (Some(registered), Some(current)) = (entry_agent.as_deref(), current_agent) {
+            if registered != current {
+                log::debug!(
+                    "retro session fix-up skipped for call_id={call_id}: pid {pid} was reused (agent {registered} -> {current})"
+                );
+                continue;
+            }
+        }
+        match store.update_fallback_session_id(&call_id, &session_id) {
+            Ok(n) if n > 0 => {
+                log::debug!("retro session fix-up: call_id={call_id} session_id={session_id}");
+            }
+            Ok(_) => {}
+            Err(e) => {
+                log::warn!("retro session fix-up failed for call_id={call_id}: {e}");
+                failed.push((call_id, registered_at, entry_agent));
+            }
+        }
+    }
+    if !failed.is_empty() {
+        fixups.put(pid, failed);
+    }
 }
 
 /// Record `agent_crash` interruption events for the pending calls of an
@@ -2794,5 +2963,198 @@ mod tests {
             pid: 1,
         });
         assert!(!events_are_empty_llm(&[empty, tool]));
+    }
+
+    // ── Tests for retroactive session fix-up (issue #2059) ──
+
+    /// Build a mapper that learned `pid` → the cosh session UUID from a
+    /// FileWrite of the atomic-write temp file, exactly as at runtime.
+    fn make_mapper_with_pid(pid: u32) -> ResponseSessionMapper {
+        let mut mapper = ResponseSessionMapper::new();
+        mapper.process_filewrite(&FileWriteEvent {
+            pid,
+            tid: pid,
+            uid: 0,
+            timestamp_ns: 0,
+            write_size: 0,
+            comm: "cosh-core".to_string(),
+            filename:
+                ".550e8400-e29b-41d4-a716-446655440000.0198f00d-1a2b-4c3d-8e4f-556677889900.tmp"
+                    .to_string(),
+            cgroup_id: 0,
+            buf: Vec::new(),
+        });
+        mapper
+    }
+
+    fn make_fixup_cache() -> lru::LruCache<u32, Vec<RetroFixupEntry>> {
+        // Capacity constant is non-zero, unwrap cannot fire.
+        lru::LruCache::new(std::num::NonZeroUsize::new(RETRO_FIXUP_CAPACITY).unwrap())
+    }
+
+    #[test]
+    fn test_retro_fixup_call_ids_skips_pid_zero() {
+        let events = vec![GenAISemanticEvent::LLMCall(make_test_llm_call("call-a"))];
+        // pid 0 is the missing-pending_info placeholder — never registered.
+        assert!(retro_fixup_call_ids(0, &events).is_empty());
+        assert_eq!(retro_fixup_call_ids(4242, &events), vec!["call-a"]);
+    }
+
+    /// End-to-end narrow chain: a call escapes the deferral window with a
+    /// hash fallback session_id, gets registered, and a later FileWrite from
+    /// the same pid repairs the DB row. Reverting the fix-up makes the final
+    /// session_id assertion fail (the row would keep the 32-hex fallback).
+    #[test]
+    fn test_retro_session_fixup_repairs_timeout_escaped_call() {
+        let dir = unique_tmp_dir("retro-fixup");
+        let store =
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store");
+        let mut info = make_test_pending_info("retro-call-1");
+        info.pid = 4242;
+        // The 32-hex shape the id_resolver fallback produces.
+        info.session_id = Some("0123456789abcdef0123456789abcdef".to_string());
+        store.insert_pending(&info).expect("insert_pending");
+
+        let mut fixups = make_fixup_cache();
+        fixups.put(
+            4242,
+            vec![("retro-call-1".to_string(), std::time::Instant::now(), None)],
+        );
+
+        let mapper = make_mapper_with_pid(4242);
+        apply_retro_session_fixup(&mut fixups, &mapper, &store, 4242, None);
+
+        let rows = store.list_pending_for_pids(&[4242]).expect("list pending");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].1.as_deref(),
+            Some("550e8400-e29b-41d4-a716-446655440000"),
+            "fallback session_id must be repaired to the mapper UUID"
+        );
+        assert!(
+            fixups.peek(&4242).is_none(),
+            "pid entry must be consumed after the fix-up"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A FileWrite that does not yield a mapping for the pid must keep the
+    /// registration for later writes and leave the row untouched.
+    #[test]
+    fn test_retro_session_fixup_waits_for_mapping() {
+        let dir = unique_tmp_dir("retro-wait");
+        let store =
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store");
+        let mut info = make_test_pending_info("retro-call-2");
+        info.pid = 4242;
+        info.session_id = Some("0123456789abcdef0123456789abcdef".to_string());
+        store.insert_pending(&info).expect("insert_pending");
+
+        let mut fixups = make_fixup_cache();
+        fixups.put(
+            4242,
+            vec![("retro-call-2".to_string(), std::time::Instant::now(), None)],
+        );
+
+        // Mapper knows a different pid only.
+        let mapper = make_mapper_with_pid(9999);
+        apply_retro_session_fixup(&mut fixups, &mapper, &store, 4242, None);
+
+        let rows = store.list_pending_for_pids(&[4242]).expect("list pending");
+        assert_eq!(
+            rows[0].1.as_deref(),
+            Some("0123456789abcdef0123456789abcdef"),
+            "row must stay on the fallback while the mapping is unknown"
+        );
+        assert!(
+            fixups.peek(&4242).is_some(),
+            "entry must survive until the mapping arrives or expires"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Entries older than RETRO_FIXUP_WINDOW must be dropped without touching
+    /// the DB, even when the mapping is available.
+    #[test]
+    fn test_retro_session_fixup_drops_expired_entries() {
+        // Back-date the registration beyond the window. On hosts whose
+        // monotonic clock started less than the window ago this cannot be
+        // represented — skip silently (Instant cannot be mocked).
+        let Some(expired_at) = std::time::Instant::now()
+            .checked_sub(RETRO_FIXUP_WINDOW + std::time::Duration::from_secs(1))
+        else {
+            return;
+        };
+
+        let dir = unique_tmp_dir("retro-expired");
+        let store =
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store");
+        let mut info = make_test_pending_info("retro-call-3");
+        info.pid = 4242;
+        info.session_id = Some("0123456789abcdef0123456789abcdef".to_string());
+        store.insert_pending(&info).expect("insert_pending");
+
+        let mut fixups = make_fixup_cache();
+        fixups.put(4242, vec![("retro-call-3".to_string(), expired_at, None)]);
+
+        let mapper = make_mapper_with_pid(4242);
+        apply_retro_session_fixup(&mut fixups, &mapper, &store, 4242, None);
+
+        let rows = store.list_pending_for_pids(&[4242]).expect("list pending");
+        assert_eq!(
+            rows[0].1.as_deref(),
+            Some("0123456789abcdef0123456789abcdef"),
+            "expired entries must not touch the DB"
+        );
+        assert!(
+            fixups.peek(&4242).is_none(),
+            "expired entries are discarded together with the pid entry"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A pid recycled by a different traced agent must not have its old
+    /// entries repaired: registered agent and current agent both known but
+    /// different → drop, no DB write. Reverting the agent guard in
+    /// `apply_retro_session_fixup` makes this test fail (the row would be
+    /// repaired with the new process's session).
+    #[test]
+    fn test_retro_session_fixup_skips_reused_pid() {
+        let dir = unique_tmp_dir("retro-pid-reuse");
+        let store =
+            GenAISqliteStore::new_with_path(&dir.join("genai_events.db")).expect("genai store");
+        let mut info = make_test_pending_info("retro-call-4");
+        info.pid = 4242;
+        info.session_id = Some("0123456789abcdef0123456789abcdef".to_string());
+        store.insert_pending(&info).expect("insert_pending");
+
+        let mut fixups = make_fixup_cache();
+        fixups.put(
+            4242,
+            vec![(
+                "retro-call-4".to_string(),
+                std::time::Instant::now(),
+                Some("cosh".to_string()),
+            )],
+        );
+
+        let mapper = make_mapper_with_pid(4242);
+        apply_retro_session_fixup(&mut fixups, &mapper, &store, 4242, Some("other-agent"));
+
+        let rows = store.list_pending_for_pids(&[4242]).expect("list pending");
+        assert_eq!(
+            rows[0].1.as_deref(),
+            Some("0123456789abcdef0123456789abcdef"),
+            "entries registered under another agent must not be repaired"
+        );
+        assert!(
+            fixups.peek(&4242).is_none(),
+            "reused-pid entries are dropped, not retried"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Why

Fixes defect 2 of #2059: after a cosh-core process crash/restart, agentsight assigned LLM calls from the new pid to a fresh fallback session instead of regrouping them into the original session. After #2080, the deferred backfill already covers completed calls on normal restarts; empirical tracing showed exactly two remaining gaps, both fixed here.

## What changed

1. **Crash-drain session inference now goes through `ResponseSessionMapper`** — mapper hit first, pid anchor as fallback, matching the inference order used by `call_builder`.
2. **Calls escaping the 5s deferred window are registered in a pending LRU** (capacity 256, 10min window, agent consistency check). Once a later filewrite establishes the pid→session mapping, an `UPDATE` retroactively corrects `session_id`; a guard restricts the fix to rows still in 32-hex fallback form.

**Answering the issue's evaluation question**: mapper-first + pid-anchor-fallback is sufficient for completed calls, because the #2080 pid_map is rebuilt automatically on every file write and the deferred backfill covers the normal restart path. Extra cross-pid regrouping logic would only serve two scenarios, both intentionally not addressed: (a) first-turn hang — the old pid never wrote to disk, so no mapping source of truth exists (information-theoretically unreachable); (b) conversation-anchor continuation across processes — would require `last_user_raw` text-based merging, whose mis-merge risk is disproportionate to the benefit; a separate issue is recommended.

## Related issue

closes #2059

Note: the issue's optional item (distinguishing orchestrated termination from unexpected crash) is explicitly marked as separable in the issue and is not included in this PR.

## User / Agent impact

Dashboard sessions now stay contiguous across cosh-core restarts instead of splitting into orphan fallback sessions. No CLI/API surface change.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Known residual limitations:
- If a same-named agent's pid wraps around within the 10min window, an orphan fallback row could be mis-corrected. Probability is extremely low; the 32-hex guard plus agent consistency check bound the blast radius.
- The retro `UPDATE` only fixes SQLite (the dashboard's primary source); already-exported logtail/FFI events are not amended.

## Validation

- ECS with rustc 1.89.0 (matching CI): `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — all green, **1491 passed / 0 failed**.
- 4 discriminative counter-checks: reverting each fix makes its corresponding test fail precisely.
- Real-machine e2e cross-pid mapping verification including negative controls. The ECS host has no cosh binary or API key, so the full LLM chain is covered by unit tests rather than live e2e — stated as-is.
- Two rounds of adversarial review (3-dimension parallel + full re-review) converged with 0 blocking findings.

## Documentation and rollback

No documentation change. Revert the single commit to roll back; no schema migration involved.
