### PR TITLE
fix(anolisa): support native qoder plugins

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -42,7 +42,11 @@ pub const CLAIM_SCHEMA_VERSION: u32 = 1;
 
 /// Schema version for [`DriverPayload`]. Bumped independently of
 /// [`CLAIM_SCHEMA_VERSION`] when a driver's typed payload changes shape.
-pub const DRIVER_SCHEMA_VERSION: u32 = 1;
+pub const DRIVER_SCHEMA_VERSION: u32 = 3;
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
 
 /// A single adapter receipt: "the current user's `component` has, through
 /// `framework`'s driver, taken over the framework-side state described by
@@ -579,20 +583,31 @@ pub struct QoderManagedHook {
     pub entry: Value,
 }
 
-/// Qoder driver payload. Holds [`ClaimResource::id`] references and the
-/// exact hook specs ANOLISA wrote — never argv, script paths, or the settings
-/// path itself. The qodercli invocation is rebuilt by the built-in driver,
-/// and the driver recomputes the `settings.json` path from the caller's home
-/// directory rather than reading it back from the receipt, so a forged
-/// payload cannot redirect the write.
+/// Qoder driver payload.
+///
+/// Native receipts reference only the framework-managed plugin. Legacy
+/// receipts also retain the exact settings resource and hook specs that
+/// ANOLISA owns so status and cleanup remain backward compatible.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct QoderClaim {
     /// Resource id of the installed plugin
     /// ([`ClaimResourceKind::FrameworkPlugin`]).
     pub plugin_resource: String,
-    /// Resource id of the user's `settings.json` ANOLISA edits in place
-    /// ([`ClaimResourceKind::ExternalPath`]).
-    pub settings_resource: String,
+    /// Legacy resource id of the user's `settings.json` ANOLISA edits in place
+    /// ([`ClaimResourceKind::ExternalPath`]). Native receipts omit this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings_resource: Option<String>,
+    /// Whether the native plugin registration existed before ANOLISA enable.
+    /// Such a plugin is retained on disable because ANOLISA cannot claim
+    /// ownership of framework state it did not create.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub plugin_preexisting: bool,
+    /// Whether ANOLISA confirmed a successful native plugin installation.
+    /// Native enable persists this transition immediately after qodercli
+    /// succeeds, so a retained write-ahead receipt never infers ownership
+    /// from an install attempt that may not have created the registration.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub plugin_install_confirmed: bool,
     /// Hook names ANOLISA merged into `settings.json` at enable time.
     /// These names are metadata for human/debug visibility; lifecycle logic
     /// uses [`Self::managed_hook_specs`]. `disable` prunes only exact hook
@@ -1520,7 +1535,7 @@ mod tests {
             enabled_at: "2026-07-08T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/qoder"),
             bundle_digest: Some("sha256:90de".to_string()),
-            driver_schema: DRIVER_SCHEMA_VERSION,
+            driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
             resources: vec![
@@ -1542,7 +1557,9 @@ mod tests {
             ],
             driver_payload: DriverPayload::Qoder(QoderClaim {
                 plugin_resource: "qoder_plugin".to_string(),
-                settings_resource: "qoder_settings".to_string(),
+                settings_resource: Some("qoder_settings".to_string()),
+                plugin_preexisting: false,
+                plugin_install_confirmed: false,
                 managed_hooks: vec!["tokenless-rewrite".to_string()],
                 managed_hook_specs: vec![QoderManagedHook {
                     event: "PreToolUse".to_string(),
@@ -1568,6 +1585,10 @@ mod tests {
             adapter_claims: vec![sample_qoder_claim()],
         };
         let text = toml::to_string_pretty(&wrapper).expect("serialize Qoder to TOML");
+        assert!(
+            text.contains("settings_resource = \"qoder_settings\""),
+            "legacy receipt keeps its string settings reference: {text}"
+        );
         let parsed: Wrapper = toml::from_str(&text).expect("parse Qoder from TOML");
         assert_eq!(wrapper, parsed, "Qoder round-trip mismatch; TOML:\n{text}");
 
@@ -1575,6 +1596,77 @@ mod tests {
         let json = serde_json::to_string(&claim).expect("serialize Qoder JSON");
         let back: AdapterClaim = serde_json::from_str(&json).expect("parse Qoder JSON");
         assert_eq!(claim, back);
+    }
+
+    #[test]
+    fn native_qoder_claim_omits_settings_resource() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            adapter_claims: Vec<AdapterClaim>,
+        }
+
+        let mut claim = sample_qoder_claim();
+        claim
+            .resources
+            .retain(|resource| resource.id == "qoder_plugin");
+        let DriverPayload::Qoder(payload) = &mut claim.driver_payload else {
+            unreachable!("sample is a Qoder claim")
+        };
+        payload.settings_resource = None;
+        payload.plugin_preexisting = false;
+        payload.plugin_install_confirmed = true;
+        payload.managed_hooks.clear();
+        payload.managed_hook_specs.clear();
+        claim.driver_schema = DRIVER_SCHEMA_VERSION;
+        let wrapper = Wrapper {
+            adapter_claims: vec![claim],
+        };
+
+        let text = toml::to_string_pretty(&wrapper).expect("serialize native Qoder receipt");
+        assert!(!text.contains("settings_resource"), "native TOML: {text}");
+        assert!(
+            text.contains("plugin_install_confirmed = true"),
+            "native TOML: {text}"
+        );
+        assert_eq!(wrapper.adapter_claims[0].driver_schema, 3);
+        let parsed: Wrapper = toml::from_str(&text).expect("parse native Qoder receipt");
+        assert_eq!(wrapper, parsed);
+    }
+
+    #[test]
+    fn native_qoder_v2_receipt_defaults_install_confirmation_to_false() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            adapter_claims: Vec<AdapterClaim>,
+        }
+
+        let mut claim = sample_qoder_claim();
+        claim
+            .resources
+            .retain(|resource| resource.id == "qoder_plugin");
+        let DriverPayload::Qoder(payload) = &mut claim.driver_payload else {
+            unreachable!("sample is a Qoder claim")
+        };
+        payload.settings_resource = None;
+        payload.plugin_preexisting = false;
+        payload.plugin_install_confirmed = false;
+        payload.managed_hooks.clear();
+        payload.managed_hook_specs.clear();
+        claim.driver_schema = 2;
+        let text = toml::to_string_pretty(&Wrapper {
+            adapter_claims: vec![claim],
+        })
+        .expect("serialize v2 Native Qoder receipt");
+        assert!(
+            !text.contains("plugin_install_confirmed"),
+            "v2 TOML: {text}"
+        );
+
+        let parsed: Wrapper = toml::from_str(&text).expect("parse v2 Native Qoder receipt");
+        let DriverPayload::Qoder(payload) = &parsed.adapter_claims[0].driver_payload else {
+            unreachable!("fixture is a Qoder claim")
+        };
+        assert!(!payload.plugin_install_confirmed);
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -164,6 +164,11 @@ pub enum PreparedEnable {
         /// claiming an entry until its `config set` command succeeds.
         selected_config_indices: Vec<usize>,
     },
+    /// Qoder native-plugin capabilities resolved before installation.
+    QoderNative {
+        /// Exact qodercli program selected during the read-only preflight.
+        program: String,
+    },
 }
 
 /// Manager-owned persistence channel for resources applied incrementally.
@@ -264,6 +269,8 @@ pub enum AdapterConditionKind {
     ResourceBundleMatches,
     /// The plugin is still present in the framework registry.
     PluginRegistered,
+    /// The framework reports the plugin's declared resources as loaded.
+    PluginResourcesLoaded,
     /// The framework-native activation policy currently enables the plugin.
     ActivationEnabled,
     /// A marketplace source is still registered (future drivers).
@@ -365,6 +372,23 @@ pub trait AdapterOps {
     /// A non-zero exit or a timeout is reported through [`CliOutput`], not
     /// as an error, so the driver decides how to interpret it.
     fn run_framework_cli(&self, cmd: FrameworkCommand) -> Result<CliOutput, AdapterError>;
+
+    /// Spawn a framework CLI whose stdout is structured JSON that must be
+    /// captured beyond the ordinary diagnostic-output limit. The Manager
+    /// still applies a larger finite bound and keeps stderr at the normal
+    /// cap, so unexpectedly large framework output cannot grow without
+    /// limit.
+    ///
+    /// Custom operation providers default to the ordinary runner; the
+    /// production Manager overrides this method with the structured-output
+    /// capture policy.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when the process cannot be spawned.
+    fn run_framework_cli_json(&self, cmd: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+        self.run_framework_cli(cmd)
+    }
 
     /// Recursively copy a directory tree from `src` to `dst`. The Manager
     /// validates that `dst` is under an allowed external root before
@@ -534,6 +558,21 @@ pub trait FrameworkDriver: Send + Sync {
         _prior: &AdapterClaim,
         _next: &mut AdapterClaim,
     ) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    /// Validate the final prepared receipt after re-enable facts have been
+    /// preserved, but before the Manager persists it or mutates framework
+    /// state.
+    ///
+    /// Drivers can use this hook for ownership conflicts that are visible
+    /// during read-only preparation but may be resolved by a validated prior
+    /// receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns a driver-specific ownership or receipt consistency error.
+    fn validate_prepared_enable(&self, _claim: &AdapterClaim) -> Result<(), AdapterError> {
         Ok(())
     }
 

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -55,6 +55,13 @@ const LOG_SOURCE: &str = "anolisa-cli";
 /// Output beyond this is drained (so the child never blocks on a full
 /// pipe) but discarded before logging.
 const OUTPUT_CAP: usize = 64 * 1024;
+/// Cap on stdout for framework commands that return structured JSON.
+///
+/// Inventory commands need substantially more than diagnostic commands:
+/// Qoder reports every plugin and its resources in one document. Four MiB
+/// covers thousands of ordinary entries while retaining a finite memory
+/// bound. Stderr remains subject to [`OUTPUT_CAP`].
+const JSON_OUTPUT_CAP: usize = 4 * 1024 * 1024;
 /// Outcome of [`AdapterManager::enable`].
 #[derive(Debug, Clone)]
 pub enum EnableOutcome {
@@ -775,6 +782,7 @@ impl AdapterManager {
             &claim_allowed_roots,
             &self.all_datadir_roots,
         )?;
+        driver.validate_prepared_enable(&claim)?;
 
         state.upsert_adapter_claim(claim.clone());
         state.save(&self.state_path)?;
@@ -1941,6 +1949,12 @@ impl AdapterOps for ManagerOps {
         Ok(output)
     }
 
+    fn run_framework_cli_json(&self, cmd: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+        let output = run_capture_with_stdout_cap(&cmd, JSON_OUTPUT_CAP)?;
+        self.record(&cmd, &output);
+        Ok(output)
+    }
+
     fn copy_tree(&self, src: &Path, dst: &Path) -> Result<(), AdapterError> {
         validate_ops_path(src, &self.allowed_roots)?;
         validate_ops_path(dst, &self.allowed_roots)?;
@@ -2188,6 +2202,15 @@ fn symlink_file(_target: &Path, _link: &Path) -> std::io::Result<()> {
 /// truncated output. The child's stdout/stderr are drained on separate
 /// threads so a full pipe can never deadlock the wait loop.
 fn run_capture(cmd: &FrameworkCommand) -> Result<CliOutput, AdapterError> {
+    run_capture_with_stdout_cap(cmd, OUTPUT_CAP)
+}
+
+/// Run a framework CLI with a caller-selected bounded stdout capture.
+/// Stderr stays on the ordinary diagnostic cap regardless of stdout policy.
+fn run_capture_with_stdout_cap(
+    cmd: &FrameworkCommand,
+    stdout_cap: usize,
+) -> Result<CliOutput, AdapterError> {
     let mut command = Command::new(&cmd.program);
     command
         .args(&cmd.args)
@@ -2216,7 +2239,7 @@ fn run_capture(cmd: &FrameworkCommand) -> Result<CliOutput, AdapterError> {
         }
     })?;
 
-    let stdout_handle = child.stdout.take().map(|r| spawn_drain(r, OUTPUT_CAP));
+    let stdout_handle = child.stdout.take().map(|r| spawn_drain(r, stdout_cap));
     let stderr_handle = child.stderr.take().map(|r| spawn_drain(r, OUTPUT_CAP));
     let start = Instant::now();
     let mut stdin_handle = if let Some(input) = &cmd.stdin {

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -389,6 +389,11 @@ impl FrameworkDriver for OpenClawDriver {
                         "openclaw plugin enable requires prepared host capabilities",
                     ));
                 }
+                PreparedEnable::QoderNative { .. } => {
+                    return Err(prepared_state_mismatch(
+                        "openclaw plugin enable received Qoder capabilities",
+                    ));
+                }
             }
         };
         validate_config_claim_state(claim)?;

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
@@ -1,44 +1,19 @@
 //! Qoder (`qodercli`) framework driver.
 //!
-//! Qoder CLI installs a plugin from a directory whose name becomes the
-//! plugin id (`qodercli plugins install <dir>`), then activates it through
-//! two entries in `~/.qoder/settings.json`: the plugin's hooks under
-//! `.hooks`, and `<plugin>@local` under `.plugins.enabled`. ANOLISA
-//! reproduces the legacy install script's behavior entirely in this driver
-//! — it never shells out to `scripts/install.sh` / `uninstall.sh`:
+//! The driver supports two unambiguous bundle layouts. Native bundles carry
+//! `.qoder-plugin/plugin.json` plus `hooks/hooks.json`; their complete
+//! lifecycle is delegated to `qodercli plugins`, and registration,
+//! activation, and loaded hooks are verified from `plugins list --json`.
+//! ANOLISA installs the original resource root without staging or rewriting
+//! plugin files and never edits `~/.qoder/settings.json` for this mode.
 //!
-//! ```text
-//! qodercli plugins install <staging>/<plugin>   # staging = <data>/qoder-plugins
-//! # merge our hooks + <plugin>@local into ~/.qoder/settings.json in place
-//! ```
-//!
-//! The plugin bundle lives under a resource directory named `qoder`, but
-//! `qodercli` derives the plugin id from the *directory name*, so enable
-//! stages a real copy of the bundle under a directory named after the
-//! plugin id (`tokenless`) and installs from there — mirroring the legacy
-//! script's private tempdir. The staged copy's `hooks.json` is patched
-//! first: qodercli copies the plugin into its cache verbatim, and
-//! consumers that load the cached `hooks.json` directly (the Qoder IDE
-//! shares `~/.qoder` with qodercli) never expand
-//! `${QODER_TOKENLESS_HOOKS}` — staging a symlink to the raw bundle would
-//! leave them with broken hook commands whose non-zero exit is treated as
-//! a tool-call block. Staging is install-time only and is removed
-//! immediately after install.
-//!
-//! **settings.json is merged, then atomically swapped in via rename.** All
-//! reads and writes go through the Manager's controlled
-//! [`AdapterOps`](super::driver::AdapterOps); the driver only ever adds or
-//! removes ANOLISA-managed entries (the exact hook entries resolved from the
-//! bundle at enable time and persisted in the receipt, plus the
-//! `<plugin>@local` plugin entry). A settings file that exists but cannot be
-//! parsed is left untouched: enable fails closed and disable reports cleanup
-//! incomplete, so ANOLISA never clobbers a config it cannot safely merge.
-//!
-//! `qodercli plugins list` has been observed to omit freshly installed
-//! plugins, so `status` does **not** trust it: plugin registration is
-//! reported `Unknown` rather than faked healthy. The reliable, CLI-free
-//! signal is the presence of our managed entries in `settings.json`, which
-//! `status` verifies directly.
+//! Legacy bundles carry the same manifest plus a root-level `hooks.json`.
+//! That branch preserves the original Tokenless integration exactly: it
+//! stages a plugin-id-named copy, expands `${QODER_TOKENLESS_HOOKS}`, installs
+//! the copy, and atomically merges only its owned hooks and activation entry
+//! into `settings.json`. Legacy status remains settings-based because older
+//! qodercli inventories could omit freshly installed plugins, and legacy
+//! disable prunes only the exact entries persisted in its receipt.
 //!
 //! Env contract: `QODERCLI_BIN` overrides the executable (tests point it at
 //! a fake CLI); otherwise the binary is resolved in the legacy order
@@ -74,13 +49,17 @@ use settings::{
 /// Default timeout for a `qodercli` invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Qoder-native plugin manifest inside the bundle. The contract may override
-/// the entry, but this is the default the legacy layout ships.
+/// Qoder plugin manifest shared by native and legacy layouts.
 const QODER_PLUGIN_MANIFEST: &str = ".qoder-plugin/plugin.json";
 
-/// Hook declarations shipped alongside the plugin manifest, merged into the
-/// user's `settings.json` at enable time.
+/// Legacy hook declarations merged into the user's `settings.json`.
 const QODER_HOOKS_FILE: &str = "hooks.json";
+
+/// Qoder-native hook declarations auto-discovered by `qodercli`.
+const QODER_NATIVE_HOOKS_FILE: &str = "hooks/hooks.json";
+
+/// Native lifecycle mutations are always owned in Qoder's user scope.
+const QODER_NATIVE_SCOPE: &str = "user";
 
 /// Placeholder in `hooks.json` for the absolute hook-scripts directory,
 /// expanded to `<resource_root>/../common/hooks` before the entries are
@@ -90,6 +69,12 @@ const HOOKS_PLACEHOLDER: &str = "${QODER_TOKENLESS_HOOKS}";
 /// Resource ids used in Qoder receipts.
 const RES_PLUGIN: &str = "qoder_plugin";
 const RES_SETTINGS: &str = "qoder_settings";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QoderBundleKind {
+    Native,
+    Legacy,
+}
 
 /// Qoder driver. Stateless; all per-operation context arrives via
 /// [`DriverCtx`].
@@ -114,13 +99,11 @@ impl FrameworkDriver for QoderDriver {
     }
 
     fn probe_bundle(&self, resource_root: &Path, declared_entry: Option<&str>) -> bool {
-        // Mirrors read_bundle's mandatory checks: the plugin manifest (or
-        // the contract-declared entry) AND hooks.json must both be
-        // present — a manifest-only leftover is not a usable bundle.
-        resource_root
-            .join(declared_entry.unwrap_or(QODER_PLUGIN_MANIFEST))
-            .is_file()
-            && resource_root.join(QODER_HOOKS_FILE).is_file()
+        if declared_entry.is_some_and(|entry| entry != QODER_PLUGIN_MANIFEST) {
+            return false;
+        }
+        resource_root.join(QODER_PLUGIN_MANIFEST).is_file()
+            && classify_bundle(resource_root).is_ok()
     }
 
     fn detect(&self, env: &HostEnv) -> DetectResult {
@@ -161,10 +144,17 @@ impl FrameworkDriver for QoderDriver {
                 reason: "resource root does not exist or is not a directory".to_string(),
             });
         }
-        let manifest = ctx
-            .declared_bundle_entry
-            .as_deref()
-            .unwrap_or(QODER_PLUGIN_MANIFEST);
+        if let Some(entry) = ctx.declared_bundle_entry.as_deref()
+            && entry != QODER_PLUGIN_MANIFEST
+        {
+            return Err(AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: format!(
+                    "qoder bundle entry must be the native manifest '{QODER_PLUGIN_MANIFEST}', got '{entry}'"
+                ),
+            });
+        }
+        let manifest = QODER_PLUGIN_MANIFEST;
         if !root.join(manifest).is_file() {
             return Err(AdapterError::BundleInvalid {
                 root: root.clone(),
@@ -173,17 +163,18 @@ impl FrameworkDriver for QoderDriver {
                 ),
             });
         }
-        if !root.join(QODER_HOOKS_FILE).is_file() {
-            return Err(AdapterError::BundleInvalid {
-                root: root.clone(),
-                reason: format!("qoder '{QODER_HOOKS_FILE}' missing from resource root"),
-            });
-        }
-        let plugin_id = ctx
-            .declared_plugin_id
-            .clone()
-            .filter(|id| !id.is_empty())
-            .unwrap_or_else(|| ctx.component.clone());
+        let kind = classify_bundle(root).map_err(|reason| AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason,
+        })?;
+        let plugin_id = match kind {
+            QoderBundleKind::Native => read_native_bundle(ctx, manifest)?,
+            QoderBundleKind::Legacy => ctx
+                .declared_plugin_id
+                .clone()
+                .filter(|id| !id.is_empty())
+                .unwrap_or_else(|| ctx.component.clone()),
+        };
         // Validate the resolved plugin id (including the component-name
         // default) before it can reach an argv or a staging directory name.
         validate_plugin_id(&plugin_id)?;
@@ -202,6 +193,26 @@ impl FrameworkDriver for QoderDriver {
         let plugin = plugin_name(bundle, ctx);
         let program =
             qodercli_program(ctx.user_home.as_deref()).unwrap_or_else(|| "qodercli".to_string());
+        let kind = classify_bundle(&bundle.resource_root).map_err(|reason| {
+            AdapterError::BundleInvalid {
+                root: bundle.resource_root.clone(),
+                reason,
+            }
+        })?;
+        if kind == QoderBundleKind::Native {
+            let install_cmd = build_native_install_cmd(&program, &bundle.resource_root);
+            return Ok(DriverPlan {
+                framework: self.name().to_string(),
+                component: ctx.component.clone(),
+                actions: vec![
+                    "validate the native Qoder plugin bundle and CLI capabilities".to_string(),
+                    format!("install and enable native Qoder plugin '{plugin}'"),
+                    "verify registration, activation, and loaded hooks via JSON inventory"
+                        .to_string(),
+                ],
+                register_command: Some(display_command(&install_cmd)),
+            });
+        }
         let staging = staging_symlink(ctx.user_home.as_deref(), &plugin);
         let staging_display = staging
             .as_ref()
@@ -241,6 +252,92 @@ impl FrameworkDriver for QoderDriver {
     ) -> Result<(AdapterClaim, PreparedEnable), AdapterError> {
         let plugin = plugin_name(bundle, ctx);
         validate_plugin_id(&plugin)?;
+        let kind = classify_bundle(&bundle.resource_root).map_err(|reason| {
+            AdapterError::BundleInvalid {
+                root: bundle.resource_root.clone(),
+                reason,
+            }
+        })?;
+        if kind == QoderBundleKind::Native {
+            let program = require_native_qodercli(ctx)?;
+            let validate_capability = ctx
+                .ops
+                .run_framework_cli(build_native_help_cmd(&program, "validate"))?;
+            for subcommand in ["install", "list", "uninstall"] {
+                require_cli_success(
+                    &program,
+                    &format!("plugins {subcommand} --help"),
+                    ctx.ops
+                        .run_framework_cli(build_native_help_cmd(&program, subcommand))?,
+                )?;
+            }
+            if validate_capability.success() {
+                require_cli_success(
+                    &program,
+                    "plugins validate",
+                    ctx.ops.run_framework_cli(build_native_validate_cmd(
+                        &program,
+                        &bundle.resource_root,
+                    ))?,
+                )?;
+            }
+            let inventory = ctx
+                .ops
+                .run_framework_cli_json(build_native_list_cmd(&program))?;
+            require_cli_success(&program, "plugins list --json", inventory.clone())?;
+            let expected = plugin_entry(&plugin);
+            let matching =
+                parse_native_plugin_matches(&inventory.stdout, &expected).map_err(|reason| {
+                    AdapterError::FrameworkCli {
+                        program: program.clone(),
+                        reason: format!(
+                            "Qoder native plugin inventory is unavailable ({reason}); upgrade Qoder"
+                        ),
+                    }
+                })?;
+            if !matching.non_user_scopes.is_empty() {
+                return Err(AdapterError::FrameworkCli {
+                    program,
+                    reason: format!(
+                        "refusing to install {expected} while matching non-user Qoder registration(s) exist in scope(s) {}; Qoder shares the local plugin cache across scopes",
+                        matching.non_user_scopes.join(", ")
+                    ),
+                });
+            }
+            let plugin_preexisting = matching.user.is_some();
+
+            let claim = AdapterClaim {
+                claim_schema: CLAIM_SCHEMA_VERSION,
+                component: ctx.component.clone(),
+                framework: self.name().to_string(),
+                plugin_id: Some(plugin.clone()),
+                adapter_type: ctx.adapter_type.clone(),
+                enabled_at: now_iso8601(),
+                resource_root: bundle.resource_root.clone(),
+                bundle_digest: bundle.digest.clone(),
+                driver_schema: DRIVER_SCHEMA_VERSION,
+                status: ClaimStatus::Enabled,
+                notices: Vec::new(),
+                resources: vec![ClaimResource {
+                    id: RES_PLUGIN.to_string(),
+                    purpose: "qoder_plugin".to_string(),
+                    kind: ClaimResourceKind::FrameworkPlugin {
+                        framework: self.name().to_string(),
+                        plugin_id: plugin,
+                    },
+                }],
+                driver_payload: DriverPayload::Qoder(QoderClaim {
+                    plugin_resource: RES_PLUGIN.to_string(),
+                    settings_resource: None,
+                    plugin_preexisting,
+                    plugin_install_confirmed: false,
+                    managed_hooks: Vec::new(),
+                    managed_hook_specs: Vec::new(),
+                }),
+            };
+            return Ok((claim, PreparedEnable::QoderNative { program }));
+        }
+
         let settings =
             settings_path(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
                 program: "qodercli".to_string(),
@@ -283,7 +380,9 @@ impl FrameworkDriver for QoderDriver {
                 resources,
                 driver_payload: DriverPayload::Qoder(QoderClaim {
                     plugin_resource: RES_PLUGIN.to_string(),
-                    settings_resource: RES_SETTINGS.to_string(),
+                    settings_resource: Some(RES_SETTINGS.to_string()),
+                    plugin_preexisting: false,
+                    plugin_install_confirmed: false,
                     managed_hooks,
                     managed_hook_specs,
                 }),
@@ -292,13 +391,127 @@ impl FrameworkDriver for QoderDriver {
         ))
     }
 
+    fn preserve_reenable_facts(
+        &self,
+        prior: &AdapterClaim,
+        next: &mut AdapterClaim,
+    ) -> Result<(), AdapterError> {
+        let prior_native = native_claim(prior)?;
+        let next_native = native_claim(next)?;
+        if prior_native != next_native {
+            let prior_kind = if prior_native { "native" } else { "legacy" };
+            let next_kind = if next_native { "native" } else { "legacy" };
+            return Err(AdapterError::BundleInvalid {
+                root: next.resource_root.clone(),
+                reason: format!(
+                    "qoder bundle lifecycle changed from {prior_kind} to {next_kind}; disable the existing adapter before re-enabling"
+                ),
+            });
+        }
+        if next_native {
+            let prior_plugin =
+                resolve_plugin(prior).ok_or_else(|| AdapterError::BundleInvalid {
+                    root: prior.resource_root.clone(),
+                    reason: "existing qoder receipt has no plugin resource".to_string(),
+                })?;
+            let next_plugin = resolve_plugin(next).ok_or_else(|| AdapterError::BundleInvalid {
+                root: next.resource_root.clone(),
+                reason: "new qoder receipt has no plugin resource".to_string(),
+            })?;
+            if prior_plugin != next_plugin {
+                return Err(AdapterError::BundleInvalid {
+                    root: next.resource_root.clone(),
+                    reason: format!(
+                        "qoder native plugin id changed from '{prior_plugin}' to '{next_plugin}'; disable the existing adapter before re-enabling"
+                    ),
+                });
+            }
+            let prior_payload =
+                qoder_payload(prior).ok_or_else(|| AdapterError::BundleInvalid {
+                    root: prior.resource_root.clone(),
+                    reason: "existing qoder receipt has a non-qoder driver payload".to_string(),
+                })?;
+            let prior_owned =
+                !prior_payload.plugin_preexisting && native_install_confirmed(prior, prior_payload);
+            let next_root = next.resource_root.clone();
+            let next_payload =
+                qoder_payload_mut(next).ok_or_else(|| AdapterError::BundleInvalid {
+                    root: next_root,
+                    reason: "new qoder receipt has a non-qoder driver payload".to_string(),
+                })?;
+            // Ownership can cross a same-ID re-enable only while the
+            // registration is still present and a prior install checkpoint
+            // proved ANOLISA created it. An absent registration starts a new
+            // unconfirmed write-ahead lifecycle.
+            if next_payload.plugin_preexisting && prior_owned {
+                next_payload.plugin_preexisting = false;
+                next_payload.plugin_install_confirmed = true;
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_prepared_enable(&self, claim: &AdapterClaim) -> Result<(), AdapterError> {
+        if native_claim(claim)?
+            && qoder_payload(claim).is_some_and(|payload| payload.plugin_preexisting)
+        {
+            let plugin = resolve_plugin(claim).ok_or_else(|| AdapterError::BundleInvalid {
+                root: claim.resource_root.clone(),
+                reason: "qoder receipt has no plugin resource".to_string(),
+            })?;
+            return Err(AdapterError::FrameworkCli {
+                program: "qodercli".to_string(),
+                reason: format!(
+                    "refusing to replace pre-existing user-scope Qoder plugin '{}'; remove it explicitly before enabling",
+                    plugin_entry(&plugin)
+                ),
+            });
+        }
+        Ok(())
+    }
+
     fn apply_enable(
         &self,
         claim: &mut AdapterClaim,
-        _prepared: &PreparedEnable,
+        prepared: &PreparedEnable,
         ctx: &DriverCtx,
-        _progress: &mut dyn super::driver::EnableProgress,
+        progress: &mut dyn super::driver::EnableProgress,
     ) -> Result<(), AdapterError> {
+        if native_claim(claim)? {
+            let PreparedEnable::QoderNative { program } = prepared else {
+                return Err(AdapterError::BundleInvalid {
+                    root: claim.resource_root.clone(),
+                    reason: "native Qoder enable requires prepared CLI capabilities".to_string(),
+                });
+            };
+            let plugin = resolve_plugin(claim).ok_or_else(|| AdapterError::BundleInvalid {
+                root: claim.resource_root.clone(),
+                reason: "qoder receipt has no plugin resource".to_string(),
+            })?;
+            let output = ctx
+                .ops
+                .run_framework_cli(build_native_install_cmd(program, &claim.resource_root))?;
+            require_cli_success(program, "plugins install", output)?;
+            let root = claim.resource_root.clone();
+            let payload = qoder_payload_mut(claim).ok_or_else(|| AdapterError::BundleInvalid {
+                root,
+                reason: "qoder receipt has a non-qoder driver payload".to_string(),
+            })?;
+            payload.plugin_install_confirmed = true;
+            progress.persist_claim(claim)?;
+            return verify_native_plugin(ctx, program, &plugin).map_err(|reason| {
+                AdapterError::FrameworkCli {
+                    program: program.clone(),
+                    reason,
+                }
+            });
+        }
+        if !matches!(prepared, PreparedEnable::None) {
+            return Err(AdapterError::BundleInvalid {
+                root: claim.resource_root.clone(),
+                reason: "legacy Qoder enable received native CLI capabilities".to_string(),
+            });
+        }
         // Resolve plugin + settings strictly from the receipt's payload
         // references (Manager-validated), failing closed on a malformed
         // receipt rather than falling back to ctx-derived defaults.
@@ -378,6 +591,9 @@ impl FrameworkDriver for QoderDriver {
         claim: &AdapterClaim,
         ctx: &DriverCtx,
     ) -> Result<AdapterStatusReport, AdapterError> {
+        if native_claim(claim)? {
+            return native_status(claim, ctx);
+        }
         let mut conditions = Vec::new();
         let detect = self.detect(&HostEnv {
             user_home: ctx.user_home.clone(),
@@ -504,6 +720,9 @@ impl FrameworkDriver for QoderDriver {
         claim: &AdapterClaim,
         ctx: &DriverCtx,
     ) -> Result<DisableReport, AdapterError> {
+        if native_claim(claim)? {
+            return disable_native(claim, ctx);
+        }
         // Framework-side deregistration needs the CLI. Without it, the plugin
         // would stay in qodercli's cache, so keep the receipt for a retry
         // rather than pruning settings and pretending cleanup finished.
@@ -583,6 +802,80 @@ impl FrameworkDriver for QoderDriver {
 // ---------------------------------------------------------------------------
 // Pure path / identifier helpers
 // ---------------------------------------------------------------------------
+
+fn classify_bundle(resource_root: &Path) -> Result<QoderBundleKind, String> {
+    let legacy = resource_root.join(QODER_HOOKS_FILE).is_file();
+    let native = resource_root.join(QODER_NATIVE_HOOKS_FILE).is_file();
+    match (native, legacy) {
+        (true, false) => Ok(QoderBundleKind::Native),
+        (false, true) => Ok(QoderBundleKind::Legacy),
+        (true, true) => Err(format!(
+            "qoder bundle is ambiguous: both '{QODER_NATIVE_HOOKS_FILE}' and '{QODER_HOOKS_FILE}' exist"
+        )),
+        (false, false) => Err(format!(
+            "qoder bundle has neither '{QODER_NATIVE_HOOKS_FILE}' nor '{QODER_HOOKS_FILE}'"
+        )),
+    }
+}
+
+fn read_native_bundle(ctx: &DriverCtx, manifest: &str) -> Result<String, AdapterError> {
+    let root = &ctx.resource_root;
+    let manifest_path = root.join(manifest);
+    let bytes = ctx
+        .ops
+        .read_file(&manifest_path)?
+        .ok_or_else(|| AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason: format!("qoder plugin manifest '{manifest}' is missing"),
+        })?;
+    let value: Value =
+        serde_json::from_slice(&bytes).map_err(|source| AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason: format!("failed to parse qoder plugin manifest '{manifest}': {source}"),
+        })?;
+    let manifest_name = value
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason: format!("qoder plugin manifest '{manifest}' has no non-empty 'name'"),
+        })?;
+    if let Some(declared) = ctx
+        .declared_plugin_id
+        .as_deref()
+        .filter(|declared| !declared.is_empty())
+        && declared != manifest_name
+    {
+        return Err(AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason: format!(
+                "declared qoder plugin id '{declared}' does not match manifest name '{manifest_name}'"
+            ),
+        });
+    }
+
+    let hooks_path = root.join(QODER_NATIVE_HOOKS_FILE);
+    let hooks_bytes =
+        ctx.ops
+            .read_file(&hooks_path)?
+            .ok_or_else(|| AdapterError::BundleInvalid {
+                root: root.clone(),
+                reason: format!("native qoder hooks '{QODER_NATIVE_HOOKS_FILE}' are missing"),
+            })?;
+    let hooks: Value =
+        serde_json::from_slice(&hooks_bytes).map_err(|source| AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason: format!("failed to parse {QODER_NATIVE_HOOKS_FILE}: {source}"),
+        })?;
+    if !hooks.get("hooks").is_some_and(Value::is_object) {
+        return Err(AdapterError::BundleInvalid {
+            root: root.clone(),
+            reason: format!("{QODER_NATIVE_HOOKS_FILE} lacks the top-level 'hooks' object"),
+        });
+    }
+    Ok(manifest_name.to_string())
+}
 
 /// Plugin name for the receipt: the bundle's resolved id, else component.
 fn plugin_name(bundle: &AdapterBundle, ctx: &DriverCtx) -> String {
@@ -678,6 +971,45 @@ fn qoder_payload(claim: &AdapterClaim) -> Option<&QoderClaim> {
     }
 }
 
+fn qoder_payload_mut(claim: &mut AdapterClaim) -> Option<&mut QoderClaim> {
+    match &mut claim.driver_payload {
+        DriverPayload::Qoder(qoder) => Some(qoder),
+        _ => None,
+    }
+}
+
+/// Only the explicit schema-v3 checkpoint proves ANOLISA installed a Native
+/// plugin. Older receipts were written as `Enabled` before mutation, so
+/// their status cannot safely imply ownership.
+fn native_install_confirmed(claim: &AdapterClaim, payload: &QoderClaim) -> bool {
+    claim.driver_schema >= DRIVER_SCHEMA_VERSION && payload.plugin_install_confirmed
+}
+
+/// Native receipts omit legacy settings ownership and hook specs.
+fn native_claim(claim: &AdapterClaim) -> Result<bool, AdapterError> {
+    let payload = qoder_payload(claim).ok_or_else(|| AdapterError::BundleInvalid {
+        root: claim.resource_root.clone(),
+        reason: "qoder receipt has a non-qoder driver payload".to_string(),
+    })?;
+    if payload.settings_resource.is_none()
+        && (!payload.managed_hooks.is_empty() || !payload.managed_hook_specs.is_empty())
+    {
+        return Err(AdapterError::BundleInvalid {
+            root: claim.resource_root.clone(),
+            reason: "qoder receipt is inconsistent: settings resource is absent while legacy managed hook facts remain"
+                .to_string(),
+        });
+    }
+    if payload.plugin_preexisting && payload.plugin_install_confirmed {
+        return Err(AdapterError::BundleInvalid {
+            root: claim.resource_root.clone(),
+            reason: "qoder receipt is inconsistent: a pre-existing plugin cannot have an ANOLISA install confirmation"
+                .to_string(),
+        });
+    }
+    Ok(payload.settings_resource.is_none())
+}
+
 /// Resolve the plugin name strictly from the payload's `plugin_resource`
 /// reference. Returns `None` (fail closed) when the payload is not Qoder's,
 /// the referenced resource is missing, or it is not a `FrameworkPlugin`.
@@ -711,12 +1043,11 @@ fn resolve_plugin(claim: &AdapterClaim) -> Option<String> {
 /// `ExternalPath`, or `user_home` is unknown.
 fn resolve_settings(claim: &AdapterClaim, user_home: Option<&Path>) -> Option<PathBuf> {
     let payload = qoder_payload(claim)?;
-    let recorded = claim
-        .resource(&payload.settings_resource)
-        .and_then(|r| match &r.kind {
-            ClaimResourceKind::ExternalPath { path } => Some(path.clone()),
-            _ => None,
-        })?;
+    let resource_id = payload.settings_resource.as_deref()?;
+    let recorded = claim.resource(resource_id).and_then(|r| match &r.kind {
+        ClaimResourceKind::ExternalPath { path } => Some(path.clone()),
+        _ => None,
+    })?;
     let expected = settings_path(user_home)?;
     (recorded == expected).then_some(recorded)
 }
@@ -724,6 +1055,425 @@ fn resolve_settings(claim: &AdapterClaim, user_home: Option<&Path>) -> Option<Pa
 /// Exact Qoder hook entries ANOLISA owns, persisted in the receipt payload.
 fn managed_hook_specs(claim: &AdapterClaim) -> Option<&[QoderManagedHook]> {
     qoder_payload(claim).map(|q| q.managed_hook_specs.as_slice())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NativePluginInventory {
+    enabled: bool,
+    hooks_loaded: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativePluginMatches {
+    user: Option<NativePluginInventory>,
+    non_user_scopes: Vec<String>,
+}
+
+fn parse_plugin_items(text: &str) -> Result<Vec<Value>, String> {
+    let root: Value =
+        serde_json::from_str(text).map_err(|source| format!("invalid JSON: {source}"))?;
+    if let Some(items) = root.as_array() {
+        return Ok(items.clone());
+    }
+    ["plugins", "installed", "items"]
+        .iter()
+        .find_map(|key| root.get(key).and_then(Value::as_array))
+        .cloned()
+        .ok_or_else(|| "plugin inventory root is not an array".to_string())
+}
+
+fn parse_native_plugin(
+    text: &str,
+    expected_id: &str,
+) -> Result<Option<NativePluginInventory>, String> {
+    Ok(parse_native_plugin_matches(text, expected_id)?.user)
+}
+
+fn parse_native_plugin_matches(
+    text: &str,
+    expected_id: &str,
+) -> Result<NativePluginMatches, String> {
+    let items = parse_plugin_items(text)?;
+    let matching = items
+        .iter()
+        .filter(|item| {
+            item.get("id").and_then(Value::as_str) == Some(expected_id)
+                || item.get("pluginId").and_then(Value::as_str) == Some(expected_id)
+        })
+        .map(|item| {
+            let scope = item
+                .get("scope")
+                .and_then(Value::as_str)
+                .ok_or_else(|| format!("{expected_id} has no string 'scope' provenance"))?;
+            Ok((scope, item))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let mut non_user_scopes = matching
+        .iter()
+        .filter(|&(scope, _)| *scope != QODER_NATIVE_SCOPE)
+        .map(|(scope, _)| (*scope).to_string())
+        .collect::<Vec<_>>();
+    non_user_scopes.sort();
+    non_user_scopes.dedup();
+    let mut user_plugins = matching
+        .iter()
+        .filter_map(|(scope, item)| (*scope == QODER_NATIVE_SCOPE).then_some(*item));
+    let Some(plugin) = user_plugins.next() else {
+        return Ok(NativePluginMatches {
+            user: None,
+            non_user_scopes,
+        });
+    };
+    if user_plugins.next().is_some() {
+        return Err(format!(
+            "{expected_id} has multiple '{QODER_NATIVE_SCOPE}'-scope inventory entries"
+        ));
+    }
+    let enabled = plugin
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| format!("{expected_id} has no boolean 'enabled' state"))?;
+    let hooks_loaded = plugin
+        .get("resources")
+        .and_then(Value::as_object)
+        .and_then(|resources| resources.get("hooks"))
+        .and_then(Value::as_array)
+        .is_some_and(|hooks| !hooks.is_empty());
+    Ok(NativePluginMatches {
+        user: Some(NativePluginInventory {
+            enabled,
+            hooks_loaded,
+        }),
+        non_user_scopes,
+    })
+}
+
+fn require_cli_success(
+    program: &str,
+    action: &str,
+    output: super::driver::CliOutput,
+) -> Result<(), AdapterError> {
+    if output.success() {
+        Ok(())
+    } else {
+        Err(AdapterError::FrameworkCli {
+            program: program.to_string(),
+            reason: cli_failure_reason(action, &output),
+        })
+    }
+}
+
+fn require_native_qodercli(ctx: &DriverCtx) -> Result<String, AdapterError> {
+    qodercli_program(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
+        program: "qodercli".to_string(),
+        reason: "qodercli not found on PATH or under ~/.qoder/bin".to_string(),
+    })
+}
+
+fn verify_native_plugin(ctx: &DriverCtx, program: &str, plugin: &str) -> Result<(), String> {
+    let output = ctx
+        .ops
+        .run_framework_cli_json(build_native_list_cmd(program))
+        .map_err(|error| error.to_string())?;
+    if !output.success() {
+        return Err(cli_failure_reason("plugins list --json", &output));
+    }
+    let expected = plugin_entry(plugin);
+    let inventory = parse_native_plugin(&output.stdout, &expected)?
+        .ok_or_else(|| format!("{expected} is absent after install"))?;
+    if !inventory.enabled {
+        return Err(format!("{expected} is installed but disabled"));
+    }
+    if !inventory.hooks_loaded {
+        return Err(format!("{expected} reports no loaded hooks"));
+    }
+    Ok(())
+}
+
+fn native_status(
+    claim: &AdapterClaim,
+    ctx: &DriverCtx,
+) -> Result<AdapterStatusReport, AdapterError> {
+    let detect = QoderDriver.detect(&HostEnv {
+        user_home: ctx.user_home.clone(),
+    });
+    let mut conditions = vec![
+        AdapterCondition {
+            kind: AdapterConditionKind::FrameworkDetected,
+            status: bool_status(detect.detected),
+            reason: Some(detect.reason),
+            resource: None,
+        },
+        bundle_match_condition(claim),
+    ];
+    let Some(plugin) = resolve_plugin(claim) else {
+        push_native_conditions(
+            &mut conditions,
+            ConditionStatus::False,
+            ConditionStatus::False,
+            ConditionStatus::False,
+            ConditionStatus::False,
+            Some("receipt has no Qoder plugin resource".to_string()),
+        );
+        return Ok(AdapterStatusReport {
+            summary: summarize_native(claim.status, false, ConditionStatus::False),
+            conditions,
+        });
+    };
+    let Some(program) = qodercli_program(ctx.user_home.as_deref()) else {
+        push_native_conditions(
+            &mut conditions,
+            ConditionStatus::Unknown,
+            ConditionStatus::Unknown,
+            ConditionStatus::Unknown,
+            ConditionStatus::False,
+            Some("qodercli unavailable; plugin inventory cannot be read".to_string()),
+        );
+        return Ok(AdapterStatusReport {
+            summary: summarize_native(claim.status, false, ConditionStatus::False),
+            conditions,
+        });
+    };
+    let output = match ctx
+        .ops
+        .run_framework_cli_json(build_native_list_cmd(&program))
+    {
+        Ok(output) => output,
+        Err(error) => {
+            push_native_conditions(
+                &mut conditions,
+                ConditionStatus::Unknown,
+                ConditionStatus::Unknown,
+                ConditionStatus::Unknown,
+                ConditionStatus::False,
+                Some(format!("cannot read Qoder plugin inventory: {error}")),
+            );
+            return Ok(AdapterStatusReport {
+                summary: summarize_native(claim.status, true, ConditionStatus::Unknown),
+                conditions,
+            });
+        }
+    };
+    if !output.success() {
+        push_native_conditions(
+            &mut conditions,
+            ConditionStatus::Unknown,
+            ConditionStatus::Unknown,
+            ConditionStatus::Unknown,
+            ConditionStatus::False,
+            Some(cli_failure_reason("plugins list --json", &output)),
+        );
+        return Ok(AdapterStatusReport {
+            summary: summarize_native(claim.status, true, ConditionStatus::Unknown),
+            conditions,
+        });
+    }
+    let expected = plugin_entry(&plugin);
+    let inventory = match parse_native_plugin(&output.stdout, &expected) {
+        Ok(inventory) => inventory,
+        Err(reason) => {
+            push_native_conditions(
+                &mut conditions,
+                ConditionStatus::Unknown,
+                ConditionStatus::Unknown,
+                ConditionStatus::Unknown,
+                ConditionStatus::False,
+                Some(reason),
+            );
+            return Ok(AdapterStatusReport {
+                summary: summarize_native(claim.status, true, ConditionStatus::Unknown),
+                conditions,
+            });
+        }
+    };
+    let (registered, enabled, hooks, reason) = match inventory {
+        Some(inventory) => (
+            ConditionStatus::True,
+            bool_status(inventory.enabled),
+            bool_status(inventory.hooks_loaded),
+            (!inventory.hooks_loaded).then(|| format!("{expected} reports no loaded hooks")),
+        ),
+        None => (
+            ConditionStatus::False,
+            ConditionStatus::False,
+            ConditionStatus::False,
+            Some(format!("{expected} is absent")),
+        ),
+    };
+    push_native_conditions(
+        &mut conditions,
+        registered,
+        enabled,
+        hooks,
+        ConditionStatus::True,
+        reason,
+    );
+    let health = if registered == ConditionStatus::True
+        && enabled == ConditionStatus::True
+        && hooks == ConditionStatus::True
+    {
+        ConditionStatus::True
+    } else {
+        ConditionStatus::False
+    };
+    Ok(AdapterStatusReport {
+        summary: summarize_native(claim.status, true, health),
+        conditions,
+    })
+}
+
+fn push_native_conditions(
+    conditions: &mut Vec<AdapterCondition>,
+    registered: ConditionStatus,
+    enabled: ConditionStatus,
+    hooks: ConditionStatus,
+    verification: ConditionStatus,
+    reason: Option<String>,
+) {
+    for (kind, status) in [
+        (AdapterConditionKind::PluginRegistered, registered),
+        (AdapterConditionKind::ActivationEnabled, enabled),
+        (AdapterConditionKind::PluginResourcesLoaded, hooks),
+        (AdapterConditionKind::VerificationSupported, verification),
+    ] {
+        conditions.push(AdapterCondition {
+            kind,
+            status,
+            reason: reason.clone(),
+            resource: (kind != AdapterConditionKind::VerificationSupported).then(|| {
+                ClaimResourceRef {
+                    id: RES_PLUGIN.to_string(),
+                }
+            }),
+        });
+    }
+}
+
+fn summarize_native(
+    claim_status: ClaimStatus,
+    detected: bool,
+    health: ConditionStatus,
+) -> AdapterSummary {
+    if claim_status == ClaimStatus::CleanupFailed {
+        return AdapterSummary::CleanupFailed;
+    }
+    if !detected || health == ConditionStatus::False {
+        return AdapterSummary::Degraded;
+    }
+    match health {
+        ConditionStatus::True => AdapterSummary::Healthy,
+        ConditionStatus::Unknown => AdapterSummary::Unknown,
+        ConditionStatus::False => AdapterSummary::Degraded,
+    }
+}
+
+fn disable_native(claim: &AdapterClaim, ctx: &DriverCtx) -> Result<DisableReport, AdapterError> {
+    let Some(payload) = qoder_payload(claim) else {
+        return Ok(DisableReport {
+            cleanup_complete: false,
+            messages: vec![
+                "qoder receipt has a non-qoder driver payload; receipt kept".to_string(),
+            ],
+        });
+    };
+    let Some(plugin) = resolve_plugin(claim) else {
+        return Ok(DisableReport {
+            cleanup_complete: false,
+            messages: vec!["qoder receipt has no plugin resource; receipt kept".to_string()],
+        });
+    };
+    if payload.plugin_preexisting {
+        return Ok(DisableReport {
+            cleanup_complete: true,
+            messages: vec![format!(
+                "retained pre-existing native Qoder plugin '{}'; ANOLISA never owned this registration",
+                plugin_entry(&plugin)
+            )],
+        });
+    }
+    let Some(program) = qodercli_program(ctx.user_home.as_deref()) else {
+        return Ok(DisableReport {
+            cleanup_complete: false,
+            messages: vec!["qodercli unavailable; receipt kept for retry".to_string()],
+        });
+    };
+    let expected = plugin_entry(&plugin);
+    if !native_install_confirmed(claim, payload) {
+        let (cleanup_complete, message) = match ctx
+            .ops
+            .run_framework_cli_json(build_native_list_cmd(&program))
+        {
+            Ok(output) if output.success() => {
+                match parse_native_plugin(&output.stdout, &expected) {
+                    Ok(None) => (
+                        true,
+                        format!(
+                            "verified {expected} is absent; removed unconfirmed native Qoder receipt"
+                        ),
+                    ),
+                    Ok(Some(_)) => (
+                        false,
+                        format!(
+                            "{expected} is registered but ANOLISA install ownership was never confirmed; left it untouched and kept receipt"
+                        ),
+                    ),
+                    Err(reason) => (
+                        false,
+                        format!("cannot verify unconfirmed Qoder receipt: {reason}"),
+                    ),
+                }
+            }
+            Ok(output) => (false, cli_failure_reason("plugins list --json", &output)),
+            Err(error) => (false, format!("Qoder inventory could not run: {error}")),
+        };
+        return Ok(DisableReport {
+            cleanup_complete,
+            messages: vec![message],
+        });
+    }
+    let mut messages = Vec::new();
+    match ctx
+        .ops
+        .run_framework_cli(build_native_uninstall_cmd(&program, &plugin))
+    {
+        Ok(output) if output.success() => {
+            messages.push(format!("uninstalled native Qoder plugin '{plugin}'"));
+        }
+        Ok(output) => messages.push(cli_failure_reason("plugins uninstall", &output)),
+        Err(error) => messages.push(format!("plugins uninstall could not run: {error}")),
+    }
+
+    let cleanup_complete = match ctx
+        .ops
+        .run_framework_cli_json(build_native_list_cmd(&program))
+    {
+        Ok(output) if output.success() => match parse_native_plugin(&output.stdout, &expected) {
+            Ok(None) => {
+                messages.push(format!("verified {expected} is absent"));
+                true
+            }
+            Ok(Some(_)) => {
+                messages.push(format!("{expected} remains registered after uninstall"));
+                false
+            }
+            Err(reason) => {
+                messages.push(format!("cannot verify Qoder uninstall: {reason}"));
+                false
+            }
+        },
+        Ok(output) => {
+            messages.push(cli_failure_reason("plugins list --json", &output));
+            false
+        }
+        Err(error) => {
+            messages.push(format!("cannot verify Qoder uninstall: {error}"));
+            false
+        }
+    };
+    Ok(DisableReport {
+        cleanup_complete,
+        messages,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -865,6 +1615,65 @@ fn build_uninstall_cmd(program: &str, plugin: &str) -> FrameworkCommand {
     )
 }
 
+fn build_native_help_cmd(program: &str, subcommand: &str) -> FrameworkCommand {
+    base_cmd(
+        program,
+        vec![
+            "plugins".to_string(),
+            subcommand.to_string(),
+            "--help".to_string(),
+        ],
+    )
+}
+
+fn build_native_validate_cmd(program: &str, root: &Path) -> FrameworkCommand {
+    base_cmd(
+        program,
+        vec![
+            "plugins".to_string(),
+            "validate".to_string(),
+            root.to_string_lossy().into_owned(),
+        ],
+    )
+}
+
+fn build_native_install_cmd(program: &str, root: &Path) -> FrameworkCommand {
+    base_cmd(
+        program,
+        vec![
+            "plugins".to_string(),
+            "install".to_string(),
+            root.to_string_lossy().into_owned(),
+            "--scope".to_string(),
+            "user".to_string(),
+        ],
+    )
+}
+
+fn build_native_list_cmd(program: &str) -> FrameworkCommand {
+    base_cmd(
+        program,
+        vec![
+            "plugins".to_string(),
+            "list".to_string(),
+            "--json".to_string(),
+        ],
+    )
+}
+
+fn build_native_uninstall_cmd(program: &str, plugin: &str) -> FrameworkCommand {
+    base_cmd(
+        program,
+        vec![
+            "plugins".to_string(),
+            "uninstall".to_string(),
+            plugin.to_string(),
+            "--scope".to_string(),
+            "user".to_string(),
+        ],
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Status assembly
 // ---------------------------------------------------------------------------
@@ -934,6 +1743,127 @@ mod tests {
         );
         let uninstall = build_uninstall_cmd("qodercli", "tokenless");
         assert_eq!(uninstall.args, vec!["plugins", "uninstall", "tokenless"]);
+
+        let root = Path::new("/data/adapters/tokenless/qoder");
+        assert_eq!(
+            build_native_validate_cmd("qodercli", root).args,
+            vec!["plugins", "validate", "/data/adapters/tokenless/qoder"]
+        );
+        assert_eq!(
+            build_native_install_cmd("qodercli", root).args,
+            vec![
+                "plugins",
+                "install",
+                "/data/adapters/tokenless/qoder",
+                "--scope",
+                "user"
+            ]
+        );
+        assert_eq!(
+            build_native_list_cmd("qodercli").args,
+            vec!["plugins", "list", "--json"]
+        );
+        assert_eq!(
+            build_native_uninstall_cmd("qodercli", "tokenless").args,
+            vec!["plugins", "uninstall", "tokenless", "--scope", "user"]
+        );
+    }
+
+    #[test]
+    fn native_inventory_requires_enabled_plugin_with_hooks() {
+        let valid = r#"[{"id":"tokenless@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}}]"#;
+        assert_eq!(
+            parse_native_plugin(valid, "tokenless@local"),
+            Ok(Some(NativePluginInventory {
+                enabled: true,
+                hooks_loaded: true,
+            }))
+        );
+        assert_eq!(
+            parse_native_plugin(r#"{"plugins":[]}"#, "tokenless@local"),
+            Ok(None)
+        );
+        assert!(parse_native_plugin("not-json", "tokenless@local").is_err());
+        assert!(
+            parse_native_plugin(
+                r#"[{"id":"tokenless@local","scope":"user","resources":{"hooks":[{}]}}]"#,
+                "tokenless@local"
+            )
+            .is_err()
+        );
+        assert_eq!(
+            parse_native_plugin(
+                r#"[{"pluginId":"tokenless@local","scope":"user","enabled":false,"resources":{"hooks":[]}}]"#,
+                "tokenless@local"
+            ),
+            Ok(Some(NativePluginInventory {
+                enabled: false,
+                hooks_loaded: false,
+            }))
+        );
+    }
+
+    #[test]
+    fn native_inventory_preserves_cross_scope_conflicts() {
+        let mixed = r#"[
+            {"id":"tokenless@local","scope":"project","enabled":false,"resources":{"hooks":[]}},
+            {"id":"tokenless@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}}
+        ]"#;
+        assert_eq!(
+            parse_native_plugin(mixed, "tokenless@local"),
+            Ok(Some(NativePluginInventory {
+                enabled: true,
+                hooks_loaded: true,
+            }))
+        );
+        assert_eq!(
+            parse_native_plugin_matches(mixed, "tokenless@local"),
+            Ok(NativePluginMatches {
+                user: Some(NativePluginInventory {
+                    enabled: true,
+                    hooks_loaded: true,
+                }),
+                non_user_scopes: vec!["project".to_string()],
+            })
+        );
+        assert_eq!(
+            parse_native_plugin(
+                r#"[{"id":"tokenless@local","scope":"project","enabled":true,"resources":{"hooks":[{}]}}]"#,
+                "tokenless@local"
+            ),
+            Ok(None)
+        );
+        assert_eq!(
+            parse_native_plugin_matches(
+                r#"[
+                    {"id":"tokenless@local","scope":"project"},
+                    {"id":"tokenless@local","scope":"local"},
+                    {"id":"tokenless@local","scope":"project"}
+                ]"#,
+                "tokenless@local"
+            ),
+            Ok(NativePluginMatches {
+                user: None,
+                non_user_scopes: vec!["local".to_string(), "project".to_string()],
+            })
+        );
+        assert!(
+            parse_native_plugin(
+                r#"[{"id":"tokenless@local","enabled":true,"resources":{"hooks":[{}]}}]"#,
+                "tokenless@local"
+            )
+            .is_err()
+        );
+        assert!(
+            parse_native_plugin(
+                r#"[
+                    {"id":"tokenless@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}},
+                    {"id":"tokenless@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}}
+                ]"#,
+                "tokenless@local"
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1001,8 +1931,8 @@ mod tests {
             fn create_symlink(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
                 unimplemented!()
             }
-            fn read_file(&self, _: &Path) -> Result<Option<Vec<u8>>, AdapterError> {
-                unimplemented!()
+            fn read_file(&self, path: &Path) -> Result<Option<Vec<u8>>, AdapterError> {
+                Ok(std::fs::read(path).ok())
             }
         }
         let ops = StubOps;
@@ -1032,9 +1962,69 @@ mod tests {
             .expect_err("hooks.json missing must fail");
         assert!(matches!(err, AdapterError::BundleInvalid { .. }));
 
-        // Both present -> ok.
+        // Legacy root hooks only -> ok.
         std::fs::write(root.join(QODER_HOOKS_FILE), b"{}").expect("write hooks");
-        let bundle = driver.read_bundle(&mk_ctx(&root)).expect("both present");
+        let bundle = driver.read_bundle(&mk_ctx(&root)).expect("legacy bundle");
         assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
+
+        // Qoder CLI ignores alternate manifest paths, so the driver must
+        // reject a contract that declares one even when the bundle is
+        // otherwise complete.
+        std::fs::write(root.join("custom.json"), br#"{"name":"tokenless"}"#)
+            .expect("write alternate manifest");
+        let mut alternate_ctx = mk_ctx(&root);
+        alternate_ctx.declared_bundle_entry = Some("custom.json".to_string());
+        assert!(!driver.probe_bundle(&root, Some("custom.json")));
+        let err = driver
+            .read_bundle(&alternate_ctx)
+            .expect_err("alternate manifest must be rejected");
+        assert!(matches!(err, AdapterError::BundleInvalid { .. }));
+
+        // Native nested hooks only -> manifest name is authoritative.
+        std::fs::remove_file(root.join(QODER_HOOKS_FILE)).expect("remove legacy hooks");
+        std::fs::create_dir_all(root.join("hooks")).expect("mkdir native hooks");
+        std::fs::write(
+            root.join(QODER_NATIVE_HOOKS_FILE),
+            br#"{"hooks":{"PreToolUse":[]}}"#,
+        )
+        .expect("write native hooks");
+        let bundle = driver.read_bundle(&mk_ctx(&root)).expect("native bundle");
+        assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
+
+        // Both layouts are ambiguous and fail closed in probe and read.
+        std::fs::write(root.join(QODER_HOOKS_FILE), b"{}").expect("write legacy hooks");
+        assert!(!driver.probe_bundle(&root, None));
+        assert!(matches!(
+            driver.read_bundle(&mk_ctx(&root)),
+            Err(AdapterError::BundleInvalid { .. })
+        ));
+        std::fs::remove_file(root.join(QODER_HOOKS_FILE)).expect("remove legacy hooks");
+
+        // Native hook JSON must parse and expose a top-level hooks object.
+        std::fs::write(root.join(QODER_NATIVE_HOOKS_FILE), b"not-json")
+            .expect("write invalid hooks");
+        assert!(matches!(
+            driver.read_bundle(&mk_ctx(&root)),
+            Err(AdapterError::BundleInvalid { .. })
+        ));
+        std::fs::write(root.join(QODER_NATIVE_HOOKS_FILE), br#"{"hooks":[]}"#)
+            .expect("write wrong hook shape");
+        assert!(matches!(
+            driver.read_bundle(&mk_ctx(&root)),
+            Err(AdapterError::BundleInvalid { .. })
+        ));
+
+        // Contract plugin_id and native manifest name must agree.
+        std::fs::write(
+            root.join(QODER_NATIVE_HOOKS_FILE),
+            br#"{"hooks":{"PreToolUse":[]}}"#,
+        )
+        .expect("restore native hooks");
+        std::fs::write(root.join(QODER_PLUGIN_MANIFEST), br#"{"name":"sec-core"}"#)
+            .expect("write mismatched manifest");
+        assert!(matches!(
+            driver.read_bundle(&mk_ctx(&root)),
+            Err(AdapterError::BundleInvalid { .. })
+        ));
     }
 }

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
 use anolisa_core::adapter::AdapterError;
-use anolisa_core::adapter::claim::{ClaimResourceKind, ClaimStatus};
+use anolisa_core::adapter::claim::{ClaimResourceKind, ClaimStatus, DriverPayload};
 use anolisa_core::adapter::driver::{AdapterConditionKind, AdapterSummary, ConditionStatus};
 use anolisa_core::adapter::manager::{AdapterManager, EnableOutcome};
 use anolisa_platform::fs_layout::FsLayout;
@@ -46,6 +46,9 @@ const MANAGED_ENV: &[&str] = &[
     "FAKE_QODER_LOG",
     "FAKE_QODER_CACHE",
     "FAKE_QODER_FAIL",
+    "FAKE_QODER_LARGE_INVENTORY",
+    "FAKE_QODER_PLUGIN_ID",
+    "FAKE_QODER_PROJECT_PLUGIN",
 ];
 
 struct EnvGuard {
@@ -1013,13 +1016,62 @@ fn stage_qoder_bundle(root: &Path) {
     .expect("hooks.json");
 }
 
-/// Fake `qodercli`: records each argv line to `$FAKE_QODER_LOG` and mirrors
-/// qodercli's plugin cache under `$FAKE_QODER_CACHE` — `plugins install`
-/// copies the staged plugin dir verbatim, like the real CLI — so the
-/// driver's cache-based removal check reflects prior install/uninstall
-/// calls and tests can assert on the cached bundle contents.
-/// `$FAKE_QODER_FAIL=uninstall` fails the uninstall without clearing the
-/// cache, so the driver cannot confirm removal.
+/// Qoder-native fixture using the same nested hook layout as sec-core.
+fn stage_native_qoder_bundle(root: &Path) {
+    std::fs::create_dir_all(root.join(".qoder-plugin")).expect("qoder-plugin");
+    std::fs::create_dir_all(root.join("hooks")).expect("hooks");
+    std::fs::write(
+        root.join(".qoder-plugin/plugin.json"),
+        br#"{"name":"tokenless","version":"0.6.0"}"#,
+    )
+    .expect("plugin.json");
+    std::fs::write(
+        root.join("hooks/hooks.json"),
+        br#"{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "", "hooks": [
+        { "type": "command", "command": "python3",
+          "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"] } ] }
+    ]
+  }
+}
+"#,
+    )
+    .expect("hooks/hooks.json");
+    std::fs::write(
+        root.join("hooks/observability_hook.py"),
+        b"print('observability')\n",
+    )
+    .expect("observability hook");
+}
+
+fn set_native_qoder_plugin_id(world: &World, plugin_id: &str) {
+    std::fs::write(
+        world.resource_root.join(".qoder-plugin/plugin.json"),
+        format!(r#"{{"name":"{plugin_id}","version":"0.6.0"}}"#),
+    )
+    .expect("replace native plugin id");
+
+    let contract_path = world
+        .layout
+        .state_dir
+        .join("component-manifests")
+        .join(COMPONENT)
+        .join("component.toml");
+    let contract = std::fs::read_to_string(&contract_path).expect("read component contract");
+    let prior = format!("plugin_id = \"{COMPONENT}\"");
+    assert_eq!(contract.matches(&prior).count(), 1);
+    std::fs::write(
+        contract_path,
+        contract.replace(&prior, &format!("plugin_id = \"{plugin_id}\"")),
+    )
+    .expect("replace contract plugin id");
+}
+
+/// Fake `qodercli`: records argv, mirrors the local plugin cache, and emits
+/// the JSON inventory used by the native lifecycle. Failure modes cover
+/// read-only preflight, post-install verification, and uninstall retention.
 fn write_fake_qodercli(dir: &Path) -> PathBuf {
     let path = dir.join("qodercli");
     write_exec(
@@ -1027,13 +1079,68 @@ fn write_fake_qodercli(dir: &Path) -> PathBuf {
         r#"#!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_QODER_LOG"
 cache="$FAKE_QODER_CACHE"
+plugin="${FAKE_QODER_PLUGIN_ID:-tokenless}"
 if [ "$1" = "plugins" ]; then
+  if [ "$3" = "--help" ]; then
+    [ "$FAKE_QODER_FAIL" = "help-$2" ] && { echo "unsupported $2" >&2; exit 1; }
+    exit 0
+  fi
   case "$2" in
-    install) mkdir -p "$cache" && cp -R "$3" "$cache/" 2>/dev/null ;;
+    validate)
+      [ "$FAKE_QODER_FAIL" = "validate" ] && { echo "validate boom" >&2; exit 1; } ;;
+    install)
+      [ "$FAKE_QODER_FAIL" = "install" ] && { echo "install boom" >&2; exit 1; }
+      mkdir -p "$cache"
+      if [ "$4" = "--scope" ]; then
+        rm -rf "$cache/$plugin"
+        cp -R "$3" "$cache/$plugin" 2>/dev/null
+        : > "$cache/.user-$plugin"
+      else
+        cp -R "$3" "$cache/" 2>/dev/null
+      fi ;;
     uninstall)
       [ "$FAKE_QODER_FAIL" = "uninstall" ] && { echo "uninstall boom" >&2; exit 1; }
-      rm -rf "$cache/$3" 2>/dev/null || true ;;
-    list) ;;
+      [ "$FAKE_QODER_FAIL" = "uninstall-retain" ] && exit 0
+      rm -f "$cache/.user-$3"
+      if [ "$FAKE_QODER_PROJECT_PLUGIN" != "1" ]; then
+        rm -rf "$cache/$3" 2>/dev/null || true
+      fi ;;
+    list)
+      [ "$FAKE_QODER_FAIL" = "list" ] && { echo "list boom" >&2; exit 1; }
+      if [ "$FAKE_QODER_FAIL" = "list-invalid" ]; then
+        printf '%s\n' '{invalid'
+      elif [ "$FAKE_QODER_FAIL" = "post-list-fail" ] && [ -d "$cache/$plugin" ]; then
+        echo "post-install list boom" >&2
+        exit 1
+      elif [ "$FAKE_QODER_LARGE_INVENTORY" = "1" ]; then
+        printf '['
+        i=0
+        while [ "$i" -lt 900 ]; do
+          [ "$i" -gt 0 ] && printf ','
+          printf '{"id":"filler-%s@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}}' "$i"
+          i=$((i + 1))
+        done
+        if [ -d "$cache/$plugin" ]; then
+          printf ',{"id":"%s@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}}' "$plugin"
+        fi
+        printf ']\n'
+      elif [ "$FAKE_QODER_PROJECT_PLUGIN" = "1" ]; then
+        if [ -f "$cache/.user-$plugin" ]; then
+          printf '[{"id":"%s@local","scope":"project","enabled":true,"resources":{"hooks":[{}]}},{"id":"%s@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}}]\n' "$plugin" "$plugin"
+        else
+          printf '[{"id":"%s@local","scope":"project","enabled":true,"resources":{"hooks":[{}]}}]\n' "$plugin"
+        fi
+      elif [ ! -d "$cache/$plugin" ] || [ "$FAKE_QODER_FAIL" = "post-list-absent" ]; then
+        printf '%s\n' '[]'
+      elif [ "$FAKE_QODER_FAIL" = "post-list-invalid" ]; then
+        printf '%s\n' '{invalid'
+      elif [ "$FAKE_QODER_FAIL" = "post-list-disabled" ]; then
+        printf '[{"id":"%s@local","scope":"user","enabled":false,"resources":{"hooks":[{}]}}]\n' "$plugin"
+      elif [ "$FAKE_QODER_FAIL" = "post-list-no-hooks" ]; then
+        printf '[{"id":"%s@local","scope":"user","enabled":true,"resources":{"hooks":[]}}]\n' "$plugin"
+      else
+        printf '[{"id":"%s@local","scope":"user","enabled":true,"resources":{"hooks":[{}]}}]\n' "$plugin"
+      fi ;;
   esac
   exit 0
 fi
@@ -1103,6 +1210,960 @@ fn enabled_plugins(settings: &serde_json::Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+#[test]
+fn qoder_native_enable_status_disable_uses_cli_lifecycle() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, settings, cache, staging) = apply_qoder_env(&guard, &world, &fake);
+    let original_settings = b"{\n  \"theme\": \"night\"\n}\n";
+    std::fs::create_dir_all(settings.parent().expect("settings parent")).expect("mkdir .qoder");
+    std::fs::write(&settings, original_settings).expect("seed settings");
+
+    let manager = world.manager();
+    let claim = match manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("enable native plugin")
+    {
+        EnableOutcome::Enabled(claim) => *claim,
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
+    };
+
+    assert_eq!(claim.driver_schema, 3);
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    for command in [
+        "plugins validate --help".to_string(),
+        "plugins install --help".to_string(),
+        "plugins list --help".to_string(),
+        "plugins uninstall --help".to_string(),
+        format!("plugins validate {}", world.resource_root.display()),
+        format!(
+            "plugins install {} --scope user",
+            world.resource_root.display()
+        ),
+    ] {
+        assert!(
+            log_text.lines().any(|line| line == command),
+            "missing native command {command:?} in {log_text}"
+        );
+    }
+    assert!(
+        !staging.exists(),
+        "native install must not create a staging copy"
+    );
+    assert_eq!(
+        std::fs::read(&settings).expect("settings unchanged"),
+        original_settings,
+        "native lifecycle must leave settings.json byte-for-byte unchanged"
+    );
+    let source_hooks = std::fs::read_to_string(world.resource_root.join("hooks/hooks.json"))
+        .expect("source hooks");
+    let cached_hooks =
+        std::fs::read_to_string(cache.join("tokenless/hooks/hooks.json")).expect("cached hooks");
+    assert!(source_hooks.contains("${QODER_PLUGIN_ROOT}"));
+    assert!(cached_hooks.contains("${QODER_PLUGIN_ROOT}"));
+
+    assert_eq!(claim.resources.len(), 1);
+    assert!(matches!(
+        &claim.resources[0].kind,
+        ClaimResourceKind::FrameworkPlugin { framework, plugin_id }
+            if framework == "qoder" && plugin_id == "tokenless"
+    ));
+    let DriverPayload::Qoder(payload) = &claim.driver_payload else {
+        panic!("expected Qoder receipt payload");
+    };
+    assert!(payload.settings_resource.is_none());
+    assert!(!payload.plugin_preexisting);
+    assert!(payload.plugin_install_confirmed);
+    assert!(payload.managed_hooks.is_empty());
+    assert!(payload.managed_hook_specs.is_empty());
+
+    let status = manager.status(Some(COMPONENT)).expect("native status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+    for kind in [
+        AdapterConditionKind::PluginRegistered,
+        AdapterConditionKind::ActivationEnabled,
+        AdapterConditionKind::PluginResourcesLoaded,
+        AdapterConditionKind::VerificationSupported,
+    ] {
+        assert!(status.entries[0].report.conditions.iter().any(|condition| {
+            condition.kind == kind && condition.status == ConditionStatus::True
+        }));
+    }
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("disable native plugin");
+    assert!(disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+    assert!(!cache.join("tokenless").exists());
+    assert_eq!(
+        std::fs::read(&settings).expect("settings unchanged after disable"),
+        original_settings
+    );
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert!(
+        log_text
+            .lines()
+            .any(|line| line == "plugins uninstall tokenless --scope user")
+    );
+}
+
+#[test]
+fn qoder_native_enable_tolerates_unavailable_validate_command() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, _cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    guard.set("FAKE_QODER_FAIL", Path::new("help-validate"));
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("native install does not require validate support");
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert!(
+        log_text
+            .lines()
+            .any(|line| line == "plugins validate --help")
+    );
+    assert!(
+        !log_text
+            .lines()
+            .any(|line| { line == format!("plugins validate {}", world.resource_root.display()) }),
+        "unsupported validate command must not be invoked: {log_text}"
+    );
+    assert!(log_text.lines().any(|line| {
+        line == format!(
+            "plugins install {} --scope user",
+            world.resource_root.display()
+        )
+    }));
+    assert!(
+        manager
+            .disable(COMPONENT, Some("qoder"), false)
+            .expect("disable")
+            .claim_removed
+    );
+}
+
+#[test]
+fn qoder_native_enable_rejects_same_id_project_scope_with_shared_cache() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    guard.set("FAKE_QODER_PROJECT_PLUGIN", Path::new("1"));
+    let shared_cache = cache.join("tokenless");
+    std::fs::create_dir_all(&shared_cache).expect("project plugin shared cache");
+    std::fs::write(shared_cache.join("owner.txt"), b"project-owned\n")
+        .expect("project ownership marker");
+
+    let manager = world.manager();
+    let error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("project registration must block the shared-cache install");
+    assert!(
+        matches!(&error, AdapterError::FrameworkCli { reason, .. }
+            if reason.contains("matching non-user Qoder registration")
+                && reason.contains("project")
+                && reason.contains("shares the local plugin cache")),
+        "unexpected project-scope conflict: {error:?}"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qoder")
+            .is_none(),
+        "scope conflict must fail before the write-ahead receipt"
+    );
+    assert_eq!(
+        std::fs::read(shared_cache.join("owner.txt")).expect("project marker retained"),
+        b"project-owned\n"
+    );
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert!(
+        !log_text.lines().any(|line| {
+            (line.starts_with("plugins install ") || line.starts_with("plugins uninstall "))
+                && line.ends_with(" --scope user")
+        }),
+        "scope conflict must not mutate the shared cache: {log_text}"
+    );
+}
+
+#[test]
+fn qoder_native_lifecycle_reads_inventory_larger_than_default_capture() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (_log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    guard.set("FAKE_QODER_LARGE_INVENTORY", Path::new("1"));
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("enable must parse the target after more than 64 KiB of inventory");
+    assert!(cache.join("tokenless").exists());
+    assert_eq!(
+        manager.status(Some(COMPONENT)).expect("status").entries[0]
+            .report
+            .summary,
+        AdapterSummary::Healthy
+    );
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("disable must verify absence in the large inventory");
+    assert!(disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+    assert!(!cache.join("tokenless").exists());
+}
+
+#[test]
+fn qoder_native_preflight_failures_do_not_write_receipts() {
+    let guard = EnvGuard::acquire();
+    for failure in ["help-install", "validate", "list", "list-invalid"] {
+        let world = stage(
+            "qoder",
+            "plugin",
+            "{datadir}/adapters/{component}/qoder/",
+            stage_native_qoder_bundle,
+        );
+        let fake = write_fake_qodercli(&world.prefix);
+        let (_log, settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+        guard.set("FAKE_QODER_FAIL", Path::new(failure));
+
+        world
+            .manager()
+            .enable(COMPONENT, Some("qoder"), false)
+            .expect_err("native preflight must fail");
+        assert!(
+            world
+                .load_state()
+                .find_adapter_claim(COMPONENT, "qoder")
+                .is_none(),
+            "preflight failure {failure} must not persist a receipt"
+        );
+        assert!(!cache.join("tokenless").exists());
+        assert!(!settings.exists());
+    }
+}
+
+#[test]
+fn qoder_native_apply_failures_keep_write_ahead_receipt() {
+    let guard = EnvGuard::acquire();
+    for failure in [
+        "install",
+        "post-list-fail",
+        "post-list-invalid",
+        "post-list-absent",
+        "post-list-disabled",
+        "post-list-no-hooks",
+    ] {
+        let world = stage(
+            "qoder",
+            "plugin",
+            "{datadir}/adapters/{component}/qoder/",
+            stage_native_qoder_bundle,
+        );
+        let fake = write_fake_qodercli(&world.prefix);
+        let (log, settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+        let original_settings = b"{\"keep\":true}\n";
+        std::fs::create_dir_all(settings.parent().expect("settings parent")).expect("mkdir .qoder");
+        std::fs::write(&settings, original_settings).expect("seed settings");
+        guard.set("FAKE_QODER_FAIL", Path::new(failure));
+
+        world
+            .manager()
+            .enable(COMPONENT, Some("qoder"), false)
+            .expect_err("native apply must fail");
+        let claim = world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qoder")
+            .cloned()
+            .expect("write-ahead receipt kept");
+        assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+        let DriverPayload::Qoder(payload) = &claim.driver_payload else {
+            panic!("expected Qoder receipt payload");
+        };
+        assert_eq!(
+            payload.plugin_install_confirmed,
+            failure != "install",
+            "only a successful install command may confirm ownership"
+        );
+        assert_eq!(
+            std::fs::read(&settings).expect("settings unchanged"),
+            original_settings
+        );
+        assert_eq!(
+            cache.join("tokenless").exists(),
+            failure != "install",
+            "post-install failures keep qodercli's installed plugin"
+        );
+        let log_text = std::fs::read_to_string(&log).expect("qoder log");
+        assert!(
+            !log_text
+                .lines()
+                .any(|line| line == "plugins uninstall tokenless --scope user"),
+            "enable verification failure must not guess whether uninstall is safe"
+        );
+    }
+}
+
+#[test]
+fn qoder_native_failed_install_never_adopts_later_user_plugin() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    guard.set("FAKE_QODER_FAIL", Path::new("install"));
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("initial install fails before creating a plugin");
+
+    let failed_claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qoder")
+        .cloned()
+        .expect("failed write-ahead receipt retained");
+    assert_eq!(failed_claim.status, ClaimStatus::CleanupFailed);
+    let DriverPayload::Qoder(payload) = &failed_claim.driver_payload else {
+        panic!("expected Qoder receipt payload");
+    };
+    assert!(!payload.plugin_preexisting);
+    assert!(!payload.plugin_install_confirmed);
+
+    let user_plugin = cache.join("tokenless");
+    std::fs::create_dir_all(&user_plugin).expect("user-installed plugin");
+    std::fs::write(user_plugin.join("owner.txt"), b"user-owned\n").expect("user ownership marker");
+    guard.set("FAKE_QODER_FAIL", Path::new(""));
+
+    let retry_error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("retry must not adopt the user's plugin");
+    assert!(
+        matches!(&retry_error, AdapterError::FrameworkCli { reason, .. }
+            if reason.contains("pre-existing user-scope")),
+        "unexpected retry error: {retry_error:?}"
+    );
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("disable fails closed for unconfirmed ownership");
+    assert!(!disabled.claim_removed);
+    assert!(!disabled.report.cleanup_complete);
+    assert_eq!(
+        std::fs::read(user_plugin.join("owner.txt")).expect("user plugin retained"),
+        b"user-owned\n"
+    );
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert_eq!(
+        log_text
+            .lines()
+            .filter(|line| {
+                line.starts_with("plugins install ") && line.ends_with(" --scope user")
+            })
+            .count(),
+        1,
+        "retry must not run another install: {log_text}"
+    );
+    assert!(
+        !log_text
+            .lines()
+            .any(|line| line == "plugins uninstall tokenless --scope user"),
+        "disable must not uninstall an unconfirmed registration: {log_text}"
+    );
+
+    std::fs::remove_dir_all(&user_plugin).expect("user removes their plugin");
+    let cleaned = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("absence permits receipt cleanup");
+    assert!(cleaned.claim_removed);
+    assert!(cleaned.report.cleanup_complete);
+}
+
+#[test]
+fn qoder_native_post_install_failure_keeps_confirmed_cleanup_ownership() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    guard.set("FAKE_QODER_FAIL", Path::new("post-list-disabled"));
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("post-install verification fails");
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qoder")
+        .cloned()
+        .expect("cleanup receipt retained");
+    let DriverPayload::Qoder(payload) = &claim.driver_payload else {
+        panic!("expected Qoder receipt payload");
+    };
+    assert!(payload.plugin_install_confirmed);
+
+    guard.set("FAKE_QODER_FAIL", Path::new(""));
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("confirmed install remains eligible for cleanup");
+    assert!(disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+    assert!(!cache.join("tokenless").exists());
+    assert!(
+        std::fs::read_to_string(&log)
+            .expect("qoder log")
+            .lines()
+            .any(|line| line == "plugins uninstall tokenless --scope user")
+    );
+}
+
+#[test]
+fn qoder_native_v2_preapply_receipt_never_claims_later_user_plugin() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    guard.set("FAKE_QODER_FAIL", Path::new("install"));
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("create an unconfirmed write-ahead receipt without a plugin");
+
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    let claim = state
+        .adapter_claims
+        .iter_mut()
+        .find(|claim| claim.component == COMPONENT && claim.framework == "qoder")
+        .expect("qoder claim");
+    // Schema v2 had no durable post-install checkpoint. `Enabled` is the
+    // exact pre-apply state the Manager persisted, so a crash could leave
+    // this value even though qodercli never created the registration.
+    claim.driver_schema = 2;
+    claim.status = ClaimStatus::Enabled;
+    let DriverPayload::Qoder(payload) = &mut claim.driver_payload else {
+        panic!("expected Qoder receipt payload");
+    };
+    payload.plugin_install_confirmed = false;
+    state.save(&state_path).expect("save v2 receipt fixture");
+
+    let user_plugin = cache.join("tokenless");
+    std::fs::create_dir_all(&user_plugin).expect("later user plugin");
+    std::fs::write(user_plugin.join("owner.txt"), b"user-owned\n").expect("user ownership marker");
+    guard.set("FAKE_QODER_FAIL", Path::new(""));
+
+    let retry_error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("v2 receipt must not authorize replacing the later user plugin");
+    assert!(
+        matches!(&retry_error, AdapterError::FrameworkCli { reason, .. }
+            if reason.contains("pre-existing user-scope")),
+        "unexpected v2 retry error: {retry_error:?}"
+    );
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("v2 receipt must keep unconfirmed registration untouched");
+    assert!(!disabled.claim_removed);
+    assert!(!disabled.report.cleanup_complete);
+    assert_eq!(
+        std::fs::read(user_plugin.join("owner.txt")).expect("user marker retained"),
+        b"user-owned\n"
+    );
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert_eq!(
+        log_text
+            .lines()
+            .filter(|line| {
+                line.starts_with("plugins install ") && line.ends_with(" --scope user")
+            })
+            .count(),
+        1,
+        "retry must not run a second install: {log_text}"
+    );
+    assert!(
+        !log_text
+            .lines()
+            .any(|line| line == "plugins uninstall tokenless --scope user"),
+        "disable must not uninstall the later user registration: {log_text}"
+    );
+}
+
+#[test]
+fn qoder_native_enable_rejects_unowned_preexisting_user_plugin() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    let preexisting = cache.join("tokenless");
+    std::fs::create_dir_all(&preexisting).expect("pre-existing plugin cache");
+    std::fs::write(preexisting.join("owner.txt"), b"user-owned\n").expect("ownership marker");
+    std::fs::write(preexisting.join("version.txt"), b"0.9.0\n").expect("pre-existing version");
+    std::fs::write(world.resource_root.join("version.txt"), b"9.9.9\n")
+        .expect("replacement version");
+
+    let manager = world.manager();
+    let error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("unowned user plugin must block enable");
+    assert!(
+        matches!(&error, AdapterError::FrameworkCli { reason, .. } if reason.contains("pre-existing user-scope")),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qoder")
+            .is_none(),
+        "ownership conflict must fail before receipt persistence"
+    );
+    assert_eq!(
+        std::fs::read(preexisting.join("version.txt")).expect("pre-existing version retained"),
+        b"0.9.0\n"
+    );
+    assert_eq!(
+        std::fs::read(preexisting.join("owner.txt")).expect("pre-existing plugin retained"),
+        b"user-owned\n"
+    );
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("disable without receipt is a no-op");
+    assert!(!disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert!(
+        !log_text
+            .lines()
+            .any(|line| line.starts_with("plugins install ") && line.ends_with(" --scope user")),
+        "enable must not replace a pre-existing plugin: {log_text}"
+    );
+    assert!(
+        !log_text
+            .lines()
+            .any(|line| line == "plugins uninstall tokenless --scope user"),
+        "disable must not uninstall a pre-existing plugin: {log_text}"
+    );
+}
+
+#[test]
+fn qoder_native_reenable_can_replace_anolisa_owned_user_plugin() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    std::fs::write(world.resource_root.join("generation.txt"), b"first\n")
+        .expect("first generation");
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("initial enable");
+    std::fs::write(world.resource_root.join("generation.txt"), b"second\n")
+        .expect("second generation");
+    let claim = match manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("owned re-enable")
+    {
+        EnableOutcome::Enabled(claim) => *claim,
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
+    };
+    let DriverPayload::Qoder(payload) = &claim.driver_payload else {
+        panic!("expected Qoder receipt payload");
+    };
+    assert!(!payload.plugin_preexisting);
+    assert!(payload.plugin_install_confirmed);
+    assert_eq!(
+        std::fs::read(cache.join("tokenless/generation.txt")).expect("cached generation"),
+        b"second\n"
+    );
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert_eq!(
+        log_text
+            .lines()
+            .filter(|line| {
+                line.starts_with("plugins install ") && line.ends_with(" --scope user")
+            })
+            .count(),
+        2
+    );
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("disable owned plugin");
+    assert!(disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+}
+
+#[test]
+fn qoder_native_reenable_rejects_preexisting_different_plugin_id() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("initial native enable");
+
+    let replacement = cache.join("replacement");
+    std::fs::create_dir_all(&replacement).expect("pre-existing replacement plugin");
+    std::fs::write(replacement.join("owner.txt"), b"user-owned\n")
+        .expect("replacement ownership marker");
+    set_native_qoder_plugin_id(&world, "replacement");
+    guard.set("FAKE_QODER_PLUGIN_ID", Path::new("replacement"));
+
+    let error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("a different pre-existing plugin id must not inherit ownership");
+    assert!(
+        matches!(&error, AdapterError::BundleInvalid { reason, .. }
+            if reason.contains("changed from 'tokenless' to 'replacement'")),
+        "unexpected error: {error:?}"
+    );
+    let retained = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qoder")
+        .cloned()
+        .expect("original receipt retained");
+    assert_eq!(retained.plugin_id.as_deref(), Some("tokenless"));
+    assert_eq!(
+        std::fs::read(replacement.join("owner.txt")).expect("replacement plugin retained"),
+        b"user-owned\n"
+    );
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert_eq!(
+        log_text
+            .lines()
+            .filter(|line| {
+                line.starts_with("plugins install ") && line.ends_with(" --scope user")
+            })
+            .count(),
+        1,
+        "re-enable must not install the replacement plugin: {log_text}"
+    );
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("original plugin cleanup remains available");
+    assert!(disabled.claim_removed);
+    assert!(!cache.join("tokenless").exists());
+    assert_eq!(
+        std::fs::read(replacement.join("owner.txt")).expect("replacement remains after cleanup"),
+        b"user-owned\n"
+    );
+}
+
+#[test]
+fn qoder_native_reenable_rejects_absent_different_plugin_id() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("initial native enable");
+
+    set_native_qoder_plugin_id(&world, "replacement");
+    guard.set("FAKE_QODER_PLUGIN_ID", Path::new("replacement"));
+    let error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("an absent different plugin id must not replace the cleanup claim");
+    assert!(
+        matches!(&error, AdapterError::BundleInvalid { reason, .. }
+            if reason.contains("changed from 'tokenless' to 'replacement'")),
+        "unexpected error: {error:?}"
+    );
+    assert!(!cache.join("replacement").exists());
+    let retained = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qoder")
+        .cloned()
+        .expect("original receipt retained");
+    assert_eq!(retained.plugin_id.as_deref(), Some("tokenless"));
+    let log_text = std::fs::read_to_string(&log).expect("qoder log");
+    assert_eq!(
+        log_text
+            .lines()
+            .filter(|line| {
+                line.starts_with("plugins install ") && line.ends_with(" --scope user")
+            })
+            .count(),
+        1,
+        "re-enable must not install the replacement plugin: {log_text}"
+    );
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("original plugin cleanup remains available");
+    assert!(disabled.claim_removed);
+    assert!(!cache.join("tokenless").exists());
+    assert!(!cache.join("replacement").exists());
+}
+
+#[test]
+fn qoder_native_rejects_custom_manifest_before_cli_or_receipt() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let manifest_path = world
+        .layout
+        .state_dir
+        .join("component-manifests")
+        .join(COMPONENT)
+        .join("component.toml");
+    let mut contract = std::fs::read_to_string(&manifest_path).expect("read contract");
+    contract.push_str("\n[adapters.bundle]\nentry = \"custom.json\"\n");
+    std::fs::write(&manifest_path, contract).expect("write custom entry");
+    std::fs::remove_file(world.resource_root.join(".qoder-plugin/plugin.json"))
+        .expect("remove native manifest");
+    std::fs::write(
+        world.resource_root.join("custom.json"),
+        br#"{"name":"tokenless","version":"9.9.9"}"#,
+    )
+    .expect("write ignored custom manifest");
+    let fake = write_fake_qodercli(&world.prefix);
+    let (log, _settings, cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    let error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("custom manifest must fail before qodercli install");
+    assert!(
+        matches!(&error, AdapterError::BundleInvalid { reason, .. } if reason.contains(".qoder-plugin/plugin.json")),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qoder")
+            .is_none()
+    );
+    assert!(!cache.join("tokenless").exists());
+    assert!(
+        std::fs::read_to_string(&log)
+            .unwrap_or_default()
+            .lines()
+            .all(|line| !line.starts_with("plugins install "))
+    );
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("disable without receipt is a no-op");
+    assert!(!disabled.claim_removed);
+    assert!(disabled.report.cleanup_complete);
+}
+
+#[test]
+fn qoder_native_disable_keeps_receipt_until_absence_is_verified() {
+    let guard = EnvGuard::acquire();
+    for failure in ["uninstall", "uninstall-retain", "list", "list-invalid"] {
+        let world = stage(
+            "qoder",
+            "plugin",
+            "{datadir}/adapters/{component}/qoder/",
+            stage_native_qoder_bundle,
+        );
+        let fake = write_fake_qodercli(&world.prefix);
+        apply_qoder_env(&guard, &world, &fake);
+        guard.set("FAKE_QODER_FAIL", Path::new(""));
+        let manager = world.manager();
+        manager
+            .enable(COMPONENT, Some("qoder"), false)
+            .expect("enable native plugin");
+        guard.set("FAKE_QODER_FAIL", Path::new(failure));
+
+        let disabled = manager
+            .disable(COMPONENT, Some("qoder"), false)
+            .expect("disable returns a cleanup report");
+        assert!(!disabled.claim_removed, "receipt kept for {failure}");
+        assert!(!disabled.report.cleanup_complete);
+        let claim = world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qoder")
+            .cloned()
+            .expect("receipt kept");
+        assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+    }
+}
+
+#[test]
+fn qoder_cross_layout_reenable_preserves_legacy_receipt_for_cleanup() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    let (_log, settings, _cache, _staging) = apply_qoder_env(&guard, &world, &fake);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("legacy enable");
+
+    std::fs::remove_file(world.resource_root.join("hooks.json")).expect("remove legacy hooks");
+    stage_native_qoder_bundle(&world.resource_root);
+    let error = manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect_err("cross-layout re-enable must be explicit");
+    assert!(
+        matches!(error, AdapterError::BundleInvalid { .. }),
+        "unexpected error: {error:?}"
+    );
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, "qoder")
+        .cloned()
+        .expect("legacy receipt retained");
+    let DriverPayload::Qoder(payload) = &claim.driver_payload else {
+        panic!("expected Qoder receipt payload");
+    };
+    assert!(payload.settings_resource.is_some());
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("legacy cleanup remains available");
+    assert!(disabled.claim_removed);
+    let settings = read_json(&settings);
+    assert!(!enabled_plugins(&settings).contains(&"tokenless@local".to_string()));
+    assert!(hook_names(&settings, "PreToolUse").is_empty());
+}
+
+#[test]
+fn qoder_native_disable_without_cli_keeps_receipt() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    apply_qoder_env(&guard, &world, &fake);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("enable native plugin");
+    guard.set("QODERCLI_BIN", &world.prefix.join("missing-qodercli"));
+
+    let disabled = manager
+        .disable(COMPONENT, Some("qoder"), false)
+        .expect("disable returns a cleanup report");
+    assert!(!disabled.claim_removed);
+    assert!(!disabled.report.cleanup_complete);
+    assert_eq!(
+        world
+            .load_state()
+            .find_adapter_claim(COMPONENT, "qoder")
+            .expect("receipt kept")
+            .status,
+        ClaimStatus::CleanupFailed
+    );
+}
+
+#[test]
+fn qoder_native_status_fails_closed_for_unverifiable_or_inconsistent_state() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "qoder",
+        "plugin",
+        "{datadir}/adapters/{component}/qoder/",
+        stage_native_qoder_bundle,
+    );
+    let fake = write_fake_qodercli(&world.prefix);
+    apply_qoder_env(&guard, &world, &fake);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("qoder"), false)
+        .expect("enable native plugin");
+
+    guard.set("FAKE_QODER_FAIL", Path::new("list-invalid"));
+    let status = manager.status(Some(COMPONENT)).expect("status report");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Unknown);
+    assert!(status.entries[0].report.conditions.iter().any(|condition| {
+        condition.kind == AdapterConditionKind::VerificationSupported
+            && condition.status == ConditionStatus::False
+    }));
+
+    guard.set("FAKE_QODER_FAIL", Path::new(""));
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    let claim = state
+        .adapter_claims
+        .iter_mut()
+        .find(|claim| claim.component == COMPONENT)
+        .expect("claim");
+    let DriverPayload::Qoder(payload) = &mut claim.driver_payload else {
+        panic!("expected Qoder receipt payload");
+    };
+    payload.managed_hooks.push("forged-hook".to_string());
+    state.save(&state_path).expect("save forged receipt");
+    assert!(matches!(
+        manager.status(Some(COMPONENT)),
+        Err(AdapterError::BundleInvalid { .. })
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Why

Qoder native hook plugins are discovered and managed by qodercli, but the ANOLISA driver only supported the legacy Tokenless layout by copying bundles, rewriting hooks, and editing settings.json. This caused native bundles such as sec-core to be rejected or installed through an incompatible lifecycle.

## What changed

- Classify Qoder bundles as Native (`hooks/hooks.json`) or Legacy (root `hooks.json`) and reject ambiguous layouts.
- Require Qoder's fixed `.qoder-plugin/plugin.json` manifest so receipt identity matches the plugin qodercli actually registers.
- Delegate Native validation, installation, inventory verification, status, and uninstall to `qodercli plugins`.
- Reject an existing matching registration in any Qoder scope before mutation because project, local, and user registrations share the local plugin cache.
- Permit same-ID re-enable only when the prior schema-v3 receipt contains the explicit successful-install checkpoint.
- Reject Native re-enable when the Plugin ID changes, preserving the old receipt until its plugin is explicitly disabled.
- Persist an install-confirmation checkpoint immediately after qodercli succeeds and before inventory verification; failed install attempts never imply ownership.
- Make retry and disable fail closed for unconfirmed and pre-v3 Native receipts: registered plugins are left untouched, while a verified absence permits receipt cleanup.
- Capture structured CLI inventory with a separate 4 MiB stdout bound instead of the ordinary 64 KiB diagnostic limit.
- Keep Native plugin files and `settings.json` untouched, with write-ahead receipts retained on uncertain cleanup.
- Evolve the driver receipt schema to v3 while preserving Legacy v1 deserialization.
- Preserve the existing Legacy Tokenless staging and settings lifecycle unchanged.

## Related issue

Closes #2191

## User / Agent impact

ANOLISA can enable Qoder native hook plugins through the framework-supported plugin lifecycle. Existing Tokenless installations and legacy receipts continue to use their current behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change adds a new Qoder adapter lifecycle without removing the legacy path. ANOLISA refuses to install while the same Plugin ID exists in any scope, because qodercli backs those registrations with a shared cache. Native cleanup fails closed whenever inventory cannot prove the user-scope plugin is absent. Pre-v3 Native receipts have no durable install checkpoint and therefore never authorize replacement or uninstall; users must remove a matching registration explicitly before the stale receipt can be cleaned up.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- Native integration coverage includes direct resource-root installation, byte-stable settings, preserved `${QODER_PLUGIN_ROOT}`, shared-cache cross-scope rejection, same-ID owned re-enable, cross-ID re-enable rejection, pre-existing ownership conflicts, failed-install/user-install retry and disable safety, schema-v2 pre-apply crash safety, post-install verification cleanup, fixed-manifest identity, inventory failures, inventory larger than 64 KiB, and uninstall verification.
- Existing Qoder Legacy tests pass unchanged.
- Qoder CLI 1.1.9 reproductions confirmed that same-ID user installs replace the active version and an alternate manifest path registers a different directory-derived ID.

## Documentation and rollback

No documentation files changed; the PR is limited to the ANOLISA driver and tests. Reverting commit `8bc15dc9` restores the prior Legacy-only Qoder behavior.