### PR TITLE
feat(blaze): implement sandbox guest operations

### DIFF
--- a/docs/user-guide/en/runtime/blaze.md
+++ b/docs/user-guide/en/runtime/blaze.md
@@ -65,3 +65,63 @@ and verify guest connectivity for the host environment.
 
 To disable the capability, set `enable_network = false` or remove the key, then
 destroy existing network-enabled sandboxes through the normal instance API.
+
+## Guest Operations
+
+Guest operations are available only while a sandbox is `Running` and its
+backend reports a compatible guest endpoint. A cold create that reports such
+an endpoint waits for the guest agent before publishing `Running`. Backends
+without an endpoint, including production mock fallback, skip that wait and
+return HTTP 409 for guest operations. Warm-pool activation validates the
+retained backend owner and storage before publishing `Running`, but it does
+not repeat the guest readiness probe. `Running` on this path therefore does
+not guarantee that the guest endpoint is still responsive: the first guest
+request performs the normal bounded connection and can return a guest error.
+Callers should apply the retry and outcome rules below to that first request.
+
+Guest operations and lifecycle changes use the same per-sandbox operation
+lock. After obtaining the lock, the manager checks `Running` again so a request
+does not contact an old runtime after a concurrent lifecycle change.
+
+The sandbox routes are:
+
+- `POST /v1/sandboxes/{id}/exec` — execute one command;
+- `POST /v1/sandboxes/{id}/read` — read one file; and
+- `POST /v1/sandboxes/{id}/write` — replace one file.
+
+The corresponding `/v1/instances/{id}/...` routes provide the same behavior.
+Exec requests use the following shape:
+
+```json
+{"cmd":"uname -a","cwd":"/","env":{"LANG":"C"},"timeout":10}
+```
+
+Write requests provide a path and standard-base64 data:
+
+```json
+{"path":"/tmp/input","data_b64":"aGVsbG8="}
+```
+
+Read requests provide only `path`. Successful file reads and command output
+use standard base64. Exec timeouts range from 1 through 20 seconds. Guest
+routes reject an HTTP envelope larger than 22 MiB while reading it, and file
+data is limited to 16 MiB after decoding.
+
+A failure before exec or write delivery is safe for caller-directed retry. A
+pre-delivery timeout uses `"code": "guest_timeout"`. If delivery began but
+the daemon cannot determine the result, it returns HTTP 504 with
+`"code": "guest_outcome_unknown"`; reconcile guest state instead of
+automatically replaying the operation. Reads do not change guest state.
+Oversized input returns HTTP 413. An oversized read response returns HTTP 502
+with `"code": "guest_response_too_large"`.
+
+Each request is fully buffered within its per-request limit. The limit does not
+bound aggregate concurrency, so clients should also cap concurrent guest
+operations. Streaming files, interactive terminals, and session reuse are not
+supported.
+
+The optional TCP listener does not yet enforce a daemon-wide access boundary.
+Leave `listen.http_addr` disabled in production until
+[issue #2223](https://github.com/alibaba/anolisa/issues/2223) is resolved.
+Daemon shutdown also does not yet wait for every active HTTP handler or release
+all runtime owners, so an in-flight request may observe a closed connection.

--- a/docs/user-guide/zh/runtime/blaze.md
+++ b/docs/user-guide/zh/runtime/blaze.md
@@ -58,3 +58,54 @@ Blaze 负责配置 sandbox 本地的网络路径。主机以外的路由和 DNS 
 
 如需关闭该能力，将 `enable_network` 设置为 `false` 或删除该配置项，再通过
 正常的 instance API 销毁已经启用网络的 sandbox。
+
+## Guest 操作
+
+只有 sandbox 处于 `Running` 且 backend 报告兼容的 guest endpoint 时，
+才能执行 guest 操作。冷启动 backend 如果报告了该 endpoint，创建流程会在
+发布 `Running` 前等待 guest agent。没有 endpoint 的 backend（包括生产环境
+mock fallback）会跳过等待，guest 操作返回 HTTP 409。当前从 warm pool 激活
+实例时，manager 会先验证保留的 backend owner 和 storage，再发布 `Running`，
+但不会再次执行 guest readiness 探测。因此 warm 路径的 `Running` 不保证 guest
+endpoint 仍然可响应；第一次 guest 请求仍会执行有界连接，并可能返回 guest
+错误。调用方应对第一次请求采用下文说明的重试和结果判定规则。
+
+Guest 操作和 lifecycle 变更使用同一个 sandbox operation lock。取得锁后，
+manager 会再次检查 `Running`，避免并发 lifecycle 变更后请求仍访问旧 runtime。
+
+Sandbox 路由包括：
+
+- `POST /v1/sandboxes/{id}/exec` — 执行一条命令；
+- `POST /v1/sandboxes/{id}/read` — 读取一个文件；
+- `POST /v1/sandboxes/{id}/write` — 替换一个文件。
+
+对应的 `/v1/instances/{id}/...` 路由提供相同行为。Exec 请求格式如下：
+
+```json
+{"cmd":"uname -a","cwd":"/","env":{"LANG":"C"},"timeout":10}
+```
+
+Write 请求提供路径和 standard-base64 数据：
+
+```json
+{"path":"/tmp/input","data_b64":"aGVsbG8="}
+```
+
+Read 请求只提供 `path`。成功的文件读取结果和命令输出使用 standard base64。
+Exec timeout 范围是 1 至 20 秒。Guest 路由会在读取过程中拒绝超过 22 MiB 的
+HTTP envelope，文件数据解码后最多为 16 MiB。
+
+Exec 或 write 在送达前失败时，可以由调用方决定重试；送达前超时使用
+`"code": "guest_timeout"`。如果已经开始送达，但 daemon 无法确定结果，
+返回 HTTP 504 和 `"code": "guest_outcome_unknown"`；此时应先核对 guest
+状态，不能自动重放。Read 不改变 guest 状态。输入过大时返回 HTTP 413；
+read 响应过大时返回 HTTP 502 和
+`"code": "guest_response_too_large"`。
+
+每个请求都会在单请求上限内完整缓冲。该上限不限制所有并发请求的总量，调用方
+还需要控制 guest 操作并发数。当前不支持文件流式传输、交互式终端和会话复用。
+
+可选 TCP listener 目前没有 daemon 级访问边界。在
+[issue #2223](https://github.com/alibaba/anolisa/issues/2223) 解决前，生产配置应
+保持 `listen.http_addr` 关闭。Daemon 停止时也不会等待全部 HTTP handler 或
+释放所有 runtime owner，因此正在执行的请求可能看到连接关闭。

--- a/src/blaze/Cargo.lock
+++ b/src/blaze/Cargo.lock
@@ -133,6 +133,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "blaze-core",
  "chrono",
  "clap",
@@ -310,6 +311,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -987,6 +1000,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/src/blaze/Cargo.toml
+++ b/src/blaze/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1.0"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["net"] }
+tokio-util = { version = "0.7", features = ["net", "rt"] }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
@@ -43,6 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 semver = "1.0"
+base64 = "0.22"
 
 # Internal crates
 blaze-core = { path = "crates/blaze-core" }

--- a/src/blaze/README.md
+++ b/src/blaze/README.md
@@ -15,6 +15,8 @@ Designed as the per-host agent for E2B-style orchestrator platforms.
 - **Policy-driven backend selection** — workload class → backend priority list
 - **Lifecycle state machine** — 9 states: Pending, Creating, Running, Paused,
   Checkpointed, RecoveryRequired, Reset, Warm, and Destroyed
+- **Guest operations** — bounded command execution and file transfer for
+  running backends that expose a guest endpoint
 - **Warm pool management** — pre-warmed instances with TTL-based GC
 - **Template registry** — in-memory template tracking with idle eviction
 - **Kernel hook registry** — state tracking for pre/post hooks
@@ -42,8 +44,12 @@ curl --unix-socket /run/blaze/api.sock http://localhost/v1/health
 # Create a sandbox
 curl -X POST --unix-socket /run/blaze/api.sock http://localhost/v1/sandboxes \
   -H 'Content-Type: application/json' \
-  -d '{"workload_class":"agent-rl","image_digest":"sha256:..."}'
+  -d '{"workload_class":"agent-tool","image_digest":"sha256:..."}'
 ```
+
+The quick-start request uses an example policy with Firecracker guest transport
+disabled, so an image without the compatible guest agent does not wait for guest
+readiness. Enable the transport only for images that run that agent.
 
 ## Configuration
 
@@ -118,11 +124,17 @@ The `file` provider uses standard filesystem operations for sandbox storage. The
 | POST | `/v1/sandboxes` | Create a sandbox |
 | GET | `/v1/sandboxes/{id}` | Get sandbox details |
 | DELETE | `/v1/sandboxes/{id}` | Destroy a sandbox |
+| POST | `/v1/sandboxes/{id}/exec` | Execute a guest command |
+| POST | `/v1/sandboxes/{id}/read` | Read a guest file |
+| POST | `/v1/sandboxes/{id}/write` | Replace a guest file |
 | GET | `/v1/instances` | Alias for listing sandboxes |
 | POST | `/v1/instances` | Alias for creating a sandbox |
 | GET | `/v1/instances/{id}` | Alias for sandbox details |
 | DELETE | `/v1/instances/{id}` | Alias for destroying a sandbox |
 | POST | `/v1/instances/{id}/destroy` | Compatible destroy action |
+| POST | `/v1/instances/{id}/exec` | Compatible guest command action |
+| POST | `/v1/instances/{id}/read` | Compatible guest file read action |
+| POST | `/v1/instances/{id}/write` | Compatible guest file write action |
 | POST | `/v1/instances/{id}/checkpoint` | Record checkpoint state |
 | POST | `/v1/instances/{id}/reset` | Record reset and return to the warm pool |
 | GET | `/v1/pools` | List warm pools |
@@ -154,6 +166,15 @@ and an existing backend process is not adopted after restart. Failed recovery
 does not run in a background retry loop. The checkpoint and reset endpoints
 retain their existing metadata transitions; this recovery flow does not add
 backend snapshot or restore operations.
+
+### Guest operations
+
+Running sandboxes can execute bounded commands and transfer bounded files when
+their backend exposes a compatible guest endpoint. Production mock fallback
+does not advertise this capability. See the
+[Blaze user guide](../../docs/user-guide/en/runtime/blaze.md#guest-operations)
+for request formats, limits, readiness, error handling, and current shutdown
+boundaries.
 
 #### Health Check
 

--- a/src/blaze/README_zh.md
+++ b/src/blaze/README_zh.md
@@ -14,6 +14,7 @@ Prometheus 指标导出，设计为 E2B 类编排平台的单机执行代理。
 - **策略驱动后端选择** — workload class → 后端优先级列表
 - **生命周期状态机** — 9 种状态：Pending、Creating、Running、Paused、
   Checkpointed、RecoveryRequired、Reset、Warm 和 Destroyed
+- **Guest 操作** — 对提供 guest endpoint 的运行中后端执行有界命令和文件传输
 - **Warm pool 管理** — 预热实例 + 基于 TTL 的 GC
 - **模板注册表** — 内存中模板追踪，支持空闲驱逐
 - **内核 hook 注册** — 前/后置 hook 状态追踪
@@ -41,8 +42,12 @@ curl --unix-socket /run/blaze/api.sock http://localhost/v1/health
 # 创建 sandbox
 curl -X POST --unix-socket /run/blaze/api.sock http://localhost/v1/sandboxes \
   -H 'Content-Type: application/json' \
-  -d '{"workload_class":"agent-rl","image_digest":"sha256:..."}'
+  -d '{"workload_class":"agent-tool","image_digest":"sha256:..."}'
 ```
+
+快速开始使用关闭 Firecracker guest transport 的示例策略，因此没有兼容
+guest agent 的镜像不会等待 guest 就绪。只有镜像运行了对应 agent 时才应
+启用该 transport。
 
 ## 配置
 
@@ -114,11 +119,17 @@ images_dir = "/var/lib/blaze/images"
 | POST | `/v1/sandboxes` | 创建 sandbox |
 | GET | `/v1/sandboxes/{id}` | 获取 sandbox 详情 |
 | DELETE | `/v1/sandboxes/{id}` | 销毁 sandbox |
+| POST | `/v1/sandboxes/{id}/exec` | 执行 guest 命令 |
+| POST | `/v1/sandboxes/{id}/read` | 读取 guest 文件 |
+| POST | `/v1/sandboxes/{id}/write` | 替换 guest 文件 |
 | GET | `/v1/instances` | 列出 sandbox 的兼容入口 |
 | POST | `/v1/instances` | 创建 sandbox 的兼容入口 |
 | GET | `/v1/instances/{id}` | 获取 sandbox 详情的兼容入口 |
 | DELETE | `/v1/instances/{id}` | 销毁 sandbox 的兼容入口 |
 | POST | `/v1/instances/{id}/destroy` | 保留的销毁 action |
+| POST | `/v1/instances/{id}/exec` | Guest 命令兼容入口 |
+| POST | `/v1/instances/{id}/read` | Guest 文件读取兼容入口 |
+| POST | `/v1/instances/{id}/write` | Guest 文件写入兼容入口 |
 | POST | `/v1/instances/{id}/checkpoint` | 记录 checkpoint 状态 |
 | POST | `/v1/instances/{id}/reset` | 记录 reset 并返回 warm pool |
 | GET | `/v1/pools` | 列出 warm pool |
@@ -146,6 +157,13 @@ daemon 启动时会逐个处理未结束的 sandbox。单个 sandbox 清理失�
 创建会被清理而不是从原位置继续，重启后也不会接管先前的后端进程。恢复失败
 后目前没有后台循环自动重试。checkpoint 和 reset 接口保持原有的元数据状态
 变化；这里的恢复流程没有增加后端 snapshot 或 restore 操作。
+
+### Guest 操作
+
+当 backend 提供兼容的 guest endpoint 时，运行中的 sandbox 可以执行有界
+命令和文件传输。生产环境的 mock fallback 不会声明该能力。请求格式、上限、
+就绪检查、错误处理和当前关闭边界参见
+[Blaze 用户指南](../../docs/user-guide/zh/runtime/blaze.md#guest-操作)。
 
 #### 健康检查
 

--- a/src/blaze/crates/blaze-core/src/guest_protocol.rs
+++ b/src/blaze/crates/blaze-core/src/guest_protocol.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Wire DTOs shared with a compatible sandbox guest agent.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Firecracker vsock port used by the compatible sandbox guest agent.
+pub const DEFAULT_GUEST_PORT: u32 = 5000;
+
+/// Maximum accepted JSON response line, excluding the newline delimiter.
+pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+
+/// Guest operation names implemented by `sandbox-agent`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GuestOp {
+    /// Check whether the guest agent can serve requests.
+    Ping,
+    /// Execute one shell command.
+    Exec,
+    /// Read one guest file.
+    Read,
+    /// Replace one guest file.
+    Write,
+}
+
+/// One newline-delimited request sent after the Firecracker CONNECT handshake.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuestRequest {
+    /// Correlation identifier echoed by the guest.
+    pub id: String,
+    /// Requested guest operation.
+    pub op: GuestOp,
+    /// Shell command for [`GuestOp::Exec`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cmd: Option<String>,
+    /// Working directory for command execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Environment additions for command execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+    /// Guest-side timeout in seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u32>,
+    /// Guest path for file operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Standard-base64 file bytes for [`GuestOp::Write`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_b64: Option<String>,
+}
+
+/// One newline-delimited response returned by the compatible guest agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuestResponse {
+    /// Correlation identifier copied from the request.
+    pub id: String,
+    /// Whether the operation completed successfully.
+    pub ok: bool,
+    /// Guest error message when `ok` is false.
+    #[serde(default)]
+    pub err: Option<String>,
+    /// Command exit status.
+    #[serde(default)]
+    pub rc: Option<i32>,
+    /// Standard-base64 command stdout.
+    #[serde(default)]
+    pub stdout_b64: Option<String>,
+    /// Standard-base64 command stderr.
+    #[serde(default)]
+    pub stderr_b64: Option<String>,
+    /// Standard-base64 file bytes.
+    #[serde(default)]
+    pub data_b64: Option<String>,
+}
+
+impl GuestRequest {
+    /// Build a request with operation-specific fields initially absent.
+    pub fn new(id: String, op: GuestOp) -> Self {
+        Self {
+            id,
+            op,
+            cmd: None,
+            cwd: None,
+            env: None,
+            timeout: None,
+            path: None,
+            data_b64: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn request_uses_wire_operation_names_and_omits_absent_fields() {
+        let request = GuestRequest::new("request-1".to_string(), GuestOp::Exec);
+
+        assert_eq!(
+            serde_json::to_value(request).expect("serialize request"),
+            json!({
+                "id": "request-1",
+                "op": "exec",
+            })
+        );
+    }
+
+    #[test]
+    fn response_requires_outcome_and_defaults_optional_fields() {
+        assert!(serde_json::from_value::<GuestResponse>(json!({"id": "request-1"})).is_err());
+        assert!(serde_json::from_value::<GuestResponse>(json!({"ok": true})).is_err());
+        let response: GuestResponse = serde_json::from_value(json!({
+            "id": "request-1",
+            "ok": true
+        }))
+        .expect("deserialize response");
+
+        assert_eq!(response.id, "request-1");
+        assert!(response.ok);
+        assert!(response.err.is_none());
+        assert!(response.rc.is_none());
+        assert!(response.stdout_b64.is_none());
+        assert!(response.stderr_b64.is_none());
+        assert!(response.data_b64.is_none());
+    }
+}

--- a/src/blaze/crates/blaze-core/src/lib.rs
+++ b/src/blaze/crates/blaze-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`config`]: daemon TOML configuration
 //! - [`policy`]: workload class + policy file schema
 //! - [`backend`]: backend kinds + selection / fallback
+//! - [`guest_protocol`]: guest-agent wire DTOs
 //! - [`lifecycle`]: sandbox state machine + JSON persistence
 //! - [`pool`]: warm-pool key/stat/manager
 //! - [`template`]: template registry + refcnt + GC
@@ -18,6 +19,7 @@
 pub mod backend;
 pub mod config;
 pub mod error;
+pub mod guest_protocol;
 pub mod kernel;
 pub mod lifecycle;
 pub mod policy;

--- a/src/blaze/crates/blaze-core/src/policy.rs
+++ b/src/blaze/crates/blaze-core/src/policy.rs
@@ -358,7 +358,9 @@ pub struct FirecrackerConfig {
     /// Guest kernel command line.
     #[serde(default = "default_fc_boot_args")]
     pub boot_args: String,
-    /// Enable virtio-vsock (Phase 2+; parsed today but not yet wired).
+    /// Enable guest operations over virtio-vsock.
+    ///
+    /// This is disabled by default and requires a compatible guest service.
     #[serde(default)]
     pub enable_vsock: bool,
     /// Create an isolated network namespace, veth uplink, tap, and NAT.

--- a/src/blaze/crates/blazed/Cargo.toml
+++ b/src/blaze/crates/blazed/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -10,13 +10,15 @@ use std::convert::Infallible;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use blaze_core::backend::{BackendKind, BackendStatus, select_backend};
 use blaze_core::kernel::HookKind;
 use blaze_core::lifecycle::{SandboxInstance, SandboxState, StartPath};
 use blaze_core::policy::{ImageMetadata, RuntimeDecision, WorkloadClass, parse_duration};
 use blaze_core::pool::{PoolConfig, PoolKey};
 use http_body_util::{BodyExt, Full};
-use hyper::body::{Bytes, Incoming};
+use hyper::body::{Body, Bytes, Incoming};
 use hyper::header::CONTENT_TYPE;
 use hyper::{Method, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -24,8 +26,12 @@ use serde_json::json;
 use uuid::Uuid;
 
 use crate::error::{BlazeDaemonError, Result};
+use crate::guest::MAX_GUEST_FILE_BYTES;
 use crate::sandbox::CreateSandbox;
 use crate::state::ServerState;
+
+const MAX_EXEC_TIMEOUT_SECS: u32 = 20;
+const MAX_GUEST_HTTP_BODY_BYTES: usize = 22 * 1024 * 1024;
 
 /// Top-level request handler. Always returns `Ok(Response)`; internal
 /// errors are turned into JSON error bodies so hyper never sees a panic.
@@ -33,13 +39,25 @@ pub async fn handle(
     req: Request<Incoming>,
     state: Arc<ServerState>,
 ) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
+    handle_request(req, state).await
+}
+
+async fn handle_request<B>(
+    req: Request<B>,
+    state: Arc<ServerState>,
+) -> std::result::Result<Response<Full<Bytes>>, Infallible>
+where
+    B: Body<Data = Bytes> + Unpin,
+    B::Error: std::fmt::Display,
+{
     state.metrics.inc(&state.metrics.requests_total);
 
     let method = req.method().clone();
     let path = req.uri().path().to_string();
     let query = req.uri().query().unwrap_or("").to_string();
+    let limit = guest_body_route(&method, &path).then_some(MAX_GUEST_HTTP_BODY_BYTES);
 
-    let response = match collect_body(req).await {
+    let response = match collect_body(req, limit).await {
         Ok(body) => dispatch(&method, &path, &query, body, &state).await,
         Err(e) => Err(e),
     };
@@ -51,9 +69,58 @@ pub async fn handle(
     Ok(resp)
 }
 
-async fn collect_body(req: Request<Incoming>) -> Result<Vec<u8>> {
-    let collected = req.into_body().collect().await?;
-    Ok(collected.to_bytes().to_vec())
+fn guest_body_route(method: &Method, path: &str) -> bool {
+    if method != Method::POST {
+        return false;
+    }
+    let parts = path
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    matches!(
+        parts.as_slice(),
+        [
+            "v1",
+            "instances" | "sandboxes",
+            _,
+            "exec" | "read" | "write"
+        ]
+    )
+}
+
+async fn collect_body<B>(req: Request<B>, limit: Option<usize>) -> Result<Vec<u8>>
+where
+    B: Body<Data = Bytes> + Unpin,
+    B::Error: std::fmt::Display,
+{
+    let mut body = req.into_body();
+    let mut collected = Vec::new();
+    while let Some(frame) = body.frame().await {
+        let frame = frame
+            .map_err(|error| BlazeDaemonError::BadRequest(format!("request body: {error}")))?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        if let Some(limit) = limit
+            && collected.len().saturating_add(data.len()) > limit
+        {
+            return Err(crate::guest::GuestError::PayloadTooLarge {
+                actual: collected.len().saturating_add(data.len()),
+                limit,
+            }
+            .into());
+        }
+        collected.extend_from_slice(&data);
+    }
+    Ok(collected)
+}
+
+const fn max_base64_len(decoded_bytes: usize) -> usize {
+    decoded_bytes
+        .saturating_add(2)
+        .saturating_div(3)
+        .saturating_mul(4)
 }
 
 async fn dispatch(
@@ -78,6 +145,15 @@ async fn dispatch(
         }
         ("GET", ["v1", "instances", id]) | ("GET", ["v1", "sandboxes", id]) => {
             get_instance(state, id)
+        }
+        ("POST", ["v1", "sandboxes", id, "exec"]) | ("POST", ["v1", "instances", id, "exec"]) => {
+            exec_instance(state, id, &body).await
+        }
+        ("POST", ["v1", "sandboxes", id, "read"]) | ("POST", ["v1", "instances", id, "read"]) => {
+            read_instance_file(state, id, &body).await
+        }
+        ("POST", ["v1", "sandboxes", id, "write"]) | ("POST", ["v1", "instances", id, "write"]) => {
+            write_instance_file(state, id, &body).await
         }
         ("POST", ["v1", "instances", id, "checkpoint"]) => checkpoint(state, id).await,
         ("POST", ["v1", "instances", id, "reset"]) => reset_instance(state, id).await,
@@ -329,6 +405,113 @@ async fn destroy_instance(state: &Arc<ServerState>, id: &str) -> Result<Response
     }))
 }
 
+#[derive(Debug, Deserialize)]
+struct ExecRequest {
+    cmd: String,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    timeout: Option<u32>,
+}
+
+async fn exec_instance(
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> Result<Response<Full<Bytes>>> {
+    let request: ExecRequest = serde_json::from_slice(body)
+        .map_err(|error| BlazeDaemonError::BadRequest(format!("invalid exec body: {error}")))?;
+    if request.cmd.is_empty() {
+        return Err(BlazeDaemonError::BadRequest(
+            "exec command is required".to_string(),
+        ));
+    }
+    let timeout = request.timeout.unwrap_or(MAX_EXEC_TIMEOUT_SECS);
+    if timeout == 0 || timeout > MAX_EXEC_TIMEOUT_SECS {
+        return Err(BlazeDaemonError::BadRequest(format!(
+            "exec timeout must be between 1 and {MAX_EXEC_TIMEOUT_SECS} seconds"
+        )));
+    }
+    let result = state
+        .manager
+        .exec(
+            parse_uuid(id)?,
+            request.cmd,
+            request.cwd,
+            request.env,
+            timeout,
+        )
+        .await?;
+    json_ok(&json!({
+        "exit_code": result.exit_code,
+        "stdout_b64": BASE64.encode(result.stdout),
+        "stderr_b64": BASE64.encode(result.stderr),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct FileRequest {
+    path: String,
+    #[serde(default)]
+    data_b64: Option<String>,
+}
+
+async fn read_instance_file(
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> Result<Response<Full<Bytes>>> {
+    let request: FileRequest = serde_json::from_slice(body)
+        .map_err(|error| BlazeDaemonError::BadRequest(format!("invalid read body: {error}")))?;
+    let data = state
+        .manager
+        .read_file(parse_uuid(id)?, request.path)
+        .await?;
+    json_ok(&json!({"data_b64": BASE64.encode(data)}))
+}
+
+async fn write_instance_file(
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> Result<Response<Full<Bytes>>> {
+    let request: FileRequest = serde_json::from_slice(body)
+        .map_err(|error| BlazeDaemonError::BadRequest(format!("invalid write body: {error}")))?;
+    let encoded = request
+        .data_b64
+        .ok_or_else(|| BlazeDaemonError::BadRequest("data_b64 is required".to_string()))?;
+    let data = decode_guest_file(&encoded, MAX_GUEST_FILE_BYTES)?;
+    state
+        .manager
+        .write_file(parse_uuid(id)?, request.path, &data)
+        .await?;
+    json_ok(&json!({"written": true, "bytes": data.len()}))
+}
+
+fn decode_guest_file(encoded: &str, limit: usize) -> Result<Vec<u8>> {
+    let encoded_limit = max_base64_len(limit);
+    if encoded.len() > encoded_limit {
+        return Err(crate::guest::GuestError::PayloadTooLarge {
+            actual: encoded.len(),
+            limit: encoded_limit,
+        }
+        .into());
+    }
+    let data = BASE64
+        .decode(encoded)
+        .map_err(|error| BlazeDaemonError::BadRequest(format!("invalid base64: {error}")))?;
+    if data.len() > limit {
+        return Err(crate::guest::GuestError::PayloadTooLarge {
+            actual: data.len(),
+            limit,
+        }
+        .into());
+    }
+    Ok(data)
+}
+
 // ---------------------------------------------------------------------------
 // Pools
 // ---------------------------------------------------------------------------
@@ -567,10 +750,13 @@ fn json_response<T: Serialize>(status: StatusCode, value: &T) -> Result<Response
 fn error_response(err: &BlazeDaemonError) -> Response<Full<Bytes>> {
     let status =
         StatusCode::from_u16(err.status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-    let body = json!({
+    let mut body = json!({
         "error": err.to_string(),
         "status": status.as_u16(),
     });
+    if let Some(code) = err.api_code() {
+        body["code"] = json!(code);
+    }
     let bytes = serde_json::to_vec_pretty(&body)
         .unwrap_or_else(|_| br#"{"error":"serialize_failed"}"#.to_vec());
     Response::builder()
@@ -614,8 +800,8 @@ mod tests {
 
     use crate::file_provider::FileStorageProvider;
     use crate::spawner::{
-        BackendInstance, BackendSpawner, DynBackendInstance, DynSpawner, MockSpawner, SpawnFailure,
-        SpawnResult, SpawnerRegistry,
+        BackendInstance, BackendSpawner, DynBackendInstance, DynSpawner, GuestMockSpawner,
+        MockSpawner, SpawnFailure, SpawnResult, SpawnerRegistry,
     };
     use crate::state::ServerState;
 
@@ -712,6 +898,22 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "test-failpoints")]
+    fn guest_mock_state(temp: &tempfile::TempDir, pooled: bool) -> Arc<ServerState> {
+        let config = test_config(temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        build_test_state(
+            config,
+            test_policy(BackendKind::Mock, pooled),
+            spawners(BackendKind::Mock, Arc::new(GuestMockSpawner)),
+            BackendKind::Mock,
+            storage,
+        )
+    }
+
     async fn created_json(state: &Arc<ServerState>, request: &[u8]) -> serde_json::Value {
         let response = create_instance(state, request).await.expect("create");
         serde_json::from_slice(
@@ -734,6 +936,32 @@ mod tests {
         let response = dispatch(&method, path, "", body, state)
             .await
             .expect("dispatch");
+        let status = response.status();
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        let value = serde_json::from_slice(&body).expect("response json");
+        (status, value)
+    }
+
+    async fn handled_json(
+        state: &Arc<ServerState>,
+        method: Method,
+        path: &str,
+        body: Vec<u8>,
+    ) -> (StatusCode, serde_json::Value) {
+        let request = Request::builder()
+            .method(method)
+            .uri(path)
+            .header(hyper::header::CONTENT_LENGTH, body.len())
+            .body(Full::new(Bytes::from(body)))
+            .expect("request");
+        let response = handle_request(request, state.clone())
+            .await
+            .expect("infallible response");
         let status = response.status();
         let body = response
             .into_body()
@@ -1033,6 +1261,39 @@ mod tests {
             _run_dir: &Path,
         ) -> blaze_core::Result<()> {
             self.orphan_cleanup_count.fetch_add(1, Ordering::AcqRel);
+            Ok(())
+        }
+    }
+
+    struct StalledGuestOwner {
+        instance_id: Uuid,
+        socket: PathBuf,
+        kill_count: Arc<AtomicUsize>,
+        killed: AtomicBool,
+    }
+
+    #[async_trait]
+    impl BackendInstance for StalledGuestOwner {
+        fn backend(&self) -> BackendKind {
+            BackendKind::Mock
+        }
+
+        fn guest_socket_path(&self) -> &Path {
+            &self.socket
+        }
+
+        async fn try_wait(&self) -> blaze_core::Result<Option<SpawnResult>> {
+            Ok(self.killed.load(Ordering::Acquire).then_some(SpawnResult {
+                instance_id: self.instance_id,
+                exit_code: Some(0),
+                signal: None,
+            }))
+        }
+
+        async fn kill(&self) -> blaze_core::Result<()> {
+            if !self.killed.swap(true, Ordering::AcqRel) {
+                self.kill_count.fetch_add(1, Ordering::AcqRel);
+            }
             Ok(())
         }
     }
@@ -1413,6 +1674,327 @@ mod tests {
                 .quarantine_count,
             1
         );
+    }
+
+    #[tokio::test]
+    async fn sandbox_guest_routes_use_owned_runtime() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(GuestMockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+        let created = created_json(&state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("instance id");
+
+        let (status, exec) = dispatched_json(
+            &state,
+            Method::POST,
+            &format!("/v1/sandboxes/{id}/exec"),
+            serde_json::to_vec(&json!({
+                "cmd": "printf routed",
+                "timeout": 5,
+            }))
+            .expect("exec request"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(exec["exit_code"], 0);
+        assert_eq!(exec["stdout_b64"], BASE64.encode(b"printf routed"));
+
+        let encoded = "AAEC/2d1ZXN0";
+        let (status, written) = dispatched_json(
+            &state,
+            Method::POST,
+            &format!("/v1/instances/{id}/write"),
+            serde_json::to_vec(&json!({
+                "path": "/tmp/value",
+                "data_b64": encoded,
+            }))
+            .expect("write request"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(written["bytes"], 9);
+
+        let (status, read) = dispatched_json(
+            &state,
+            Method::POST,
+            &format!("/v1/sandboxes/{id}/read"),
+            serde_json::to_vec(&json!({"path": "/tmp/value"})).expect("read request"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(read["data_b64"], encoded);
+
+        let invalid_timeout = dispatch(
+            &Method::POST,
+            &format!("/v1/sandboxes/{id}/exec"),
+            "",
+            serde_json::to_vec(&json!({
+                "cmd": "true",
+                "timeout": MAX_EXEC_TIMEOUT_SECS + 1,
+            }))
+            .expect("invalid request"),
+            &state,
+        )
+        .await
+        .expect_err("timeout above the API limit must fail");
+        assert!(matches!(invalid_timeout, BlazeDaemonError::BadRequest(_)));
+
+        assert_eq!(
+            decode_guest_file(&BASE64.encode(b"1234"), 4).expect("boundary"),
+            b"1234"
+        );
+        assert!(matches!(
+            decode_guest_file(&BASE64.encode(b"12345"), 4),
+            Err(BlazeDaemonError::Guest(
+                crate::guest::GuestError::PayloadTooLarge { .. }
+            ))
+        ));
+        assert!(matches!(
+            decode_guest_file("not/base64!", 16),
+            Err(BlazeDaemonError::BadRequest(_))
+        ));
+
+        let (status, destroyed) = dispatched_json(
+            &state,
+            Method::DELETE,
+            &format!("/v1/sandboxes/{id}"),
+            Vec::new(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(destroyed["destroyed"], true);
+    }
+
+    #[tokio::test]
+    async fn production_mock_rejects_guest_operations() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+        let created = created_json(&state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("instance id");
+
+        let (status, error) = handled_json(
+            &state,
+            Method::POST,
+            &format!("/v1/sandboxes/{id}/exec"),
+            serde_json::to_vec(&json!({"cmd": "true"})).expect("exec request"),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            error["error"]
+                .as_str()
+                .expect("error message")
+                .contains("no guest transport")
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_write_respects_http_and_decoded_limits() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(GuestMockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+        let created = created_json(&state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("instance id");
+        let uuid = Uuid::parse_str(id).expect("uuid");
+        let path = format!("/v1/sandboxes/{id}/write");
+
+        let envelope_payload = vec![b'y'; 17 * 1024 * 1024];
+        let envelope_body = serde_json::to_vec(&json!({
+            "path": "/tmp/http-envelope",
+            "data_b64": BASE64.encode(&envelope_payload),
+        }))
+        .expect("write request above the guest HTTP limit");
+        assert!(envelope_body.len() > MAX_GUEST_HTTP_BODY_BYTES);
+        let (status, error) = handled_json(&state, Method::POST, &path, envelope_body).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(error["status"], 413);
+
+        let mut payload = vec![b'z'; MAX_GUEST_FILE_BYTES];
+        let body = serde_json::to_vec(&json!({
+            "path": "/tmp/max-size",
+            "data_b64": BASE64.encode(&payload),
+        }))
+        .expect("write request");
+        assert!(body.len() <= MAX_GUEST_HTTP_BODY_BYTES);
+
+        let (status, written) = handled_json(&state, Method::POST, &path, body).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(written["bytes"], MAX_GUEST_FILE_BYTES);
+        let readback = state
+            .manager
+            .read_file(uuid, "/tmp/max-size".into())
+            .await
+            .expect("read maximum file");
+        assert_eq!(readback, payload);
+        drop(readback);
+
+        payload.push(b'z');
+        let oversized = serde_json::to_vec(&json!({
+            "path": "/tmp/too-large",
+            "data_b64": BASE64.encode(&payload),
+        }))
+        .expect("oversized write request");
+        assert!(oversized.len() <= MAX_GUEST_HTTP_BODY_BYTES);
+        let (status, error) = handled_json(&state, Method::POST, &path, oversized).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(error["status"], 413);
+    }
+
+    #[tokio::test]
+    async fn write_route_reports_unknown_after_delivery_failure() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+        let created = created_json(&state, &test_request()).await;
+        let id = created["instance"]["id"].as_str().expect("instance id");
+        let uuid = Uuid::parse_str(id).expect("uuid");
+        state
+            .manager
+            .backend_owner(uuid)
+            .expect("mock owner")
+            .kill()
+            .await
+            .expect("stop mock guest");
+
+        let socket = temp.path().join("uncertain.uds");
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind guest endpoint");
+        state
+            .manager
+            .insert_backend_owner(
+                uuid,
+                Arc::new(StalledGuestOwner {
+                    instance_id: uuid,
+                    socket,
+                    kill_count: Arc::new(AtomicUsize::new(0)),
+                    killed: AtomicBool::new(false),
+                }),
+            )
+            .expect("replace backend owner");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept guest request");
+            let mut reader = tokio::io::BufReader::new(stream);
+            let mut connect = String::new();
+            reader.read_line(&mut connect).await.expect("read connect");
+            assert_eq!(connect, "CONNECT 5000\n");
+            reader
+                .get_mut()
+                .write_all(b"OK 5000\n")
+                .await
+                .expect("write handshake");
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read guest request");
+            let request: serde_json::Value =
+                serde_json::from_str(&request).expect("parse guest request");
+            assert_eq!(request["op"], "write");
+        });
+
+        let body = serde_json::to_vec(&json!({
+            "path": "/tmp/value",
+            "data_b64": BASE64.encode(b"value"),
+        }))
+        .expect("write request");
+        let (status, error) = handled_json(
+            &state,
+            Method::POST,
+            &format!("/v1/sandboxes/{id}/write"),
+            body,
+        )
+        .await;
+        assert_eq!(status, StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(error["code"], "guest_outcome_unknown");
+        server.await.expect("guest server");
+    }
+
+    #[tokio::test]
+    async fn unknown_guest_outcome_has_stable_api_code() {
+        let response = error_response(&BlazeDaemonError::Guest(
+            crate::guest::GuestError::OutcomeUnknown("response lost".into()),
+        ));
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("error json");
+        assert_eq!(value["code"], "guest_outcome_unknown");
+        assert_eq!(value["status"], 504);
+
+        let response = error_response(&BlazeDaemonError::Guest(
+            crate::guest::GuestError::ResponseTooLarge {
+                actual: 5,
+                limit: 4,
+            },
+        ));
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("error json");
+        assert_eq!(value["code"], "guest_response_too_large");
+
+        let response = error_response(&BlazeDaemonError::Guest(crate::guest::GuestError::Timeout(
+            "connect stalled".into(),
+        )));
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("error json");
+        assert_eq!(value["code"], "guest_timeout");
     }
 
     #[tokio::test]
@@ -1818,6 +2400,37 @@ mod tests {
     #[tokio::test]
     async fn warm_final_commit_failure_restores_the_claim() {
         assert_warm_state_commit_failure_restores_claim("warm-final-state-commit").await;
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn guest_readiness_failure_compensates_owned_resources() {
+        let request = test_request();
+        let temp = tempfile::tempdir().expect("temp");
+        let state = guest_mock_state(&temp, false);
+        let hook = crate::failpoint::TestFailpoint::new(&["create-guest-ready"]);
+
+        hook.run(create_instance(&state, &request))
+            .await
+            .expect_err("guest readiness failure");
+
+        let instance = state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("destroyed create");
+        assert_eq!(instance.state, SandboxState::Destroyed);
+        assert!(state.manager.backend_owner(instance.id).is_none());
+        assert!(
+            !temp
+                .path()
+                .join("instances")
+                .join(instance.id.to_string())
+                .exists()
+        );
     }
 
     #[cfg(feature = "test-failpoints")]

--- a/src/blaze/crates/blazed/src/error.rs
+++ b/src/blaze/crates/blazed/src/error.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Local errors for the blazed binary (daemon + CLI client).
+//! Local errors for the daemon binary and HTTP API.
 //!
 //! Wraps [`blaze_core::BlazeError`] so the daemon can additionally
 //! surface I/O, hyper, and CLI-side failures without expanding the
@@ -15,6 +15,9 @@ pub type Result<T> = std::result::Result<T, BlazeDaemonError>;
 pub enum BlazeDaemonError {
     #[error("core error: {0}")]
     Core(#[from] blaze_core::BlazeError),
+
+    #[error(transparent)]
+    Guest(#[from] crate::guest::GuestError),
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
@@ -51,6 +54,9 @@ pub enum BlazeDaemonError {
     #[error("not found: {0}")]
     NotFound(String),
 
+    #[error("conflict: {0}")]
+    Conflict(String),
+
     #[error("operation requires recovery: {0}")]
     RecoveryRequired(String),
 
@@ -59,16 +65,54 @@ pub enum BlazeDaemonError {
 }
 
 impl BlazeDaemonError {
+    /// Stable machine-readable code for errors that callers must branch on.
+    pub fn api_code(&self) -> Option<&'static str> {
+        match self {
+            BlazeDaemonError::Guest(crate::guest::GuestError::Io(_)) => {
+                Some("guest_transport_error")
+            }
+            BlazeDaemonError::Guest(crate::guest::GuestError::Json(_))
+            | BlazeDaemonError::Guest(crate::guest::GuestError::Protocol(_)) => {
+                Some("guest_response_invalid")
+            }
+            BlazeDaemonError::Guest(crate::guest::GuestError::InvalidArgument(_)) => {
+                Some("guest_invalid_request")
+            }
+            BlazeDaemonError::Guest(crate::guest::GuestError::Timeout(_)) => Some("guest_timeout"),
+            BlazeDaemonError::Guest(crate::guest::GuestError::OutcomeUnknown(_)) => {
+                Some("guest_outcome_unknown")
+            }
+            BlazeDaemonError::Guest(crate::guest::GuestError::Rejected(_)) => {
+                Some("guest_rejected")
+            }
+            BlazeDaemonError::Guest(crate::guest::GuestError::PayloadTooLarge { .. }) => {
+                Some("guest_request_too_large")
+            }
+            BlazeDaemonError::Guest(crate::guest::GuestError::ResponseTooLarge { .. }) => {
+                Some("guest_response_too_large")
+            }
+            BlazeDaemonError::Guest(crate::guest::GuestError::Cancelled) => Some("guest_cancelled"),
+            _ => None,
+        }
+    }
+
     /// HTTP status code that should accompany this error in API responses.
     pub fn status_code(&self) -> u16 {
         match self {
             BlazeDaemonError::BadRequest(_) => 400,
             BlazeDaemonError::NotFound(_) => 404,
+            BlazeDaemonError::Conflict(_) => 409,
             BlazeDaemonError::RecoveryRequired(_) => 500,
             BlazeDaemonError::HttpStatus { status, .. } => *status,
             BlazeDaemonError::Core(blaze_core::BlazeError::PolicyEvalError { .. })
             | BlazeDaemonError::Core(blaze_core::BlazeError::InvalidStateTransition { .. }) => 422,
             BlazeDaemonError::Core(blaze_core::BlazeError::BackendUnavailable { .. }) => 503,
+            BlazeDaemonError::Guest(crate::guest::GuestError::InvalidArgument(_)) => 400,
+            BlazeDaemonError::Guest(crate::guest::GuestError::Timeout(_)) => 504,
+            BlazeDaemonError::Guest(crate::guest::GuestError::OutcomeUnknown(_)) => 504,
+            BlazeDaemonError::Guest(crate::guest::GuestError::PayloadTooLarge { .. }) => 413,
+            BlazeDaemonError::Guest(crate::guest::GuestError::Cancelled) => 503,
+            BlazeDaemonError::Guest(_) => 502,
             _ => 500,
         }
     }

--- a/src/blaze/crates/blazed/src/failpoint.rs
+++ b/src/blaze/crates/blazed/src/failpoint.rs
@@ -122,6 +122,16 @@ pub(crate) fn storage(name: &str) -> blaze_core::Result<()> {
     Ok(())
 }
 
+/// Return a guest-domain error when `name` is currently armed.
+pub(crate) fn guest(name: &str) -> crate::guest::Result<()> {
+    if hit(name) {
+        return Err(crate::guest::GuestError::Rejected(format!(
+            "test failpoint '{name}' triggered"
+        )));
+    }
+    Ok(())
+}
+
 /// Return a daemon state-commit error when `name` is currently armed.
 pub(crate) fn state(name: &str) -> crate::error::Result<()> {
     if hit(name) {

--- a/src/blaze/crates/blazed/src/failpoint_disabled.rs
+++ b/src/blaze/crates/blazed/src/failpoint_disabled.rs
@@ -16,6 +16,11 @@ pub(crate) fn storage(_name: &str) -> blaze_core::Result<()> {
     Ok(())
 }
 
+/// Leave guest operations unchanged in production builds.
+pub(crate) fn guest(_name: &str) -> crate::guest::Result<()> {
+    Ok(())
+}
+
 /// Leave state commits unchanged in production builds.
 pub(crate) fn state(_name: &str) -> crate::error::Result<()> {
     Ok(())
@@ -31,6 +36,7 @@ mod tests {
         super::announce();
         super::backend("any").expect("backend hook");
         super::storage("any").expect("storage hook");
+        super::guest("any").expect("guest hook");
         super::state("any").expect("state hook");
         super::pause("any").await;
     }

--- a/src/blaze/crates/blazed/src/guest.rs
+++ b/src/blaze/crates/blazed/src/guest.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Firecracker-vsock guest agent client.
+
+pub mod client;
+
+pub use client::GuestClient;
+pub use client::GuestExecResult;
+
+use thiserror::Error;
+
+/// Maximum decoded file payload accepted by guest read and write operations.
+pub(crate) const MAX_GUEST_FILE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Guest protocol and transport failures.
+#[derive(Debug, Error)]
+pub enum GuestError {
+    /// Unix socket I/O failed.
+    #[error("guest transport error: {0}")]
+    Io(#[from] std::io::Error),
+    /// JSON encoding or decoding failed.
+    #[error("guest JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    /// Firecracker vsock or guest framing was invalid.
+    #[error("guest protocol error: {0}")]
+    Protocol(String),
+    /// Caller supplied an invalid guest operation argument.
+    #[error("invalid guest request: {0}")]
+    InvalidArgument(String),
+    /// A bounded guest operation timed out.
+    #[error("guest operation timed out: {0}")]
+    Timeout(String),
+    /// A state-changing request timed out after it may have reached the guest.
+    #[error("guest operation outcome is unknown: {0}")]
+    OutcomeUnknown(String),
+    /// The guest returned an application error.
+    #[error("guest operation failed: {0}")]
+    Rejected(String),
+    /// Caller-supplied decoded file data exceeded the guest file hard limit.
+    #[error("guest payload too large: {actual} bytes exceeds {limit}")]
+    PayloadTooLarge {
+        /// Decoded or framed byte count.
+        actual: usize,
+        /// Configured limit.
+        limit: usize,
+    },
+    /// A guest response exceeded the bounded frame or decoded output limit.
+    #[error("guest response too large: {actual} bytes exceeds {limit}")]
+    ResponseTooLarge {
+        /// Decoded or framed byte count.
+        actual: usize,
+        /// Configured limit.
+        limit: usize,
+    },
+    /// Readiness polling was cancelled by its caller.
+    #[error("guest readiness wait cancelled")]
+    Cancelled,
+}
+
+/// Result alias for guest operations.
+pub type Result<T> = std::result::Result<T, GuestError>;

--- a/src/blaze/crates/blazed/src/guest/client.rs
+++ b/src/blaze/crates/blazed/src/guest/client.rs
@@ -1,0 +1,1051 @@
+// SPDX-License-Identifier: Apache-2.0
+//! JSON-line client layered over Firecracker's vsock Unix socket proxy.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use blaze_core::guest_protocol::{
+    DEFAULT_GUEST_PORT, DEFAULT_MAX_RESPONSE_BYTES, GuestOp, GuestRequest, GuestResponse,
+};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use super::{GuestError, Result};
+
+const READY_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(250);
+const PROTOCOL_GRACE: Duration = Duration::from_secs(10);
+const MAX_EXEC_COMMAND_BYTES: usize = 64 * 1024;
+const MAX_EXEC_CWD_BYTES: usize = 4096;
+const MAX_EXEC_ENV_ENTRIES: usize = 256;
+const MAX_EXEC_ENV_BYTES: usize = 64 * 1024;
+
+/// Result of one command executed by the guest agent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuestExecResult {
+    /// Guest process exit status.
+    pub exit_code: i32,
+    /// Decoded stdout bytes.
+    pub stdout: Vec<u8>,
+    /// Decoded stderr bytes.
+    pub stderr: Vec<u8>,
+}
+
+/// Client for one Firecracker guest agent.
+#[derive(Debug, Clone)]
+pub struct GuestClient {
+    vsock_path: PathBuf,
+    port: u32,
+    io_timeout: Duration,
+    max_response_bytes: usize,
+    max_file_bytes: usize,
+}
+
+impl GuestClient {
+    /// Create a client with production protocol defaults.
+    pub fn new(vsock_path: PathBuf, io_timeout: Duration, max_file_bytes: usize) -> Self {
+        Self {
+            vsock_path,
+            port: DEFAULT_GUEST_PORT,
+            io_timeout,
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+            max_file_bytes,
+        }
+    }
+
+    /// Override protocol limits for focused tests.
+    #[cfg(test)]
+    fn with_response_limit(mut self, max_response_bytes: usize) -> Self {
+        self.max_response_bytes = max_response_bytes;
+        self
+    }
+
+    /// Check whether the guest agent is responsive.
+    pub async fn ping(&self) -> Result<()> {
+        let request = GuestRequest::new(Uuid::new_v4().to_string(), GuestOp::Ping);
+        self.send_recv(&request).await?;
+        Ok(())
+    }
+
+    /// Poll readiness with bounded exponential backoff.
+    pub async fn wait_ready(
+        &self,
+        deadline: Duration,
+        cancellation: &CancellationToken,
+    ) -> Result<()> {
+        let started = Instant::now();
+        let mut backoff = Duration::from_millis(10);
+        let mut last_error = None;
+        while started.elapsed() < deadline {
+            let remaining = deadline.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                break;
+            }
+            let attempt_timeout = READY_ATTEMPT_TIMEOUT.min(remaining);
+            tokio::select! {
+                _ = cancellation.cancelled() => return Err(GuestError::Cancelled),
+                result = tokio::time::timeout(attempt_timeout, self.ping()) => {
+                    match result {
+                        Ok(Ok(())) => return Ok(()),
+                        Ok(Err(error)) => last_error = Some(error),
+                        Err(_) => {
+                            last_error = Some(GuestError::Timeout(format!(
+                                "readiness ping exceeded {attempt_timeout:?}"
+                            )));
+                        }
+                    }
+                }
+            }
+            let remaining = deadline.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                break;
+            }
+            tokio::select! {
+                _ = cancellation.cancelled() => return Err(GuestError::Cancelled),
+                _ = tokio::time::sleep(backoff.min(remaining)) => {}
+            }
+            backoff = (backoff * 2).min(Duration::from_millis(250));
+        }
+        Err(GuestError::Timeout(format!(
+            "guest at {} was not ready within {:?}: {}",
+            self.vsock_path.display(),
+            deadline,
+            last_error
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "no attempt completed".to_string())
+        )))
+    }
+
+    /// Execute one shell command in the guest.
+    pub async fn exec(
+        &self,
+        command: String,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
+        timeout_secs: u32,
+    ) -> Result<GuestExecResult> {
+        validate_exec_inputs(&command, cwd.as_deref(), env.as_ref())?;
+        let mut request = GuestRequest::new(Uuid::new_v4().to_string(), GuestOp::Exec);
+        request.cmd = Some(command);
+        request.cwd = Some(cwd.unwrap_or_else(|| "/".to_string()));
+        request.env = env;
+        request.timeout = Some(timeout_secs);
+        let timeout = operation_timeout(timeout_secs);
+        if timeout > self.io_timeout {
+            return Err(GuestError::InvalidArgument(format!(
+                "exec timeout plus protocol grace ({timeout:?}) exceeds configured limit {:?}",
+                self.io_timeout
+            )));
+        }
+        let response = self.send_recv_with_timeout(&request, timeout).await?;
+        let exit_code = response
+            .rc
+            .ok_or_else(|| {
+                GuestError::Protocol("successful exec response is missing rc".to_string())
+            })
+            .map_err(|error| classify_after_request(GuestOp::Exec, error))?;
+        let stdout = decode_limited(
+            response.stdout_b64.as_deref().unwrap_or_default(),
+            self.max_response_bytes,
+        )
+        .map_err(|error| classify_after_request(GuestOp::Exec, error))?;
+        let stderr = decode_limited(
+            response.stderr_b64.as_deref().unwrap_or_default(),
+            self.max_response_bytes,
+        )
+        .map_err(|error| classify_after_request(GuestOp::Exec, error))?;
+        Ok(GuestExecResult {
+            exit_code,
+            stdout,
+            stderr,
+        })
+    }
+
+    /// Read one guest file.
+    pub async fn read_file(&self, path: String) -> Result<Vec<u8>> {
+        validate_guest_path(&path)?;
+        let mut request = GuestRequest::new(Uuid::new_v4().to_string(), GuestOp::Read);
+        request.path = Some(path);
+        let guest_timeout = request_timeout_secs(self.io_timeout);
+        request.timeout = Some(guest_timeout);
+        let response = self
+            .send_recv_with_timeout(
+                &request,
+                operation_timeout(guest_timeout).min(self.io_timeout),
+            )
+            .await?;
+        let data = response.data_b64.as_deref().ok_or_else(|| {
+            GuestError::Protocol("successful read response is missing data_b64".to_string())
+        })?;
+        decode_limited(data, self.max_file_bytes)
+    }
+
+    /// Replace one guest file.
+    pub async fn write_file(&self, path: String, data: &[u8]) -> Result<()> {
+        validate_guest_path(&path)?;
+        if data.len() > self.max_file_bytes {
+            return Err(GuestError::PayloadTooLarge {
+                actual: data.len(),
+                limit: self.max_file_bytes,
+            });
+        }
+        let mut request = GuestRequest::new(Uuid::new_v4().to_string(), GuestOp::Write);
+        request.path = Some(path);
+        request.data_b64 = Some(BASE64.encode(data));
+        let guest_timeout = request_timeout_secs(self.io_timeout);
+        request.timeout = Some(guest_timeout);
+        self.send_recv_with_timeout(
+            &request,
+            operation_timeout(guest_timeout).min(self.io_timeout),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn send_recv(&self, request: &GuestRequest) -> Result<GuestResponse> {
+        self.send_recv_with_timeout(request, self.io_timeout).await
+    }
+
+    async fn send_recv_with_timeout(
+        &self,
+        request: &GuestRequest,
+        timeout: Duration,
+    ) -> Result<GuestResponse> {
+        let mut encoded = serde_json::to_vec(request)?;
+        encoded.push(b'\n');
+
+        let started = Instant::now();
+        let mut stream = match tokio::time::timeout(timeout, self.connect_guest()).await {
+            Ok(result) => result?,
+            Err(_) => return Err(self.timeout_error(request, timeout, "before request delivery")),
+        };
+        let remaining = timeout.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Err(self.timeout_error(request, timeout, "before request delivery"));
+        }
+
+        match tokio::time::timeout(
+            remaining,
+            self.exchange_request(&mut stream, request, &encoded),
+        )
+        .await
+        {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(error)) => Err(classify_after_request(request.op, error)),
+            Err(_) => Err(classify_after_request(
+                request.op,
+                self.timeout_error(request, timeout, "after request delivery began"),
+            )),
+        }
+    }
+
+    async fn connect_guest(&self) -> Result<UnixStream> {
+        let mut stream = UnixStream::connect(&self.vsock_path).await?;
+        stream
+            .write_all(format!("CONNECT {}\n", self.port).as_bytes())
+            .await?;
+        let handshake = read_line(&mut stream, 128).await?;
+        let handshake = std::str::from_utf8(&handshake).map_err(|error| {
+            GuestError::Protocol(format!("CONNECT response is not UTF-8: {error}"))
+        })?;
+        let peer_cid = handshake
+            .strip_prefix("OK ")
+            .and_then(|value| value.parse::<u32>().ok());
+        if peer_cid.is_none() {
+            return Err(GuestError::Protocol(format!(
+                "unexpected CONNECT {} response: expected \"OK <numeric-peer-cid>\", received {handshake:?}",
+                self.port,
+            )));
+        }
+        Ok(stream)
+    }
+
+    async fn exchange_request(
+        &self,
+        stream: &mut UnixStream,
+        request: &GuestRequest,
+        encoded: &[u8],
+    ) -> Result<GuestResponse> {
+        stream.write_all(encoded).await?;
+        stream.flush().await?;
+        let line = read_line(stream, self.max_response_bytes).await?;
+        let response: GuestResponse = serde_json::from_slice(&line)?;
+        if response.id != request.id {
+            return Err(GuestError::Protocol(format!(
+                "response id mismatch: sent {}, received {}",
+                request.id, response.id
+            )));
+        }
+        if !response.ok {
+            return Err(GuestError::Rejected(response.err.unwrap_or_else(|| {
+                "guest rejected request without an error".to_string()
+            })));
+        }
+        Ok(response)
+    }
+
+    fn timeout_error(&self, request: &GuestRequest, timeout: Duration, phase: &str) -> GuestError {
+        GuestError::Timeout(format!(
+            "{:?} request to {} exceeded {:?} {phase}",
+            request.op,
+            self.vsock_path.display(),
+            timeout
+        ))
+    }
+}
+
+fn classify_after_request(operation: GuestOp, error: GuestError) -> GuestError {
+    if matches!(operation, GuestOp::Exec | GuestOp::Write)
+        && !matches!(
+            error,
+            GuestError::Rejected(_) | GuestError::OutcomeUnknown(_)
+        )
+    {
+        GuestError::OutcomeUnknown(error.to_string())
+    } else {
+        error
+    }
+}
+
+fn operation_timeout(guest_timeout_secs: u32) -> Duration {
+    Duration::from_secs(u64::from(guest_timeout_secs)).saturating_add(PROTOCOL_GRACE)
+}
+
+fn request_timeout_secs(io_timeout: Duration) -> u32 {
+    io_timeout
+        .saturating_sub(PROTOCOL_GRACE)
+        .as_secs()
+        .clamp(1, u64::from(u32::MAX)) as u32
+}
+
+async fn read_line<R>(stream: &mut R, limit: usize) -> Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let bounded = limit.saturating_add(1);
+    let mut reader = BufReader::new(stream).take(bounded as u64);
+    let mut output = Vec::with_capacity(limit.min(8192));
+    let count = reader.read_until(b'\n', &mut output).await?;
+    if output.last() == Some(&b'\n') {
+        output.pop();
+        if output.len() <= limit {
+            return Ok(output);
+        }
+    }
+    if output.len() > limit {
+        return Err(GuestError::ResponseTooLarge {
+            actual: output.len(),
+            limit,
+        });
+    }
+    debug_assert_eq!(count, output.len());
+    Err(GuestError::Protocol(
+        "connection closed before newline delimiter".to_string(),
+    ))
+}
+
+fn decode_limited(encoded: &str, limit: usize) -> Result<Vec<u8>> {
+    let encoded_limit = limit.div_ceil(3).saturating_mul(4);
+    if encoded.len() > encoded_limit {
+        return Err(GuestError::ResponseTooLarge {
+            actual: encoded.len(),
+            limit: encoded_limit,
+        });
+    }
+    let decoded = BASE64
+        .decode(encoded)
+        .map_err(|error| GuestError::Protocol(format!("invalid base64 payload: {error}")))?;
+    if decoded.len() > limit {
+        return Err(GuestError::ResponseTooLarge {
+            actual: decoded.len(),
+            limit,
+        });
+    }
+    Ok(decoded)
+}
+
+fn validate_exec_inputs(
+    command: &str,
+    cwd: Option<&str>,
+    env: Option<&HashMap<String, String>>,
+) -> Result<()> {
+    if command.is_empty() {
+        return Err(GuestError::InvalidArgument(
+            "exec command is empty".to_string(),
+        ));
+    }
+    if command.len() > MAX_EXEC_COMMAND_BYTES || command.contains('\0') {
+        return Err(GuestError::InvalidArgument(format!(
+            "exec command must be NUL-free and at most {MAX_EXEC_COMMAND_BYTES} bytes"
+        )));
+    }
+    if let Some(cwd) = cwd
+        && (cwd.len() > MAX_EXEC_CWD_BYTES || cwd.contains('\0'))
+    {
+        return Err(GuestError::InvalidArgument(format!(
+            "exec cwd must be NUL-free and at most {MAX_EXEC_CWD_BYTES} bytes"
+        )));
+    }
+    if let Some(env) = env {
+        if env.len() > MAX_EXEC_ENV_ENTRIES {
+            return Err(GuestError::InvalidArgument(format!(
+                "exec environment has {} entries; limit is {MAX_EXEC_ENV_ENTRIES}",
+                env.len()
+            )));
+        }
+        let mut total = 0_usize;
+        for (key, value) in env {
+            if key.is_empty() || key.contains('=') || key.contains('\0') || value.contains('\0') {
+                return Err(GuestError::InvalidArgument(
+                    "exec environment keys must be non-empty and contain no '=', and keys and \
+                     values must be NUL-free"
+                        .to_string(),
+                ));
+            }
+            total = total
+                .checked_add(key.len())
+                .and_then(|bytes| bytes.checked_add(value.len()))
+                .ok_or_else(|| {
+                    GuestError::InvalidArgument("exec environment size overflow".to_string())
+                })?;
+            if total > MAX_EXEC_ENV_BYTES {
+                return Err(GuestError::InvalidArgument(format!(
+                    "exec environment is {total} bytes; limit is {MAX_EXEC_ENV_BYTES}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_guest_path(path: &str) -> Result<()> {
+    if path.is_empty() || !path.starts_with('/') || path.len() > 4096 || path.contains('\0') {
+        return Err(GuestError::InvalidArgument(
+            "guest file path must be absolute, NUL-free, and at most 4096 bytes".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use serde_json::json;
+    use tokio::net::UnixListener;
+
+    use super::*;
+
+    async fn spawn_server(
+        socket: PathBuf,
+        response: Arc<dyn Fn(serde_json::Value) -> serde_json::Value + Send + Sync>,
+    ) {
+        let listener = UnixListener::bind(socket).expect("bind");
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let response = response.clone();
+                tokio::spawn(async move {
+                    let connect = read_line(&mut stream, 128).await.expect("connect");
+                    assert_eq!(connect, b"CONNECT 5000");
+                    stream.write_all(b"OK 1073742006\n").await.expect("ok");
+                    let request = read_line(&mut stream, 4096).await.expect("request");
+                    let request: serde_json::Value =
+                        serde_json::from_slice(&request).expect("json");
+                    let response = response(request);
+                    let mut bytes = serde_json::to_vec(&response).expect("encode");
+                    bytes.push(b'\n');
+                    stream.write_all(&bytes).await.expect("write");
+                });
+            }
+        });
+    }
+
+    async fn accept_request(listener: &UnixListener) -> (UnixStream, serde_json::Value) {
+        let (mut stream, _) = listener.accept().await.expect("accept");
+        let connect = read_line(&mut stream, 128).await.expect("connect");
+        assert_eq!(connect, b"CONNECT 5000");
+        stream.write_all(b"OK 1073742006\n").await.expect("ok");
+        let request = read_line(&mut stream, 4096).await.expect("request");
+        let request = serde_json::from_slice(&request).expect("json");
+        (stream, request)
+    }
+
+    #[test]
+    fn side_effect_errors_become_unknown_only_after_delivery_starts() {
+        for operation in [GuestOp::Exec, GuestOp::Write] {
+            assert!(matches!(
+                classify_after_request(operation, GuestError::Protocol("EOF".into())),
+                GuestError::OutcomeUnknown(_)
+            ));
+            assert!(matches!(
+                classify_after_request(
+                    operation,
+                    GuestError::ResponseTooLarge {
+                        actual: 5,
+                        limit: 4,
+                    },
+                ),
+                GuestError::OutcomeUnknown(_)
+            ));
+            assert!(matches!(
+                classify_after_request(operation, GuestError::Rejected("denied".into())),
+                GuestError::Rejected(_)
+            ));
+        }
+
+        assert!(matches!(
+            classify_after_request(GuestOp::Read, GuestError::Protocol("EOF".into())),
+            GuestError::Protocol(_)
+        ));
+        assert!(matches!(
+            classify_after_request(
+                GuestOp::Read,
+                GuestError::ResponseTooLarge {
+                    actual: 5,
+                    limit: 4,
+                },
+            ),
+            GuestError::ResponseTooLarge { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn ping_exec_read_and_write_follow_existing_protocol() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = requests.clone();
+        spawn_server(
+            socket.clone(),
+            Arc::new(move |request| {
+                server_requests.fetch_add(1, Ordering::Relaxed);
+                match request["op"].as_str().expect("op") {
+                    "exec" => json!({
+                        "id": request["id"],
+                        "ok": true,
+                        "rc": 7,
+                        "stdout_b64": BASE64.encode(b"out"),
+                        "stderr_b64": BASE64.encode(b"err")
+                    }),
+                    "read" => {
+                        assert_eq!(request["timeout"], 5);
+                        json!({
+                            "id": request["id"],
+                            "ok": true,
+                            "data_b64": BASE64.encode(b"data")
+                        })
+                    }
+                    "write" => {
+                        assert_eq!(request["timeout"], 5);
+                        json!({"id": request["id"], "ok": true})
+                    }
+                    _ => json!({"id": request["id"], "ok": true}),
+                }
+            }),
+        )
+        .await;
+        let client = GuestClient::new(socket, Duration::from_secs(15), 1024);
+        client.ping().await.expect("ping");
+        let exec = client
+            .exec("exit 7".into(), None, None, 1)
+            .await
+            .expect("exec");
+        assert_eq!(exec.exit_code, 7);
+        assert_eq!(exec.stdout, b"out");
+        assert_eq!(
+            client.read_file("/tmp/x".into()).await.expect("read"),
+            b"data"
+        );
+        client
+            .write_file("/tmp/x".into(), b"replacement")
+            .await
+            .expect("write");
+        assert_eq!(requests.load(Ordering::Relaxed), 4);
+    }
+
+    #[tokio::test]
+    async fn mismatched_response_id_is_rejected() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        spawn_server(
+            socket.clone(),
+            Arc::new(|_| json!({"id": "wrong", "ok": true})),
+        )
+        .await;
+        let error = GuestClient::new(socket, Duration::from_secs(1), 1024)
+            .ping()
+            .await
+            .expect_err("mismatch");
+        assert!(matches!(error, GuestError::Protocol(_)));
+    }
+
+    #[tokio::test]
+    async fn malformed_json_is_rejected_without_poisoning_the_next_call() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let server = tokio::spawn(async move {
+            let (mut first, _) = accept_request(&listener).await;
+            first.write_all(b"{not-json}\n").await.expect("malformed");
+
+            let (mut second, request) = accept_request(&listener).await;
+            let mut response =
+                serde_json::to_vec(&json!({"id": request["id"], "ok": true})).expect("response");
+            response.push(b'\n');
+            second.write_all(&response).await.expect("valid");
+        });
+        let client = GuestClient::new(socket, Duration::from_secs(1), 1024);
+        assert!(matches!(client.ping().await, Err(GuestError::Json(_))));
+        client.ping().await.expect("subsequent request");
+        server.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn missing_socket_is_reported_as_connection_failure() {
+        let temp = tempfile::tempdir().expect("temp");
+        let client = GuestClient::new(
+            temp.path().join("missing.uds"),
+            Duration::from_millis(100),
+            1024,
+        );
+        let error = client.ping().await.expect_err("connection failure");
+        assert!(matches!(error, GuestError::Io(_)));
+
+        let write_error = client
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("write did not reach the guest");
+        assert!(matches!(write_error, GuestError::Io(_)));
+    }
+
+    #[tokio::test]
+    async fn invalid_exec_timeout_is_a_caller_error() {
+        let temp = tempfile::tempdir().expect("temp");
+        let error = GuestClient::new(
+            temp.path().join("missing.uds"),
+            Duration::from_secs(15),
+            1024,
+        )
+        .exec("true".into(), None, None, 6)
+        .await
+        .expect_err("timeout exceeds request budget");
+        assert!(matches!(error, GuestError::InvalidArgument(_)));
+        assert_eq!(
+            crate::error::BlazeDaemonError::from(error).status_code(),
+            400
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_response_requires_a_numeric_peer_cid() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let connect = read_line(&mut stream, 128).await.expect("connect");
+            assert_eq!(connect, b"CONNECT 5000");
+            stream
+                .write_all(b"OK not-a-cid\n")
+                .await
+                .expect("invalid peer cid");
+        });
+        let error = GuestClient::new(socket, Duration::from_secs(1), 1024)
+            .ping()
+            .await
+            .expect_err("invalid peer cid");
+        assert!(matches!(error, GuestError::Protocol(_)));
+        server.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn guest_rejection_is_returned_without_panicking() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        spawn_server(
+            socket.clone(),
+            Arc::new(|request| json!({"id": request["id"], "ok": false, "err": "denied by guest"})),
+        )
+        .await;
+        let error = GuestClient::new(socket, Duration::from_secs(1), 1024)
+            .ping()
+            .await
+            .expect_err("rejected");
+        assert!(matches!(error, GuestError::Rejected(message) if message == "denied by guest"));
+    }
+
+    #[tokio::test]
+    async fn read_and_write_response_timeouts_are_bounded() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = accept_request(&listener).await;
+                tokio::spawn(async move {
+                    let _stream = stream;
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                });
+            }
+        });
+        let client = GuestClient::new(socket, Duration::from_millis(30), 1024);
+        let read_error = client
+            .read_file("/tmp/x".into())
+            .await
+            .expect_err("read timeout");
+        assert!(matches!(read_error, GuestError::Timeout(_)));
+        let write_error = client
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("write timeout");
+        assert!(matches!(write_error, GuestError::OutcomeUnknown(_)));
+        server.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn mutating_handshake_timeout_is_retryable() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let server = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.expect("accept");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+
+        let error = GuestClient::new(socket, Duration::from_millis(20), 1024)
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("handshake timeout");
+        assert!(matches!(error, GuestError::Timeout(_)));
+        server.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn mutating_response_corruption_has_unknown_outcome() {
+        let temp = tempfile::tempdir().expect("temp");
+
+        let malformed_socket = temp.path().join("malformed.uds");
+        let malformed_listener = UnixListener::bind(&malformed_socket).expect("bind");
+        tokio::spawn(async move {
+            let (mut stream, _) = accept_request(&malformed_listener).await;
+            stream.write_all(b"{not-json}\n").await.expect("response");
+        });
+        let malformed = GuestClient::new(malformed_socket, Duration::from_secs(15), 1024)
+            .exec("true".into(), None, None, 1)
+            .await
+            .expect_err("malformed response");
+        assert!(matches!(malformed, GuestError::OutcomeUnknown(_)));
+
+        let mismatch_socket = temp.path().join("mismatch.uds");
+        spawn_server(
+            mismatch_socket.clone(),
+            Arc::new(|_| json!({"id": "wrong", "ok": true})),
+        )
+        .await;
+        let mismatch = GuestClient::new(mismatch_socket, Duration::from_secs(1), 1024)
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("mismatched response");
+        assert!(matches!(mismatch, GuestError::OutcomeUnknown(_)));
+
+        let missing_ok_socket = temp.path().join("missing-ok.uds");
+        spawn_server(
+            missing_ok_socket.clone(),
+            Arc::new(|request| json!({"id": request["id"]})),
+        )
+        .await;
+        let missing_ok = GuestClient::new(missing_ok_socket, Duration::from_secs(1), 1024)
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("missing outcome flag");
+        assert!(matches!(missing_ok, GuestError::OutcomeUnknown(_)));
+
+        let eof_socket = temp.path().join("eof.uds");
+        let eof_listener = UnixListener::bind(&eof_socket).expect("bind");
+        tokio::spawn(async move {
+            let (_stream, _) = accept_request(&eof_listener).await;
+        });
+        let eof = GuestClient::new(eof_socket, Duration::from_secs(1), 1024)
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("response EOF");
+        assert!(matches!(eof, GuestError::OutcomeUnknown(_)));
+
+        let oversized_socket = temp.path().join("oversized-write.uds");
+        spawn_server(
+            oversized_socket.clone(),
+            Arc::new(|request| json!({"id": request["id"], "ok": true, "padding": "xxxxxxxx"})),
+        )
+        .await;
+        let oversized = GuestClient::new(oversized_socket, Duration::from_secs(1), 1024)
+            .with_response_limit(4)
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("oversized response");
+        assert!(matches!(oversized, GuestError::OutcomeUnknown(_)));
+    }
+
+    #[tokio::test]
+    async fn explicit_mutating_rejection_has_known_outcome() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("rejected.uds");
+        spawn_server(
+            socket.clone(),
+            Arc::new(|request| json!({"id": request["id"], "ok": false, "err": "write denied"})),
+        )
+        .await;
+
+        let error = GuestClient::new(socket, Duration::from_secs(1), 1024)
+            .write_file("/tmp/x".into(), b"value")
+            .await
+            .expect_err("guest rejection");
+        assert!(matches!(error, GuestError::Rejected(message) if message == "write denied"));
+    }
+
+    #[tokio::test]
+    async fn successful_responses_require_operation_fields() {
+        let temp = tempfile::tempdir().expect("temp");
+        let exec_socket = temp.path().join("exec.uds");
+        spawn_server(
+            exec_socket.clone(),
+            Arc::new(|request| json!({"id": request["id"], "ok": true})),
+        )
+        .await;
+        let exec = GuestClient::new(exec_socket, Duration::from_secs(15), 1024)
+            .exec("true".into(), None, None, 1)
+            .await
+            .expect_err("missing rc");
+        assert!(
+            matches!(exec, GuestError::OutcomeUnknown(message) if message.contains("missing rc"))
+        );
+
+        let read_socket = temp.path().join("read.uds");
+        spawn_server(
+            read_socket.clone(),
+            Arc::new(|request| json!({"id": request["id"], "ok": true})),
+        )
+        .await;
+        let read = GuestClient::new(read_socket, Duration::from_secs(1), 1024)
+            .read_file("/tmp/x".into())
+            .await
+            .expect_err("missing data");
+        assert!(
+            matches!(read, GuestError::Protocol(message) if message.contains("missing data_b64"))
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_inputs_are_bounded_before_connecting() {
+        let temp = tempfile::tempdir().expect("temp");
+        let client = GuestClient::new(
+            temp.path().join("missing.uds"),
+            Duration::from_secs(15),
+            1024,
+        );
+        let command = "x".repeat(MAX_EXEC_COMMAND_BYTES + 1);
+        assert!(matches!(
+            client.exec(command, None, None, 1).await,
+            Err(GuestError::InvalidArgument(_))
+        ));
+
+        let mut env = HashMap::new();
+        env.insert("KEY".to_string(), "x".repeat(MAX_EXEC_ENV_BYTES));
+        assert!(matches!(
+            client.exec("true".into(), None, Some(env), 1).await,
+            Err(GuestError::InvalidArgument(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn oversized_response_is_rejected() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        spawn_server(
+            socket.clone(),
+            Arc::new(|request| json!({"id": request["id"], "ok": true, "data_b64": "AAAAAAAA"})),
+        )
+        .await;
+        let error = GuestClient::new(socket, Duration::from_secs(1), 1024)
+            .with_response_limit(4)
+            .read_file("/tmp/x".into())
+            .await
+            .expect_err("oversized line");
+        assert!(matches!(error, GuestError::ResponseTooLarge { .. }));
+    }
+
+    #[tokio::test]
+    async fn line_reader_accepts_the_limit_and_rejects_one_more_byte() {
+        let (mut exact_reader, mut exact_writer) = tokio::io::duplex(64);
+        tokio::spawn(async move {
+            exact_writer
+                .write_all(b"1234\n")
+                .await
+                .expect("write exact");
+        });
+        assert_eq!(
+            read_line(&mut exact_reader, 4).await.expect("exact limit"),
+            b"1234"
+        );
+
+        let (mut oversized_reader, mut oversized_writer) = tokio::io::duplex(64);
+        tokio::spawn(async move {
+            oversized_writer
+                .write_all(b"12345\n")
+                .await
+                .expect("write oversized");
+        });
+        assert!(matches!(
+            read_line(&mut oversized_reader, 4)
+                .await
+                .expect_err("one byte over"),
+            GuestError::ResponseTooLarge {
+                actual: 5,
+                limit: 4
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_and_decoded_oversized_base64_are_rejected() {
+        let temp = tempfile::tempdir().expect("temp");
+        let invalid_socket = temp.path().join("invalid.uds");
+        spawn_server(
+            invalid_socket.clone(),
+            Arc::new(|request| json!({"id": request["id"], "ok": true, "data_b64": "not/base64!"})),
+        )
+        .await;
+        let invalid = GuestClient::new(invalid_socket, Duration::from_secs(1), 16)
+            .read_file("/tmp/x".into())
+            .await
+            .expect_err("invalid base64");
+        assert!(matches!(invalid, GuestError::Protocol(_)));
+
+        let oversized_socket = temp.path().join("oversized.uds");
+        spawn_server(
+            oversized_socket.clone(),
+            Arc::new(|request| {
+                json!({
+                    "id": request["id"],
+                    "ok": true,
+                    "data_b64": BASE64.encode(b"12345")
+                })
+            }),
+        )
+        .await;
+        let oversized = GuestClient::new(oversized_socket, Duration::from_secs(1), 4)
+            .read_file("/tmp/x".into())
+            .await
+            .expect_err("decoded limit");
+        assert!(matches!(
+            oversized,
+            GuestError::ResponseTooLarge {
+                actual: 5,
+                limit: 4
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn oversized_write_is_rejected_before_connecting() {
+        let temp = tempfile::tempdir().expect("temp");
+        let error = GuestClient::new(temp.path().join("missing.uds"), Duration::from_secs(1), 4)
+            .write_file("/tmp/x".into(), b"12345")
+            .await
+            .expect_err("write limit");
+        assert!(matches!(
+            error,
+            GuestError::PayloadTooLarge {
+                actual: 5,
+                limit: 4
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn wait_ready_honors_cancellation() {
+        let temp = tempfile::tempdir().expect("temp");
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let error = GuestClient::new(
+            temp.path().join("missing.uds"),
+            Duration::from_millis(10),
+            1024,
+        )
+        .wait_ready(Duration::from_secs(1), &cancellation)
+        .await
+        .expect_err("cancelled");
+        assert!(matches!(error, GuestError::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn wait_ready_stops_at_its_deadline() {
+        let temp = tempfile::tempdir().expect("temp");
+        let started = Instant::now();
+        let error = GuestClient::new(
+            temp.path().join("missing.uds"),
+            Duration::from_secs(1),
+            1024,
+        )
+        .wait_ready(Duration::from_millis(60), &CancellationToken::new())
+        .await
+        .expect_err("deadline");
+        assert!(matches!(error, GuestError::Timeout(_)));
+        assert!(started.elapsed() < Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn wait_ready_retries_after_one_stalled_connection() {
+        let temp = tempfile::tempdir().expect("temp");
+        let socket = temp.path().join("vsock.uds");
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server_attempts = attempts.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let attempt = server_attempts.fetch_add(1, Ordering::Relaxed);
+                tokio::spawn(async move {
+                    if attempt == 0 {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        return;
+                    }
+                    let connect = read_line(&mut stream, 128).await.expect("connect");
+                    assert_eq!(connect, b"CONNECT 5000");
+                    stream.write_all(b"OK 5000\n").await.expect("ok");
+                    let request = read_line(&mut stream, 4096).await.expect("request");
+                    let request: serde_json::Value =
+                        serde_json::from_slice(&request).expect("json");
+                    let response = json!({"id": request["id"], "ok": true});
+                    let mut bytes = serde_json::to_vec(&response).expect("encode");
+                    bytes.push(b'\n');
+                    stream.write_all(&bytes).await.expect("write");
+                });
+            }
+        });
+
+        GuestClient::new(socket, Duration::from_secs(5), 1024)
+            .wait_ready(Duration::from_secs(1), &CancellationToken::new())
+            .await
+            .expect("second readiness attempt");
+        assert!(attempts.load(Ordering::Relaxed) >= 2);
+    }
+
+    #[test]
+    fn guest_path_validation_does_not_treat_guest_paths_as_host_paths() {
+        assert!(validate_guest_path("/tmp/../etc/hosts").is_ok());
+        assert!(matches!(
+            validate_guest_path("relative"),
+            Err(GuestError::InvalidArgument(_))
+        ));
+    }
+}

--- a/src/blaze/crates/blazed/src/main.rs
+++ b/src/blaze/crates/blazed/src/main.rs
@@ -14,6 +14,7 @@ mod failpoint;
 #[path = "failpoint_disabled.rs"]
 mod failpoint;
 mod file_provider;
+mod guest;
 mod metrics;
 mod sandbox;
 mod spawner;

--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use blaze_core::BlazeError;
 use blaze_core::backend::{BackendKind, SpawnRequest};
@@ -13,12 +14,16 @@ use blaze_core::lifecycle::{
 use blaze_core::policy::RuntimeDecision;
 use blaze_core::pool::{PoolKey, PoolManager};
 use blaze_core::storage::{AcquireOpts, StorageProvider, StorageSlot};
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::error::{BlazeDaemonError, Result};
+use crate::guest::{GuestClient, GuestExecResult, MAX_GUEST_FILE_BYTES};
 use crate::metrics::Metrics;
 use crate::spawner::{DynBackendInstance, SpawnerRegistry};
+
+const GUEST_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Inputs already parsed and policy-evaluated by the API.
 #[derive(Debug, Clone)]
@@ -169,6 +174,15 @@ impl SandboxManager {
         }
     }
 
+    #[cfg(test)]
+    pub fn insert_backend_owner(&self, id: Uuid, owner: DynBackendInstance) -> Result<()> {
+        self.backend_instances
+            .lock()
+            .map_err(|_| poisoned("backend_instances"))?
+            .insert(id, owner);
+        Ok(())
+    }
+
     /// Return all persisted sandbox metadata.
     pub fn list(&self) -> Result<Vec<SandboxInstance>> {
         Ok(self
@@ -188,6 +202,40 @@ impl SandboxManager {
             .get(&id)
             .cloned()
             .ok_or_else(|| BlazeDaemonError::NotFound(format!("instance {id}")))
+    }
+
+    /// Execute one command through the running sandbox guest.
+    pub async fn exec(
+        &self,
+        id: Uuid,
+        command: String,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
+        timeout_secs: u32,
+    ) -> Result<GuestExecResult> {
+        let _operation = self.lock_running(id).await?;
+        self.guest_client(id)?
+            .exec(command, cwd, env, timeout_secs)
+            .await
+            .map_err(BlazeDaemonError::from)
+    }
+
+    /// Read one file through the running sandbox guest.
+    pub async fn read_file(&self, id: Uuid, path: String) -> Result<Vec<u8>> {
+        let _operation = self.lock_running(id).await?;
+        self.guest_client(id)?
+            .read_file(path)
+            .await
+            .map_err(BlazeDaemonError::from)
+    }
+
+    /// Replace one file through the running sandbox guest.
+    pub async fn write_file(&self, id: Uuid, path: String, data: &[u8]) -> Result<()> {
+        let _operation = self.lock_running(id).await?;
+        self.guest_client(id)?
+            .write_file(path, data)
+            .await
+            .map_err(BlazeDaemonError::from)
     }
 
     /// Create a cold sandbox or activate a compatible warm runtime.
@@ -300,6 +348,20 @@ impl SandboxManager {
             Ok(backend_instance) => {
                 instance.backend_ownership = BackendOwnership::Running;
                 let actual_backend = backend_instance.backend();
+                if let Err(error) = self
+                    .wait_for_guest_ready(&backend_instance, "create-guest-ready")
+                    .await
+                {
+                    return Err(self
+                        .cleanup_failed_create(
+                            &mut instance,
+                            storage,
+                            Some(backend_instance),
+                            false,
+                            error.into(),
+                        )
+                        .await);
+                }
                 let mut backend_instance = Some(backend_instance);
                 let registered = match self.backend_instances.lock() {
                     Ok(mut instances) => {
@@ -818,6 +880,59 @@ impl SandboxManager {
             }
         }
         report
+    }
+
+    async fn lock_running(&self, id: Uuid) -> Result<OwnedMutexGuard<()>> {
+        let operation = self.operation_lock(id).lock_owned().await;
+        let instance = self.get(id)?;
+        if instance.state != SandboxState::Running || instance.operation.is_some() {
+            return Err(BlazeDaemonError::Conflict(format!(
+                "instance {id} is not available for guest operations"
+            )));
+        }
+        Ok(operation)
+    }
+
+    fn guest_client(&self, id: Uuid) -> Result<GuestClient> {
+        let backend = self
+            .backend_instances
+            .lock()
+            .map_err(|_| poisoned("backend_instances"))?
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| {
+                BlazeDaemonError::Conflict(format!("instance {id} has no backend owner"))
+            })?;
+        let socket = backend.guest_socket_path();
+        if socket.as_os_str().is_empty() {
+            return Err(BlazeDaemonError::Conflict(format!(
+                "instance {id} has no guest transport"
+            )));
+        }
+        Ok(GuestClient::new(
+            socket.to_path_buf(),
+            GUEST_REQUEST_TIMEOUT,
+            MAX_GUEST_FILE_BYTES,
+        ))
+    }
+
+    async fn wait_for_guest_ready(
+        &self,
+        backend: &DynBackendInstance,
+        failpoint: &str,
+    ) -> crate::guest::Result<()> {
+        let socket = backend.guest_socket_path();
+        if socket.as_os_str().is_empty() {
+            return Ok(());
+        }
+        crate::failpoint::guest(failpoint)?;
+        GuestClient::new(
+            socket.to_path_buf(),
+            GUEST_REQUEST_TIMEOUT,
+            MAX_GUEST_FILE_BYTES,
+        )
+        .wait_ready(GUEST_REQUEST_TIMEOUT, &CancellationToken::new())
+        .await
     }
 
     async fn cleanup_failed_create(

--- a/src/blaze/crates/blazed/src/spawner.rs
+++ b/src/blaze/crates/blazed/src/spawner.rs
@@ -16,7 +16,13 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use blaze_core::backend::{BackendKind, SpawnRequest};
+#[cfg(test)]
+use blaze_core::guest_protocol::DEFAULT_MAX_RESPONSE_BYTES;
 use blaze_core::{BlazeError, Result};
+#[cfg(test)]
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
+#[cfg(test)]
+use tokio::net::UnixListener;
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -44,6 +50,10 @@ pub struct SpawnResult {
 pub trait BackendInstance: Send + Sync {
     /// Concrete backend implementation.
     fn backend(&self) -> BackendKind;
+    /// Guest transport endpoint, or an empty path for guestless backends.
+    fn guest_socket_path(&self) -> &Path {
+        Path::new("")
+    }
     /// Report an observed backend exit without waiting.
     ///
     /// `None` means the owned process or task was running when checked.
@@ -404,6 +414,220 @@ impl BackendInstance for MockInstance {
     }
 }
 
+/// Guest-capable mock used only by unit and integration tests.
+#[cfg(test)]
+pub(crate) struct GuestMockSpawner;
+
+#[cfg(test)]
+#[async_trait]
+impl BackendSpawner for GuestMockSpawner {
+    async fn spawn(
+        &self,
+        request: SpawnRequest,
+    ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+        spawn_guest_mock_instance(request.instance_id, request.run_dir)
+            .await
+            .map_err(SpawnFailure::from)
+    }
+
+    async fn probe(&self, _binary_path: &Path) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn cleanup_orphan(&self, _instance_id: Uuid, _run_dir: &Path) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+struct GuestMockInstance {
+    instance_id: Uuid,
+    guest_socket_path: PathBuf,
+    cancellation: CancellationToken,
+    task: Mutex<Option<JoinHandle<()>>>,
+    killed: AtomicBool,
+}
+
+#[cfg(test)]
+async fn spawn_guest_mock_instance(
+    instance_id: Uuid,
+    run_dir: PathBuf,
+) -> Result<DynBackendInstance> {
+    tokio::fs::create_dir_all(&run_dir).await?;
+    let socket = run_dir.join("vsock.uds");
+    if socket.exists() {
+        tokio::fs::remove_file(&socket).await?;
+    }
+    let listener = UnixListener::bind(&socket)?;
+    let cancellation = CancellationToken::new();
+    let task_token = cancellation.clone();
+    let files = Arc::new(Mutex::new(HashMap::new()));
+    let task_files = files.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = task_token.cancelled() => break,
+                accepted = listener.accept() => {
+                    let Ok((stream, _)) = accepted else {
+                        break;
+                    };
+                    let files = task_files.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = serve_mock_guest(stream, files).await {
+                            tracing::debug!(%error, "test guest connection ended");
+                        }
+                    });
+                }
+            }
+        }
+    });
+    Ok(Arc::new(GuestMockInstance {
+        instance_id,
+        guest_socket_path: socket,
+        cancellation,
+        task: Mutex::new(Some(task)),
+        killed: AtomicBool::new(false),
+    }))
+}
+
+#[cfg(test)]
+#[async_trait]
+impl BackendInstance for GuestMockInstance {
+    fn backend(&self) -> BackendKind {
+        BackendKind::Mock
+    }
+
+    fn guest_socket_path(&self) -> &Path {
+        &self.guest_socket_path
+    }
+
+    async fn try_wait(&self) -> Result<Option<SpawnResult>> {
+        let mut task = self.task.lock().await;
+        match task.as_ref() {
+            Some(handle) if !handle.is_finished() => Ok(None),
+            Some(_) => {
+                if let Some(handle) = task.take() {
+                    let _ = handle.await;
+                }
+                Ok(Some(SpawnResult {
+                    instance_id: self.instance_id,
+                    exit_code: Some(0),
+                    signal: None,
+                }))
+            }
+            None => Ok(Some(SpawnResult {
+                instance_id: self.instance_id,
+                exit_code: Some(0),
+                signal: None,
+            })),
+        }
+    }
+
+    async fn kill(&self) -> Result<()> {
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let mut task = self.task.lock().await;
+        if self.killed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        self.cancellation.cancel();
+        if let Some(task) = task.take() {
+            let _ = task.await;
+        }
+        if self.guest_socket_path.exists() {
+            tokio::fs::remove_file(&self.guest_socket_path).await?;
+        }
+        self.killed.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+async fn serve_mock_guest(
+    mut stream: tokio::net::UnixStream,
+    files: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+) -> std::io::Result<()> {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+
+    let connect = read_mock_line(&mut stream, 128).await?;
+    if !connect.starts_with(b"CONNECT ") {
+        return Ok(());
+    }
+    stream.write_all(b"OK 5000\n").await?;
+    let request = read_mock_line(&mut stream, DEFAULT_MAX_RESPONSE_BYTES).await?;
+    let request: serde_json::Value = match serde_json::from_slice(&request) {
+        Ok(request) => request,
+        Err(_) => return Ok(()),
+    };
+    let id = request.get("id").cloned().unwrap_or_default();
+    let response = match request.get("op").and_then(serde_json::Value::as_str) {
+        Some("exec") => {
+            let command = request
+                .get("cmd")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            serde_json::json!({
+                "id": id,
+                "ok": true,
+                "rc": 0,
+                "stdout_b64": BASE64.encode(command.as_bytes()),
+                "stderr_b64": ""
+            })
+        }
+        Some("read") => {
+            let path = request
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            let data = files.lock().await.get(path).cloned().unwrap_or_default();
+            serde_json::json!({"id": id, "ok": true, "data_b64": BASE64.encode(data)})
+        }
+        Some("write") => {
+            let path = request
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let data = request
+                .get("data_b64")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|encoded| BASE64.decode(encoded).ok())
+                .unwrap_or_default();
+            files.lock().await.insert(path, data);
+            serde_json::json!({"id": id, "ok": true})
+        }
+        _ => serde_json::json!({"id": id, "ok": true}),
+    };
+    let mut encoded = serde_json::to_vec(&response).unwrap_or_else(|_| b"{}".to_vec());
+    encoded.push(b'\n');
+    stream.write_all(&encoded).await
+}
+
+#[cfg(test)]
+async fn read_mock_line<R>(stream: &mut R, limit: usize) -> std::io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(stream).take(limit.saturating_add(1) as u64);
+    let mut output = Vec::with_capacity(limit.min(8192));
+    reader.read_until(b'\n', &mut output).await?;
+    if output.last() == Some(&b'\n') {
+        output.pop();
+        if output.len() <= limit {
+            return Ok(output);
+        }
+    }
+    if output.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "mock guest line too long",
+        ));
+    }
+    Ok(output)
+}
+
 pub(super) async fn terminate_child(child: &mut Child, backend: &str) -> Result<()> {
     if child.try_wait()?.is_some() {
         return Ok(());
@@ -616,6 +840,8 @@ mod tests {
     use blaze_core::policy::BackendConfigs;
     use blaze_core::storage::StorageSlot;
 
+    use crate::guest::GuestClient;
+
     use super::*;
 
     fn request(root: &Path) -> SpawnRequest {
@@ -661,12 +887,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mock_instance_reports_liveness_and_supports_idempotent_kill() {
+    async fn production_mock_does_not_advertise_guest_transport() {
         let temp = tempfile::tempdir().expect("temp");
         let instance = MockSpawner
             .spawn(request(temp.path()))
             .await
             .expect("spawn");
+
+        assert!(instance.guest_socket_path().as_os_str().is_empty());
+        assert!(!temp.path().join("run/vsock.uds").exists());
+        instance.kill().await.expect("kill");
+    }
+
+    #[tokio::test]
+    async fn test_guest_instance_supports_io_and_idempotent_kill() {
+        let temp = tempfile::tempdir().expect("temp");
+        let instance = GuestMockSpawner
+            .spawn(request(temp.path()))
+            .await
+            .expect("spawn");
+        let client = GuestClient::new(
+            temp.path().join("run/vsock.uds"),
+            Duration::from_secs(1),
+            1024,
+        );
+        client
+            .write_file("/tmp/value".into(), b"hello")
+            .await
+            .expect("write");
+        assert_eq!(
+            client.read_file("/tmp/value".into()).await.expect("read"),
+            b"hello"
+        );
         assert_eq!(instance.try_wait().await.expect("try wait"), None);
         instance.kill().await.expect("kill");
         assert!(instance.try_wait().await.expect("try wait").is_some());

--- a/src/blaze/crates/blazed/src/spawner/firecracker.rs
+++ b/src/blaze/crates/blazed/src/spawner/firecracker.rs
@@ -315,12 +315,15 @@ impl FirecrackerSpawner {
         let instance = FirecrackerInstance::new(
             request.instance_id,
             Some(child),
-            runtime_files(
-                api_socket,
-                guest_socket,
-                pid_file,
-                stopped_marker,
-                network_file,
+            configured_runtime_files(
+                runtime_files(
+                    api_socket,
+                    guest_socket,
+                    pid_file,
+                    stopped_marker,
+                    network_file,
+                ),
+                fc_config.enable_vsock,
             ),
             network,
             self.network.clone(),
@@ -417,6 +420,16 @@ fn runtime_files(
     }
 }
 
+fn configured_runtime_files(
+    mut files: FirecrackerRuntimeFiles,
+    enable_vsock: bool,
+) -> FirecrackerRuntimeFiles {
+    if !enable_vsock {
+        files.guest_socket = PathBuf::new();
+    }
+    files
+}
+
 impl FirecrackerInstance {
     fn new(
         instance_id: Uuid,
@@ -442,6 +455,10 @@ impl FirecrackerInstance {
 impl BackendInstance for FirecrackerInstance {
     fn backend(&self) -> BackendKind {
         BackendKind::Firecracker
+    }
+
+    fn guest_socket_path(&self) -> &Path {
+        &self.files.guest_socket
     }
 
     async fn try_wait(&self) -> Result<Option<SpawnResult>> {
@@ -737,6 +754,9 @@ async fn wait_for_socket(socket: &Path, child: &mut Child, timeout: Duration) ->
 }
 
 async fn remove_if_exists(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        return Ok(());
+    }
     match tokio::fs::remove_file(path).await {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -977,6 +997,68 @@ mod tests {
             serde_json::from_slice(&std::fs::read(path).expect("read config"))
                 .expect("parse config");
         assert!(value.get("network-interfaces").is_none());
+    }
+
+    #[test]
+    fn vm_config_and_reported_guest_transport_agree() {
+        let temp = tempfile::tempdir().expect("temp");
+        let request = spawn_request(temp.path());
+        let socket = temp.path().join("vsock.uds");
+        let disabled = FirecrackerConfig::default();
+        let disabled_path = write_vm_config(
+            &temp.path().join("images"),
+            &request,
+            &disabled,
+            &socket,
+            None,
+        )
+        .expect("disabled config");
+        let disabled_value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(disabled_path).expect("read disabled config"))
+                .expect("parse disabled config");
+        assert!(disabled_value.get("vsock").is_none());
+        let files = configured_runtime_files(
+            runtime_files(
+                temp.path().join("api.sock"),
+                socket.clone(),
+                temp.path().join("firecracker.pid"),
+                stopped_marker(temp.path()),
+                temp.path().join("network.json"),
+            ),
+            disabled.enable_vsock,
+        );
+        assert!(files.guest_socket.as_os_str().is_empty());
+
+        let enabled = FirecrackerConfig {
+            enable_vsock: true,
+            ..FirecrackerConfig::default()
+        };
+        let enabled_path = write_vm_config(
+            &temp.path().join("images"),
+            &request,
+            &enabled,
+            &socket,
+            None,
+        )
+        .expect("enabled config");
+        let enabled_value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(enabled_path).expect("read enabled config"))
+                .expect("parse enabled config");
+        assert_eq!(
+            enabled_value["vsock"]["uds_path"],
+            path_string(&socket, "socket").expect("socket path")
+        );
+        let files = configured_runtime_files(
+            runtime_files(
+                temp.path().join("api.sock"),
+                socket.clone(),
+                temp.path().join("firecracker.pid"),
+                stopped_marker(temp.path()),
+                temp.path().join("network.json"),
+            ),
+            enabled.enable_vsock,
+        );
+        assert_eq!(files.guest_socket, socket);
     }
 
     #[test]

--- a/src/blaze/examples/policies/agent-rl.toml
+++ b/src/blaze/examples/policies/agent-rl.toml
@@ -117,7 +117,7 @@ memory = "4G"
 # ---------------------------------------------------------------------------
 [backend.firecracker]
 boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
-enable_vsock = true   # parsed but not yet wired (Phase 2+)
+enable_vsock = true   # requires the compatible guest agent on vsock port 5000
 enable_network = false # opt in to a per-sandbox netns, tap, veth, and NAT
 serial_log = false
 

--- a/src/blaze/examples/policies/agent-tool.toml
+++ b/src/blaze/examples/policies/agent-tool.toml
@@ -105,7 +105,7 @@ memory = "1G"
 # ---------------------------------------------------------------------------
 [backend.firecracker]
 boot_args = "console=ttyS0 reboot=k panic=1 pci=off"
-enable_vsock = false  # parsed but not yet wired (Phase 2+)
+enable_vsock = false  # enable only when the image runs the compatible guest agent
 enable_network = false # opt in to a per-sandbox netns, tap, veth, and NAT
 memory = "2G"
 vcpus = 2


### PR DESCRIPTION
## Why

Managed sandboxes already own their backend process and storage slot, but callers cannot execute commands or transfer files through a compatible guest endpoint. A shared protocol and delivery-aware error model are needed so callers can distinguish retry-safe failures from operations whose result became uncertain after delivery began.

## What changed

**Before:** Blaze had no shared guest wire protocol and no daemon route for sandbox command execution or file transfer.

**After:** Supported backends can expose an optional guest endpoint. The daemon serializes guest work with lifecycle operations, rechecks that the sandbox is Running, and offers bounded exec, read, and write routes with stable error outcomes. The production mock fallback does not advertise guest transport; guest-capable simulation is test-only.

- Commit `74f8b5322` defines the required-ID ping, exec, read, and write protocol. It is a same-PR foundation and opens no connection by itself.
- Commit `05b8ffb6c` implements the bounded JSON-line client, backend endpoint ownership, readiness checks, lifecycle serialization, live sandbox/instance API routes, and production-mock rejection. Guest HTTP envelopes are limited to 22 MiB and decoded files to 16 MiB.
- Commit `61f3d574d` documents the API, limits, readiness, retry boundaries, supported backend conditions, and current daemon-wide boundaries in the bilingual user guide.

These commits form one PR because the protocol is consumed by exactly this transport and public API path; separating them would leave either an unused wire contract or routes without their required validation and outcome model.

## Related issue

closes #2214

Tracked under #1829. Daemon-wide API access control is tracked separately in #2223.

## User / Agent impact

Callers can execute bounded commands and read or write bounded files in a Running sandbox when its selected backend exposes the compatible guest endpoint. Backends without that endpoint retain their existing creation behavior and reject guest operations.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The new operations are gated by backend capability and existing lifecycle ownership. Inputs, outputs, deadlines, and HTTP envelopes are bounded. The optional TCP listener remains disabled by default; deployments must keep it disabled until the daemon-wide boundary in #2223 is implemented. Accepted-connection draining and ordered cleanup of all runtime owners remain separate release work.

## Validation

Each exact commit was exported to an independent Linux source directory with an empty Cargo target and passed:

- `cargo fmt --all -- --check`
- `cargo build --workspace --locked`
- default and all-features `cargo clippy --workspace --all-targets --locked -- -D warnings`
- default and all-features `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`

At `05b8ffb6c` and `61f3d574d`, default tests passed with 52 core and 99 daemon tests; all-features tests passed with 52 core and 109 daemon tests. Documentation lint and relative-link checks passed at `61f3d574d`. Commitlint passed for all three submitted commits immediately before push.

Hosted CI results are not yet available for the rewritten head.

## Documentation and rollback

English and Chinese user guides cover routes, encoding, limits, readiness, warm-pool behavior, outcome handling, production fallback behavior, and current operational boundaries. Reverting this PR removes the guest protocol and routes; backends that do not expose a guest endpoint are behaviorally unchanged.