### PR TITLE
fix(tokenless): pass --agent-id in adapter command strings

### DIFF
--- a/src/tokenless/adapters/tokenless/claude-code/hooks/hooks.json
+++ b/src/tokenless/adapters/tokenless/claude-code/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" rewrite_hook.py",
+            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" rewrite_hook.py --agent-id claude-code",
             "timeout": 10
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" compress_response_hook.py",
+            "command": "TOKENLESS_AGENT_ID=claude-code bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" compress_response_hook.py --agent-id claude-code",
             "timeout": 15
           }
         ]

--- a/src/tokenless/adapters/tokenless/qwencode/qwen-extension.json.in
+++ b/src/tokenless/adapters/tokenless/qwencode/qwen-extension.json.in
@@ -29,7 +29,7 @@
             "type": "command",
             "name": "tokenless-rewrite",
             "description": "Rewrites shell commands via rtk for token savings",
-            "command": "bash \"${extensionPath}/hooks/run-hook.sh\" rewrite_hook.py",
+            "command": "bash \"${extensionPath}/hooks/run-hook.sh\" rewrite_hook.py --agent-id qwencode",
             "timeout": 5000,
             "env": { "TOKENLESS_AGENT_ID": "qwencode" }
           }
@@ -44,7 +44,7 @@
             "type": "command",
             "name": "tokenless-compress-response",
             "description": "Compresses tool responses and encodes to TOON format",
-            "command": "bash \"${extensionPath}/hooks/run-hook.sh\" compress_response_hook.py",
+            "command": "bash \"${extensionPath}/hooks/run-hook.sh\" compress_response_hook.py --agent-id qwencode",
             "timeout": 10000,
             "env": { "TOKENLESS_AGENT_ID": "qwencode" }
           }
@@ -58,7 +58,7 @@
             "type": "command",
             "name": "tokenless-compress-schema",
             "description": "Compresses tool schema definitions for token savings",
-            "command": "bash \"${extensionPath}/hooks/run-hook.sh\" compress_schema_hook.py",
+            "command": "bash \"${extensionPath}/hooks/run-hook.sh\" compress_schema_hook.py --agent-id qwencode",
             "timeout": 10000,
             "env": { "TOKENLESS_AGENT_ID": "qwencode" }
           }


### PR DESCRIPTION
## Summary

Adapters that invoke the shared Python hooks via `run-hook.sh` (qwencode, claude-code) relied solely on the `hooks.json` `env` block (`TOKENLESS_AGENT_ID`) for stats attribution. Hosts that do not propagate the declared `env` map to every hook execution context cause `resolve_agent_id()` to fall back to the `"unknown"` sentinel, scattering a single session's records across multiple `agent_id` values.

The `--agent-id` command argument is the robust channel since the host always honours the hook `command` string. Add `--agent-id` to:
- **qwencode**: rewrite, compress-response, compress-schema command strings
- **claude-code**: rewrite, compress-response command strings

The qoder adapter already passes `--agent-id` in its command strings. The hermes, openclaw, and codex adapters use hardcoded constants or inline env prefixes and are not affected by env-block propagation gaps.

## Related Issue

Closes #2158

## Type / Scope

- [x] Bug fix
- [x] tokenless

## Testing

`python3 tests/test_resolve_agent_id.py` — 7 tests passed
`python3 tests/test_rewrite_hook.py` — 11 tests passed
`python3 tests/test_compress_response_hook.py` — 14 tests passed (skipped: 14, requires tokenless binary)
`python3 tests/test_compress_schema_hook.py` — 7 tests passed (skipped: 7, requires tokenless binary)

Verified JSON validity of both modified adapter config files.