### PR TITLE
fix(cosh-ng): [core] confine file writes

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/tool/atomic_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/atomic_file.rs
@@ -1,17 +1,24 @@
 //! Durable atomic replacement for general user files written by tools.
 
+use std::ffi::OsString;
 use std::fmt;
-use std::fs::{self, File, OpenOptions, Permissions};
+use std::fs::{File, Permissions};
 use std::io::{self, Read, Write};
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
+use rustix::fs::{openat, renameat, unlinkat, AtFlags, Mode, OFlags};
+#[cfg(target_os = "linux")]
+use rustix::fs::{openat2, ResolveFlags, CWD};
 
 #[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::os::unix::fs::MetadataExt;
+
+use super::workspace_fs::WorkspaceWriteTarget;
 
 const TEMP_NAME_ATTEMPTS: usize = 16;
-const SYMLINK_LIMIT: usize = 40;
 
 #[derive(Debug)]
 pub(super) enum ReplaceError {
@@ -75,8 +82,8 @@ pub(super) struct FileSnapshot {
 }
 
 impl FileSnapshot {
-    fn read(path: &Path) -> io::Result<Self> {
-        let mut file = File::open(path)?;
+    fn read(target: &WorkspaceWriteTarget) -> io::Result<Self> {
+        let mut file = open_target(target, OFlags::RDONLY | OFlags::CLOEXEC)?;
         let metadata = file.metadata()?;
         let mut bytes = Vec::with_capacity(metadata.len().try_into().unwrap_or(0));
         file.read_to_end(&mut bytes)?;
@@ -108,9 +115,16 @@ impl FileSnapshot {
     }
 }
 
-pub(super) async fn read_snapshot(path: PathBuf) -> Result<FileSnapshot, ReplaceError> {
-    let error_path = path.clone();
-    tokio::task::spawn_blocking(move || FileSnapshot::read(&path))
+pub(super) async fn read_snapshot(
+    target: &WorkspaceWriteTarget,
+) -> Result<FileSnapshot, ReplaceError> {
+    let error_path = target.display_path.clone();
+    let target = clone_target(target).map_err(|source| ReplaceError::Io {
+        operation: "clone parent directory for snapshot read",
+        path: error_path.clone(),
+        source,
+    })?;
+    tokio::task::spawn_blocking(move || FileSnapshot::read(&target))
         .await
         .map_err(|error| ReplaceError::Io {
             operation: "join snapshot read for",
@@ -125,14 +139,19 @@ pub(super) async fn read_snapshot(path: PathBuf) -> Result<FileSnapshot, Replace
 }
 
 pub(super) async fn replace(
-    path: PathBuf,
+    target: &WorkspaceWriteTarget,
     bytes: Vec<u8>,
     expected: Option<FileSnapshot>,
 ) -> Result<(), ReplaceError> {
-    let error_path = path.clone();
+    let error_path = target.display_path.clone();
+    let target = clone_target(target).map_err(|source| ReplaceError::Io {
+        operation: "clone parent directory for atomic replacement",
+        path: error_path.clone(),
+        source,
+    })?;
     tokio::task::spawn_blocking(move || {
         replace_with_hooks(
-            &path,
+            &target,
             &bytes,
             expected.as_ref(),
             |_, _| Ok(()),
@@ -149,7 +168,7 @@ pub(super) async fn replace(
 }
 
 fn replace_with_hooks<BeforeWrite, BeforeCommit, BeforeDirectorySync>(
-    requested_path: &Path,
+    target: &WorkspaceWriteTarget,
     bytes: &[u8],
     expected: Option<&FileSnapshot>,
     before_write: BeforeWrite,
@@ -161,22 +180,16 @@ where
     BeforeCommit: FnOnce(&Path, &Path) -> io::Result<()>,
     BeforeDirectorySync: FnOnce(&Path) -> io::Result<()>,
 {
-    let target = resolve_target(requested_path).map_err(|source| ReplaceError::Io {
-        operation: "resolve",
-        path: requested_path.to_path_buf(),
-        source,
-    })?;
-    let parent = target.parent().unwrap_or_else(|| Path::new("."));
-    let permissions = target_permissions(&target)?;
-    let (mut temporary, mut guard) = create_temporary(parent)?;
+    let permissions = target_permissions(target)?;
+    let (mut temporary, mut guard) = create_temporary(target)?;
 
     if let Some(permissions) = permissions {
         temporary
             .set_permissions(permissions)
             .map_err(|source| io_error("preserve permissions on", guard.path(), source))?;
     }
-    before_write(&target, guard.path())
-        .map_err(|source| io_error("prepare temporary file for", &target, source))?;
+    before_write(&target.display_path, guard.path())
+        .map_err(|source| io_error("prepare temporary file for", &target.display_path, source))?;
     temporary
         .write_all(bytes)
         .map_err(|source| io_error("write temporary file", guard.path(), source))?;
@@ -190,99 +203,108 @@ where
 
     // The directory inode stays stable across rename, so every helper user
     // serializes the snapshot check and commit on the same advisory lock.
-    let directory =
-        File::open(parent).map_err(|source| io_error("open parent directory", parent, source))?;
+    let directory = open_parent_for_lock(&target.parent)
+        .map_err(|source| io_error("open parent directory", &target.display_path, source))?;
     directory
         .lock_exclusive()
-        .map_err(|source| io_error("lock parent directory", parent, source))?;
-    before_commit(&target, guard.path())
-        .map_err(|source| io_error("prepare replacement of", &target, source))?;
+        .map_err(|source| io_error("lock parent directory", &target.display_path, source))?;
+    before_commit(&target.display_path, guard.path())
+        .map_err(|source| io_error("prepare replacement of", &target.display_path, source))?;
     if let Some(expected) = expected {
-        let current = match FileSnapshot::read(&target) {
+        let current = match FileSnapshot::read(target) {
             Ok(current) => current,
             Err(source) if source.kind() == io::ErrorKind::NotFound => {
-                return Err(ReplaceError::Conflict { path: target });
+                return Err(ReplaceError::Conflict {
+                    path: target.display_path.clone(),
+                });
             }
-            Err(source) => return Err(io_error("verify", &target, source)),
+            Err(source) => return Err(io_error("verify", &target.display_path, source)),
         };
         if !expected.still_matches(&current) {
-            return Err(ReplaceError::Conflict { path: target });
+            return Err(ReplaceError::Conflict {
+                path: target.display_path.clone(),
+            });
         }
     }
 
-    fs::rename(guard.path(), &target)
-        .map_err(|source| io_error("atomically replace", &target, source))?;
+    renameat(&target.parent, &guard.name, &target.parent, &target.name)
+        .map_err(errno_to_io)
+        .map_err(|source| io_error("atomically replace", &target.display_path, source))?;
     guard.disarm();
 
-    before_directory_sync(parent).map_err(|source| ReplaceError::Committed {
-        path: target.clone(),
+    let parent_path = target
+        .display_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+    before_directory_sync(parent_path).map_err(|source| ReplaceError::Committed {
+        path: target.display_path.clone(),
         source,
     })?;
     directory
         .sync_all()
         .map_err(|source| ReplaceError::Committed {
-            path: target,
+            path: target.display_path.clone(),
             source,
         })?;
     Ok(())
 }
 
-fn resolve_target(path: &Path) -> io::Result<PathBuf> {
-    let mut target = path.to_path_buf();
-    let mut followed = 0;
-    loop {
-        match fs::symlink_metadata(&target) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
-                if followed == SYMLINK_LIMIT {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "too many symbolic links while resolving target",
-                    ));
-                }
-                let referent = fs::read_link(&target)?;
-                target = if referent.is_absolute() {
-                    referent
-                } else {
-                    target
-                        .parent()
-                        .unwrap_or_else(|| Path::new("."))
-                        .join(referent)
-                };
-                followed += 1;
-            }
-            Ok(_) => return Ok(target),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(target),
-            Err(error) => return Err(error),
-        }
-    }
-}
+fn target_permissions(target: &WorkspaceWriteTarget) -> Result<Option<Permissions>, ReplaceError> {
+    #[cfg(target_os = "linux")]
+    let flags = OFlags::PATH | OFlags::CLOEXEC;
+    #[cfg(target_os = "macos")]
+    let flags = OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NONBLOCK;
 
-fn target_permissions(path: &Path) -> Result<Option<Permissions>, ReplaceError> {
-    match fs::metadata(path) {
+    match open_target(target, flags).and_then(|file| file.metadata()) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(io_error(
+            "inspect permissions for",
+            &target.display_path,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "resolved target was replaced by a symbolic link",
+            ),
+        )),
         Ok(metadata) => Ok(Some(metadata.permissions())),
         Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(None),
-        Err(source) => Err(io_error("inspect permissions for", path, source)),
+        Err(source) => Err(io_error(
+            "inspect permissions for",
+            &target.display_path,
+            source,
+        )),
     }
 }
 
-fn create_temporary(parent: &Path) -> Result<(File, TemporaryGuard), ReplaceError> {
+fn create_temporary(target: &WorkspaceWriteTarget) -> Result<(File, TemporaryGuard), ReplaceError> {
     for _ in 0..TEMP_NAME_ATTEMPTS {
-        let path = parent.join(format!(".cosh-tmp-{}", uuid::Uuid::new_v4()));
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        options.mode(0o666);
-
-        match options.open(&path) {
-            Ok(file) => return Ok((file, TemporaryGuard::new(path))),
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-            Err(source) => return Err(io_error("create temporary file", &path, source)),
+        let name = OsString::from(format!(".cosh-tmp-{}", uuid::Uuid::new_v4()));
+        let guard_parent = target.parent.try_clone().map_err(|source| {
+            io_error("clone temporary file parent", &target.display_path, source)
+        })?;
+        match openat(
+            &target.parent,
+            &name,
+            OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC,
+            Mode::from_raw_mode(0o666),
+        ) {
+            Ok(file) => {
+                let file = File::from(file);
+                let guard = TemporaryGuard::new(guard_parent, target, name);
+                return Ok((file, guard));
+            }
+            Err(rustix::io::Errno::EXIST) => continue,
+            Err(error) => {
+                return Err(io_error(
+                    "create temporary file",
+                    &target.display_path,
+                    errno_to_io(error),
+                ))
+            }
         }
     }
 
     Err(io_error(
         "create unique temporary file in",
-        parent,
+        &target.display_path,
         io::Error::new(
             io::ErrorKind::AlreadyExists,
             "temporary name collision limit reached",
@@ -299,17 +321,24 @@ fn io_error(operation: &'static str, path: &Path, source: io::Error) -> ReplaceE
 }
 
 struct TemporaryGuard {
-    path: PathBuf,
+    parent: File,
+    name: OsString,
+    display_path: PathBuf,
     armed: bool,
 }
 
 impl TemporaryGuard {
-    fn new(path: PathBuf) -> Self {
-        Self { path, armed: true }
+    fn new(parent: File, target: &WorkspaceWriteTarget, name: OsString) -> Self {
+        Self {
+            parent,
+            display_path: target.display_path.with_file_name(&name),
+            name,
+            armed: true,
+        }
     }
 
     fn path(&self) -> &Path {
-        &self.path
+        &self.display_path
     }
 
     fn disarm(&mut self) {
@@ -320,14 +349,63 @@ impl TemporaryGuard {
 impl Drop for TemporaryGuard {
     fn drop(&mut self) {
         if self.armed {
-            let _ = fs::remove_file(&self.path);
+            let _ = unlinkat(&self.parent, &self.name, AtFlags::empty());
         }
     }
 }
 
+fn clone_target(target: &WorkspaceWriteTarget) -> io::Result<WorkspaceWriteTarget> {
+    Ok(WorkspaceWriteTarget {
+        parent: target.parent.try_clone()?,
+        name: target.name.clone(),
+        display_path: target.display_path.clone(),
+    })
+}
+
+fn open_target(target: &WorkspaceWriteTarget, flags: OFlags) -> io::Result<File> {
+    openat(
+        &target.parent,
+        &target.name,
+        flags | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map(File::from)
+    .map_err(errno_to_io)
+}
+
+#[cfg(target_os = "linux")]
+fn open_parent_for_lock(parent: &File) -> io::Result<File> {
+    let descriptor_path = PathBuf::from(format!("/proc/self/fd/{}", parent.as_raw_fd()));
+    openat2(
+        CWD,
+        descriptor_path,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+        ResolveFlags::empty(),
+    )
+    .map(File::from)
+    .map_err(errno_to_io)
+}
+
+#[cfg(target_os = "macos")]
+fn open_parent_for_lock(parent: &File) -> io::Result<File> {
+    openat(
+        parent,
+        ".",
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map(File::from)
+    .map_err(errno_to_io)
+}
+
+fn errno_to_io(error: rustix::io::Errno) -> io::Error {
+    io::Error::from_raw_os_error(error.raw_os_error())
+}
+
 #[cfg(test)]
 pub(super) fn replace_with_before_commit_for_test<BeforeCommit>(
-    path: &Path,
+    target: &WorkspaceWriteTarget,
     bytes: &[u8],
     expected: &FileSnapshot,
     before_commit: BeforeCommit,
@@ -336,7 +414,7 @@ where
     BeforeCommit: FnOnce(&Path, &Path) -> io::Result<()>,
 {
     replace_with_hooks(
-        path,
+        target,
         bytes,
         Some(expected),
         |_, _| Ok(()),
@@ -347,6 +425,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::io::{Seek, SeekFrom};
 
     #[cfg(unix)]
@@ -366,18 +445,31 @@ mod tests {
             .collect()
     }
 
+    fn prepare_test_target(path: &Path) -> WorkspaceWriteTarget {
+        let parent = path.parent().expect("test target has a parent");
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("test target name is UTF-8");
+        super::super::workspace_fs::WorkspaceFs::new(parent)
+            .unwrap()
+            .prepare_write(parent, name, false)
+            .unwrap()
+    }
+
     #[test]
     #[cfg(unix)]
     fn replacement_uses_rename_and_preserves_permissions() {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("source.rs");
         fs::write(&target, b"old content").unwrap();
+        let write_target = prepare_test_target(&target);
         fs::set_permissions(&target, Permissions::from_mode(0o640)).unwrap();
         let original_inode = fs::metadata(&target).unwrap().ino();
         let mut original_handle = File::open(&target).unwrap();
 
         replace_with_hooks(
-            &target,
+            &write_target,
             b"new content",
             None,
             |_, _| Ok(()),
@@ -406,10 +498,11 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("config.toml");
         fs::write(&target, b"stable").unwrap();
+        let write_target = prepare_test_target(&target);
         let mut temporary_path = None;
 
         let error = replace_with_hooks(
-            &target,
+            &write_target,
             b"candidate",
             None,
             |_, _| Ok(()),
@@ -440,10 +533,11 @@ mod tests {
     fn rename_failure_keeps_target_and_cleans_temp() {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("existing-directory");
+        let write_target = prepare_test_target(&target);
         fs::create_dir(&target).unwrap();
 
         let error = replace_with_hooks(
-            &target,
+            &write_target,
             b"candidate",
             None,
             |_, _| Ok(()),
@@ -462,10 +556,11 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("source.rs");
         fs::write(&target, b"original").unwrap();
-        let snapshot = FileSnapshot::read(&target).unwrap();
+        let write_target = prepare_test_target(&target);
+        let snapshot = FileSnapshot::read(&write_target).unwrap();
 
         let error = replace_with_hooks(
-            &target,
+            &write_target,
             b"edited",
             Some(&snapshot),
             |_, _| Ok(()),
@@ -485,10 +580,11 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("source.rs");
         fs::write(&target, b"original").unwrap();
-        let snapshot = FileSnapshot::read(&target).unwrap();
+        let write_target = prepare_test_target(&target);
+        let snapshot = FileSnapshot::read(&write_target).unwrap();
 
         let error = replace_with_hooks(
-            &target,
+            &write_target,
             b"edited",
             Some(&snapshot),
             |_, _| Ok(()),
@@ -511,12 +607,13 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("credentials.txt");
         fs::write(&target, b"old secret").unwrap();
+        let write_target = prepare_test_target(&target);
         fs::set_permissions(&target, Permissions::from_mode(0o600)).unwrap();
         let mut observed_mode = None;
         let mut observed_length = None;
 
         let error = replace_with_hooks(
-            &target,
+            &write_target,
             b"new secret",
             None,
             |_, temporary| {
@@ -545,12 +642,13 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("source.rs");
         fs::write(&target, b"original").unwrap();
-        let first_snapshot = read_snapshot(target.clone()).await.unwrap();
-        let second_snapshot = read_snapshot(target.clone()).await.unwrap();
+        let write_target = prepare_test_target(&target);
+        let first_snapshot = read_snapshot(&write_target).await.unwrap();
+        let second_snapshot = read_snapshot(&write_target).await.unwrap();
 
         let (first, second) = tokio::join!(
-            replace(target.clone(), b"first".to_vec(), Some(first_snapshot)),
-            replace(target.clone(), b"second".to_vec(), Some(second_snapshot)),
+            replace(&write_target, b"first".to_vec(), Some(first_snapshot)),
+            replace(&write_target, b"second".to_vec(), Some(second_snapshot)),
         );
 
         assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
@@ -570,9 +668,10 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("source.rs");
         fs::write(&target, b"old").unwrap();
+        let write_target = prepare_test_target(&target);
 
         let error = replace_with_hooks(
-            &target,
+            &write_target,
             b"new",
             None,
             |_, _| Ok(()),

--- a/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/edit.rs
@@ -79,33 +79,46 @@ impl EditTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let path = resolve_path(path_str, &ctx.cwd);
+        let workspace = match ctx.workspace() {
+            Ok(workspace) => workspace,
+            Err(error) => return Ok(ToolResult::error(error)),
+        };
+        let cwd = ctx.cwd.clone();
+        let path = path_str.to_owned();
+        let prepared =
+            tokio::task::spawn_blocking(move || workspace.prepare_write(&cwd, &path, false))
+                .await
+                .map_err(|error| format!("Edit prepare task failed: {error}"))?;
+        let target = match prepared {
+            Ok(target) => target,
+            Err(error) => return Ok(ToolResult::error(error)),
+        };
+        let display_path = target.display_path.clone();
 
-        if !path.exists() {
-            return Ok(ToolResult::error(format!(
-                "File not found: {}",
-                path.display()
-            )));
-        }
-
-        let snapshot = atomic_file::read_snapshot(path.clone())
-            .await
-            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+        let snapshot = match atomic_file::read_snapshot(&target).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return Ok(ToolResult::error(format!(
+                    "Failed to read {}: {error}",
+                    display_path.display()
+                )))
+            }
+        };
         let content = std::str::from_utf8(snapshot.bytes())
-            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+            .map_err(|e| format!("Failed to read {}: {e}", display_path.display()))?;
         after_snapshot().await;
 
         let count = content.matches(old_string).count();
         if count == 0 {
             return Ok(ToolResult::error(format!(
                 "old_string not found in {}",
-                path.display()
+                display_path.display()
             )));
         }
         if count > 1 && !replace_all {
             return Ok(ToolResult::error(format!(
                 "old_string found {count} times in {}. Use replace_all=true to replace all, or provide more context to make the match unique.",
-                path.display()
+                display_path.display()
             )));
         }
 
@@ -116,76 +129,75 @@ impl EditTool {
         };
 
         if let Err(error) =
-            atomic_file::replace(path.clone(), new_content.into_bytes(), Some(snapshot)).await
+            atomic_file::replace(&target, new_content.into_bytes(), Some(snapshot)).await
         {
             if matches!(error, ReplaceError::Conflict { .. }) {
                 return Ok(ToolResult::error(error.to_string()));
             }
-            return Err(format!("Failed to write {}: {error}", path.display()));
+            return Ok(ToolResult::error(format!(
+                "Failed to write {}: {error}",
+                display_path.display()
+            )));
         }
 
         Ok(ToolResult::success(format!(
             "Replaced {count} occurrence(s) in {}",
-            path.display()
+            display_path.display()
         )))
     }
 }
-
-// resolve_path is provided by the parent module (super::resolve_path)
-// and supports ~ expansion.
-use super::resolve_path;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::Path;
     use std::sync::Arc;
-    use tempfile::NamedTempFile;
     use tokio::sync::Barrier;
 
-    fn test_ctx() -> ToolContext {
-        let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp"));
-        ToolContext::new(root.clone(), "test".to_string(), root)
+    fn test_ctx(root: &Path) -> ToolContext {
+        ToolContext::new(root.to_path_buf(), "test".to_string(), root.to_path_buf())
     }
 
     #[tokio::test]
     async fn edit_single_replacement() {
-        let tmp = NamedTempFile::new().unwrap();
-        std::fs::write(tmp.path(), "hello world").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.txt");
+        fs::write(&path, "hello world").unwrap();
 
         let tool = EditTool;
         let result = tool
             .invoke(
                 serde_json::json!({
-                    "path": tmp.path().to_str().unwrap(),
+                    "path": path.to_str().unwrap(),
                     "old_string": "hello",
                     "new_string": "goodbye"
                 }),
-                &test_ctx(),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
         assert!(!result.is_error);
 
-        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        let content = std::fs::read_to_string(path).unwrap();
         assert_eq!(content, "goodbye world");
     }
 
     #[tokio::test]
     async fn edit_not_found() {
-        let tmp = NamedTempFile::new().unwrap();
-        std::fs::write(tmp.path(), "hello world").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.txt");
+        fs::write(&path, "hello world").unwrap();
 
         let tool = EditTool;
         let result = tool
             .invoke(
                 serde_json::json!({
-                    "path": tmp.path().to_str().unwrap(),
+                    "path": path.to_str().unwrap(),
                     "old_string": "xyz",
                     "new_string": "abc"
                 }),
-                &test_ctx(),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
@@ -194,19 +206,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn edit_missing_file_returns_tool_error() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("missing.txt");
+
+        let result = EditTool
+            .invoke(
+                serde_json::json!({
+                    "path": path,
+                    "old_string": "old",
+                    "new_string": "new"
+                }),
+                &test_ctx(directory.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.to_ascii_lowercase().contains("no such file"));
+    }
+
+    #[tokio::test]
+    async fn edit_rejects_external_path_as_tool_error() {
+        let workspace = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        fs::write(outside.path(), "stable").unwrap();
+
+        let result = EditTool
+            .invoke(
+                serde_json::json!({
+                    "path": outside.path(),
+                    "old_string": "stable",
+                    "new_string": "blocked"
+                }),
+                &test_ctx(workspace.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("escapes workspace root"));
+        assert_eq!(fs::read_to_string(outside.path()).unwrap(), "stable");
+    }
+
+    #[tokio::test]
     async fn edit_ambiguous_without_replace_all() {
-        let tmp = NamedTempFile::new().unwrap();
-        std::fs::write(tmp.path(), "aaa bbb aaa").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.txt");
+        fs::write(&path, "aaa bbb aaa").unwrap();
 
         let tool = EditTool;
         let result = tool
             .invoke(
                 serde_json::json!({
-                    "path": tmp.path().to_str().unwrap(),
+                    "path": path.to_str().unwrap(),
                     "old_string": "aaa",
                     "new_string": "ccc"
                 }),
-                &test_ctx(),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
@@ -216,25 +273,26 @@ mod tests {
 
     #[tokio::test]
     async fn edit_replace_all() {
-        let tmp = NamedTempFile::new().unwrap();
-        std::fs::write(tmp.path(), "aaa bbb aaa").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.txt");
+        fs::write(&path, "aaa bbb aaa").unwrap();
 
         let tool = EditTool;
         let result = tool
             .invoke(
                 serde_json::json!({
-                    "path": tmp.path().to_str().unwrap(),
+                    "path": path.to_str().unwrap(),
                     "old_string": "aaa",
                     "new_string": "ccc",
                     "replace_all": true
                 }),
-                &test_ctx(),
+                &test_ctx(directory.path()),
             )
             .await
             .unwrap();
         assert!(!result.is_error);
 
-        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        let content = std::fs::read_to_string(path).unwrap();
         assert_eq!(content, "ccc bbb ccc");
     }
 
@@ -243,10 +301,14 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("source.rs");
         fs::write(&path, "hello world").unwrap();
-        let snapshot = atomic_file::read_snapshot(path.clone()).await.unwrap();
+        let workspace = super::super::workspace_fs::WorkspaceFs::new(directory.path()).unwrap();
+        let target = workspace
+            .prepare_write(directory.path(), "source.rs", false)
+            .unwrap();
+        let snapshot = atomic_file::read_snapshot(&target).await.unwrap();
 
         let error = atomic_file::replace_with_before_commit_for_test(
-            &path,
+            &target,
             b"goodbye world",
             &snapshot,
             |target, _| {
@@ -267,7 +329,7 @@ mod tests {
         let path = directory.path().join("source.rs");
         fs::write(&path, "hello world").unwrap();
         let tool = EditTool;
-        let context = test_ctx();
+        let context = test_ctx(directory.path());
         let barrier = Arc::new(Barrier::new(2));
 
         let first_barrier = Arc::clone(&barrier);

--- a/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
@@ -60,16 +60,6 @@ pub(super) fn expand_tilde(path_str: &str) -> PathBuf {
     }
 }
 
-/// Resolve a path string, expanding `~` and relative paths against `cwd`.
-pub(super) fn resolve_path(path_str: &str, cwd: &std::path::Path) -> PathBuf {
-    let expanded = expand_tilde(path_str);
-    if expanded.is_absolute() {
-        expanded
-    } else {
-        cwd.join(expanded)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum ToolKind {
     ReadOnly,
@@ -630,21 +620,5 @@ mod tests {
     fn expand_tilde_no_tilde_passthrough() {
         let result = expand_tilde("relative/path");
         assert_eq!(result, PathBuf::from("relative/path"));
-    }
-
-    #[test]
-    fn resolve_path_tilde_is_absolute() {
-        let cwd = std::path::Path::new("/tmp");
-        let result = resolve_path("~/test.rs", cwd);
-        assert!(result.is_absolute());
-        assert!(!result.starts_with(cwd));
-        assert!(result.ends_with("test.rs"));
-    }
-
-    #[test]
-    fn resolve_path_relative_joins_cwd() {
-        let cwd = std::path::Path::new("/workspace");
-        let result = resolve_path("src/main.rs", cwd);
-        assert_eq!(result, PathBuf::from("/workspace/src/main.rs"));
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/tool/workspace_fs.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/workspace_fs.rs
@@ -7,14 +7,14 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
-use std::os::unix::ffi::OsStringExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "macos")]
-use rustix::fs::open;
+use rustix::fs::{mkdirat, open, openat, readlinkat, statat, AtFlags};
 #[cfg(target_os = "linux")]
-use rustix::fs::{openat2, readlinkat, ResolveFlags, CWD};
+use rustix::fs::{mkdirat, openat2, readlinkat, ResolveFlags, CWD};
 use rustix::fs::{Dir, FileType, Mode, OFlags};
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
@@ -24,7 +24,6 @@ use super::expand_tilde;
 const MAX_WALK_ENTRIES: usize = 10_000;
 const MAX_IGNORE_FILE_BYTES: u64 = 1024 * 1024;
 const MAX_IGNORE_TOTAL_BYTES: u64 = 4 * 1024 * 1024;
-#[cfg(target_os = "linux")]
 const MAX_SYMLINKS: usize = 40;
 #[cfg(target_os = "linux")]
 const RESOLVE_FLAGS: ResolveFlags = ResolveFlags::BENEATH
@@ -100,6 +99,30 @@ pub(super) struct WorkspaceFile {
     pub relative_path: PathBuf,
     pub display_path: PathBuf,
     pub file: File,
+}
+
+/// A write target whose parent directory is pinned by descriptor.
+pub(super) struct WorkspaceWriteTarget {
+    pub parent: File,
+    pub name: OsString,
+    pub display_path: PathBuf,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy)]
+enum ResolveMode {
+    Readable,
+    Pinned,
+    Write {
+        create_parents: bool,
+        must_be_directory: bool,
+    },
+}
+
+#[cfg(target_os = "linux")]
+enum ResolvedBeneath {
+    Node(Option<File>),
+    Write(WorkspaceWriteTarget),
 }
 
 /// A directory opened beneath the workspace root.
@@ -305,6 +328,249 @@ impl WorkspaceFs {
         self.root.join(relative_path)
     }
 
+    #[cfg(target_os = "linux")]
+    pub(super) fn prepare_write(
+        &self,
+        cwd: &Path,
+        path: &str,
+        create_parents: bool,
+    ) -> Result<WorkspaceWriteTarget, String> {
+        let must_be_directory = path_requires_directory(Path::new(path));
+        let relative_path = self.resolve_user_path(cwd, path)?;
+        match self.resolve_beneath(
+            &relative_path,
+            ResolveMode::Write {
+                create_parents,
+                must_be_directory,
+            },
+        ) {
+            Ok(ResolvedBeneath::Write(target)) => Ok(target),
+            Ok(ResolvedBeneath::Node(_)) => Err(format!(
+                "Path does not name a writable file: {}",
+                self.display_path(&relative_path).display()
+            )),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) fn prepare_write(
+        &self,
+        cwd: &Path,
+        path: &str,
+        create_parents: bool,
+    ) -> Result<WorkspaceWriteTarget, String> {
+        let must_be_directory = path_requires_directory(Path::new(path));
+        let relative_path = self.resolve_user_path(cwd, path)?;
+        self.prepare_write_beneath(&relative_path, create_parents, must_be_directory)
+            .map_err(|error| error.to_string())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn prepare_write_beneath(
+        &self,
+        relative_path: &Path,
+        create_parents: bool,
+        must_be_directory: bool,
+    ) -> Result<WorkspaceWriteTarget, WorkspaceOpenError> {
+        let display_path = self.display_path(relative_path);
+        let mut remaining = RemainingPath::new(relative_path, must_be_directory)?;
+        let root = self.directory.try_clone().map_err(|error| {
+            WorkspaceOpenError::Other(format!(
+                "Failed to clone workspace root descriptor {}: {error}",
+                self.root.display()
+            ))
+        })?;
+        let mut directories = vec![root];
+        let root_device = directories[0]
+            .metadata()
+            .map_err(|error| {
+                WorkspaceOpenError::Other(format!(
+                    "Failed to inspect pinned workspace root {}: {error}",
+                    self.root.display()
+                ))
+            })?
+            .dev();
+        let mut followed_symlinks = 0;
+
+        loop {
+            let Some(component) = remaining.pop_front() else {
+                return Err(WorkspaceOpenError::Other(format!(
+                    "Path must name a file: {}",
+                    display_path.display()
+                )));
+            };
+            if component == "." {
+                continue;
+            }
+            if component == ".." {
+                if directories.len() == 1 {
+                    return Err(WorkspaceOpenError::Escape(display_path));
+                }
+                directories.pop();
+                continue;
+            }
+
+            let current = directories.last().expect("workspace root descriptor");
+            let metadata = match statat(current, &component, AtFlags::SYMLINK_NOFOLLOW) {
+                Ok(metadata) => metadata,
+                Err(rustix::io::Errno::NOENT) if remaining.is_empty() => {
+                    if remaining.must_be_directory() {
+                        return Err(WorkspaceOpenError::Other(format!(
+                            "Not a directory: {}",
+                            display_path.display()
+                        )));
+                    }
+                    return Ok(WorkspaceWriteTarget {
+                        parent: current.try_clone().map_err(|error| {
+                            WorkspaceOpenError::Other(format!(
+                                "Failed to clone parent directory for {}: {error}",
+                                display_path.display()
+                            ))
+                        })?,
+                        name: component,
+                        display_path,
+                    });
+                }
+                Err(rustix::io::Errno::NOENT) if create_parents => {
+                    match mkdirat(current, &component, Mode::from_raw_mode(0o777)) {
+                        Ok(()) | Err(rustix::io::Errno::EXIST) => {
+                            remaining.push_front(component);
+                            continue;
+                        }
+                        Err(error) => {
+                            return Err(WorkspaceOpenError::Other(format!(
+                                "Failed to create parent directory {}: {error}",
+                                display_path.display()
+                            )));
+                        }
+                    }
+                }
+                Err(rustix::io::Errno::NOENT) => {
+                    return Err(WorkspaceOpenError::Other(format!(
+                        "Path not found: {}",
+                        display_path.display()
+                    )));
+                }
+                Err(rustix::io::Errno::ACCESS | rustix::io::Errno::PERM) => {
+                    return Err(WorkspaceOpenError::Inaccessible(display_path));
+                }
+                Err(error) => {
+                    return Err(WorkspaceOpenError::Other(format!(
+                        "Failed to inspect {}: {error}",
+                        display_path.display()
+                    )));
+                }
+            };
+            let file_type = FileType::from_raw_mode(metadata.st_mode);
+
+            if file_type == FileType::Symlink {
+                followed_symlinks += 1;
+                if followed_symlinks > MAX_SYMLINKS {
+                    return Err(WorkspaceOpenError::SymlinkLoop(display_path));
+                }
+                let target = readlinkat(current, &component, Vec::new()).map_err(|error| {
+                    WorkspaceOpenError::Other(format!(
+                        "Failed to read symbolic link {}: {error}",
+                        display_path.display()
+                    ))
+                })?;
+                let verified = statat(current, &component, AtFlags::SYMLINK_NOFOLLOW)
+                    .map_err(|_| WorkspaceOpenError::Escape(display_path.clone()))?;
+                if FileType::from_raw_mode(verified.st_mode) != FileType::Symlink
+                    || metadata.st_dev != verified.st_dev
+                    || metadata.st_ino != verified.st_ino
+                {
+                    return Err(WorkspaceOpenError::Escape(display_path));
+                }
+
+                let target = PathBuf::from(OsString::from_vec(target.into_bytes()));
+                let target_must_be_directory = path_requires_directory(&target);
+                let target = if target.is_absolute() {
+                    let target = self
+                        .strip_root_prefix(&target)
+                        .map_err(|_| WorkspaceOpenError::Escape(display_path.clone()))?;
+                    directories.truncate(1);
+                    target
+                } else {
+                    target.as_path()
+                };
+                remaining.prepend(target, target_must_be_directory)?;
+                continue;
+            }
+
+            if metadata.st_dev as u64 != root_device {
+                return Err(WorkspaceOpenError::Escape(display_path));
+            }
+
+            if remaining.is_empty() {
+                if remaining.must_be_directory() && file_type != FileType::Directory {
+                    return Err(WorkspaceOpenError::Other(format!(
+                        "Not a directory: {}",
+                        display_path.display()
+                    )));
+                }
+                return if file_type == FileType::RegularFile {
+                    Ok(WorkspaceWriteTarget {
+                        parent: current.try_clone().map_err(|error| {
+                            WorkspaceOpenError::Other(format!(
+                                "Failed to clone parent directory for {}: {error}",
+                                display_path.display()
+                            ))
+                        })?,
+                        name: component,
+                        display_path,
+                    })
+                } else if file_type == FileType::Directory {
+                    Err(WorkspaceOpenError::Other(format!(
+                        "Not a file: {}",
+                        display_path.display()
+                    )))
+                } else {
+                    Err(WorkspaceOpenError::Unsupported(display_path))
+                };
+            }
+            if file_type != FileType::Directory {
+                return Err(WorkspaceOpenError::Other(format!(
+                    "Not a directory: {}",
+                    display_path.display()
+                )));
+            }
+
+            let flags = OFlags::RDONLY
+                | OFlags::DIRECTORY
+                | OFlags::CLOEXEC
+                | OFlags::NOFOLLOW
+                | OFlags::NONBLOCK;
+            let directory = match openat(current, &component, flags, Mode::empty()) {
+                Ok(directory) => directory,
+                Err(rustix::io::Errno::LOOP) => {
+                    return Err(WorkspaceOpenError::Escape(display_path));
+                }
+                Err(error) => {
+                    return Err(WorkspaceOpenError::Other(format!(
+                        "Failed to open parent directory {}: {error}",
+                        display_path.display()
+                    )));
+                }
+            };
+            let directory = File::from(directory);
+            let opened = directory.metadata().map_err(|error| {
+                WorkspaceOpenError::Other(format!(
+                    "Failed to inspect parent directory {}: {error}",
+                    display_path.display()
+                ))
+            })?;
+            if opened.dev() != root_device
+                || opened.dev() != metadata.st_dev as u64
+                || opened.ino() != metadata.st_ino as u64
+            {
+                return Err(WorkspaceOpenError::Escape(display_path));
+            }
+            directories.push(directory);
+        }
+    }
+
     fn strip_root_prefix<'a>(&self, path: &'a Path) -> Result<&'a Path, ()> {
         path.strip_prefix(&self.root)
             .or_else(|_| path.strip_prefix(&self.requested_root))
@@ -468,7 +734,10 @@ impl WorkspaceFs {
 
     #[cfg(target_os = "linux")]
     fn open_beneath(&self, relative_path: &Path) -> Result<Option<File>, WorkspaceOpenError> {
-        self.resolve_beneath(relative_path, true)
+        match self.resolve_beneath(relative_path, ResolveMode::Readable)? {
+            ResolvedBeneath::Node(node) => Ok(node),
+            ResolvedBeneath::Write(_) => unreachable!("read resolution returned a write target"),
+        }
     }
 
     #[cfg(target_os = "macos")]
@@ -478,17 +747,26 @@ impl WorkspaceFs {
 
     #[cfg(target_os = "linux")]
     fn pin_beneath(&self, relative_path: &Path) -> Result<Option<File>, WorkspaceOpenError> {
-        self.resolve_beneath(relative_path, false)
+        match self.resolve_beneath(relative_path, ResolveMode::Pinned)? {
+            ResolvedBeneath::Node(node) => Ok(node),
+            ResolvedBeneath::Write(_) => unreachable!("pin resolution returned a write target"),
+        }
     }
 
     #[cfg(target_os = "linux")]
     fn resolve_beneath(
         &self,
         relative_path: &Path,
-        readable: bool,
-    ) -> Result<Option<File>, WorkspaceOpenError> {
+        mode: ResolveMode,
+    ) -> Result<ResolvedBeneath, WorkspaceOpenError> {
         let display_path = self.display_path(relative_path);
-        let mut remaining = path_components(relative_path)?;
+        let must_be_directory = match mode {
+            ResolveMode::Write {
+                must_be_directory, ..
+            } => must_be_directory,
+            ResolveMode::Readable | ResolveMode::Pinned => path_requires_directory(relative_path),
+        };
+        let mut remaining = RemainingPath::new(relative_path, must_be_directory)?;
         let root = self.directory.try_clone().map_err(|error| {
             WorkspaceOpenError::Other(format!(
                 "Failed to clone workspace root descriptor {}: {error}",
@@ -500,14 +778,17 @@ impl WorkspaceFs {
 
         loop {
             let Some(component) = remaining.pop_front() else {
-                return if readable {
-                    reopen_pinned(
+                return match mode {
+                    ResolveMode::Readable => Ok(ResolvedBeneath::Node(reopen_pinned(
                         directories.last().expect("workspace root descriptor"),
                         &display_path,
                         true,
-                    )
-                } else {
-                    Ok(directories.pop())
+                    )?)),
+                    ResolveMode::Pinned => Ok(ResolvedBeneath::Node(directories.pop())),
+                    ResolveMode::Write { .. } => Err(WorkspaceOpenError::Other(format!(
+                        "Path must name a file: {}",
+                        display_path.display()
+                    ))),
                 };
             };
             if component == "." {
@@ -524,11 +805,62 @@ impl WorkspaceFs {
             let current = directories.last().expect("workspace root descriptor");
             // Pin before inspecting so a concurrent rename cannot change which
             // symlink target or directory the remainder is resolved against.
-            let Some(pinned) =
-                open_component(current, Path::new(&component), &display_path, PIN_FLAGS)?
-            else {
-                return Ok(None);
-            };
+            let pinned =
+                match open_component(current, Path::new(&component), &display_path, PIN_FLAGS)? {
+                    Some(pinned) => pinned,
+                    None => {
+                        if remaining.is_empty() && matches!(mode, ResolveMode::Write { .. }) {
+                            if remaining.must_be_directory() {
+                                return Err(WorkspaceOpenError::Other(format!(
+                                    "Not a directory: {}",
+                                    display_path.display()
+                                )));
+                            }
+                            return Ok(ResolvedBeneath::Write(WorkspaceWriteTarget {
+                                parent: current.try_clone().map_err(|error| {
+                                    WorkspaceOpenError::Other(format!(
+                                        "Failed to clone parent directory for {}: {error}",
+                                        display_path.display()
+                                    ))
+                                })?,
+                                name: component,
+                                display_path,
+                            }));
+                        }
+                        if !matches!(
+                            mode,
+                            ResolveMode::Write {
+                                create_parents: true,
+                                ..
+                            }
+                        ) {
+                            return match mode {
+                                ResolveMode::Readable | ResolveMode::Pinned => {
+                                    Ok(ResolvedBeneath::Node(None))
+                                }
+                                ResolveMode::Write { .. } => Err(WorkspaceOpenError::Other(
+                                    format!("Path not found: {}", display_path.display()),
+                                )),
+                            };
+                        }
+                        match mkdirat(current, &component, Mode::from_raw_mode(0o777)) {
+                            Ok(()) | Err(rustix::io::Errno::EXIST) => {}
+                            Err(error) => {
+                                return Err(WorkspaceOpenError::Other(format!(
+                                    "Failed to create parent directory {}: {error}",
+                                    display_path.display()
+                                )))
+                            }
+                        }
+                        open_component(current, Path::new(&component), &display_path, PIN_FLAGS)?
+                            .ok_or_else(|| {
+                                WorkspaceOpenError::Other(format!(
+                                    "Parent directory disappeared while opening {}",
+                                    display_path.display()
+                                ))
+                            })?
+                    }
+                };
             let metadata = pinned.metadata().map_err(|error| {
                 WorkspaceOpenError::Other(format!(
                     "Failed to inspect {}: {error}",
@@ -548,6 +880,7 @@ impl WorkspaceFs {
                     ))
                 })?;
                 let target = PathBuf::from(OsString::from_vec(target.into_bytes()));
+                let target_must_be_directory = path_requires_directory(&target);
                 let target = if target.is_absolute() {
                     // The kernel cannot reinterpret a host-absolute target for
                     // RESOLVE_BENEATH, so reroot only lexically internal targets.
@@ -559,7 +892,7 @@ impl WorkspaceFs {
                 } else {
                     target.as_path()
                 };
-                prepend_components(&mut remaining, target)?;
+                remaining.prepend(target, target_must_be_directory)?;
                 continue;
             }
 
@@ -574,14 +907,38 @@ impl WorkspaceFs {
                 continue;
             }
 
-            return if readable && metadata.is_file() {
-                reopen_pinned(&pinned, &display_path, false)
-            } else if readable && metadata.is_dir() {
-                reopen_pinned(&pinned, &display_path, true)
-            } else if readable {
-                Err(WorkspaceOpenError::Unsupported(display_path))
-            } else {
-                Ok(Some(pinned))
+            if remaining.must_be_directory() && !metadata.is_dir() {
+                return Err(WorkspaceOpenError::Other(format!(
+                    "Not a directory: {}",
+                    display_path.display()
+                )));
+            }
+
+            return match mode {
+                ResolveMode::Readable if metadata.is_file() => Ok(ResolvedBeneath::Node(
+                    reopen_pinned(&pinned, &display_path, false)?,
+                )),
+                ResolveMode::Readable if metadata.is_dir() => Ok(ResolvedBeneath::Node(
+                    reopen_pinned(&pinned, &display_path, true)?,
+                )),
+                ResolveMode::Readable => Err(WorkspaceOpenError::Unsupported(display_path)),
+                ResolveMode::Pinned => Ok(ResolvedBeneath::Node(Some(pinned))),
+                ResolveMode::Write { .. } if metadata.is_file() => {
+                    Ok(ResolvedBeneath::Write(WorkspaceWriteTarget {
+                        parent: current.try_clone().map_err(|error| {
+                            WorkspaceOpenError::Other(format!(
+                                "Failed to clone parent directory for {}: {error}",
+                                display_path.display()
+                            ))
+                        })?,
+                        name: component,
+                        display_path,
+                    }))
+                }
+                ResolveMode::Write { .. } if metadata.is_dir() => Err(WorkspaceOpenError::Other(
+                    format!("Not a file: {}", display_path.display()),
+                )),
+                ResolveMode::Write { .. } => Err(WorkspaceOpenError::Unsupported(display_path)),
             };
         }
     }
@@ -1548,36 +1905,68 @@ fn root_path_from_descriptor(
     Ok(root)
 }
 
-#[cfg(target_os = "linux")]
-fn path_components(path: &Path) -> Result<VecDeque<OsString>, WorkspaceOpenError> {
-    let mut components = VecDeque::new();
-    prepend_components(&mut components, path)?;
-    Ok(components)
+struct RemainingPath {
+    components: VecDeque<OsString>,
+    must_be_directory: bool,
 }
 
-#[cfg(target_os = "linux")]
-fn prepend_components(
-    remaining: &mut VecDeque<OsString>,
-    path: &Path,
-) -> Result<(), WorkspaceOpenError> {
-    let mut components = Vec::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => components.push(OsString::from(".")),
-            std::path::Component::ParentDir => components.push(OsString::from("..")),
-            std::path::Component::Normal(component) => components.push(component.to_os_string()),
-            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
-                return Err(WorkspaceOpenError::Other(format!(
-                    "Workspace-relative path must not be absolute: {}",
-                    path.display()
-                )));
+impl RemainingPath {
+    fn new(path: &Path, must_be_directory: bool) -> Result<Self, WorkspaceOpenError> {
+        let mut remaining = Self {
+            components: VecDeque::new(),
+            must_be_directory,
+        };
+        remaining.prepend(path, false)?;
+        Ok(remaining)
+    }
+
+    fn prepend(&mut self, path: &Path, must_be_directory: bool) -> Result<(), WorkspaceOpenError> {
+        if self.components.is_empty() {
+            self.must_be_directory |= must_be_directory;
+        }
+
+        let mut components = Vec::new();
+        for component in path.components() {
+            match component {
+                std::path::Component::CurDir => components.push(OsString::from(".")),
+                std::path::Component::ParentDir => components.push(OsString::from("..")),
+                std::path::Component::Normal(component) => {
+                    components.push(component.to_os_string());
+                }
+                std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                    return Err(WorkspaceOpenError::Other(format!(
+                        "Workspace-relative path must not be absolute: {}",
+                        path.display()
+                    )));
+                }
             }
         }
+        for component in components.into_iter().rev() {
+            self.components.push_front(component);
+        }
+        Ok(())
     }
-    for component in components.into_iter().rev() {
-        remaining.push_front(component);
+
+    fn pop_front(&mut self) -> Option<OsString> {
+        self.components.pop_front()
     }
-    Ok(())
+
+    fn push_front(&mut self, component: OsString) {
+        self.components.push_front(component);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.components.is_empty()
+    }
+
+    fn must_be_directory(&self) -> bool {
+        self.must_be_directory
+    }
+}
+
+fn path_requires_directory(path: &Path) -> bool {
+    let bytes = path.as_os_str().as_bytes();
+    bytes.ends_with(b"/") || bytes == b"." || bytes.ends_with(b"/.")
 }
 
 #[cfg(target_os = "linux")]

--- a/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
@@ -55,32 +55,39 @@ impl Tool for WriteFileTool {
             )));
         }
 
-        let path = resolve_path(path_str, &ctx.cwd);
+        let workspace = match ctx.workspace() {
+            Ok(workspace) => workspace,
+            Err(error) => return Ok(ToolResult::error(error)),
+        };
+        let cwd = ctx.cwd.clone();
+        let path = path_str.to_owned();
+        let prepared =
+            tokio::task::spawn_blocking(move || workspace.prepare_write(&cwd, &path, true))
+                .await
+                .map_err(|error| format!("Write-file prepare task failed: {error}"))?;
+        let target = match prepared {
+            Ok(target) => target,
+            Err(error) => return Ok(ToolResult::error(error)),
+        };
+        let display_path = target.display_path.clone();
 
-        if let Some(parent) = path.parent() {
-            if !parent.exists() {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| format!("Failed to create directory {}: {e}", parent.display()))?;
-            }
+        if let Err(error) =
+            super::atomic_file::replace(&target, content.as_bytes().to_vec(), None).await
+        {
+            return Ok(ToolResult::error(format!(
+                "Failed to write {}: {error}",
+                display_path.display()
+            )));
         }
-
-        super::atomic_file::replace(path.clone(), content.as_bytes().to_vec(), None)
-            .await
-            .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
 
         let lines = content.lines().count();
         let bytes = content.len();
         Ok(ToolResult::success(format!(
             "Wrote {bytes} bytes ({lines} lines) to {}",
-            path.display()
+            display_path.display()
         )))
     }
 }
-
-// resolve_path is provided by the parent module (super::resolve_path)
-// and supports ~ expansion.
-use super::resolve_path;
 
 fn placeholder_markers(content: &str) -> Vec<&'static str> {
     let upper = content.to_ascii_uppercase();
@@ -189,6 +196,272 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_rejects_parent_traversal_as_tool_error() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let outside = parent.path().join("outside.txt");
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": "../outside.txt", "content": "blocked"}),
+                &test_ctx_in(&workspace),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("escapes workspace root"));
+        assert!(!outside.exists());
+    }
+
+    #[tokio::test]
+    async fn write_rejects_parent_traversal_when_creating_parents() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let outside = parent.path().join("created-outside");
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({
+                    "path": "../created-outside/nested.txt",
+                    "content": "blocked"
+                }),
+                &test_ctx_in(&workspace),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(!outside.exists());
+    }
+
+    #[tokio::test]
+    async fn write_rejects_absolute_external_path_as_tool_error() {
+        let workspace = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        let original = std::fs::read(outside.path()).unwrap();
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({
+                    "path": outside.path(),
+                    "content": "blocked"
+                }),
+                &test_ctx_in(workspace.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("escapes workspace root"));
+        assert_eq!(std::fs::read(outside.path()).unwrap(), original);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_rejects_external_final_and_parent_symlinks() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        let outside = parent.path().join("outside");
+        std::fs::create_dir(&workspace).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        let outside_file = outside.join("target.txt");
+        std::fs::write(&outside_file, "stable").unwrap();
+
+        symlink(&outside_file, workspace.join("file-link")).unwrap();
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": "file-link", "content": "blocked"}),
+                &test_ctx_in(&workspace),
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert_eq!(std::fs::read_to_string(&outside_file).unwrap(), "stable");
+
+        symlink(&outside, workspace.join("dir-link")).unwrap();
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({
+                    "path": "dir-link/new/nested.txt",
+                    "content": "blocked"
+                }),
+                &test_ctx_in(&workspace),
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(!outside.join("new").exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_preserves_internal_file_and_directory_symlinks() {
+        let workspace = tempfile::tempdir().unwrap();
+        let target = workspace.path().join("target.txt");
+        let directory = workspace.path().join("directory");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::create_dir(&directory).unwrap();
+        symlink("target.txt", workspace.path().join("file-link")).unwrap();
+        symlink("directory", workspace.path().join("directory-link")).unwrap();
+
+        let tool = WriteFileTool;
+        let file_result = tool
+            .invoke(
+                serde_json::json!({"path": "file-link", "content": "new"}),
+                &test_ctx_in(workspace.path()),
+            )
+            .await
+            .unwrap();
+        let directory_result = tool
+            .invoke(
+                serde_json::json!({
+                    "path": "directory-link/nested.txt",
+                    "content": "nested"
+                }),
+                &test_ctx_in(workspace.path()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!file_result.is_error);
+        assert!(!directory_result.is_error);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "new");
+        assert_eq!(
+            std::fs::read_to_string(directory.join("nested.txt")).unwrap(),
+            "nested"
+        );
+        assert!(workspace.path().join("file-link").is_symlink());
+        assert!(workspace.path().join("directory-link").is_symlink());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_rejects_directory_constrained_file_targets() {
+        let workspace = tempfile::tempdir().unwrap();
+        let target = workspace.path().join("target.txt");
+        let trailing_link = workspace.path().join("trailing-link");
+        let dot_link = workspace.path().join("dot-link");
+        std::fs::write(&target, "stable").unwrap();
+        symlink("target.txt/", &trailing_link).unwrap();
+        symlink("target.txt/.", &dot_link).unwrap();
+
+        for path in ["target.txt/", "target.txt/.", "trailing-link", "dot-link"] {
+            let result = WriteFileTool
+                .invoke(
+                    serde_json::json!({"path": path, "content": "blocked"}),
+                    &test_ctx_in(workspace.path()),
+                )
+                .await
+                .unwrap();
+
+            assert!(result.is_error, "write unexpectedly succeeded for {path}");
+            assert_eq!(std::fs::read_to_string(&target).unwrap(), "stable");
+        }
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": "missing.txt/", "content": "blocked"}),
+                &test_ctx_in(workspace.path()),
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(!workspace.path().join("missing.txt").exists());
+        assert!(trailing_link.is_symlink());
+        assert!(dot_link.is_symlink());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_rejects_dangling_external_symlink() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        let outside = parent.path().join("not-created.txt");
+        std::fs::create_dir(&workspace).unwrap();
+        symlink(&outside, workspace.join("dangling-link")).unwrap();
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": "dangling-link", "content": "blocked"}),
+                &test_ctx_in(&workspace),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(!outside.exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_uses_pinned_root_after_path_replacement() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace = parent.path().join("workspace");
+        let moved = parent.path().join("moved-workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let context = test_ctx_in(&workspace);
+        std::fs::rename(&workspace, &moved).unwrap();
+        std::fs::create_dir(&workspace).unwrap();
+
+        let result = WriteFileTool
+            .invoke(
+                serde_json::json!({"path": "result.txt", "content": "pinned"}),
+                &context,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert_eq!(
+            std::fs::read_to_string(moved.join("result.txt")).unwrap(),
+            "pinned"
+        );
+        assert!(!workspace.join("result.txt").exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn prepared_target_rejects_final_symlink_swap() {
+        let parent = tempfile::tempdir().unwrap();
+        let workspace_path = parent.path().join("workspace");
+        let outside = parent.path().join("outside.txt");
+        std::fs::create_dir(&workspace_path).unwrap();
+        std::fs::write(workspace_path.join("inside.txt"), "old").unwrap();
+        std::fs::write(&outside, "outside").unwrap();
+        symlink("inside.txt", workspace_path.join("link.txt")).unwrap();
+
+        let workspace = super::super::workspace_fs::WorkspaceFs::new(&workspace_path).unwrap();
+        let target = workspace
+            .prepare_write(&workspace_path, "link.txt", false)
+            .unwrap();
+        assert_eq!(
+            super::super::atomic_file::read_snapshot(&target)
+                .await
+                .unwrap()
+                .bytes(),
+            b"old"
+        );
+        let resolved_leaf = workspace_path.join("inside.txt");
+        std::fs::remove_file(&resolved_leaf).unwrap();
+        symlink(&outside, &resolved_leaf).unwrap();
+        assert!(super::super::atomic_file::read_snapshot(&target)
+            .await
+            .is_err());
+
+        let result = super::super::atomic_file::replace(&target, b"new".to_vec(), None).await;
+        assert!(result.is_err());
+
+        assert_eq!(
+            std::fs::read_link(&resolved_leaf).unwrap(),
+            outside.as_path()
+        );
+        assert_eq!(std::fs::read_to_string(outside).unwrap(), "outside");
+    }
+
+    #[tokio::test]
     #[cfg(unix)]
     async fn write_follows_relative_dangling_symlink() {
         let dir = tempfile::tempdir().unwrap();
@@ -257,15 +530,19 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (link, target) = create_symlink_chain(dir.path(), 41);
 
-        let error = WriteFileTool
+        let result = WriteFileTool
             .invoke(
                 serde_json::json!({"path": link, "content": "forty-one links"}),
                 &test_ctx_in(dir.path()),
             )
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(error.contains("too many symbolic links"));
+        assert!(result.is_error);
+        assert!(result
+            .output
+            .to_ascii_lowercase()
+            .contains("too many symbolic links"));
         assert!(!target.exists());
         assert!(link.is_symlink());
     }


### PR DESCRIPTION
## Why

`write_file` and `edit` resolved paths without the pinned workspace filesystem,
so auto-approved tool calls could traverse or follow symlinks outside the
workspace. The write path also remained vulnerable to path replacement races
after validation.

## What changed

- Resolve write targets beneath pinned workspace directory descriptors.
- Perform snapshot reads and atomic replacement relative to pinned parent FDs.
- Reject traversal, external symlinks, and resolved-leaf symlink races.
- Create missing parent directories safely beneath the workspace.
- Move blocking path preparation off Tokio worker threads.

## Related issue

closes #2183

## User / Agent impact

`write_file` and `edit` now reject paths outside the session workspace without
modifying external files. Internal symlinks, nested directory creation, atomic
replacement, permission preservation, and edit conflict detection remain
supported.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

Writes that previously targeted paths outside the workspace now fail closed.
The descriptor-relative atomic replacement is covered by traversal, symlink,
root-replacement, durability, permission, and concurrency regression tests.

## Validation

- `cargo test --package cosh-core tool::` — 205 passed
- `cargo fmt --all -- --check`
- `cargo clippy --package cosh-core --all-targets -- -D warnings`
- `git diff --check`
- Workspace-wide gates were not run; broader coverage is delegated to CI.

## Documentation and rollback

No documentation changes are required. Reverting commit `2566aeba` restores
the previous behavior, but also restores the workspace escape vulnerability.
