### PR TITLE
fix(sec-core): include raw skill dirs

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
@@ -315,7 +315,7 @@ Qoder CLI is a low-level integrity gate: the plugin registers a dedicated `PreTo
 
 OpenClaw defaults to `enabled=true, policy="ask"`; Hermes defaults to `enabled=true, policy="ask"`; copilot-shell and Qoder CLI register the Skill Ledger PreToolUse hook by default in their manifests, with the policy controlled via `SKILL_LEDGER_HOOK_POLICY`. Apart from the Qoder CLI low-level gate above, the other compatibility hooks remain fail-open when the CLI infrastructure misbehaves, avoiding blocked Skill loads.
 
-The copilot-shell hook currently covers three directory classes — project / user / system: `<cwd>/.copilot-shell/skills/`, `~/.copilot-shell/skills/`, `/usr/share/anolisa/skills/`. Skills from custom, extension, remote, or other paths make the hook fail open and skip the skill-ledger check; the OpenClaw plugin extracts the Skill directory from the `SKILL.md` path it reads.
+The copilot-shell hook currently covers three directory classes — project / user / system: `<cwd>/.copilot-shell/skills/`, `~/.copilot-shell/skills/`, and the RPM and raw-install system roots `/usr/share/anolisa/skills/` and `/usr/local/share/anolisa/skills/`. Skills from custom, extension, remote, or other paths make the hook fail open and skip the skill-ledger check; the OpenClaw plugin extracts the Skill directory from the `SKILL.md` path it reads.
 
 For batch certification or post-install certification, complete directory resolution and certification before letting the Agent read uncertified Skill content: avoid proactively reading an uncertified Skill's `SKILL.md` or auxiliary files before batch certification; after a successful install, locate the final local directory, confirm it contains `SKILL.md`, then run quick-scan certification.
 
@@ -397,7 +397,7 @@ Note: a hook's `ask` confirmation only lets the current host operation continue 
 
 #### Configuring Skill Directories (for batch scans)
 
-Five built-in directories are included by default: `~/.openclaw/skills/*`, `~/.copilot-shell/skills/*`, `~/.hermes/skills/**`, `~/.qoder/skills/*`, `/usr/share/anolisa/skills/*`. Project-level Qoder directories are not relative defaults; after an explicit `scan` or `certify` on a project Skill, its absolute directory is written to `managedSkillDirs` via the auto-memoization mechanism. To add other directories, create or edit `~/.config/agent-sec/skill-ledger/config.json`:
+Six built-in directories are included by default: `~/.openclaw/skills/*`, `~/.copilot-shell/skills/*`, `~/.hermes/skills/**`, `~/.qoder/skills/*`, `/usr/share/anolisa/skills/*`, `/usr/local/share/anolisa/skills/*`. Project-level Qoder directories are not relative defaults; after an explicit `scan` or `certify` on a project Skill, its absolute directory is written to `managedSkillDirs` via the auto-memoization mechanism. To add other directories, create or edit `~/.config/agent-sec/skill-ledger/config.json`:
 
 ```json
 {

--- a/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
@@ -301,7 +301,7 @@ Qoder CLI 是低层完整性门禁：plugin 为 `Skill` tool 注册独立的 `Pr
 
 OpenClaw 默认 `enabled=true, policy="ask"`；Hermes 默认 `enabled=true, policy="ask"`；copilot-shell 和 Qoder CLI 默认 manifest 注册 Skill Ledger PreToolUse hook，并通过 `SKILL_LEDGER_HOOK_POLICY` 控制 policy。除 Qoder CLI 上述低层门禁外，其它兼容 hook 在 CLI 基础设施异常时保持 fail-open，避免阻断 Skill 加载。
 
-copilot-shell hook 当前仅覆盖 project / user / system 三类目录：`<cwd>/.copilot-shell/skills/`、`~/.copilot-shell/skills/`、`/usr/share/anolisa/skills/`。若 Skill 来自 custom、extension、remote 或其它路径，hook 会 fail-open 并跳过 skill-ledger 检查；OpenClaw 插件则按读取到的 `SKILL.md` 路径提取 Skill 目录。
+copilot-shell hook 当前仅覆盖 project / user / system 三类目录：`<cwd>/.copilot-shell/skills/`、`~/.copilot-shell/skills/`，以及 RPM 与 raw install 对应的 system 根目录 `/usr/share/anolisa/skills/` 和 `/usr/local/share/anolisa/skills/`。若 Skill 来自 custom、extension、remote 或其它路径，hook 会 fail-open 并跳过 skill-ledger 检查；OpenClaw 插件则按读取到的 `SKILL.md` 路径提取 Skill 目录。
 
 批量认证或安装后认证场景中，建议先完成目录定位和认证，再让 Agent 读取未认证 Skill 内容：批量认证前避免主动读取未认证 Skill 的 `SKILL.md` 或辅助文件；安装成功后应先定位最终本地目录，确认包含 `SKILL.md`，再执行快速扫描认证。
 
@@ -383,7 +383,7 @@ agent-sec-cli skill-ledger decide /path/to/skill --clear
 
 #### 配置 Skill 目录（批量扫描使用）
 
-默认已包含五个内置目录：`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`。项目级 Qoder 目录不作为相对默认项；对项目 Skill 显式执行 `scan` 或 `certify` 后，其绝对目录会沿用自动记忆机制写入 `managedSkillDirs`。如需添加其它目录，创建或编辑 `~/.config/agent-sec/skill-ledger/config.json`：
+默认已包含六个内置目录：`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`、`/usr/local/share/anolisa/skills/*`。项目级 Qoder 目录不作为相对默认项；对项目 Skill 显式执行 `scan` 或 `certify` 后，其绝对目录会沿用自动记忆机制写入 `managedSkillDirs`。如需添加其它目录，创建或编辑 `~/.config/agent-sec/skill-ledger/config.json`：
 
 ```json
 {

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
@@ -45,6 +45,7 @@ DEFAULT_SKILL_DIRS = [
     "~/.hermes/skills/**",
     "~/.qoder/skills/*",
     "/usr/share/anolisa/skills/*",
+    "/usr/local/share/anolisa/skills/*",
 ]
 _IGNORED_RECURSIVE_DIRS = frozenset(
     {".git", ".github", ".hub", ".archive", ".skill-meta"}

--- a/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
@@ -202,7 +202,8 @@ def _resolve_skill_dir(skill_name: str, cwd: str) -> tuple[str | None, bool]:
 
     Current hook scope is intentionally limited to:
     project (.copilot-shell/skills/) → user (~/.copilot-shell/skills/)
-    → system (/usr/share/anolisa/skills/).
+    → system (/usr/share/anolisa/skills/) → raw system
+    (/usr/local/share/anolisa/skills/).
 
     Returns ``(path, traversal_detected)``:
     - ``(str, False)`` — resolved successfully.

--- a/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
@@ -116,12 +116,14 @@ def _supported_skill_bases(cwd: str) -> list[Path]:
 
     Current scope is intentionally limited to:
     project (.copilot-shell/skills/) → user (~/.copilot-shell/skills/)
-    → system (/usr/share/anolisa/skills/).
+    → system (/usr/share/anolisa/skills/) → raw system
+    (/usr/local/share/anolisa/skills/).
     """
     return [
         Path(cwd) / ".copilot-shell" / "skills",
         Path.home() / ".copilot-shell" / "skills",
         Path("/usr/share/anolisa/skills"),
+        Path("/usr/local/share/anolisa/skills"),
     ]
 
 

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
@@ -251,7 +251,7 @@ class SigningBackend(Protocol):
 
 不存在的目录会被静默忽略。
 
-**默认值**：内置五个默认目录（`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`），覆盖 OpenClaw、copilot-shell、Hermes、Qoder 用户级和系统级 Skill。项目级 Qoder 目录不使用相对默认项，由 Qoder hook 根据事件中的绝对 `cwd` 运行时解析；显式 `scan` / `certify` 后再通过自动记忆写入绝对 `managedSkillDirs`。
+**默认值**：内置六个默认目录（`~/.openclaw/skills/*`、`~/.copilot-shell/skills/*`、`~/.hermes/skills/**`、`~/.qoder/skills/*`、`/usr/share/anolisa/skills/*`、`/usr/local/share/anolisa/skills/*`），覆盖 OpenClaw、copilot-shell、Hermes、Qoder 用户级，以及 RPM 与 raw install 系统级 Skill。项目级 Qoder 目录不使用相对默认项，由 Qoder hook 根据事件中的绝对 `cwd` 运行时解析；显式 `scan` / `certify` 后再通过自动记忆写入绝对 `managedSkillDirs`。
 
 **合并策略**：默认目录默认启用，由 `enableDefaultSkillDirs` 控制；`managedSkillDirs` 存放 skill-ledger 动态管理或用户额外配置的目录，不再兼容旧的 `skillDirs` 字段。解析时默认目录在前，`managedSkillDirs` 在后，自动去重。`scanners` 按 `name` 合并，用户配置可覆盖同名扫描器；`activationPolicy` 是全局运行态策略，当前只执行 `pass_warn_only` 行为，历史配置值 `pass_only` / `latest_scanned` 会兼容读取并归一化；`signingBackend` 当前会被读取到配置摘要中，但不会改变实际签名后端。
 
@@ -714,7 +714,8 @@ OpenClaw、copilot-shell 和 Hermes 遇到 CLI 不可用、执行失败、超时
 **Skill 目录定位（当前版本范围）**：copilot-shell hook 仅覆盖 project → user → system 三类 skill：
 - project：`<cwd>/.copilot-shell/skills/<skill>/`
 - user：`~/.copilot-shell/skills/<skill>/`
-- system：`/usr/share/anolisa/skills/<skill>/`
+- system（RPM）：`/usr/share/anolisa/skills/<skill>/`
+- system（raw install）：`/usr/local/share/anolisa/skills/<skill>/`
 
 当 PreToolUse 事件包含 `skill_context.file_path` 时，hook 优先使用该路径解决 `SKILL.md` 中 `name` 与目录名不一致的问题；但该路径仍必须落在上述 project/user/system 根目录内。若路径落在 custom、extension、remote 或其他目录，当前版本不执行 skill-ledger 检查，hook fail-open，并仅写入 debug 日志说明该 skill 不在当前 hook 支持范围内。
 

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
@@ -48,6 +48,7 @@ class TestDefaultConfig(unittest.TestCase):
         self.assertIn("~/.hermes/skills/**", dirs)
         self.assertIn("~/.qoder/skills/*", dirs)
         self.assertIn("/usr/share/anolisa/skills/*", dirs)
+        self.assertIn("/usr/local/share/anolisa/skills/*", dirs)
         self.assertNotIn(".qoder/skills/*", dirs)
         self.assertTrue(_DEFAULT_CONFIG["enableDefaultSkillDirs"])
         self.assertEqual(_DEFAULT_CONFIG["managedSkillDirs"], [])

--- a/src/agent-sec-core/tests/unit-test/test_cosh_skill_ledger_hook.py
+++ b/src/agent-sec-core/tests/unit-test/test_cosh_skill_ledger_hook.py
@@ -1,0 +1,17 @@
+"""Unit tests for the Cosh Skill Ledger hook path defaults."""
+
+from pathlib import Path
+
+from standalone_hook_test_loader import load_standalone_hook
+
+_ROOT = Path(__file__).resolve().parents[2]
+_HOOK_PATH = _ROOT / "cosh-extension" / "hooks" / "skill_ledger_hook.py"
+
+skill_ledger_hook = load_standalone_hook("cosh_skill_ledger_hook", _HOOK_PATH)
+
+
+def test_supported_skill_bases_include_rpm_and_raw_system_roots() -> None:
+    bases = skill_ledger_hook._supported_skill_bases("/workspace")
+
+    assert Path("/usr/share/anolisa/skills") in bases
+    assert Path("/usr/local/share/anolisa/skills") in bases


### PR DESCRIPTION
## Description

This PR fixes raw install Skill Ledger discovery for sec-core.

Raw system installs place bundled skills under `/usr/local/share/anolisa/skills`, while the existing Skill Ledger defaults and the Cosh Skill Ledger hook only covered the RPM system path under `/usr/share/anolisa/skills`. This change keeps the RPM path intact and adds the raw default path to both discovery surfaces:

- `agent-sec-cli` Skill Ledger default scan directories now include `/usr/local/share/anolisa/skills/*`.
- The Cosh Skill Ledger hook system-skill allowlist now includes `/usr/local/share/anolisa/skills`.


## Related Issue

no-issue: follow-up raw install compatibility fix

## Type / Scope

- [x] Bug fix
- [x] sec-core
- [x] Tests
- [ ] Documentation
- [ ] CI / packaging

## Testing

```bash
uv run --project agent-sec-cli pytest tests/unit-test/test_cosh_skill_ledger_hook.py tests/unit-test/skill_ledger/test_config.py -q
```

Result:

```text
45 passed, 3 subtests passed
```