### PR TITLE
fix(cosh-ng): [shell] panel-family hint card

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/evidence/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/mod.rs
@@ -16,5 +16,7 @@ pub(crate) use context_window::{
 };
 pub(crate) use model::{evidence_capture_status_for_block, EvidenceCaptureStatus};
 pub(crate) use output_policy::output_excerpt_status_for_block;
-pub(crate) use output_text::{clean_terminal_control_sequences, redact_sensitive_output};
+pub(crate) use output_text::{
+    clean_terminal_control_sequences, redact_sensitive_output, ControlSequenceScanner,
+};
 pub(crate) use redaction::{redact_sensitive_text, truncate_provider_authored_command_text};

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/output_policy.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/output_policy.rs
@@ -717,7 +717,9 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).expect("dir");
         let output = dir.join("output.txt");
-        std::fs::write(&output, "\x1b[31mred\x1b[0m\r\nplain\x07\n").expect("write output");
+        // `ESC ( B` charset selection: the nF final byte must not leak
+        // into the excerpt (#2196 review: single stripping authority).
+        std::fs::write(&output, "\x1b(B\x1b[31mred\x1b[0m\r\nplain\x07\n").expect("write output");
         let output_ref = output.to_str().expect("utf8 output path");
 
         let excerpt =

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/output_text.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/output_text.rs
@@ -87,74 +87,164 @@ pub(super) fn redact_sensitive_output_with_policy(text: &str) -> (String, bool, 
 /// never match while the terminal still shows an ordinary assignment.
 pub(crate) fn clean_terminal_control_sequences(text: &str) -> String {
     let mut output = String::new();
-    let mut chars = text.chars().peekable();
-    while let Some(ch) = chars.next() {
-        match ch {
-            '\x1b' => match chars.peek() {
-                Some('[') => {
-                    chars.next();
-                    consume_csi_body(&mut chars);
-                }
-                Some(']') => {
-                    chars.next();
-                    consume_string_sequence_body(&mut chars, true);
-                }
-                Some('P') | Some('X') | Some('^') | Some('_') => {
-                    chars.next();
-                    consume_string_sequence_body(&mut chars, false);
-                }
-                // Bare ESC (or a two-byte escape): drop the introducer; any
-                // remaining byte is either consumed by later rules or plain
-                // printable text.
-                _ => {}
-            },
-            // C1 forms of the same introducers.
-            '\u{9b}' => consume_csi_body(&mut chars),
-            '\u{9d}' => consume_string_sequence_body(&mut chars, true),
-            '\u{90}' | '\u{98}' | '\u{9e}' | '\u{9f}' => {
-                consume_string_sequence_body(&mut chars, false)
-            }
-            '\r' => {}
-            _ if ch.is_control() && !matches!(ch, '\n' | '\t') => {}
-            _ if is_invisible_format_char(ch) => {}
-            _ => output.push(ch),
+    let mut scanner = ControlSequenceScanner::new();
+    for ch in text.chars() {
+        if let Some(visible) = scanner.push(ch) {
+            output.push(visible);
         }
     }
     output
 }
 
-/// Consumes a CSI body: everything up to and including the final byte in
-/// `@..=~`. An unterminated sequence consumes to the end (fail closed).
-fn consume_csi_body(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
-    for next in chars.by_ref() {
-        if ('@'..='~').contains(&next) {
-            break;
-        }
-    }
+/// Escape-sequence consumption state carried between characters, so the
+/// scan can resume across arbitrarily split input (#2196 review R7: the
+/// prompt-tail tracker feeds PTY chunks incrementally instead of
+/// re-cleaning the whole command output on every sample).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum ScanState {
+    /// Plain text; the next character is a visibility decision.
+    #[default]
+    Ground,
+    /// Saw ESC; the next character selects the sequence kind.
+    Escape,
+    /// Inside a CSI body, consuming to the final byte in `@..=~`; an
+    /// unterminated sequence consumes to the end (fail closed).
+    Csi,
+    /// Inside an OSC/DCS/SOS/PM/APC payload. ST (`ESC \` or C1 U+009C)
+    /// always terminates; OSC additionally accepts BEL. A payload ESC that
+    /// is NOT part of ST stays inside the payload — releasing the string
+    /// early would let the rest of a malformed payload flow into the
+    /// output. Unterminated payloads consume to the end (fail closed).
+    StringBody {
+        bel_terminates: bool,
+        pending_st: bool,
+    },
+    /// Inside nF intermediates (0x20..=0x2F), consuming to the final byte.
+    NfIntermediates,
 }
 
-/// Consumes an OSC/DCS/SOS/PM/APC payload up to its terminator.
-///
-/// ST (`ESC \` or C1 `U+009C`) always terminates; OSC additionally accepts
-/// BEL. A bare ESC that is NOT part of ST stays inside the payload and
-/// consumption continues — releasing the string early would let the rest of
-/// a malformed payload flow into the output. Unterminated payloads consume
-/// to the end (fail closed) so they can never leak.
-fn consume_string_sequence_body(
-    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
-    bel_terminates: bool,
-) {
-    while let Some(next) = chars.next() {
-        match next {
-            '\u{7}' if bel_terminates => break,
-            '\u{9c}' => break,
-            '\x1b' if chars.peek() == Some(&'\\') => {
-                chars.next();
-                break;
+/// Streaming form of [`clean_terminal_control_sequences`]: identical
+/// semantics, one character at a time, with the consumption state held
+/// between calls so input may be split anywhere (chunk boundaries included).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ControlSequenceScanner {
+    state: ScanState,
+}
+
+impl ControlSequenceScanner {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feeds one character; returns it when it is visible output.
+    pub(crate) fn push(&mut self, ch: char) -> Option<char> {
+        match self.state {
+            ScanState::Ground => match ch {
+                '\x1b' => {
+                    self.state = ScanState::Escape;
+                    None
+                }
+                // C1 forms of the introducers.
+                '\u{9b}' => {
+                    self.state = ScanState::Csi;
+                    None
+                }
+                '\u{9d}' => {
+                    self.state = ScanState::StringBody {
+                        bel_terminates: true,
+                        pending_st: false,
+                    };
+                    None
+                }
+                '\u{90}' | '\u{98}' | '\u{9e}' | '\u{9f}' => {
+                    self.state = ScanState::StringBody {
+                        bel_terminates: false,
+                        pending_st: false,
+                    };
+                    None
+                }
+                '\r' => None,
+                _ if ch.is_control() && !matches!(ch, '\n' | '\t') => None,
+                _ if is_invisible_format_char(ch) => None,
+                _ => Some(ch),
+            },
+            ScanState::Escape => match ch {
+                '[' => {
+                    self.state = ScanState::Csi;
+                    None
+                }
+                ']' => {
+                    self.state = ScanState::StringBody {
+                        bel_terminates: true,
+                        pending_st: false,
+                    };
+                    None
+                }
+                'P' | 'X' | '^' | '_' => {
+                    self.state = ScanState::StringBody {
+                        bel_terminates: false,
+                        pending_st: false,
+                    };
+                    None
+                }
+                // nF sequences such as charset selection `ESC ( B`: consume
+                // the intermediates plus the final byte, so the final can
+                // never leak as visible text (#2196 review: single
+                // stripping authority).
+                '\u{20}'..='\u{2f}' => {
+                    self.state = ScanState::NfIntermediates;
+                    None
+                }
+                // ECMA-48 two-byte escapes (`ESC Fp`/`ESC Fe`/`ESC Fs`,
+                // e.g. the keypad-mode `ESC =` that terminfo smkx emits):
+                // consume the final byte so it cannot leak as visible text
+                // (#2196 review R6: a pager starting under an agent handoff
+                // put `=` into the input-wait hint card).
+                '\u{30}'..='\u{7e}' => {
+                    self.state = ScanState::Ground;
+                    None
+                }
+                // ESC ESC: the second ESC re-arms the escape state.
+                '\x1b' => None,
+                // Bare ESC followed by a control byte: drop the introducer;
+                // the byte takes its ground meaning.
+                _ => {
+                    self.state = ScanState::Ground;
+                    self.push(ch)
+                }
+            },
+            ScanState::Csi => {
+                if ('@'..='~').contains(&ch) {
+                    self.state = ScanState::Ground;
+                }
+                None
             }
-            // A bare ESC that is not ST belongs to the (malformed) payload;
-            // keep consuming until a real terminator or the end of input.
-            _ => {}
+            ScanState::StringBody {
+                bel_terminates,
+                pending_st,
+            } => {
+                if pending_st && ch == '\\' {
+                    self.state = ScanState::Ground;
+                    return None;
+                }
+                match ch {
+                    '\u{7}' if bel_terminates => self.state = ScanState::Ground,
+                    '\u{9c}' => self.state = ScanState::Ground,
+                    _ => {
+                        self.state = ScanState::StringBody {
+                            bel_terminates,
+                            pending_st: ch == '\x1b',
+                        }
+                    }
+                }
+                None
+            }
+            ScanState::NfIntermediates => {
+                if !('\u{20}'..='\u{2f}').contains(&ch) {
+                    self.state = ScanState::Ground;
+                }
+                None
+            }
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/public.rs
@@ -4,7 +4,9 @@ mod output_text;
 mod redaction;
 
 pub(crate) use model::{evidence_capture_status_for_block, EvidenceCaptureStatus};
-pub(crate) use output_text::redact_sensitive_output;
+pub(crate) use output_text::{
+    clean_terminal_control_sequences, redact_sensitive_output, ControlSequenceScanner,
+};
 
 pub use context_window::{
     build_context_window, build_related_history_index, context_blocks_from_entries,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
@@ -206,6 +206,20 @@ pub(crate) fn run_raw(
         .unwrap_or_default();
     // #2025: the relay renders the input-wait hint card itself.
     config.hint_language = inline_state.language;
+    // #2179: inject the panel-family framing so the relay-side hint card
+    // shares the NoticePanel width contract, closed borders, and plain
+    // fallback with every other panel. `for_terminal()` re-reads the
+    // terminal width per emission, so resizes are picked up for free.
+    let hint_card_language = inline_state.language;
+    config.set_hint_card_renderer(move |title, body| {
+        crate::ui::agent_render::RatatuiInlineRenderer::for_terminal()
+            .with_language(hint_card_language)
+            .notice_panel_lines(crate::ui::agent_render::NoticePanelModel {
+                title,
+                body,
+                footer: None,
+            })
+    });
     match cosh_config.analysis_mode.as_str() {
         "auto" => inline_state.analysis_mode = AnalysisMode::Auto,
         "manual" => inline_state.analysis_mode = AnalysisMode::Manual,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
@@ -18,6 +18,7 @@ mod routing;
 mod scripted;
 
 pub use line_interactive::{run_line_interactive_bash, LineInteractiveOutput};
+pub(crate) use model::HintCardRenderer;
 pub use model::{ScriptedInput, ShellHostConfig, ShellHostOutput};
 pub(crate) use raw_relay::interactive_sentinel::InputWaitStatus;
 pub use raw_runner::{

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
@@ -30,6 +30,35 @@ impl std::fmt::Debug for ShellHistoryFileObserver {
     }
 }
 
+/// #2179: renders the input-wait hint card body into panel-family framed
+/// lines. Injected by the runtime bootstrap (which owns the UI renderer)
+/// so the relay-side sentinel emits the exact NoticePanel framing — width
+/// contract, closed borders, plain fallback — without the shell host
+/// depending on the UI layer.
+type HintCardRenderFn = dyn Fn(&str, Vec<String>) -> Vec<String> + Send + Sync + 'static;
+
+#[derive(Clone)]
+pub(crate) struct HintCardRenderer(Arc<HintCardRenderFn>);
+
+impl std::fmt::Debug for HintCardRenderer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("HintCardRenderer")
+    }
+}
+
+impl HintCardRenderer {
+    pub(crate) fn new<F>(render: F) -> Self
+    where
+        F: Fn(&str, Vec<String>) -> Vec<String> + Send + Sync + 'static,
+    {
+        Self(Arc::new(render))
+    }
+
+    pub(crate) fn render(&self, title: &str, body: Vec<String>) -> Vec<String> {
+        (self.0)(title, body)
+    }
+}
+
 impl ShellHistoryFileObserver {
     pub(super) fn new<F>(observer: F) -> Self
     where
@@ -82,6 +111,9 @@ pub struct ShellHostConfig {
     pub(crate) input_wait_status: InputWaitStatus,
     /// #2025/#2161: language for the relay-rendered input-wait hint card.
     pub(crate) hint_language: crate::config::Language,
+    /// #2179: panel-family renderer for the hint card; when absent the
+    /// sentinel stays fail-quiet and emits no card.
+    pub(crate) hint_card_renderer: Option<HintCardRenderer>,
     /// #2161: mirrors `shell.input_wait_timeout_secs` so the hint card can
     /// forecast the auto-interrupt (0 = disabled, no forecast line).
     pub(crate) input_wait_timeout_secs: u64,
@@ -107,6 +139,7 @@ impl ShellHostConfig {
             raw_action_watchdog: Duration::from_secs(120),
             input_wait_status: InputWaitStatus::default(),
             hint_language: crate::config::Language::default(),
+            hint_card_renderer: None,
             input_wait_timeout_secs: 120,
             shell_environment_observer: None,
             shell_history_file_observer: None,
@@ -121,6 +154,19 @@ impl ShellHostConfig {
     pub fn with_ai_enabled(mut self, enabled: bool) -> Self {
         self.input_classifier = self.input_classifier.with_ai_enabled(enabled);
         self
+    }
+
+    /// Installs the input-wait hint card frame renderer (#2196 review):
+    /// `new()` leaves it unset and the sentinel then stays fail-quiet, so
+    /// crate-external callers of the public raw relay entry points need
+    /// this to opt back into the card. The closure receives the card
+    /// title and body lines and returns the framed lines to emit; the
+    /// in-process runtime injects the NoticePanel framing here.
+    pub fn set_hint_card_renderer<F>(&mut self, render: F)
+    where
+        F: Fn(&str, Vec<String>) -> Vec<String> + Send + Sync + 'static,
+    {
+        self.hint_card_renderer = Some(HintCardRenderer::new(render));
     }
 
     pub(crate) fn set_shell_environment_observer<F>(&mut self, observer: F)

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -1,11 +1,14 @@
 // Owner: shell_host. Routing marker handling is isolated in osc/routing.rs;
 // the pending-handoff claim slot (#2142) is owned by osc/handoff_claim.rs;
-// alt-screen tracking (#2025) is owned by osc/alt_screen.rs.
+// alt-screen tracking (#2025) is owned by osc/alt_screen.rs; CurrentCommand
+// state and the display-window helpers are owned by osc/command.rs.
 mod alt_screen;
+mod command;
 mod handoff_claim;
 mod routing;
 
 use alt_screen::AltScreenTracker;
+use command::CurrentCommand;
 use handoff_claim::{
     claim_pending_command_origin, pending_origin_for_request, PendingCommandOrigin,
 };
@@ -41,19 +44,6 @@ const ERASE_TO_END_OF_LINE: &[u8] = b"\x1b[K";
 const BEL: u8 = b'\x07';
 const SHELL_PATH_MAX_BYTES: usize = 8 * 1024;
 const SHELL_HISTORY_FILE_MAX_BYTES: usize = 4 * 1024;
-
-#[derive(Debug)]
-struct CurrentCommand {
-    id: String,
-    command: String,
-    cwd: String,
-    origin: CommandOrigin,
-    audit_identity: Option<ShellCommandAuditIdentity>,
-    started_at_ms: u64,
-    output_start: usize,
-    attempt_generation: Option<u64>,
-    shell_environment_generation: Option<u64>,
-}
 
 /// Why a display cut was recorded, so consumers can tell an intercepted
 /// input (shell has not painted a prompt for it yet) apart from a real
@@ -494,12 +484,6 @@ impl OscParser {
         self.alt_screen.active()
     }
 
-    /// #2025: origin of the command currently tracked between preexec and
-    /// precmd, used by the interactive sentinel's trigger gate.
-    pub(super) fn active_command_origin(&self) -> Option<CommandOrigin> {
-        self.current.as_ref().map(|current| current.origin)
-    }
-
     fn filter_pending_handoff_echo(&mut self, data: &[u8]) -> Vec<u8> {
         let mut output = Vec::with_capacity(data.len());
         for byte in data.iter().copied() {
@@ -665,29 +649,6 @@ impl OscParser {
 
     pub(super) fn drain_intervention_display_cuts(&mut self) -> Vec<(usize, DisplayCutKind)> {
         std::mem::take(&mut self.intervention_display_cuts)
-    }
-
-    /// True while a marker-tracked foreground command is running (between
-    /// its preexec and precmd markers).
-    pub(super) fn has_active_foreground_command(&self) -> bool {
-        self.current.is_some()
-    }
-
-    pub(super) fn last_prompt_display(&self) -> &[u8] {
-        let Some(start) = self.last_prompt_display_start else {
-            return &[];
-        };
-        if start >= self.display.len() {
-            return &[];
-        }
-        &self.display[start..]
-    }
-
-    /// True after the shell's post-hook marker is followed by visible prompt
-    /// bytes, excluding output produced by user prompt hooks.
-    pub(super) fn has_prompt_painted_since_ready(&self) -> bool {
-        self.prompt_ready_display_start
-            .is_some_and(|start| start < self.display.len())
     }
 
     /// Arms the one-shot blank-echo drop for the synthetic PS1 repaint

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -9,6 +9,7 @@ mod routing;
 
 use alt_screen::AltScreenTracker;
 use command::CurrentCommand;
+pub(crate) use command::{VisibleTailTracker, VISIBLE_TAIL_MAX_CHARS};
 use handoff_claim::{
     claim_pending_command_origin, pending_origin_for_request, PendingCommandOrigin,
 };
@@ -91,6 +92,9 @@ pub(super) struct OscParser {
     /// invalidation barrier; a fresh command-less prompt report
     /// (`ShellReady`) re-arms it.
     pty_input_barrier_pushed: bool,
+    /// #2196 R7: bounded last-visible-line tracker for the active command,
+    /// fed incrementally per PTY chunk; owned by osc/command.rs.
+    visible_tail: VisibleTailTracker,
     /// #2025: alternate-screen tracking, owned by osc/alt_screen.rs.
     alt_screen: AltScreenTracker,
 }
@@ -137,6 +141,7 @@ impl OscParser {
             history_file_observer: None,
             main_prompt_gate: crate::raw_input::MainPromptGate::default(),
             pty_input_barrier_pushed: false,
+            visible_tail: VisibleTailTracker::default(),
             alt_screen: AltScreenTracker::default(),
         }
     }
@@ -269,6 +274,10 @@ impl OscParser {
             }
             "preexec" => {
                 self.main_prompt_gate.set_at_prompt(false);
+                // #2196 R7: the visible-tail window starts at the command
+                // boundary, so earlier output can never resurface as the
+                // prompt tail.
+                self.visible_tail.reset();
                 let command = marker.command.unwrap_or_default();
                 self.command_seq += 1;
                 let command_id = format!("cmd-{}", self.command_seq);
@@ -474,6 +483,7 @@ impl OscParser {
             return;
         }
         self.alt_screen.observe(&data);
+        self.visible_tail.feed(&data);
         self.display.extend_from_slice(&data);
         self.append_clean(&data);
     }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
@@ -1,7 +1,11 @@
-// Owner: shell_host. CurrentCommand state and the prompt display-window
-// helpers, carved out of osc.rs (#2196 review: the file had crossed the
-// 1000-line growth bar); `OscParser` keeps thin delegation over this data.
+// Owner: shell_host. CurrentCommand state, the prompt display-window
+// helpers, and the bounded visible-tail tracker, carved out of osc.rs
+// (#2196 review: the file had crossed the 1000-line growth bar);
+// `OscParser` keeps thin delegation over this data.
+use std::collections::VecDeque;
+
 use super::OscParser;
+use crate::evidence::ControlSequenceScanner;
 use crate::types::{CommandOrigin, ShellCommandAuditIdentity};
 
 /// A foreground command tracked between its preexec and precmd markers.
@@ -18,6 +22,143 @@ pub(super) struct CurrentCommand {
     pub(super) shell_environment_generation: Option<u64>,
 }
 
+/// Upper bound (in chars) for a visible line to stay a prompt-tail
+/// candidate. Real prompts fit comfortably; a longer line is log spill —
+/// and returning only its trailing window would hand
+/// `redact_sensitive_text` a suffix with the field-name prefix cut off,
+/// bypassing redaction (#2196 review R8) — so over-long lines are
+/// disqualified outright instead of truncated.
+pub(crate) const VISIBLE_TAIL_MAX_CHARS: usize = 512;
+
+/// Incrementally tracks the last non-blank VISIBLE line of the active
+/// command's output (#2196 review R7): the previous design re-cleaned the
+/// whole `display` window on every sentinel sample, which turned an
+/// approved handoff that logs hundreds of MB before blocking in `read`
+/// into an O(output) scan-and-copy inside the relay's main loop. The
+/// tracker instead consumes each PTY chunk once as it is appended, carries
+/// the escape-scanner state and any split UTF-8 char across chunk
+/// boundaries, and disqualifies lines beyond [`VISIBLE_TAIL_MAX_CHARS`]
+/// (fail-safe per R8: no tail rather than a redaction-bypassing suffix),
+/// so sampling is O(1) and retained state has a hard bound.
+#[derive(Debug, Default)]
+pub(crate) struct VisibleTailTracker {
+    scanner: ControlSequenceScanner,
+    /// Last completed non-blank visible line (bounded by construction:
+    /// only lines that never overflowed are stored).
+    last_nonblank: Option<String>,
+    /// Visible chars of the still-unfinished line (bounded).
+    pending: VecDeque<char>,
+    /// The unfinished line overflowed the candidate bound: its content is
+    /// dropped, the line stays disqualified until the next newline, and
+    /// completing it acts as a barrier that also clears `last_nonblank`
+    /// (R9: never fall back to output older than the over-long line).
+    pending_disqualified: bool,
+    /// Bytes of a UTF-8 char split across chunk boundaries (max 3).
+    utf8_carry: Vec<u8>,
+}
+
+impl VisibleTailTracker {
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub(crate) fn feed(&mut self, data: &[u8]) {
+        let mut bytes;
+        let mut input = if self.utf8_carry.is_empty() {
+            data
+        } else {
+            bytes = std::mem::take(&mut self.utf8_carry);
+            bytes.extend_from_slice(data);
+            &bytes[..]
+        };
+        loop {
+            match std::str::from_utf8(input) {
+                Ok(valid) => {
+                    self.feed_chars(valid);
+                    return;
+                }
+                Err(err) => {
+                    let (valid, rest) = input.split_at(err.valid_up_to());
+                    // SAFETY of interpretation: `valid_up_to` guarantees
+                    // the prefix is valid UTF-8.
+                    self.feed_chars(std::str::from_utf8(valid).unwrap_or(""));
+                    match err.error_len() {
+                        // Incomplete char at the end: carry it into the
+                        // next chunk.
+                        None => {
+                            self.utf8_carry = rest.to_vec();
+                            return;
+                        }
+                        // Invalid bytes mid-stream: substitute like the
+                        // lossy decode the batch path used.
+                        Some(skip) => {
+                            if let Some(replaced) = self.scanner.push('\u{fffd}') {
+                                self.push_visible(replaced);
+                            }
+                            input = &rest[skip..];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn feed_chars(&mut self, text: &str) {
+        for ch in text.chars() {
+            if let Some(visible) = self.scanner.push(ch) {
+                self.push_visible(visible);
+            }
+        }
+    }
+
+    fn push_visible(&mut self, visible: char) {
+        if visible == '\n' {
+            if self.pending_disqualified {
+                // R9: the finished over-long line is a BARRIER, not a
+                // skip — dropping only the line itself would fall back to
+                // an older `last_nonblank` and replay unrelated output as
+                // the prompt. Everything before the barrier loses
+                // candidacy; only lines after it can become the tail.
+                self.last_nonblank = None;
+            } else if !self.pending.iter().all(|c| c.is_whitespace()) {
+                self.last_nonblank = Some(self.pending.iter().collect());
+            }
+            self.pending.clear();
+            self.pending_disqualified = false;
+            return;
+        }
+        if self.pending_disqualified {
+            return;
+        }
+        if self.pending.len() == VISIBLE_TAIL_MAX_CHARS {
+            // R8: dropping the front would hand redaction a suffix with
+            // the sensitive field name cut off; the whole line loses tail
+            // candidacy instead.
+            self.pending.clear();
+            self.pending_disqualified = true;
+            return;
+        }
+        self.pending.push_back(visible);
+    }
+
+    /// Last non-blank visible line so far: the unfinished line when it has
+    /// visible content, otherwise the last completed non-blank candidate
+    /// line (#2179: with `echo "prompt"` + `read` the newline-terminated
+    /// prompt leaves the final unfinished line empty). An over-long
+    /// unfinished line yields NO tail at all (R8): the cursor sits on a
+    /// non-candidate line, and surfacing an earlier line would present
+    /// unrelated output as the prompt.
+    pub(crate) fn tail(&self) -> String {
+        if self.pending_disqualified {
+            return String::new();
+        }
+        if !self.pending.iter().all(|c| c.is_whitespace()) {
+            return self.pending.iter().collect();
+        }
+        self.last_nonblank.clone().unwrap_or_default()
+    }
+}
+
 impl OscParser {
     /// #2025: origin of the command currently tracked between preexec and
     /// precmd, used by the interactive sentinel's trigger gate.
@@ -29,6 +170,17 @@ impl OscParser {
     /// its preexec and precmd markers).
     pub(crate) fn has_active_foreground_command(&self) -> bool {
         self.current.is_some()
+    }
+
+    /// Bounded last non-blank visible line of the running foreground
+    /// command's output (#2196 reviews: anchored at the preexec marker so
+    /// earlier commands' output is never replayed as the prompt, stripped
+    /// by the crate's one escape authority, and O(1) to sample).
+    pub(crate) fn active_command_visible_tail(&self) -> String {
+        if self.current.is_none() {
+            return String::new();
+        }
+        self.visible_tail.tail()
     }
 
     pub(crate) fn last_prompt_display(&self) -> &[u8] {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
@@ -1,0 +1,50 @@
+// Owner: shell_host. CurrentCommand state and the prompt display-window
+// helpers, carved out of osc.rs (#2196 review: the file had crossed the
+// 1000-line growth bar); `OscParser` keeps thin delegation over this data.
+use super::OscParser;
+use crate::types::{CommandOrigin, ShellCommandAuditIdentity};
+
+/// A foreground command tracked between its preexec and precmd markers.
+#[derive(Debug)]
+pub(super) struct CurrentCommand {
+    pub(super) id: String,
+    pub(super) command: String,
+    pub(super) cwd: String,
+    pub(super) origin: CommandOrigin,
+    pub(super) audit_identity: Option<ShellCommandAuditIdentity>,
+    pub(super) started_at_ms: u64,
+    pub(super) output_start: usize,
+    pub(super) attempt_generation: Option<u64>,
+    pub(super) shell_environment_generation: Option<u64>,
+}
+
+impl OscParser {
+    /// #2025: origin of the command currently tracked between preexec and
+    /// precmd, used by the interactive sentinel's trigger gate.
+    pub(crate) fn active_command_origin(&self) -> Option<CommandOrigin> {
+        self.current.as_ref().map(|current| current.origin)
+    }
+
+    /// True while a marker-tracked foreground command is running (between
+    /// its preexec and precmd markers).
+    pub(crate) fn has_active_foreground_command(&self) -> bool {
+        self.current.is_some()
+    }
+
+    pub(crate) fn last_prompt_display(&self) -> &[u8] {
+        let Some(start) = self.last_prompt_display_start else {
+            return &[];
+        };
+        if start >= self.display.len() {
+            return &[];
+        }
+        &self.display[start..]
+    }
+
+    /// True after the shell's post-hook marker is followed by visible prompt
+    /// bytes, excluding output produced by user prompt hooks.
+    pub(crate) fn has_prompt_painted_since_ready(&self) -> bool {
+        self.prompt_ready_display_start
+            .is_some_and(|start| start < self.display.len())
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/public.rs
@@ -10,3 +10,4 @@ pub use implementation::{
 };
 
 pub(crate) use implementation::run_streaming_line_bash;
+pub(crate) use implementation::HintCardRenderer;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -84,6 +84,7 @@ pub(super) fn read_raw_until_exit<W: Write, F>(
     input_wait_status: &InputWaitStatus,
     hint_i18n: &crate::i18n::I18n,
     input_wait_timeout_secs: u64,
+    hint_card_renderer: Option<&crate::shell_host::HintCardRenderer>,
 ) -> io::Result<bool>
 where
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
@@ -362,7 +363,7 @@ where
             input_wait_status,
             hint_i18n,
             input_wait_timeout_secs,
-            last_winsize.ws_col,
+            hint_card_renderer,
         )?;
         if let Some(watchdog) = watchdog {
             if watchdog.expired(driver_completed_at) {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::i18n::{I18n, MessageId};
+use crate::shell_host::HintCardRenderer;
 use crate::types::CommandOrigin;
 
 use super::super::osc::OscParser;
@@ -145,7 +146,9 @@ pub(crate) fn sample_interactive_state(master_fd: i32, shell_pgid: i32) -> Inter
 }
 
 /// One-shot inline hint card (spec Q6, user-decided 2026-08-04): a
-/// yellow-bordered notice card appended to the terminal stream once per
+/// NoticePanel-family card (#2179: same framing, width contract, and
+/// plain fallback as every other panel, produced by the injected
+/// [`HintCardRenderer`]) appended to the terminal stream once per
 /// episode/kind, followed by a redraw of the program's own prompt tail so
 /// the user's typing target visually returns to the bottom (continuity).
 /// Fullscreen (alt-screen) episodes render nothing: any in-screen insert
@@ -155,7 +158,7 @@ pub(crate) fn hint_card(
     prompt_tail: &str,
     i18n: &I18n,
     input_wait_timeout_secs: u64,
-    cols: u16,
+    renderer: &HintCardRenderer,
 ) -> Option<String> {
     if matches!(kind, InteractiveHintKind::Fullscreen { .. }) {
         return None;
@@ -175,44 +178,27 @@ pub(crate) fn hint_card(
     let (safe_tail, _) = crate::evidence::redact_sensitive_text(prompt_tail.trim_end());
     let safe_tail = safe_tail.trim().to_string();
 
-    let width = usize::from(cols).clamp(40, 100);
-    let inner = width - 2;
-    let mut lines: Vec<String> = Vec::new();
-    let title = i18n.t(MessageId::ShellInputWaitHintTitle);
-    let title_width = approx_display_width(title);
-    let dashes = inner.saturating_sub(title_width + 3);
-    lines.push(format!(
-        "\x1b[33m╭─ {title} {}\x1b[0m",
-        "─".repeat(dashes.max(1))
-    ));
-    let body_line = |text: &str, dim: bool| {
-        let clipped = clip_to_width(text, inner.saturating_sub(2));
-        if dim {
-            format!("\x1b[33m│\x1b[0m \x1b[2m{clipped}\x1b[0m")
-        } else {
-            format!("\x1b[33m│\x1b[0m {clipped}")
-        }
-    };
+    let mut body: Vec<String> = Vec::new();
     if safe_tail.is_empty() {
-        lines.push(body_line(kind_body, false));
+        body.push(kind_body.to_string());
     } else {
-        lines.push(body_line(&safe_tail, false));
-        lines.push(body_line(kind_body, true));
+        body.push(safe_tail.clone());
+        body.push(kind_body.to_string());
     }
-    lines.push(body_line(
-        i18n.t(MessageId::ShellInputWaitHintGuidanceBody),
-        true,
-    ));
+    body.push(
+        i18n.t(MessageId::ShellInputWaitHintGuidanceBody)
+            .to_string(),
+    );
     if input_wait_timeout_secs > 0 && timeout_eligible(kind) {
-        lines.push(body_line(
-            &i18n.format(
-                MessageId::ShellInputWaitHintTimeoutForecastBody,
-                &[("seconds", &input_wait_timeout_secs.to_string())],
-            ),
-            true,
+        body.push(i18n.format(
+            MessageId::ShellInputWaitHintTimeoutForecastBody,
+            &[("seconds", &input_wait_timeout_secs.to_string())],
         ));
     }
-    lines.push(format!("\x1b[33m╰{}\x1b[0m", "─".repeat(inner)));
+    let lines = renderer.render(i18n.t(MessageId::ShellInputWaitHintTitle), body);
+    if lines.is_empty() {
+        return None;
+    }
 
     let mut rendered = format!("\r\n{}\r\n", lines.join("\r\n"));
     if !safe_tail.is_empty() {
@@ -222,95 +208,6 @@ pub(crate) fn hint_card(
         rendered.push(' ');
     }
     Some(rendered)
-}
-
-/// Extracts the current unfinished display line (after the last newline),
-/// stripped of CSI/OSC escape sequences and control bytes — the "prompt
-/// tail" the foreground program is waiting on.
-pub(crate) fn prompt_tail_from_display(display: &[u8]) -> String {
-    let start = display
-        .iter()
-        .rposition(|&b| b == b'\n')
-        .map(|i| i + 1)
-        .unwrap_or(0);
-    let tail = String::from_utf8_lossy(&display[start..]);
-    strip_escape_sequences(&tail)
-}
-
-fn strip_escape_sequences(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut chars = text.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '\u{1b}' {
-            match chars.peek() {
-                Some('[') => {
-                    chars.next();
-                    for follow in chars.by_ref() {
-                        if follow.is_ascii_alphabetic() || follow == '~' {
-                            break;
-                        }
-                    }
-                }
-                // String-family introducers (OSC / DCS / SOS / PM / APC):
-                // consume until BEL or the ST pair `ESC \` (#2168 review:
-                // treating only OSC here left DCS/APC payloads visible).
-                Some(']' | 'P' | 'X' | '^' | '_') => {
-                    chars.next();
-                    while let Some(follow) = chars.next() {
-                        if follow == '\u{7}' {
-                            break;
-                        }
-                        if follow == '\u{1b}' && chars.peek() == Some(&'\\') {
-                            chars.next();
-                            break;
-                        }
-                    }
-                }
-                // nF sequences such as charset selection `ESC ( B`: consume
-                // intermediates (0x20..=0x2F) plus the final byte, instead
-                // of dropping a single char and leaking the final.
-                Some('\u{20}'..='\u{2f}') => {
-                    while let Some(&follow) = chars.peek() {
-                        chars.next();
-                        if !('\u{20}'..='\u{2f}').contains(&follow) {
-                            break;
-                        }
-                    }
-                }
-                _ => {
-                    chars.next();
-                }
-            }
-            continue;
-        }
-        if c == '\r' || c.is_control() {
-            continue;
-        }
-        out.push(c);
-    }
-    out
-}
-
-/// Coarse display width (ASCII = 1 column, everything else = 2): enough
-/// to keep the card border aligned for the zh/en copy and typical prompt
-/// tails without pulling a unicode-width dependency into the relay.
-fn approx_display_width(text: &str) -> usize {
-    text.chars().map(|c| if c.is_ascii() { 1 } else { 2 }).sum()
-}
-
-fn clip_to_width(text: &str, max_width: usize) -> String {
-    let mut width = 0;
-    let mut out = String::new();
-    for c in text.chars() {
-        let w = if c.is_ascii() { 1 } else { 2 };
-        if width + w > max_width.saturating_sub(1) {
-            out.push('…');
-            break;
-        }
-        width += w;
-        out.push(c);
-    }
-    out
 }
 
 /// Timeout eligibility for the #2161 input-wait interrupt: only kinds
@@ -449,7 +346,7 @@ pub(super) fn emit_interactive_hint_if_waiting<W: std::io::Write>(
     input_wait_status: &InputWaitStatus,
     hint_i18n: &I18n,
     input_wait_timeout_secs: u64,
-    cols: u16,
+    hint_card_renderer: Option<&HintCardRenderer>,
 ) -> std::io::Result<()> {
     let is_agent_handoff = matches!(
         parser.active_command_origin(),
@@ -484,16 +381,26 @@ pub(super) fn emit_interactive_hint_if_waiting<W: std::io::Write>(
         .map(std::mem::discriminant)
         .is_none_or(|seen| seen != std::mem::discriminant(&kind));
     if changed {
-        let prompt_tail = prompt_tail_from_display(&parser.display);
-        if let Some(card) = hint_card(
-            &kind,
-            &prompt_tail,
-            hint_i18n,
-            input_wait_timeout_secs,
-            cols,
-        ) {
-            output.write_all(card.as_bytes())?;
-            output.flush()?;
+        // #2179 fail-quiet: no injected panel renderer means no card, but
+        // the episode kind is still recorded so re-entry stays deduped.
+        if let Some(renderer) = hint_card_renderer {
+            // Prompt tail: the parser's incrementally maintained, bounded
+            // visible tail (#2196 reviews R1/R4/R5/R7 — window anchored at
+            // preexec, one escape-stripping authority with state carried
+            // across chunks, retained lines capped, O(1) per sample; the
+            // last non-blank visible line keeps the #2179 echo+read
+            // semantics).
+            let prompt_tail = parser.active_command_visible_tail();
+            if let Some(card) = hint_card(
+                &kind,
+                &prompt_tail,
+                hint_i18n,
+                input_wait_timeout_secs,
+                renderer,
+            ) {
+                output.write_all(card.as_bytes())?;
+                output.flush()?;
+            }
         }
         *shown = Some(kind);
     }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/interactive_sentinel_tests.rs
@@ -1,5 +1,26 @@
 use super::*;
 
+use super::super::super::osc::{VisibleTailTracker, VISIBLE_TAIL_MAX_CHARS};
+
+/// Test shim over the bounded tracker (#2196 R7): every input is fed
+/// twice — whole-buffer and byte-at-a-time — so each assertion also pins
+/// cross-chunk escape-state and UTF-8 carry invariance.
+fn prompt_tail_from_display(display: &[u8]) -> String {
+    let mut whole = VisibleTailTracker::default();
+    whole.feed(display);
+    let mut split = VisibleTailTracker::default();
+    for byte in display {
+        split.feed(std::slice::from_ref(byte));
+    }
+    let tail = whole.tail();
+    assert_eq!(
+        tail,
+        split.tail(),
+        "chunk-split feed must agree: {display:?}"
+    );
+    tail
+}
+
 fn snap(echo_off: bool, icanon: bool, blocked: bool) -> InteractiveSnapshot {
     InteractiveSnapshot {
         echo_off,
@@ -109,6 +130,15 @@ fn timeout_eligibility_requires_blocked_read_evidence() {
 #[test]
 fn hint_card_covers_presentation_contract() {
     let i18n = crate::i18n::I18n::new(crate::config::Language::EnUs);
+    // The layout gate forbids shell_host tests from reaching into the UI
+    // layer, so this fake stands in for the injected panel renderer; the
+    // real NoticePanel framing is asserted in ui/agent_render tests and
+    // the production closure lives in the runtime bootstrap.
+    let renderer = crate::shell_host::HintCardRenderer::new(|title, body| {
+        let mut lines = vec![format!("[{title}]")];
+        lines.extend(body);
+        lines
+    });
     // Fullscreen: in-screen insert exempt (D10) => nothing rendered.
     assert_eq!(
         hint_card(
@@ -116,7 +146,7 @@ fn hint_card_covers_presentation_contract() {
             "anything",
             &i18n,
             120,
-            80
+            &renderer
         ),
         None
     );
@@ -126,7 +156,7 @@ fn hint_card_covers_presentation_contract() {
         "Confirm? (y/n):",
         &i18n,
         120,
-        80,
+        &renderer,
     )
     .expect("card rendered");
     assert!(card.contains("Command is waiting for input"), "{card}");
@@ -136,24 +166,31 @@ fn hint_card_covers_presentation_contract() {
     );
     assert!(card.contains("Auto-interrupts after 120s"), "{card}");
     assert!(card.trim_end().ends_with("Confirm? (y/n):"), "{card}");
+    // The renderer owns the framing: sentinel lines reach it unframed and
+    // come back joined with raw-mode `\r\n` endings.
+    assert!(card.starts_with("\r\n["), "{card}");
     // Timeout disabled: no forecast line.
     let card = hint_card(
         &InteractiveHintKind::StdinWait,
         "Confirm? (y/n):",
         &i18n,
         0,
-        80,
+        &renderer,
     )
     .expect("card rendered");
     assert!(!card.contains("Auto-interrupts"), "{card}");
     // Empty tail (e.g. read -s without prompt text): kind body only,
     // no redraw suffix.
-    let card =
-        hint_card(&InteractiveHintKind::Password, "", &i18n, 120, 80).expect("card rendered");
+    let card = hint_card(&InteractiveHintKind::Password, "", &i18n, 120, &renderer)
+        .expect("card rendered");
     assert!(card.contains("password/hidden input"), "{card}");
-    assert!(
-        card.trim_end().ends_with('\u{1b}') || card.ends_with("\r\n"),
-        "{card}"
+    assert!(card.ends_with("\r\n"), "{card}");
+    // A renderer that yields nothing (e.g. plain sink filtered it away)
+    // collapses to no card at all, never a bare frame.
+    let empty = crate::shell_host::HintCardRenderer::new(|_, _| Vec::new());
+    assert_eq!(
+        hint_card(&InteractiveHintKind::Password, "", &i18n, 120, &empty),
+        None
     );
 }
 
@@ -164,26 +201,176 @@ fn prompt_tail_extraction_strips_escapes_and_controls() {
     assert_eq!(prompt_tail_from_display(b""), "");
     let osc = b"step\n\x1b]0;title\x07Grant it? ";
     assert_eq!(prompt_tail_from_display(osc), "Grant it? ");
+    // #2179: `echo "prompt"` + `read` leaves the final line empty; the
+    // extractor walks back to the last non-blank line so the card still
+    // echoes and replays the program's own question.
+    assert_eq!(
+        prompt_tail_from_display(b"=== step ===\nType y or n:\n"),
+        "Type y or n:"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"Type y or n:\n\x1b[0m \n"),
+        "Type y or n:"
+    );
+    assert_eq!(prompt_tail_from_display(b"\n\n\n"), "");
+
+    // #2196 review R4 matrix: stripping is a single stateful pass before
+    // line anchoring, so string-family payloads spanning LF never surface
+    // as fake prompt lines. Rows: introducer kind x terminator x trailing
+    // visible text (PM/SOS share the same introducer branch as APC).
+    assert_eq!(
+        prompt_tail_from_display(b"\x1b]0;hidden\nFAKE\x07"),
+        "",
+        "OSC payload spanning LF, BEL-terminated: nothing visible"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"\x1b]0;hidden\nFAKE\x07Type y or n: "),
+        "Type y or n: ",
+        "text after the BEL terminator is the real prompt"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"\x1b]0;hidden\nmore\x1b\\Grant it? "),
+        "Grant it? ",
+        "OSC payload spanning LF, ST-terminated"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"echo done\n\x1bPdcs\npayload\x1b\\prompt: "),
+        "prompt: ",
+        "DCS payload spanning LF, ST-terminated"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"\x1b_apc\nrest\x1b\\ok: "),
+        "ok: ",
+        "APC payload spanning LF, ST-terminated"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"\x1b^pm\nrest\x1b\\"),
+        "",
+        "PM payload spanning LF: fully hidden"
+    );
+    // #2196 review R5: BEL terminates OSC only; APC/DCS/SOS/PM run until
+    // ST, so a BEL inside the payload must not release the rest as text.
+    assert_eq!(
+        prompt_tail_from_display(b"\x1b_hidden\x07FAKE\x1b\\\n"),
+        "",
+        "APC containing BEL, ST-terminated, trailing LF: nothing visible"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"\x1bPhidden\x07still-hidden\x1b\\Type y or n: \n"),
+        "Type y or n: ",
+        "DCS containing BEL: only text after ST is the prompt"
+    );
+    assert_eq!(
+        prompt_tail_from_display(b"before\n\x1b]0;unterminated\nFAKE"),
+        "before",
+        "unterminated payload is consumed to the window end (fail-safe)"
+    );
+    // Multi-byte chars survive the byte-at-a-time feed (UTF-8 carry).
+    assert_eq!(
+        prompt_tail_from_display("回答完毕\n请输入密码: ".as_bytes()),
+        "请输入密码: "
+    );
+
+    // #2196 R7 bounds: a handoff that logs heavily before blocking must
+    // not require rescanning its output — the tracker is incremental and
+    // every retained line is capped.
+    let mut heavy = VisibleTailTracker::default();
+    for index in 0..100_000 {
+        heavy.feed(format!("log line {index} with padding\n").as_bytes());
+    }
+    heavy.feed(b"\x1b[1mType y or n: \x1b[0m");
+    assert_eq!(heavy.tail(), "Type y or n: ");
+    // #2196 R8: an over-long line loses tail candidacy outright — keeping
+    // only its trailing window would hand redaction a suffix with the
+    // sensitive field-name prefix cut off (`password=` + 600 chars), so
+    // the sanitized secret would reach the card verbatim.
+    let mut secret_line = VisibleTailTracker::default();
+    let mut assignment = b"password=".to_vec();
+    assignment.extend(std::iter::repeat_n(b'a', 600));
+    secret_line.feed(&assignment);
+    assert_eq!(
+        secret_line.tail(),
+        "",
+        "an over-long unfinished line must not surface any suffix"
+    );
+    let (redacted, _) = crate::evidence::redact_sensitive_text(&secret_line.tail());
+    assert!(!redacted.contains('a'), "nothing to redact, nothing leaked");
+    // R9: completing the over-long line is a barrier — the tail must not
+    // fall back to output older than it (`Status` here), it stays empty
+    // while the command blocks silently after the newline.
+    let mut barrier = VisibleTailTracker::default();
+    barrier.feed(b"Status\n");
+    barrier.feed(&assignment);
+    barrier.feed(b"\n");
+    assert_eq!(
+        barrier.tail(),
+        "",
+        "an over-long line must not fall back to earlier output"
+    );
+    // After the barrier, a normal prompt line recovers.
+    barrier.feed(b"Type y or n: ");
+    assert_eq!(barrier.tail(), "Type y or n: ");
+    secret_line.feed(b"\nType y or n: ");
+    assert_eq!(secret_line.tail(), "Type y or n: ");
+
+    // #2196 review: the tail is anchored on the active command's display
+    // window, so a previous command's output is never replayed as the
+    // prompt (a bare `read` with no output yields no tail at all).
+    let mut parser = OscParser::new(
+        "sentinel-prompt-window".to_string(),
+        std::env::temp_dir().join("cosh-sentinel-prompt-window"),
+        "test-marker-token".to_string(),
+    );
+    parser
+        .feed(b"stale previous output\n")
+        .expect("feed stale output");
+    assert_eq!(
+        parser.active_command_visible_tail(),
+        "",
+        "no active command means no window, even with session history"
+    );
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"preexec\",\"token\":\"test-marker-token\",\"session_id\":\"sentinel-prompt-window\",\"command\":\"read -s secret\",\"cwd\":\"/tmp\"}\x07")
+        .expect("feed preexec");
+    assert_eq!(
+        parser.active_command_visible_tail(),
+        "",
+        "a silent command must not inherit the previous command's output"
+    );
+    parser.feed(b"Type y or n:\n").expect("feed prompt");
+    assert_eq!(parser.active_command_visible_tail(), "Type y or n:");
 }
 
 #[test]
-fn strip_escape_sequences_covers_string_family_and_nf_variants() {
-    // DCS / APC payloads terminated by ST must not leak (#2168 review).
+fn prompt_tail_strips_string_family_and_nf_variants() {
+    // Terminator semantics are owned by the delegated
+    // `evidence::clean_terminal_control_sequences` (#2196 review R5):
+    // ST always terminates, BEL terminates OSC only.
     assert_eq!(
-        strip_escape_sequences("\x1bPpayload\x1b\\Continue? "),
+        prompt_tail_from_display(b"\x1bPpayload\x1b\\Continue? "),
         "Continue? "
     );
     assert_eq!(
-        strip_escape_sequences("\x1b_meta\x07Proceed? "),
-        "Proceed? "
+        prompt_tail_from_display(b"\x1b_meta\x07Proceed? "),
+        "",
+        "BEL does not end APC; the whole remainder stays hidden"
     );
     // Charset selection `ESC ( B` drops the final byte too.
-    assert_eq!(strip_escape_sequences("\x1b(BAnswer: "), "Answer: ");
-    // Two-char escapes and an orphan trailing ESC stay silent.
-    assert_eq!(strip_escape_sequences("\x1b=ok\x1b"), "ok");
+    assert_eq!(prompt_tail_from_display(b"\x1b(BAnswer: "), "Answer: ");
+    // ECMA-48 two-byte escapes consume their final byte (#2196 review R6:
+    // terminfo smkx ends in `ESC =`, so a pager starting under a handoff
+    // must not surface `=` as the prompt).
+    assert_eq!(prompt_tail_from_display(b"\x1b=ok\x1b"), "ok");
+    assert_eq!(
+        prompt_tail_from_display(b"\x1b[?1h\x1b="),
+        "",
+        "keypad-mode init alone leaves no visible prompt"
+    );
+    // An orphan trailing ESC stays silent.
+    assert_eq!(prompt_tail_from_display(b"ok\x1b"), "ok");
     // Unterminated string sequences swallow the tail (fail-quiet:
     // an empty tail suppresses the redraw, never shows raw bytes).
-    assert_eq!(strip_escape_sequences("\x1b]0;title"), "");
+    assert_eq!(prompt_tail_from_display(b"\x1b]0;title"), "");
 }
 
 #[cfg(target_os = "linux")]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -360,6 +360,7 @@ where
         &config.input_wait_status,
         &crate::i18n::I18n::new(config.hint_language),
         config.input_wait_timeout_secs,
+        config.hint_card_renderer.as_ref(),
     )?;
     let display_start = session.parser.display.len();
     session.parser.flush_pending();

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/mod.rs
@@ -238,9 +238,20 @@ impl RatatuiInlineRenderer {
         output: &mut W,
         model: NoticePanelModel<'_>,
     ) -> io::Result<()> {
+        for line in self.notice_panel_lines(model) {
+            writeln!(output, "{line}")?;
+        }
+        Ok(())
+    }
+
+    /// Offscreen form of [`Self::write_notice_panel`]: returns the fully
+    /// framed panel lines (no trailing newlines) so callers that own a
+    /// non-`Write` sink — such as the raw relay splicing a hint card into
+    /// a live PTY stream with `\r\n` endings — reuse the exact panel
+    /// family framing, width contract, and plain fallback.
+    pub fn notice_panel_lines(&self, model: NoticePanelModel<'_>) -> Vec<String> {
         let lines = model.body.into_iter().map(Line::from).collect();
-        self.write_block(
-            output,
+        self.block_lines(
             model.title,
             self.render_lines(lines, self.content_width()),
             model.footer,
@@ -280,23 +291,30 @@ impl RatatuiInlineRenderer {
         body: Vec<String>,
         footer: Option<&str>,
     ) -> io::Result<()> {
+        for line in self.block_lines(title, body, footer) {
+            writeln!(output, "{line}")?;
+        }
+        Ok(())
+    }
+
+    fn block_lines(&self, title: &str, body: Vec<String>, footer: Option<&str>) -> Vec<String> {
         if self.plain {
-            writeln!(output, "{title}:")?;
+            let mut out = vec![format!("{title}:")];
             for line in body {
                 if line.trim().is_empty() {
-                    writeln!(output)?;
+                    out.push(String::new());
                 } else {
-                    writeln!(output, "  {line}")?;
+                    out.push(format!("  {line}"));
                 }
             }
             if let Some(footer) = footer {
                 for line in
                     self.render_lines(vec![Line::from(footer.to_string())], self.content_width())
                 {
-                    writeln!(output, "  {line}")?;
+                    out.push(format!("  {line}"));
                 }
             }
-            return Ok(());
+            return out;
         }
 
         let mut lines = body;
@@ -305,11 +323,7 @@ impl RatatuiInlineRenderer {
                 self.render_lines(vec![Line::from(footer.to_string())], self.content_width()),
             );
         }
-        let rendered_lines = self.rich_block_lines(title, lines);
-        for line in rendered_lines {
-            writeln!(output, "{line}")?;
-        }
-        Ok(())
+        self.rich_block_lines(title, lines)
     }
 
     fn write_styled_block<W: Write>(

--- a/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ui/agent_render/tests.rs
@@ -156,6 +156,47 @@ fn streaming_agent_prefers_word_boundaries_across_deltas() {
 }
 
 #[test]
+fn notice_panel_lines_matches_write_form_and_closes_borders() {
+    // #2179: the offscreen form feeds the relay-injected hint card; it
+    // must be byte-identical to the written panel so the hint card shares
+    // the family framing, and every framed line must close both borders
+    // at the panel standard width.
+    let renderer = RatatuiInlineRenderer::with_width(80);
+    let model = || NoticePanelModel {
+        title: "Command is waiting for input",
+        body: vec![
+            "Type y or n:".to_string(),
+            "Reply directly, or press Ctrl+C to interrupt.".to_string(),
+        ],
+        footer: None,
+    };
+    let lines = renderer.notice_panel_lines(model());
+    let mut written = Vec::new();
+    renderer.write_notice_panel(&mut written, model()).unwrap();
+    assert_eq!(
+        lines.join("\n") + "\n",
+        String::from_utf8(written).unwrap(),
+        "offscreen lines must match the written panel"
+    );
+    let joined = lines.join("\n");
+    let width = usize::from(renderer.panel_standard_width());
+    assert_box_lines_aligned(joined.trim_end(), width);
+    assert!(lines.first().is_some_and(|l| l.trim_end().ends_with('╮')));
+    assert!(lines.last().is_some_and(|l| l.trim_end().ends_with('╯')));
+    for line in &lines[1..lines.len() - 1] {
+        assert!(
+            line.trim_end().ends_with('│'),
+            "body rows must close the right border: {line:?}"
+        );
+    }
+
+    // Plain form: same content contract, no box drawing.
+    let plain = RatatuiInlineRenderer::plain_with_width(44).notice_panel_lines(model());
+    assert!(plain[0].starts_with("Command is waiting for input:"));
+    assert!(plain.iter().all(|l| !l.contains('│')));
+}
+
+#[test]
 fn plain_renderer_uses_text_blocks_without_box_drawing() {
     let renderer = RatatuiInlineRenderer::plain_with_width(44);
     let mut output = Vec::new();

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/handoff.rs
@@ -1471,3 +1471,73 @@ fn raw_relay_zsh_secret_handoff_survives_a_bypass_prefixed_race() {
         "{terminal}"
     );
 }
+
+/// #2196 review regression: `ShellHostConfig::new()` leaves the hint card
+/// renderer unset (fail-quiet), so the public raw relay surface must offer
+/// a working opt-in path. Wires a marker frame through the public
+/// `set_hint_card_renderer` and drives an agent handoff into a blocked tty
+/// read via the public bash entry point; the marker proves the sentinel
+/// reached the injected renderer. The card is relay-injected into the
+/// output sink (never echoed back by the PTY), so the assertion reads the
+/// sink instead of `terminal_output`. Linux-only: the blocked-read
+/// classification needs /proc evidence.
+#[cfg(target_os = "linux")]
+#[test]
+fn raw_relay_bash_public_config_renders_hint_card_for_waiting_handoff() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    struct SharedSink(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+    impl Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("sink lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-public-hint-card-work-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let mut config = ShellHostConfig::new("public-hint-card-test", &work_dir);
+    config.native_mode = false;
+    config.set_hint_card_renderer(|title, body| {
+        let mut lines = vec![format!("[public-frame] {title}")];
+        lines.extend(body);
+        lines
+    });
+
+    // A forked child (`bash -c`) keeps the read outside the relay shell's
+    // own process group: the sentinel requires a foreign foreground pgid
+    // before it consults the /proc blocked-read evidence, and a bare
+    // `read` builtin would run inside the shell itself and never qualify.
+    let command = r#"bash -c 'read -p "Type y or n: " answer; echo "answer=$answer"'"#;
+    let sink = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let output = run_raw_relay_bash_with_actions_output_control(
+        &config,
+        vec![
+            // The sentinel needs a 2s output-quiet window plus a 1s sample
+            // interval before it may emit; the margin covers loaded runners.
+            RawRelayAction::wait(Duration::from_millis(6_000)),
+            RawRelayAction::line("y"),
+            RawRelayAction::wait(Duration::from_millis(500)),
+            RawRelayAction::line("exit"),
+        ],
+        SharedSink(sink.clone()),
+        emit_pager_policy_handoff(command, ImplicitPagerPolicy::Inherit),
+    )
+    .expect("raw relay bash public hint card handoff");
+
+    let relayed = String::from_utf8_lossy(&sink.lock().expect("sink lock")).into_owned();
+    assert!(
+        relayed.contains("[public-frame]"),
+        "hint card must reach the renderer injected through the public config path: {relayed}"
+    );
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    assert!(terminal.contains("answer=y"), "{terminal}");
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 693
+check_overlap_ceiling cosh-shell cosh-shell 694
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
# fix(cosh-ng): [shell] panel-family hint card

Fixes #2179 — the input-wait hint card shipped by #2168 broke the panel family three ways on real machines: the frame never closed on the right, the width was a local `clamp(40,100)` instead of the `panel_standard_width()` contract, and the common `echo "prompt"` + `read` shape (newline-terminated prompt) degraded the card body to fallback copy and silently skipped the continuity redraw.

## Changes

- **ui**: expose `notice_panel_lines` — the offscreen form of `write_notice_panel`. Both share the extracted `block_lines`, keeping written and offscreen output byte-identical; a caller that owns a non-`Write` sink (the raw relay splicing into a live PTY stream) reuses the exact family framing, width contract, and plain fallback.
- **shell_host**: new `HintCardRenderer` injection newtype on `ShellHostConfig` (same pattern as the existing shell observers). The sentinel keeps content assembly — kind copy, secret redaction, timeout forecast, D10 fullscreen exemption — and hands framing to the injected renderer; absent renderer stays fail-quiet (no card, episode still deduped). The hand-drawn ANSI frame and its coarse width helpers are deleted. The layout gate forbids `shell_host -> ui` dependencies, so injection is the only compliant reuse path.
- **runtime bootstrap**: injects the closure built on `RatatuiInlineRenderer::for_terminal()` + `NoticePanelModel`; width is re-read per emission, so terminal resizes are picked up for free.
- **sentinel**: the hint card reads `OscParser::active_command_visible_tail()` — the last non-blank visible line of the running command, restoring the in-card prompt echo and the A+ continuity redraw for the echo+read shape (defect 3).

Review rounds folded in:

- **Codex P2**: the tail window is anchored at the preexec marker instead of the session-wide buffer — a silent command yields no tail rather than replaying a previous command's output (final form: the tracker resets at preexec).
- **Maintainer R1 P2**: public `ShellHostConfig::set_hint_card_renderer` (plain-closure signature, no UI-layer types) restores the hint-card opt-in for crate-external callers of the public raw relay entry points; the runtime bootstrap injects through the same setter.
- **Maintainer R3+R4 P2**: the tail extractor no longer splits on LF before stripping, and the private stripper is deleted — stripping now delegates to `evidence::clean_terminal_control_sequences`, the crate's single authority (correct per-introducer terminators: ST always, BEL for OSC only; unterminated payloads consumed to the end); the nF (charset) handling moved into that authority. Regression matrix covers OSC/DCS/APC/PM x BEL-inside-payload/ST x trailing text x unterminated.
- **Maintainer R6 P2**: whole-window cleaning on every sentinel sample was an O(output) scan-and-copy in the relay loop (stall/OOM path for handoffs that log heavily before blocking). Replaced by an incremental design: the escape authority became a resumable `ControlSequenceScanner` and `OscParser` owns a bounded `VisibleTailTracker` (fed once per PTY chunk, reset at preexec, UTF-8 carry) — sentinel sampling is O(1) with hard-bounded state; matrix rows are fed whole-buffer and byte-at-a-time, plus a 100k-line regression. Folded into the fix commit per the Fix attribution rule (R7).
- **Maintainer R7 P2**: truncating an over-long line to its trailing window would hand redaction a suffix with the sensitive field-name prefix cut off (`password=` + 600 chars). Over-long lines (>512 visible chars) lose tail candidacy outright; a disqualified cursor line yields no tail, and completing one is a barrier that also clears the stored last line (R8: never fall back to output older than the over-long line). Regressions pin the sensitive-assignment case, the barrier case, and recovery on the next prompt line.
- **Maintainer R5 P2**: the shared cleaner also consumes ECMA-48 two-byte escape finals (terminfo smkx ends in `ESC =`, which a starting pager would otherwise surface as the prompt); the `ESC =` regression is restored plus a keypad-mode-init empty-tail case.
- **Maintainer R2 P2**: `CurrentCommand` and the display-window helpers moved to `osc/command.rs` (existing carve-out pattern), keeping osc.rs under the 1000-line growth bar (998 lines at the final head) and below the pre-PR main baseline (1027).

Three commits (osc carve-out refactor → fix → inventory tail; in-PR regressions folded into their source commit per the Fix attribution rule); 18 files, +823/−271.

## Tests

- New: `notice_panel_lines_matches_write_form_and_closes_borders` (ui — byte-identical write/offscreen forms, closed borders at `panel_standard_width()`, plain fallback), jump/blank-line anchors added to `prompt_tail_extraction_strips_escapes_and_controls` (now also covering the active-command display window: no window without an active command, silent commands inherit nothing), empty-renderer fail-quiet anchor in `hint_card_covers_presentation_contract` (shell_host — fake renderer per layout gate; family framing asserted on the ui side).
- New (integration, Linux-gated): `raw_relay_bash_public_config_renders_hint_card_for_waiting_handoff` — from `ShellHostConfig::new()` + the public setter through the public bash raw relay entry into a blocked read; asserts the injected frame reaches the relay output sink (the card is relay-injected, never echoed by the PTY).
- Suites at current head: CI `Test cosh-ng` full suite green (arbiter). Container (alinux3/aarch64) `--lib --bins`: 1305 ✓ with 2 pre-existing environment failures (`-- --list` inventory at this head: 1307 lib / 2406 bin) (`readonly_compound` executor reaping; reproduced identically on pristine origin/main in the same container). Host macOS: green except 5 pre-existing hooks-loader environment failures (also reproduced on origin/main). `clippy -p cosh-shell --all-targets -D warnings` 0, fmt ✓, `check-layout.sh` ✓, `check-test-inventory.sh` ✓ (lib/bin overlap ceiling 693→694: one shared ui test on top of main's 688→693 baseline raise).
- Preflight: fmt/gates/commit-lint/drift clean; host workspace clippy fails on macOS due to pre-existing cosh-core Linux-only rustix APIs (unrelated; container is the arbiter). L3 deep security review: 0 findings.

## Verification (real adapter, real PTY)

Scripted PTY driver against the real cosh-core adapter (auto approval → handoff), both prompt shapes, FAIL side built from the pre-fix rendering path and PASS side from this branch, on alinux3/aarch64 containers:

| verdict field | FAIL inline | FAIL newline | PASS inline | PASS newline |
|---|---|---|---|---|
| card_seen | true | true | true | true |
| borders_closed | **false** | **false** | ✅ true | ✅ true |
| prompt_inside_card | true | **false** | ✅ true | ✅ true |
| prompt_replayed_after_card | true | **false** | ✅ true | ✅ true |
| answered_ok | true | true | true | true |

Excluded scope: full real-provider acceptance matrix beyond the two prompt shapes; Alinux4 release verification (tracked in #2174).

## Evidence

Assets on fork branch `pr-2196-assets` (SHA-pinned `29d5f3c1`).

**Defect 3 side-by-side — `echo "prompt"` + `read` shape** (FAIL: open frame, fallback copy, no replay → PASS: closed panel-family card, prompt echoed in-card and replayed):

| FAIL (pre-fix rendering path) | PASS (this branch) |
|---|---|
| ![fail-newline-card](https://raw.githubusercontent.com/SunnyQjm/anolisa/29d5f3c196bb6a45d2d8130f443c7c6772b4f986/fail-newline-card.png) | ![pass-newline-card](https://raw.githubusercontent.com/SunnyQjm/anolisa/29d5f3c196bb6a45d2d8130f443c7c6772b4f986/pass-newline-card.png) |

Full session replays (approval → handoff → hint card → attended answer → turn convergence):

- FAIL inline (`read -p`): ![fail-inline](https://raw.githubusercontent.com/SunnyQjm/anolisa/29d5f3c196bb6a45d2d8130f443c7c6772b4f986/fail-inline.gif)
- FAIL newline (`echo`+`read`): ![fail-newline](https://raw.githubusercontent.com/SunnyQjm/anolisa/29d5f3c196bb6a45d2d8130f443c7c6772b4f986/fail-newline.gif)
- PASS inline: ![pass-inline](https://raw.githubusercontent.com/SunnyQjm/anolisa/29d5f3c196bb6a45d2d8130f443c7c6772b4f986/pass-inline.gif)
- PASS newline: ![pass-newline](https://raw.githubusercontent.com/SunnyQjm/anolisa/29d5f3c196bb6a45d2d8130f443c7c6772b4f986/pass-newline.gif)







