### PR TITLE
fix(blaze): claim daemon state ownership

### DIFF
--- a/src/blaze/Cargo.toml
+++ b/src/blaze/Cargo.toml
@@ -25,6 +25,7 @@ toml = "0.8"
 # Error handling
 thiserror = "2.0"
 anyhow = "1.0"
+libc = "0.2"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
@@ -33,7 +34,6 @@ hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
 async-trait = "0.1"
-libc = "0.2"
 
 # Logging
 tracing = "0.1"

--- a/src/blaze/crates/blazed/Cargo.toml
+++ b/src/blaze/crates/blazed/Cargo.toml
@@ -24,13 +24,13 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+libc = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 http-body-util = { workspace = true }
 async-trait = { workspace = true }
-libc = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Daemon runtime: bind UDS, accept connections, wire signal handlers.
 
+use std::convert::Infallible;
+use std::future::Future;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -12,14 +14,18 @@ use blaze_core::pool::PoolManager;
 use blaze_core::storage::StorageProvider;
 use blaze_core::template::TemplateRegistry;
 use http_body_util::Full;
-use hyper::body::Bytes;
+use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
+use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
-use tokio::net::{TcpListener, UnixListener};
+use tokio::net::TcpListener;
 use tokio::signal::unix::{SignalKind, signal};
+use tokio::task::{JoinError, JoinSet};
+use tokio_util::sync::CancellationToken;
 
 use crate::api;
+use crate::daemon_socket::{DaemonLock, DaemonSocket, ensure_socket_lock_namespace};
 use crate::error::{BlazeDaemonError, Result};
 use crate::spawner::{
     BubblewrapSpawner, DynSpawner, FirecrackerSpawner, MockSpawner, SpawnerRegistry,
@@ -33,6 +39,8 @@ pub async fn run(config_path: &Path) -> Result<()> {
     tracing::info!(?config_path, "loaded daemon config");
 
     ensure_dirs(&config)?;
+    let socket_path = config.daemon.socket.clone();
+    let daemon_lock = DaemonLock::acquire(&config.daemon.state_dir, &socket_path)?;
     let policy = load_policy_engine(&config)?;
     let pool = PoolManager::new();
     let template = TemplateRegistry::new();
@@ -77,7 +85,6 @@ pub async fn run(config_path: &Path) -> Result<()> {
         Arc::new(fp)
     };
 
-    let socket_path = config.daemon.socket.clone();
     let http_addr = config.listen.http_addr.clone();
     let state = Arc::new(ServerState::build(
         config,
@@ -104,13 +111,7 @@ pub async fn run(config_path: &Path) -> Result<()> {
         );
     }
 
-    if socket_path.exists() {
-        std::fs::remove_file(&socket_path)?;
-    }
-    if let Some(parent) = socket_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let listener = UnixListener::bind(&socket_path)?;
+    let listener = DaemonSocket::bind(daemon_lock).await?;
     tracing::info!(socket = %socket_path.display(), "blaze UDS API listening");
 
     // Optional TCP listener for remote platform API
@@ -129,6 +130,17 @@ pub async fn run(config_path: &Path) -> Result<()> {
 
 fn ensure_dirs(cfg: &DaemonConfig) -> Result<()> {
     cfg.validate()?;
+    if let Some(parent) = cfg
+        .daemon
+        .socket
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Establish the lock namespace with its required mode before an
+    // overlapping configured directory can create it with ordinary defaults.
+    ensure_socket_lock_namespace(&cfg.daemon.socket)?;
     std::fs::create_dir_all(&cfg.daemon.state_dir)?;
     std::fs::create_dir_all(&cfg.template.dir)?;
     std::fs::create_dir_all(&cfg.storage.images_dir)?;
@@ -136,9 +148,6 @@ fn ensure_dirs(cfg: &DaemonConfig) -> Result<()> {
     let images_dir = std::fs::canonicalize(&cfg.storage.images_dir)?;
     let instances_dir = std::fs::canonicalize(&cfg.storage.instances_dir)?;
     blaze_core::config::validate_storage_paths(&images_dir, &instances_dir)?;
-    if let Some(parent) = cfg.daemon.socket.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     Ok(())
 }
 
@@ -247,13 +256,18 @@ fn load_policy_engine(cfg: &DaemonConfig) -> Result<PolicyEngine> {
     }
 }
 
-async fn serve(uds: UnixListener, tcp: Option<TcpListener>, state: Arc<ServerState>) -> Result<()> {
+async fn serve(
+    mut uds: DaemonSocket,
+    tcp: Option<TcpListener>,
+    state: Arc<ServerState>,
+) -> Result<()> {
     let mut sighup = signal(SignalKind::hangup())
         .map_err(|e| BlazeDaemonError::Internal(format!("install SIGHUP handler: {e}")))?;
     let mut sigterm = signal(SignalKind::terminate())
         .map_err(|e| BlazeDaemonError::Internal(format!("install SIGTERM handler: {e}")))?;
     let mut sigint = signal(SignalKind::interrupt())
         .map_err(|e| BlazeDaemonError::Internal(format!("install SIGINT handler: {e}")))?;
+    let mut connections = ConnectionTasks::new();
 
     loop {
         tokio::select! {
@@ -265,7 +279,7 @@ async fn serve(uds: UnixListener, tcp: Option<TcpListener>, state: Arc<ServerSta
                         continue;
                     }
                 };
-                spawn_conn(TokioIo::new(stream), state.clone());
+                spawn_conn(&mut connections, TokioIo::new(stream), state.clone());
             }
             res = async { match &tcp { Some(l) => l.accept().await, None => std::future::pending().await }}, if tcp.is_some() => {
                 let (stream, peer) = match res {
@@ -276,7 +290,10 @@ async fn serve(uds: UnixListener, tcp: Option<TcpListener>, state: Arc<ServerSta
                     }
                 };
                 tracing::debug!(?peer, "TCP connection");
-                spawn_conn(TokioIo::new(stream), state.clone());
+                spawn_conn(&mut connections, TokioIo::new(stream), state.clone());
+            }
+            Some(result) = connections.join_next(), if !connections.is_empty() => {
+                report_connection_result(result);
             }
             _ = sighup.recv() => {
                 tracing::info!("SIGHUP received: reloading policies");
@@ -295,24 +312,89 @@ async fn serve(uds: UnixListener, tcp: Option<TcpListener>, state: Arc<ServerSta
         }
     }
 
+    uds.stop_accepting();
+    drop(tcp);
+    connections.graceful_shutdown().await;
     tracing::info!("blaze daemon stopped");
     Ok(())
 }
 
-fn spawn_conn<I>(io: TokioIo<I>, state: Arc<ServerState>)
+struct ConnectionTasks {
+    tasks: JoinSet<()>,
+    shutdown: CancellationToken,
+}
+
+impl ConnectionTasks {
+    fn new() -> Self {
+        Self {
+            tasks: JoinSet::new(),
+            shutdown: CancellationToken::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    fn join_next(
+        &mut self,
+    ) -> impl Future<Output = Option<std::result::Result<(), JoinError>>> + '_ {
+        self.tasks.join_next()
+    }
+
+    fn spawn<F>(&mut self, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.tasks.spawn(task);
+    }
+
+    async fn graceful_shutdown(&mut self) {
+        self.shutdown.cancel();
+        while let Some(result) = self.tasks.join_next().await {
+            report_connection_result(result);
+        }
+    }
+}
+
+fn spawn_conn<I>(connections: &mut ConnectionTasks, io: TokioIo<I>, state: Arc<ServerState>)
 where
     I: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
-    tokio::spawn(async move {
-        let svc = service_fn(move |req| {
-            let state = state.clone();
-            async move { api::handle(req, state).await }
-        });
-        if let Err(err) = http1::Builder::new().serve_connection(io, svc).await {
+    spawn_conn_with_handler(connections, io, move |req| {
+        let state = state.clone();
+        async move { api::handle(req, state).await }
+    });
+}
+
+fn spawn_conn_with_handler<I, F, Fut>(connections: &mut ConnectionTasks, io: TokioIo<I>, handler: F)
+where
+    I: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+    F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = std::result::Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+{
+    let shutdown = connections.shutdown.clone();
+    connections.spawn(async move {
+        let connection = http1::Builder::new().serve_connection(io, service_fn(handler));
+        tokio::pin!(connection);
+
+        let result = tokio::select! {
+            result = &mut connection => result,
+            () = shutdown.cancelled() => {
+                connection.as_mut().graceful_shutdown();
+                connection.await
+            }
+        };
+        if let Err(err) = result {
             tracing::debug!(?err, "connection closed with error");
         }
-        let _: Option<Full<Bytes>> = None;
     });
+}
+
+fn report_connection_result(result: std::result::Result<(), JoinError>) {
+    if let Err(error) = result {
+        tracing::warn!(?error, "connection task failed");
+    }
 }
 
 fn reload_policies(state: &Arc<ServerState>) -> Result<()> {
@@ -334,4 +416,105 @@ fn reload_policies(state: &Arc<ServerState>) -> Result<()> {
     }
     tracing::info!(policies = count, "policy engine reloaded via SIGHUP");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+    use std::sync::Mutex;
+
+    use http_body_util::Full;
+    use tokio::io::AsyncWriteExt;
+    use tokio::sync::{Notify, oneshot};
+
+    use super::*;
+
+    fn daemon_config(temp: &tempfile::TempDir) -> DaemonConfig {
+        let mut config = DaemonConfig::default();
+        config.daemon.state_dir = temp.path().join("state");
+        config.daemon.socket = temp.path().join("api.sock");
+        config.template.dir = temp.path().join("templates");
+        config.storage.images_dir = temp.path().join("images");
+        config.storage.instances_dir = temp.path().join("instances");
+        config
+    }
+
+    #[tokio::test]
+    async fn startup_creates_overlapping_lock_namespace_with_private_mode() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut config = daemon_config(&temp);
+        config.daemon.state_dir = temp.path().join(".blaze-socket-locks");
+        config.daemon.socket = temp.path().join("daemon");
+
+        ensure_dirs(&config).expect("create configured directories");
+        let lock = DaemonLock::acquire(&config.daemon.state_dir, &config.daemon.socket)
+            .expect("claim daemon ownership");
+        let daemon = DaemonSocket::bind(lock)
+            .await
+            .expect("serve when state and socket lock namespace overlap");
+
+        let metadata =
+            std::fs::symlink_metadata(&config.daemon.state_dir).expect("lock namespace metadata");
+        assert!(metadata.file_type().is_dir());
+        assert_eq!(metadata.permissions().mode() & 0o7777, 0o700);
+        assert!(
+            std::fs::symlink_metadata(&config.daemon.socket)
+                .expect("daemon socket metadata")
+                .file_type()
+                .is_socket()
+        );
+        drop(daemon);
+    }
+
+    #[tokio::test]
+    async fn ownership_is_retained_until_inflight_request_finishes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let lock = DaemonLock::acquire(temp.path(), &socket_path).expect("claim daemon state");
+        let mut connections = ConnectionTasks::new();
+        let shutdown = connections.shutdown.clone();
+        let (server, mut client) = tokio::io::duplex(1024);
+        let (started_tx, started_rx) = oneshot::channel();
+        let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+        let release = Arc::new(Notify::new());
+        let handler_release = release.clone();
+
+        spawn_conn_with_handler(&mut connections, TokioIo::new(server), move |_request| {
+            let started_tx = started_tx.clone();
+            let release = handler_release.clone();
+            async move {
+                if let Some(started_tx) = started_tx.lock().expect("started lock").take() {
+                    started_tx.send(()).expect("publish request start");
+                }
+                release.notified().await;
+                Ok(Response::new(Full::new(Bytes::from_static(b"done"))))
+            }
+        });
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .expect("send request");
+        started_rx.await.expect("request entered handler");
+
+        let owner = tokio::spawn(async move {
+            let _lock = lock;
+            connections.graceful_shutdown().await;
+        });
+        shutdown.cancelled().await;
+
+        let error = DaemonLock::acquire(temp.path(), &socket_path)
+            .err()
+            .expect("in-flight request must retain daemon ownership");
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonStateAlreadyOwned { .. }
+        ));
+
+        release.notify_one();
+        owner.await.expect("daemon shutdown task");
+
+        let recovered =
+            DaemonLock::acquire(temp.path(), &socket_path).expect("ownership releases after drain");
+        drop(recovered);
+    }
 }

--- a/src/blaze/crates/blazed/src/daemon_socket.rs
+++ b/src/blaze/crates/blazed/src/daemon_socket.rs
@@ -1,0 +1,937 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Exclusive daemon state ownership and Unix-domain socket binding.
+
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{DirBuilderExt, FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::net::{UnixListener, UnixStream};
+use tokio::time::timeout;
+
+use crate::error::{BlazeDaemonError, Result};
+
+const LOCK_MODE: u32 = 0o600;
+const LOCK_DIRECTORY_MODE: u32 = 0o700;
+const SOCKET_LOCK_DIRECTORY: &str = ".blaze-socket-locks";
+const SOCKET_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// A bound API socket whose state ownership remains held for the same lifetime.
+pub(super) struct DaemonSocket {
+    listener: Option<UnixListener>,
+    _lock: DaemonLock,
+}
+
+impl DaemonSocket {
+    /// Examines and replaces the socket only under exclusive ownership.
+    pub(super) async fn bind(lock: DaemonLock) -> Result<Self> {
+        let socket_path = &lock.socket_path;
+        prepare_socket_path(socket_path).await?;
+        let listener =
+            UnixListener::bind(socket_path).map_err(|source| BlazeDaemonError::DaemonSocketIo {
+                path: socket_path.to_path_buf(),
+                source,
+            })?;
+        Ok(Self {
+            listener: Some(listener),
+            _lock: lock,
+        })
+    }
+
+    /// Accepts the next client while retaining exclusive daemon ownership.
+    pub(super) async fn accept(&self) -> io::Result<(UnixStream, tokio::net::unix::SocketAddr)> {
+        let listener = self.listener.as_ref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotConnected,
+                "daemon socket is no longer accepting connections",
+            )
+        })?;
+        listener.accept().await
+    }
+
+    /// Closes the listener while retaining daemon ownership for cleanup.
+    pub(super) fn stop_accepting(&mut self) {
+        self.listener.take();
+    }
+}
+
+/// Exclusive daemon ownership tied to one state directory and API socket.
+pub(super) struct DaemonLock {
+    state_file: File,
+    socket_file: Option<File>,
+    socket_path: PathBuf,
+}
+
+impl DaemonLock {
+    /// Acquires ownership before daemon subsystems begin startup.
+    pub(super) fn acquire(state_dir: &Path, socket_path: &Path) -> Result<Self> {
+        let canonical_state_dir =
+            fs::canonicalize(state_dir).map_err(|source| BlazeDaemonError::DaemonLockIo {
+                path: state_dir.to_path_buf(),
+                source,
+            })?;
+        let state_lock_path = state_lock_path_for(&canonical_state_dir);
+        let (state_file, state_metadata) = open_validated_lock_file(&state_lock_path)?;
+        lock_opened_file(&state_file, &state_lock_path, &state_metadata, || {
+            BlazeDaemonError::DaemonStateAlreadyOwned {
+                state_dir: canonical_state_dir,
+            }
+        })?;
+
+        let canonical_socket_path = canonicalize_socket_path(socket_path)?;
+        let socket_lock_path = socket_lock_path_for(&canonical_socket_path)?;
+        let (socket_file, socket_metadata) = open_validated_lock_file(&socket_lock_path)?;
+        let shared_lock_object = same_file_object(&state_metadata, &socket_metadata);
+
+        // A state directory may alias the endpoint lock namespace through a
+        // separate mount. Compare the validated objects rather than their path
+        // spellings so this process never contends with its own state lock.
+        let socket_file = if shared_lock_object {
+            validate_locked_path(&socket_lock_path, &socket_metadata).map_err(|reason| {
+                BlazeDaemonError::InvalidDaemonLock {
+                    path: socket_lock_path,
+                    reason,
+                }
+            })?;
+            None
+        } else {
+            lock_opened_file(&socket_file, &socket_lock_path, &socket_metadata, || {
+                BlazeDaemonError::DaemonSocketAlreadyOwned {
+                    socket: canonical_socket_path.clone(),
+                }
+            })?;
+            Some(socket_file)
+        };
+
+        // Every lock file is deliberately left on disk. Removing an advisory
+        // lock file would let a new process lock a different inode during
+        // teardown.
+        Ok(Self {
+            state_file,
+            socket_file,
+            socket_path: canonical_socket_path,
+        })
+    }
+}
+
+impl Drop for DaemonLock {
+    fn drop(&mut self) {
+        // SAFETY: every acquired file remains open while its advisory lock is
+        // released. Process termination still closes the descriptors and
+        // releases the locks if this destructor cannot run.
+        unsafe {
+            if let Some(socket_file) = &self.socket_file {
+                libc::flock(socket_file.as_raw_fd(), libc::LOCK_UN);
+            }
+            libc::flock(self.state_file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+fn state_lock_path_for(state_dir: &Path) -> PathBuf {
+    state_dir.join("daemon.lock")
+}
+
+fn canonicalize_socket_path(socket_path: &Path) -> Result<PathBuf> {
+    let file_name =
+        socket_path
+            .file_name()
+            .ok_or_else(|| BlazeDaemonError::InvalidDaemonSocket {
+                path: socket_path.to_path_buf(),
+                reason: "socket path must name an endpoint".to_string(),
+            })?;
+    let parent = socket_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let canonical_parent =
+        fs::canonicalize(parent).map_err(|source| BlazeDaemonError::DaemonSocketIo {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    Ok(canonical_parent.join(file_name))
+}
+
+fn socket_lock_path_for(socket_path: &Path) -> Result<PathBuf> {
+    let parent = socket_path
+        .parent()
+        .ok_or_else(|| BlazeDaemonError::InvalidDaemonSocket {
+            path: socket_path.to_path_buf(),
+            reason: "canonical socket path must have a parent directory".to_string(),
+        })?;
+    let file_name =
+        socket_path
+            .file_name()
+            .ok_or_else(|| BlazeDaemonError::InvalidDaemonSocket {
+                path: socket_path.to_path_buf(),
+                reason: "socket path must name an endpoint".to_string(),
+            })?;
+    let lock_directory = parent.join(SOCKET_LOCK_DIRECTORY);
+    ensure_lock_directory(&lock_directory)?;
+
+    let mut lock_name = OsString::from(file_name);
+    lock_name.push(".lock");
+    Ok(lock_directory.join(lock_name))
+}
+
+/// Creates and validates the socket lock namespace before other configured
+/// directories can create an overlapping path with ordinary permissions.
+pub(super) fn ensure_socket_lock_namespace(socket_path: &Path) -> Result<()> {
+    let canonical_socket_path = canonicalize_socket_path(socket_path)?;
+    let parent =
+        canonical_socket_path
+            .parent()
+            .ok_or_else(|| BlazeDaemonError::InvalidDaemonSocket {
+                path: socket_path.to_path_buf(),
+                reason: "canonical socket path must have a parent directory".to_string(),
+            })?;
+    ensure_lock_directory(&parent.join(SOCKET_LOCK_DIRECTORY))
+}
+
+fn ensure_lock_directory(path: &Path) -> Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(LOCK_DIRECTORY_MODE);
+    let created = match builder.create(path) {
+        Ok(()) => true,
+        Err(source) if source.kind() == io::ErrorKind::AlreadyExists => false,
+        Err(source) => {
+            return Err(BlazeDaemonError::DaemonLockIo {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    if created {
+        fs::set_permissions(path, fs::Permissions::from_mode(LOCK_DIRECTORY_MODE)).map_err(
+            |source| BlazeDaemonError::DaemonLockIo {
+                path: path.to_path_buf(),
+                source,
+            },
+        )?;
+    }
+
+    let metadata = fs::symlink_metadata(path).map_err(|source| BlazeDaemonError::DaemonLockIo {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let reason = if !metadata.file_type().is_dir() {
+        Some("lock namespace is not a directory".to_string())
+    } else if metadata.mode() & 0o7777 != LOCK_DIRECTORY_MODE {
+        Some(format!(
+            "lock namespace mode must be {LOCK_DIRECTORY_MODE:#o}, found {:#o}",
+            metadata.mode() & 0o7777
+        ))
+    } else {
+        // SAFETY: `geteuid` has no preconditions and does not modify memory.
+        let effective_uid = unsafe { libc::geteuid() };
+        (metadata.uid() != effective_uid).then(|| {
+            format!(
+                "lock namespace owner uid {} does not match effective uid {effective_uid}",
+                metadata.uid()
+            )
+        })
+    };
+    if let Some(reason) = reason {
+        return Err(BlazeDaemonError::InvalidDaemonLock {
+            path: path.to_path_buf(),
+            reason,
+        });
+    }
+    Ok(())
+}
+
+fn open_validated_lock_file(path: &Path) -> Result<(File, fs::Metadata)> {
+    let (file, created) = open_lock_file(path)?;
+    if created {
+        file.set_permissions(fs::Permissions::from_mode(LOCK_MODE))
+            .map_err(|source| BlazeDaemonError::DaemonLockIo {
+                path: path.to_path_buf(),
+                source,
+            })?;
+    }
+
+    let opened_metadata = validate_opened_lock(&file, path).map_err(|reason| {
+        BlazeDaemonError::InvalidDaemonLock {
+            path: path.to_path_buf(),
+            reason,
+        }
+    })?;
+
+    Ok((file, opened_metadata))
+}
+
+fn same_file_object(first: &fs::Metadata, second: &fs::Metadata) -> bool {
+    first.dev() == second.dev() && first.ino() == second.ino()
+}
+
+fn lock_opened_file<F>(
+    file: &File,
+    path: &Path,
+    opened_metadata: &fs::Metadata,
+    already_owned: F,
+) -> Result<()>
+where
+    F: FnOnce() -> BlazeDaemonError,
+{
+    // SAFETY: `file` owns a valid descriptor for the entire call. `flock`
+    // changes only the advisory lock associated with that open file.
+    let lock_result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if lock_result != 0 {
+        let source = io::Error::last_os_error();
+        if source.kind() == io::ErrorKind::WouldBlock {
+            return Err(already_owned());
+        }
+        return Err(BlazeDaemonError::DaemonLockIo {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
+
+    validate_locked_path(path, opened_metadata).map_err(|reason| {
+        BlazeDaemonError::InvalidDaemonLock {
+            path: path.to_path_buf(),
+            reason,
+        }
+    })?;
+    Ok(())
+}
+
+fn open_lock_file(path: &Path) -> Result<(File, bool)> {
+    match lock_options(true).open(path) {
+        Ok(file) => Ok((file, true)),
+        Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {
+            let file = lock_options(false).open(path).map_err(|source| {
+                BlazeDaemonError::DaemonLockIo {
+                    path: path.to_path_buf(),
+                    source,
+                }
+            })?;
+            Ok((file, false))
+        }
+        Err(source) => Err(BlazeDaemonError::DaemonLockIo {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn lock_options(create_new: bool) -> OpenOptions {
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create_new(create_new)
+        .mode(LOCK_MODE)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    options
+}
+
+fn validate_opened_lock(file: &File, path: &Path) -> std::result::Result<fs::Metadata, String> {
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("cannot inspect opened file: {error}"))?;
+    if !metadata.file_type().is_file() {
+        return Err("lock target is not a regular file".to_string());
+    }
+    if metadata.mode() & 0o7777 != LOCK_MODE {
+        return Err(format!(
+            "mode must be {LOCK_MODE:#o}, found {:#o}",
+            metadata.mode() & 0o7777
+        ));
+    }
+    // SAFETY: `geteuid` has no preconditions and does not modify memory.
+    let effective_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != effective_uid {
+        return Err(format!(
+            "owner uid {} does not match effective uid {effective_uid}",
+            metadata.uid()
+        ));
+    }
+    if metadata.nlink() != 1 {
+        return Err(format!(
+            "lock file must have one link, found {}",
+            metadata.nlink()
+        ));
+    }
+
+    let path_metadata =
+        fs::symlink_metadata(path).map_err(|error| format!("cannot inspect path: {error}"))?;
+    if path_metadata.file_type().is_symlink() {
+        return Err("lock path is a symbolic link".to_string());
+    }
+    if path_metadata.dev() != metadata.dev() || path_metadata.ino() != metadata.ino() {
+        return Err("lock path changed while it was opened".to_string());
+    }
+    Ok(metadata)
+}
+
+fn validate_locked_path(
+    path: &Path,
+    opened_metadata: &fs::Metadata,
+) -> std::result::Result<(), String> {
+    let path_metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("cannot inspect locked path: {error}"))?;
+    if path_metadata.file_type().is_symlink() {
+        return Err("lock path became a symbolic link".to_string());
+    }
+    if path_metadata.dev() != opened_metadata.dev() || path_metadata.ino() != opened_metadata.ino()
+    {
+        return Err("lock path changed while ownership was acquired".to_string());
+    }
+    if path_metadata.mode() & 0o7777 != LOCK_MODE {
+        return Err(format!(
+            "mode changed while ownership was acquired: found {:#o}",
+            path_metadata.mode() & 0o7777
+        ));
+    }
+    Ok(())
+}
+
+async fn prepare_socket_path(socket_path: &Path) -> Result<()> {
+    match fs::symlink_metadata(socket_path) {
+        Ok(metadata) if metadata.file_type().is_socket() => {
+            match timeout(SOCKET_PROBE_TIMEOUT, UnixStream::connect(socket_path)).await {
+                Ok(Ok(_stream)) => Err(BlazeDaemonError::DaemonSocketAlreadyOwned {
+                    socket: socket_path.to_path_buf(),
+                }),
+                Ok(Err(source)) if source.kind() == io::ErrorKind::ConnectionRefused => {
+                    fs::remove_file(socket_path).map_err(|source| {
+                        BlazeDaemonError::DaemonSocketIo {
+                            path: socket_path.to_path_buf(),
+                            source,
+                        }
+                    })
+                }
+                Ok(Err(source)) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+                Ok(Err(source)) => Err(BlazeDaemonError::DaemonSocketIo {
+                    path: socket_path.to_path_buf(),
+                    source,
+                }),
+                Err(_) => Err(BlazeDaemonError::InvalidDaemonSocket {
+                    path: socket_path.to_path_buf(),
+                    reason: "existing socket did not complete the ownership probe".to_string(),
+                }),
+            }
+        }
+        Ok(metadata) => {
+            let kind = if metadata.file_type().is_symlink() {
+                "symbolic link"
+            } else if metadata.is_dir() {
+                "directory"
+            } else {
+                "non-socket file"
+            };
+            Err(BlazeDaemonError::InvalidDaemonSocket {
+                path: socket_path.to_path_buf(),
+                reason: format!("existing path is a {kind}"),
+            })
+        }
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(BlazeDaemonError::DaemonSocketIo {
+            path: socket_path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use std::os::unix::net::UnixListener as StdUnixListener;
+    use std::process::{Command, Stdio};
+
+    const ABRUPT_EXIT_SOCKET_ENV: &str = "BLAZE_TEST_ABRUPT_EXIT_SOCKET";
+    const ABRUPT_EXIT_READY_ENV: &str = "BLAZE_TEST_ABRUPT_EXIT_READY";
+    const STALE_SOCKET_RETRY_TIMEOUT: Duration = Duration::from_secs(2);
+    const STALE_SOCKET_RETRY_INTERVAL: Duration = Duration::from_millis(10);
+    static SOCKET_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    async fn serialize_socket_test() -> tokio::sync::MutexGuard<'static, ()> {
+        // The abrupt-exit test starts a helper process. Between fork and exec,
+        // that helper can inherit another concurrent test's listener and keep
+        // its endpoint reachable after the parent test drops the listener.
+        SOCKET_TEST_LOCK.lock().await
+    }
+
+    fn socket_inode(path: &Path) -> u64 {
+        fs::symlink_metadata(path).expect("socket metadata").ino()
+    }
+
+    fn acquire_for_socket(path: &Path) -> Result<DaemonLock> {
+        DaemonLock::acquire(path.parent().expect("socket parent"), path)
+    }
+
+    async fn claim_and_bind(path: &Path) -> Result<DaemonSocket> {
+        DaemonSocket::bind(acquire_for_socket(path)?).await
+    }
+
+    async fn claim_and_bind_after_stale_release(path: &Path) -> Result<DaemonSocket> {
+        let deadline = tokio::time::Instant::now() + STALE_SOCKET_RETRY_TIMEOUT;
+        loop {
+            match claim_and_bind(path).await {
+                Err(error @ BlazeDaemonError::DaemonSocketAlreadyOwned { .. }) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(error);
+                    }
+                    // A parallel test can fork while this listener is open.
+                    // The child may briefly retain the listener until exec,
+                    // even though Drop has already released both lock files.
+                    tokio::time::sleep(STALE_SOCKET_RETRY_INTERVAL).await;
+                }
+                result => return result,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn second_daemon_cannot_replace_owned_socket() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let first = claim_and_bind(&socket_path)
+            .await
+            .expect("first daemon binds");
+        let first_inode = socket_inode(&socket_path);
+
+        let error = acquire_for_socket(&socket_path)
+            .err()
+            .expect("second daemon must be rejected");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonStateAlreadyOwned { .. }
+        ));
+        assert_eq!(socket_inode(&socket_path), first_inode);
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn same_state_directory_rejects_a_different_socket() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first_socket = temp.path().join("first.sock");
+        let second_socket = temp.path().join("second.sock");
+        let first = claim_and_bind(&first_socket)
+            .await
+            .expect("first daemon binds");
+
+        let error = acquire_for_socket(&second_socket)
+            .err()
+            .expect("the shared state directory must reject a second daemon");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonStateAlreadyOwned { .. }
+        ));
+        assert!(!second_socket.exists());
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn same_socket_rejects_a_different_state_directory() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first_state = temp.path().join("first-state");
+        let second_state = temp.path().join("second-state");
+        fs::create_dir(&first_state).expect("create first state directory");
+        fs::create_dir(&second_state).expect("create second state directory");
+        let socket_path = temp.path().join("api.sock");
+        let stale = StdUnixListener::bind(&socket_path).expect("bind stale socket");
+        drop(stale);
+        let first = DaemonSocket::bind(
+            DaemonLock::acquire(&first_state, &socket_path).expect("claim first daemon"),
+        )
+        .await
+        .expect("first daemon replaces stale socket");
+        let first_inode = socket_inode(&socket_path);
+
+        let error = DaemonLock::acquire(&second_state, &socket_path)
+            .err()
+            .expect("the shared socket must reject a second daemon");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonSocketAlreadyOwned { .. }
+        ));
+        assert_eq!(socket_inode(&socket_path), first_inode);
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn socket_lock_does_not_conflict_with_state_lock_name() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("daemon");
+
+        let daemon = claim_and_bind(&socket_path)
+            .await
+            .expect("state and socket ownership use separate lock namespaces");
+
+        assert!(
+            fs::symlink_metadata(&socket_path)
+                .expect("socket metadata")
+                .file_type()
+                .is_socket()
+        );
+        assert!(state_lock_path_for(temp.path()).is_file());
+        drop(daemon);
+    }
+
+    #[test]
+    fn shared_state_and_socket_lock_identity_is_acquired_once() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state_dir = temp.path().join(SOCKET_LOCK_DIRECTORY);
+        let state_alias = temp.path().join("state-alias");
+        fs::DirBuilder::new()
+            .mode(LOCK_DIRECTORY_MODE)
+            .create(&state_dir)
+            .expect("create shared lock directory");
+        symlink(&state_dir, &state_alias).expect("create state directory alias");
+        let socket_path = temp.path().join("daemon");
+
+        let daemon = DaemonLock::acquire(&state_alias, &socket_path)
+            .expect("one daemon may share its state and socket lock identity");
+
+        let state_error = DaemonLock::acquire(&state_dir, &temp.path().join("other.sock"))
+            .err()
+            .expect("the shared state identity remains exclusive");
+        assert!(matches!(
+            state_error,
+            BlazeDaemonError::DaemonStateAlreadyOwned { .. }
+        ));
+
+        let other_state = temp.path().join("other-state");
+        fs::create_dir(&other_state).expect("create other state directory");
+        let socket_error = DaemonLock::acquire(&other_state, &socket_path)
+            .err()
+            .expect("the shared socket identity remains exclusive");
+        assert!(matches!(
+            socket_error,
+            BlazeDaemonError::DaemonSocketAlreadyOwned { .. }
+        ));
+
+        drop(daemon);
+    }
+
+    #[test]
+    fn same_file_object_uses_opened_fd_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let lock_dir = temp.path().join("lock-dir");
+        let lock_alias = temp.path().join("lock-alias");
+        fs::create_dir(&lock_dir).expect("create lock directory");
+        symlink(&lock_dir, &lock_alias).expect("create lock directory alias");
+        let first_path = lock_dir.join("shared.lock");
+        let second_path = lock_alias.join("shared.lock");
+
+        let (first_file, first_metadata) =
+            open_validated_lock_file(&first_path).expect("open first lock path");
+        let (second_file, second_metadata) =
+            open_validated_lock_file(&second_path).expect("open aliased lock path");
+        let repeated_metadata = first_file.metadata().expect("inspect first lock again");
+
+        assert!(same_file_object(&first_metadata, &repeated_metadata));
+        assert_ne!(first_path, second_path);
+        assert_ne!(first_file.as_raw_fd(), second_file.as_raw_fd());
+        assert!(same_file_object(&first_metadata, &second_metadata));
+    }
+
+    #[tokio::test]
+    async fn socket_lock_name_remains_available_as_an_endpoint() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first_state = temp.path().join("first-state");
+        let second_state = temp.path().join("second-state");
+        fs::create_dir(&first_state).expect("create first state directory");
+        fs::create_dir(&second_state).expect("create second state directory");
+        let first_socket = temp.path().join("api.sock");
+        let second_socket = temp.path().join("api.sock.lock");
+        let first = DaemonSocket::bind(
+            DaemonLock::acquire(&first_state, &first_socket).expect("claim first daemon"),
+        )
+        .await
+        .expect("first daemon binds");
+
+        let second = DaemonSocket::bind(
+            DaemonLock::acquire(&second_state, &second_socket).expect("claim second daemon"),
+        )
+        .await
+        .expect("lock suffix remains a valid endpoint name");
+
+        assert!(
+            fs::symlink_metadata(&second_socket)
+                .expect("second socket metadata")
+                .file_type()
+                .is_socket()
+        );
+        drop(second);
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn canonical_state_directory_aliases_share_one_lock() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state_dir = temp.path().join("state");
+        let state_alias = temp.path().join("state-alias");
+        fs::create_dir(&state_dir).expect("create state directory");
+        symlink(&state_dir, &state_alias).expect("create state directory alias");
+        let first_socket = temp.path().join("first.sock");
+        let second_socket = temp.path().join("second.sock");
+        let first = DaemonLock::acquire(&state_dir, &first_socket).expect("first daemon locks");
+
+        let error = DaemonLock::acquire(&state_alias, &second_socket)
+            .err()
+            .expect("canonical aliases must contend on one lock");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonStateAlreadyOwned { .. }
+        ));
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn canonical_socket_directory_aliases_share_one_lock() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first_state = temp.path().join("first-state");
+        let second_state = temp.path().join("second-state");
+        let socket_dir = temp.path().join("socket-dir");
+        let socket_alias = temp.path().join("socket-alias");
+        fs::create_dir(&first_state).expect("create first state directory");
+        fs::create_dir(&second_state).expect("create second state directory");
+        fs::create_dir(&socket_dir).expect("create socket directory");
+        symlink(&socket_dir, &socket_alias).expect("create socket directory alias");
+        let first_socket = socket_dir.join("api.sock");
+        let second_socket = socket_alias.join("api.sock");
+        let first =
+            DaemonLock::acquire(&first_state, &first_socket).expect("first daemon locks socket");
+
+        let error = DaemonLock::acquire(&second_state, &second_socket)
+            .err()
+            .expect("canonical socket aliases must contend on one lock");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonSocketAlreadyOwned { .. }
+        ));
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn released_lock_is_immediate_and_stale_socket_is_eventually_replaced() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let first = claim_and_bind(&socket_path)
+            .await
+            .expect("first daemon binds");
+        drop(first);
+
+        let released = acquire_for_socket(&socket_path).expect("released lock is reusable");
+        drop(released);
+
+        let second = claim_and_bind_after_stale_release(&socket_path)
+            .await
+            .expect("stale socket becomes replaceable");
+
+        assert!(
+            fs::symlink_metadata(&socket_path)
+                .expect("replacement socket metadata")
+                .file_type()
+                .is_socket()
+        );
+        drop(second);
+    }
+
+    #[tokio::test]
+    async fn closing_listener_retains_daemon_ownership() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let mut daemon = claim_and_bind(&socket_path).await.expect("daemon binds");
+
+        daemon.stop_accepting();
+        let error = acquire_for_socket(&socket_path)
+            .err()
+            .expect("closed listener must retain daemon ownership");
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonStateAlreadyOwned { .. }
+        ));
+
+        drop(daemon);
+        let recovered = acquire_for_socket(&socket_path).expect("ownership releases with daemon");
+        drop(recovered);
+    }
+
+    #[tokio::test]
+    async fn lock_is_released_after_owner_process_exits_abruptly() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let ready_path = temp.path().join("lock-ready");
+        let status = Command::new(std::env::current_exe().expect("current test binary"))
+            .arg("--exact")
+            .arg("daemon_socket::tests::abrupt_exit_lock_helper")
+            .arg("--nocapture")
+            .env(ABRUPT_EXIT_SOCKET_ENV, &socket_path)
+            .env(ABRUPT_EXIT_READY_ENV, &ready_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("run abrupt-exit helper");
+
+        assert_eq!(status.code(), Some(73));
+        assert_eq!(
+            fs::read(&ready_path).expect("helper acquired lock"),
+            b"locked"
+        );
+
+        let recovered = acquire_for_socket(&socket_path).expect("kernel released process lock");
+        drop(recovered);
+    }
+
+    #[test]
+    fn abrupt_exit_lock_helper() {
+        let Some(socket_path) = std::env::var_os(ABRUPT_EXIT_SOCKET_ENV) else {
+            return;
+        };
+        let Some(ready_path) = std::env::var_os(ABRUPT_EXIT_READY_ENV) else {
+            return;
+        };
+        let _lock =
+            acquire_for_socket(Path::new(&socket_path)).expect("helper acquires daemon lock");
+        fs::write(ready_path, b"locked").expect("publish helper readiness");
+
+        // SAFETY: `_exit` terminates only this dedicated helper process. It
+        // intentionally skips Rust destructors to exercise kernel lock release.
+        unsafe {
+            libc::_exit(73);
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_socket_is_untouched_when_lock_is_held() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let stale = StdUnixListener::bind(&socket_path).expect("bind stale socket");
+        drop(stale);
+        let stale_inode = socket_inode(&socket_path);
+        let lock = acquire_for_socket(&socket_path).expect("hold daemon lock");
+
+        let error = acquire_for_socket(&socket_path)
+            .err()
+            .expect("competing daemon must be rejected");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonStateAlreadyOwned { .. }
+        ));
+        assert_eq!(socket_inode(&socket_path), stale_inode);
+        drop(lock);
+
+        let daemon = claim_and_bind(&socket_path)
+            .await
+            .expect("owner may replace stale socket");
+        assert!(
+            fs::symlink_metadata(&socket_path)
+                .expect("replacement socket metadata")
+                .file_type()
+                .is_socket()
+        );
+        drop(daemon);
+    }
+
+    #[tokio::test]
+    async fn symlinked_lock_is_rejected_without_touching_socket() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let stale = StdUnixListener::bind(&socket_path).expect("bind stale socket");
+        drop(stale);
+        let stale_inode = socket_inode(&socket_path);
+        let target = temp.path().join("lock-target");
+        File::create(&target).expect("create target");
+        symlink(
+            &target,
+            state_lock_path_for(socket_path.parent().expect("socket parent")),
+        )
+        .expect("create lock symlink");
+
+        assert!(acquire_for_socket(&socket_path).is_err());
+        assert_eq!(socket_inode(&socket_path), stale_inode);
+    }
+
+    #[tokio::test]
+    async fn live_socket_without_lock_is_preserved() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let legacy_listener =
+            StdUnixListener::bind(&socket_path).expect("bind legacy daemon socket");
+        let original_inode = socket_inode(&socket_path);
+        let lock = acquire_for_socket(&socket_path).expect("acquire new daemon lock");
+
+        let error = DaemonSocket::bind(lock)
+            .await
+            .err()
+            .expect("live socket must be rejected");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::DaemonSocketAlreadyOwned { .. }
+        ));
+        assert_eq!(socket_inode(&socket_path), original_inode);
+        drop(legacy_listener);
+    }
+
+    #[tokio::test]
+    async fn insecure_lock_mode_is_rejected_without_touching_socket() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        let stale = StdUnixListener::bind(&socket_path).expect("bind stale socket");
+        drop(stale);
+        let stale_inode = socket_inode(&socket_path);
+        let lock_path = state_lock_path_for(socket_path.parent().expect("socket parent"));
+        let lock = File::create(&lock_path).expect("create lock");
+        lock.set_permissions(fs::Permissions::from_mode(0o644))
+            .expect("set insecure mode");
+
+        let error = acquire_for_socket(&socket_path)
+            .err()
+            .expect("insecure lock must be rejected");
+
+        assert!(matches!(error, BlazeDaemonError::InvalidDaemonLock { .. }));
+        assert_eq!(socket_inode(&socket_path), stale_inode);
+    }
+
+    #[tokio::test]
+    async fn non_socket_endpoint_is_rejected_without_removal() {
+        let _test_guard = serialize_socket_test().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let socket_path = temp.path().join("api.sock");
+        fs::write(&socket_path, b"do not remove").expect("write endpoint sentinel");
+
+        let lock = acquire_for_socket(&socket_path).expect("acquire daemon lock");
+        let error = DaemonSocket::bind(lock)
+            .await
+            .err()
+            .expect("non-socket endpoint must be rejected");
+
+        assert!(matches!(
+            error,
+            BlazeDaemonError::InvalidDaemonSocket { .. }
+        ));
+        assert_eq!(
+            fs::read(&socket_path).expect("sentinel remains"),
+            b"do not remove"
+        );
+    }
+}

--- a/src/blaze/crates/blazed/src/error.rs
+++ b/src/blaze/crates/blazed/src/error.rs
@@ -60,6 +60,32 @@ pub enum BlazeDaemonError {
     #[error("operation requires recovery: {0}")]
     RecoveryRequired(String),
 
+    #[error("another blaze daemon already owns state directory {state_dir}")]
+    DaemonStateAlreadyOwned { state_dir: PathBuf },
+
+    #[error("another blaze daemon already owns API socket {socket}")]
+    DaemonSocketAlreadyOwned { socket: PathBuf },
+
+    #[error("cannot access daemon lock {path}: {source}")]
+    DaemonLockIo {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("refusing daemon lock {path}: {reason}")]
+    InvalidDaemonLock { path: PathBuf, reason: String },
+
+    #[error("cannot prepare daemon API socket {path}: {source}")]
+    DaemonSocketIo {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("refusing daemon API socket {path}: {reason}")]
+    InvalidDaemonSocket { path: PathBuf, reason: String },
+
     #[error("internal error: {0}")]
     Internal(String),
 }

--- a/src/blaze/crates/blazed/src/main.rs
+++ b/src/blaze/crates/blazed/src/main.rs
@@ -7,6 +7,7 @@
 mod api;
 mod cli;
 mod daemon;
+mod daemon_socket;
 mod error;
 #[cfg(feature = "test-failpoints")]
 mod failpoint;


### PR DESCRIPTION
## Why

`blazed` previously removed its configured Unix-domain socket before binding it. A second daemon could therefore replace a live endpoint and initialize the same persistent state directory concurrently.

Two separate identities must be protected: the persistent state directory and the API socket. Daemons sharing state must not run concurrently even when they use different sockets, and daemons sharing a socket must not race during stale endpoint replacement even when they use different state directories.

Startup reconciliation must run only after one process owns both identities. This PR establishes that ownership boundary without adding reconciliation or sandbox lifecycle behavior; it remains an independent follow-up to the lifecycle feature already merged in #2000.

Before this change:

```text
load config -> initialize subsystems -> remove configured socket -> bind -> serve
```

After this change:

```text
load config -> ensure directories
            -> claim canonical state directory and API socket
            -> initialize subsystems -> inspect and bind socket
            -> serve tracked connections
shutdown    -> stop listeners -> gracefully drain in-flight requests
            -> release socket and state ownership
```

## What changed

This PR contains one atomic commit:

- **`fix(blaze): claim daemon state ownership`** acquires persistent locks for the canonical state directory and canonical API socket before subsystem initialization.
- The state lock prevents concurrent use of persistent state. The socket lock serializes endpoint probing, stale removal, and binding across daemon configurations that use different state directories.
- Startup establishes the dedicated socket-lock namespace with mode `0700` before creating any overlapping configured directory, so a fresh shared-identity configuration does not fail its own validation.
- If the configured state and socket identities resolve to the same validated lock file, the daemon recognizes the opened file object by device and inode and acquires it once; distinct identities remain independently locked.
- Existing endpoints are inspected before binding: a live socket is preserved, only a stale socket is replaced, and unexpected lock or endpoint objects stop startup without being deleted.
- Accepted HTTP connections are tracked. SIGTERM and SIGINT stop new accepts, request graceful connection shutdown, and wait for in-flight handlers before both locks are released.

Tests cover shared state with different sockets, a shared socket with different state directories, identical state/socket lock identities (including file-object aliases), the real fresh-start directory path, canonical path aliases, abrupt process exit, stale socket recovery, invalid filesystem objects, and shutdown while a request is in flight.

The two locks, endpoint handling, connection draining, and regression tests belong in one commit because together they establish one invariant: another daemon cannot own either shared identity while the current daemon can still modify state or serve the endpoint.

## Related issue

closes #2194

#2000 has already merged; this bug fix is intentionally independent and can land afterward without changing the merged lifecycle API.

## User / Agent impact

A second daemon now fails before initialization when it shares either the configured state directory or API socket with a running daemon. During graceful shutdown, the daemon stops accepting new connections and completes in-flight requests before releasing ownership. Restart after an abrupt process exit can reclaim both locks and replace a stale socket.

There are no CLI, API, or configuration-schema changes.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The daemon creates `daemon.lock` in its canonical state directory and a socket-specific lock beneath `.blaze-socket-locks` in the canonical socket parent. Both files use mode `0600` and deliberately remain in place between runs. When both configured identities refer to the same validated file object, that object is acquired once rather than self-contending. An existing lock with unexpected ownership, mode, type, or link count causes startup to fail rather than modifying that object.

Graceful shutdown waits for accepted requests to finish. An operator can still terminate an unresponsive process forcibly; process exit releases both kernel-managed locks.

The change remains compatible with an older running daemon: if its socket is reachable but no socket lock exists, the new daemon preserves that socket and exits.

## Validation

Verified from exact commit `61435a23e99445cb5c2b7ff78967d742c3f2cb36`, exported with `git archive` and unpacked into fresh source and target directories on Linux x86_64:

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo build --workspace --all-targets --locked`
- `cargo build --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked` — 171 passed (52 `blaze-core`, 119 `blazed`)
- `cargo test --workspace --all-features --locked` — 181 passed (52 `blaze-core`, 129 `blazed`)
- default and all-feature `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- fresh-start shared-namespace regression — 1 passed
- daemon-socket regression suite — 18 passed

Focused regression coverage includes:

- `daemon::tests::startup_creates_overlapping_lock_namespace_with_private_mode`
- `daemon::tests::ownership_is_retained_until_inflight_request_finishes`
- `daemon_socket::tests::released_lock_is_immediate_and_stale_socket_is_eventually_replaced`
- `daemon_socket::tests::same_state_directory_rejects_a_different_socket`
- `daemon_socket::tests::same_socket_rejects_a_different_state_directory`
- `daemon_socket::tests::canonical_socket_directory_aliases_share_one_lock`
- `daemon_socket::tests::shared_state_and_socket_lock_identity_is_acquired_once`
- `daemon_socket::tests::same_file_object_uses_opened_fd_identity`

Hosted checks for this freshly pushed head are not yet being claimed.

## Documentation and rollback

No user documentation changes are required because the public CLI, API, and configuration schema are unchanged.

Reverting the single commit restores the previous startup behavior. The persistent lock files may remain; older code ignores them.