### PR TITLE
fix(cosh-ng): list hooks commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/hooks.rs
@@ -284,10 +284,26 @@ fn hooks_status_body(
 }
 
 fn hooks_usage_body(i18n: &I18n) -> Vec<String> {
-    [MessageId::SlashHooksUsageListLine]
-        .into_iter()
-        .map(|id| i18n.t(id).to_string())
-        .collect()
+    [
+        MessageId::SlashHooksUsageListLine,
+        MessageId::SlashHooksUsageHistoryLine,
+        MessageId::SlashHooksUsageEventsLine,
+        MessageId::SlashHooksUsageAnalyzeLine,
+        MessageId::SlashHooksUsageIgnoreLine,
+        MessageId::SlashHooksUsageDetailsLine,
+        MessageId::SlashHooksUsageFeedbackLine,
+        MessageId::SlashHooksUsageClearFeedbackLine,
+        MessageId::SlashHooksUsageMuteLine,
+        MessageId::SlashHooksUsageUnmuteLine,
+        MessageId::SlashHooksUsageTrustProjectLine,
+        MessageId::SlashHooksUsageUntrustProjectLine,
+        MessageId::SlashHooksUsageClearProjectTrustLine,
+        MessageId::SlashHooksUsageEnableLine,
+        MessageId::SlashHooksUsageDisableLine,
+    ]
+    .into_iter()
+    .map(|id| i18n.t(id).to_string())
+    .collect()
 }
 
 fn render_project_hook_trust<W: Write>(

--- a/src/cosh-ng/crates/cosh-shell/src/slash/hooks_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/hooks_tests.rs
@@ -218,24 +218,30 @@ fn hooks_history_and_events_empty_state_use_zh_catalog_text() {
 }
 
 #[test]
-fn hooks_usage_uses_zh_catalog_text() {
-    let mut state = zh_state();
+fn hooks_help_and_unknown_command_list_subcommands_in_zh() {
+    for subcommand in ["--help", "bogus"] {
+        let mut state = zh_state();
+        let output = render_hooks_test_command(Some(subcommand), None, None, &mut state);
 
-    let output = render_hooks_test_command(Some("bogus"), None, None, &mut state);
-
-    assert!(output.contains("用法"), "{output}");
-    assert!(
-        output.contains("/hooks                - 显示 Hook 状态"),
-        "{output}"
-    );
-    assert!(!output.contains("/hooks clear-project-trust"), "{output}");
-    assert!(!output.contains("/hooks feedback"), "{output}");
-    assert!(!output.contains("/hooks analyze"), "{output}");
-    assert!(!output.contains("show hook status"), "{output}");
-    assert!(
-        !output.contains("clear project hook trust store"),
-        "{output}"
-    );
+        assert!(output.contains("用法"), "{output}");
+        assert!(
+            output.contains("/hooks                - 显示 Hook 状态"),
+            "{output}"
+        );
+        assert!(output.contains("/hooks history"), "{output}");
+        assert!(output.contains("/hooks enable <id>"), "{output}");
+        assert!(output.contains("/hooks disable <id>"), "{output}");
+        assert!(output.contains("/hooks clear-project-trust"), "{output}");
+        assert!(
+            output.contains("/hooks feedback noisy|useful <id>"),
+            "{output}"
+        );
+        assert!(!output.contains("show hook status"), "{output}");
+        assert!(
+            !output.contains("clear project hook trust store"),
+            "{output}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

`/hooks --help` only showed the status command, hiding available hook actions.

## What changed

List every implemented `/hooks` subcommand using the existing localized strings.

## Related issue

closes #2045

## User / Agent impact

`/hooks --help` now shows the available hook actions.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: this only expands help text.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell hooks_help_lists_subcommands_in_zh`
- `cargo test --package cosh-shell --bin cosh-shell`
- `cargo clippy --package cosh-shell --bin cosh-shell -- -D warnings`

## Documentation and rollback

No documentation change. Revert this commit to restore the prior help output.