### PR TITLE
feat(blaze): add periodic sandbox artifact synchronization

### DIFF
--- a/docs/user-guide/en/README.md
+++ b/docs/user-guide/en/README.md
@@ -76,7 +76,7 @@ ANOLISA provides a complete server-side runtime for AI Agent workloads. Componen
 
 | Document | Component | Description |
 |----------|-----------|-------------|
-| [Blaze Firecracker Networking](runtime/blaze.md) | blaze | Opt-in per-sandbox VM networking, host requirements, lifecycle, and operator boundary |
+| [Blaze Sandbox Runtime](runtime/blaze.md) | blaze | Opt-in VM networking and periodic storage artifact synchronization for managed sandboxes |
 | [Workspace Checkpoints](runtime/ws-ckpt.md) | ws-ckpt | Instant snapshot/rollback via btrfs COW |
 | [Skill Filesystem](runtime/skillfs.md) | skillfs | FUSE virtual views with progressive disclosure |
 

--- a/docs/user-guide/en/runtime/blaze.md
+++ b/docs/user-guide/en/runtime/blaze.md
@@ -125,3 +125,55 @@ Leave `listen.http_addr` disabled in production until
 [issue #2223](https://github.com/alibaba/anolisa/issues/2223) is resolved.
 Daemon shutdown also does not yet wait for every active HTTP handler or release
 all runtime owners, so an in-flight request may observe a closed connection.
+
+## Storage Artifact Synchronization
+
+Blaze can periodically persist the already-written host artifacts and directory
+metadata owned by running sandboxes. The worker is disabled by default, so
+existing deployments retain their previous behavior until an interval is
+configured.
+
+### Configuration
+
+Set the interval and per-sandbox deadline in the daemon configuration:
+
+```toml
+[storage]
+sync_interval = "30s"
+sync_timeout = "10s"
+```
+
+`sync_interval = "disabled"` stops the periodic worker. `sync_timeout`
+bounds how long the scheduler waits for one complete provider attempt:
+reconstructing its storage slot and synchronizing that slot.
+
+Each storage-provider synchronization call persists the already-written bytes
+and directory metadata visible to that call. Concurrent artifact updates may
+become visible in the current attempt or a later one.
+
+### Runtime behavior
+
+Each sweep selects sandboxes that are running and still own a complete storage
+slot. A sandbox whose operation lock is already held is deferred without
+waiting, allowing the sweep to continue to later sandboxes. Lifecycle changes,
+guest requests, and storage artifact synchronization share this lock. After acquiring
+an available lock, the worker rechecks lifecycle state before calling the
+storage provider. A record that still says `Running` after the lock is acquired
+but retains an unfinished operation or non-running backend ownership is
+inconsistent and is reported as failed rather than deferred.
+The first sweep starts after one complete configured interval. Missed timer
+ticks are skipped instead of queued, preventing a slow sweep from accumulating
+work.
+
+A completed failure affects only that sandbox. Blaze retains storage ownership
+and leaves lifecycle state unchanged, so a later sweep or destroy can retry.
+If filesystem work cannot stop at the deadline, it keeps the sandbox operation
+lock and the single synchronization permit until completion. Later attempts
+are deferred instead of accumulating additional blocking work. Guest and
+lifecycle operations that arrive while the lock is retained wait for the
+provider work to finish; `sync_timeout` bounds scheduler waiting, not those
+operations.
+
+When the service loop stops, Blaze cancels and joins the periodic scheduler.
+Provider work that cannot be cancelled remains under its sandbox lock until it
+completes. Daemon-wide connection draining and runtime cleanup remain separate.

--- a/docs/user-guide/zh/README.md
+++ b/docs/user-guide/zh/README.md
@@ -76,7 +76,7 @@ ANOLISA 为 AI Agent 提供完整的服务端运行时能力。通过 `anolisa` 
 
 | 文档 | 组件 | 说明 |
 |------|------|------|
-| [Blaze Firecracker 网络](runtime/blaze.md) | blaze | 可选的单 sandbox VM 网络、主机要求、生命周期与运维边界 |
+| [Blaze Sandbox Runtime](runtime/blaze.md) | blaze | Managed sandbox 的可选 VM 网络与周期存储制品同步 |
 | [工作区快照](runtime/ws-ckpt.md) | ws-ckpt | 秒级快照创建/回滚，基于 btrfs COW |
 | [技能文件系统](runtime/skillfs.md) | skillfs | FUSE 虚拟视图、渐进披露 |
 

--- a/docs/user-guide/zh/runtime/blaze.md
+++ b/docs/user-guide/zh/runtime/blaze.md
@@ -109,3 +109,47 @@ read 响应过大时返回 HTTP 502 和
 [issue #2223](https://github.com/alibaba/anolisa/issues/2223) 解决前，生产配置应
 保持 `listen.http_addr` 关闭。Daemon 停止时也不会等待全部 HTTP handler 或
 释放所有 runtime owner，因此正在执行的请求可能看到连接关闭。
+
+## 存储制品同步
+
+Blaze 可以定期持久化 running sandbox 中已经写入的宿主机制品和目录元数据。
+该 worker 默认关闭；只有配置同步周期后，现有部署的行为才会改变。
+
+### 配置方法
+
+在 daemon 配置中设置同步周期和单个 sandbox 的执行时限：
+
+```toml
+[storage]
+sync_interval = "30s"
+sync_timeout = "10s"
+```
+
+`sync_interval = "disabled"` 会关闭周期 worker。`sync_timeout` 限制
+scheduler 等待单个完整 provider attempt 的时间，包括重建 storage slot 和
+同步该 slot。
+
+每次 storage-provider 同步调用会持久化本次调用可见、且已经写入的字节与目录
+元数据。并发发生的制品更新可能在本次或后续 attempt 中变为可见。
+
+### 运行行为
+
+每轮 sweep 会选择处于 running 状态且仍持有完整 storage slot 的 sandbox。它会
+对 operation lock 已被占用的 sandbox 直接推迟本轮处理，而不等待该 lock，使
+sweep 可以继续处理后续 sandbox。Lifecycle 变更、guest 请求和存储制品同步共用这把
+lock。取得可用 lock 后，worker 会在调用 storage provider 前再次检查 lifecycle
+状态。如果取得 lock 后记录仍为 `Running`，但保留了未完成的 operation 或非
+running 的 backend ownership，该记录属于不一致状态，会记为失败而不是推迟。
+第一次 sweep 会在完整的配置周期过去后启动，而不是在 worker 启动时立即执行。
+定时器错过的 tick 会被跳过而不是排队，避免慢速 sweep 累积任务。
+
+已经返回的失败只影响对应 sandbox。Blaze 会保留 storage slot 的 ownership，
+且不改变 lifecycle 状态，因此后续 sweep 或 destroy 仍可重试。如果文件系统
+操作在 deadline 到达时无法停止，它会继续持有 sandbox operation lock 和唯一
+的同步许可直至完成；后续 attempt 会被推迟，而不会累积更多 blocking 任务。
+在此期间到达的 guest 和 lifecycle 操作会等待 provider 工作完成；
+`sync_timeout` 只限制 scheduler 的等待时间，不限制这些操作的等待时间。
+
+service loop 停止时，Blaze 会取消并等待周期 scheduler 退出。无法取消的
+provider 工作会继续由对应 sandbox lock 持有直至完成；daemon 级连接排空和
+runtime 清理仍属于独立职责。

--- a/src/blaze/Cargo.lock
+++ b/src/blaze/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "libc",
+ "rustix",
  "serde",
  "serde_json",
  "tempfile",

--- a/src/blaze/Cargo.toml
+++ b/src/blaze/Cargo.toml
@@ -44,6 +44,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 semver = "1.0"
 base64 = "0.22"
+rustix = { version = "1.1", features = ["fs"] }
 
 # Internal crates
 blaze-core = { path = "crates/blaze-core" }

--- a/src/blaze/README.md
+++ b/src/blaze/README.md
@@ -110,10 +110,20 @@ provider = "file"       # Storage provider selection. Currently supported: "file
 images_dir = "/var/lib/blaze/images"
 # pool_size = 0           # [Reserved] Warm pool slots (not yet active)
 # prefork = false         # [Reserved] Pre-start VMs in pool (not yet active)
-# flush_interval = "30s"  # [Reserved] Dirty data flush period (not yet active)
+sync_interval = "disabled" # Set a positive duration to persist already-written slot artifacts.
+sync_timeout = "30s"       # Maximum scheduler wait for reconstruction plus artifact sync.
 ```
 
 The `file` provider uses standard filesystem operations for sandbox storage. The `auto` provider probes available backends in priority order (currently equivalent to `file`). Unrecognized values will log a warning and fall back to `file`.
+When periodic synchronization is enabled, a completed provider failure is
+isolated from later sandboxes. If a provider cannot stop its filesystem work at
+the deadline, that work keeps the sandbox operation lock and the single
+synchronization permit until completion; later attempts are deferred instead
+of accumulating. The worker stops scheduling new work when the service loop
+ends.
+
+See the [Storage Artifact Synchronization user guide](../../docs/user-guide/en/runtime/blaze.md#storage-artifact-synchronization)
+for configuration, selection, retry, and worker shutdown behavior.
 
 ## API Endpoints
 

--- a/src/blaze/README_zh.md
+++ b/src/blaze/README_zh.md
@@ -105,10 +105,18 @@ provider = "file"       # 存储 provider 选择。当前支持："file"、"auto
 images_dir = "/var/lib/blaze/images"
 # pool_size = 0           # [Reserved] 预热存储槽位数（尚未启用）
 # prefork = false         # [Reserved] 是否在槽位中预启动 VM（尚未启用）
-# flush_interval = "30s"  # [Reserved] 脏数据刷盘周期（尚未启用）
+sync_interval = "disabled" # 设置正数 duration 后持久化 slot 中已经写入的制品。
+sync_timeout = "30s"       # scheduler 等待 slot 重建与制品同步的最长时间。
 ```
 
 `file` provider 使用标准文件系统操作管理 sandbox 存储。`auto` 按优先级探测可用 provider（当前等同于 `file`）。无法识别的值将记录告警并回退到 `file`。
+启用周期同步后，已经返回的 provider 失败不会中断后续 sandbox。如果 provider
+在 deadline 到达时仍无法停止文件系统操作，该操作会继续持有 sandbox operation
+lock 和唯一的同步许可直至完成；后续同步会被推迟而不会不断累积。service loop
+结束时，worker 会停止调度新任务。
+
+[存储制品同步用户指南](../../docs/user-guide/zh/runtime/blaze.md#存储制品同步)进一步说明
+配置、选择、重试和 worker 关闭行为。
 
 ## API 端点
 

--- a/src/blaze/crates/blaze-core/src/config.rs
+++ b/src/blaze/crates/blaze-core/src/config.rs
@@ -4,10 +4,12 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{BlazeError, ConfigErrorSource, Result};
+use crate::policy::parse_duration;
 
 /// Top-level daemon configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -160,10 +162,15 @@ pub struct StorageSection {
     #[serde(default)]
     pub prefork: bool,
 
-    /// Interval for synchronizing provider-owned storage artifacts.
-    /// NOTE: Reserved for future use. Not yet wired into runtime.
+    /// Interval for persisting already-written provider-owned artifacts.
+    ///
+    /// The literal `disabled` turns off periodic synchronization.
     #[serde(default = "default_sync_interval", alias = "flush_interval")]
     pub sync_interval: String,
+
+    /// Maximum time the scheduler waits for one artifact synchronization attempt.
+    #[serde(default = "default_sync_timeout")]
+    pub sync_timeout: String,
 
     /// Logical size of file-provider root filesystem slots.
     #[serde(default = "default_rootfs_size")]
@@ -183,9 +190,40 @@ impl Default for StorageSection {
             pool_size: 0,
             prefork: false,
             sync_interval: default_sync_interval(),
+            sync_timeout: default_sync_timeout(),
             rootfs_size: default_rootfs_size(),
             mem_size: default_mem_size(),
         }
+    }
+}
+
+/// Parsed periodic storage-artifact synchronization policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageSyncSchedule {
+    /// Do not run periodic storage-artifact synchronization.
+    Disabled,
+    /// Run one sweep after every configured interval.
+    Every(Duration),
+}
+
+impl StorageSection {
+    /// Parse the periodic storage-artifact synchronization setting.
+    pub fn sync_schedule(&self) -> Result<StorageSyncSchedule> {
+        if self.sync_interval == "disabled" {
+            return Ok(StorageSyncSchedule::Disabled);
+        }
+        let duration = parse_duration(&self.sync_interval)
+            .ok_or_else(|| invalid_storage_duration("sync_interval", &self.sync_interval, true))?;
+        validate_storage_clock_duration("sync_interval", &self.sync_interval, duration)?;
+        Ok(StorageSyncSchedule::Every(duration))
+    }
+
+    /// Parse the maximum duration of one artifact synchronization attempt.
+    pub fn sync_timeout_duration(&self) -> Result<Duration> {
+        let duration = parse_duration(&self.sync_timeout)
+            .ok_or_else(|| invalid_storage_duration("sync_timeout", &self.sync_timeout, false))?;
+        validate_storage_clock_duration("sync_timeout", &self.sync_timeout, duration)?;
+        Ok(duration)
     }
 }
 
@@ -201,8 +239,35 @@ impl DaemonConfig {
 
     /// Validate cross-field invariants that serde cannot express.
     pub fn validate(&self) -> Result<()> {
-        validate_storage_paths(&self.storage.images_dir, &self.storage.instances_dir)
+        validate_storage_paths(&self.storage.images_dir, &self.storage.instances_dir)?;
+        self.storage.sync_schedule()?;
+        self.storage.sync_timeout_duration()?;
+        Ok(())
     }
+}
+
+fn invalid_storage_duration(name: &str, value: &str, allow_disabled: bool) -> BlazeError {
+    let expected = if allow_disabled {
+        "a positive duration or \"disabled\""
+    } else {
+        "a positive duration"
+    };
+    BlazeError::ConfigError {
+        source: ConfigErrorSource::InvalidValue(format!(
+            "storage.{name} ({value:?}) must be {expected}"
+        )),
+    }
+}
+
+fn validate_storage_clock_duration(name: &str, value: &str, duration: Duration) -> Result<()> {
+    if std::time::Instant::now().checked_add(duration).is_none() {
+        return Err(BlazeError::ConfigError {
+            source: ConfigErrorSource::InvalidValue(format!(
+                "storage.{name} ({value:?}) exceeds the monotonic clock range"
+            )),
+        });
+    }
+    Ok(())
 }
 
 /// Reject storage roots whose ownership domains overlap.
@@ -267,6 +332,9 @@ fn default_storage_provider() -> String {
     "file".to_string()
 }
 fn default_sync_interval() -> String {
+    "disabled".to_string()
+}
+fn default_sync_timeout() -> String {
     "30s".to_string()
 }
 fn default_rootfs_size() -> u64 {
@@ -287,6 +355,10 @@ mod tests {
         assert_eq!(cfg.policy.on_load_error, PolicyLoadErrorMode::Fail);
         assert!(cfg.backends.is_empty());
         assert_ne!(cfg.storage.images_dir, cfg.storage.instances_dir);
+        assert_eq!(
+            cfg.storage.sync_schedule().expect("sync schedule"),
+            StorageSyncSchedule::Disabled
+        );
     }
 
     #[test]
@@ -327,6 +399,24 @@ mod tests {
     }
 
     #[test]
+    fn storage_sync_schedule_accepts_disabled_or_positive_duration() {
+        let mut cfg = DaemonConfig::default();
+        cfg.storage.sync_interval = "disabled".into();
+        cfg.validate().expect("disabled schedule");
+        assert_eq!(
+            cfg.storage.sync_schedule().expect("schedule"),
+            StorageSyncSchedule::Disabled
+        );
+
+        cfg.storage.sync_interval = "15s".into();
+        cfg.validate().expect("positive schedule");
+        assert_eq!(
+            cfg.storage.sync_schedule().expect("schedule"),
+            StorageSyncSchedule::Every(Duration::from_secs(15))
+        );
+    }
+
+    #[test]
     fn storage_sync_interval_accepts_legacy_input_alias() {
         let cfg: DaemonConfig = toml::from_str(
             r#"
@@ -337,9 +427,10 @@ mod tests {
         .expect("legacy interval key parses");
 
         assert_eq!(cfg.storage.sync_interval, "15s");
-        let encoded = toml::to_string(&cfg).expect("config serializes");
-        assert!(encoded.contains("sync_interval = \"15s\""), "{encoded}");
-        assert!(!encoded.contains("flush_interval"), "{encoded}");
+        assert_eq!(
+            cfg.storage.sync_schedule().expect("schedule"),
+            StorageSyncSchedule::Every(Duration::from_secs(15))
+        );
     }
 
     #[test]
@@ -355,5 +446,46 @@ mod tests {
 
         assert!(error.to_string().contains("duplicate field"), "{error}");
         assert!(error.to_string().contains("sync_interval"), "{error}");
+    }
+
+    #[test]
+    fn storage_sync_schedule_rejects_invalid_values() {
+        for interval in ["0s", "not-a-duration"] {
+            let mut cfg = DaemonConfig::default();
+            cfg.storage.sync_interval = interval.into();
+            let error = cfg.validate().expect_err("invalid sync interval");
+            assert!(
+                error.to_string().contains("storage.sync_interval"),
+                "{error}"
+            );
+        }
+
+        for timeout in ["0s", "disabled", "not-a-duration"] {
+            let mut cfg = DaemonConfig::default();
+            cfg.storage.sync_timeout = timeout.into();
+            let error = cfg.validate().expect_err("invalid sync timeout");
+            assert!(
+                error.to_string().contains("storage.sync_timeout"),
+                "{error}"
+            );
+        }
+
+        for (field, value) in [
+            ("sync_interval", "18446744073709551615s"),
+            ("sync_timeout", "18446744073709551615s"),
+        ] {
+            let mut cfg = DaemonConfig::default();
+            if field == "sync_interval" {
+                cfg.storage.sync_interval = value.into();
+            } else {
+                cfg.storage.sync_timeout = value.into();
+            }
+            let error = cfg.validate().expect_err("clock range overflow");
+            assert!(error.to_string().contains(field), "{error}");
+            assert!(
+                error.to_string().contains("monotonic clock range"),
+                "{error}"
+            );
+        }
     }
 }

--- a/src/blaze/crates/blaze-core/src/config.rs
+++ b/src/blaze/crates/blaze-core/src/config.rs
@@ -160,10 +160,10 @@ pub struct StorageSection {
     #[serde(default)]
     pub prefork: bool,
 
-    /// Interval for flushing dirty data.
+    /// Interval for synchronizing provider-owned storage artifacts.
     /// NOTE: Reserved for future use. Not yet wired into runtime.
-    #[serde(default = "default_flush_interval")]
-    pub flush_interval: String,
+    #[serde(default = "default_sync_interval", alias = "flush_interval")]
+    pub sync_interval: String,
 
     /// Logical size of file-provider root filesystem slots.
     #[serde(default = "default_rootfs_size")]
@@ -182,7 +182,7 @@ impl Default for StorageSection {
             provider: default_storage_provider(),
             pool_size: 0,
             prefork: false,
-            flush_interval: default_flush_interval(),
+            sync_interval: default_sync_interval(),
             rootfs_size: default_rootfs_size(),
             mem_size: default_mem_size(),
         }
@@ -266,7 +266,7 @@ fn default_instances_dir() -> PathBuf {
 fn default_storage_provider() -> String {
     "file".to_string()
 }
-fn default_flush_interval() -> String {
+fn default_sync_interval() -> String {
     "30s".to_string()
 }
 fn default_rootfs_size() -> u64 {
@@ -324,5 +324,36 @@ mod tests {
             let error = cfg.validate().expect_err("overlapping paths");
             assert!(error.to_string().contains("must be disjoint"));
         }
+    }
+
+    #[test]
+    fn storage_sync_interval_accepts_legacy_input_alias() {
+        let cfg: DaemonConfig = toml::from_str(
+            r#"
+                [storage]
+                flush_interval = "15s"
+            "#,
+        )
+        .expect("legacy interval key parses");
+
+        assert_eq!(cfg.storage.sync_interval, "15s");
+        let encoded = toml::to_string(&cfg).expect("config serializes");
+        assert!(encoded.contains("sync_interval = \"15s\""), "{encoded}");
+        assert!(!encoded.contains("flush_interval"), "{encoded}");
+    }
+
+    #[test]
+    fn storage_sync_interval_rejects_duplicate_aliases() {
+        let error = toml::from_str::<DaemonConfig>(
+            r#"
+                [storage]
+                flush_interval = "15s"
+                sync_interval = "30s"
+            "#,
+        )
+        .expect_err("legacy and canonical interval keys must not coexist");
+
+        assert!(error.to_string().contains("duplicate field"), "{error}");
+        assert!(error.to_string().contains("sync_interval"), "{error}");
     }
 }

--- a/src/blaze/crates/blaze-core/src/storage.rs
+++ b/src/blaze/crates/blaze-core/src/storage.rs
@@ -125,8 +125,12 @@ pub trait StorageProvider: Send + Sync {
     /// root and must not trust persisted path strings.
     async fn reconstruct(&self, instance_id: &str) -> Result<StorageSlot>;
 
-    /// Flush dirty data to persistent storage (implementation may be no-op).
-    async fn flush_dirty(&self, slot: &StorageSlot) -> Result<()>;
+    /// Synchronize already-written provider artifacts to persistent storage.
+    ///
+    /// This operation persists the files and directory metadata that already
+    /// belong to `slot` and are visible to the provider call. Artifact updates
+    /// that race with one call may become visible in that call or a later one.
+    async fn sync_artifacts(&self, slot: &StorageSlot) -> Result<()>;
 
     /// Query warm pool status.
     fn pool_status(&self) -> PoolStatus;

--- a/src/blaze/crates/blaze-core/src/storage.rs
+++ b/src/blaze/crates/blaze-core/src/storage.rs
@@ -130,6 +130,10 @@ pub trait StorageProvider: Send + Sync {
     /// This operation persists the files and directory metadata that already
     /// belong to `slot` and are visible to the provider call. Artifact updates
     /// that race with one call may become visible in that call or a later one.
+    ///
+    /// The daemon may stop waiting at its configured deadline, but keeps the
+    /// future supervised under slot ownership until it completes. A later
+    /// synchronization or cleanup must remain safe after completion.
     async fn sync_artifacts(&self, slot: &StorageSlot) -> Result<()>;
 
     /// Query warm pool status.

--- a/src/blaze/crates/blazed/Cargo.toml
+++ b/src/blaze/crates/blazed/Cargo.toml
@@ -31,6 +31,7 @@ hyper-util = { workspace = true }
 http-body-util = { workspace = true }
 async-trait = { workspace = true }
 libc = { workspace = true }
+rustix = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
@@ -39,3 +40,4 @@ base64 = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { workspace = true, features = ["test-util"] }

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -1021,8 +1021,8 @@ mod tests {
             self.inner.reconstruct(instance_id).await
         }
 
-        async fn flush_dirty(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
-            self.inner.flush_dirty(slot).await
+        async fn sync_artifacts(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
+            self.inner.sync_artifacts(slot).await
         }
 
         fn pool_status(&self) -> PoolStatus {
@@ -1074,8 +1074,8 @@ mod tests {
             self.inner.reconstruct(instance_id).await
         }
 
-        async fn flush_dirty(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
-            self.inner.flush_dirty(slot).await
+        async fn sync_artifacts(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
+            self.inner.sync_artifacts(slot).await
         }
 
         fn pool_status(&self) -> PoolStatus {
@@ -1367,8 +1367,8 @@ mod tests {
             self.inner.reconstruct(instance_id).await
         }
 
-        async fn flush_dirty(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
-            self.inner.flush_dirty(slot).await
+        async fn sync_artifacts(&self, slot: &StorageSlot) -> blaze_core::Result<()> {
+            self.inner.sync_artifacts(slot).await
         }
 
         fn pool_status(&self) -> PoolStatus {

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -3,9 +3,10 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use blaze_core::backend::BackendKind;
-use blaze_core::config::{DaemonConfig, PolicyLoadErrorMode};
+use blaze_core::config::{DaemonConfig, PolicyLoadErrorMode, StorageSyncSchedule};
 use blaze_core::kernel::HookRegistry;
 use blaze_core::policy::PolicyEngine;
 use blaze_core::pool::PoolManager;
@@ -21,6 +22,7 @@ use tokio::signal::unix::{SignalKind, signal};
 
 use crate::api;
 use crate::error::{BlazeDaemonError, Result};
+use crate::sandbox::StorageSyncLoop;
 use crate::spawner::{
     BubblewrapSpawner, DynSpawner, FirecrackerSpawner, MockSpawner, SpawnerRegistry,
 };
@@ -30,6 +32,8 @@ use crate::state::ServerState;
 /// bind the API socket, and run the accept loop until SIGTERM/SIGINT.
 pub async fn run(config_path: &Path) -> Result<()> {
     let config = DaemonConfig::load(config_path)?;
+    let sync_schedule = config.storage.sync_schedule()?;
+    let sync_timeout = config.storage.sync_timeout_duration()?;
     tracing::info!(?config_path, "loaded daemon config");
 
     ensure_dirs(&config)?;
@@ -124,7 +128,7 @@ pub async fn run(config_path: &Path) -> Result<()> {
         None
     };
 
-    serve(listener, tcp_listener, state).await
+    serve(listener, tcp_listener, state, sync_schedule, sync_timeout).await
 }
 
 fn ensure_dirs(cfg: &DaemonConfig) -> Result<()> {
@@ -247,16 +251,38 @@ fn load_policy_engine(cfg: &DaemonConfig) -> Result<PolicyEngine> {
     }
 }
 
-async fn serve(uds: UnixListener, tcp: Option<TcpListener>, state: Arc<ServerState>) -> Result<()> {
+async fn serve(
+    uds: UnixListener,
+    tcp: Option<TcpListener>,
+    state: Arc<ServerState>,
+    sync_schedule: StorageSyncSchedule,
+    sync_timeout: Duration,
+) -> Result<()> {
     let mut sighup = signal(SignalKind::hangup())
         .map_err(|e| BlazeDaemonError::Internal(format!("install SIGHUP handler: {e}")))?;
     let mut sigterm = signal(SignalKind::terminate())
         .map_err(|e| BlazeDaemonError::Internal(format!("install SIGTERM handler: {e}")))?;
     let mut sigint = signal(SignalKind::interrupt())
         .map_err(|e| BlazeDaemonError::Internal(format!("install SIGINT handler: {e}")))?;
+    let mut sync_loop = match sync_schedule {
+        StorageSyncSchedule::Disabled => {
+            tracing::info!("periodic storage artifact synchronization is disabled");
+            None
+        }
+        StorageSyncSchedule::Every(interval) => Some(
+            state
+                .manager
+                .start_storage_sync_loop(interval, sync_timeout),
+        ),
+    };
+    let mut service_result = Ok(());
 
     loop {
         tokio::select! {
+            result = observe_storage_sync_exit(&mut sync_loop), if sync_loop.is_some() => {
+                service_result = result;
+                break;
+            }
             res = uds.accept() => {
                 let (stream, _peer) = match res {
                     Ok(s) => s,
@@ -295,8 +321,33 @@ async fn serve(uds: UnixListener, tcp: Option<TcpListener>, state: Arc<ServerSta
         }
     }
 
+    if let Some(sync_loop) = sync_loop.as_mut() {
+        service_result = merge_stage_result(
+            service_result,
+            "storage artifact synchronization shutdown",
+            sync_loop.shutdown().await,
+        );
+    }
     tracing::info!("blaze daemon stopped");
-    Ok(())
+    service_result
+}
+
+async fn observe_storage_sync_exit(sync_loop: &mut Option<StorageSyncLoop>) -> Result<()> {
+    sync_loop
+        .as_mut()
+        .expect("storage sync loop exists while its select branch is enabled")
+        .observe_exit()
+        .await
+}
+
+fn merge_stage_result(current: Result<()>, stage: &str, next: Result<()>) -> Result<()> {
+    match (current, next) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(previous), Err(next)) => Err(BlazeDaemonError::RecoveryRequired(format!(
+            "service failed: {previous}; {stage} failed: {next}"
+        ))),
+    }
 }
 
 fn spawn_conn<I>(io: TokioIo<I>, state: Arc<ServerState>)
@@ -334,4 +385,35 @@ fn reload_policies(state: &Arc<ServerState>) -> Result<()> {
     }
     tracing::info!(policies = count, "policy engine reloaded via SIGHUP");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_and_worker_shutdown_failures_are_both_retained() {
+        let service = Err(BlazeDaemonError::Internal(
+            "storage synchronization worker failed".to_string(),
+        ));
+        let shutdown = Err(BlazeDaemonError::Internal(
+            "worker shutdown failed".to_string(),
+        ));
+
+        let error = merge_stage_result(
+            service,
+            "storage artifact synchronization shutdown",
+            shutdown,
+        )
+        .expect_err("both failures must be reported");
+
+        assert!(error.to_string().contains("service failed"));
+        assert!(error.to_string().contains("synchronization worker failed"));
+        assert!(
+            error
+                .to_string()
+                .contains("storage artifact synchronization shutdown")
+        );
+        assert!(error.to_string().contains("worker shutdown failed"));
+    }
 }

--- a/src/blaze/crates/blazed/src/file_provider.rs
+++ b/src/blaze/crates/blazed/src/file_provider.rs
@@ -229,8 +229,8 @@ impl StorageProvider for FileStorageProvider {
         Ok(slot)
     }
 
-    async fn flush_dirty(&self, slot: &StorageSlot) -> Result<()> {
-        crate::failpoint::storage("flush-storage")?;
+    async fn sync_artifacts(&self, slot: &StorageSlot) -> Result<()> {
+        crate::failpoint::storage("sync-artifacts")?;
         // Never trust paths carried by a runtime or persisted slot. Rebuild
         // the complete provider-owned artifact set from the validated ID.
         let canonical = self.slot_for_id(&slot.id)?;
@@ -246,19 +246,27 @@ impl StorageProvider for FileStorageProvider {
                 .open(path)
                 .await
                 .map_err(|error| BlazeError::StorageError {
-                    msg: format!("flush '{}': open {}: {error}", slot.id, path.display()),
+                    msg: format!(
+                        "sync artifacts '{}': open {}: {error}",
+                        slot.id,
+                        path.display()
+                    ),
                 })?;
             file.sync_all()
                 .await
                 .map_err(|error| BlazeError::StorageError {
-                    msg: format!("flush '{}': sync {}: {error}", slot.id, path.display()),
+                    msg: format!(
+                        "sync artifacts '{}': sync {}: {error}",
+                        slot.id,
+                        path.display()
+                    ),
                 })?;
         }
         let directory = tokio::fs::File::open(&canonical.instance_dir)
             .await
             .map_err(|error| BlazeError::StorageError {
                 msg: format!(
-                    "flush '{}': open directory {}: {error}",
+                    "sync artifacts '{}': open directory {}: {error}",
                     slot.id,
                     canonical.instance_dir.display()
                 ),
@@ -268,7 +276,7 @@ impl StorageProvider for FileStorageProvider {
             .await
             .map_err(|error| BlazeError::StorageError {
                 msg: format!(
-                    "flush '{}': sync directory {}: {error}",
+                    "sync artifacts '{}': sync directory {}: {error}",
                     slot.id,
                     canonical.instance_dir.display()
                 ),
@@ -601,12 +609,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn flush_rederives_canonical_paths_from_slot_id() {
+    async fn sync_artifacts_rederives_canonical_paths_from_slot_id() {
         let temp = tempfile::TempDir::new().unwrap();
         let provider = FileStorageProvider::new(temp.path().to_path_buf());
         let slot = provider
             .acquire(&AcquireOpts {
-                instance_id: "flush-canonical".into(),
+                instance_id: "sync-canonical".into(),
                 rootfs_size: 64,
                 mem_size: 32,
             })
@@ -627,18 +635,18 @@ mod tests {
         forged.instance_dir = PathBuf::from("/must/not/be/opened");
 
         provider
-            .flush_dirty(&forged)
+            .sync_artifacts(&forged)
             .await
             .expect("provider uses canonical paths");
     }
 
     #[tokio::test]
-    async fn flush_rejects_incomplete_provider_slot() {
+    async fn sync_artifacts_rejects_incomplete_provider_slot() {
         let temp = tempfile::TempDir::new().unwrap();
         let provider = FileStorageProvider::new(temp.path().to_path_buf());
         let slot = provider
             .acquire(&AcquireOpts {
-                instance_id: "flush-incomplete".into(),
+                instance_id: "sync-incomplete".into(),
                 rootfs_size: 64,
                 mem_size: 32,
             })
@@ -647,7 +655,7 @@ mod tests {
         tokio::fs::remove_file(&slot.mem_diff_path).await.unwrap();
 
         let error = provider
-            .flush_dirty(&slot)
+            .sync_artifacts(&slot)
             .await
             .expect_err("missing artifact must fail the sweep item");
         assert!(error.to_string().contains("mem.diff"), "{error}");

--- a/src/blaze/crates/blazed/src/file_provider.rs
+++ b/src/blaze/crates/blazed/src/file_provider.rs
@@ -4,8 +4,10 @@
 //! instance slots use separate roots; runtime pooling is owned by the daemon.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use rustix::fs::{Mode, OFlags, open, openat};
 
 use blaze_core::error::{BlazeError, Result};
 use blaze_core::storage::{
@@ -17,6 +19,32 @@ use blaze_core::storage::{
 pub struct FileStorageProvider {
     images_dir: PathBuf,
     instances_dir: PathBuf,
+    #[cfg(test)]
+    artifact_sync_open_hook: Option<std::sync::Arc<ArtifactSyncOpenHook>>,
+}
+
+#[cfg(test)]
+pub(crate) struct ArtifactSyncOpenHook {
+    opened: tokio::sync::Notify,
+    resume: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+impl ArtifactSyncOpenHook {
+    pub(crate) fn new() -> Self {
+        Self {
+            opened: tokio::sync::Notify::new(),
+            resume: tokio::sync::Notify::new(),
+        }
+    }
+
+    pub(crate) async fn wait_until_open(&self) {
+        self.opened.notified().await;
+    }
+
+    pub(crate) fn resume(&self) {
+        self.resume.notify_one();
+    }
 }
 
 impl FileStorageProvider {
@@ -29,6 +57,7 @@ impl FileStorageProvider {
         Self {
             images_dir: instances_dir.clone(),
             instances_dir,
+            artifact_sync_open_hook: None,
         }
     }
 
@@ -37,6 +66,21 @@ impl FileStorageProvider {
         Self {
             images_dir,
             instances_dir,
+            #[cfg(test)]
+            artifact_sync_open_hook: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_artifact_sync_open_hook(
+        images_dir: PathBuf,
+        instances_dir: PathBuf,
+        hook: std::sync::Arc<ArtifactSyncOpenHook>,
+    ) -> Self {
+        Self {
+            images_dir,
+            instances_dir,
+            artifact_sync_open_hook: Some(hook),
         }
     }
 
@@ -234,24 +278,44 @@ impl StorageProvider for FileStorageProvider {
         // Never trust paths carried by a runtime or persisted slot. Rebuild
         // the complete provider-owned artifact set from the validated ID.
         let canonical = self.slot_for_id(&slot.id)?;
-        for path in [
-            &canonical.rootfs_path,
-            &canonical.mem_path,
-            &canonical.mem_diff_path,
-            &canonical.rootfs_diff_path,
+        let instance_dir = canonical.instance_dir.clone();
+        let directory_fd = open_required_slot_path(
+            &slot.id,
+            &canonical.instance_dir,
+            RequiredPathType::Directory,
+            move || {
+                open(
+                    &instance_dir,
+                    OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                    Mode::empty(),
+                )
+            },
+        )
+        .await?;
+        #[cfg(test)]
+        if let Some(hook) = &self.artifact_sync_open_hook {
+            hook.opened.notify_one();
+            hook.resume.notified().await;
+        }
+        let directory_fd = Arc::new(directory_fd);
+        for (name, path) in [
+            ("rootfs.ext4", &canonical.rootfs_path),
+            ("mem.bin", &canonical.mem_path),
+            ("mem.diff", &canonical.mem_diff_path),
+            ("rootfs.diff", &canonical.rootfs_diff_path),
         ] {
-            let file = tokio::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(path)
-                .await
-                .map_err(|error| BlazeError::StorageError {
-                    msg: format!(
-                        "sync artifacts '{}': open {}: {error}",
-                        slot.id,
-                        path.display()
-                    ),
-                })?;
+            let open_directory_fd = Arc::clone(&directory_fd);
+            let file_fd =
+                open_required_slot_path(&slot.id, path, RequiredPathType::File, move || {
+                    openat(
+                        &*open_directory_fd,
+                        name,
+                        OFlags::RDWR | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+                        Mode::empty(),
+                    )
+                })
+                .await?;
+            let file = tokio::fs::File::from_std(std::fs::File::from(file_fd));
             file.sync_all()
                 .await
                 .map_err(|error| BlazeError::StorageError {
@@ -262,15 +326,13 @@ impl StorageProvider for FileStorageProvider {
                     ),
                 })?;
         }
-        let directory = tokio::fs::File::open(&canonical.instance_dir)
-            .await
-            .map_err(|error| BlazeError::StorageError {
-                msg: format!(
-                    "sync artifacts '{}': open directory {}: {error}",
-                    slot.id,
-                    canonical.instance_dir.display()
-                ),
-            })?;
+        let directory_fd = Arc::try_unwrap(directory_fd).map_err(|_| BlazeError::StorageError {
+            msg: format!(
+                "sync artifacts '{}': directory descriptor remained shared after opening artifacts",
+                slot.id
+            ),
+        })?;
+        let directory = tokio::fs::File::from_std(std::fs::File::from(directory_fd));
         directory
             .sync_all()
             .await
@@ -291,6 +353,64 @@ impl StorageProvider for FileStorageProvider {
     async fn drain_pool(&self) -> Result<usize> {
         Ok(0)
     }
+}
+
+async fn open_required_slot_path<F>(
+    instance_id: &str,
+    path: &Path,
+    required_type: RequiredPathType,
+    open_path: F,
+) -> Result<std::os::fd::OwnedFd>
+where
+    F: FnOnce() -> rustix::io::Result<std::os::fd::OwnedFd> + Send + 'static,
+{
+    let task_instance_id = instance_id.to_string();
+    let task_path = path.to_path_buf();
+    let join_instance_id = task_instance_id.clone();
+    let join_path = task_path.clone();
+    tokio::task::spawn_blocking(move || {
+        let file = open_path().map_err(|error| {
+            if matches!(
+                error,
+                rustix::io::Errno::NOENT | rustix::io::Errno::NOTDIR | rustix::io::Errno::LOOP
+            ) {
+                BlazeError::StorageIncomplete {
+                    instance_id: task_instance_id.clone(),
+                    path: task_path.clone(),
+                    expected: required_type.description(),
+                }
+            } else {
+                BlazeError::StorageError {
+                    msg: format!(
+                        "sync artifacts '{task_instance_id}': open {}: {error}",
+                        task_path.display()
+                    ),
+                }
+            }
+        })?;
+        let file = std::fs::File::from(file);
+        let metadata = file.metadata().map_err(|error| BlazeError::StorageError {
+            msg: format!(
+                "sync artifacts '{task_instance_id}': inspect {}: {error}",
+                task_path.display()
+            ),
+        })?;
+        if !required_type.matches(&metadata) {
+            return Err(BlazeError::StorageIncomplete {
+                instance_id: task_instance_id,
+                path: task_path,
+                expected: required_type.description(),
+            });
+        }
+        Ok(file.into())
+    })
+    .await
+    .map_err(|error| BlazeError::StorageError {
+        msg: format!(
+            "sync artifacts '{join_instance_id}': open task for {} failed: {error}",
+            join_path.display()
+        ),
+    })?
 }
 
 async fn create_or_copy(
@@ -606,6 +726,77 @@ mod tests {
                 .is_symlink()
         );
         assert!(external.is_file());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn slot_open_does_not_block_async_runtime() -> Result<()> {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("artifact");
+        tokio::fs::write(&path, b"artifact").await?;
+
+        let (opened_tx, opened_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let watchdog_release = release_tx.clone();
+        let (watchdog_cancel_tx, watchdog_cancel_rx) = mpsc::channel();
+        let watchdog_fired = Arc::new(AtomicBool::new(false));
+        let watchdog_state = Arc::clone(&watchdog_fired);
+        let watchdog = std::thread::spawn(move || {
+            if watchdog_cancel_rx
+                .recv_timeout(Duration::from_secs(2))
+                .is_err()
+            {
+                watchdog_state.store(true, Ordering::SeqCst);
+                let _ = watchdog_release.send(());
+            }
+        });
+
+        let path_to_open = path.clone();
+        let open_future = open_required_slot_path(
+            "runtime-progress",
+            &path,
+            RequiredPathType::File,
+            move || {
+                let _ = opened_tx.send(());
+                if release_rx.recv().is_err() {
+                    return Err(rustix::io::Errno::INTR);
+                }
+                open(
+                    &path_to_open,
+                    OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                    Mode::empty(),
+                )
+            },
+        );
+        let runtime_progress = async {
+            let opened = tokio::time::timeout(Duration::from_secs(4), opened_rx).await;
+            assert!(
+                matches!(opened, Ok(Ok(()))),
+                "blocking slot open did not start"
+            );
+            tokio::task::yield_now().await;
+            assert!(
+                !watchdog_fired.load(Ordering::SeqCst),
+                "blocking slot open stalled the current-thread runtime"
+            );
+            assert!(release_tx.send(()).is_ok(), "release slot open");
+            assert!(
+                watchdog_cancel_tx.send(()).is_ok(),
+                "cancel slot-open watchdog"
+            );
+        };
+
+        let (open_result, ()) = tokio::join!(open_future, runtime_progress);
+        assert!(watchdog.join().is_ok(), "slot-open watchdog panicked");
+        assert!(
+            !watchdog_fired.load(Ordering::SeqCst),
+            "slot-open watchdog released a blocked runtime"
+        );
+        open_result?;
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/blaze/crates/blazed/src/sandbox.rs
+++ b/src/blaze/crates/blazed/src/sandbox.rs
@@ -2,5 +2,7 @@
 //! Managed sandbox lifecycle and runtime ownership.
 
 mod manager;
+mod storage_sync;
 
 pub use manager::{CreateSandbox, SandboxManager, SandboxManagerInit};
+pub(crate) use storage_sync::StorageSyncLoop;

--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Recoverable sandbox create, warm activation, destroy, and startup cleanup.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -14,7 +14,7 @@ use blaze_core::lifecycle::{
 use blaze_core::policy::RuntimeDecision;
 use blaze_core::pool::{PoolKey, PoolManager};
 use blaze_core::storage::{AcquireOpts, StorageProvider, StorageSlot};
-use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard, Semaphore};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -76,6 +76,8 @@ pub struct SandboxManager {
     instances: Arc<Mutex<HashMap<Uuid, SandboxInstance>>>,
     backend_instances: Arc<Mutex<HashMap<Uuid, DynBackendInstance>>>,
     operation_locks: Mutex<HashMap<Uuid, Arc<AsyncMutex<()>>>>,
+    pub(super) storage_sync_inflight: Arc<Mutex<HashSet<Uuid>>>,
+    pub(super) storage_sync_permits: Arc<Semaphore>,
     pool: Arc<Mutex<PoolManager>>,
     spawners: Arc<SpawnerRegistry>,
     active_backend: BackendKind,
@@ -138,6 +140,10 @@ impl SandboxManager {
                 instances,
                 backend_instances,
                 operation_locks: Mutex::new(operation_locks),
+                storage_sync_inflight: Arc::new(Mutex::new(HashSet::new())),
+                // The periodic worker is sequential. Retain that bound when a
+                // timed-out provider operation has to finish in the background.
+                storage_sync_permits: Arc::new(Semaphore::new(1)),
                 pool,
                 spawners: Arc::new(spawners),
                 active_backend,
@@ -166,8 +172,7 @@ impl SandboxManager {
         }
     }
 
-    #[cfg(test)]
-    pub fn backend_owner(&self, id: Uuid) -> Option<DynBackendInstance> {
+    pub(crate) fn backend_owner(&self, id: Uuid) -> Option<DynBackendInstance> {
         match self.backend_instances.lock() {
             Ok(instances) => instances.get(&id).cloned(),
             Err(poisoned) => poisoned.into_inner().get(&id).cloned(),
@@ -175,12 +180,23 @@ impl SandboxManager {
     }
 
     #[cfg(test)]
-    pub fn insert_backend_owner(&self, id: Uuid, owner: DynBackendInstance) -> Result<()> {
+    pub(crate) fn insert_backend_owner(&self, id: Uuid, owner: DynBackendInstance) -> Result<()> {
         self.backend_instances
             .lock()
             .map_err(|_| poisoned("backend_instances"))?
             .insert(id, owner);
         Ok(())
+    }
+
+    pub(super) async fn reconstruct_storage(&self, id: Uuid) -> Result<StorageSlot> {
+        self.storage
+            .reconstruct(&id.to_string())
+            .await
+            .map_err(Into::into)
+    }
+
+    pub(super) async fn sync_storage(&self, slot: &StorageSlot) -> Result<()> {
+        self.storage.sync_artifacts(slot).await.map_err(Into::into)
     }
 
     /// Return all persisted sandbox metadata.

--- a/src/blaze/crates/blazed/src/sandbox/storage_sync.rs
+++ b/src/blaze/crates/blazed/src/sandbox/storage_sync.rs
@@ -1,0 +1,1239 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Periodic persistence of already-written provider-owned sandbox artifacts.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use blaze_core::lifecycle::{BackendOwnership, SandboxState};
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, MissedTickBehavior};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+#[cfg(test)]
+use tokio::sync::Notify;
+
+use crate::error::{BlazeDaemonError, Result};
+
+use super::manager::SandboxManager;
+
+/// Supervised periodic storage-artifact synchronization task.
+pub(crate) struct StorageSyncLoop {
+    cancellation: CancellationToken,
+    task: Option<JoinHandle<()>>,
+    attempts: AttemptSupervisor,
+    #[cfg(test)]
+    started: Arc<Notify>,
+}
+
+impl StorageSyncLoop {
+    /// Wait for an early worker exit and report it as a daemon failure.
+    pub(crate) async fn observe_exit(&mut self) -> Result<()> {
+        self.join().await?;
+        Err(BlazeDaemonError::Internal(
+            "storage artifact synchronization task exited unexpectedly".to_string(),
+        ))
+    }
+
+    /// Request cooperative shutdown and join the worker before returning.
+    pub(crate) async fn shutdown(&mut self) -> Result<()> {
+        self.cancellation.cancel();
+        let worker_result = self.join().await;
+        self.attempts.join_all().await;
+        worker_result
+    }
+
+    async fn join(&mut self) -> Result<()> {
+        let Some(task) = self.task.as_mut() else {
+            return Ok(());
+        };
+        let result = task.await;
+        self.task.take();
+        result.map_err(join_error)
+    }
+
+    #[cfg(test)]
+    async fn wait_started(&self) {
+        self.started.notified().await;
+    }
+}
+
+impl Drop for StorageSyncLoop {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+        if let Some(task) = self.task.as_ref() {
+            task.abort();
+        }
+    }
+}
+
+fn join_error(error: tokio::task::JoinError) -> BlazeDaemonError {
+    BlazeDaemonError::Internal(format!(
+        "storage artifact synchronization task join failed: {error}"
+    ))
+}
+
+/// Counters emitted for one storage-artifact synchronization sweep.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StorageSyncSummary {
+    /// Running records selected before any provider await.
+    pub(crate) selected: usize,
+    /// Provider calls that completed successfully.
+    pub(crate) synced: usize,
+    /// Records that are no longer Running when artifact sync owns their lock.
+    pub(crate) skipped: usize,
+    /// Records deferred behind another sandbox operation or occupied sync capacity.
+    pub(crate) deferred: usize,
+    /// Inconsistent Running records, invalid owners, and provider failures.
+    pub(crate) failed: usize,
+}
+
+enum StorageSyncAttempt {
+    Synced,
+    Skipped,
+    Deferred,
+    Cancelled,
+}
+
+struct StorageSyncOwnership {
+    id: Uuid,
+    inflight: Arc<Mutex<HashSet<Uuid>>>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl StorageSyncOwnership {
+    fn begin(
+        id: Uuid,
+        inflight: Arc<Mutex<HashSet<Uuid>>>,
+        permit: OwnedSemaphorePermit,
+    ) -> Result<Option<Self>> {
+        let mut active = inflight.lock().map_err(|_| {
+            BlazeDaemonError::Internal(
+                "storage artifact synchronization claims poisoned".to_string(),
+            )
+        })?;
+        if !active.insert(id) {
+            return Ok(None);
+        }
+        drop(active);
+        Ok(Some(Self {
+            id,
+            inflight,
+            _permit: permit,
+        }))
+    }
+}
+
+impl Drop for StorageSyncOwnership {
+    fn drop(&mut self) {
+        match self.inflight.lock() {
+            Ok(mut active) => {
+                active.remove(&self.id);
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().remove(&self.id);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct AttemptSupervisor {
+    tasks: Arc<Mutex<Vec<LateAttempt>>>,
+}
+
+struct LateAttempt {
+    id: Uuid,
+    reason: &'static str,
+    task: JoinHandle<Result<StorageSyncAttempt>>,
+}
+
+impl AttemptSupervisor {
+    fn register(
+        &self,
+        id: Uuid,
+        reason: &'static str,
+        task: JoinHandle<Result<StorageSyncAttempt>>,
+    ) {
+        self.with_tasks(|tasks| tasks.push(LateAttempt { id, reason, task }));
+    }
+
+    async fn reap_finished(&self) {
+        let finished = self.with_tasks(|tasks| {
+            let mut finished = Vec::new();
+            let mut pending = Vec::with_capacity(tasks.len());
+            for attempt in tasks.drain(..) {
+                if attempt.task.is_finished() {
+                    finished.push(attempt);
+                } else {
+                    pending.push(attempt);
+                }
+            }
+            *tasks = pending;
+            finished
+        });
+        join_late_attempts(finished).await;
+    }
+
+    async fn join_all(&self) {
+        let attempts = self.with_tasks(std::mem::take);
+        join_late_attempts(attempts).await;
+    }
+
+    fn with_tasks<T>(&self, operation: impl FnOnce(&mut Vec<LateAttempt>) -> T) -> T {
+        match self.tasks.lock() {
+            Ok(mut tasks) => operation(&mut tasks),
+            Err(poisoned) => operation(&mut poisoned.into_inner()),
+        }
+    }
+}
+
+async fn join_late_attempts(attempts: Vec<LateAttempt>) {
+    for LateAttempt { id, reason, task } in attempts {
+        match task.await {
+            Ok(Ok(StorageSyncAttempt::Synced)) => {
+                tracing::info!(sandbox_id = %id, %reason, "late storage artifact synchronization completed");
+            }
+            Ok(Ok(
+                StorageSyncAttempt::Skipped
+                | StorageSyncAttempt::Deferred
+                | StorageSyncAttempt::Cancelled,
+            )) => {
+                tracing::warn!(sandbox_id = %id, %reason, "late storage artifact synchronization ended before artifact sync completed");
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(sandbox_id = %id, %reason, %error, "late storage artifact synchronization failed");
+            }
+            Err(error) => {
+                tracing::warn!(sandbox_id = %id, %reason, %error, "late storage artifact synchronization task failed");
+            }
+        }
+    }
+}
+
+impl SandboxManager {
+    /// Start a cancellable periodic storage-artifact synchronization worker.
+    ///
+    /// The first sweep starts after one complete interval. Missed ticks are
+    /// skipped instead of being queued behind a slow sweep.
+    pub(crate) fn start_storage_sync_loop(
+        self: &Arc<Self>,
+        interval: Duration,
+        attempt_timeout: Duration,
+    ) -> StorageSyncLoop {
+        let manager = self.clone();
+        let cancellation = CancellationToken::new();
+        let worker_cancellation = cancellation.clone();
+        let attempts = AttemptSupervisor::default();
+        let worker_attempts = attempts.clone();
+        #[cfg(test)]
+        let started = Arc::new(Notify::new());
+        #[cfg(test)]
+        let worker_started = started.clone();
+        tracing::info!(
+            interval_secs = interval.as_secs_f64(),
+            attempt_timeout_secs = attempt_timeout.as_secs_f64(),
+            "starting storage artifact synchronization task"
+        );
+        let task = tokio::spawn(async move {
+            let first_tick = Instant::now() + interval;
+            let mut ticker = tokio::time::interval_at(first_tick, interval);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            #[cfg(test)]
+            worker_started.notify_one();
+            loop {
+                worker_attempts.reap_finished().await;
+                tokio::select! {
+                    biased;
+                    _ = worker_cancellation.cancelled() => break,
+                    _ = ticker.tick() => {
+                        let summary = manager
+                            .sync_all_artifacts_until(
+                                &worker_cancellation,
+                                attempt_timeout,
+                                &worker_attempts,
+                            )
+                            .await;
+                        let Some(summary) = summary else {
+                            break;
+                        };
+                        tracing::debug!(
+                            selected = summary.selected,
+                            synced = summary.synced,
+                            skipped = summary.skipped,
+                            deferred = summary.deferred,
+                            failed = summary.failed,
+                            "storage artifact synchronization sweep completed"
+                        );
+                    }
+                }
+            }
+            tracing::info!("storage artifact synchronization task stopped");
+        });
+        StorageSyncLoop {
+            cancellation,
+            task: Some(task),
+            attempts,
+            #[cfg(test)]
+            started,
+        }
+    }
+
+    #[cfg(test)]
+    async fn sync_all_artifacts(self: &Arc<Self>, attempt_timeout: Duration) -> StorageSyncSummary {
+        self.sync_all_artifacts_until(
+            &CancellationToken::new(),
+            attempt_timeout,
+            &AttemptSupervisor::default(),
+        )
+        .await
+        .expect("uncancelled sweep")
+    }
+
+    async fn sync_all_artifacts_until(
+        self: &Arc<Self>,
+        cancellation: &CancellationToken,
+        attempt_timeout: Duration,
+        attempts: &AttemptSupervisor,
+    ) -> Option<StorageSyncSummary> {
+        let running_ids = match self.list() {
+            Ok(instances) => instances
+                .into_iter()
+                .filter_map(|instance| {
+                    (instance.state == SandboxState::Running).then_some(instance.id)
+                })
+                .collect::<Vec<_>>(),
+            Err(error) => {
+                tracing::error!(%error, "cannot select storage artifact synchronization candidates");
+                return Some(StorageSyncSummary {
+                    failed: 1,
+                    ..StorageSyncSummary::default()
+                });
+            }
+        };
+        let mut summary = StorageSyncSummary {
+            selected: running_ids.len(),
+            ..StorageSyncSummary::default()
+        };
+        for id in running_ids {
+            match self
+                .sync_artifacts_if_running(id, cancellation, attempt_timeout, attempts)
+                .await
+            {
+                Ok(StorageSyncAttempt::Synced) => summary.synced += 1,
+                Ok(StorageSyncAttempt::Skipped) => summary.skipped += 1,
+                Ok(StorageSyncAttempt::Deferred) => summary.deferred += 1,
+                Ok(StorageSyncAttempt::Cancelled) => return None,
+                Err(error) => {
+                    summary.failed += 1;
+                    tracing::warn!(
+                        sandbox_id = %id,
+                        %error,
+                        "sandbox storage artifact synchronization failed"
+                    );
+                }
+            }
+        }
+        Some(summary)
+    }
+
+    async fn sync_artifacts_if_running(
+        self: &Arc<Self>,
+        id: Uuid,
+        cancellation: &CancellationToken,
+        attempt_timeout: Duration,
+        attempts: &AttemptSupervisor,
+    ) -> Result<StorageSyncAttempt> {
+        let already_inflight = self
+            .storage_sync_inflight
+            .lock()
+            .map_err(|_| {
+                BlazeDaemonError::Internal(
+                    "storage artifact synchronization claims poisoned".to_string(),
+                )
+            })?
+            .contains(&id);
+        if already_inflight {
+            return Ok(StorageSyncAttempt::Deferred);
+        }
+        if cancellation.is_cancelled() {
+            return Ok(StorageSyncAttempt::Cancelled);
+        }
+        let observed = self.get(id)?;
+        if observed.state != SandboxState::Running {
+            return Ok(StorageSyncAttempt::Skipped);
+        }
+        let operation_lock = self.operation_lock(id);
+        let _operation = match operation_lock.try_lock_owned() {
+            Ok(operation) => operation,
+            Err(_) => return Ok(StorageSyncAttempt::Deferred),
+        };
+        let instance = self.get(id)?;
+        if instance.state != SandboxState::Running {
+            return Ok(StorageSyncAttempt::Skipped);
+        }
+        if let Some(operation) = instance.operation {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "instance {id} is Running with unfinished {:?} operation",
+                operation.kind
+            )));
+        }
+        if instance.backend_ownership != BackendOwnership::Running {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "instance {id} is Running with {} backend ownership",
+                format!("{:?}", instance.backend_ownership).to_lowercase()
+            )));
+        }
+        let backend = self.backend_owner(id).ok_or_else(|| {
+            BlazeDaemonError::RecoveryRequired(format!(
+                "instance {id} is Running without a backend owner"
+            ))
+        })?;
+        let permit = match self.storage_sync_permits.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => return Ok(StorageSyncAttempt::Deferred),
+        };
+        let Some(ownership) =
+            StorageSyncOwnership::begin(id, self.storage_sync_inflight.clone(), permit)?
+        else {
+            return Ok(StorageSyncAttempt::Deferred);
+        };
+        let manager = self.clone();
+        let mut attempt = tokio::spawn(async move {
+            let _operation = _operation;
+            let _ownership = ownership;
+            if let Some(status) = backend.try_wait().await? {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "instance {id} backend already exited: {status:?}"
+                )));
+            }
+            let storage = manager.reconstruct_storage(id).await.map_err(|error| {
+                BlazeDaemonError::RecoveryRequired(format!(
+                    "instance {id} has no complete storage owner: {error}"
+                ))
+            })?;
+            manager.sync_storage(&storage).await?;
+            Ok(StorageSyncAttempt::Synced)
+        });
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                attempts.register(id, "worker cancellation", attempt);
+                Ok(StorageSyncAttempt::Cancelled)
+            },
+            result = tokio::time::timeout(attempt_timeout, &mut attempt) => {
+                match result {
+                    Ok(result) => result.map_err(join_error)?,
+                    Err(_) => {
+                        attempts.register(id, "attempt timeout", attempt);
+                        Err(BlazeDaemonError::Internal(format!(
+                            "storage artifact synchronization attempt for {id} timed out after {:.3} seconds",
+                            attempt_timeout.as_secs_f64()
+                        )))
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use blaze_core::backend::{BackendKind, SpawnRequest};
+    use blaze_core::error::{BlazeError, Result as CoreResult};
+    use blaze_core::lifecycle::{
+        BackendOwnership, OperationKind, SandboxInstance, SandboxState, StartPath,
+    };
+    use blaze_core::policy::{BackendConfigs, WorkloadClass};
+    use blaze_core::pool::PoolManager;
+    use blaze_core::storage::{
+        AcquireOpts, PoolStatus, StorageAcquireError, StorageProvider, StorageSlot,
+    };
+    use tokio::sync::Notify;
+
+    use crate::file_provider::{ArtifactSyncOpenHook, FileStorageProvider};
+    use crate::sandbox::manager::{SandboxManagerInit, SandboxManagerResources};
+    use crate::spawner::{
+        BackendInstance, BackendSpawner, MockSpawner, SpawnResult, SpawnerRegistry,
+    };
+
+    use super::*;
+
+    struct RecordingStorage {
+        inner: FileStorageProvider,
+        instances: PathBuf,
+        calls: Mutex<Vec<String>>,
+        call_recorded: Notify,
+        failures: Mutex<HashSet<String>>,
+        block_next: AtomicBool,
+        started: Notify,
+        release_blocked: Notify,
+        blocked_reconstructs: Mutex<HashSet<String>>,
+        reconstruct_started: Notify,
+        release_reconstruct: Notify,
+    }
+
+    struct BlockingBackend {
+        block_next: AtomicBool,
+        started: Notify,
+        release: Notify,
+    }
+
+    impl BlockingBackend {
+        fn new() -> Self {
+            Self {
+                block_next: AtomicBool::new(true),
+                started: Notify::new(),
+                release: Notify::new(),
+            }
+        }
+
+        fn resume(&self) {
+            self.release.notify_one();
+        }
+    }
+
+    #[async_trait]
+    impl BackendInstance for BlockingBackend {
+        fn backend(&self) -> BackendKind {
+            BackendKind::Mock
+        }
+
+        async fn try_wait(&self) -> CoreResult<Option<SpawnResult>> {
+            if self.block_next.swap(false, Ordering::AcqRel) {
+                self.started.notify_one();
+                self.release.notified().await;
+            }
+            Ok(None)
+        }
+
+        async fn kill(&self) -> CoreResult<()> {
+            Ok(())
+        }
+    }
+
+    impl RecordingStorage {
+        fn new(images: PathBuf, instances: PathBuf) -> Self {
+            Self {
+                inner: FileStorageProvider::with_images(images, instances.clone()),
+                instances,
+                calls: Mutex::new(Vec::new()),
+                call_recorded: Notify::new(),
+                failures: Mutex::new(HashSet::new()),
+                block_next: AtomicBool::new(false),
+                started: Notify::new(),
+                release_blocked: Notify::new(),
+                blocked_reconstructs: Mutex::new(HashSet::new()),
+                reconstruct_started: Notify::new(),
+                release_reconstruct: Notify::new(),
+            }
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().expect("calls").clone()
+        }
+
+        async fn wait_for_calls(&self, expected: usize) {
+            loop {
+                let call_recorded = self.call_recorded.notified();
+                if self.calls.lock().expect("calls").len() >= expected {
+                    return;
+                }
+                call_recorded.await;
+            }
+        }
+
+        fn fail(&self, id: Uuid) {
+            self.failures
+                .lock()
+                .expect("failures")
+                .insert(id.to_string());
+        }
+
+        fn block_once(&self) {
+            self.block_next.store(true, Ordering::Release);
+        }
+
+        fn resume_blocked(&self) {
+            self.release_blocked.notify_one();
+        }
+
+        fn block_reconstruct(&self, id: Uuid) {
+            self.blocked_reconstructs
+                .lock()
+                .expect("blocked reconstructs")
+                .insert(id.to_string());
+        }
+
+        fn resume_reconstruct(&self) {
+            self.release_reconstruct.notify_one();
+        }
+    }
+
+    #[async_trait]
+    impl StorageProvider for RecordingStorage {
+        async fn probe(&self) -> CoreResult<bool> {
+            self.inner.probe().await
+        }
+
+        async fn acquire(
+            &self,
+            opts: &AcquireOpts,
+        ) -> std::result::Result<StorageSlot, StorageAcquireError> {
+            self.inner.acquire(opts).await
+        }
+
+        async fn release(&self, slot: StorageSlot) -> CoreResult<()> {
+            self.inner.release(slot).await
+        }
+
+        async fn release_by_id(&self, instance_id: &str) -> CoreResult<()> {
+            self.inner.release_by_id(instance_id).await
+        }
+
+        async fn reconstruct(&self, instance_id: &str) -> CoreResult<StorageSlot> {
+            if self
+                .blocked_reconstructs
+                .lock()
+                .expect("blocked reconstructs")
+                .remove(instance_id)
+            {
+                self.reconstruct_started.notify_one();
+                self.release_reconstruct.notified().await;
+            }
+            self.inner.reconstruct(instance_id).await
+        }
+
+        async fn sync_artifacts(&self, slot: &StorageSlot) -> CoreResult<()> {
+            self.calls.lock().expect("calls").push(slot.id.clone());
+            self.call_recorded.notify_waiters();
+            if self.block_next.swap(false, Ordering::AcqRel) {
+                self.started.notify_one();
+                self.release_blocked.notified().await;
+            }
+            if self.failures.lock().expect("failures").contains(&slot.id) {
+                return Err(BlazeError::StorageError {
+                    msg: format!(
+                        "injected storage artifact synchronization failure for {}",
+                        slot.id
+                    ),
+                });
+            }
+            Ok(())
+        }
+
+        fn pool_status(&self) -> PoolStatus {
+            self.inner.pool_status()
+        }
+
+        async fn drain_pool(&self) -> CoreResult<usize> {
+            self.inner.drain_pool().await
+        }
+    }
+
+    fn manager(
+        temp: &Path,
+        storage: Arc<dyn StorageProvider>,
+    ) -> (Arc<SandboxManager>, SandboxManagerResources) {
+        let state_dir = temp.join("state");
+        let images = temp.join("images");
+        let instances = temp.join("instances");
+        for directory in [&state_dir, &images, &instances] {
+            std::fs::create_dir_all(directory).expect("test directory");
+        }
+        let mut spawners = SpawnerRegistry::new();
+        spawners.insert(BackendKind::Mock, Arc::new(MockSpawner));
+        let (manager, resources) = SandboxManager::new(SandboxManagerInit {
+            instances: HashMap::new(),
+            pool: PoolManager::new(),
+            spawners,
+            active_backend: BackendKind::Mock,
+            storage,
+            state_dir,
+            rootfs_size: 64,
+            mem_size: 32,
+        });
+        (Arc::new(manager), resources)
+    }
+
+    async fn insert_running(
+        manager: &SandboxManager,
+        resources: &SandboxManagerResources,
+        storage: &RecordingStorage,
+        id: Uuid,
+        acquire_storage: bool,
+        insert_backend: bool,
+        active_operation: bool,
+    ) {
+        let slot = if acquire_storage {
+            Some(
+                storage
+                    .acquire(&AcquireOpts {
+                        instance_id: id.to_string(),
+                        rootfs_size: 64,
+                        mem_size: 32,
+                    })
+                    .await
+                    .expect("slot"),
+            )
+        } else {
+            None
+        };
+        register_running(
+            manager,
+            resources,
+            id,
+            slot,
+            storage.instances.join(id.to_string()).join("runtime"),
+            insert_backend,
+            active_operation,
+        )
+        .await;
+    }
+
+    async fn register_running(
+        manager: &SandboxManager,
+        resources: &SandboxManagerResources,
+        id: Uuid,
+        slot: Option<StorageSlot>,
+        run_dir: PathBuf,
+        insert_backend: bool,
+        active_operation: bool,
+    ) {
+        let mut metadata = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:sync-test".into(),
+            StartPath::Cold,
+            "sync-test".into(),
+        );
+        metadata.id = id;
+        metadata
+            .transition(SandboxState::Creating)
+            .expect("pending to creating");
+        metadata
+            .transition(SandboxState::Running)
+            .expect("creating to running");
+        metadata.backend_ownership = BackendOwnership::Running;
+        if active_operation {
+            metadata.begin_operation(OperationKind::Create);
+        }
+        resources
+            .instances
+            .lock()
+            .expect("instances")
+            .insert(id, metadata);
+        if insert_backend {
+            let slot = slot.clone().unwrap_or_else(|| StorageSlot {
+                id: id.to_string(),
+                rootfs_path: PathBuf::new(),
+                mem_path: PathBuf::new(),
+                mem_diff_path: PathBuf::new(),
+                rootfs_diff_path: PathBuf::new(),
+                instance_dir: PathBuf::new(),
+            });
+            let owner = MockSpawner
+                .spawn(SpawnRequest {
+                    instance_id: id,
+                    run_dir,
+                    binary_path: PathBuf::new(),
+                    storage: slot,
+                    backend: BackendConfigs::default(),
+                    vm: None,
+                })
+                .await
+                .expect("mock owner");
+            manager
+                .insert_backend_owner(id, owner)
+                .expect("register owner");
+        }
+    }
+
+    async fn settle() {
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    async fn wait_for_operation_unlock(manager: &SandboxManager, id: Uuid) {
+        let operation_lock = manager.operation_lock(id);
+        let guard = tokio::time::timeout(Duration::from_secs(5), operation_lock.lock_owned())
+            .await
+            .unwrap_or_else(|_| panic!("operation lock for {id} remained held"));
+        drop(guard);
+    }
+
+    async fn file_manager_with_artifact_sync_hook(
+        temp: &Path,
+    ) -> (
+        Arc<SandboxManager>,
+        Arc<ArtifactSyncOpenHook>,
+        StorageSlot,
+        PathBuf,
+    ) {
+        let images = temp.join("images");
+        let instances = temp.join("instances");
+        std::fs::create_dir_all(&images).expect("images");
+        std::fs::create_dir_all(&instances).expect("instances");
+        let hook = Arc::new(ArtifactSyncOpenHook::new());
+        let storage = Arc::new(FileStorageProvider::with_artifact_sync_open_hook(
+            images,
+            instances.clone(),
+            hook.clone(),
+        ));
+        let id = Uuid::new_v4();
+        let slot = storage
+            .acquire(&AcquireOpts {
+                instance_id: id.to_string(),
+                rootfs_size: 64,
+                mem_size: 32,
+            })
+            .await
+            .expect("slot");
+        let (manager, resources) = manager(temp, storage);
+        register_running(
+            &manager,
+            &resources,
+            id,
+            Some(slot.clone()),
+            slot.instance_dir.join("runtime"),
+            true,
+            false,
+        )
+        .await;
+        (manager, hook, slot, instances)
+    }
+
+    #[tokio::test]
+    async fn sweep_syncs_running_records_and_isolates_failures() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let failing = Uuid::new_v4();
+        let succeeding = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, failing, true, true, false).await;
+        insert_running(
+            &manager, &resources, &storage, succeeding, true, true, false,
+        )
+        .await;
+        storage.fail(failing);
+
+        let summary = manager.sync_all_artifacts(Duration::from_secs(1)).await;
+
+        assert_eq!(
+            summary,
+            StorageSyncSummary {
+                selected: 2,
+                synced: 1,
+                skipped: 0,
+                deferred: 0,
+                failed: 1,
+            }
+        );
+        assert_eq!(
+            storage.calls().into_iter().collect::<HashSet<_>>(),
+            HashSet::from([failing.to_string(), succeeding.to_string()])
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sweep_keeps_sync_bound_to_the_open_slot_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("temp");
+        let (manager, hook, slot, instances) =
+            file_manager_with_artifact_sync_hook(temp.path()).await;
+
+        let sweep = {
+            let manager = manager.clone();
+            tokio::spawn(async move { manager.sync_all_artifacts(Duration::from_secs(5)).await })
+        };
+        hook.wait_until_open().await;
+
+        let detached = instances.join(format!("{}.detached", slot.id));
+        tokio::fs::rename(&slot.instance_dir, &detached)
+            .await
+            .expect("detach opened slot");
+        let outside = temp.path().join("outside");
+        tokio::fs::create_dir(&outside).await.expect("outside");
+        for artifact in ["rootfs.ext4", "mem.bin", "mem.diff", "rootfs.diff"] {
+            tokio::fs::write(outside.join(artifact), b"outside")
+                .await
+                .expect("outside artifact");
+        }
+        symlink(&outside, &slot.instance_dir).expect("replacement link");
+        hook.resume();
+
+        assert_eq!(
+            sweep.await.expect("sweep"),
+            StorageSyncSummary {
+                selected: 1,
+                synced: 1,
+                skipped: 0,
+                deferred: 0,
+                failed: 0,
+            }
+        );
+        for artifact in ["rootfs.ext4", "mem.bin", "mem.diff", "rootfs.diff"] {
+            assert_eq!(
+                tokio::fs::read(outside.join(artifact))
+                    .await
+                    .expect("outside artifact"),
+                b"outside"
+            );
+        }
+        assert!(detached.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sweep_rejects_an_artifact_replaced_after_the_slot_is_open() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("temp");
+        let (manager, hook, slot, _) = file_manager_with_artifact_sync_hook(temp.path()).await;
+        let outside = temp.path().join("outside-memory-diff");
+        tokio::fs::write(&outside, b"outside")
+            .await
+            .expect("outside artifact");
+        let sweep = {
+            let manager = manager.clone();
+            tokio::spawn(async move { manager.sync_all_artifacts(Duration::from_secs(5)).await })
+        };
+        hook.wait_until_open().await;
+
+        tokio::fs::remove_file(&slot.mem_diff_path)
+            .await
+            .expect("remove slot artifact");
+        symlink(&outside, &slot.mem_diff_path).expect("replacement link");
+        hook.resume();
+
+        assert_eq!(
+            sweep.await.expect("sweep"),
+            StorageSyncSummary {
+                selected: 1,
+                synced: 0,
+                skipped: 0,
+                deferred: 0,
+                failed: 1,
+            }
+        );
+        assert_eq!(
+            tokio::fs::read(&outside).await.expect("outside artifact"),
+            b"outside"
+        );
+        assert!(
+            std::fs::symlink_metadata(&slot.mem_diff_path)
+                .expect("replacement link")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_reports_incomplete_running_owners_without_syncing() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        insert_running(
+            &manager,
+            &resources,
+            &storage,
+            Uuid::new_v4(),
+            true,
+            false,
+            false,
+        )
+        .await;
+        insert_running(
+            &manager,
+            &resources,
+            &storage,
+            Uuid::new_v4(),
+            false,
+            true,
+            false,
+        )
+        .await;
+        insert_running(
+            &manager,
+            &resources,
+            &storage,
+            Uuid::new_v4(),
+            true,
+            true,
+            true,
+        )
+        .await;
+
+        assert_eq!(
+            manager.sync_all_artifacts(Duration::from_secs(1)).await,
+            StorageSyncSummary {
+                selected: 3,
+                synced: 0,
+                skipped: 0,
+                deferred: 0,
+                failed: 3,
+            }
+        );
+        assert!(storage.calls().is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_provider_call_retains_ownership_and_bounds_late_work() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let id = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, id, true, true, false).await;
+        storage.block_once();
+
+        let first = {
+            let manager = manager.clone();
+            tokio::spawn(async move { manager.sync_all_artifacts(Duration::from_secs(5)).await })
+        };
+        storage.started.notified().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert_eq!(first.await.expect("sweep").failed, 1);
+        assert!(manager.operation_lock(id).try_lock().is_err());
+
+        let second = manager.sync_all_artifacts(Duration::from_secs(5)).await;
+        assert_eq!(second.deferred, 1);
+        assert_eq!(second.synced, 0);
+        assert_eq!(storage.calls(), vec![id.to_string()]);
+
+        storage.resume_blocked();
+        wait_for_operation_unlock(&manager, id).await;
+        let retry = manager.sync_all_artifacts(Duration::from_secs(5)).await;
+        assert_eq!(retry.synced, 1);
+        assert_eq!(storage.calls(), vec![id.to_string(), id.to_string()]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconstruction_timeout_retains_lock_and_defers_more_provider_work() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let blocked = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, blocked, true, true, false).await;
+        storage.block_reconstruct(blocked);
+
+        let sweep = {
+            let manager = manager.clone();
+            tokio::spawn(async move { manager.sync_all_artifacts(Duration::from_secs(5)).await })
+        };
+        storage.reconstruct_started.notified().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+
+        assert_eq!(sweep.await.expect("sweep").failed, 1);
+        assert!(manager.operation_lock(blocked).try_lock().is_err());
+
+        let later = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, later, true, true, false).await;
+        let deferred = manager.sync_all_artifacts(Duration::from_secs(5)).await;
+        assert_eq!(deferred.selected, 2);
+        assert_eq!(deferred.deferred, 2);
+        assert!(storage.calls().is_empty());
+
+        storage.resume_reconstruct();
+        wait_for_operation_unlock(&manager, blocked).await;
+        let retry = manager.sync_all_artifacts(Duration::from_secs(5)).await;
+        assert_eq!(retry.synced, 2);
+        assert!(storage.calls().contains(&blocked.to_string()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backend_liveness_uses_the_attempt_deadline_and_retains_ownership() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let blocked = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, blocked, true, true, false).await;
+        let backend = Arc::new(BlockingBackend::new());
+        manager
+            .insert_backend_owner(blocked, backend.clone())
+            .expect("replace backend owner");
+
+        let sweep = {
+            let manager = manager.clone();
+            tokio::spawn(async move { manager.sync_all_artifacts(Duration::from_secs(5)).await })
+        };
+        backend.started.notified().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+
+        assert_eq!(sweep.await.expect("sweep").failed, 1);
+        assert!(manager.operation_lock(blocked).try_lock().is_err());
+        assert_eq!(manager.storage_sync_permits.available_permits(), 0);
+
+        let later = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, later, true, true, false).await;
+        let next = manager.sync_all_artifacts(Duration::from_secs(5)).await;
+        assert_eq!(next.selected, 2);
+        assert_eq!(next.deferred, 2);
+        assert!(storage.calls().is_empty());
+
+        backend.resume();
+        wait_for_operation_unlock(&manager, blocked).await;
+        let retry = manager.sync_all_artifacts(Duration::from_secs(5)).await;
+        assert_eq!(retry.synced, 2);
+    }
+
+    #[tokio::test]
+    async fn sweep_defers_active_operations_and_continues() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let blocked = Uuid::new_v4();
+        let ready = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, blocked, true, true, false).await;
+        insert_running(&manager, &resources, &storage, ready, true, true, false).await;
+        let lock = manager.operation_lock(blocked);
+        let guard = lock.lock().await;
+        resources
+            .instances
+            .lock()
+            .expect("instances")
+            .get_mut(&blocked)
+            .expect("metadata")
+            .begin_operation(OperationKind::Destroy);
+
+        let summary = manager.sync_all_artifacts(Duration::from_secs(1)).await;
+
+        assert_eq!(summary.selected, 2);
+        assert_eq!(summary.synced, 1);
+        assert_eq!(summary.deferred, 1);
+        assert_eq!(storage.calls(), vec![ready.to_string()]);
+        drop(guard);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn periodic_worker_delays_first_tick_and_stops_before_next_sweep() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let id = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, id, true, true, false).await;
+
+        let mut worker =
+            manager.start_storage_sync_loop(Duration::from_secs(10), Duration::from_secs(5));
+        worker.wait_started().await;
+        settle().await;
+        assert!(storage.calls().is_empty());
+        tokio::time::advance(Duration::from_secs(10)).await;
+        storage.wait_for_calls(1).await;
+        assert_eq!(storage.calls(), vec![id.to_string()]);
+
+        worker.shutdown().await.expect("worker shutdown");
+        tokio::time::advance(Duration::from_secs(30)).await;
+        settle().await;
+        assert_eq!(storage.calls(), vec![id.to_string()]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn worker_defers_a_busy_operation_lock_before_shutdown() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let id = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, id, true, true, false).await;
+        let lock = manager.operation_lock(id);
+        let guard = lock.lock().await;
+        let mut worker =
+            manager.start_storage_sync_loop(Duration::from_secs(10), Duration::from_secs(5));
+        worker.wait_started().await;
+        tokio::time::advance(Duration::from_secs(10)).await;
+        settle().await;
+
+        worker.shutdown().await.expect("worker shutdown");
+        drop(guard);
+        assert!(storage.calls().is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn worker_shutdown_joins_active_provider_attempts() {
+        let temp = tempfile::tempdir().expect("temp");
+        let storage = Arc::new(RecordingStorage::new(
+            temp.path().join("images"),
+            temp.path().join("instances"),
+        ));
+        let (manager, resources) = manager(temp.path(), storage.clone());
+        let id = Uuid::new_v4();
+        insert_running(&manager, &resources, &storage, id, true, true, false).await;
+        storage.block_once();
+
+        let mut worker =
+            manager.start_storage_sync_loop(Duration::from_secs(10), Duration::from_secs(5));
+        worker.wait_started().await;
+        tokio::time::advance(Duration::from_secs(10)).await;
+        storage.started.notified().await;
+
+        let shutdown = tokio::spawn(async move { worker.shutdown().await });
+        settle().await;
+        assert!(!shutdown.is_finished());
+        assert!(manager.operation_lock(id).try_lock().is_err());
+        assert_eq!(manager.storage_sync_permits.available_permits(), 0);
+
+        storage.resume_blocked();
+        shutdown
+            .await
+            .expect("shutdown task")
+            .expect("worker shutdown");
+        wait_for_operation_unlock(&manager, id).await;
+        assert_eq!(manager.storage_sync_permits.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn supervisor_reports_an_unexpected_worker_exit() {
+        let cancellation = CancellationToken::new();
+        let mut worker = StorageSyncLoop {
+            cancellation,
+            task: Some(tokio::spawn(async {})),
+            attempts: AttemptSupervisor::default(),
+            started: Arc::new(Notify::new()),
+        };
+
+        let error = worker
+            .observe_exit()
+            .await
+            .expect_err("early worker exit must stop the daemon");
+
+        assert!(error.to_string().contains("exited unexpectedly"));
+        worker
+            .shutdown()
+            .await
+            .expect("finished worker is already joined");
+    }
+}

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -33,7 +33,7 @@ pub struct ServerState {
     pub template: Mutex<TemplateRegistry>,
     pub hook: Mutex<HookRegistry>,
     pub instances: Arc<Mutex<HashMap<Uuid, SandboxInstance>>>,
-    pub manager: SandboxManager,
+    pub manager: Arc<SandboxManager>,
     /// The backend kind that `build_spawner` actually probed and selected.
     /// API handlers use this to constrain availability to the single active
     /// backend rather than reporting all configured binaries.
@@ -81,7 +81,7 @@ impl ServerState {
             template: Mutex::new(template),
             hook: Mutex::new(hook),
             instances: resources.instances,
-            manager,
+            manager: Arc::new(manager),
             active_backend,
             storage,
             state_dir,

--- a/src/blaze/docs/design/storage-artifact-synchronization.md
+++ b/src/blaze/docs/design/storage-artifact-synchronization.md
@@ -1,0 +1,80 @@
+# Storage Artifact Synchronization
+
+[中文版](storage-artifact-synchronization_zh.md)
+
+Blaze can periodically ask the configured `StorageProvider` to persist the
+already-written files and directory metadata owned by running sandboxes. This
+closes the gap between a provider that can synchronize one slot's host
+artifacts and a daemon that schedules the operation safely across all eligible
+sandboxes.
+
+Periodic synchronization is disabled by default. Set
+`storage.sync_interval` to a positive duration to enable it.
+`storage.sync_timeout` is a positive duration that bounds how long the
+scheduler waits for each provider attempt and defaults to 30 seconds.
+
+## Which sandboxes are synchronized
+
+At the beginning of a sweep, the manager selects records whose lifecycle state
+is `Running`. Before it calls the provider for one sandbox, it tries to enter
+the same operation lock used by lifecycle changes and guest exec, read, and
+write requests without waiting. A busy lock defers that sandbox to a later
+sweep so one active sandbox operation cannot prevent the worker from reaching
+other eligible records. After acquiring the lock, the manager checks the
+record again.
+
+The provider call runs only when all of these conditions still hold:
+
+- the lifecycle state is `Running`;
+- there is no unfinished lifecycle operation;
+- metadata says the backend is running and the daemon still owns that backend;
+- the provider can reconstruct a complete slot from the sandbox ID.
+
+A sandbox that is no longer Running is skipped. An inconsistent Running record
+is reported as a failed item instead of being silently omitted. The remaining
+sandboxes in the sweep still run.
+
+The first sweep starts after one complete interval. Missed ticks are skipped
+instead of queued, so a slow sweep cannot create an unbounded backlog.
+
+## Failure and retry behavior
+
+Each provider attempt has one scheduler deadline covering slot reconstruction
+and synchronization. A completed failure leaves the slot owned by the sandbox
+and does not change lifecycle state. A later sweep or destroy can therefore
+retry the provider operation.
+
+Some filesystem operations cannot be cancelled after they start. When one of
+those operations exceeds the deadline, the scheduler reports the timeout but
+the attempt continues to hold the sandbox operation lock. It also retains the
+single synchronization permit, so later attempts are deferred instead of
+creating more blocking filesystem work. Once the late attempt completes, the
+lock and permit are released and normal retry resumes. Guest and lifecycle
+operations that arrive while the lock is retained wait for the provider work
+to finish. The configured timeout bounds scheduler waiting, not their wait.
+
+`StorageProvider::sync_artifacts` is the provider-specific persistence boundary.
+The file provider calls `sync_all` for the canonical `rootfs.ext4`, `mem.bin`,
+`mem.diff`, and `rootfs.diff` files, then synchronizes the slot directory.
+Other providers can use a different mechanism while preserving the same
+ownership-until-completion contract.
+
+## Capability boundary
+
+Each provider synchronization call persists the already-written artifact bytes
+and directory metadata visible to that call. Changes that race with an attempt
+may reach the persistence boundary in that attempt or a later one.
+
+## Daemon shutdown
+
+The daemon supervises the periodic worker while serving requests. If the
+worker exits unexpectedly, the daemon leaves its accept loop and reports the
+worker failure. On a termination signal, the daemon first leaves that accept
+loop, then cancels and joins the periodic scheduler. Provider work that cannot
+be cancelled remains under its sandbox lock until it completes.
+
+This change owns only the worker lifecycle. Draining already accepted
+connections and releasing daemon-wide runtime resources are separate shutdown
+responsibilities. Until those responsibilities are implemented, operators
+must not treat service-loop return as proof that every in-flight handler and
+runtime owner has finished.

--- a/src/blaze/docs/design/storage-artifact-synchronization_zh.md
+++ b/src/blaze/docs/design/storage-artifact-synchronization_zh.md
@@ -1,0 +1,66 @@
+# 存储制品同步
+
+[English](storage-artifact-synchronization.md)
+
+Blaze 可以定期要求已配置的 `StorageProvider` 持久化 running sandbox 中已经
+写入的宿主机制品文件和目录元数据。这样，provider 不仅具备同步单个 slot
+制品的能力，daemon 也能安全调度所有符合条件的 sandbox。
+
+周期同步默认关闭。将 `storage.sync_interval` 设置为正数 duration 后启用。
+`storage.sync_timeout` 是 scheduler 等待单次 provider attempt 的最长时间，
+默认值为 30 秒。
+
+## 哪些 sandbox 会被同步
+
+每轮开始时，manager 先选择 lifecycle 状态为 `Running` 的记录。调用某个
+sandbox 的 provider 前，会尝试非阻塞地取得 lifecycle 变更和 guest exec、read、
+write 请求共用的 operation lock。lock 已被占用时，该 sandbox 会推迟到后续
+sweep，避免一个正在进行的 sandbox 操作阻止 worker 继续处理其他符合条件的
+记录。取得 lock 后，manager 会再次检查记录。
+
+只有同时满足以下条件时才会调用 provider：
+
+- lifecycle 状态仍为 `Running`；
+- 没有未结束的 lifecycle operation；
+- metadata 记录 backend 正在运行，而且 daemon 仍持有该 backend；
+- provider 可以根据 sandbox ID 重建完整 slot。
+
+已经不再处于 Running 状态的 sandbox 会被跳过。状态为 Running 但 ownership
+不完整的记录会计为失败，而不是被静默遗漏；本轮的其他 sandbox 仍会继续处理。
+
+第一次 sweep 在一个完整 interval 后开始。错过的 tick 会被跳过，不会排队，
+因此耗时较长的一轮不会形成无界积压。
+
+## 失败与重试
+
+每次 provider attempt 都有一个覆盖 slot 重建和同步的 scheduler deadline。
+已经返回的失败不会改变 lifecycle 状态，slot 仍归 sandbox 持有；后续 sweep
+或 destroy 可以再次尝试。
+
+某些文件系统操作开始后无法取消。这类操作超过 deadline 时，scheduler 会报告
+超时，但原 attempt 仍持有 sandbox operation lock。它还会继续占用唯一的同步
+许可，因此后续 attempt 会被推迟，而不会继续创建 blocking 文件系统任务。
+原 attempt 完成后会释放 lock 和许可，正常重试随之恢复。在此期间到达的 guest
+和 lifecycle 操作会等待 provider 工作完成；配置的 timeout 只限制 scheduler
+的等待时间，不限制这些操作的等待时间。
+
+`StorageProvider::sync_artifacts` 是 provider 特定的持久化边界。file provider
+会依次对规范的 `rootfs.ext4`、`mem.bin`、`mem.diff` 和 `rootfs.diff` 文件执行
+`sync_all`，然后同步 slot 目录；其他 provider 可以采用不同机制，但必须保持
+相同的 ownership-until-completion 合同。
+
+## 能力边界
+
+每次 provider 同步调用会持久化本次调用可见、且已经写入的制品字节与目录元数据。
+与一次同步并发发生的更新可能在本次或后续同步中到达持久化边界。
+
+## Daemon 关闭
+
+daemon 提供请求服务时会同时监控周期 worker。如果 worker 意外退出，daemon
+会退出 accept loop，并报告 worker 错误。收到终止信号后，daemon 先退出
+accept loop，再取消并等待周期 scheduler 退出。无法取消的 provider 工作会
+继续由对应 sandbox lock 持有，直至完成。
+
+这个改动只负责同步 worker 的生命周期。排空已经接收的连接以及释放 daemon
+持有的全部 runtime 资源属于其他关闭职责；在这些职责实现之前，不能把
+service loop 返回理解为所有正在处理的请求和 runtime owner 都已经结束。

--- a/src/blaze/examples/config.toml
+++ b/src/blaze/examples/config.toml
@@ -94,8 +94,12 @@ mem_size = 4294967296
 # Whether to prefork (pre-allocate) storage slots at daemon startup.
 # prefork = false         # [Reserved] Pre-start VMs in pool (not yet active)
 
-# Interval between flush-dirty sweeps.
-# flush_interval = "30s"   # [Reserved] Dirty data flush period (not yet active)
+# Periodic artifact synchronization is opt-in. Set a positive duration to
+# persist already-written sandbox slot files and directory metadata.
+sync_interval = "disabled"
+
+# Maximum time the scheduler waits for one artifact synchronization attempt.
+sync_timeout = "30s"
 
 # ---------------------------------------------------------------------------
 # Instance pool settings (global defaults for warm-pool recycling).


### PR DESCRIPTION
## Why

The file provider can persist the files and directory metadata already written to one sandbox slot, but its previous contract and configuration names did not accurately describe that host-artifact boundary. The daemon also had no production worker that selected eligible Running sandboxes or coordinated this provider operation with lifecycle and guest operations.

Blaze needs an opt-in periodic path that accurately states this host-artifact boundary and keeps each attempt owned until the underlying provider work finishes, even when scheduler waiting reaches its deadline.

## What changed

**Before:**

- The provider operation could synchronize one slot only when called directly.
- The daemon never scheduled that operation for Running sandboxes.
- The provider contract and interval setting did not clearly state that each call covers the already-written host artifacts visible to that provider call.

**After:**

- The provider contract is named `StorageProvider::sync_artifacts`, and `storage.sync_interval` is the canonical configuration key. The previous interval key remains accepted only as an input alias; supplying both names is rejected.
- A disabled-by-default daemon worker selects Running sandboxes, takes the shared operation lock without blocking the rest of the sweep, rechecks lifecycle and backend ownership, reconstructs the provider slot, and synchronizes that slot.
- `storage.sync_timeout` bounds scheduler waiting for reconstruction and provider synchronization. Work that outlives that wait retains its operation lock, in-flight claim, and single provider permit until it actually completes.
- The file provider binds synchronization to the validated slot directory, synchronizes the canonical artifact files, and then synchronizes the slot directory.
- One sandbox failure is reported without stopping the rest of the sweep. Worker shutdown joins the scheduler and every attempt it started.

```mermaid
flowchart LR
    A["Interval tick"] --> B["Select Running sandboxes"]
    B --> C["Try shared operation lock"]
    C --> D["Recheck lifecycle and backend ownership"]
    D --> E["Reconstruct provider slot"]
    E --> F["sync_artifacts"]
    F --> G["Record per-sandbox result"]
```

A successful attempt means that the already-written bytes and directory metadata visible to each provider call reached that provider's persistence boundary. Concurrent artifact updates may become visible in the current attempt or a later one.

### Commits

1. `872e6900628e` — **clarify the existing artifact synchronization contract.** Renames the provider method, configuration field, failpoint, errors, adapters, and focused tests. It preserves legacy interval input compatibility while making `sync_interval` the only serialized name.
2. `6403d5abe050` — **schedule synchronization for eligible Running sandboxes.** Adds configuration validation, sandbox selection, shared-lock coordination, deadline supervision, descriptor-bound file-provider synchronization, failure isolation, and worker shutdown.
3. `8a482d04bb54` — **document the operator-facing behavior.** Updates examples, READMEs, user guides, and design references in English and Chinese, including the precise capability and timeout boundaries. Changelog entries remain reserved for a release version-bump PR.

These commits belong in one PR because the terminology change defines the contract consumed by the scheduler, the scheduler makes that contract operational, and the documentation explains the same independently usable capability. Splitting any one of them would leave either an ambiguous contract, an unused scheduler contract, or undocumented operator behavior.

### Still to do

1. Add daemon-wide accepted-connection draining and ordered cleanup of unrelated runtime owners before treating daemon shutdown as globally quiescent.
2. Close the narrow configuration-to-scheduler clock-range window tracked in [#2231](https://github.com/alibaba/anolisa/issues/2231); current validation rejects clearly unrepresentable durations, but the scheduling-point arithmetic remains a focused follow-up.

## Related issue

closes #2215

Tracked under #1829.

## User / Agent impact

Operators can opt into periodic synchronization with a positive `storage.sync_interval`; omitted configuration remains disabled. A provider failure remains isolated to its sandbox, and a late provider operation cannot be overtaken by another synchronization, guest operation, or lifecycle transition on the same sandbox.

Existing configurations using the previous interval key continue to parse. Because that key now opts into the worker, deployments that previously set it but want no periodic work should use `sync_interval = "disabled"`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Compatibility or rollback guidance is needed

Rust `StorageProvider` implementations must rename their method to `sync_artifacts`. Configuration input remains compatible through a one-way alias, while serialization and documentation use only `sync_interval`. Providing both interval names is an error rather than silently choosing one.

The timeout bounds scheduler waiting; it does not cancel an underlying blocking filesystem operation or bound how long another operation may wait for the same sandbox lock. The schedule remains disabled by default. The clock-range finding is only partially resolved: configuration-time validation is present, while the scheduling-point check remains tracked in [#2231](https://github.com/alibaba/anolisa/issues/2231).

## Validation

All three exact commits were archived directly from Git and verified in separate Linux x86_64 source trees with matching local/remote archive digests.

For `872e6900628e`, `6403d5abe050`, and `8a482d04bb54`, all applicable commands passed:

- `cargo fmt --all -- --check`
- `cargo build --workspace --all-targets --locked`
- `cargo build --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked`

Exact results:

- `872e6900628e`: archive SHA-256 `98b25080b0dc0241d65fd55d5ee17fcb24ade60bcbffdafabcd840403874258b`; workspace tests 161 default / 171 all-features; config 2/2; provider synchronization 2/2; scheduler not yet introduced.
- `6403d5abe050`: archive SHA-256 `46a68be13d163c123305663688a4da8c5c74e6e21ced1f9ac7a34b04f09a517c`; workspace tests 177 default / 187 all-features; config 4/4; scheduler 12/12; provider synchronization 2/2.
- `8a482d04bb54`: archive SHA-256 `8fa425f3c9d0f2fc77d07fc8387b257129168942bd6e362707614fe3f22cb87f`; workspace tests 177 default / 187 all-features; config 4/4; scheduler 12/12; provider synchronization 2/2.
- Final head: `scripts/docs-lint.sh`, `python3 scripts/docs-link-check.py`, exact parent-to-head `git diff --check`, and commitlint for all three commits passed.

All reported tests completed with zero failures. Hosted checks are reported by GitHub separately.

## Documentation and rollback

The English and Chinese examples, READMEs, user guides, and design references document configuration, eligibility, lock sharing, retry behavior, scheduler deadlines, shutdown, and the persistence boundary. Changelog aggregation remains deferred to a release version-bump PR.

Set `storage.sync_interval = "disabled"` to stop the periodic worker without reverting the PR. Reverting all three commits restores the previous Rust contract and removes the scheduler and its documentation.