### PR TITLE
feat(sec-core): add observability hook env toggle

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -235,6 +235,21 @@ agent-sec-cli harden --downstream-help
 
 Interactive event review tool for auditing Agent behavior.
 
+The OpenClaw, Hermes, cosh, Qwen Code, Qoder, and Codex integrations enable
+their observability hooks by default. To disable hook recording, set
+`OBSERVABILITY_HOOK_ENABLED=false` before starting the host and restart the host
+after changing it. The variable accepts only `true` / `false` (ignoring case and
+surrounding whitespace); an unset or invalid value keeps recording enabled.
+
+For OpenClaw and Hermes, the existing observability capability `enabled` setting
+is an independent gate. Either switch can disable recording;
+`OBSERVABILITY_HOOK_ENABLED=true` does not override a capability disabled in
+plugin configuration.
+
+```bash
+export OBSERVABILITY_HOOK_ENABLED=false
+```
+
 ```bash
 # Open interactive TUI (requires interactive terminal)
 agent-sec-cli observability review

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -232,6 +232,19 @@ agent-sec-cli harden --downstream-help
 
 交互式事件审阅工具，用于审计 Agent 行为。
 
+OpenClaw、Hermes、cosh、Qwen Code、Qoder 和 Codex 集成默认启用 Observability hook。
+若需停止 hook 记录，请在启动宿主前设置 `OBSERVABILITY_HOOK_ENABLED=false`；修改后需重启
+宿主进程。该变量仅接受 `true` / `false`（忽略大小写和首尾空白）；未设置或值无效时保持
+默认开启。
+
+对于 OpenClaw 和 Hermes，原有 Observability capability 的 `enabled` 配置仍是独立开关。
+任一开关关闭都会停止记录；`OBSERVABILITY_HOOK_ENABLED=true` 不会覆盖插件配置中已关闭的
+capability。
+
+```bash
+export OBSERVABILITY_HOOK_ENABLED=false
+```
+
 ```bash
 # 打开交互式 TUI（需要交互终端）
 agent-sec-cli observability review

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -134,6 +134,24 @@ agent-sec-core/
 └── README_zh.md
 ```
 
+## Observability Hook Toggle
+
+The OpenClaw, Hermes, cosh, Qwen Code, Qoder, and Codex integrations enable
+their observability hooks by default. To disable them, set this variable before
+starting the host:
+
+```bash
+export OBSERVABILITY_HOOK_ENABLED=false
+```
+
+The variable accepts only `true` / `false` (ignoring case and surrounding
+whitespace). An unset or invalid value keeps the hook enabled. Restart the host
+after changing it.
+
+For OpenClaw and Hermes, the existing observability capability `enabled` setting
+remains an independent gate. Either switch can disable recording; setting this
+variable to `true` does not re-enable a capability disabled in plugin configuration.
+
 ## Quick Start
 
 ### Prerequisites

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -134,6 +134,22 @@ agent-sec-core/
 └── README_zh.md
 ```
 
+## Observability Hook 开关
+
+OpenClaw、Hermes、cosh、Qwen Code、Qoder 和 Codex 集成默认都会启用
+Observability hook。若需关闭，请在启动对应宿主前设置：
+
+```bash
+export OBSERVABILITY_HOOK_ENABLED=false
+```
+
+该变量仅接受 `true` / `false`（忽略大小写和首尾空白）；未设置或值无效时保持默认开启。
+修改后需重启对应宿主进程。
+
+对于 OpenClaw 和 Hermes，原有 Observability capability 的 `enabled` 配置仍是独立开关。
+任一开关关闭都会停止记录；将该环境变量设为 `true`，不会重新启用已在插件配置中关闭的
+capability。
+
 ## 快速开始
 
 ### 前置条件

--- a/src/agent-sec-core/codex-plugin/README.md
+++ b/src/agent-sec-core/codex-plugin/README.md
@@ -74,6 +74,7 @@ codex plugin marketplace remove agent-sec
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
+| `OBSERVABILITY_HOOK_ENABLED` | `true` | 仅显式设为 `false` 时关闭 Observability hook；修改后需重启 Codex |
 | `CODE_SCANNER_MODE` | `observe` | 代码扫描透出模式：`observe`(仅观察记录，不拦截) / `deny`(检测到风险时强制拦截) |
 | `CODE_SCANNER_TIMEOUT` | `10` | 代码扫描 agent-sec-cli 超时秒数 |
 | `PROMPT_SCANNER_MODE` | `observe` | 提示词注入检测透出模式：`observe`(仅观察记录，不拦截) / `deny`(检测到注入时拦截 prompt) |

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/observability_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/observability_hook.py
@@ -14,7 +14,10 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+from hook_config import env_flag_enabled
+
 _CLI_TIMEOUT_SECONDS = 3
+_HOOK_ENABLED = env_flag_enabled("OBSERVABILITY_HOOK_ENABLED", True)
 # Read one extra byte below to distinguish an exact-limit payload from truncation.
 _MAX_PAYLOAD_SIZE = 1024 * 1024
 _OBSERVABILITY_COMMAND = [
@@ -474,6 +477,10 @@ def _record_observability(record: dict[str, Any]) -> None:
 
 def main() -> None:
     """Read one Codex hook event, record it best-effort, and always continue."""
+    if not _HOOK_ENABLED:
+        print(_noop())
+        return
+
     try:
         payload = _read_stdin_payload()
         if payload is None:

--- a/src/agent-sec-core/cosh-extension/hooks/observability_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/observability_hook.py
@@ -15,10 +15,12 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from hook_config import env_flag_enabled
 from pii_text import json_dumps as _json_dumps
 from pii_text import text_sha256, value_to_text
 
 _CLI_TIMEOUT_SECONDS = 3
+_HOOK_ENABLED = env_flag_enabled("OBSERVABILITY_HOOK_ENABLED", True)
 # Read one extra byte below to distinguish an exact-limit payload from truncation.
 _MAX_PAYLOAD_SIZE = 1024 * 1024
 _OBSERVABILITY_COMMAND = [
@@ -464,6 +466,10 @@ def _record_observability(record: dict[str, Any]) -> None:
 
 
 def main() -> None:
+    if not _HOOK_ENABLED:
+        print(_noop())
+        return
+
     try:
         payload = _read_stdin_payload()
         if payload is None:

--- a/src/agent-sec-core/hermes-plugin/README.md
+++ b/src/agent-sec-core/hermes-plugin/README.md
@@ -94,6 +94,11 @@ timeout = 5
 `timeout` 控制 `agent-sec-cli observability record` 子进程。CLI 失败、超时、invalid record
 或缺少必需 metadata 都是 fail-open。
 
+Observability hook 默认开启。启动 Hermes 前设置
+`OBSERVABILITY_HOOK_ENABLED=false` 可关闭记录而无需修改 `config.toml`；未设置或值无效时
+保持开启。修改环境变量后需重启 Hermes。`enabled = false` 仍会直接跳过 capability 注册，
+两种开关任一关闭都会停止 Observability CLI 调用。
+
 ## 可用 Hook 列表
 
 Hermes 支持的 hook 及其回调签名：

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/observability.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/observability.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import Any
 
 from ..cli_runner import record_hermes_observability
+from ..hook_config import env_flag_enabled
 from ..observability.record import build_record
 from .base import AgentSecCoreCapability
 
@@ -40,7 +41,7 @@ class ObservabilityCapability(AgentSecCoreCapability):
     name = "Observability"
 
     def _on_register(self, config: dict) -> None:
-        pass
+        self._hook_enabled = env_flag_enabled("OBSERVABILITY_HOOK_ENABLED", True)
 
     def get_hooks_define(self) -> dict[str, Callable]:
         return {
@@ -53,6 +54,9 @@ class ObservabilityCapability(AgentSecCoreCapability):
         }
 
     def _emit(self, hook_name: str, data: dict[str, Any]) -> None:
+        if not getattr(self, "_hook_enabled", True):
+            return
+
         record = build_record(hook_name, data)
         if record is None:
             return

--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -339,6 +339,12 @@ The `observability` capability is enabled by default and invokes:
 agent-sec-cli observability record --format json --stdin
 ```
 
+Set `OBSERVABILITY_HOOK_ENABLED=false` before starting the OpenClaw gateway to
+disable all observability hook work without changing plugin configuration. An
+unset or invalid value keeps it enabled; restart the gateway after changing the
+variable. Setting `capabilities.observability.enabled` to `false` also disables
+the capability, so either setting can turn observability off.
+
 Each hook emits one JSON record with `hook`, `observedAt`, `metadata`, and hook-specific `metrics`. The plugin registers OpenClaw hook names, but sends the generic `agent-sec-cli` hook name in `payload.hook`. Failures, missing CLI, malformed output, and timeouts are fail-open and never block OpenClaw behavior.
 
 OpenClaw runtimes that expose `model_call_started` and `model_call_ended` provide model-call telemetry. Older runtimes load the plugin but skip unknown telemetry sources. Newer OpenClaw versions may provide richer fields on those hooks; the plugin sends whichever accepted metrics are present.

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/observability.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/observability.ts
@@ -11,7 +11,7 @@ import type {
   PluginHookToolContext,
 } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SecurityCapability } from "../types.js";
-import { recordOpenClawObservability } from "../utils.js";
+import { envFlagEnabled, recordOpenClawObservability } from "../utils.js";
 import type { CliResult } from "../utils.js";
 import {
   OBSERVABILITY_HOOKS,
@@ -42,12 +42,13 @@ export const observability: SecurityCapability = {
   name: "OpenClaw Observability",
   hooks: [...OBSERVABILITY_HOOKS],
   register(api) {
+    const hookEnabled = envFlagEnabled("OBSERVABILITY_HOOK_ENABLED", true);
     api.on(
       "llm_input",
       (
         event: PluginHookLlmInputEvent,
         ctx: PluginHookAgentContext,
-      ) => observeHook(api, "llm_input", event, ctx),
+      ) => observeHook(api, hookEnabled, "llm_input", event, ctx),
       { priority: OBSERVABILITY_PRIORITY },
     );
     api.on(
@@ -55,7 +56,7 @@ export const observability: SecurityCapability = {
       (
         event: PluginHookModelCallStartedEvent,
         ctx: PluginHookAgentContext,
-      ) => observeHook(api, "model_call_started", event, ctx),
+      ) => observeHook(api, hookEnabled, "model_call_started", event, ctx),
       { priority: OBSERVABILITY_PRIORITY },
     );
     api.on(
@@ -63,7 +64,7 @@ export const observability: SecurityCapability = {
       (
         event: PluginHookModelCallEndedEvent,
         ctx: PluginHookAgentContext,
-      ) => observeHook(api, "model_call_ended", event, ctx),
+      ) => observeHook(api, hookEnabled, "model_call_ended", event, ctx),
       { priority: OBSERVABILITY_PRIORITY },
     );
     api.on(
@@ -71,7 +72,7 @@ export const observability: SecurityCapability = {
       (
         event: PluginHookLlmOutputEvent,
         ctx: PluginHookAgentContext,
-      ) => observeHook(api, "llm_output", event, ctx),
+      ) => observeHook(api, hookEnabled, "llm_output", event, ctx),
       { priority: OBSERVABILITY_PRIORITY },
     );
     api.on(
@@ -79,7 +80,7 @@ export const observability: SecurityCapability = {
       (
         event: PluginHookAgentEndEvent,
         ctx: PluginHookAgentContext,
-      ) => observeHook(api, "agent_end", event, ctx),
+      ) => observeHook(api, hookEnabled, "agent_end", event, ctx),
       { priority: OBSERVABILITY_PRIORITY },
     );
     api.on(
@@ -87,7 +88,7 @@ export const observability: SecurityCapability = {
       (
         event: PluginHookBeforeToolCallEvent,
         ctx: PluginHookToolContext,
-      ) => observeHook(api, "before_tool_call", event, ctx),
+      ) => observeHook(api, hookEnabled, "before_tool_call", event, ctx),
       { priority: OBSERVABILITY_LATE_PRIORITY },
     );
     api.on(
@@ -95,7 +96,7 @@ export const observability: SecurityCapability = {
       (
         event: PluginHookAfterToolCallEvent,
         ctx: PluginHookToolContext,
-      ) => observeHook(api, "after_tool_call", event, ctx),
+      ) => observeHook(api, hookEnabled, "after_tool_call", event, ctx),
       { priority: OBSERVABILITY_PRIORITY },
     );
   },
@@ -103,10 +104,15 @@ export const observability: SecurityCapability = {
 
 function observeHook(
   api: OpenClawPluginApi,
+  hookEnabled: boolean,
   hookName: ObservabilityHookName,
   event: ObservabilityHookEvent,
   ctx: ObservabilityHookContext,
 ): void {
+  if (!hookEnabled) {
+    return;
+  }
+
   try {
     const payload = buildOpenClawObservabilityRecord(hookName, event, ctx);
     if (payload === undefined) {

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/observability-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/observability-test.ts
@@ -129,6 +129,7 @@ function beforeToolCallEvent() {
 let capturedArgs: string[] | undefined;
 let capturedStdin: string | undefined;
 let capturedRecords: { args: string[]; stdin: string | undefined }[] = [];
+let previousObservabilityHookEnabled: string | undefined;
 
 function mockCli(
   result: CliResult = { exitCode: 0, stdout: "", stderr: "" },
@@ -172,10 +173,17 @@ describe("observability", () => {
     capturedArgs = undefined;
     capturedStdin = undefined;
     capturedRecords = [];
+    previousObservabilityHookEnabled = process.env.OBSERVABILITY_HOOK_ENABLED;
+    delete process.env.OBSERVABILITY_HOOK_ENABLED;
   });
 
   afterEach(() => {
     _resetCliMock();
+    if (previousObservabilityHookEnabled === undefined) {
+      delete process.env.OBSERVABILITY_HOOK_ENABLED;
+    } else {
+      process.env.OBSERVABILITY_HOOK_ENABLED = previousObservabilityHookEnabled;
+    }
   });
 
   it("registers the configured observability hooks when enabled by default", () => {
@@ -187,6 +195,42 @@ describe("observability", () => {
     assert.equal(hooks.some((hook) => hook.hookName === "before_model_resolve"), false);
     assert.equal(hooks.find((hook) => hook.hookName === "before_tool_call")?.priority, -10_000);
     assert.equal(hooks.find((hook) => hook.hookName === "llm_input")?.priority, 1000);
+  });
+
+  it("skips all observability hook work when disabled by environment", async () => {
+    process.env.OBSERVABILITY_HOOK_ENABLED = "false";
+    let cliCalls = 0;
+    _setCliMock(async () => {
+      cliCalls++;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+    const { api, hooks } = createMockApi();
+    observability.register(api);
+    const event = {
+      sessionId: "session-disabled",
+      runId: "run-disabled",
+      callId: "call-disabled",
+      toolCallId: "tool-disabled",
+      provider: "openai",
+      model: "gpt-test",
+      prompt: "hello",
+      durationMs: 1,
+      outcome: "success",
+      assistantTexts: ["done"],
+      success: true,
+      toolName: "exec",
+      params: { command: "true" },
+      result: { content: "ok" },
+    };
+    const ctx = { sessionId: "session-disabled", runId: "run-disabled" };
+
+    for (const hook of hooks) {
+      assert.equal(hook.handler(event, ctx), undefined);
+    }
+    await flushObservabilityWork();
+
+    assert.equal(cliCalls, 0);
+    assert.deepEqual(capturedRecords, []);
   });
 
   it("emits the expected CLI payload for before_tool_call", async () => {

--- a/src/agent-sec-core/qoder-plugin/hooks/observability_hook.py
+++ b/src/agent-sec-core/qoder-plugin/hooks/observability_hook.py
@@ -14,9 +14,10 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Callable
 
-from qoder_hook_common import trace_context
+from qoder_hook_common import env_flag_enabled, trace_context
 
 _CLI_TIMEOUT_SECONDS = 3
+_HOOK_ENABLED = env_flag_enabled("OBSERVABILITY_HOOK_ENABLED", True)
 _MAX_PAYLOAD_SIZE = 1024 * 1024
 # Qoder does not expose a stable run identifier across its hook events. Match
 # the Hermes/Qwen adapters and use a schema-compatible zero GUID rather than
@@ -520,6 +521,9 @@ def _record_observability(record: dict[str, Any], context: dict[str, str]) -> No
 
 def main() -> None:
     """Read one Qoder hook event and record it without affecting execution."""
+    if not _HOOK_ENABLED:
+        return
+
     input_data: Any = None
     try:
         try:

--- a/src/agent-sec-core/qwen-code-extension/README.md
+++ b/src/agent-sec-core/qwen-code-extension/README.md
@@ -179,7 +179,9 @@ scanner 返回 `deny`，才会按上述点位阻断。
 
 `agent-sec-observability` 仍异步执行并保持 fail-open：任何脚本、PII 扫描或记录写入异常
 都不会改变 Qwen Code 的执行决策。敏感指标在写入前由本地 `scan-pii` 脱敏；脱敏失败时
-直接丢弃对应敏感字段。
+直接丢弃对应敏感字段。Observability hook 默认开启；启动 Qwen Code 前设置
+`OBSERVABILITY_HOOK_ENABLED=false` 可将其关闭，未设置或值无效时仍保持开启。修改后需
+重启 Qwen Code。
 
 Code scanner hook 与 observability hook 独立挂载，作为同步
 `PreToolUse` hook 仅处理 `run_shell_command`；默认 `CODE_SCANNER_MODE=observe` 不改变

--- a/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/observability_hook.py
@@ -11,11 +11,13 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from hook_config import env_flag_enabled
 from pii_text import json_dumps as _json_dumps
 from pii_text import text_sha256, value_to_text
 from trace_context import trace_context, with_trace_context
 
 _CLI_TIMEOUT_SECONDS = 3
+_HOOK_ENABLED = env_flag_enabled("OBSERVABILITY_HOOK_ENABLED", True)
 # Read one extra byte below to distinguish an exact-limit payload from truncation.
 _MAX_PAYLOAD_SIZE = 1024 * 1024
 # Qwen Code HookInput does not currently expose one stable run identifier across
@@ -407,6 +409,10 @@ def _record_observability(record: dict[str, Any]) -> None:
 
 
 def main() -> None:
+    if not _HOOK_ENABLED:
+        print(_noop())
+        return
+
     try:
         payload = _read_stdin_payload()
         if payload is None:


### PR DESCRIPTION
## Why
Add an env toggle to enable/disable observability hook in agent plugins
<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
