### PR TITLE
fix(tokenless): add /usr/local legacy paths to env-check candidates

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -955,6 +955,7 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
             "{}/.local/share/anolisa/adapters/tokenless/tokenless-env-fix.sh",
             home
         )),
+        Some("/usr/local/share/anolisa/adapters/tokenless/tokenless-env-fix.sh".to_string()),
         Some("/usr/share/anolisa/adapters/tokenless/tokenless-env-fix.sh".to_string()),
     ];
     let fix_script = fix_script_candidates
@@ -1123,6 +1124,9 @@ fn find_spec_path() -> Result<PathBuf, String> {
             "{}/.local/share/anolisa/adapters/tokenless/tool-ready-spec.json",
             home
         ))),
+        Some(PathBuf::from(
+            "/usr/local/share/anolisa/adapters/tokenless/tool-ready-spec.json",
+        )),
         Some(PathBuf::from(
             "/usr/share/anolisa/adapters/tokenless/tool-ready-spec.json",
         )),


### PR DESCRIPTION
## Summary

Add missing legacy `/usr/local/share/anolisa/adapters/tokenless/` paths (without `common/` subdirectory) to both `find_spec_path()` and `auto_fix()` in `env_check.rs`.

The shell hook (`tool_ready_hook.sh`) already covers this case via `${SCRIPT_DIR}/..` relative resolution, but the Rust implementation did not include the `/usr/local` legacy variants, causing env-check to report "not found" on systems with pre-FHS-refactor installations under `/usr/local`.

## Changes

- `find_spec_path()`: Added `/usr/local/share/anolisa/adapters/tokenless/tool-ready-spec.json` to the legacy candidates list
- `auto_fix()`: Added `/usr/local/share/anolisa/adapters/tokenless/tokenless-env-fix.sh` to the legacy candidates list

## Testing

- `cargo test` — all 128 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

closes #N/A (internal tracking: ANO-3989)