### PR TITLE
fix(tokenless): wire --agent-id arg to claude-code recorder hooks

### DIFF
--- a/src/tokenless/adapters/tokenless/claude-code/hooks/hooks.json
+++ b/src/tokenless/adapters/tokenless/claude-code/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" rewrite_hook.py",
+            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" rewrite_hook.py --agent-id claude-code",
             "timeout": 10
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" compress_response_hook.py",
+            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" compress_response_hook.py --agent-id claude-code",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Description

PR #2159 (`ac7cf4f4`) added the `--agent-id` command-argument channel as the robust attribution path and wired it for the qoder adapter. This PR applies the same hardening to the **claude-code** adapter's two Python recorder hooks.

The claude-code hooks currently set `TOKENLESS_AGENT_ID=claude-code` as an inline env prefix in the command string, which is more reliable than an `env:` block. However, adding `--agent-id claude-code` as a command argument ensures attribution survives any process isolation that strips the inline env (e.g. Node wrapper launch paths, `npm`-installed Claude Code), using the same robust channel that `resolve_agent_id()` now prefers.

Changes:
- `rewrite_hook.py` invocation: add `--agent-id claude-code` after the script name
- `compress_response_hook.py` invocation: add `--agent-id claude-code` after the script name
- `tool_ready_hook.sh` entry unchanged — it does not record stats

`run-hook.sh` passes extra args through to the hook script via `"$@"`, so no changes are needed there.

## Related Issue

Supplements #2159. Closes #2158.

## Testing

Existing `tests/test_resolve_agent_id.py` (7 tests) all pass — the `--agent-id` argument channel was already tested there.

Manual verification: the `--agent-id` argument is passed through `run-hook.sh` via `"$@"` to the Python hook scripts.