### PR TITLE
fix(tokenless): add qwencode allow rules to agentsight config

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -85,7 +85,10 @@
       {"rule": ["openclaw"], "agent_name": "OpenClaw"},
       {"rule": ["claude*"], "agent_name": "Claude"},
       {"rule": ["*/claude*"], "agent_name": "Claude"},
-      {"rule": ["*node*", "*claude*"], "agent_name": "Claude"}
+      {"rule": ["*node*", "*claude*"], "agent_name": "Claude"},
+      {"rule": ["qwen*"], "agent_name": "QwenCode"},
+      {"rule": ["*/qwen*"], "agent_name": "QwenCode"},
+      {"rule": ["*node*", "*qwen*"], "agent_name": "QwenCode"}
     ]
   },
   "codex_offsets": {

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -387,4 +387,39 @@ mod tests {
             Some("Claude")
         );
     }
+
+    #[test]
+    fn test_default_rules_capture_qwencode_bare_name() {
+        assert_eq!(
+            match_default_rules(&["qwen"], "").as_deref(),
+            Some("QwenCode")
+        );
+    }
+
+    #[test]
+    fn test_default_rules_capture_qwencode_absolute_path() {
+        assert_eq!(
+            match_default_rules(&["/usr/local/bin/qwen"], "").as_deref(),
+            Some("QwenCode")
+        );
+        assert_eq!(
+            match_default_rules(&["/home/user/.local/bin/qwen-code"], "").as_deref(),
+            Some("QwenCode")
+        );
+    }
+
+    #[test]
+    fn test_default_rules_capture_qwencode_node_wrapper() {
+        assert_eq!(
+            match_default_rules(
+                &[
+                    "node",
+                    "/usr/local/lib/node_modules/@qwen-code/cli/index.js"
+                ],
+                ""
+            )
+            .as_deref(),
+            Some("QwenCode")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Adds three cmdline allow rules for Qwen Code (`qwen*`, `*/qwen*`, `*node* *qwen*`) to `src/agentsight/agentsight.json`
- These rules are embedded in the agentsight binary and written to `/etc/agentsight/config.json` on first install, allowing AgentSight to discover Qwen Code processes
- Without these rules, agentsight could not track tokenless activity for qwencode users, making the `tokenless` adapter for qwencode effectively invisible to the observability layer

## Root cause

The qwencode tokenless adapter was declared in `manifest.json.in`, the Makefile, and all adapter scripts, but the agentsight process-discovery config (`agentsight.json`) had no cmdline patterns for the `qwen` binary. Users deploying the qwencode adapter would see no token-savings data in the agentsight dashboard.

## Changes

- `src/agentsight/agentsight.json`: add `QwenCode` agent rules after the existing `Claude` rules, following the same 3-pattern convention (bare name, absolute path, node-wrapper)
- `src/agentsight/src/discovery/matcher.rs`: add three unit tests covering the new rules

## Testing

```
cargo test --package agentsight --lib -- discovery::matcher::tests
# 25/25 passed (includes 3 new qwencode tests)

cargo clippy --package agentsight --lib -- -D warnings
# clean

cargo fmt --package agentsight -- --check
# clean
```

No schema_version bump required: the change is a pure addition of optional allow-list entries, fully backward-compatible with existing on-disk configs.